### PR TITLE
Remove Unlocked suffix in clearAllPromisesUnlocked()

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -60,7 +60,7 @@ class ExchangeQueue {
  public:
   ~ExchangeQueue() {
     std::lock_guard<std::mutex> l(mutex_);
-    clearAllPromisesUnlocked();
+    clearAllPromises();
   }
 
   std::mutex& mutex() {
@@ -94,7 +94,7 @@ class ExchangeQueue {
     }
     error_ = error;
     atEnd_ = true;
-    clearAllPromisesUnlocked();
+    clearAllPromises();
   }
 
   std::unique_ptr<SerializedPage> dequeue(bool* atEnd, ContinueFuture* future) {
@@ -133,11 +133,11 @@ class ExchangeQueue {
   void checkComplete() {
     if (noMoreSources_ && numCompleted_ == numSources_) {
       atEnd_ = true;
-      clearAllPromisesUnlocked();
+      clearAllPromises();
     }
   }
 
-  void clearAllPromisesUnlocked() {
+  void clearAllPromises() {
     for (auto& promise : promises_) {
       promise.setValue(true);
     }


### PR DESCRIPTION
Summary: Change the name of the method to align to repo convention.

Differential Revision: D30403528

