### PR TITLE
Make constant folding a flag during expr compilation

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1023,9 +1023,11 @@ std::string Expr::toString() const {
 
 ExprSet::ExprSet(
     std::vector<std::shared_ptr<const core::ITypedExpr>>&& sources,
-    core::ExecCtx* execCtx)
+    core::ExecCtx* execCtx,
+    bool enableConstantFolding)
     : execCtx_(execCtx) {
-  exprs_ = compileExpressions(std::move(sources), execCtx, this);
+  exprs_ = compileExpressions(
+      std::move(sources), execCtx, this, enableConstantFolding);
 }
 
 void ExprSet::eval(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -334,7 +334,8 @@ class ExprSet {
  public:
   explicit ExprSet(
       std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
-      core::ExecCtx* execCtx);
+      core::ExecCtx* execCtx,
+      bool enableConstantFolding = true);
 
   // Initialize and evaluate all expressions available in this ExprSet.
   void eval(

--- a/velox/expression/ExprCompiler.h
+++ b/velox/expression/ExprCompiler.h
@@ -26,6 +26,7 @@ class ExprSet;
 std::vector<std::shared_ptr<Expr>> compileExpressions(
     std::vector<core::TypedExprPtr>&& sources,
     core::ExecCtx* execCtx,
-    ExprSet* exprSet);
+    ExprSet* exprSet,
+    bool enableConstantFolding = true);
 
 } // namespace facebook::velox::exec

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -94,7 +94,7 @@ struct Timestamp {
     auto bt = gmtime((const time_t*)&seconds_);
     if (!bt) {
       const auto& error_message = folly::to<std::string>(
-          "Can't convert Seconds to time", folly::to<std::string>(seconds_));
+          "Can't convert Seconds to time: ", folly::to<std::string>(seconds_));
       throw std::runtime_error{error_message};
     }
 


### PR DESCRIPTION
Summary:
Making constant folding a flag during expr compilation by adding a
constructor flag to ExprSet. This will be used by the simplified eval path in
the next few diffs.

Reviewed By: mbasmanova, funrollloops

Differential Revision: D30091279

