### PR TITLE
Make Task take consumer supplier

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -185,6 +185,10 @@ using OperatorSupplier = std::function<std::unique_ptr<Operator>(
     int32_t operatorId,
     DriverCtx* FOLLY_NONNULL ctx)>;
 
+using Consumer =
+    std::function<BlockingReason(RowVectorPtr, ContinueFuture* FOLLY_NULLABLE)>;
+using ConsumerSupplier = std::function<Consumer()>;
+
 struct DriverFactory {
   std::vector<std::shared_ptr<const core::PlanNode>> planNodes;
   // Function that will generate the final operator of a driver being

--- a/velox/exec/LocalPlanner.h
+++ b/velox/exec/LocalPlanner.h
@@ -22,7 +22,7 @@ class LocalPlanner {
  public:
   static void plan(
       const std::shared_ptr<const core::PlanNode>& planNode,
-      std::function<BlockingReason(RowVectorPtr, ContinueFuture*)> consumer,
+      ConsumerSupplier consumerSupplier,
       std::vector<std::unique_ptr<DriverFactory>>* driverFactories);
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Task takes an instance of consumer, which doesn't support consumers that are stateful since the callable object will be shared across all threads.

Make Task take consumer supplier so consumer instance can be created for individual thread.

Differential Revision: D30297104

