### PR TITLE
ExpressionExplorer

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -46,3 +46,13 @@ target_link_libraries(
 add_library(velox_vector_fuzzer VectorFuzzer.cpp)
 
 target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
+
+add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
+
+target_link_libraries(velox_expression_fuzzer velox_type velox_vector_fuzzer
+                      velox_vector_test_lib)
+
+add_executable(velox_expression_fuzzer_main ExpressionFuzzerMain.cpp)
+
+target_link_libraries(velox_expression_fuzzer_main velox_expression_fuzzer
+                      velox_functions_common)

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <glog/logging.h>
+#include <exception>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/tests/ExpressionFuzzer.h"
+#include "velox/expression/tests/VectorFuzzer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/VectorMaker.h"
+
+DEFINE_int32(
+    batch_size,
+    100,
+    "The number of elements on each generated vector.");
+
+DEFINE_int32(
+    null_chance,
+    10,
+    "Chance of adding a null constant to the plan, or null value in a vector "
+    "(expressed using '1 in x' semantic).");
+
+namespace facebook::velox::test {
+
+namespace {
+
+// Called if at least one of the ptrs has an exception.
+void compareExceptions(std::exception_ptr eptr1, std::exception_ptr eptr2) {
+  // If we don't have two exceptions, fail.
+  if (!eptr1 || !eptr2) {
+    LOG(ERROR) << "Only one path threw exception:";
+
+    if (!eptr1) {
+      std::rethrow_exception(eptr2);
+    }
+    std::rethrow_exception(eptr1);
+  }
+
+  // Otherwise, make sure the exceptions are the same.
+  try {
+    std::rethrow_exception(eptr1);
+  } catch (const VeloxException& ve1) {
+    try {
+      std::rethrow_exception(eptr2);
+    } catch (const VeloxException& ve2) {
+      // Error messages sometimes differ; check at least error codes.
+      VELOX_CHECK_EQ(ve1.errorCode(), ve2.errorCode());
+      VELOX_CHECK_EQ(ve1.errorSource(), ve2.errorSource());
+      VELOX_CHECK_EQ(ve1.exceptionName(), ve2.exceptionName());
+      VLOG(1) << "Both paths failed: '" << ve1.message() << "', and '"
+              << ve2.message() << "'.";
+      return;
+    }
+  } catch (const std::exception& e1) {
+    try {
+      std::rethrow_exception(eptr2);
+    } catch (const std::exception& e2) {
+      VELOX_CHECK_EQ(std::string(e1.what()), std::string(e2.what()));
+      return;
+    }
+  }
+  VELOX_FAIL("Got two incompatible exceptions.");
+}
+
+void compareVectors(const VectorPtr& vec1, const VectorPtr& vec2) {
+  size_t vectorSize = vec1->size();
+
+  // If one of the vectors is constant, they will report kMaxElements as size().
+  if (vec1->isConstantEncoding() || vec2->isConstantEncoding()) {
+    // If one is constant, use the size of the other; if both are, assume size
+    // is 1.
+    vectorSize = std::min(vec1->size(), vec2->size());
+    if (vectorSize == BaseVector::kMaxElements) {
+      vectorSize = 1;
+    }
+  } else {
+    VELOX_CHECK_EQ(vec1->size(), vec2->size());
+  }
+
+  // Print vector contents if in verbose mode.
+  if (VLOG_IS_ON(1)) {
+    LOG(INFO) << "== Result contents (common vs. simple): ";
+    for (auto i = 0; i < vectorSize; i++) {
+      LOG(INFO) << "At " << i << ": [" << vec1->toString(i) << " vs "
+                << vec2->toString(i) << "]";
+    }
+    LOG(INFO) << "===================";
+  }
+
+  for (auto i = 0; i < vectorSize; i++) {
+    VELOX_CHECK(
+        vec1->equalValueAt(vec2.get(), i, i), "Different results at idx {}", i);
+  }
+  LOG(INFO) << "All results match.";
+}
+
+VectorFuzzer::Options getFuzzerOptions() {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = FLAGS_batch_size;
+  opts.stringVariableLength = true;
+  opts.stringLength = 100;
+  opts.nullChance = FLAGS_null_chance;
+  return opts;
+}
+
+} // namespace
+
+std::string CallableSignature::toString() const {
+  std::string buf = name;
+  buf.append("( ");
+  for (const auto& arg : args) {
+    buf.append(arg->toString());
+    buf.append(" ");
+  }
+  buf.append(") -> ");
+  buf.append(returnType->toString());
+  return buf;
+}
+
+class ExpressionFuzzer {
+ public:
+  ExpressionFuzzer(
+      std::vector<CallableSignature> signatures,
+      size_t initialSeed)
+      : signatures_(std::move(signatures)),
+        vectorFuzzer_(getFuzzerOptions(), execCtx_.pool()) {
+    seed(initialSeed);
+
+    // Generates signaturesMap, which maps a given type to the function
+    // signature that return it.
+    for (const auto& it : signatures_) {
+      signaturesMap_[it.returnType->kind()].push_back(&it);
+    }
+  }
+
+ private:
+  void seed(size_t seed) {
+    currentSeed_ = seed;
+    vectorFuzzer_.reSeed(seed);
+    rng_.seed(currentSeed_);
+  }
+
+  void reSeed() {
+    seed(folly::Random::rand32(rng_));
+  }
+
+  // Returns true 1/n of times.
+  bool oneIn(size_t n) {
+    return folly::Random::oneIn(n, rng_);
+  }
+
+  RowVectorPtr generateRowVector() {
+    std::vector<VectorPtr> vectors;
+    vectors.reserve(inputRowTypes_.size());
+    size_t idx = 0;
+
+    for (const auto& inputRowType : inputRowTypes_) {
+      auto vector = vectorFuzzer_.fuzz(inputRowType);
+
+      // If verbose mode, print the whole vector.
+      if (VLOG_IS_ON(1)) {
+        for (size_t i = 0; i < vector->size(); ++i) {
+          if (vector->isNullAt(i)) {
+            LOG(INFO) << "C" << idx << "[" << i << "]: null";
+          } else {
+            LOG(INFO) << "C" << idx << "[" << i << "]: " << vector->toString(i);
+          }
+        }
+      }
+      LOG(INFO) << "\t" << vector->toString();
+      vectors.emplace_back(vector);
+      ++idx;
+    }
+    return vectors.empty() ? nullptr : vectorMaker_.rowVector(vectors);
+  }
+
+  core::TypedExprPtr generateArgConstant(const TypePtr& arg) {
+    // One in ten times return a NULL constant.
+    if (oneIn(FLAGS_null_chance)) {
+      return std::make_shared<core::ConstantTypedExpr>(
+          variant::null(arg->kind()));
+    }
+    return std::make_shared<core::ConstantTypedExpr>(
+        vectorFuzzer_.randVariant(arg));
+  }
+
+  core::TypedExprPtr generateArgColumn(const TypePtr& arg) {
+    inputRowTypes_.emplace_back(arg);
+
+    return std::make_shared<core::FieldAccessTypedExpr>(
+        arg,
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::InputTypedExpr>(ROW({arg}))},
+        fmt::format("c{}", inputRowTypes_.size() - 1));
+  }
+
+  std::vector<core::TypedExprPtr> generateArgs(const CallableSignature& input) {
+    std::vector<core::TypedExprPtr> outputArgs;
+
+    for (const auto& arg : input.args) {
+      size_t type = folly::Random::rand32(3, rng_);
+
+      // Toss a coin a choose between a constant, a column reference, or another
+      // expression (function).
+      //
+      // TODO: Add more expression types:
+      // - Conjunctions
+      // - IF/ELSE/SWITCH
+      // - Lambdas
+      // - Try
+      if (type == 0) {
+        outputArgs.emplace_back(generateArgConstant(arg));
+      } else if (type == 1) {
+        outputArgs.emplace_back(generateArgColumn(arg));
+      } else if (type == 2) {
+        outputArgs.emplace_back(generateExpression(arg));
+      } else {
+        VELOX_UNREACHABLE();
+      }
+    }
+    return outputArgs;
+  }
+
+  core::TypedExprPtr generateExpression(const TypePtr& returnType) {
+    // If no functions can return `returnType`, return a constant instead.
+    auto it = signaturesMap_.find(returnType->kind());
+    if (it == signaturesMap_.end()) {
+      LOG(INFO) << "Couldn't find any function to return '"
+                << returnType->toString() << "'. Returning a constant instead.";
+      return generateArgConstant(returnType);
+    }
+
+    // Randomly pick a function that can return `returnType`.
+    const auto& eligible = it->second;
+    size_t idx = folly::Random::rand32(eligible.size(), rng_);
+    const auto& chosen = eligible[idx];
+
+    // Generate the function args recursively.
+    auto args = generateArgs(*chosen);
+    return std::make_shared<core::CallTypedExpr>(
+        chosen->returnType, args, chosen->name);
+  }
+
+ public:
+  void go(size_t steps) {
+    for (size_t i = 0; i < steps; ++i) {
+      LOG(INFO) << "==============================> Started iteration " << i
+                << " (seed: " << currentSeed_ << ")";
+      inputRowTypes_.clear();
+
+      // Pick a random signature to chose the root return type.
+      size_t idx = folly::Random::rand32(signatures_.size(), rng_);
+      const auto& rootType = signatures_[idx].returnType;
+
+      // Generate an expression tree.
+      auto plan = generateExpression(rootType);
+      LOG(INFO) << "Generated expression: " << plan->toString();
+
+      // Generate the input data vectors.
+      auto rowVector = generateRowVector();
+      SelectivityVector rows{rowVector ? rowVector->size() : 1};
+
+      if (rowVector) {
+        LOG(INFO) << "Generated " << rowVector->childrenSize() << " vectors:";
+        for (const auto& child : rowVector->children()) {
+          LOG(INFO) << "\t" << child->toString();
+        }
+      }
+
+      // Execute expression using both common and simplified evals.
+      std::vector<VectorPtr> commonEvalResult(1);
+      std::vector<VectorPtr> simplifiedEvalResult(1);
+
+      std::exception_ptr exceptionCommonPtr;
+      std::exception_ptr exceptionSimplifiedPtr;
+
+      VLOG(1) << "Starting common eval execution.";
+
+      // Execute with common expression eval path.
+      try {
+        exec::ExprSet exprSetCommon({plan}, &execCtx_);
+        exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
+
+        exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
+      } catch (...) {
+        exceptionCommonPtr = std::current_exception();
+      }
+
+      VLOG(1) << "Starting simplified eval execution.";
+
+      // Execute with simplified expression eval path.
+      try {
+        exec::ExprSetSimplified exprSetSimplified({plan}, &execCtx_);
+        exec::EvalCtx evalCtxSimplified(
+            &execCtx_, &exprSetSimplified, rowVector.get());
+
+        exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
+      } catch (...) {
+        exceptionSimplifiedPtr = std::current_exception();
+      }
+
+      // Compare results or exceptions (if any). Fail is anything is different.
+      if (exceptionCommonPtr || exceptionSimplifiedPtr) {
+        compareExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
+      } else {
+        compareVectors(commonEvalResult.front(), simplifiedEvalResult.front());
+      }
+
+      LOG(INFO) << "==============================> Done with iteration " << i;
+      reSeed();
+    }
+  }
+
+ private:
+  folly::Random::DefaultGenerator rng_;
+  size_t currentSeed_{0};
+
+  const std::vector<CallableSignature> signatures_;
+
+  // Maps a given type to the functions that return that type.
+  std::unordered_map<TypeKind, std::vector<const CallableSignature*>>
+      signaturesMap_;
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  core::ExecCtx execCtx_{memory::getDefaultScopedMemoryPool(), queryCtx_.get()};
+
+  test::VectorMaker vectorMaker_{execCtx_.pool()};
+  VectorFuzzer vectorFuzzer_;
+
+  // Contains the input column references that need to be generated for one
+  // particular iteration.
+  std::vector<TypePtr> inputRowTypes_;
+};
+
+void expressionFuzzer(
+    std::vector<CallableSignature> signatures,
+    size_t steps,
+    size_t seed) {
+  ExpressionFuzzer(std::move(signatures), seed).go(steps);
+}
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+
+// Represents one available function signature.
+struct CallableSignature {
+  // Function name.
+  std::string name;
+
+  // Input arguments and return type.
+  std::vector<TypePtr> args;
+  TypePtr returnType;
+
+  // Convenience print function.
+  std::string toString() const;
+};
+
+// Generates random expressions based on `signatures` and random input data (via
+// VectorFuzzer). Generates `steps` distinct expressions.
+void expressionFuzzer(
+    std::vector<CallableSignature> signatures,
+    size_t steps,
+    size_t seed);
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionFuzzerMain.cpp
+++ b/velox/expression/tests/ExpressionFuzzerMain.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/FunctionRegistry.h"
+#include "velox/expression/VectorFunctionRegistry.h"
+#include "velox/expression/tests/ExpressionFuzzer.h"
+#include "velox/functions/common/CoreFunctions.h"
+
+DEFINE_int64(
+    seed,
+    123456,
+    "Initial seed for random number generator "
+    "(use it to reproduce previous results).");
+
+DEFINE_int32(steps, 1, "Number of expressions to generate.");
+
+namespace facebook::velox::test {
+
+// Fetches all available function signatures.
+// TODO: Only simple functions for now.
+std::vector<CallableSignature> getAllSignatures() {
+  std::vector<CallableSignature> functions;
+
+  // TODO: Skipping buggy functions for now.
+  std::unordered_set<std::string> skipFunctions = {"xxhash64", "from_unixtime"};
+  auto keys = exec::AdaptedVectorFunctions().Keys();
+
+  for (const auto& key : keys) {
+    auto func = facebook::velox::core::ScalarFunctions().Create(key);
+
+    if (!func->isDeterministic()) {
+      LOG(WARNING) << "Skipping non-deterministic function: " << key.name();
+      continue;
+    }
+
+    if (skipFunctions.count(key.name()) > 0) {
+      LOG(WARNING) << "Skipping known buggy function: " << key.name();
+      continue;
+    }
+
+    CallableSignature temp{key.name(), key.types(), func->returnType()};
+    functions.emplace_back(temp);
+  }
+  return functions;
+}
+
+} // namespace facebook::velox::test
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // TODO: Only simple functions for now.
+  functions::registerFunctions();
+  auto signatures = test::getAllSignatures();
+
+  test::expressionFuzzer(std::move(signatures), FLAGS_steps, FLAGS_seed);
+  return 0;
+}

--- a/velox/expression/tests/VectorFuzzer.cpp
+++ b/velox/expression/tests/VectorFuzzer.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -106,14 +108,6 @@ variant randVariantImpl(
   }
 }
 
-variant randVariant(
-    const TypePtr& arg,
-    folly::Random::DefaultGenerator& rng,
-    const VectorFuzzer::Options& opts) {
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      randVariantImpl, arg->kind(), rng, opts);
-}
-
 template <TypeKind kind>
 void fuzzFlatImpl(
     const VectorPtr& vector,
@@ -147,7 +141,7 @@ VectorPtr VectorFuzzer::fuzz(const TypePtr& type) {
       vector = BaseVector::createNullConstant(type, opts_.vectorSize, pool_);
     } else {
       vector = BaseVector::createConstant(
-          randVariant(type, rng_, opts_), opts_.vectorSize, pool_);
+          randVariant(type), opts_.vectorSize, pool_);
     }
   } else {
     vector = fuzzFlat(type);
@@ -189,6 +183,11 @@ VectorPtr VectorFuzzer::fuzzDictionary(const VectorPtr& vector) {
   // TODO: We can fuzz nulls here as well.
   return BaseVector::wrapInDictionary(
       BufferPtr(nullptr), indices, vectorSize, vector);
+}
+
+variant VectorFuzzer::randVariant(const TypePtr& arg) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      randVariantImpl, arg->kind(), rng_, opts_);
 }
 
 } // namespace facebook::velox

--- a/velox/expression/tests/VectorFuzzer.h
+++ b/velox/expression/tests/VectorFuzzer.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -60,6 +62,12 @@ class VectorFuzzer {
   // Wraps `vector` using a randomized indices vector, returning a
   // DictionaryVector.
   VectorPtr fuzzDictionary(const VectorPtr& vector);
+
+  variant randVariant(const TypePtr& arg);
+
+  void reSeed(size_t seed) {
+    rng_.seed(seed);
+  }
 
  private:
   // Returns true 1/n of times.


### PR DESCRIPTION
Summary:
This diffs adds a first cut for expression explorer, a binary that
generates random expressions and input vectors (via VectorFuzzer), executes
them using both current and simplified evals, and ensures results are the same.

Differential Revision: D30387958

