### PR TITLE
Create and map a version of strpos that returns an int32 as instr for Spark

### DIFF
--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -47,7 +47,6 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, prefix + "upper");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_strpos, prefix + "strpos");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, prefix + "ROW");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
@@ -85,6 +84,7 @@ void registerFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, prefix + "subscript");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_regexp_split, prefix + "split");
 
+  exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(
       "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/String.cpp
+++ b/velox/functions/sparksql/String.cpp
@@ -19,6 +19,58 @@
 namespace facebook::velox::functions::sparksql {
 namespace {
 
+template <bool isAscii>
+int32_t instr(
+    const folly::StringPiece haystack,
+    const folly::StringPiece needle) {
+  int32_t offset = haystack.find(needle);
+  if constexpr (isAscii) {
+    return offset + 1;
+  } else {
+    // If the string is unicode, convert the byte offset to a codepoints.
+    return offset == -1 ? 0 : lengthUnicode(haystack.data(), offset) + 1;
+  }
+}
+
+class Instr : public exec::VectorFunction {
+  bool ensureStringEncodingSetAtAllInputs() const override {
+    return true;
+  }
+
+  void apply(
+      const SelectivityVector& selected,
+      std::vector<VectorPtr>& args,
+      exec::Expr*,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    VELOX_CHECK_EQ(args.size(), 2);
+    VELOX_CHECK_EQ(args[0]->typeKind(), TypeKind::VARCHAR);
+    VELOX_CHECK_EQ(args[1]->typeKind(), TypeKind::VARCHAR);
+    exec::LocalDecodedVector haystack(context, *args[0], selected);
+    exec::LocalDecodedVector needle(context, *args[1], selected);
+    BaseVector::ensureWritable(selected, INTEGER(), context->pool(), result);
+    auto* output = (*result)->as<FlatVector<int32_t>>();
+
+    if (getStringEncodingOrUTF8(args[0].get()) == StringEncodingMode::ASCII) {
+      selected.applyToSelected([&](vector_size_t row) {
+        output->set(
+            row,
+            instr<true>(
+                haystack->valueAt<StringView>(row),
+                needle->valueAt<StringView>(row)));
+      });
+    } else {
+      selected.applyToSelected([&](vector_size_t row) {
+        output->set(
+            row,
+            instr<false>(
+                haystack->valueAt<StringView>(row),
+                needle->valueAt<StringView>(row)));
+      });
+    }
+  }
+};
+
 class Length : public exec::VectorFunction {
   bool ensureStringEncodingSetAtAllInputs() const override {
     return true;
@@ -53,6 +105,23 @@ class Length : public exec::VectorFunction {
 };
 
 } // namespace
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> instrSignatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType("INTEGER")
+          .argumentType("VARCHAR")
+          .argumentType("VARCHAR")
+          .build(),
+  };
+}
+
+std::shared_ptr<exec::VectorFunction> makeInstr(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  static const auto kInstrFunction = std::make_shared<Instr>();
+  return kInstrFunction;
+}
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> lengthSignatures() {
   return {

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -17,6 +17,12 @@
 
 namespace facebook::velox::functions::sparksql {
 
+std::vector<std::shared_ptr<exec::FunctionSignature>> instrSignatures();
+
+std::shared_ptr<exec::VectorFunction> makeInstr(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
+
 std::vector<std::shared_ptr<exec::FunctionSignature>> lengthSignatures();
 
 std::shared_ptr<exec::VectorFunction> makeLength(


### PR DESCRIPTION
Summary: The equivalent of `strpos` in Spark is `instr`, and it expects an int32 result.

Differential Revision: D30355883

