### PR TITLE
Fix SelectivityVector::select

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -217,10 +217,7 @@ class SelectivityVector {
    */
   void select(const SelectivityVector& other) {
     bits::orBits(
-        bits_.data(),
-        other.bits_.data(),
-        0,
-        std::min(size_, other.size()));
+        bits_.data(), other.bits_.data(), 0, std::min(size_, other.size()));
     updateBounds();
   }
 

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -60,7 +60,11 @@ void assertState(
   }
 }
 
-void assertIsValid(int from, int to, const SelectivityVector& vector, bool value) {
+void assertIsValid(
+    int from,
+    int to,
+    const SelectivityVector& vector,
+    bool value) {
   for (int i = from; i < to; i++) {
     ASSERT_EQ(value, vector.isValid(i));
   }


### PR DESCRIPTION
Currently SelectivityVector::select will not OR any bits if a vector doesnt have any set any bits in them. It will also not OR anything outside the begin_, end_ range, which is not what a user might expect. 