### PR TITLE
UnsafeRow to vector deserializer

### DIFF
--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -12,4 +12,4 @@
 
 add_subdirectory(tests)
 
-add_library(velox_row INTERFACE)
+add_library(velox_row INTERFACE UnsafeRowDeserializer.h)

--- a/velox/row/UnsafeRowDeserializer.h
+++ b/velox/row/UnsafeRowDeserializer.h
@@ -1,0 +1,922 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if ENABLE_CONCEPTS
+#include <concepts>
+#endif
+
+#include <queue>
+#include "velox/row/UnsafeRow.h"
+#include "velox/row/UnsafeRowParser.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook {
+namespace velox {
+namespace row {
+
+/**
+ * A virtual class that represents iterators that loop through UnsafeRow data.
+ */
+struct UnsafeRowDataIterator {
+ public:
+  /**
+   * UnsafeRowDataIterator constructor.
+   * @param isNull whether the element is null
+   * @param type the element type
+   */
+  UnsafeRowDataIterator(bool isNull, TypePtr type)
+  : isNull_(isNull), type_(type){};
+
+  virtual ~UnsafeRowDataIterator() = 0;
+
+  /**
+   * @return true if element is null.
+   */
+  bool isNull() {
+    return isNull_;
+  }
+
+  /**
+   * @return the element type.
+   */
+  TypePtr type() {
+    return type_;
+  }
+
+  /**
+   * @return the element size.
+   */
+  virtual size_t size() = 0;
+
+ private:
+  /**
+   * Whether the element is null.
+   */
+  bool isNull_ = false;
+
+  /**
+   * The element type.
+   */
+  TypePtr type_;
+};
+
+UnsafeRowDataIterator::~UnsafeRowDataIterator() {}
+
+using DataIteratorPtr = std::shared_ptr<UnsafeRowDataIterator>;
+
+static DataIteratorPtr getIteratorPtr(
+    std::optional<std::string_view> data,
+    TypePtr type);
+
+/**
+ * Iterator that represents a primitive object. Primitive includes strings
+ * and anything that can be represented as a c++ fundamental type with at most
+ * 8 bytes.
+ */
+struct UnsafeRowPrimitiveIterator : UnsafeRowDataIterator {
+ public:
+  /**
+   * UnsafeRowPrimitiveIterator constructor.
+   * @param data The part of the UnsafeRow data buffer that contains the
+   * primitive value
+   * @param type The element type
+   */
+  UnsafeRowPrimitiveIterator(std::optional<std::string_view> data, TypePtr type)
+  : UnsafeRowDataIterator(!data.has_value(), type), data_(data) {}
+
+  /**
+   * @return a string_view over the part of the UnsafeRow data buffer that
+   * contains the primitive value.
+   */
+  std::optional<std::string_view> data() {
+    return data_;
+  }
+
+  /**
+   * @return A primitive value occupies 1 field, so return 0 if the element is
+   * null, 1 otherwise.
+   */
+  size_t size() override {
+    return isNull() ? 0 : 1;
+  }
+
+ private:
+  /**
+   * A string_view over the part of the UnsafeRow data buffer that contains the
+   * primitive value.
+   */
+  std::optional<std::string_view> data_;
+};
+
+/**
+ * Iterator to traverse through an UnsafeRow array representation.  This is used
+ * for:
+ * UnsafeRow array objects, UnsafeRow Map keys, and UnsafeRow Map values.
+ */
+struct UnsafeRowArrayIterator : UnsafeRowDataIterator {
+ public:
+  /**
+   * Constructor for UnsafeRowArray.
+   * @param data The unsafe row array representation data
+   * @param isFixedLength whether the elements in the array is fixed length
+   * @param fixedDataWidth the data width if the element is fixed length
+   */
+  UnsafeRowArrayIterator(
+      std::optional<std::string_view> data,
+      bool isFixedLength,
+      size_t fixedDataWidth = 0,
+      TypePtr type = nullptr)
+      : UnsafeRowDataIterator(!data.has_value(), type),
+      isFixedLength_(isFixedLength),
+      fixedDataWidth_(fixedDataWidth) {
+    {
+      if (data.has_value()) {
+        /*
+         * [number of elements : 1 word]
+         * [nullset : (num elements + 63) / 64 words]
+         * [fixed length data or offsets: (num elements) words]
+         * [variable length data: variable]
+         */
+        numElements_ = reinterpret_cast<const uint64_t*>(data->data())[0];
+
+        if (numElements_ == 0) {
+          return;
+        }
+
+        const char* nullSet = data->data() + UnsafeRow::kFieldWidthBytes;
+        auto nullLengthBytes = UnsafeRow::getNullLength(numElements_);
+        nulls_ = std::string_view(nullSet, nullLengthBytes);
+
+        // numElements : 1 word, nullSet : nullLengthBytes
+        elementsBaseOffset_ = UnsafeRow::kFieldWidthBytes + nullLengthBytes;
+        arrayElementStart_ = data->data() + elementsBaseOffset_;
+      }
+    }
+  }
+
+  /**
+   * @return the size of the array
+   */
+  size_t size() override {
+    return isNull() ? 0 : numElements_;
+  }
+
+  /**
+   * @return return whether there's a next element.
+   */
+  bool hasNext() {
+    return idx_ < numElements_;
+  }
+
+  bool childIsFixedLength() {
+    return isFixedLength_;
+  }
+
+  /**
+   * Exception to indicate the element is out of bounds.
+   */
+  class IndexOutOfBounds : public std::exception {};
+
+  /**
+   * @return throws IndexOutOfBounds if there is no next element,
+   * std::nullopt if the next element is null, or the next element.
+   */
+  std::optional<std::string_view> next() {
+    if (idx_ >= numElements_) {
+      throw IndexOutOfBounds();
+    }
+
+    auto elementsOriginal = arrayElementStart_;
+    auto elementsBaseOffsetOriginal = elementsBaseOffset_;
+
+    if (isFixedLength_) {
+      // Fixed width data is represented as continuous T * data
+      arrayElementStart_ += fixedDataWidth_;
+    } else {
+      // increment element pointer to the next variable length element
+      arrayElementStart_ += UnsafeRow::kFieldWidthBytes;
+      // increment base offset
+      elementsBaseOffset_ += UnsafeRow::kFieldWidthBytes;
+    }
+
+    // if null
+    if (bits::isBitSet(nulls_.data(), idx_++)) {
+      return std::nullopt;
+    }
+
+    if (isFixedLength_) {
+      return std::string_view(elementsOriginal, fixedDataWidth_);
+    }
+
+    auto [size, offset] = readDataPointer(elementsOriginal);
+    return std::string_view(
+        elementsOriginal - elementsBaseOffsetOriginal + offset, size);
+  }
+
+ private:
+  /**
+   * The number of elements in the array.
+   */
+  size_t numElements_;
+
+  /**
+   * The UnsfaeRow nulls set.
+   */
+  std::string_view nulls_;
+
+  /**
+   * The start of the elements in the array (i.e. the array representation
+   * not including the UnsafeRow array metadata).
+   */
+  const char* arrayElementStart_;
+
+  /**
+   * The elements offset with respect to the beginning of the array data
+   */
+  size_t elementsBaseOffset_;
+
+  /**
+   * Whether the elements are fixed length.
+   */
+  bool isFixedLength_;
+
+  /**
+   * The width of the elements if it is fixed length
+   */
+  size_t fixedDataWidth_;
+
+  /**
+   * The current element index.
+   */
+  size_t idx_ = 0;
+
+  /**
+   * Reads an UnsafeRow data pointer.
+   * @param data
+   * @return the size and offset as a tuple
+   */
+  std::tuple<uint32_t, uint32_t> readDataPointer(const char* data) {
+    const uint64_t* dataPointer = &reinterpret_cast<const uint64_t*>(data)[0];
+    uint32_t size = reinterpret_cast<const uint32_t*>(dataPointer)[0];
+    uint32_t offset = reinterpret_cast<const uint32_t*>(dataPointer)[1];
+    return std::tuple(size, offset);
+  }
+};
+using ArrayIteratorPtr = std::shared_ptr<UnsafeRowArrayIterator>;
+
+/**
+ * Iterator representation of an UnsafeRowMap object.
+ */
+struct UnsafeRowMapIterator : UnsafeRowDataIterator {
+ public:
+  /**
+   * UnsafeRowMapIterator constructor. The elements in an UnsafeRow Map appears
+   * as an UnsafeRow array.
+   * @param data
+   * @param type
+   */
+  UnsafeRowMapIterator(
+      std::optional<std::string_view> data,
+      TypePtr type = nullptr)
+      : UnsafeRowDataIterator(!data.has_value(), type) {
+    /*
+     * UnsafeRow Map representation:
+     * [offset to values : 1 word]
+     * [keys in the form of an UnsafeRowArray]
+     * [values in the form of an UnsafeRowArray]
+     */
+
+    if (!data.has_value()) {
+      return;
+    }
+
+    auto mapTypePtr = std::dynamic_pointer_cast<const MapType>(type);
+
+    // offsetToValues is at least 8, even if the map is empty
+    size_t offsetToValues = reinterpret_cast<const uint64_t*>(data->data())[0];
+
+    auto keysStart = data->data() + UnsafeRow::kFieldWidthBytes;
+    auto keysData = std::string_view(keysStart, offsetToValues);
+    auto valuesStart = keysStart + offsetToValues;
+    auto valuesData =
+        std::string_view(valuesStart, data->size() - keysData.size());
+
+    // UnsafeRow complex elements are in the form of UnsafeRowArrays, wrap the
+    // elements with an ArrayIterator so we can interpret the data.
+    keysIteratorWrapper_ = std::dynamic_pointer_cast<UnsafeRowArrayIterator>(
+        getIteratorPtr(keysData, ARRAY(mapTypePtr->keyType())));
+    valuesIteratorWrapper_ = std::dynamic_pointer_cast<UnsafeRowArrayIterator>(
+        getIteratorPtr(valuesData, ARRAY(mapTypePtr->valueType())));
+
+    // The number of keys and values must be the same
+    assert(keysIteratorWrapper_->size() == valuesIteratorWrapper_->size());
+    numElements_ = keysIteratorWrapper_->size();
+  }
+
+  /**
+   * @return the keysIteratorWrapper.
+   */
+  ArrayIteratorPtr keysIteratorWrapper() {
+    return keysIteratorWrapper_;
+  }
+
+  /**
+   * @return the valuesIteratorWrapper.
+   */
+  ArrayIteratorPtr valuesIteratorWrapper() {
+    return valuesIteratorWrapper_;
+  }
+
+  /**
+   * @return the number of key-value pairs in the map.
+   */
+  size_t size() override {
+    return numElements_;
+  }
+
+ private:
+  /**
+   * The number of key-value pairs in the map.
+   */
+  size_t numElements_;
+
+  /**
+   * The keys iterator wrapped as an UnsafeRowArray.
+   */
+  ArrayIteratorPtr keysIteratorWrapper_;
+
+  /**
+   * The values iterator wrapped as an UnsafeRowArray.
+   */
+  ArrayIteratorPtr valuesIteratorWrapper_;
+};
+
+/**
+ * Constructs a DataIteratorPtr based on the specified type.
+ * @param data a string_view over the data to be converted to a DataIteratorPtr.
+ * @param type the element type
+ * @return a DataIteratorPtr.
+ */
+static DataIteratorPtr getIteratorPtr(
+    std::optional<std::string_view> data,
+    TypePtr type) {
+  if (type->isPrimitiveType()) {
+    return std::make_shared<UnsafeRowPrimitiveIterator>(data, type);
+  }
+  if (type->isArray()) {
+    auto arrayTypePtr = std::dynamic_pointer_cast<const ArrayType>(type);
+    auto childTypePtr = arrayTypePtr->elementType();
+    size_t childWidth =
+        childTypePtr->isFixedWidth() ? childTypePtr->cppSizeInBytes() : 0;
+
+    return std::make_shared<UnsafeRowArrayIterator>(
+        data, childTypePtr->isFixedWidth(), childWidth, type);
+  }
+  if (type->isMap()) {
+    return std::make_shared<UnsafeRowMapIterator>(data, type);
+  }
+
+  return nullptr;
+}
+
+/**
+ * UnsafeRowDeserializer for primitive types.
+ */
+struct UnsafeRowPrimitiveDeserializer {
+  /**
+   * @tparam T the native type to deserialize to
+   * @param data
+   * @return the native type value
+   */
+  template <typename T>
+  static T deserializeFixedWidth(std::string_view data) {
+    assert(std::is_fundamental_v<T>);
+    return reinterpret_cast<const T*>(data.data())[0];
+  }
+
+  /**
+   * @param data
+   * @return the value in velox::StringView
+   */
+  static StringView deserializeStringView(std::string_view data) {
+    return StringView(data.data(), data.size());
+  }
+};
+
+/**
+ * TempaltedDeserializer that deserializes to std:: objects.
+ * @tparam SqlType
+ * @tparam NativeType
+ */
+template <typename SqlType, typename NativeType>
+struct UnsafeRowStaticDeserializer {
+  /**
+   * Deserializes primitive types.
+   * @param data
+   * @return The std::optional<NativeType> value
+   */
+  static std::optional<NativeType> deserialize(
+      std::optional<std::string_view> data) {
+    if constexpr (
+        UnsafeRowStaticUtilities::simpleSqlTypeToTypeKind<SqlType>() ==
+        TypeKind::INVALID) {
+      throw("Invalid type");
+    } else {
+      if (!data.has_value()) {
+        return std::nullopt;
+      } else if constexpr (UnsafeRowStaticUtilities::isFixedWidth<SqlType>()) {
+        return UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+        NativeType>(data.value());
+      } else if constexpr (TypeTraits<UnsafeRowStaticUtilities::
+      simpleSqlTypeToTypeKind<SqlType>()>::
+      isPrimitive) {
+        // NativeElement is std::string_view instead of velox::StringView, so
+        // append the next std::string_view directly
+        return data;
+      } else {
+        // Complex types will be captured via template specializations
+        throw("Unsupported type");
+      }
+    }
+  }
+};
+
+/**
+ * Partial template expansion for Array types.
+ * @tparam SqlElement
+ * @tparam NativeElement
+ */
+template <typename SqlElement, typename NativeElement>
+struct UnsafeRowStaticDeserializer<
+    Array<SqlElement>,
+    std::vector<NativeElement>> {
+  /**
+   * Serializes an Array into a vector.
+   * @param data
+   * @return std::optional<std::vector<std::optional<NativeElement>>>
+   */
+  static std::optional<std::vector<std::optional<NativeElement>>> deserialize(
+      std::optional<std::string_view> data) {
+    if (!data.has_value()) {
+      return std::nullopt;
+    }
+
+    std::vector<std::optional<NativeElement>> retVal;
+
+    auto arrayIterator = UnsafeRowArrayIterator(
+        data.value(),
+        UnsafeRowStaticUtilities::isFixedWidth<SqlElement>(),
+        sizeof(NativeElement));
+
+    while (arrayIterator.hasNext()) {
+      auto element =
+          UnsafeRowStaticDeserializer<SqlElement, NativeElement>::deserialize(
+              arrayIterator.next());
+      retVal.push_back(element);
+    }
+    return retVal;
+  }
+};
+
+/**
+ * Partial template expansion for Map types.
+ * @tparam SqlKey
+ * @tparam SqlVal
+ * @tparam NativeKey
+ * @tparam NativeVal
+ */
+template <
+    typename SqlKey,
+    typename SqlVal,
+    typename NativeKey,
+    typename NativeVal>
+    struct UnsafeRowStaticDeserializer<
+        Map<SqlKey, SqlVal>,
+        std::multimap<NativeKey, NativeVal>> {
+      /**
+       * Deserializes an UnsafeRow map into a std::multimap.  Note that UnsafeRow
+       * does not guarantee unique keys, so we do not want to return a std::map.
+       * From sql documentation, primary key cannot be null, so NativeKey does not
+       * have to be nullable.
+       * @param data
+       * @return std::optional<
+          std::multimap<NativeKey, std::optional<NativeVal>>>
+       */
+      static std::optional<std::multimap<NativeKey, std::optional<NativeVal>>>
+      deserialize(std::optional<std::string_view> data) {
+        if (!data.has_value()) {
+          return std::nullopt;
+        }
+
+        // parser the UnsafeRow Map and get the string_view over the keys and vals
+        size_t offsetToValues = reinterpret_cast<const uint64_t*>(data->data())[0];
+        auto keysStart = data->data() + UnsafeRow::kFieldWidthBytes;
+        auto keysData = std::string_view(keysStart, offsetToValues);
+        auto valuesStart = keysStart + offsetToValues;
+        auto valuesData =
+            std::string_view(valuesStart, data->size() - keysData.size());
+
+        // create UnsafeRowArrayIterators to iterate through the key-value pairs
+        auto keyIterator = UnsafeRowArrayIterator(
+            keysData,
+            UnsafeRowStaticUtilities::isFixedWidth<SqlKey>(),
+            sizeof(NativeKey));
+        auto valIterator = UnsafeRowArrayIterator(
+            valuesData,
+            UnsafeRowStaticUtilities::isFixedWidth<SqlVal>(),
+            sizeof(NativeVal));
+
+        assert(keyIterator.size() == valIterator.size());
+
+        std::multimap<NativeKey, std::optional<NativeVal>> retVal;
+        while (keyIterator.hasNext() && valIterator.hasNext()) {
+          std::optional<NativeKey> key =
+              UnsafeRowStaticDeserializer<SqlKey, NativeKey>::deserialize(
+                  keyIterator.next());
+          std::optional<NativeVal> val =
+              UnsafeRowStaticDeserializer<SqlVal, NativeKey>::deserialize(
+                  valIterator.next());
+          if (key.has_value()) {
+            // Sql does not allow null primary keys
+            NativeKey nonNullKey = key.value();
+            retVal.insert(std::make_pair(key.value(), val));
+          }
+        }
+
+        return retVal;
+      }
+    };
+
+/**
+ * UnsafeRow dynamic deserializer using TypePtr, deserializes an UnsafeRow to
+ * a Vector.
+ */
+struct UnsafeRowDynamicVectorDeserializer {
+  /**
+   * Runs modified BFS on the DataIteratorsPtr traversalQueue, returns a vector
+   * of DataIteratorsPtr in its flattened representation. The flattened
+   * representation can then be converted to the Vector representation.
+   * @param traversalQueue
+   * @param retVal the return vector value
+   * @return the element's flattened DataIteratorsPtr representation
+   */
+  static std::vector<DataIteratorPtr> getFlattenedIteratorsBFS(
+      std::deque<DataIteratorPtr>& traversalQueue,
+      std::vector<DataIteratorPtr>& retVal) {
+    while (!traversalQueue.empty()) {
+      auto currIterator = traversalQueue.front();
+      traversalQueue.pop_front();
+
+      if (!currIterator->isNull()) {
+        // If the current iterator is a primitive type, we've reached the root.
+        // If the current iterator is a map type, delay flattening the elements
+        // until we convert the map iterator to a map vector.
+
+        if (currIterator->type()->isArray()) {
+          auto arrayTypePtr =
+              std::dynamic_pointer_cast<const ArrayType>(currIterator->type());
+          auto arrayIteratorPtr =
+              std::dynamic_pointer_cast<UnsafeRowArrayIterator>(currIterator);
+
+          while (arrayIteratorPtr->hasNext()) {
+            auto childIterator = getIteratorPtr(
+                arrayIteratorPtr->next(), arrayTypePtr->elementType());
+            // Primitive type means we've reached the root, don't add it to the
+            // traversal queue.  For map types, we delay flattening the elements
+            // until conversion to vectors.
+            if (!arrayTypePtr->elementType()->isPrimitiveType() &&
+            !arrayTypePtr->elementType()->isMap()) {
+              traversalQueue.emplace_back(childIterator);
+            }
+            retVal.emplace_back(childIterator);
+          }
+        }
+      }
+    }
+    return retVal;
+  }
+
+  /**
+   * Construct a flattened representation of the UnsafeRow using
+   * DataIteratorsPtr.
+   * @param data
+   * @param type
+   * @return the element's flattened DataIteratorsPtr representation
+   */
+  static std::vector<DataIteratorPtr> flattenComplexData(
+      std::optional<std::string_view> data,
+      TypePtr type) {
+    std::vector<DataIteratorPtr> retVal;
+
+    // If the element is primitive, wrap the primitive type with an
+    // ArrayIteratorPtr so we can loop through the list of values, return the
+    // list of PrimitiveIterators directly
+    if (type->isPrimitiveType()) {
+      auto arrayIteratorWrapper =
+          std::dynamic_pointer_cast<UnsafeRowArrayIterator>(
+              getIteratorPtr(data, ARRAY(type)));
+      while (arrayIteratorWrapper->hasNext()) {
+        retVal.emplace_back(getIteratorPtr(arrayIteratorWrapper->next(), type));
+      }
+      return retVal;
+    }
+
+    // For complex types, run BFS to get the flattened representation.
+    std::deque<DataIteratorPtr> traversalQueue;
+    auto iterator = getIteratorPtr(data, type);
+    traversalQueue.emplace_back(iterator);
+    retVal.emplace_back(iterator);
+
+    return getFlattenedIteratorsBFS(traversalQueue, retVal);
+  }
+
+  /**
+   * Allocate and populate the metadata Vectors in ArrayVector or MapVector.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param pool
+   * @param numIteratorsToProcess
+   * @return the populated metadata vectors and the number of null elements.
+   */
+  inline static std::tuple<BufferPtr, BufferPtr, BufferPtr, size_t>
+  populateMetadataVectors(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess) {
+    BufferPtr offsets =
+        AlignedBuffer::allocate<int32_t>(numIteratorsToProcess, pool);
+    BufferPtr lengths =
+        AlignedBuffer::allocate<vector_size_t>(numIteratorsToProcess, pool);
+    BufferPtr nulls = AlignedBuffer::allocate<char>(
+        bits::nbytes(numIteratorsToProcess), pool);
+    auto* offsetsPtr = offsets->asMutable<int32_t>();
+    auto* lengthsPtr = lengths->asMutable<vector_size_t>();
+    auto* nullsPtr = nulls->asMutable<uint64_t>();
+    size_t nullCount = 0;
+
+    for (int i = 0; i < numIteratorsToProcess; i++) {
+      DataIteratorPtr currItr = dataIterators[i];
+      bits::setBit(
+          nullsPtr, i, bits::kNull ? currItr->isNull() : !currItr->isNull());
+      nullCount += currItr->isNull();
+      lengthsPtr[i] = currItr->isNull() ? 0 : currItr->size();
+      offsetsPtr[i] = i == 0 ? 0 : offsetsPtr[i - 1] + lengthsPtr[i - 1];
+    }
+
+    return std::tuple(offsets, lengths, nulls, nullCount);
+  }
+
+  /**
+   * Give some number of dataIterators, find the total number of elements
+   * encapsulated by the dataIterators.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param numIteratorsToProcess
+   * @return
+   */
+  inline static size_t getNumChildrenElements(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      size_t numIteratorsToProcess) {
+    size_t totalNumElements = 0;
+    for (auto itr = dataIterators; itr != dataIterators + numIteratorsToProcess;
+    ++itr) {
+      DataIteratorPtr itrPtr = *itr;
+      totalNumElements += itrPtr->size();
+    }
+    return totalNumElements;
+  }
+
+  /**
+   * Converts a list of UnsafeRowMapIterators to Vectors.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param pool
+   * @param numIteratorsToProcess The number of adjacent UnsafeRowMapIterators
+   * @return a MapVectorPtr
+   */
+  static VectorPtr convertMapIteratorsToVectors(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess) {
+    TypePtr type = (*dataIterators)->type();
+    assert(type->isMap());
+
+    size_t numMaps = numIteratorsToProcess;
+
+    auto [offsets, lengths, nulls, nullCount] =
+        populateMetadataVectors(dataIterators, pool, numMaps);
+
+    std::deque<DataIteratorPtr> keysTraversalQueue, valuesTraversalQueue;
+    for (int i = 0; i < numMaps; i++) {
+      // add the iterator wrappers to the traversal queue but not the final
+      // flattened iterators
+      auto mapIteratorPtr =
+          std::dynamic_pointer_cast<UnsafeRowMapIterator>(dataIterators[i]);
+      keysTraversalQueue.emplace_back(mapIteratorPtr->keysIteratorWrapper());
+      valuesTraversalQueue.emplace_back(
+          mapIteratorPtr->valuesIteratorWrapper());
+    }
+    std::vector<DataIteratorPtr> flattenedKeys, flattenedValues;
+    getFlattenedIteratorsBFS(keysTraversalQueue, flattenedKeys);
+    getFlattenedIteratorsBFS(valuesTraversalQueue, flattenedValues);
+
+    size_t totalNumElements =
+        getNumChildrenElements(dataIterators, numIteratorsToProcess);
+
+    VectorPtr keys =
+        convertToVectors(flattenedKeys.begin(), pool, totalNumElements);
+    VectorPtr values =
+        convertToVectors(flattenedValues.begin(), pool, totalNumElements);
+
+    return std::make_shared<MapVector>(
+        pool, type, nulls, numMaps, offsets, lengths, keys, values, nullCount);
+  }
+
+  /**
+   * Converts a list of UnsafeRowArrayIterators to Vectors.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param pool
+   * @param numIteratorsToProcess The number of adjacent UnsafeRowArrayIterators
+   * @return an ArrayVectorPtr
+   */
+  static VectorPtr convertArrayIteratorsToVectors(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess) {
+    TypePtr type = (*dataIterators)->type();
+    assert(type->isArray());
+
+    size_t numArrays = numIteratorsToProcess;
+
+    auto [offsets, lengths, nulls, nullCount] =
+        populateMetadataVectors(dataIterators, pool, numArrays);
+
+    // get the array elements
+    size_t totalNumElements =
+        getNumChildrenElements(dataIterators, numIteratorsToProcess);
+    VectorPtr elements = convertToVectors(
+        dataIterators + numIteratorsToProcess, pool, totalNumElements);
+
+    return std::make_shared<ArrayVector>(
+        pool, type, nulls, numArrays, offsets, lengths, elements, nullCount);
+  }
+
+  /**
+   * Converts a list of UnsafeRowPrimitiveIterators to a FlatVector
+   * @tparam T the element's NativeType
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param type The element type
+   * @param pool
+   * @param numIteratorsToProcess The number of adjacent
+   * UnsafeRowPrimitiveIterators
+   * @return a FlatVector
+   */
+  template <typename T>
+  static VectorPtr createFlatVector(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      TypePtr type,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess) {
+    auto vector = BaseVector::create(type, numIteratorsToProcess, pool);
+
+    size_t nullCount = 0;
+    for (size_t i = 0; i < numIteratorsToProcess; i++) {
+      auto iterator = std::dynamic_pointer_cast<UnsafeRowPrimitiveIterator>(
+          dataIterators[i]);
+
+      if (iterator->isNull()) {
+        vector->setNull(i, true);
+      } else {
+        vector->setNull(i, false);
+
+        if constexpr (std::is_same_v<T, StringView>) {
+          StringView val =
+              UnsafeRowPrimitiveDeserializer::deserializeStringView(
+                  iterator->data()->data());
+          auto flatVector = vector->asFlatVector<StringView>();
+          flatVector->set(i, val);
+        } else {
+          T val = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<T>(
+              iterator->data()->data());
+          auto flatVector = vector->asFlatVector<T>();
+          flatVector->set(i, val);
+        }
+        nullCount++;
+      }
+    }
+    vector->setNullCount(nullCount);
+    return vector;
+  }
+
+  /**
+   * Calls createFlatVector with the correct template argument.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param pool
+   * @param numIteratorsToProcess
+   * @return A FlatVector
+   */
+  static VectorPtr convertPrimitiveIteratorsToVectors(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess) {
+    TypePtr type = (*dataIterators)->type();
+    assert(type->isPrimitiveType());
+
+    if (type->isBoolean()) {
+      return createFlatVector<TypeTraits<TypeKind::BOOLEAN>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isTinyint()) {
+      return createFlatVector<TypeTraits<TypeKind::TINYINT>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isSmallint()) {
+      return createFlatVector<TypeTraits<TypeKind::SMALLINT>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isInteger()) {
+      return createFlatVector<TypeTraits<TypeKind::INTEGER>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isBigint()) {
+      return createFlatVector<TypeTraits<TypeKind::BIGINT>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isReal()) {
+      return createFlatVector<TypeTraits<TypeKind::REAL>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isDouble()) {
+      return createFlatVector<TypeTraits<TypeKind::DOUBLE>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isVarchar() || type->isVarbinary()) {
+      return createFlatVector<StringView>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else if (type->isTimestamp()) {
+      return createFlatVector<TypeTraits<TypeKind::TIMESTAMP>::NativeType>(
+          dataIterators, type, pool, numIteratorsToProcess);
+    } else {
+      throw("Unsupported root type in a complex type.");
+    }
+  }
+
+  /**
+   * Calls the correct function to convert the iterators to vectors based on
+   * element type.
+   * @param dataIterators iterator that points to the first dataIterator to
+   * process.
+   * @param pool
+   * @param numIteratorsToProcess
+   * @return
+   */
+  static VectorPtr convertToVectors(
+      std::vector<DataIteratorPtr>::iterator dataIterators,
+      memory::MemoryPool* pool,
+      size_t numIteratorsToProcess = 1) {
+    TypePtr type = (*dataIterators)->type();
+
+    if (type->isMap()) {
+      return convertMapIteratorsToVectors(
+          dataIterators, pool, numIteratorsToProcess);
+    } else if (type->isArray()) {
+      return convertArrayIteratorsToVectors(
+          dataIterators, pool, numIteratorsToProcess);
+    } else if (type->isPrimitiveType()) {
+      return convertPrimitiveIteratorsToVectors(
+          dataIterators, pool, numIteratorsToProcess);
+    } else {
+      throw("Unsupported type");
+    }
+  }
+
+  /**
+   * Deserializes a complex element type to its Vector representation.
+   * @param data A string_view over a given element in the UnsafeRow.
+   * @param type the element type.
+   * @param pool the memory pool to allocate Vectors from
+   * @return a VectorPtr
+   */
+  static VectorPtr deserializeComplex(
+      std::optional<std::string_view> data,
+      TypePtr type,
+      memory::MemoryPool* pool) {
+    // flatten data
+    std::vector<DataIteratorPtr> iterators = flattenComplexData(data, type);
+    // deserialize to vector
+    return convertToVectors(iterators.begin(), pool);
+  }
+};
+
+} // namespace row
+} // namespace velox
+} // namespace facebook

--- a/velox/row/UnsafeRowParser.h
+++ b/velox/row/UnsafeRowParser.h
@@ -77,37 +77,37 @@ struct UnsafeRowStaticParser {
   const UnsafeRow row;
 
   UnsafeRowStaticParser<SqlTypes...>(std::string_view data)
-      : row(UnsafeRow(
-            const_cast<char*>(data.data()),
-            std::tuple_size<std::tuple<SqlTypes...>>::value)) {}
+  : row(UnsafeRow(
+      const_cast<char*>(data.data()),
+      std::tuple_size<std::tuple<SqlTypes...>>::value)) {}
 
-  /**
-   *
-   * @tparam idx
-   * @return
-   */
-  template <size_t idx>
-  const std::string_view dataAt() const {
-    using CurrentType = type_at<idx>;
+      /**
+       *
+       * @tparam idx
+       * @return
+       */
+      template <size_t idx>
+      const std::string_view dataAt() const {
+        using CurrentType = type_at<idx>;
 
-    constexpr bool isFixedWidth =
-        UnsafeRowStaticUtilities::isFixedWidth<CurrentType>();
-    using NativeType =
-        typename TypeTraits<UnsafeRowStaticUtilities::simpleSqlTypeToTypeKind<
+        constexpr bool isFixedWidth =
+            UnsafeRowStaticUtilities::isFixedWidth<CurrentType>();
+        using NativeType =
+            typename TypeTraits<UnsafeRowStaticUtilities::simpleSqlTypeToTypeKind<
             CurrentType>()>::NativeType;
-    if constexpr (!std::is_same_v<NativeType, void>) {
-      return row.readDataAt(idx, isFixedWidth, sizeof(NativeType));
-    }
-    return row.readDataAt(idx, isFixedWidth);
-  }
+        if constexpr (!std::is_same_v<NativeType, void>) {
+          return row.readDataAt(idx, isFixedWidth, sizeof(NativeType));
+        }
+        return row.readDataAt(idx, isFixedWidth);
+      }
 
-  /**
-   * @param idx
-   * @return whether the element is null at the given index
-   */
-  bool isNullAt(size_t idx) const {
-    return row.isNullAt(idx);
-  }
+      /**
+       * @param idx
+       * @return whether the element is null at the given index
+       */
+      bool isNullAt(size_t idx) const {
+        return row.isNullAt(idx);
+      }
 };
 
 /**
@@ -125,8 +125,8 @@ struct UnsafeRowDynamicParser {
   const UnsafeRow row;
 
   UnsafeRowDynamicParser(std::vector<TypePtr>& types, std::string_view& data)
-      : types(types),
-        row(UnsafeRow(const_cast<char*>(data.data()), types.size())) {}
+  : types(types),
+  row(UnsafeRow(const_cast<char*>(data.data()), types.size())) {}
 
   /**
    * @param idx

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_row_test UnsafeRowSerializerTest.cpp)
+add_executable(velox_row_test UnsafeRowSerializerTest.cpp UnsafeRowDeserializerTest.cpp)
 
 add_test(velox_row_test velox_row_test)
 

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -1,0 +1,780 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/row/UnsafeRowDeserializer.h"
+#include <gtest/gtest.h>
+#include "velox/row/UnsafeRowParser.h"
+
+#include "velox/vector/BaseVector.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::row;
+
+class UnsafeRowDeserializerTest : public ::testing::Test {};
+
+class UnsafeRowStaticDeserializerTest : public ::testing::Test {};
+
+class UnsafeRowVectorDeserializerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    testing::Test::SetUp();
+    pool_ = memory::getDefaultScopedMemoryPool();
+    bufferPtr = AlignedBuffer::allocate<char>(1024, pool_.get(), true);
+    buffer = bufferPtr->asMutable<char>();
+  }
+
+  void TearDown() override {}
+
+  /**
+   * Checks the Vector metadata (i.e. size, offsets, sizes, nulls) in an
+   * ArrayVector or MapVector.
+   * @tparam ComplexVectorPtr ArrayVectorPtr or MapVectorPtr
+   * @param vector
+   * @param expectedSize
+   * @param expectedOffsets
+   * @param expectedSizes
+   * @param expectedNulls
+   * @return testing::AssertionFailure if any value is not as expected,
+   * testing::AssertionSuccess otherwise
+   */
+  template <typename ComplexVectorPtr>
+  testing::AssertionResult checkVectorMetadata(
+      ComplexVectorPtr vector,
+      size_t expectedSize,
+      int32_t* expectedOffsets,
+      vector_size_t* expectedSizes,
+      bool* expectedNulls) {
+    if (vector->size() != expectedSize) {
+      return testing::AssertionFailure() << "Expected size is " << expectedSize
+      << " but got " << vector->size();
+    }
+
+    auto offsets = (vector->offsets())->template asMutable<int32_t>();
+    auto sizes = (vector->sizes())->template asMutable<vector_size_t>();
+
+    for (int i = 0; i < expectedSize; i++) {
+      if (std::memcmp(expectedOffsets + i, offsets + i, sizeof(int32_t)) != 0) {
+        return testing::AssertionFailure()
+        << "Vector offsets and expected offsets differ at index " << i;
+      }
+      if (std::memcmp(expectedSizes + i, sizes + i, sizeof(vector_size_t)) !=
+      0) {
+        return testing::AssertionFailure()
+        << "Vector sizes and expected sizes differ at index " << i;
+      }
+      if (vector->isNullAt(i) != expectedNulls[i])
+        return testing::AssertionFailure()
+        << "Vector nulls and expected nulls differ at index " << i;
+    }
+
+    return testing::AssertionSuccess();
+  }
+
+  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+
+  BufferPtr bufferPtr;
+
+  // variable pointing to the row pointer held by the smart pointer BufferPtr
+  char* buffer;
+};
+
+template <typename T>
+testing::AssertionResult checkVariableLengthData(
+    std::optional<std::string_view> element,
+    size_t expectedSize,
+    T* expectedValue) {
+  if (element->size() != expectedSize) {
+    return testing::AssertionFailure()
+    << "Expected serializedSize " << expectedSize << " but got "
+    << element->size();
+  }
+
+  for (int i = 0; i < expectedSize; i++) {
+    if (std::memcmp(
+        element->data() + i,
+        reinterpret_cast<const uint8_t*>(expectedValue) + i,
+        1) != 0) {
+      return testing::AssertionFailure()
+      << "Buffer and expectedValue differ at index " << i;
+    }
+  }
+  return testing::AssertionSuccess();
+}
+
+/**
+ * Checks that an UnsafeRowPrimitiveIterator is set correctly.
+ * @tparam T the element's native type
+ * @param iteratorPtr
+ * @param expectedKind
+ * @param expectedIsNull
+ * @param val
+ * @return testing::AssertionFailure if any value is not as expected,
+ * testing::AssertionSuccess otherwise
+ */
+template <typename T>
+testing::AssertionResult checkPrimitiveIterator(
+    DataIteratorPtr iteratorPtr,
+    TypeKind expectedKind,
+    bool expectedIsNull,
+    size_t val = 0) {
+  auto iterator =
+      std::dynamic_pointer_cast<UnsafeRowPrimitiveIterator>(iteratorPtr);
+  if (!iterator) {
+    return testing::AssertionFailure()
+    << "DataIteratorPtr is not a PrimitiveIterator";
+  }
+  if (iterator->type()->kind() != expectedKind) {
+    return testing::AssertionFailure();
+  }
+  if (iterator->isNull() != expectedIsNull) {
+    return testing::AssertionFailure();
+  }
+  if (!expectedIsNull) {
+    if (reinterpret_cast<const T*>(iterator->data()->data())[0] != val) {
+      return testing::AssertionFailure();
+    }
+  }
+  return testing::AssertionSuccess();
+}
+
+TEST_F(UnsafeRowDeserializerTest, DeserializePrimitives) {
+  /*
+   * UnsfafeRow with 7 elements:
+   *  index | type        | value
+   *  ------|-------------|-------
+   *  0     | BOOLEAN     | true
+   *  1     | TINYINT     | 0x1
+   *  2     | SMALLINT    | 0x2222
+   *  3     | INTEGER     | 0x33333333
+   *  4     | BIGINT      | null
+   *  5     | REAL        | 1.2345
+   *  6     | DOUBLE      | null
+   */
+  // generated from Spark Java implementation
+  uint8_t data[8][8] = {
+      {0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x33, 0x33, 0x33, 0x33, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x19, 0x04, 0x9e, 0x3f, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData = std::string_view(reinterpret_cast<const char*>(data), 8 * 8);
+  std::vector<TypePtr> rowTypes{
+    BOOLEAN(), TINYINT(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()};
+
+  UnsafeRowDynamicParser rowParser = UnsafeRowDynamicParser(rowTypes, rowData);
+
+  ASSERT_FALSE(rowParser.isNullAt(0));
+  auto val0 = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+      TypeTraits<TypeKind::BOOLEAN>::NativeType>(rowParser.dataAt(0));
+  ASSERT_EQ(val0, true);
+
+  ASSERT_FALSE(rowParser.isNullAt(1));
+  auto val1 = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+      TypeTraits<TypeKind::TINYINT>::NativeType>(rowParser.dataAt(1));
+  ASSERT_EQ(val1, 0x1);
+
+  ASSERT_FALSE(rowParser.isNullAt(2));
+  auto val2 = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+      TypeTraits<TypeKind::SMALLINT>::NativeType>(rowParser.dataAt(2));
+  ASSERT_EQ(val2, 0x2222);
+
+  ASSERT_FALSE(rowParser.isNullAt(3));
+  auto val3 = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+      TypeTraits<TypeKind::INTEGER>::NativeType>(rowParser.dataAt(3));
+  ASSERT_EQ(val3, 0x33333333);
+
+  ASSERT_TRUE(rowParser.isNullAt(4));
+
+  ASSERT_FALSE(rowParser.isNullAt(5));
+  auto val5 = UnsafeRowPrimitiveDeserializer::deserializeFixedWidth<
+      TypeTraits<TypeKind::REAL>::NativeType>(rowParser.dataAt(5));
+  ASSERT_EQ(val5, (float)1.2345);
+
+  ASSERT_TRUE(rowParser.isNullAt(6));
+}
+
+TEST_F(UnsafeRowDeserializerTest, DeserializeStrings) {
+  /*
+   * index | string value
+   * ------|-------------
+   * 0     | u8"hello"
+   * 1     | null
+   * 2     | u8"This is a rather long string.  Quite long indeed."
+   */
+
+  uint8_t data[12][8] = {
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x05, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x31, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00},
+      {0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00},
+      {0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20},
+      {0x61, 0x20, 0x72, 0x61, 0x74, 0x68, 0x65, 0x72},
+      {0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x20, 0x73, 0x74},
+      {0x72, 0x69, 0x6e, 0x67, 0x2e, 0x20, 0x20, 0x51},
+      {0x75, 0x69, 0x74, 0x65, 0x20, 0x6c, 0x6f, 0x6e},
+      {0x67, 0x20, 0x69, 0x6e, 0x64, 0x65, 0x65, 0x64},
+      {0x2e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData = std::string_view(reinterpret_cast<const char*>(data), 12 * 8);
+  std::vector<TypePtr> rowTypes{VARCHAR(), VARCHAR(), VARCHAR()};
+
+  UnsafeRowDynamicParser rowParser = UnsafeRowDynamicParser(rowTypes, rowData);
+
+  ASSERT_FALSE(rowParser.isNullAt(0));
+  StringView val0 = UnsafeRowPrimitiveDeserializer::deserializeStringView(
+      rowParser.dataAt(0));
+  checkVariableLengthData(
+      std::string_view(val0.data(), val0.size()), 0x05, u8"hello");
+
+  ASSERT_TRUE(rowParser.isNullAt(1));
+
+  ASSERT_FALSE(rowParser.isNullAt(2));
+  StringView val2 = UnsafeRowPrimitiveDeserializer::deserializeStringView(
+      rowParser.dataAt(2));
+  checkVariableLengthData(
+      std::string_view(val2.data(), val2.size()),
+      0x31,
+      u8"This is a rather long string.  Quite long indeed.");
+}
+
+TEST_F(UnsafeRowDeserializerTest, UnsafeRowArrayIterator) {
+  // We only test the UnsafeRowArrayIterators because all UnsafeRow complex
+  // types are represented as arrays.
+
+  /*
+   * [
+   *   [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
+   *   null,
+   *   [7, null, 9]
+   * ]
+   */
+
+  // an unsafe row with 1 element, where the first element is an array of arrays
+  // generated from Spark Java implementation
+  uint8_t data[14][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x60, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x20, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00},
+      {0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04},
+      {0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x07, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  // The outer array contains 3 variable length elements.
+  auto arrayData = std::string_view(
+      reinterpret_cast<const char*>(reinterpret_cast<const char*>(data) + 16),
+      12 * 8);
+  auto outerArray = UnsafeRowArrayIterator(arrayData, false);
+
+  ASSERT_TRUE(outerArray.hasNext());
+  std::optional<std::string_view> first = outerArray.next();
+  uint8_t firstExpected[4][8] = {
+      {0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04},
+      {0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00}};
+  ASSERT_TRUE(checkVariableLengthData(first, 0x20, firstExpected));
+
+  // second element is null
+  ASSERT_TRUE(outerArray.hasNext());
+  std::optional<std::string_view> second = outerArray.next();
+  ASSERT_FALSE(second.has_value());
+
+  ASSERT_TRUE(outerArray.hasNext());
+  std::optional<std::string_view> third = outerArray.next();
+  uint8_t thirdExpected[4][8] = {
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x07, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  ASSERT_TRUE(checkVariableLengthData(third, 0x18, thirdExpected));
+  return;
+
+  // no more elements
+  ASSERT_FALSE(outerArray.hasNext());
+  EXPECT_THROW(outerArray.next(), UnsafeRowArrayIterator::IndexOutOfBounds);
+
+  // Check that we can traverse through the third inner array
+  // The third inner array contains fixed length elements
+  // [7, null, 9]
+  auto thirdInnerArray = UnsafeRowArrayIterator(third.value(), true, 1);
+  ASSERT_TRUE(thirdInnerArray.hasNext());
+  std::optional<std::string_view> thirdInnerArray1 = thirdInnerArray.next();
+  ASSERT_EQ(thirdInnerArray1->size(), 1);
+  ASSERT_EQ(thirdInnerArray1->data()[0], 0x7);
+
+  ASSERT_TRUE(thirdInnerArray.hasNext());
+  std::optional<std::string_view> thirdInnerArray2 = thirdInnerArray.next();
+  ASSERT_FALSE(thirdInnerArray2.has_value());
+
+  ASSERT_TRUE(thirdInnerArray.hasNext());
+  std::optional<std::string_view> thirdInnerArray3 = thirdInnerArray.next();
+  ASSERT_EQ(thirdInnerArray3->size(), 1);
+  ASSERT_EQ(thirdInnerArray3->data()[0], 0x9);
+}
+
+TEST_F(UnsafeRowStaticDeserializerTest, FixedWidthArrayStdContainer) {
+  /*
+   * UnsafeRow with 2 elements:
+   * Element 1: Array of TinyInt with 5 elements
+   *   [0x01, 0x02, null, 0x03, null],
+   * Element 2: Array of SmallInt with 5 elements
+   *   [0x1111, 0x2222, null, 0x4444, 0x5555]
+   */
+  uint8_t data[10][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00},
+      {0x20, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00},
+      {0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00},
+      {0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x11, 0x11, 0x22, 0x22, 0x00, 0x00, 0x44, 0x44},
+      {0x55, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData = std::string_view(reinterpret_cast<const char*>(data), 10 * 8);
+  UnsafeRowStaticParser rowParser =
+      UnsafeRowStaticParser<Array<TinyintType>, Array<SmallintType>>(rowData);
+
+  std::optional<std::vector<std::optional<uint8_t>>> val0 =
+      UnsafeRowStaticDeserializer<Array<TinyintType>, std::vector<uint8_t>>::
+      deserialize(rowParser.dataAt<0>());
+  ASSERT_TRUE(val0.has_value());
+  auto vector0 = val0.value();
+  ASSERT_EQ(vector0.size(), 5);
+  ASSERT_EQ(vector0[0], 0x01);
+  ASSERT_EQ(vector0[1], 0x02);
+  ASSERT_FALSE(vector0[2].has_value());
+  ASSERT_EQ(vector0[3], 0x03);
+  ASSERT_FALSE(vector0[4].has_value());
+
+  std::optional<std::vector<std::optional<uint16_t>>> val1 =
+      UnsafeRowStaticDeserializer<Array<SmallintType>, std::vector<uint16_t>>::
+      deserialize(rowParser.dataAt<1>());
+  ASSERT_TRUE(val1.has_value());
+  auto vector1 = val1.value();
+  ASSERT_EQ(vector1.size(), 5);
+  ASSERT_EQ(vector1[0], 0x1111);
+  ASSERT_EQ(vector1[1], 0x2222);
+  ASSERT_FALSE(vector1[2].has_value());
+  ASSERT_EQ(vector1[3], 0x4444);
+  ASSERT_EQ(vector1[4], 0x5555);
+}
+
+TEST_F(UnsafeRowStaticDeserializerTest, MapStdContainer) {
+  /*
+    { 1 : 2, 3: null}
+  */
+
+  uint8_t data[9][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x38, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData = std::string_view(reinterpret_cast<const char*>(data), 9 * 8);
+  UnsafeRowStaticParser rowParser =
+      UnsafeRowStaticParser<Map<SmallintType, SmallintType>>(rowData);
+
+  auto val0 = UnsafeRowStaticDeserializer<
+      Map<SmallintType, SmallintType>,
+      std::multimap<int16_t, int16_t>>::deserialize(rowParser.dataAt<0>());
+
+  ASSERT_EQ(val0->size(), 2);
+  ASSERT_EQ(val0->find(1)->second.value(), 2);
+  ASSERT_FALSE(val0->find(3)->second.has_value());
+}
+
+TEST_F(UnsafeRowVectorDeserializerTest, FixedWidthArray) {
+  /*
+   * UnsafeRow with 2 elements (element 2 is ignored):
+   * Element 1: Array of TinyInt with 5 elements
+   *   [0x01, 0x02, null, 0x03, null],
+   *
+   * ArrayVector<FlatVector<int8_t>>:
+   * offsets: 0
+   * sizes: 5
+   *    FlatVector<int8_t>>:
+   *    0x01, 0x02, null, 0x03, null
+   *
+   * This test only checks for the first element
+   */
+  uint8_t data[10][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00},
+      {0x20, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00},
+      {0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00},
+      {0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x11, 0x11, 0x22, 0x22, 0x00, 0x00, 0x44, 0x44},
+      {0x55, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData = std::string_view(reinterpret_cast<const char*>(data), 10 * 8);
+  std::vector<TypePtr> rowTypes{ARRAY(TINYINT()), ARRAY(SMALLINT())};
+  UnsafeRowDynamicParser rowParser = UnsafeRowDynamicParser(rowTypes, rowData);
+
+  // first test flattenComplexData
+  std::vector<DataIteratorPtr> array0Iter =
+      UnsafeRowDynamicVectorDeserializer::flattenComplexData(
+          rowParser.dataAt(0), rowTypes.at(0));
+  // 1 ArrayIterator + 5 PrimitiveIterators
+  ASSERT_EQ(array0Iter.size(), 6);
+
+  auto array0Iter0 =
+      std::dynamic_pointer_cast<UnsafeRowArrayIterator>(array0Iter[0]);
+  ASSERT_TRUE(array0Iter0);
+  ASSERT_TRUE(array0Iter0->type()->isArray());
+  ASSERT_EQ(array0Iter0->size(), 5);
+  ASSERT_FALSE(array0Iter0->isNull());
+  ASSERT_TRUE(array0Iter0->childIsFixedLength());
+
+  ASSERT_TRUE(checkPrimitiveIterator<uint8_t>(
+      array0Iter[1], TypeKind::TINYINT, false, 0x1));
+  ASSERT_TRUE(checkPrimitiveIterator<uint8_t>(
+      array0Iter[2], TypeKind::TINYINT, false, 0x2));
+  ASSERT_TRUE(
+      checkPrimitiveIterator<uint8_t>(array0Iter[3], TypeKind::TINYINT, true));
+  ASSERT_TRUE(checkPrimitiveIterator<uint8_t>(
+      array0Iter[4], TypeKind::TINYINT, false, 0x3));
+  ASSERT_TRUE(
+      checkPrimitiveIterator<uint8_t>(array0Iter[5], TypeKind::TINYINT, true));
+
+  VectorPtr val0 = UnsafeRowDynamicVectorDeserializer::deserializeComplex(
+      rowParser.dataAt(0), rowParser.typeAt(0), pool_.get());
+  /*
+   * ArrayVector<FlatVector<int8_t>>:
+   * offsets: 0
+   * sizes: 5
+   */
+  auto arrayVectorPtr = std::dynamic_pointer_cast<ArrayVector>(val0);
+  ASSERT_TRUE(arrayVectorPtr);
+  auto arrayVectorSize = 1;
+  int32_t arrayVectorOffsets[1] = {0};
+  vector_size_t arrayVectorLengths[1] = {5};
+  bool arrayVectorNulls[1] = {0};
+  ASSERT_TRUE(checkVectorMetadata(
+      arrayVectorPtr,
+      arrayVectorSize,
+      arrayVectorOffsets,
+      arrayVectorLengths,
+      arrayVectorNulls));
+
+  // FlatVector<int8_t>
+  //   0x01, 0x02, null, 0x03, null
+  auto arrayFlatVector = arrayVectorPtr->elements()->asFlatVector<int8_t>();
+  ASSERT_TRUE(arrayFlatVector);
+  ASSERT_FALSE(arrayFlatVector->isNullAt(0));
+  ASSERT_EQ(arrayFlatVector->valueAt(0), 0x01);
+  ASSERT_FALSE(arrayFlatVector->isNullAt(1));
+  ASSERT_EQ(arrayFlatVector->valueAt(1), 0x02);
+  ASSERT_TRUE(arrayFlatVector->isNullAt(2));
+  ASSERT_FALSE(arrayFlatVector->isNullAt(3));
+  ASSERT_EQ(arrayFlatVector->valueAt(3), 0x03);
+  ASSERT_TRUE(arrayFlatVector->isNullAt(4));
+}
+
+TEST_F(UnsafeRowVectorDeserializerTest, NestedArray) {
+  /*
+   * type: Array->Array->Array->TinyInt
+   * ArrayVector<ArrayVector<ArrayVector<FlatVector<int8_t>>>
+   * [
+   *  [
+   *    [1, 2], [3, 4]
+   *   ],
+   *  [
+   *    [5, 6, 7], null, [8]
+   *   ],
+   *  [
+   *    [9, 10]
+   *   ],
+   * ]
+   * ArrayVector<ArrayVector<ArrayVector<FlatVector<int8_t>>>
+   * size: 1
+   * offsets: [0]
+   * lengths: [3]
+   * // [[1, 2,], [3, 4]], [[5, 6, 7], null, [8]], [[9, 10]]
+   * elements: ArrayVector<ArrayVector<FlatVector<int8_t>>:
+   *   size: 3
+   *   offsets: [0, 2, 5]
+   *   lengths: [2, 3, 1]
+   *   nullCount: 0
+   *   // [1, 2,], [3, 4], [5, 6, 7], null, [8], [9, 10]
+   *   elements: ArrayVector<FlatVector<int8_t>>
+   *    size: 6
+   *    offsets: [0, 2, 4, 7, 7, 8]
+   *    lengths: [2, 2, 3, 0, 1, 2]
+   *    nulls: 0b001000
+   *    nullCount: 1
+   *    FlatVector<int8_t>
+   *      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+   *      size: 10
+   *      nullCount: 0
+   */
+
+  uint8_t data0[17 * 2][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x50, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00},
+      {0x58, 0x00, 0x00, 0x00, 0x78, 0x00, 0x00, 0x00},
+      {0x30, 0x00, 0x00, 0x00, 0xd0, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x38, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x03, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x05, 0x06, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x09, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData =
+      std::string_view(reinterpret_cast<const char*>(data0), 17 * 2 * 8);
+  std::vector<TypePtr> rowTypes{ARRAY(ARRAY(ARRAY(TINYINT())))};
+  UnsafeRowDynamicParser rowParser = UnsafeRowDynamicParser(rowTypes, rowData);
+
+  VectorPtr val0 = UnsafeRowDynamicVectorDeserializer::deserializeComplex(
+      rowParser.dataAt(0), rowParser.typeAt(0), pool_.get());
+
+  /*
+   * ArrayVector<ArrayVector<ArrayVector<FlatVector<int8_t>>>
+   * size: 1
+   * offsets: [0]
+   * lengths: [3]
+   */
+  auto outermostArrayVectorPtr = std::dynamic_pointer_cast<ArrayVector>(val0);
+  ASSERT_TRUE(outermostArrayVectorPtr);
+  auto outermostArraySize = 1;
+  int32_t outermostArrayOffsets[1] = {0};
+  vector_size_t outermostArraySizes[1] = {3};
+  bool outermostArrayNulls[1] = {0};
+  ASSERT_TRUE(checkVectorMetadata(
+      outermostArrayVectorPtr,
+      outermostArraySize,
+      outermostArrayOffsets,
+      outermostArraySizes,
+      outermostArrayNulls));
+
+  /*
+   * ArrayVector<ArrayVector<FlatVector<int8_t>>>
+   * size: 3
+   * offsets: [0, 2, 5]
+   * lengths: [2, 3, 1]
+   * nulls: [0, 0, 0]
+   */
+  auto outerArrayVectorPtr = std::dynamic_pointer_cast<ArrayVector>(
+      outermostArrayVectorPtr->elements());
+  ASSERT_TRUE(outerArrayVectorPtr);
+  auto outerArraySize = 3;
+  int32_t outerArrayOffsets[3] = {0, 2, 5};
+  vector_size_t outerArraySizes[3] = {2, 3, 1};
+  bool outerArrayNulls[3] = {0, 0, 0};
+  ASSERT_TRUE(checkVectorMetadata(
+      outerArrayVectorPtr,
+      outerArraySize,
+      outerArrayOffsets,
+      outerArraySizes,
+      outerArrayNulls));
+
+  /*
+   * [1, 2,], [3, 4], [5, 6, 7], null, [8], [9, 10]
+   * ArrayVector<FlatVector<int8_t>>[0]
+   * size: 6
+   * offsets: [0, 2, 4, 7, 7, 8]
+   * lengths: [2, 2, 3, 0, 1, 2]
+   * nulls: 0b001000
+   */
+  auto innerArrayVectorPtr =
+      std::dynamic_pointer_cast<ArrayVector>(outerArrayVectorPtr->elements());
+  ASSERT_TRUE(innerArrayVectorPtr);
+  auto innerArraySize = 6;
+  int32_t innerArrayOffsets[6] = {0, 2, 4, 7, 7, 8};
+  vector_size_t innerArraySizes[6] = {2, 2, 3, 0, 1, 2};
+  bool innerArrayNulls[6] = {0, 0, 0, 1, 0, 0};
+  ASSERT_TRUE(checkVectorMetadata(
+      innerArrayVectorPtr,
+      innerArraySize,
+      innerArrayOffsets,
+      innerArraySizes,
+      innerArrayNulls));
+
+  /*
+   * FlatVector<int8_t>
+   * [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+   * size: 10
+   * nullCount: 0
+   */
+  auto innermostFlatVector =
+      innerArrayVectorPtr->elements()->asFlatVector<int8_t>();
+  ASSERT_TRUE(innermostFlatVector);
+  ASSERT_EQ(innermostFlatVector->size(), 10);
+  int8_t expectedValue[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  ASSERT_EQ(
+      std::memcmp(
+          innermostFlatVector->rawValues(), expectedValue, sizeof(int8_t) * 10),
+          0);
+}
+
+TEST_F(UnsafeRowVectorDeserializerTest, NestedMap) {
+  /*
+   * TypePtr: Map<Short, Map<Short, Short>>
+   * {
+   *   1 : {
+   *          2 : 3,
+   *          4 : null
+   *        },
+   *   6 : {
+   *          7 : 8
+   *        }
+   *  }
+   * Map<Short, Map<Short, Short>>
+   *  offsets: 0
+   *  sizes: 2
+   *  keys: FlatVector<Short>
+   *    1, 6
+   *  values: MapVector<Short, Short>
+   *    offsets: 0, 2
+   *    sizes: 2, 1
+   *    nulls: 0, 0
+   *    Keys: FlatVector<Short>
+   *      2, 4, 7
+   *    Values: FlatVector<Short>
+   *      3, null, 8
+   */
+
+  uint8_t data0[12 * 2][8] = {
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0xb0, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x38, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00},
+      {0x38, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      {0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  auto rowData =
+      std::string_view(reinterpret_cast<const char*>(data0), 12 * 2 * 8);
+  std::vector<TypePtr> rowTypes{
+    MAP(SMALLINT(), MAP(SMALLINT(), SMALLINT()))};
+  UnsafeRowDynamicParser rowParser = UnsafeRowDynamicParser(rowTypes, rowData);
+
+  VectorPtr val0 = UnsafeRowDynamicVectorDeserializer::deserializeComplex(
+      rowParser.dataAt(0), rowParser.typeAt(0), pool_.get());
+
+  /*
+   * Map<Short, Map<Short, Short>>
+   *  offsets: 0
+   *  sizes: 2
+   */
+  auto outerMapVectorPtr = std::dynamic_pointer_cast<MapVector>(val0);
+  assert(outerMapVectorPtr);
+  auto outerMapSize = 1;
+  int32_t outerMapOffsets[1] = {0};
+  vector_size_t outerMapSizes[1] = {2};
+  // print_buffer(reinterpret_cast<const char
+  // *>(outerMapVectorPtr->sizes()->asMutable<vector_size_t>()), 128);
+  bool outerMapNulls[1] = {0};
+  ASSERT_TRUE(checkVectorMetadata(
+      outerMapVectorPtr,
+      outerMapSize,
+      outerMapOffsets,
+      outerMapSizes,
+      outerMapNulls));
+
+  /*
+   * keys: FlatVector<Short>
+   *    1, 6
+   */
+  auto outerKeys = outerMapVectorPtr->mapKeys()->asFlatVector<int16_t>();
+  ASSERT_TRUE(outerKeys);
+  ASSERT_EQ(outerKeys->size(), 2);
+  int16_t expectedValue[2] = {1, 6};
+  ASSERT_EQ(
+      std::memcmp(outerKeys->rawValues(), expectedValue, sizeof(int16_t) * 2),
+      0);
+
+  /*
+   *  values: MapVector<Short, Short>
+   *    offsets: 0, 2
+   *    sizes: 2, 1
+   *    nulls: 0, 0
+   */
+  auto innerMapVectorPtr =
+      std::dynamic_pointer_cast<MapVector>(outerMapVectorPtr->mapValues());
+  ASSERT_TRUE(innerMapVectorPtr);
+  auto innerMapSize = 2;
+  int32_t innerMapOffsets[2] = {0, 2};
+  vector_size_t innerMapSizes[2] = {2, 1};
+  bool innerMapNulls[2] = {0, 0};
+  ASSERT_TRUE(checkVectorMetadata(
+      innerMapVectorPtr,
+      innerMapSize,
+      innerMapOffsets,
+      innerMapSizes,
+      innerMapNulls));
+}


### PR DESCRIPTION
This is the cherry-pick and basic modification of @christycylee 's ser/deser series for UnsafeRow to velox vector, since most of the work has been rebased and merged from f4d to velox, I cherry pick the last work with several modifications:
- Fixed the non-virtual destructor compilation issue on platform009
- Replace the `const TypePtr` to `TypePtr` in the UnsafeRowDeserializerTest.cpp
- Fixed fatal unittests that caused a buffer release in the TearDown()