### PR TITLE
Create and register a version of `length` that returns an `int32`

### DIFF
--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   RegisterArithmetic.cpp
   RegisterCompare.cpp
   SplitFunctions.cpp
+  String.cpp
   Subscript.cpp)
 
 target_link_libraries(velox_functions_spark velox_functions_lib

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -26,6 +26,7 @@
 #include "velox/functions/sparksql/RegexFunctions.h"
 #include "velox/functions/sparksql/RegisterArithmetic.h"
 #include "velox/functions/sparksql/RegisterCompare.h"
+#include "velox/functions/sparksql/String.h"
 
 namespace facebook::velox::functions {
 
@@ -41,7 +42,6 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_in, prefix + "in");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, prefix + "array");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_filter, prefix + "filter");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_length, prefix + "length");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_entries, prefix + "map_entries");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_substr, prefix + "substring");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
@@ -73,6 +73,8 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "xxhash64"});
   registerFunction<udf_xxhash64<Varbinary, Varbinary>, Varbinary, Varbinary>(
       {prefix + "xxhash64"});
+  exec::registerStatefulVectorFunction(
+      "length", lengthSignatures(), makeLength);
   registerFunction<udf_md5<Varbinary, Varbinary>, Varbinary, Varbinary>(
       {prefix + "md5"});
   registerFunction<udf_md5_radix<Varchar, Varchar>, Varchar, Varchar, int32_t>(

--- a/velox/functions/sparksql/String.cpp
+++ b/velox/functions/sparksql/String.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/StringEncodingUtils.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+class Length : public exec::VectorFunction {
+  bool ensureStringEncodingSetAtAllInputs() const override {
+    return true;
+  }
+
+  void apply(
+      const SelectivityVector& selected,
+      std::vector<VectorPtr>& args,
+      exec::Expr*,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    VELOX_CHECK(
+        args[0]->typeKind() == TypeKind::VARCHAR ||
+        args[0]->typeKind() == TypeKind::VARBINARY);
+    exec::LocalDecodedVector input(context, *args[0], selected);
+    BaseVector::ensureWritable(selected, INTEGER(), context->pool(), result);
+    auto* output = (*result)->as<FlatVector<int32_t>>();
+
+    if (args[0]->typeKind() == TypeKind::VARCHAR &&
+        getStringEncodingOrUTF8(args[0].get()) != StringEncodingMode::ASCII) {
+      selected.applyToSelected([&](vector_size_t row) {
+        const StringView str = input->valueAt<StringView>(row);
+        output->set(row, lengthUnicode(str.data(), str.size()));
+      });
+    } else {
+      selected.applyToSelected([&](vector_size_t row) {
+        output->set(row, input->valueAt<StringView>(row).size());
+      });
+    }
+  }
+};
+
+} // namespace
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> lengthSignatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType("INTEGER")
+          .argumentType("VARCHAR")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("INTEGER")
+          .argumentType("VARBINARY")
+          .build(),
+  };
+}
+
+std::shared_ptr<exec::VectorFunction> makeLength(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  static const auto kLengthFunction = std::make_shared<Length>();
+  return kLengthFunction;
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions::sparksql {
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> lengthSignatures();
+
+std::shared_ptr<exec::VectorFunction> makeLength(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -14,8 +14,13 @@
 
 add_executable(
   velox_functions_spark_test
-  ArithmeticTest.cpp HashTest.cpp LeastGreatestTest.cpp RegexFunctionsTest.cpp
-  SplitFunctionsTest.cpp SubscriptTest.cpp)
+  ArithmeticTest.cpp
+  HashTest.cpp
+  LeastGreatestTest.cpp
+  RegexFunctionsTest.cpp
+  SplitFunctionsTest.cpp
+  StringTest.cpp
+  SubscriptTest.cpp)
 
 add_test(velox_functions_spark_test velox_functions_spark_test)
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/Type.h"
+
+#include <stdint.h>
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+// This is a five codepoint sequence that renders as a single emoji.
+static constexpr char kWomanFacepalmingLightSkinTone[] =
+    "\xF0\x9F\xA4\xA6\xF0\x9F\x8F\xBB\xE2\x80\x8D\xE2\x99\x80\xEF\xB8\x8F";
+
+class StringTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<int32_t> length(std::optional<std::string> arg) {
+    return evaluateOnce<int32_t>("length(c0)", arg);
+  }
+
+  std::optional<int32_t> length_bytes(std::optional<std::string> arg) {
+    return evaluateOnce<int32_t, std::string>(
+        "length(c0)", {arg}, {VarbinaryType::create()});
+  }
+};
+
+TEST_F(StringTest, LengthString) {
+  EXPECT_EQ(length(""), 0);
+  EXPECT_EQ(length(std::string("\0", 1)), 1);
+  EXPECT_EQ(length("1"), 1);
+  EXPECT_EQ(length("😋"), 1);
+  // Consists of five codepoints.
+  EXPECT_EQ(length(kWomanFacepalmingLightSkinTone), 5);
+  EXPECT_EQ(length("1234567890abdef"), 15);
+}
+
+TEST_F(StringTest, LengthBytes) {
+  EXPECT_EQ(length_bytes(""), 0);
+  EXPECT_EQ(length_bytes(std::string("\0", 1)), 1);
+  EXPECT_EQ(length_bytes("1"), 1);
+  EXPECT_EQ(length_bytes("😋"), 4);
+  EXPECT_EQ(length_bytes(kWomanFacepalmingLightSkinTone), 17);
+  EXPECT_EQ(length_bytes("1234567890abdef"), 15);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Summary: Presto's LENGTH returns an int64, which doesn't match what Spark expects.

Reviewed By: pedroerp

Differential Revision: D30355882

