### PR TITLE
Add array vector reader for simple arrays

### DIFF
--- a/velox/experimental/codegen/CMakeLists.txt
+++ b/velox/experimental/codegen/CMakeLists.txt
@@ -26,6 +26,9 @@ add_subdirectory(code_generator)
 add_subdirectory(ast)
 add_subdirectory(udf_manager)
 add_subdirectory(utils)
+add_subdirectory(benchmark)
+add_subdirectory(functions)
+add_subdirectory(vector_function)
 
 add_library(velox_experimental_codegen Codegen.cpp CodegenStubs.cpp
                                        CodegenLogger.cpp)

--- a/velox/experimental/codegen/benchmark/CMakeLists.txt
+++ b/velox/experimental/codegen/benchmark/CMakeLists.txt
@@ -13,11 +13,12 @@
 add_executable(
   velox_codegen_benchmark_single_output
   SingleOutputDefaultNullsBenchmark.cpp
-  SingleOutputNotDefaultNullsBenchmark.cpp BooleanBenchmark.cpp)
+  SingleOutputNotDefaultNullsBenchmark.cpp BooleanBenchmarks.cpp)
 
 target_link_libraries(
   velox_codegen_benchmark_single_output
   velox_exec_test_lib
+  velox_codegen_utils_resource_path
   velox_codegen_code_generator
   ${FOLLY_BENCHMARK}
   ${FOLLY_WITH_DEPENDENCIES}
@@ -26,7 +27,6 @@ target_link_libraries(
   ${GFLAGS_LIBRARIES}
   ${FMT}
   velox_core
-  koski_parser
   velox_exec_test_util
   velox_functions_lib
   velox_functions_common
@@ -46,8 +46,7 @@ add_compile_definitions(velox_codegen_test
 add_compile_definitions(
   velox_codegen_test
   CODEGEN="$<TARGET_LINKER_FILE:velox_codegen_code_generator>")
-add_compile_definitions(velox_codegen_test
-                        KOSKI_PARSER="$<TARGET_LINKER_FILE:koski_parser>")
+
 add_compile_definitions(
   velox_codegen_test
   VELOX_FUNCTIONS_LIB="$<TARGET_LINKER_FILE:velox_functions_lib>")
@@ -89,7 +88,7 @@ target_link_libraries(
   ${GLOG}
   ${FMT}
   velox_core
-  koski_parser
+  velox_codegen_utils_resource_path
   velox_exec_test_util
   velox_functions_lib
   velox_functions_common

--- a/velox/experimental/codegen/code_generator/tests/ArithmeticFunctionsTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/ArithmeticFunctionsTest.cpp
@@ -466,7 +466,11 @@ TEST_F(ArithmeticFunctionsTest, DISABLED_testRound) {
       "round(C0)", {{32}, {13}, {-13}, {1}, {-1}});
 }
 
-TEST_F(ArithmeticFunctionsTest, testHash) {
+// FIXME: This test errors on macs:
+// velox/velox/functions/common/HashImpl.h:22:31: error: implicit instantiation
+// of undefined template 'folly::hasher<std::__1::basic_string_view<char, \
+// std::__1::char_traits<char> >, void>'
+TEST_F(ArithmeticFunctionsTest, DISABLED_testHash) {
   StringView input("hi welcome");
   evaluateAndCompare<
       RowTypeTrait<TypeKind::VARCHAR>,

--- a/velox/experimental/codegen/functions/CMakeLists.txt
+++ b/velox/experimental/codegen/functions/CMakeLists.txt
@@ -10,17 +10,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_experimental_codegen_test CodegenTest.cpp)
-add_dependencies(velox_experimental_codegen_test velox_codegen_expression_test)
-target_link_libraries(
-  velox_experimental_codegen_test
-  ${GTEST_BOTH_LIBRARIES}
-  velox_core
-  velox_exec
-  velox_experimental_codegen
-  velox_exec_test_lib
-  velox_exec_test_util
-  velox_functions_common
-  velox_codegen_utils_resource_path)
-
-add_test(velox_experimental_codegen_test velox_experimental_codegen_test)
+add_library(velox_codegen_functions INTERFACE)
+target_link_libraries(velox_codegen_functions INTERFACE ${FMT})

--- a/velox/experimental/codegen/vector_function/ComplexVectorReader.h
+++ b/velox/experimental/codegen/vector_function/ComplexVectorReader.h
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <math.h>
+#include <sys/socket.h>
+#include <array>
+#include <type_traits>
+#include "velox/buffer/Buffer.h"
+#include "velox/common/base/Nulls.h"
+#include "velox/experimental/codegen/vector_function/StringTypes.h"
+#include "velox/experimental/codegen/vector_function/VectorReader-inl.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook {
+namespace velox {
+namespace codegen {
+
+template <TypeKind SQLType>
+constexpr bool arrayReadableType = TypeTraits<SQLType>::isPrimitiveType;
+
+template <typename T, typename Config>
+struct ComplexVectorReader {};
+
+// Reader for ArrayVector(FlatVector<NativeVal>)
+// Use the templated Array<> type here instead of ARRAY typekind for
+// static template expansion
+template <typename SQLElementType, typename Config>
+struct ComplexVectorReader<Array<SQLElementType>, Config> {
+  static_assert(arrayReadableType<SQLElementType::NativeType::typeKind>);
+  using ElementType = typename SQLElementType::NativeType::NativeType;
+  using ElementValueType =
+      typename VectorReader<SQLElementType, Config>::ValueType;
+  using ElementInputType =
+      typename VectorReader<SQLElementType, Config>::InputType;
+  using ValueType = std::optional<std::vector<ElementValueType>>;
+  using InputType = std::optional<std::vector<ElementInputType>>;
+
+  explicit ComplexVectorReader(VectorPtr& vector) {
+    VELOX_CHECK(vector->type()->kind() == TypeKind::ARRAY);
+    arrayVectorPtr_ = std::dynamic_pointer_cast<ArrayVector>(vector);
+    VELOX_CHECK_NOT_NULL(arrayVectorPtr_);
+  }
+
+  struct PointerType {
+    explicit PointerType(
+        ArrayVectorPtr& arrayVectorPtr,
+        size_t rowIndex,
+        vector_size_t offset)
+        : arrayVectorPtr_(arrayVectorPtr),
+          rowIndex_(rowIndex),
+          vectorReader_(
+              const_cast<VectorPtr&>(arrayVectorPtr->elements()),
+              offset) {}
+
+    inline bool has_value() {
+      return !arrayVectorPtr_->isNullAt(rowIndex_);
+    }
+
+    inline std::optional<ElementType&> value() {
+      return *(vectorReader_[0]);
+    }
+
+    inline size_t size() {
+      if (!has_value()) {
+        throw std::logic_error("element has no value");
+      }
+      return arrayVectorPtr_->sizeAt(rowIndex_);
+    }
+
+    inline void setNullAndSize() {
+      static_assert(Config::isWriter_);
+      auto mutableNulls = arrayVectorPtr_->mutableRawNulls();
+      auto oldNullCount = arrayVectorPtr_->getNullCount();
+      if (oldNullCount.hasValue()) {
+        arrayVectorPtr_->setNullCount(oldNullCount.value() + 1);
+      }
+      bits::setBit(mutableNulls, rowIndex_, bits::kNull);
+      setSize(0);
+    }
+
+    inline void setNotNullAndSize(vector_size_t size) {
+      static_assert(Config::isWriter_);
+      auto mutableNulls = arrayVectorPtr_->mutableRawNulls();
+      auto oldNullCount = arrayVectorPtr_->getNullCount();
+      if (oldNullCount.hasValue()) {
+        arrayVectorPtr_->setNullCount(oldNullCount.value() - 1);
+      }
+      bits::setBit(mutableNulls, rowIndex_, bits::kNotNull);
+      setSize(size);
+    }
+
+    inline ElementType& operator*() {
+      return *(vectorReader_[0]);
+    }
+
+    inline const ElementType& operator*() const {
+      return *(vectorReader_[0]);
+    }
+
+    inline typename VectorReader<SQLElementType, Config>::PointerType
+    operator[](size_t elementIndex) {
+      return vectorReader_[elementIndex];
+    }
+
+    inline PointerType& operator=(InputType& other) {
+      if (!other.has_value()) {
+        setNullAndSize();
+        return *this;
+      } else {
+        auto val = other.value();
+        setNotNullAndSize(val.size());
+        for (size_t i = 0; i < val.size(); i++) {
+          vectorReader_[i] = val[i];
+        }
+        return *this;
+      }
+    }
+
+    operator ValueType const() {
+      if (!has_value()) {
+        return {};
+      } else {
+        std::vector<ElementValueType> val(size());
+        for (size_t i = 0; i < size(); i++) {
+          val.push_back(this[i]);
+        }
+        return val;
+      }
+    }
+
+   private:
+    ArrayVectorPtr& arrayVectorPtr_;
+    size_t rowIndex_;
+    VectorReader<SQLElementType, Config> vectorReader_;
+
+    inline void setSize(vector_size_t size) {
+      // reserve metadata vectors and resize if needed
+      auto mutableSizes =
+          arrayVectorPtr_->mutableSizes(size)->asMutable<vector_size_t>();
+      auto mutableOffsets =
+          arrayVectorPtr_->mutableOffsets(size)->asMutable<vector_size_t>();
+
+      // FIXME: this assumes that setSize() is called in sequential
+      // order
+      mutableSizes[rowIndex_] = size;
+      if (rowIndex_ == 0) {
+        mutableOffsets[rowIndex_] = 0;
+      } else {
+        mutableOffsets[rowIndex_] =
+            mutableOffsets[rowIndex_ - 1] + mutableSizes[rowIndex_ - 1];
+      }
+      return;
+    }
+  };
+
+  inline PointerType operator[](size_t rowIndex) {
+    // We only support simple arrays for now
+    VELOX_CHECK_NOT_NULL(
+        arrayVectorPtr_->elements()->asFlatVector<ElementType>());
+    vector_size_t offset;
+    if constexpr (Config::isWriter_) {
+      if (rowIndex == 0) {
+        offset = 0;
+      } else {
+        offset = arrayVectorPtr_->offsetAt(rowIndex - 1) +
+            arrayVectorPtr_->sizeAt(rowIndex - 1);
+      }
+    } else {
+      offset = arrayVectorPtr_->offsetAt(rowIndex);
+    }
+    return PointerType{arrayVectorPtr_, rowIndex, offset};
+  }
+
+ private:
+  ArrayVectorPtr arrayVectorPtr_;
+};
+
+} // namespace codegen
+} // namespace velox
+} // namespace facebook

--- a/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
+++ b/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
@@ -18,6 +18,7 @@
 #include <thread>
 #include <type_traits>
 #include <utility>
+#include "velox/experimental/codegen/vector_function/ComplexVectorReader.h"
 #include "velox/experimental/codegen/vector_function/ConcatExpression-inl.h"
 #include "velox/experimental/codegen/vector_function/Perf.h"
 #include "velox/experimental/codegen/vector_function/VectorReader-inl.h"

--- a/velox/experimental/codegen/vector_function/VectorReader-inl.h
+++ b/velox/experimental/codegen/vector_function/VectorReader-inl.h
@@ -33,7 +33,7 @@ namespace codegen {
 //   // true means set to null, false means not null
 //   static constexpr bool intializedWithNullSet_
 //
-//   // when true, the reader will never reveive a null value to write
+//   // when true, the reader will never receive a null value to write
 //   static constexpr bool mayWriteNull_
 //
 //
@@ -78,17 +78,13 @@ struct VectorReader {
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
+      mutableRawValues_ = flatVector->mutableRawValues();
     } else {
       if constexpr (Config::mayReadNull_) {
         // TODO when read only vector does not have nulls we dont need to
         // allocate nulls
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
-    }
-
-    if constexpr (Config::isWriter_) {
-      mutableRawValues_ = flatVector->mutableRawValues();
-    } else {
       mutableRawValues_ = const_cast<NativeType*>(flatVector->rawValues());
     }
   }
@@ -183,17 +179,13 @@ struct VectorReader<
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
+      mutableRawValues_ = flatVector->template mutableRawValues<uint64_t>();
     } else {
       // TODO when read only vector does not have nulls we dont need to allocate
       // nulls
       if constexpr (Config::mayReadNull_) {
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
-    }
-
-    if constexpr (Config::isWriter_) {
-      mutableRawValues_ = flatVector->template mutableRawValues<uint64_t>();
-    } else {
       mutableRawValues_ =
           const_cast<uint64_t*>(flatVector->template rawValues<uint64_t>());
     }
@@ -311,17 +303,13 @@ struct VectorReader<
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
+      mutableRawValues_ = flatVector->template mutableRawValues<StringView>();
     } else {
       // TODO when read only vector does not have nulls we dont need to allocate
       // nulls
       if constexpr (Config::mayReadNull_) {
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
-    }
-
-    if constexpr (Config::isWriter_) {
-      mutableRawValues_ = flatVector->template mutableRawValues<StringView>();
-    } else {
       mutableRawValues_ =
           const_cast<StringView*>(flatVector->template rawValues<StringView>());
     }

--- a/velox/experimental/codegen/vector_function/tests/ArrayVectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/ArrayVectorReaderTest.cpp
@@ -1,0 +1,234 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <optional>
+#include <vector>
+#include "velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h" // NOLINT (CLANGTIDY  )
+#include "velox/experimental/codegen/vector_function/tests/VectorReaderTestBase.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::codegen {
+
+TEST_F(ComplexVectorReaderTest, ReadArraySmallintVectors) {
+  /// ArrayVector<FlatVector<int16_t>>:
+  /// [ null, [0x0333, null, 0x1444], [0x1666, 0x0777, null, 0x0999] ]
+  /// size: 3
+  /// offsets: [0, 0, 3]
+  /// lengths: [0, 3, 4]
+  /// nulls: 0b001
+  /// elements:
+  ///  FlatVector<int16_t>:
+  ///  size: 7
+  ///  [0x0333, null, 0x1444, 0x1666, 0x0777, null, 0x0999]
+  ///  nulls: 0b0100000
+  size_t flatVectorSize = 7;
+  auto flatVector =
+      makeFlatVectorPtr<int16_t>(flatVectorSize, SMALLINT(), pool_.get());
+
+  size_t arrayVectorSize = 3;
+  auto arrayVector = makeArrayVectorPtr(
+      arrayVectorSize, pool_.get(), ARRAY(SMALLINT()), flatVector);
+
+  ComplexVectorReader<Array<SmallintType>, OutputReaderConfig<false, false>>
+      writer(arrayVector);
+  ComplexVectorReader<Array<SmallintType>, InputReaderConfig<false, false>>
+      reader(arrayVector);
+
+  writer[0].setNullAndSize();
+  ASSERT_FALSE(reader[0].has_value());
+
+  writer[1].setNotNullAndSize(3);
+  writer[1][0] = 0x0333;
+  writer[1][1] = std::nullopt;
+  writer[1][2] = 0x1444;
+  ASSERT_EQ(reader[1][0].value(), 0x0333);
+  ASSERT_FALSE(reader[1][1].has_value());
+  ASSERT_EQ(reader[1][2].value(), 0x1444);
+  ASSERT_EQ(reader[1].size(), 3);
+
+  using InputType = ComplexVectorReader<
+      Array<SmallintType>,
+      OutputReaderConfig<false, false>>::InputType;
+  using ElementInputType = ComplexVectorReader<
+      Array<SmallintType>,
+      OutputReaderConfig<false, false>>::ElementInputType;
+
+  InputType smallint2 = std::make_optional(
+      std::vector<ElementInputType>{0x1666, 0x0777, std::nullopt, 0x0999});
+  writer[2] = smallint2;
+  ASSERT_EQ(reader[2][0].value(), 0x1666);
+  ASSERT_EQ(reader[2][1].value(), 0x0777);
+  ASSERT_FALSE(reader[2][2].has_value());
+  ASSERT_EQ(reader[2][3].value(), 0x0999);
+}
+
+TEST_F(ComplexVectorReaderTest, ReadArrayBoolVectors) {
+  /// ArrayVector<FlatVector<bool>>:
+  /// [ [true, false, null], null, [false, false, null, false], null]
+  /// size: 4
+  /// offsets: [0, 3, 3, 7]
+  /// lengths: [3, 0, 4, 0]
+  /// nulls: 0b1010
+  /// elements:
+  ///  FlatVector<bool>:
+  ///  size: 7
+  ///  [true, false, null, false, false, null, false]
+  ///  nulls: 0b0100100
+  size_t flatVectorSize = 7;
+  auto flatVector =
+      makeFlatVectorPtr<bool>(flatVectorSize, BOOLEAN(), pool_.get());
+
+  size_t arrayVectorSize = 4;
+  auto arrayVector = makeArrayVectorPtr(
+      arrayVectorSize, pool_.get(), ARRAY(BOOLEAN()), flatVector);
+
+  ComplexVectorReader<Array<BooleanType>, OutputReaderConfig<false, false>>
+      writer(arrayVector);
+  ComplexVectorReader<Array<BooleanType>, InputReaderConfig<false, false>>
+      reader(arrayVector);
+
+  // if we set elements one-by-one, we need to explicitly call
+  // setNotNullAndSize()
+  writer[0].setNotNullAndSize(3);
+  writer[0][0] = true;
+  writer[0][1] = false;
+  writer[0][2] = std::nullopt;
+  ASSERT_EQ(reader[0][0].value(), true);
+  ASSERT_EQ(reader[0][1].value(), false);
+  ASSERT_FALSE(reader[0][2].has_value());
+  ASSERT_EQ(reader[0].size(), 3);
+
+  writer[1].setNullAndSize();
+  ASSERT_FALSE(reader[1].has_value());
+  EXPECT_THROW(reader[1].size(), std::logic_error);
+
+  using InputType = ComplexVectorReader<
+      Array<BooleanType>,
+      OutputReaderConfig<false, false>>::InputType;
+  using ElementInputType = ComplexVectorReader<
+      Array<BooleanType>,
+      OutputReaderConfig<false, false>>::ElementInputType;
+
+  InputType bool2 = std::make_optional(
+      std::vector<ElementInputType>{false, false, std::nullopt, false});
+  writer[2] = bool2;
+  ASSERT_EQ(reader[2][0].value(), false);
+  ASSERT_EQ(reader[2][1].value(), false);
+  ASSERT_FALSE(reader[2][2].has_value());
+  ASSERT_EQ(reader[2][3].value(), false);
+  ASSERT_EQ(reader[2].size(), 4);
+
+  InputType bool3 = std::nullopt;
+  writer[3] = bool3;
+  ASSERT_FALSE(reader[3].has_value());
+  EXPECT_THROW(reader[3].size(), std::logic_error);
+}
+
+TEST_F(ComplexVectorReaderTest, ReadArrayStringVectors) {
+  /// ArrayVector<FlatVector<StringView>>:
+  /// [ hello, longString, emptyString, null ], [null, world], null, null]
+  /// size: 4
+  /// offsets: [0, 4, 6, 6]
+  /// lengths: [4, 2, 0, 0]
+  /// nulls: 0b1100
+  /// elements:
+  ///  FlatVector<StringView>:
+  ///  size: 6
+  ///  [ hello, longString, emptyString, null, null, world]
+  ///  nulls: 0b011000
+
+  auto helloRef = facebook::velox::StringView(u8"Hello", 5);
+  InputReferenceStringNullable hello{InputReferenceString(helloRef)};
+  auto longStringRef =
+      StringView(u8"This is a rather long string.  Quite long indeed.", 49);
+  InputReferenceStringNullable longString{InputReferenceString(longStringRef)};
+  auto emptyStringRef = StringView(u8"", 0);
+  InputReferenceStringNullable emptyString{
+      InputReferenceString(emptyStringRef)};
+  auto worldRef = StringView(u8"World", 5);
+  InputReferenceStringNullable world{InputReferenceString(worldRef)};
+
+  size_t flatVectorSize = 6;
+  auto flatVector =
+      makeFlatVectorPtr<StringView>(flatVectorSize, VARCHAR(), pool_.get());
+
+  size_t arrayVectorSize = 4;
+  auto arrayVector = makeArrayVectorPtr(
+      arrayVectorSize, pool_.get(), ARRAY(VARCHAR()), flatVector);
+
+  ComplexVectorReader<Array<VarcharType>, OutputReaderConfig<false, false>>
+      writer(arrayVector);
+  ComplexVectorReader<Array<VarcharType>, InputReaderConfig<false, false>>
+      reader(arrayVector);
+
+  writer[0].setNotNullAndSize(4);
+  writer[0][0] = hello;
+  writer[0][1] = longString;
+  writer[0][2] = emptyString;
+  writer[0][3] = std::nullopt;
+
+  ASSERT_TRUE(reader[0].has_value());
+
+  ASSERT_TRUE(reader[0][0].has_value());
+  ASSERT_EQ(reader[0][0].value().size(), 5);
+  ASSERT_TRUE(gtestMemcmp(
+      (*reader[0][0]).data(), (void*)helloRef.data(), (*reader[0][0]).size()));
+
+  ASSERT_TRUE(reader[0][1].has_value());
+  ASSERT_EQ(reader[0][1].value().size(), 49);
+  ASSERT_TRUE(gtestMemcmp(
+      (*reader[0][1]).data(),
+      (void*)longStringRef.data(),
+      (*reader[0][1]).size()));
+
+  ASSERT_TRUE(reader[0][2].has_value());
+  ASSERT_EQ(reader[0][2].value().size(), 0);
+  ASSERT_TRUE(gtestMemcmp(
+      (*reader[0][2]).data(), (void*)helloRef.data(), (*reader[0][2]).size()));
+
+  ASSERT_FALSE(reader[0][3].has_value());
+
+  using InputType = ComplexVectorReader<
+      Array<VarcharType>,
+      OutputReaderConfig<false, false>>::InputType;
+  using ElementInputType = ComplexVectorReader<
+      Array<VarcharType>,
+      OutputReaderConfig<false, false>>::ElementInputType;
+  InputType string1 = std::make_optional(
+      std::vector<ElementInputType>{InputReferenceStringNullable{}, world});
+  writer[1] = string1;
+
+  ASSERT_TRUE(reader[1].has_value());
+
+  ASSERT_FALSE(reader[1][0].has_value());
+
+  ASSERT_TRUE(reader[1][1].has_value());
+  ASSERT_EQ(reader[1][1].value().size(), 5);
+  ASSERT_TRUE(gtestMemcmp(
+      (*reader[1][1]).data(), (void*)worldRef.data(), (*reader[1][1]).size()));
+
+  writer[2].setNullAndSize();
+  ASSERT_FALSE(reader[2].has_value());
+  EXPECT_THROW(reader[2].size(), std::logic_error);
+
+  InputType val = std::nullopt;
+  writer[3] = val;
+  ASSERT_FALSE(reader[3].has_value());
+  EXPECT_THROW(reader[3].size(), std::logic_error);
+}
+
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_codegen_vector_function_test
-               veloxCodegenVectorFunctionTest.cpp, TempStringTest.cpp)
+add_executable(velox_codegen_vector_function_test CodegenVectorFunctionTest.cpp
+                                                  TempStringTest.cpp)
 add_test(velox_codegen_vector_function_test velox_codegen_vector_function_test)
 
 target_link_libraries(
@@ -37,7 +37,7 @@ target_link_libraries(
   velox_dwio_type_fbhive
   velox_dwrf_test_utils
   velox_presto_serializer
-  velox_transform
+  velox_transform_utils
   ${ANTLR4_RUNTIME}
   ${Boost_ATOMIC_LIBRARIES}
   ${Boost_CONTEXT_LIBRARIES}

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_codegen_vector_function_test CodegenVectorFunctionTest.cpp
-                                                  TempStringTest.cpp)
+add_executable(
+  velox_codegen_vector_function_test CodegenVectorFunctionTest.cpp
+                                     TempStringTest.cpp VectorReaderTest.cpp)
 add_test(velox_codegen_vector_function_test velox_codegen_vector_function_test)
 
 target_link_libraries(

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -76,38 +76,6 @@ TEST(TestConcat, BasicConcatRow) {
   EXPECT_EQ(std::get<1>(output), *std::get<0>(args) - *std::get<1>(args));
 }
 
-TEST(VectorReader, ReadDoublesVectors) {
-  const size_t vectorSize = 1000;
-  auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
-  auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
-
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
-  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
-  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
-
-  VectorPtr& in1 = inRowVector->as<RowVector>()->childAt(0);
-
-  SelectivityVector selectivityVector(vectorSize);
-  selectivityVector.setAll();
-  in1->resize(vectorSize);
-  in1->addNulls(nullptr, selectivityVector);
-  VectorReader<DoubleType, OutputReaderConfig<false, false>> writer(in1);
-  VectorReader<DoubleType, InputReaderConfig<false, false>> reader(in1);
-
-  for (size_t row = 0; row < vectorSize; row++) {
-    writer[row] = (double)row;
-  }
-
-  for (size_t row = 0; row < vectorSize; row++) {
-    ASSERT_DOUBLE_EQ((double)row, *reader[row]);
-  }
-
-  for (size_t row = 0; row < vectorSize; row++) {
-    ASSERT_DOUBLE_EQ(*reader[row], in1->asFlatVector<double>()->valueAt(row));
-  }
-}
-
 TEST(TestConcat, EvalConcatFunction) {
   const size_t rowLength = 1000;
   SelectivityVector rows(rowLength);
@@ -221,48 +189,6 @@ struct GeneratedVectorFunctionConfigBool {
   static constexpr bool isDefaultNull = false;
   static constexpr bool isDefaultNullStrict = false;
 };
-
-TEST(VectorReader, ReadBoolVectors) {
-  // TODO: Move those to test class
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
-  const size_t vectorSize = 1000;
-
-  auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});
-  auto outRowType = ROW({"expr1", "expr2"}, {BOOLEAN(), BOOLEAN()});
-
-  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
-  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
-
-  VectorPtr& inputVector = inRowVector->as<RowVector>()->childAt(0);
-  inputVector->resize(vectorSize);
-  VectorReader<BooleanType, InputReaderConfig<false, false>> reader(
-      inputVector);
-  VectorReader<BooleanType, OutputReaderConfig<false, false>> writer(
-      inputVector);
-
-  for (size_t row = 0; row < vectorSize; row++) {
-    writer[row] = row % 2 == 0;
-  }
-
-  // Check that writing of values to the reader was success
-  for (size_t row = 0; row < vectorSize; row++) {
-    ASSERT_DOUBLE_EQ((row % 2 == 0), *reader[row]);
-    ASSERT_DOUBLE_EQ(
-        (row % 2 == 0), inputVector->asFlatVector<bool>()->valueAt(row));
-  }
-
-  // Write a null at even indices
-  for (size_t row = 0; row < vectorSize; row++) {
-    if (row % 2) {
-      writer[row] = std::nullopt;
-    }
-  }
-
-  for (size_t row = 0; row < vectorSize; row++) {
-    ASSERT_EQ(inputVector->asFlatVector<bool>()->isNullAt(row), row % 2);
-  }
-}
 
 TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   // TODO: Move those to test class

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h" // NOLINT (CLANGTIDY  )
+#include "velox/experimental/codegen/vector_function/StringTypes.h"
+
+namespace facebook::velox::codegen {
+TEST(VectorReader, ReadDoublesVectors) {
+  const size_t vectorSize = 1000;
+  auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
+  auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
+
+  auto pool_ = memory::getDefaultScopedMemoryPool();
+  auto pool = pool_.get();
+  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
+  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
+
+  VectorPtr& in1 = inRowVector->as<RowVector>()->childAt(0);
+
+  SelectivityVector selectivityVector(vectorSize);
+  selectivityVector.setAll();
+  in1->resize(vectorSize);
+  in1->addNulls(nullptr, selectivityVector);
+  VectorReader<DoubleType, OutputReaderConfig<false, false>> writer(in1);
+  VectorReader<DoubleType, InputReaderConfig<false, false>> reader(in1);
+
+  for (size_t row = 0; row < vectorSize; row++) {
+    writer[row] = (double)row;
+  }
+
+  for (size_t row = 0; row < vectorSize; row++) {
+    ASSERT_DOUBLE_EQ((double)row, *reader[row]);
+  }
+
+  for (size_t row = 0; row < vectorSize; row++) {
+    ASSERT_DOUBLE_EQ(*reader[row], in1->asFlatVector<double>()->valueAt(row));
+  }
+}
+
+TEST(VectorReader, ReadBoolVectors) {
+  // TODO: Move those to test class
+  auto pool_ = memory::getDefaultScopedMemoryPool();
+  auto pool = pool_.get();
+  const size_t vectorSize = 1000;
+
+  auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});
+  auto outRowType = ROW({"expr1", "expr2"}, {BOOLEAN(), BOOLEAN()});
+
+  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
+  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
+
+  VectorPtr& inputVector = inRowVector->as<RowVector>()->childAt(0);
+  inputVector->resize(vectorSize);
+  VectorReader<BooleanType, InputReaderConfig<false, false>> reader(
+      inputVector);
+  VectorReader<BooleanType, OutputReaderConfig<false, false>> writer(
+      inputVector);
+
+  for (size_t row = 0; row < vectorSize; row++) {
+    writer[row] = row % 2 == 0;
+  }
+
+  // Check that writing of values to the reader was success
+  for (size_t row = 0; row < vectorSize; row++) {
+    ASSERT_DOUBLE_EQ((row % 2 == 0), *reader[row]);
+    ASSERT_DOUBLE_EQ(
+        (row % 2 == 0), inputVector->asFlatVector<bool>()->valueAt(row));
+  }
+
+  // Write a null at even indices
+  for (size_t row = 0; row < vectorSize; row++) {
+    if (row % 2) {
+      writer[row] = std::nullopt;
+    }
+  }
+
+  for (size_t row = 0; row < vectorSize; row++) {
+    ASSERT_EQ(inputVector->asFlatVector<bool>()->isNullAt(row), row % 2);
+  }
+}
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTestBase.h
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTestBase.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include "velox/experimental/codegen/vector_function/ComplexVectorReader.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::codegen {
+
+class VectorReaderTestBase : public ::testing::Test {
+ protected:
+  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
+      memory::getDefaultScopedMemoryPool();
+
+  testing::AssertionResult gtestMemcmp(void* lhs, void* rhs, size_t count) {
+    return std::memcmp(lhs, rhs, count) ? testing::AssertionFailure()
+                                        : testing::AssertionSuccess();
+  }
+};
+
+class ComplexVectorReaderTest : public VectorReaderTestBase {
+ protected:
+  template <typename T>
+  VectorPtr makeFlatVectorPtr(
+      size_t flatVectorSize,
+      const TypePtr type,
+      memory::MemoryPool* pool) {
+    auto vector = BaseVector::create(type, flatVectorSize, pool);
+    return vector;
+  }
+
+  VectorPtr makeArrayVectorPtr(
+      size_t arrayVectorSize,
+      memory::MemoryPool* pool,
+      const TypePtr type,
+      VectorPtr elements) {
+    BufferPtr offsets = AlignedBuffer::allocate<int32_t>(arrayVectorSize, pool);
+    auto* offsetsPtr = offsets->asMutable<int32_t>();
+    BufferPtr lengths =
+        AlignedBuffer::allocate<vector_size_t>(arrayVectorSize, pool);
+    auto* lengthsPtr = lengths->asMutable<vector_size_t>();
+    BufferPtr nulls =
+        AlignedBuffer::allocate<char>(bits::nbytes(arrayVectorSize), pool);
+    auto* nullsPtr = nulls->asMutable<uint64_t>();
+
+    size_t nullCount = 0;
+
+    return std::make_shared<ArrayVector>(
+        pool,
+        type,
+        nulls,
+        arrayVectorSize,
+        offsets,
+        lengths,
+        elements,
+        nullCount);
+  }
+};
+
+} // namespace facebook::velox::codegen


### PR DESCRIPTION
Summary:
1. Added VectorReader for primitive types (e.g. array of fixed length types and array of varchar / varbin types). It is located in `velox/experimental/codegen/vector_function/ComplexVectorReader.h`. The class invokes the corresponding VectorReader on its elements.
2. Added `offset` as a parameter to primitive types' VectorReaders. This field is used by the complexType VectorReaders to locate the elements.
3. Added simple string VectorReader test.
4. Added Array VectorReader test.
5. Added VectorReaderTestBase. Some of the code is borrowed from UnsafeRowSerializerTest, we can refactor to share the VectorReader utils later.

Differential Revision: D30048466

