### PR TITLE
Add tests for array-based joins

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -247,3 +247,51 @@ TEST_F(HashJoinTest, lazyVectors) {
       {{0, rightFile}, {10, leftFile}},
       "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
 }
+
+/// Test hash join where build-side keys come from a small range and allow for
+/// array-based lookup instead of a hash table.
+TEST_F(HashJoinTest, arrayBasedLookup) {
+  auto oddIndices = makeIndices(500, [](auto i) { return 2 * i + 1; });
+
+  auto leftVectors = {
+      // Join key vector is flat.
+      makeRowVector({
+          makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
+      }),
+      // Join key vector is constant. There is a match in the build side.
+      makeRowVector({
+          BaseVector::createConstant(4, 2'000, pool_.get()),
+          makeFlatVector<int64_t>(2'000, [](auto row) { return row; }),
+      }),
+      // Join key vector is constant. There is no match.
+      makeRowVector({
+          BaseVector::createConstant(5, 2'000, pool_.get()),
+          makeFlatVector<int64_t>(2'000, [](auto row) { return row; }),
+      }),
+      // Join key vector is a dictionary.
+      makeRowVector({
+          wrapInDictionary(
+              oddIndices,
+              500,
+              makeFlatVector<int32_t>(1'000, [](auto row) { return row * 4; })),
+          makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
+      })};
+
+  // 100 key values in [0, 198] range.
+  auto rightVectors = {makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row * 2; })})};
+
+  createDuckDbTable("t", {leftVectors});
+  createDuckDbTable("u", {rightVectors});
+
+  auto op =
+      PlanBuilder(10)
+          .values(leftVectors)
+          .hashJoin(
+              {0}, {0}, PlanBuilder(0).values(rightVectors).planNode(), "", {1})
+          .project({"c1 + 1"})
+          .planNode();
+
+  assertQuery(op, "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
+}

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -152,6 +152,24 @@ class OperatorTestBase : public testing::Test {
         size, sizeAt, keyAt, valueAt, isNullAt, valueIsNullAt);
   }
 
+  static VectorPtr
+  wrapInDictionary(BufferPtr indices, vector_size_t size, VectorPtr vector) {
+    return BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), std::move(indices), size, std::move(vector));
+  }
+
+  BufferPtr makeIndices(
+      vector_size_t size,
+      const std::function<vector_size_t(vector_size_t)>& indexAt) const {
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(size, pool_.get());
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    for (int i = 0; i < size; i++) {
+      rawIndices[i] = indexAt(i);
+    }
+    return indices;
+  }
+
   // Helper function for comparing vector results
   template <typename T1, typename T2>
   bool


### PR DESCRIPTION
Add a test for hash join where build-side keys come from a small range
and allow for array-based lookup instead of a hash table.