### PR TITLE
Simplified eval path - first cut (#1353)

### DIFF
--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -74,6 +74,11 @@ class ConstantExpr : public SpecialForm {
       EvalCtx* context,
       VectorPtr* result) override;
 
+  void evalSpecialFormSimplified(
+      const SelectivityVector& rows,
+      EvalCtx* context,
+      VectorPtr* result) override;
+
   const VectorPtr& value() const {
     return sharedSubexprValues_;
   }
@@ -105,6 +110,11 @@ class FieldReference : public SpecialForm {
   }
 
   void evalSpecialForm(
+      const SelectivityVector& rows,
+      EvalCtx* context,
+      VectorPtr* result) override;
+
+  void evalSpecialFormSimplified(
       const SelectivityVector& rows,
       EvalCtx* context,
       VectorPtr* result) override;

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -13,7 +13,8 @@
 # for generated headers
 include_directories(${CMAKE_BINARY_DIR})
 
-add_executable(velox_expression_test ExprTest.cpp CastExprTest.cpp)
+add_executable(velox_expression_test ExprTest.cpp CastExprTest.cpp
+                                     EvalSimplifiedTest.cpp VectorFuzzer.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/expression/tests/VectorFuzzer.h"
+#include "velox/functions/common/CoreFunctions.h"
+#include "velox/functions/common/tests/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using functions::test::FunctionBaseTest;
+
+// This test suite tests the simplified eval engine by:
+//
+//  1. Generating random vectors and encodings using VectorFuzzer;
+//  2. Executing expressions against the generate vectors using the simplified
+//  and common eval engines
+//  3. Asserting that result vectors are the same.
+//
+class EvalSimplifiedTest : public FunctionBaseTest {
+ protected:
+  void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
+    size_t vectorSize = expected->size();
+
+    // If one of the vectors is constant, they will report kMaxElements as
+    // size().
+    if (expected->isConstantEncoding() || actual->isConstantEncoding()) {
+      // If one is constant, use the size of the other; if both are, assume size
+      // is 1.
+      vectorSize = std::min(expected->size(), actual->size());
+      if (vectorSize == BaseVector::kMaxElements) {
+        vectorSize = 1;
+      }
+    } else {
+      ASSERT_EQ(expected->size(), actual->size());
+    }
+    FunctionBaseTest::assertEqualVectors(
+        expected, actual, vectorSize, fmt::format(" (seed {}).", seed_));
+  }
+
+  // Generate random (but deterministic) input row vectors.
+  RowVectorPtr genRowVector(
+      const RowTypePtr& types,
+      folly::Random::DefaultGenerator& rng) {
+    if (types == nullptr) {
+      return nullptr;
+    }
+
+    std::vector<VectorPtr> vectors;
+    vectors.reserve(types->size());
+
+    for (const auto& type : types->children()) {
+      size_t seed = folly::Random::rand32(rng);
+      vectors.emplace_back(VectorFuzzer(seed).fuzz(type, execCtx_.pool()));
+      LOG(INFO) << "\t" << vectors.back()->toString();
+    }
+    return makeRowVector(vectors);
+  }
+
+  void runTest(
+      const std::string& exprString,
+      const RowTypePtr& types = nullptr) {
+    auto expr = makeTypedExpr(exprString, types);
+
+    // Instantiate common eval.
+    exec::ExprSet exprSetCommon({expr}, &execCtx_);
+
+    // Instantiate simplified eval.
+    exec::ExprSetSimplified exprSetSimplified({expr}, &execCtx_);
+    SelectivityVector rows(batchSize_);
+
+    for (size_t i = 0; i < iterations_; ++i) {
+      LOG(INFO) << "============== Starting iteration with seed: " << seed_;
+      folly::Random::DefaultGenerator rng(seed_);
+
+      // Generate the input vectors.
+      auto rowVector = genRowVector(types, rng);
+
+      exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
+      exec::EvalCtx evalCtxSimplified(
+          &execCtx_, &exprSetSimplified, rowVector.get());
+
+      // Evaluate using both engines.
+      std::vector<VectorPtr> commonEvalResult{nullptr};
+      std::vector<VectorPtr> simplifiedEvalResult{nullptr};
+
+      exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
+      exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
+
+      // Compare results.
+      assertEqualVectors(
+          commonEvalResult.front(), simplifiedEvalResult.front());
+
+      // Update the seed for the next iteration.
+      seed_ = folly::Random::rand32(rng);
+    }
+  }
+
+  const size_t batchSize_{100};
+  const size_t iterations_{100};
+
+  // Initial seed. Will get refreshed on each iteration. In order to reproduce
+  // a test result, check the seed in the logs and paste it in here.
+  int32_t seed_{123456};
+};
+
+TEST_F(EvalSimplifiedTest, constantOnly) {
+  runTest("1 + 3 * 2 + 10 * 2");
+}
+
+TEST_F(EvalSimplifiedTest, constantAndInput) {
+  runTest("1 + c0 - 2 + c0", ROW({"c0"}, {BIGINT()}));
+}
+
+TEST_F(EvalSimplifiedTest, strings) {
+  runTest("md5(c0)", ROW({"c0"}, {VARCHAR()}));
+}
+
+TEST_F(EvalSimplifiedTest, doubles) {
+  runTest("ceil(c1) * c0", ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+}

--- a/velox/expression/tests/VectorFuzzer.cpp
+++ b/velox/expression/tests/VectorFuzzer.cpp
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/VectorFuzzer.h"
+#include "velox/type/Timestamp.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/VectorTypeUtils.h"
+
+namespace facebook::velox {
+
+namespace {
+
+// Generate random values for the different supported types.
+template <typename T>
+T rand(folly::Random::DefaultGenerator&) {
+  VELOX_NYI();
+}
+
+template <>
+int8_t rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::rand32(rng);
+}
+
+template <>
+int16_t rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::rand32(rng);
+}
+
+template <>
+int32_t rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::rand32(rng);
+}
+
+template <>
+int64_t rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::rand32(rng);
+}
+
+template <>
+double rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::randDouble01(rng);
+}
+
+template <>
+float rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::randDouble01(rng);
+}
+
+template <>
+bool rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::oneIn(2, rng);
+}
+
+template <>
+Timestamp rand(folly::Random::DefaultGenerator& rng) {
+  return Timestamp(folly::Random::rand32(rng), folly::Random::rand32(rng));
+}
+
+// TODO: Properly randomize this.
+template <>
+StringView rand(folly::Random::DefaultGenerator& rng) {
+  return StringView("my_str");
+}
+
+template <TypeKind kind>
+variant randVariantImpl(folly::Random::DefaultGenerator& rng) {
+  using TCpp = typename TypeTraits<kind>::NativeType;
+  return variant(rand<TCpp>(rng));
+}
+
+variant randVariant(const TypePtr& arg, folly::Random::DefaultGenerator& rng) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(randVariantImpl, arg->kind(), rng);
+}
+
+template <TypeKind kind>
+void fuzzFlatImpl(
+    const VectorPtr& vector,
+    folly::Random::DefaultGenerator& rng) {
+  using TFlat = typename KindToFlatVector<kind>::type;
+  using TCpp = typename TypeTraits<kind>::NativeType;
+
+  auto flatVector = vector->as<TFlat>();
+  auto* rawValues = flatVector->mutableRawValues();
+
+  for (size_t i = 0; i < vector->size(); ++i) {
+    if constexpr (std::is_same_v<TCpp, bool>) {
+      bits::setBit(rawValues, i, rand<TCpp>(rng));
+    } else {
+      // TODO: Handle StringView buffers.
+      rawValues[i] = rand<TCpp>(rng);
+    }
+  }
+}
+
+} // namespace
+
+VectorPtr VectorFuzzer::fuzz(const TypePtr& type, memory::MemoryPool* pool) {
+  VectorPtr vector;
+
+  // One in 5 chance of adding a constant vector.
+  if (oneIn(5)) {
+    // One in 5 chance of adding a NULL constant vector.
+    if (oneIn(5)) {
+      vector = BaseVector::createNullConstant(type, batchSize_, pool);
+    } else {
+      vector =
+          BaseVector::createConstant(randVariant(type, rng_), batchSize_, pool);
+    }
+  } else {
+    vector = fuzzFlat(type, pool);
+  }
+
+  // Toss a coin and add dictionary indirections.
+  while (oneIn(2)) {
+    vector = fuzzDictionary(vector, pool);
+  }
+  return vector;
+}
+
+VectorPtr VectorFuzzer::fuzzFlat(
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  auto vector = BaseVector::create(type, batchSize_, pool);
+
+  // First, fill it with random values.
+  // TODO: We should bias towards edge cases (min, max, Nan, etc).
+  auto kind = vector->typeKind();
+  VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(fuzzFlatImpl, kind, vector, rng_);
+
+  // Second, generate a random null vector.
+  for (size_t i = 0; i < vector->size(); ++i) {
+    // 1 in 10 chance of setting one element as null.
+    if (oneIn(10)) {
+      vector->setNull(i, true);
+    }
+  }
+  return vector;
+}
+
+VectorPtr VectorFuzzer::fuzzDictionary(
+    const VectorPtr& vector,
+    memory::MemoryPool* pool) {
+  const size_t vectorSize = vector->size();
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(vectorSize, pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  for (size_t i = 0; i < vectorSize; ++i) {
+    rawIndices[i] = rand<vector_size_t>(rng_) % vectorSize;
+  }
+
+  // TODO: We can fuzz nulls here as well.
+  return BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, vectorSize, vector);
+}
+
+} // namespace facebook::velox

--- a/velox/expression/tests/VectorFuzzer.h
+++ b/velox/expression/tests/VectorFuzzer.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Random.h>
+
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox {
+
+// Helper class to generate randomized vectors with random (and potentially
+// nested) encodings. Use the constructor seed to make it deterministic.
+class VectorFuzzer {
+ public:
+  explicit VectorFuzzer(size_t seed) : rng_(seed) {}
+
+  // Returns a "fuzzed" vector, containing randomized data, nulls, and indices
+  // vector (dictionary).
+  VectorPtr fuzz(const TypePtr& type, memory::MemoryPool* pool);
+
+  // Returns a flat vector with randomized data and nulls.
+  VectorPtr fuzzFlat(const TypePtr& type, memory::MemoryPool* pool);
+
+  // Wraps `vector` using a randomized indices vector, returning a
+  // DictionaryVector.
+  VectorPtr fuzzDictionary(const VectorPtr& vector, memory::MemoryPool* pool);
+
+ private:
+  // Returns true 1/n of times.
+  bool oneIn(size_t n) {
+    return folly::Random::oneIn(n, rng_);
+  }
+
+  size_t batchSize_{100};
+  folly::Random::DefaultGenerator rng_;
+};
+
+} // namespace facebook::velox

--- a/velox/functions/common/tests/FunctionBaseTest.h
+++ b/velox/functions/common/tests/FunctionBaseTest.h
@@ -381,13 +381,23 @@ class FunctionBaseTest : public testing::Test {
                                : ReturnType(result->valueAt(0));
   }
 
-  // TODO Enable ASSERT_EQ for vectors
-  void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
-    ASSERT_EQ(expected->size(), actual->size());
-    for (auto i = 0; i < expected->size(); i++) {
+  // TODO: Enable ASSERT_EQ for vectors
+  void assertEqualVectors(
+      const VectorPtr& expected,
+      const VectorPtr& actual,
+      std::optional<size_t> vectorSize = std::nullopt,
+      const std::string& additionalContext = "") {
+    // TODO: Remove vectorSize when ConstantVectors carry their proper size (as
+    // opposed to kMaxElements).
+    if (vectorSize == std::nullopt) {
+      vectorSize = expected->size();
+      ASSERT_EQ(expected->size(), actual->size());
+    }
+
+    for (auto i = 0; i < *vectorSize; i++) {
       ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
           << "at " << i << ": " << expected->toString(i) << " vs. "
-          << actual->toString(i);
+          << actual->toString(i) << additionalContext;
     }
   }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -433,6 +433,23 @@ class BaseVector {
 
   virtual void ensureWritable(const SelectivityVector& rows);
 
+  // Flattens the input vector.
+  //
+  // TODO: This method reuses ensureWritable(), which ensures that both:
+  //  (a) the vector is flattened, and
+  //  (b) it's singly-referenced
+  //
+  // We don't necessarily need (b) if we only want to flatten vectors.
+  static void flattenVector(
+      std::shared_ptr<BaseVector>* vector,
+      size_t vectorSize) {
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(vectorSize),
+        (*vector)->type(),
+        (*vector)->pool(),
+        vector);
+  }
+
   template <typename T>
   static inline vector_size_t byteSize(vector_size_t count) {
     return sizeof(T) * count;

--- a/velox/vector/SelectivityVector.cpp
+++ b/velox/vector/SelectivityVector.cpp
@@ -20,4 +20,9 @@ const SelectivityVector& SelectivityVector::empty() {
   static SelectivityVector kEmpty{SelectivityVector(0, false)};
   return kEmpty;
 }
+
+SelectivityVector SelectivityVector::empty(vector_size_t size) {
+  return SelectivityVector{size, false};
+}
+
 } // namespace facebook::velox

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -46,7 +46,13 @@ class SelectivityVector {
     }
   }
 
+  // Returns a statically allocated reference to an empty selectivity vector
+  // (size zero).
   static const SelectivityVector& empty();
+
+  // Returns a new allocated selectivity vector of size `size`, where all bits
+  // are set to false.
+  static SelectivityVector empty(vector_size_t size);
 
   void resize(int32_t size) {
     // Note default insert true's


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/f4d/pull/1353

First cut for a simplified expression evaluation path, which flattens
all vector before execution. The idea is to use this alternative path for tests
and to help isolate production issues. It will also help us understand how much
the current (complex) eval path buys us in terms of performance.
.
A few special form expression are not supported yet, in order to make this diff
a bit smaller.

Reviewed By: funrollloops

Differential Revision: D30122151

