### PR TITLE
Implement chr and ascii for SparkSQL

### DIFF
--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -62,7 +62,7 @@ void registerFunctions(const std::string& prefix) {
 
   // Register string functions.
   registerFunction<udf_chr, Varchar, int64_t>();
-  registerFunction<udf_codepoint, int32_t, Varchar>();
+  registerFunction<udf_ascii, int32_t, Varchar>();
   registerFunction<
       udf_xxhash64int<int64_t, Varchar>,
       int64_t,

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -14,8 +14,29 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/UDFOutputString.h"
 
 namespace facebook::velox::functions::sparksql {
+
+VELOX_UDF_BEGIN(ascii)
+FOLLY_ALWAYS_INLINE bool call(int32_t& result, const arg_type<Varchar>& s) {
+  result = s.empty() ? 0 : s.data()[0];
+  return true;
+}
+VELOX_UDF_END();
+
+VELOX_UDF_BEGIN(chr)
+FOLLY_ALWAYS_INLINE bool call(out_type<Varchar>& result, int64_t ord) {
+  if (ord < 0) {
+    result.resize(0);
+  } else {
+    result.resize(1);
+    *result.data() = ord;
+  }
+  return true;
+}
+VELOX_UDF_END();
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> instrSignatures();
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -27,6 +27,14 @@ static constexpr char kWomanFacepalmingLightSkinTone[] =
 
 class StringTest : public SparkFunctionBaseTest {
  protected:
+  std::optional<int32_t> ascii(std::optional<std::string> arg) {
+    return evaluateOnce<int32_t>("ascii(c0)", arg);
+  }
+
+  std::optional<std::string> chr(std::optional<int64_t> arg) {
+    return evaluateOnce<std::string>("chr(c0)", arg);
+  }
+
   std::optional<int32_t> instr(
       std::optional<std::string> haystack,
       std::optional<std::string> needle) {
@@ -42,6 +50,23 @@ class StringTest : public SparkFunctionBaseTest {
         "length(c0)", {arg}, {VarbinaryType::create()});
   }
 };
+
+TEST_F(StringTest, Ascii) {
+  EXPECT_EQ(ascii(std::string("\0", 1)), 0);
+  EXPECT_EQ(ascii(" "), 32);
+  EXPECT_EQ(ascii("😋"), -16);
+  EXPECT_EQ(ascii(""), 0);
+  EXPECT_EQ(ascii(std::nullopt), std::nullopt);
+}
+
+TEST_F(StringTest, Chr) {
+  EXPECT_EQ(chr(0), std::string("\0", 1));
+  EXPECT_EQ(chr(32), " ");
+  EXPECT_EQ(chr(-16), "");
+  EXPECT_EQ(chr(256), std::string("\0", 1));
+  EXPECT_EQ(chr(256 + 32), std::string(" ", 1));
+  EXPECT_EQ(chr(std::nullopt), std::nullopt);
+}
 
 TEST_F(StringTest, Instr) {
   EXPECT_EQ(instr("SparkSQL", "SQL"), 6);

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -197,6 +197,10 @@ struct StringView {
     return data() + size();
   }
 
+  bool empty() const {
+    return size() == 0;
+  }
+
  private:
   inline int64_t sizeAndPrefixAsInt64() const {
     return reinterpret_cast<const int64_t*>(this)[0];


### PR DESCRIPTION
Summary: In Spark, these two functions are not unicode-aware.

Differential Revision: D30414622

