### PR TITLE
Rename ToString and ToFileFormat functions

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   InputStream.cpp
   IoStatistics.cpp
   MemoryInputStream.cpp
+  Options.cpp
   TypeWithId.cpp)
 
 target_link_libraries(

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -20,7 +20,7 @@ namespace facebook {
 namespace dwio {
 namespace common {
 
-FileFormat ToFileFormat(std::string s) {
+FileFormat toFileFormat(std::string s) {
   if (s == "orc") {
     return FileFormat::ORC;
   } else if (s == "rc") {
@@ -37,7 +37,7 @@ FileFormat ToFileFormat(std::string s) {
   return FileFormat::UNKNOWN;
 }
 
-std::string ToString(FileFormat fmt) {
+std::string toString(FileFormat fmt) {
   switch (fmt) {
     case FileFormat::ORC:
       return "orc";

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -45,8 +45,8 @@ enum class FileFormat {
   JSON = 6,
 };
 
-FileFormat ToFileFormat(std::string s);
-std::string ToString(FileFormat fmt);
+FileFormat toFileFormat(std::string s);
+std::string toString(FileFormat fmt);
 
 /**
  * Formatting options for serialization.


### PR DESCRIPTION
Summary: Also, add Options.cpp which contains the implementations of the toString and toFileFormat functions to cmake.

Reviewed By: pedroerp

Differential Revision: D30513441

