### PR TITLE
Add support for semi and anti joins

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -792,6 +792,30 @@ class HashJoinNode : public PlanNode {
     return joinType_;
   }
 
+  bool isInnerJoin() const {
+    return joinType_ == JoinType::kInner;
+  }
+
+  bool isLeftJoin() const {
+    return joinType_ == JoinType::kLeft;
+  }
+
+  bool isRightJoin() const {
+    return joinType_ == JoinType::kRight;
+  }
+
+  bool isFullJoin() const {
+    return joinType_ == JoinType::kFull;
+  }
+
+  bool isSemiJoin() const {
+    return joinType_ == JoinType::kSemi;
+  }
+
+  bool isAntiJoin() const {
+    return joinType_ == JoinType::kAnti;
+  }
+
   const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys()
       const {
     return leftKeys_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -56,6 +56,8 @@ class HashProbe : public Operator {
   // 'rowNumberMapping_'. Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows);
 
+  const core::JoinType joinType_;
+
   std::unique_ptr<HashLookup> lookup_;
 
   // Channel of probe keys in 'input_'.
@@ -106,9 +108,13 @@ class HashProbe : public Operator {
 
   // Keeps track of returned results between successive batches of
   // output for a batch of input.
-  BaseHashTable::JoinResultIterator results;
+  BaseHashTable::JoinResultIterator results_;
 
-  // Active rows in the current batch of input.
+  // Input rows with no nulls in the join keys.
+  SelectivityVector nonNullRows_;
+
+  // Input rows with a hash match. This is a subset of rows with no nulls in the
+  // join keys and a superset of rows that have a match on the build side.
   SelectivityVector activeRows_;
 };
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -59,7 +59,7 @@ class BaseHashTable {
   static constexpr uint64_t kArrayHashMaxSize = 2L << 20;
   enum class HashMode { kHash, kArray, kNormalizedKey };
 
-  // Keeps track of results returned from a joi table. One batch of
+  // Keeps track of results returned from a join table. One batch of
   // keys can produce multiple batches of results. This is initialized
   // from HashLookup, which is expected to stay constant while 'this'
   // is being used.


### PR DESCRIPTION
Semi join is used for queries like:

    SELECT * FROM t WHERE t.key IN (SELECT key FROM u)

Anti join is used for queries like:

    SELECT * FROM t WHERE t.key NOT IN (SELECT key FROM u)

Semi join returns probe rows which have at least one match in the build side.
Anti join returns probe rows which have no match in the build side. There are
two exceptional cases for the anti join:

- When build side contains an entry with a null in join keys, the join returns
  no rows.
- When build side is empty, the join returns all rows.

The HashBuild operator for semi and anti join configures the hash table to not
store entries with duplicate keys as these are not needed.

Since support for anti join required handing of empty build side, I also added
a shortcut for the inner join to finish early if build side is empty.