### PR TITLE
Add SeekableInputStream backed by cache

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_caching DataCache.cpp FileIds.cpp StringIdMap.cpp
-                          AsyncDataCache.cpp)
+                          AsyncDataCache.cpp ScanTracker.cpp)
 target_link_libraries(velox_caching velox_memory velox_exception ${GLOG}
                       ${FOLLY_WITH_DEPENDENCIES})
 

--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/ScanTracker.h"
+
+#include <sstream>
+
+namespace facebook::velox::cache {
+
+void ScanTracker::recordReference(
+    const TrackingId id,
+    uint64_t bytes,
+    uint64_t /*groupId*/) {
+  std::lock_guard<std::mutex> l(mutex_);
+  data_[id].incrementReference(bytes);
+  sum_.incrementReference(bytes);
+}
+
+void ScanTracker::recordRead(
+    const TrackingId id,
+    uint64_t bytes,
+    uint64_t /*groupId*/) {
+  std::lock_guard<std::mutex> l(mutex_);
+  data_[id].incrementRead(bytes);
+  sum_.incrementRead(bytes);
+}
+
+std::string ScanTracker::toString() const {
+  std::stringstream out;
+  out << "ScanTracker for " << id_ << std::endl;
+  for (auto& pair : data_) {
+    int pct = 100 * pair.second.readBytes / (1 + pair.second.referencedBytes);
+    out << pair.first.id() << ": " << pct << "% " << pair.second.readBytes
+        << "/" << pair.second.numReads << std::endl;
+  }
+  return out.str();
+}
+} // namespace facebook::velox::cache

--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <cstdint>
+#include <mutex>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::cache {
+
+// Represents a stream in a table, e.g. nulls/lengths/data of a
+// particular column. Column-level access tracking uses this to
+// identify the column within a file or partition. The low 5 bits are
+// the stream kind, e.g. nulls, data etc. The high 27 bits are the node
+// number in the file schema tree, i.e. the column.
+class TrackingId {
+ public:
+  static constexpr int32_t kNodeShift = 5;
+
+  TrackingId() : id_(-1) {}
+
+  TrackingId(int32_t node, int8_t kind) : id_((node << kNodeShift) | kind) {
+    VELOX_CHECK_LT(kind, (1 << kNodeShift), "Tracker kind out of range");
+  }
+
+  size_t hash() const {
+    return std::hash<int32_t>()(id_);
+  }
+
+  bool operator==(const TrackingId& other) const {
+    return id_ == other.id_;
+  }
+
+  bool empty() const {
+    return id_ == -1;
+  }
+
+  int32_t id() const {
+    return id_;
+  }
+
+ private:
+  int32_t id_;
+};
+
+} // namespace facebook::velox::cache
+
+namespace std {
+template <>
+struct hash<::facebook::velox::cache::TrackingId> {
+  size_t operator()(const ::facebook::velox::cache::TrackingId id) const {
+    return id.hash();
+  }
+};
+} // namespace std
+
+namespace facebook::velox::cache {
+
+// Records references and actual uses of a stream.
+struct TrackingData {
+  int64_t referencedBytes{};
+  int64_t readBytes{};
+  int32_t numReferences{};
+  int32_t numReads{};
+  void incrementReference(uint64_t bytes) {
+    referencedBytes += bytes;
+    ++numReferences;
+  }
+
+  void incrementRead(uint64_t bytes) {
+    readBytes += bytes;
+    ++numReads;
+  }
+};
+
+// Tracks column access frequency during execution of a query. A
+// ScanTracker is created at the level of a Task/TableScan, so that
+// all threads of a scan report in the same tracker. The same
+// ScanTracker tracks all reads of all partitions of the scan. The
+// groupId argument identifies the file group (e.g. partition) a
+// tracking event pertains to, since a single ScanTracker can range
+// over multiple partitions.
+class ScanTracker {
+ public:
+  ScanTracker() {}
+
+  // Constructs a tracker with 'id'. The tracker will be owned by
+  // shared_ptr and will be referenced from a map from id to weak_ptr
+  // to 'this'. 'unregisterer' is supplied so that the destructor can
+  // remove the weak_ptr from the map of pending trackers.
+  ScanTracker(
+      std::string_view id,
+      std::function<void(ScanTracker*)> unregisterer)
+      : id_(id), unregisterer_(unregisterer) {}
+
+  ~ScanTracker() {
+    if (unregisterer_) {
+      unregisterer_(this);
+    }
+  }
+
+  // Records that a scan references 'bytes' bytes of the stream given
+  // by 'id'. This is called when preparing to read a stripe.
+  void recordReference(const TrackingId id, uint64_t bytes, uint64_t groupId);
+
+  // Records that 'bytes' bytes have actually been read from the stream
+  // given by 'id'.
+  void recordRead(const TrackingId id, uint64_t bytes, uint64_t groupId);
+
+  // True if 'trackingId' is read at least  'minReadPct' % of the time.
+  bool shouldPrefetch(TrackingId id, int32_t minReadPct) {
+    std::lock_guard<std::mutex> l(mutex_);
+    const auto& data = data_[id];
+    if (!data.numReferences) {
+      // Always prefetch first time data is mentioned.
+      return true;
+    }
+    return (100 * data.numReads) / data.numReferences >= minReadPct;
+  }
+
+  std::string_view id() const {
+    return id_;
+  }
+
+  std::string toString() const;
+
+ private:
+  std::mutex mutex_;
+  // Id of query + scan operator to track.
+  const std::string id_;
+  std::function<void(ScanTracker*)> unregisterer_;
+  folly::F14FastMap<TrackingId, TrackingData> data_;
+  TrackingData sum_;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -73,8 +73,17 @@ class BufferedInput {
     return ret;
   }
 
- private:
+  // True if there is free memory for prefetching the stripe. This is
+  // called to check if a stripe that is not next for read should be
+  // prefetched.
+  virtual bool shouldPreload() {
+    return false;
+  }
+
+ protected:
   dwio::common::InputStream& input_;
+
+ private:
   memory::MemoryPool& pool_;
   dwio::common::DataCacheConfig* dataCacheConfig_;
   std::vector<uint64_t> offsets_;
@@ -119,7 +128,7 @@ class BufferedInputFactory {
  public:
   virtual ~BufferedInputFactory() = default;
 
-  virtual std::unique_ptr<BufferedInput> build(
+  virtual std::unique_ptr<BufferedInput> create(
       dwio::common::InputStream& input,
       velox::memory::MemoryPool& pool,
       dwio::common::DataCacheConfig* dataCacheConfig = nullptr) const {

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# for generated headers
+include_directories(${CMAKE_BINARY_DIR})
+
 add_library(
   velox_dwio_dwrf_common
   BufferedInput.cpp
   ByteRLE.cpp
+  CachedBufferedInput.cpp
+  CacheInputStream.cpp
   Common.cpp
   Compression.cpp
   Config.cpp

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/common/CacheInputStream.h"
+#include <folly/executors/QueuedImmediateExecutor.h>
+
+namespace facebook::velox::dwrf {
+
+using velox::cache::ScanTracker;
+using velox::cache::TrackingId;
+using velox::memory::MappedMemory;
+
+CacheInputStream::CacheInputStream(
+    cache::AsyncDataCache* cache,
+    const dwio::common::Region region,
+    dwio::common::InputStream& input,
+    uint64_t fileNum,
+    std::shared_ptr<ScanTracker> tracker,
+    TrackingId trackingId,
+    uint64_t groupId)
+    : cache_(cache),
+      input_(input),
+      region_(region),
+      fileNum_(fileNum),
+      tracker_(std::move(tracker)),
+      trackingId_(trackingId),
+      groupId_(groupId) {}
+
+bool CacheInputStream::Next(const void** buffer, int32_t* size) {
+  if (position_ >= region_.length) {
+    *size = 0;
+    return false;
+  }
+  loadPosition();
+
+  *buffer = reinterpret_cast<const void**>(run_ + offsetInRun_);
+  *size = runSize_ - offsetInRun_;
+  if (position_ + *size > region_.length) {
+    *size = region_.length - position_;
+  }
+  offsetInRun_ += *size;
+  position_ += *size;
+  if (tracker_) {
+    tracker_->recordRead(trackingId_, *size, groupId_);
+  }
+  return true;
+}
+
+void CacheInputStream::BackUp(int32_t count) {
+  DWIO_ENSURE_GE(count, 0, "can't backup negative distances");
+
+  uint64_t unsignedCount = static_cast<uint64_t>(count);
+  DWIO_ENSURE(unsignedCount <= offsetInRun_, "Can't backup that much!");
+  position_ -= unsignedCount;
+}
+
+bool CacheInputStream::Skip(int32_t count) {
+  if (count < 0) {
+    return false;
+  }
+  uint64_t unsignedCount = static_cast<uint64_t>(count);
+  if (unsignedCount + position_ <= region_.length) {
+    position_ += unsignedCount;
+    return true;
+  }
+  position_ = region_.length;
+  return false;
+}
+
+google::protobuf::int64 CacheInputStream::ByteCount() const {
+  return static_cast<google::protobuf::int64>(position_);
+}
+
+void CacheInputStream::seekToRowGroup(PositionProvider& seekPosition) {
+  position_ = seekPosition.next();
+}
+
+std::string CacheInputStream::getName() const {
+  return fmt::format("CacheInputStream {} of {}", position_, region_.length);
+}
+
+size_t CacheInputStream::loadIndices(
+    const proto::RowIndex& /*rowIndex*/,
+    size_t startIndex) {
+  // not compressed, so only need to skip 1 value (uncompressed position)
+  return startIndex + 1;
+}
+
+namespace {
+std::vector<folly::Range<char*>> makeRanges(
+    cache::AsyncDataCacheEntry* entry,
+    size_t length) {
+  std::vector<folly::Range<char*>> buffers;
+  if (entry->tinyData() == nullptr) {
+    auto& allocation = entry->data();
+    buffers.reserve(allocation.numRuns());
+    uint64_t offsetInRuns = 0;
+    for (int i = 0; i < allocation.numRuns(); ++i) {
+      auto run = allocation.runAt(i);
+      uint64_t bytes = run.numPages() * MappedMemory::kPageSize;
+      uint64_t readSize = std::min(bytes, length - offsetInRuns);
+      buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
+      offsetInRuns += readSize;
+    }
+  } else {
+    buffers.push_back(folly::Range<char*>(entry->tinyData(), entry->size()));
+  }
+  return buffers;
+}
+} // namespace
+
+void CacheInputStream::loadSync(dwio::common::Region region) {
+  do {
+    folly::SemiFuture<bool> wait(false);
+    cache::RawFileCacheKey key{fileNum_, region.offset};
+    pin_.clear();
+    pin_ = cache_->findOrCreate(key, region.length, &wait);
+    if (pin_.empty()) {
+      VELOX_CHECK(wait.valid());
+      auto& exec = folly::QueuedImmediateExecutor::instance();
+      std::move(wait).via(&exec).wait();
+      continue;
+    }
+    if (pin_.entry()->isExclusive()) {
+      auto ranges = makeRanges(pin_.entry(), region.length);
+      input_.read(ranges, region.offset, dwio::common::LogType::FILE);
+      pin_.entry()->setValid(true);
+      pin_.entry()->setExclusiveToShared();
+    } else {
+      pin_.entry()->ensureLoaded(true);
+    }
+  } while (pin_.empty());
+}
+
+void CacheInputStream::loadPosition() {
+  auto offset = region_.offset;
+  if (pin_.empty()) {
+    auto loadRegion = region_;
+    loadRegion.offset += (position_ / loadQuantum_) * loadQuantum_;
+    loadRegion.length =
+        std::min<int32_t>(loadQuantum_, region_.length - position_);
+    loadSync(loadRegion);
+  }
+  auto* entry = pin_.entry();
+  uint64_t positionInFile = offset + position_;
+  if (entry->offset() <= positionInFile &&
+      entry->offset() + entry->size() > positionInFile) {
+    // The position is inside the range of 'entry'.
+    auto offsetInEntry = positionInFile - entry->offset();
+    if (entry->data().numPages() == 0) {
+      run_ = reinterpret_cast<uint8_t*>(entry->tinyData());
+      runSize_ = entry->size();
+      offsetInRun_ = offsetInEntry;
+      offsetOfRun_ = 0;
+    } else {
+      entry->data().findRun(offsetInEntry, &runIndex_, &offsetInRun_);
+      offsetOfRun_ = offsetInEntry - offsetInRun_;
+      auto run = entry->data().runAt(runIndex_);
+      run_ = run.data();
+      runSize_ = run.numPages() * MappedMemory::kPageSize;
+      if (offsetOfRun_ + runSize_ > entry->size()) {
+        runSize_ = entry->size() - offsetOfRun_;
+      }
+    }
+  } else {
+    pin_.clear();
+    loadPosition();
+  }
+}
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/ScanTracker.h"
+#include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/dwrf/common/InputStream.h"
+
+namespace facebook::velox::dwrf {
+
+class CacheInputStream : public SeekableInputStream {
+ public:
+  static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
+  CacheInputStream(
+      cache::AsyncDataCache* cache,
+      const dwio::common::Region region,
+      dwio::common::InputStream& input,
+      uint64_t fileNum,
+      std::shared_ptr<cache::ScanTracker> tracker,
+      cache::TrackingId trackingId,
+      uint64_t groupId);
+
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  google::protobuf::int64 ByteCount() const override;
+  void seekToRowGroup(PositionProvider& position) override;
+  std::string getName() const override;
+  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
+      override;
+
+ private:
+  void loadPosition();
+  void loadSync(dwio::common::Region region);
+  cache::AsyncDataCache* const cache_;
+  dwio::common::InputStream& input_;
+  // The region of 'input' 'this' ranges over.
+  const dwio::common::Region region_;
+  const uint64_t fileNum_;
+  std::shared_ptr<cache::ScanTracker> tracker_;
+  const cache::TrackingId trackingId_;
+  const uint64_t groupId_;
+
+  // Maximum number of bytes read from 'input' at a time. This gives the maximum
+  // pin_.entry()->size().
+  int32_t loadQuantum_{kDefaultLoadQuantum};
+
+  // Handle of cache entry.
+  cache::CachePin pin_;
+
+  // Offset of current run from start of 'entry_->data()'
+  uint64_t offsetOfRun_;
+
+  // Pointer  to start of  current run in 'entry->data()' or
+  // 'entry->tinyData()'.
+  uint8_t* run_{nullptr};
+  // Position of stream relative to 'run_'.
+  int offsetInRun_{0};
+  // Index of run in 'entry_->data()'
+  int runIndex_ = -1;
+  // Number of valid bytes above 'run_'.
+  uint32_t runSize_ = 0;
+  // Position relative to 'region_.offset'.
+  uint64_t position_ = 0;
+};
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
+#include "velox/dwio/dwrf/common/CacheInputStream.h"
+
+namespace facebook::velox::dwrf {
+
+using cache::CachePin;
+using cache::LoadState;
+using cache::RawFileCacheKey;
+using cache::ScanTracker;
+using cache::TrackingId;
+using memory::MappedMemory;
+
+std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
+    dwio::common::Region region,
+    const StreamIdentifier* si = nullptr) {
+  TrackingId id;
+  if (si) {
+    id = TrackingId(si->node, si->kind);
+  }
+  requests_.emplace_back(CacheRequest{
+      RawFileCacheKey{fileNum_, region.offset}, region.length, id, CachePin()});
+  tracker_->recordReference(id, region.length, groupId_);
+  return std::make_unique<CacheInputStream>(
+      cache_, region, input_, fileNum_, tracker_, id, groupId_);
+}
+
+bool CachedBufferedInput::isBuffered(uint64_t offset, uint64_t length) const {
+  return false;
+}
+
+bool CachedBufferedInput::shouldPreload() {
+  // True if after scheduling this for preload, half the capacity
+  // would be in a loading but not yet accessed state.
+  if (requests_.empty()) {
+    return false;
+  }
+  int32_t numPages = 0;
+  for (auto& request : requests_) {
+    numPages += bits::roundUp(
+                    std::min<int32_t>(
+                        request.size, CacheInputStream::kDefaultLoadQuantum),
+                    MappedMemory::kPageSize) /
+        MappedMemory::kPageSize;
+  }
+  auto cachePages = cache_->incrementCachedPages(0);
+  auto maxCache = cache_->maxBytes() / MappedMemory::kPageSize;
+  auto prefetchPages = cache_->incrementPrefetchPages(0);
+  if (numPages + prefetchPages < cachePages / 2) {
+    return true;
+  }
+  return false;
+}
+
+void CachedBufferedInput::load(const dwio::common::LogType) {
+  std::vector<CacheRequest*> toLoad;
+  // 'requests_ is cleared on exit.
+  int32_t numNewLoads = 0;
+  auto requests = std::move(requests_);
+  for (auto& request : requests) {
+    if (tracker_->shouldPrefetch(request.trackingId, 3)) {
+      request.pin = cache_->findOrCreate(request.key, request.size, nullptr);
+      if (request.pin.empty()) {
+        // Already loading for another thread.
+        continue;
+      }
+      if (request.pin.entry()->isExclusive()) {
+        // A new entry to be filled.
+        request.pin.entry()->setPrefetch();
+        toLoad.push_back(&request);
+      } else {
+        // Already in cache, access time is refreshed.
+        request.pin.clear();
+      }
+    }
+  }
+  if (toLoad.empty()) {
+    return;
+  }
+  loadFromSsd(toLoad);
+  if (toLoad.empty()) {
+    return;
+  }
+  std::sort(
+      toLoad.begin(),
+      toLoad.end(),
+      [&](const CacheRequest* left, const CacheRequest* right) {
+        return left->key.offset < right->key.offset;
+      });
+  // Combine adjacent short reads.
+  dwio::common::Region last = {0, 0};
+  std::vector<CachePin> readBatch;
+
+  for (const auto& request : toLoad) {
+    auto* entry = request->pin.entry();
+    auto entryRegion = dwio::common::Region{
+        static_cast<uint64_t>(entry->offset()),
+        static_cast<uint64_t>(entry->size())};
+    VELOX_CHECK_LT(0, entryRegion.length);
+    if (last.length == 0) {
+      // first region
+      last = entryRegion;
+    } else if (!tryMerge(last, entryRegion)) {
+      ++numNewLoads;
+      readRegion(std::move(readBatch));
+      last = entryRegion;
+    }
+    readBatch.push_back(std::move(request->pin));
+  }
+  ++numNewLoads;
+  readRegion(std::move(readBatch));
+  if (executor_ && numNewLoads > 1) {
+    for (auto& load : fusedLoads_) {
+      if (load->state() == LoadState::kPlanned) {
+        executor_->add(
+            [pendingLoad = load]() { pendingLoad->loadOrFuture(nullptr); });
+      }
+    }
+  }
+}
+
+bool CachedBufferedInput::tryMerge(
+    dwio::common::Region& first,
+    const dwio::common::Region& second) {
+  DWIO_ENSURE_GE(second.offset, first.offset, "regions should be sorted.");
+  int64_t gap = second.offset - first.offset - first.length;
+  if (gap < 0) {
+    // We do not support one region going to two target buffers.
+    return false;
+  }
+  // compare with 0 since it's comparison in different types
+  if (gap <= kMaxMergeDistance) {
+    int64_t extension = gap + second.length;
+
+    if (extension > 0) {
+      first.length += extension;
+      if ((input_.getStats() != nullptr) && gap > 0) {
+        input_.getStats()->incRawOverreadBytes(gap);
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+namespace {
+class DwrfFusedLoad : public cache::FusedLoad {
+ public:
+  void initialize(
+      std::vector<CachePin>&& pins,
+      std::unique_ptr<AbstractInputStreamHolder> input) {
+    input_ = std::move(input);
+    cache::FusedLoad::initialize(std::move(pins));
+  }
+
+  void loadData() override {
+    auto& stream = input_->get();
+    std::vector<folly::Range<char*>> buffers;
+    uint64_t start = pins_[0].entry()->offset();
+    uint64_t lastOffset = start;
+    for (auto& pin : pins_) {
+      auto& buffer = pin.entry()->data();
+      uint64_t startOffset = pin.entry()->offset();
+      if (lastOffset < startOffset) {
+        buffers.push_back(
+            folly::Range<char*>(nullptr, startOffset - lastOffset));
+      }
+
+      auto size = pin.entry()->size();
+      uint64_t offsetInRuns = 0;
+      if (buffer.numPages() == 0) {
+        buffers.push_back(folly::Range<char*>(pin.entry()->tinyData(), size));
+        offsetInRuns = size;
+      } else {
+        for (int i = 0; i < buffer.numRuns(); ++i) {
+          velox::memory::MappedMemory::PageRun run = buffer.runAt(i);
+          uint64_t bytes = run.numBytes();
+          uint64_t readSize = std::min(bytes, size - offsetInRuns);
+          buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
+          offsetInRuns += readSize;
+        }
+      }
+      DWIO_ENSURE(offsetInRuns == size);
+      lastOffset = startOffset + size;
+    }
+
+    stream.read(buffers, start, dwio::common::LogType::FILE);
+  }
+
+ private:
+  std::unique_ptr<AbstractInputStreamHolder> input_;
+};
+} // namespace
+
+void CachedBufferedInput::readRegion(std::vector<CachePin> pins) {
+  auto load = std::make_shared<DwrfFusedLoad>();
+  load->initialize(std::move(pins), streamSource_());
+  fusedLoads_.push_back(load);
+}
+
+std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
+    uint64_t offset,
+    uint64_t length,
+    dwio::common::LogType logType) const {
+  return std::make_unique<CacheInputStream>(
+      cache_,
+      dwio::common::Region{offset, length},
+      input_,
+      fileNum_,
+      nullptr,
+      TrackingId(),
+      0);
+}
+
+void CachedBufferedInput::loadFromSsd(std::vector<CacheRequest*> requests) {
+  // No op placeholder.
+}
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/ScanTracker.h"
+#include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/dwrf/common/BufferedInput.h"
+
+#include <folly/executors/IOThreadPoolExecutor.h>
+
+namespace facebook::velox::dwrf {
+
+// Abstract class for owning an InputStream and related structures
+// like pins into file handle caches. TODO: Make file handle cache
+// produce shared_ptr<InputStream> and write all in terms of these.
+class AbstractInputStreamHolder {
+ public:
+  virtual ~AbstractInputStreamHolder() = default;
+  virtual dwio::common::InputStream& get() = 0;
+};
+
+// Function type for making copies of InputStream for running
+// parammel loads. We cannot pass the one non-owned InputStream to
+// other threads because the BufferedInput and its owner could be
+// destroyed out of sequence and the streams are owned via
+// unique_ptr. TODO: Make all streams owned via shared_ptr.
+using StreamSource =
+    std::function<std::unique_ptr<AbstractInputStreamHolder>()>;
+
+class CachedBufferedInput : public BufferedInput {
+ public:
+  CachedBufferedInput(
+      dwio::common::InputStream& input,
+      memory::MemoryPool& pool,
+      dwio::common::DataCacheConfig* dataCacheConfig,
+      cache::AsyncDataCache* cache,
+      std::shared_ptr<cache::ScanTracker> tracker,
+      uint64_t groupId,
+      StreamSource streamSource,
+      folly::IOThreadPoolExecutor* executor)
+      : BufferedInput(input, pool, dataCacheConfig),
+        cache_(cache),
+        fileNum_(dataCacheConfig->filenum),
+        tracker_(std::move(tracker)),
+        groupId_(groupId),
+        streamSource_(streamSource),
+        executor_(executor) {}
+
+  CachedBufferedInput(CachedBufferedInput&&) = default;
+
+  ~CachedBufferedInput() {
+    for (auto& load : fusedLoads_) {
+      load->cancel();
+    }
+  }
+
+  const std::string& getName() const override {
+    return input_.getName();
+  }
+
+  std::unique_ptr<SeekableInputStream> enqueue(
+      dwio::common::Region region,
+      const StreamIdentifier* si) override;
+
+  void load(const dwio::common::LogType) override;
+
+  bool isBuffered(uint64_t offset, uint64_t length) const override;
+
+  std::unique_ptr<SeekableInputStream> read(
+      uint64_t offset,
+      uint64_t length,
+      dwio::common::LogType logType) const override;
+
+  bool shouldPreload() override;
+
+ private:
+  struct CacheRequest {
+    cache::RawFileCacheKey key;
+    uint64_t size;
+    cache::TrackingId trackingId;
+    cache::CachePin pin;
+  };
+
+  // Updates first  to include second if they are near enough to justify merging
+  // the IO.
+  bool tryMerge(
+      dwio::common::Region& first,
+      const dwio::common::Region& second);
+
+  // Schedules 'pins' to be read in a single IO covering
+  // 'region'. 'pins are sorted and non-overlapping and do not have
+  // excessive gaps between the end of one and the start of the next.
+  void readRegion(std::vector<cache::CachePin> pins);
+
+  // Removes the requests from 'toLoad' if they hit SSD cache. May start
+  // background load from SSD.
+  void loadFromSsd(std::vector<CacheRequest*> requests);
+
+  cache::AsyncDataCache* cache_;
+  const uint64_t fileNum_;
+  std::shared_ptr<cache::ScanTracker> tracker_;
+  const uint64_t groupId_;
+  StreamSource streamSource_;
+  folly::IOThreadPoolExecutor* const executor_;
+
+  // Pins that are candidates for loading.
+  std::vector<CacheRequest> requests_;
+  // Coalesced loads spanning multiple cache entries in one IO.
+  std::vector<std::shared_ptr<cache::FusedLoad>> fusedLoads_;
+};
+
+class CachedBufferedInputFactory : public BufferedInputFactory {
+ public:
+  CachedBufferedInputFactory(
+      cache::AsyncDataCache* cache,
+      std::shared_ptr<cache::ScanTracker> tracker,
+      uint64_t groupId,
+      StreamSource streamSource,
+      folly::IOThreadPoolExecutor* executor)
+      : cache_(cache),
+        tracker_(std::move(tracker)),
+        groupId_(groupId),
+        streamSource_(streamSource),
+        executor_(executor) {}
+  ~CachedBufferedInputFactory() = default;
+
+  std::unique_ptr<BufferedInput> create(
+      dwio::common::InputStream& input,
+      velox::memory::MemoryPool& pool,
+      dwio::common::DataCacheConfig* dataCacheConfig = nullptr) const {
+    return std::make_unique<CachedBufferedInput>(
+        input,
+        pool,
+        dataCacheConfig,
+        cache_,
+        tracker_,
+        groupId_,
+        streamSource_,
+        executor_);
+  }
+
+  std::string toString() const {
+    if (tracker_) {
+      return tracker_->toString();
+    }
+    return "";
+  }
+
+ private:
+  cache::AsyncDataCache* const cache_;
+  std::shared_ptr<cache::ScanTracker> tracker_;
+  const uint64_t groupId_;
+  StreamSource streamSource_;
+  folly::IOThreadPoolExecutor* executor_;
+};
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -92,7 +92,7 @@ ReaderBase::ReaderBase(
       arena_(std::make_unique<google::protobuf::Arena>()),
       bufferedInputFactory_(bufferedInputFactory),
       dataCacheConfig_(dataCacheConfig) {
-  input_ = bufferedInputFactory_->build(*stream_, pool, dataCacheConfig);
+  input_ = bufferedInputFactory_->create(*stream_, pool, dataCacheConfig);
 
   // We may have cached the tail before, in which case we can skip the read.
   if (dataCacheConfig) {

--- a/velox/dwio/dwrf/reader/StripeReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.cpp
@@ -36,7 +36,7 @@ const proto::StripeInformation& StripeReaderBase::loadStripe(
     // if file is preloaded, return stripe is preloaded
     preload = true;
   } else {
-    stripeInput_ = reader_->bufferedInputFactory().build(
+    stripeInput_ = reader_->bufferedInputFactory().create(
         reader_->getStream(),
         reader_->getMemoryPool(),
         reader_->getDataCacheConfig());

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -14,6 +14,9 @@
 
 add_subdirectory(utils)
 
+# for generated headers
+include_directories(${CMAKE_BINARY_DIR})
+
 set(VELOX_LINK_LIBS
     velox_dwio_common
     velox_dwio_common_exception
@@ -117,6 +120,12 @@ add_test(velox_dwio_dwrf_buffered_input_test
          velox_dwio_dwrf_buffered_input_test)
 
 target_link_libraries(velox_dwio_dwrf_buffered_input_test ${VELOX_LINK_LIBS}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+
+add_executable(velox_dwio_dwrf_cache_input_test CacheInputTest.cpp)
+add_test(velox_dwio_dwrf_cache_input_test velox_dwio_dwrf_cache_input_test)
+
+target_link_libraries(velox_dwio_dwrf_cache_input_test ${VELOX_LINK_LIBS}
                       ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_dictionary_encoder_test
@@ -456,7 +465,7 @@ target_link_libraries(
 add_executable(velox_dwrf_int_decoder_benchmark IntDecoderBenchmark.cpp)
 target_link_libraries(
   velox_dwrf_int_decoder_benchmark velox_dwio_common_exception velox_exception
-  velox_dwio_dwrf_common ${FOLLY} ${FOLLY_BENCHMARK})
+  ${FOLLY} ${FOLLY_BENCHMARK})
 
 add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
 target_link_libraries(

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <folly/container/F14Map.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include "velox/common/caching/FileIds.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::dwio;
+using namespace facebook::velox::cache;
+
+using facebook::dwio::common::Region;
+using memory::MappedMemory;
+
+// Testing stream producing deterministic data. The byte at offset is
+// the low byte of 'seed_' + offset.
+class TestInputStream : public common::InputStream {
+ public:
+  TestInputStream(const std::string& path, uint64_t seed, uint64_t length)
+      : InputStream(path), seed_(seed), length_(length) {}
+
+  uint64_t getLength() const override {
+    return length_;
+  }
+
+  uint64_t getNaturalReadSize() const override {
+    return 1024 * 1024;
+  }
+
+  void read(void* buffer, uint64_t length, uint64_t offset, common::LogType)
+      override {
+    int fill;
+    uint64_t content = offset + seed_;
+    uint64_t available = std::min(length_ - offset, length);
+    for (fill = 0; fill < (available); ++fill) {
+      reinterpret_cast<char*>(buffer)[fill] = content + fill;
+    }
+  }
+
+  // Asserts that 'bytes' is as would be read from 'offset'.
+  void checkData(const void* bytes, uint64_t offset, int32_t size) {
+    for (auto i = 0; i < size; ++i) {
+      char expected = seed_ + offset + i;
+      ASSERT_EQ(expected, reinterpret_cast<const char*>(bytes)[i]);
+    }
+  }
+
+ private:
+  const uint64_t seed_;
+  const uint64_t length_;
+};
+class TestInputStreamHolder : public dwrf::AbstractInputStreamHolder {
+ public:
+  TestInputStreamHolder(std::shared_ptr<common::InputStream> stream)
+      : stream_(std::move(stream)) {}
+
+  common::InputStream& get() override {
+    return *stream_;
+  }
+
+ private:
+  std::shared_ptr<common::InputStream> stream_;
+};
+
+class CacheTest : public testing::Test {
+ protected:
+  static constexpr int32_t kMaxStreams = 100;
+
+  // Describes a piece of file potentially read by this test.
+  struct StripeData {
+    TestInputStream* file;
+    std::unique_ptr<dwrf::CachedBufferedInput> input;
+    std::vector<std::unique_ptr<dwrf::SeekableInputStream>> streams;
+    std::vector<common::Region> regions;
+  };
+
+  void SetUp() override {
+    executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
+    rng_.seed(1);
+  }
+
+  void TearDown() override {
+    executor_->join();
+  }
+
+  void initializeCache(int64_t maxBytes) {
+    cache_ =
+        std::make_unique<AsyncDataCache>(MappedMemory::getInstance(), maxBytes);
+    for (auto i = 0; i < kMaxStreams; ++i) {
+      streamIds_.push_back(std::make_unique<dwrf::StreamIdentifier>(
+          i, i, 0, dwrf::StreamKind_DATA));
+    }
+    streamStarts_.resize(kMaxStreams + 1);
+    streamStarts_[0] = 0;
+    int32_t spacing = 100;
+    for (auto i = 1; i <= kMaxStreams; ++i) {
+      streamStarts_[i] = streamStarts_[i - 1] + spacing * i;
+      if (i < kMaxStreams / 3) {
+        spacing += 1000;
+      } else if (i < kMaxStreams / 3 * 2) {
+        spacing += 10000;
+      } else {
+        spacing += 100000;
+      }
+    }
+  }
+
+  uint64_t seedByPath(const std::string& path) {
+    StringIdLease lease(fileIds(), path);
+    return lease.id();
+  }
+
+  std::shared_ptr<common::InputStream>
+  inputByPath(const std::string& path, uint64_t& fileId, uint64_t& groupId) {
+    StringIdLease lease(fileIds(), path);
+    fileId = lease.id();
+    // 2 files in a group.
+    groupId = fileId / 2;
+    auto it = pathToInput_.find(lease.id());
+    if (it == pathToInput_.end()) {
+      fileIds_.push_back(lease);
+      auto stream =
+          std::make_shared<TestInputStream>(path, lease.id(), 1UL << 63);
+      pathToInput_[lease.id()] = stream;
+      return stream;
+    }
+    return it->second;
+  }
+
+  std::unique_ptr<StripeData> makeStripeData(
+      std::shared_ptr<common::InputStream> inputStream,
+      std::shared_ptr<ScanTracker> tracker,
+      uint64_t fileId,
+      uint64_t groupId,
+      int32_t numColumns,
+      int64_t offset) {
+    auto data = std::make_unique<StripeData>();
+    common::DataCacheConfig config{nullptr, fileId};
+    data->input = std::make_unique<dwrf::CachedBufferedInput>(
+        *inputStream,
+        *pool_,
+        &config,
+        cache_.get(),
+        tracker,
+        groupId,
+        [inputStream]() {
+          return std::make_unique<TestInputStreamHolder>(inputStream);
+        },
+        executor_.get());
+    data->file = dynamic_cast<TestInputStream*>(inputStream.get());
+    for (auto i = 0; i < streamStarts_.size() - 1; ++i) {
+      // Each region is covers half the space from its start to the
+      // start of the next or at max a little under 20MB.
+      Region region{
+          offset + streamStarts_[i],
+          std::min<uint64_t>(
+              (1 << 20) - 11, (streamStarts_[i + 1] - streamStarts_[i]) / 2)};
+      data->streams.push_back(
+          data->input->enqueue(region, streamIds_[i].get()));
+      data->regions.push_back(region);
+    }
+    return data;
+  }
+
+  bool shouldRead(int32_t columnIndex, int32_t readPct, int32_t modulo) {
+    return folly::Random::rand32(rng_) % 100 <
+        readPct / ((columnIndex % modulo) + 1);
+  }
+
+  void readStream(const StripeData& stripe, int32_t columnIndex) {
+    const void* data;
+    int32_t size;
+    int64_t numRead = 0;
+    auto& stream = *stripe.streams[columnIndex];
+    auto region = stripe.regions[columnIndex];
+    do {
+      stream.Next(&data, &size);
+      stripe.file->checkData(data, region.offset + numRead, size);
+      numRead += size;
+    } while (size > 0);
+    EXPECT_EQ(numRead, region.length);
+    // Test random access
+    std::vector<uint64_t> offsets = {
+        0, region.length / 3, region.length * 2 / 3};
+    dwrf::PositionProvider positions(offsets);
+    for (auto i = 0; i < offsets.size(); ++i) {
+      stream.seekToRowGroup(positions);
+      checkRandomRead(stripe, stream, offsets, i, region);
+    }
+  }
+
+  void checkRandomRead(
+      const StripeData& stripe,
+      dwrf::SeekableInputStream& stream,
+      const std::vector<uint64_t>& offsets,
+      int32_t i,
+      common::Region region) {
+    const void* data;
+    int32_t size;
+    int64_t numRead = 0;
+    auto offset = offsets[i];
+    // Reads from offset to halfway to the next offset or end.
+    auto toRead =
+        ((i == offsets.size() - 1 ? region.length : offsets[i + 1]) - offset) /
+        2;
+
+    do {
+      stream.Next(&data, &size);
+      stripe.file->checkData(data, region.offset + offset, size);
+      numRead += size;
+      offset += size;
+      if (size == 0 && numRead) {
+        FAIL() << "Stream end prematurely after  random seek";
+      }
+    } while (numRead < toRead);
+  }
+
+  // Makes a series of kReadAhead CachedBufferedInputs for consecutive
+  // stripes and starts background load guided by the load frequency
+  // in the previous stripes. When at end, destroys a set of
+  // CachedBufferedInputs and their streams while they are in a
+  // background loading state.
+  void readLoop(
+      const std::string filename,
+      int numColumns,
+      int32_t readPct,
+      int32_t readPctModulo,
+      int32_t numStripes) {
+    auto tracker = std::make_shared<ScanTracker>();
+    std::deque<std::unique_ptr<StripeData>> stripes;
+    constexpr int32_t kReadAhead = 8;
+    uint64_t fileId;
+    uint64_t groupId;
+    std::shared_ptr<common::InputStream> input =
+        inputByPath(filename, fileId, groupId);
+    uint64_t seed = seedByPath(filename);
+    for (auto stripeIndex = 0; stripeIndex < numStripes; ++stripeIndex) {
+      stripes.push_back(makeStripeData(
+          input,
+          tracker,
+          fileId,
+          groupId,
+          numColumns,
+          stripeIndex * streamStarts_[kMaxStreams - 1]));
+      stripes.back()->input->load(common::LogType::TEST);
+      if (stripeIndex > 0) {
+        while (stripes.size() < kReadAhead) {
+          stripes.push_back(makeStripeData(
+              input,
+              tracker,
+              fileId,
+              groupId,
+              numColumns,
+              stripeIndex * streamStarts_[kMaxStreams - 1]));
+          if (stripes.back()->input->shouldPreload()) {
+            stripes.back()->input->load(common::LogType::TEST);
+          }
+        }
+      }
+      auto currentStripe = std::move(stripes.front());
+      stripes.pop_front();
+      currentStripe->input->load(common::LogType::TEST);
+      for (auto i = 0; i < numColumns; ++i) {
+        int32_t columnIndex = i * (kMaxStreams / numColumns);
+        if (shouldRead(columnIndex, readPct, readPctModulo)) {
+          readStream(*currentStripe, columnIndex);
+        }
+      }
+    }
+  }
+
+  std::vector<StringIdLease> fileIds_;
+  folly::F14FastMap<uint64_t, std::shared_ptr<common::InputStream>>
+      pathToInput_;
+  common::DataCacheConfig config_;
+  std::unique_ptr<AsyncDataCache> cache_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+
+  // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
+  std::vector<std::unique_ptr<dwrf::StreamIdentifier>> streamIds_;
+
+  // Start offset of each simulated stream in a simulated stripe.
+  std::vector<uint64_t> streamStarts_;
+  folly::Random::DefaultGenerator rng_;
+};
+
+TEST_F(CacheTest, bufferedInput) {
+  // Size 160 MB. Frequent evictions and not everything fits in prefetch window.
+  initializeCache(160 << 20);
+  readLoop("testfile", 30, 70, 10, 20);
+  readLoop("testfile", 30, 70, 10, 20);
+  readLoop("testfile2", 30, 70, 70, 20);
+}
+
+TEST_F(CacheTest, TestSingleFileThreads) {
+  initializeCache(1 << 30);
+
+  const int numThreads = 4;
+  std::vector<std::thread> threads;
+  threads.reserve(numThreads);
+  for (int i = 0; i < numThreads; ++i) {
+    threads.push_back(std::thread(
+        [&]() { readLoop(fmt::format("testfile{}", i), 10, 70, 10, 20); }));
+  }
+  for (int i = 0; i < numThreads; ++i) {
+    threads[i].join();
+  }
+}


### PR DESCRIPTION
- Adds BufferedInput subclass to manage cached input
- Adds ScanTracker to record planned vs. actual reads
- Adds prefetching into cache if there is space.