### PR TITLE
Rename ChecksumAlgorithm NULL option to NULL_

### DIFF
--- a/velox/dwio/dwrf/proto/dwrf_proto.proto
+++ b/velox/dwio/dwrf/proto/dwrf_proto.proto
@@ -208,7 +208,7 @@ message UserMetadataItem {
 }
 
 enum ChecksumAlgorithm {
-  NULL = 0;
+  NULL_ = 0;
   CRC32 = 1;
   MURMUR3 = 2;
   ADLER32 = 3;


### PR DESCRIPTION
Summary:
gcc on linux (9.3 on Ubuntu 20.04) seems to have a problem with the
`NULL` option name and fails the compilation. Renaming the flag to NULL_
instead. Interestingly enough, all other usages of the flag I could find
already use "NULL_", so I'm a little confused about how this worked in the
first place:

> P445286158

Differential Revision: D30396818

