### PR TITLE
Fix bug on Expr::eval() API

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -48,7 +48,7 @@ class SimpleExpressionEvaluator : public connector::ExpressionEvaluator {
     exec::EvalCtx context(execCtx_, exprSet, input.get());
 
     std::vector<VectorPtr> results = {*result};
-    exprSet->eval(rows, &context, &results);
+    exprSet->eval(0, 1, true, rows, &context, &results);
 
     *result = results[0];
   }

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -186,7 +186,7 @@ void FilterProject::project(const SelectivityVector& rows, EvalCtx* evalCtx) {
 vector_size_t FilterProject::filter(
     EvalCtx* evalCtx,
     const SelectivityVector& allRows) {
-  exprs_->eval(allRows, evalCtx, &results_);
+  exprs_->eval(0, 1, true, allRows, evalCtx, &results_);
   return processFilterResults(results_[0], allRows, filterEvalCtx_, pool());
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -286,7 +286,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
   filterRows_.resize(numRows);
   filterRows_.setAll();
   EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput_.get());
-  filter_->eval(filterRows_, &evalCtx, &filterResult_);
+  filter_->eval(0, 1, true, filterRows_, &evalCtx, &filterResult_);
   decodedFilterResult_.decode(*filterResult_[0], filterRows_);
   int32_t numPassed = 0;
   auto rawMapping = rowNumberMapping_->asMutable<vector_size_t>();

--- a/velox/experimental/codegen/tests/CodegenTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenTest.cpp
@@ -51,14 +51,12 @@ TEST_F(CodegenTest, simpleProjectionWithConstantFields) {
   testExpressions<DoubleType>("a>b", {"2.0"}, inputRowType, 10, 100);
 };
 
-// temporarily disable a problematic test case
-/*
 TEST_F(CodegenTest, simpleProjectionWithFilter) {
   auto inputRowType = ROW({"a", "b"}, std::vector<TypePtr>{DOUBLE(), DOUBLE()});
   testExpressions<DoubleType, DoubleType>(
       "a > b", {" a + b", "a - b"}, inputRowType, 10, 100);
   testExpressions<DoubleType>("NOT a IS NULL", {"a"}, inputRowType, 10, 100);
-};*/
+};
 
 TEST_F(CodegenTest, reorderedInput) {
   std::shared_ptr<const RowType> inputRowType =


### PR DESCRIPTION
Summary:
FilterProject operator stores both filter and projection
expressions in the same ExprSet. Rolling back the change to ensure we only
calculate the first expression.

Reviewed By: mbasmanova

Differential Revision: D30203073

