### PR TITLE
Use VELOX_CHECK_EQ(a, b) instead of VELOX_CHECK(a == b) in MapKeysAndValues

### DIFF
--- a/velox/functions/common/MapKeysAndValues.cpp
+++ b/velox/functions/common/MapKeysAndValues.cpp
@@ -57,7 +57,7 @@ class MapKeysFunction : public MapKeyValueFunction {
       exec::Expr* /* caller */,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    VELOX_CHECK(args.size() == 1);
+    VELOX_CHECK_EQ(args.size(), 1);
     auto arg = args[0];
 
     VELOX_CHECK(
@@ -91,7 +91,7 @@ class MapValuesFunction : public MapKeyValueFunction {
       exec::Expr* /* caller */,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    VELOX_CHECK(args.size() == 1);
+    VELOX_CHECK_EQ(args.size(), 1);
     auto arg = args[0];
 
     VELOX_CHECK(


### PR DESCRIPTION
Summary: Minor change to give nicer error messages.

Reviewed By: amitkdutta

Differential Revision: D30527174

