### PR TITLE
Add basic implementation of Unnest operator

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   Operator.cpp
   OperatorUtils.cpp
   FilterProject.cpp
+  Unnest.cpp
   Values.cpp
   VectorHasher.cpp
   PartitionedOutputBufferManager.cpp

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -26,6 +26,7 @@
 #include "velox/exec/TableScan.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/TopN.h"
+#include "velox/exec/Unnest.h"
 #include "velox/exec/Values.h"
 
 namespace facebook::velox::exec {
@@ -290,8 +291,12 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
           localPartitionNode->outputType(),
           localPartitionNode->id(),
           ctx->driverId));
+    } else if (
+        auto unnest =
+            std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {
+      operators.push_back(std::make_unique<Unnest>(id, ctx.get(), unnest));
     } else {
-      VELOX_FAIL("Unsupported plan node");
+      VELOX_FAIL("Unsupported plan node: {}", planNode->toString());
     }
   }
   if (consumerSupplier) {

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Unnest.h"
+#include "velox/exec/OperatorUtils.h"
+
+namespace facebook::velox::exec {
+Unnest::Unnest(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::UnnestNode>& unnestNode)
+    : Operator(
+          driverCtx,
+          unnestNode->outputType(),
+          operatorId,
+          unnestNode->id(),
+          "Unnest") {
+  if (unnestNode->unnestVariables().size() > 1) {
+    VELOX_UNSUPPORTED(
+        "Unnest operator doesn't support multiple unnest columns yet");
+  }
+
+  const auto& unnestVariable = unnestNode->unnestVariables()[0];
+  if (!unnestVariable->type()->isArray()) {
+    VELOX_UNSUPPORTED(
+        "Unnest operator doesn't support non-ARRAY unnest variables yet: {}",
+        unnestVariable->type()->toString())
+  }
+
+  if (unnestNode->withOrdinality()) {
+    VELOX_UNSUPPORTED("Unnest operator doesn't support ordinality column yet");
+  }
+
+  const auto& inputType = unnestNode->sources()[0]->outputType();
+  ChannelIndex outputChannel = 0;
+  for (const auto& variable : unnestNode->replicateVariables()) {
+    identityProjections_.emplace_back(
+        inputType->getChildIdx(variable->name()), outputChannel++);
+  }
+
+  unnestChannel_ = inputType->getChildIdx(unnestVariable->name());
+}
+
+void Unnest::addInput(RowVectorPtr input) {
+  input_ = std::move(input);
+}
+
+RowVectorPtr Unnest::getOutput() {
+  if (!input_) {
+    return nullptr;
+  }
+
+  auto size = input_->size();
+
+  // Build repeated indices to apply to "replicated" columns.
+  const auto& unnestVector = input_->childAt(unnestChannel_);
+
+  inputRows_.resize(size);
+  unnestDecoded_.decode(*unnestVector, inputRows_);
+
+  auto unnestIndices = unnestDecoded_.indices();
+
+  auto unnestBase = unnestDecoded_.base()->as<ArrayVector>();
+  auto rawSizes = unnestBase->rawSizes();
+  auto rawOffsets = unnestBase->rawOffsets();
+
+  // Count number of elements.
+  vector_size_t numElements = 0;
+  for (auto row = 0; row < size; ++row) {
+    if (!unnestDecoded_.isNullAt(row)) {
+      numElements += rawSizes[unnestIndices[row]];
+    }
+  }
+
+  if (numElements == 0) {
+    // All arrays are null or empty.
+    input_ = nullptr;
+    return nullptr;
+  }
+
+  // Create "indices" buffer to repeat rows as many times as there are elements
+  // in the array.
+  BufferPtr repeatedIndices =
+      AlignedBuffer::allocate<vector_size_t>(numElements, pool());
+  auto* rawIndices = repeatedIndices->asMutable<vector_size_t>();
+  vector_size_t index = 0;
+  for (auto row = 0; row < size; ++row) {
+    if (!unnestDecoded_.isNullAt(row)) {
+      auto unnestSize = rawSizes[unnestIndices[row]];
+      for (auto i = 0; i < unnestSize; i++) {
+        rawIndices[index++] = row;
+      }
+    }
+  }
+
+  // Wrap "replicated" columns in a dictionary using 'repeatedIndices'.
+  std::vector<VectorPtr> outputs(outputType_->size());
+  for (const auto& projection : identityProjections_) {
+    outputs[projection.outputChannel] = wrapChild(
+        numElements, repeatedIndices, input_->childAt(projection.inputChannel));
+  }
+
+  // Make "elements" column. Elements may be out of order. Use a
+  // dictionary to ensure the right order.
+  BufferPtr elementIndices =
+      AlignedBuffer::allocate<vector_size_t>(numElements, pool());
+  auto* rawElementIndices = elementIndices->asMutable<vector_size_t>();
+  index = 0;
+  bool identityMapping = true;
+  for (auto row = 0; row < size; ++row) {
+    if (!unnestDecoded_.isNullAt(row)) {
+      auto offset = rawOffsets[unnestIndices[row]];
+      auto unnestSize = rawSizes[unnestIndices[row]];
+
+      if (index != offset) {
+        identityMapping = false;
+      }
+
+      for (auto i = 0; i < unnestSize; i++) {
+        rawElementIndices[index++] = offset + i;
+      }
+    }
+  }
+
+  outputs[identityProjections_.size()] = identityMapping
+      ? unnestBase->elements()
+      : wrapChild(numElements, elementIndices, unnestBase->elements());
+
+  input_ = nullptr;
+
+  return std::make_shared<RowVector>(
+      pool(), outputType_, BufferPtr(nullptr), numElements, std::move(outputs));
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+class Unnest : public Operator {
+ public:
+  Unnest(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::UnnestNode>& unnestNode);
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+ private:
+  ChannelIndex unnestChannel_;
+
+  SelectivityVector inputRows_;
+  DecodedVector unnestDecoded_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -54,7 +54,8 @@ add_executable(
   HashJoinTest.cpp
   CastExprTest.cpp
   PlanNodeToStringTest.cpp
-  FunctionSignatureBuilderTest.cpp)
+  FunctionSignatureBuilderTest.cpp
+  UnnestTest.cpp)
 
 add_test(
   NAME velox_exec_test

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -124,6 +124,16 @@ class OperatorTestBase : public testing::Test {
     return vectorMaker_.flatVectorNullable(data);
   }
 
+  template <typename T>
+  ArrayVectorPtr makeArrayVector(
+      vector_size_t size,
+      std::function<vector_size_t(vector_size_t /* row */)> sizeAt,
+      std::function<T(vector_size_t /* row */, vector_size_t /* idx */)>
+          valueAt,
+      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
+    return vectorMaker_.arrayVector<T>(size, sizeAt, valueAt, isNullAt);
+  }
+
   template <typename TKey, typename TValue>
   MapVectorPtr makeMapVector(
       vector_size_t size,

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -124,6 +124,9 @@ class PlanBuilder {
 
   std::shared_ptr<const core::FieldAccessTypedExpr> field(int index);
 
+  std::shared_ptr<const core::FieldAccessTypedExpr> field(
+      const std::string& name);
+
   PlanBuilder& partitionedOutput(
       const std::vector<ChannelIndex>& keyIndices,
       int numPartitions,
@@ -147,6 +150,11 @@ class PlanBuilder {
       const std::string& filterText,
       const std::vector<ChannelIndex>& output,
       core::JoinType joinType = core::JoinType::kInner);
+
+  PlanBuilder& unnest(
+      const std::vector<std::string>& replicateColumns,
+      const std::vector<std::string>& unnestColumns,
+      const std::optional<std::string>& ordinalColumn = std::nullopt);
 
   const std::shared_ptr<core::PlanNode>& planNode() const {
     return planNode_;

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/OperatorTestBase.h"
+#include "velox/exec/tests/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+class UnnestTest : public OperatorTestBase {};
+
+TEST_F(UnnestTest, basic) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+      makeArrayVector<int32_t>(
+          100,
+          [](auto row) { return row % 5 + 1; },
+          [](auto row, auto index) { return index * (row % 3); },
+          nullEvery(7)),
+  });
+
+  createDuckDbTable({vector});
+
+  // TODO Add tests with empty arrays. This requires better support in DuckDB.
+
+  auto op = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}).planNode();
+  assertQuery(op, "SELECT c0, UNNEST(c1) FROM tmp WHERE c0 % 7 > 0");
+}
+
+TEST_F(UnnestTest, allEmptyOrNullArrays) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+      makeArrayVector<int32_t>(
+          100,
+          [](auto /* row */) { return 0; },
+          [](auto /* row */, auto index) { return index; },
+          nullEvery(5)),
+  });
+
+  auto op = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}).planNode();
+  assertQuery(op, "SELECT 1 LIMIT 0");
+}


### PR DESCRIPTION
This is an initial cut which supports only one unnest column of type ARRAY and doesn't support WITH ORDINALITY clause.