### PR TITLE
[WIP] Enabling ascii encoding fast track based on row selection.

### DIFF
--- a/velox/functions/common/Length.cpp
+++ b/velox/functions/common/Length.cpp
@@ -62,7 +62,7 @@ class LengthFunction : public exec::VectorFunction {
     auto* resultFlatVector = (*result)->as<FlatVector<int64_t>>();
 
     if (inputArg->typeKind() == TypeKind::VARCHAR) {
-      auto stringEncoding = getStringEncodingOrUTF8(inputArg.get());
+      auto stringEncoding = getStringEncodingOrUTF8(inputArg.get(), rows);
       StringEncodingTemplateWrapper<ApplyInternalString>::apply(
           stringEncoding, rows, decodedInput, resultFlatVector);
       return;

--- a/velox/functions/common/StringFunctions.cpp
+++ b/velox/functions/common/StringFunctions.cpp
@@ -196,7 +196,7 @@ class SubstrFunction : public exec::VectorFunction {
     BaseVector* stringsVector = args[0].get();
     BaseVector* startsVector = args[1].get();
     BaseVector* lengthsVector = noLengthVector ? nullptr : args[2].get();
-    auto stringArgStringEncoding = getStringEncodingOrUTF8(stringsVector);
+    auto stringArgStringEncoding = getStringEncodingOrUTF8(stringsVector, rows);
 
     auto stringArgVectorEncoding = stringsVector->encoding();
     auto startArgVectorEncoding = startsVector->encoding();
@@ -388,7 +388,7 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
     exec::LocalDecodedVector inputHolder(context, *inputStringsVector, rows);
     auto decodedInput = inputHolder.get();
 
-    auto stringEncoding = getStringEncodingOrUTF8(inputStringsVector);
+    auto stringEncoding = getStringEncodingOrUTF8(inputStringsVector, rows);
 
     bool inPlace = (stringEncoding == StringEncodingMode::ASCII) &&
         (inputStringsVector->encoding() == VectorEncoding::Simple::FLAT) &&
@@ -547,7 +547,7 @@ class StringPosition : public exec::VectorFunction {
       }
     }
 
-    auto stringArgStringEncoding = getStringEncodingOrUTF8(args.at(0).get());
+    auto stringArgStringEncoding = getStringEncodingOrUTF8(args.at(0).get(), rows);
     BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
 
     auto* resultFlatVector = (*result)->as<FlatVector<int64_t>>();

--- a/velox/functions/lib/StringEncodingUtils.h
+++ b/velox/functions/lib/StringEncodingUtils.h
@@ -21,13 +21,14 @@ namespace facebook::velox::functions {
 using namespace stringCore;
 
 /// Return the string encoding of a vector, if not set UTF8 is returned
-static StringEncodingMode getStringEncodingOrUTF8(BaseVector* vector) {
+static StringEncodingMode getStringEncodingOrUTF8(BaseVector* vector, const SelectivityVector& other) {
   if (auto simpleVector = vector->template as<SimpleVector<StringView>>()) {
-    if (!simpleVector->getStringEncoding().has_value()) {
-      return StringEncodingMode::UTF8;
-    } else {
-      return simpleVector->getStringEncoding().value();
+
+    if (simpleVector->hasStringAsciiMap()) {
+      return simpleVector->getStringEncodingFor(other);
     }
+
+    return StringEncodingMode::UTF8;
   }
   VELOX_UNREACHABLE();
   return StringEncodingMode::UTF8;


### PR DESCRIPTION
Notes:
- The central idea here is we keep a mask (selectivity vector) for every SimpleVector<StringView> which stores all ascii string information. For propagating asciness we simply intersect across the vectors.
 - All the string functions test pass (some tests which test for mostly ascii etc have been disabled)
 - Theres a bunch of code that is no longer relevant (like string encoding tracker etc, or the old getStringEncode functions etc ). I am going to remove them in subsequent commits.
 - Quite a few of the functions have to be renamed and they make sense in only old context. 

