### PR TITLE
Fix HashProbe to load LazyVector before wrapping

### DIFF
--- a/velox/exec/tests/HiveConnectorTestBase.h
+++ b/velox/exec/tests/HiveConnectorTestBase.h
@@ -75,7 +75,19 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   std::shared_ptr<exec::Task> assertQuery(
       const std::shared_ptr<const core::PlanNode>& plan,
+      const std::string& duckDbSql) {
+    return assertQuery(
+        plan, std::vector<std::shared_ptr<TempFilePath>>(), duckDbSql);
+  }
+
+  std::shared_ptr<exec::Task> assertQuery(
+      const std::shared_ptr<const core::PlanNode>& plan,
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
+      const std::string& duckDbSql);
+
+  std::shared_ptr<exec::Task> assertQuery(
+      const std::shared_ptr<const core::PlanNode>& plan,
+      const std::unordered_map<int, std::shared_ptr<TempFilePath>>& filePaths,
       const std::string& duckDbSql);
 
   static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -33,6 +33,12 @@ class OperatorTestBase : public testing::Test {
     duckDbQueryRunner_.createTable("tmp", data);
   }
 
+  void createDuckDbTable(
+      const std::string& tableName,
+      const std::vector<RowVectorPtr>& data) {
+    duckDbQueryRunner_.createTable(tableName, data);
+  }
+
   std::shared_ptr<Task> assertQueryOrdered(
       const std::shared_ptr<const core::PlanNode>& plan,
       const std::string& duckDbSql,

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -201,7 +201,7 @@ TEST_F(TableWriteTest, constantVectors) {
           .project({"rows"})
           .planNode();
 
-  assertQuery(op, {}, fmt::format("SELECT {}", size));
+  assertQuery(op, fmt::format("SELECT {}", size));
 
   assertQuery(
       PlanBuilder().tableScan(rowType).planNode(),


### PR DESCRIPTION
HashProbe operator produces results in batches of kOutputBatchSize(=1000) rows
or less. The result of probing an input vector may not fit into a single
batch in which case it is split into multiple batches. For each batch, input
vector is wrapped in a dictionary that repeats a subset of the rows as many
times as there are hits in the hash table.

If input is a lazy vector that hasn't been loaded yet, the join produces two
dictionary vectors wrapping the same lazy vector. When first dictionary
vector is accessed (e.g. in expression evaluation) the underlying lazy vector
is loaded only for a set of rows mentioned in the dictionary. When second
dictionary vector is accessed the underlying lazy vector is already marked as
loaded and no further loading is happening. However, the rows that didn't
make it into the first batch were never loaded and thus are missing.
Accessing these rows causes a crash.

The fix is to not wrap a single lazy vector twice.