### PR TITLE
Make driver take optional executor

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -44,7 +44,9 @@ class BlockingState {
       Operator* FOLLY_NONNULL op,
       BlockingReason reason);
 
-  static void setResume(std::shared_ptr<BlockingState> state);
+  static void setResume(
+      std::shared_ptr<BlockingState> state,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr);
 
   Operator* FOLLY_NONNULL op() {
     return operator_;
@@ -116,9 +118,13 @@ class Driver {
   static folly::CPUThreadPoolExecutor* FOLLY_NONNULL
   executor(int32_t threads = 0);
 
-  static void run(std::shared_ptr<Driver> self);
+  static void run(
+      std::shared_ptr<Driver> self,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr);
 
-  static void enqueue(std::shared_ptr<Driver> instance);
+  static void enqueue(
+      std::shared_ptr<Driver> instance,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr);
 
   // Waits for activity on 'executor_' to finish and then makes a new
   // executor. Testing uses this to ensure that there are no live

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -132,7 +132,7 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
         self->drivers_.back()->initializeOperatorStats(
             self->taskStats_.pipelineStats[pipeline].operatorStats);
       }
-      Driver::enqueue(self->drivers_.back());
+      Driver::enqueue(self->drivers_.back(), self->queryCtx_->executor());
     }
   }
   self->noMoreLocalExchangeProducers();
@@ -145,7 +145,7 @@ void Task::resume(std::shared_ptr<Task> self) {
   for (auto& driver : self->drivers_) {
     if (driver) {
       VELOX_CHECK(!driver->isOnThread() && !driver->isTerminated());
-      Driver::enqueue(driver);
+      Driver::enqueue(driver, self->queryCtx_->executor());
     }
   }
 }


### PR DESCRIPTION
There are cases that may require callers to supply their own executor. Make it pluggable through the interface.

Differential Revision: D30193354

