### PR TITLE
Fix partial aggregation

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -98,7 +98,8 @@ class QueryCtx : public Context {
   }
 
   uint64_t maxPartialAggregationMemoryUsage() const {
-    return 1L << 24; // 16MB
+    return get<uint64_t>(
+        kMaxPartialAggregationMemory, kMaxPartialAggregationMemoryDefault);
   }
 
   uint64_t maxPartitionedOutputBufferSize() const {
@@ -195,6 +196,9 @@ class QueryCtx : public Context {
   static constexpr const char* kMaxLocalExchangeBufferSize =
       "max_local_exchange_buffer_size";
 
+  static constexpr const char* kMaxPartialAggregationMemory =
+      "max_partial_aggregation_memory";
+
   // Overrides the previous configuration. Note that this function is NOT
   // thread-safe and should probably only be used in tests.
   void setConfigOverridesUnsafe(
@@ -221,6 +225,9 @@ class QueryCtx : public Context {
       "driver.adaptive_filter_reordering_enabled";
 
   static constexpr uint64_t kMaxLocalExchangeBufferSizeDefault = 32UL << 20;
+
+  // 16MB
+  static constexpr uint64_t kMaxPartialAggregationMemoryDefault = 1L << 24;
 
   CancelPoolPtr cancelPool_;
   std::unique_ptr<memory::MemoryPool> pool_;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -408,6 +408,11 @@ RowVectorPtr HashAggregation::getOutput() {
     // Drop reference to input_ to make it singly-referenced at the producer and
     // allow for memory reuse.
     input_ = nullptr;
+
+    if (partialFull_) {
+      groupingSet_->resetPartial();
+      partialFull_ = false;
+    }
     return output;
   }
 

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -49,6 +49,13 @@ class OperatorTestBase : public testing::Test {
   }
 
   std::shared_ptr<Task> assertQuery(
+      const CursorParameters& params,
+      const std::string& duckDbSql) {
+    return test::assertQuery(
+        params, [&](exec::Task* /*task*/) {}, duckDbSql, duckDbQueryRunner_);
+  }
+
+  std::shared_ptr<Task> assertQuery(
       const std::shared_ptr<const core::PlanNode>& plan,
       const std::string& duckDbSql) {
     return test::assertQuery(plan, duckDbSql, duckDbQueryRunner_);

--- a/velox/exec/tests/QueryAssertions.cpp
+++ b/velox/exec/tests/QueryAssertions.cpp
@@ -524,7 +524,7 @@ std::shared_ptr<Task> assertQuery(
 }
 
 std::shared_ptr<Task> assertQuery(
-    CursorParameters& params,
+    const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,

--- a/velox/exec/tests/QueryAssertions.h
+++ b/velox/exec/tests/QueryAssertions.h
@@ -84,7 +84,7 @@ std::shared_ptr<Task> assertQuery(
     std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
 
 std::shared_ptr<Task> assertQuery(
-    CursorParameters& params,
+    const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,


### PR DESCRIPTION
HashAggregation operator could get into an invalid state where it is not
blocked, doesn't need input, but getOutput() returns null. This happened when
operator processed a "distinct" aggregation and reached a limit on the amount
of memory to use for partial aggregation. This state confused the Driver loop
and caused it to complete prematurely. This would result in either wrong
results or a crash.

The fix is to flush partial aggregation state when reached the limit.