### PR TITLE
Expose getWriterName() method to reader shim class

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReaderShared.h
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.h
@@ -147,6 +147,10 @@ class DwrfReaderShared {
     return readerBase_->getWriterVersion();
   }
 
+  const std::string& getWriterName() const {
+    return readerBase_->getWriterName();
+  }
+
   std::vector<std::string> getMetadataKeys() const;
 
   std::string getMetadataValue(const std::string& key) const;


### PR DESCRIPTION
Summary:
Already implemented in reader base, plumbing it through to the reader
shim class. Helps with internal testing and experimentation.

Reviewed By: avergottini

Differential Revision: D30127347

