### PR TITLE
Refresh ccache once per day (#1340)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,12 @@ jobs:
           paths:
             - ~/deps
       - run:
-          name: "Calculate merge-base for CCache"
-          command: git merge-base origin/main HEAD > merge-base
+          name: "Calculate merge-base date for CCache"
+          command: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
       - restore_cache:
           name: "Restore CCache cache"
           keys:
-            - velox-ccache-{{ arch }}-{{ checksum "merge-base" }}
+            - velox-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
       - run:
           name: "Build on MacOS"
           command: |
@@ -75,7 +75,7 @@ jobs:
           no_output_timeout: 1h
       - save_cache:
           name: "Save CCache cache"
-          key: velox-ccache-{{ arch }}-{{ checksum "merge-base" }}
+          key: velox-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
           paths:
             - .ccache/
 
@@ -84,12 +84,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Calculate merge-base for CCache"
-          command: git merge-base origin/main HEAD > merge-base
+          name: "Calculate merge-base date for CCache"
+          command: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
       - restore_cache:
           name: "Restore CCache cache"
           keys:
-            - velox-ccache-{{ arch }}-{{ checksum "merge-base" }}
+            - velox-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
       - run:
           name: Build
           command: |
@@ -102,16 +102,16 @@ jobs:
           no_output_timeout: 1h
       - store_artifacts:
           path: '_build/debug/.ninja_log'
+      - save_cache:
+          name: "Save CCache cache"
+          key: velox-ccache-{{ arch }}-{{ checksum "merge-base-date" }}
+          paths:
+            - .ccache/
       - run:
           name: Run Unit Tests
           command: |
             make unittest NUM_THREADS=8
           no_output_timeout: 1h
-      - save_cache:
-          name: "Save CCache cache"
-          key: velox-ccache-{{ arch }}-{{ checksum "merge-base" }}
-          paths:
-            - .ccache/
 
   format-check:
     executor: check


### PR DESCRIPTION
Summary:
The repo gets several commits per day, causing an unnecessary number of cache evictions if we use the merge-base. This PR changes the cache key to the _date_ of the merge base, so we only evict the cache once per day.

Pull Request resolved: https://github.com/facebookexternal/f4d/pull/1340

Differential Revision: D30123092

Pulled By: funrollloops

