### PR TITLE
Add arbitration of competing memory asks between Tasks

### DIFF
--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_subdirectory(tests)
 
 add_library(velox_memory Memory.cpp MemoryUsage.cpp MappedMemory.cpp
-                         MemoryUsageTracker.cpp)
+                         MemoryUsageTracker.cpp MemoryManagerStrategy.cpp)
 
 target_link_libraries(velox_memory velox_flag_definitions velox_exception
                       ${FOLLY_WITH_DEPENDENCIES} ${fmt})

--- a/velox/common/memory/MemoryManagerStrategy.cpp
+++ b/velox/common/memory/MemoryManagerStrategy.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/MemoryManagerStrategy.h"
+#include <unistd.h>
+
+#include <folly/executors/task_queue/UnboundedBlockingQueue.h>
+#include <folly/executors/thread_factory/InitThreadFactory.h>
+
+namespace facebook::velox::memory {
+
+bool MemoryManagerStrategy::initialized_;
+MemoryManagerStrategy::MemoryManagerStrategyFactory
+    MemoryManagerStrategy::factory_;
+
+// static
+MemoryManagerStrategy* MemoryManagerStrategy::instance() {
+  static std::unique_ptr<MemoryManagerStrategy> strategy =
+      (factory_) ? factory_() : createDefault();
+  initialized_ = true;
+  return strategy.get();
+}
+
+std::unique_ptr<MemoryManagerStrategy> MemoryManagerStrategy::createDefault() {
+  return std::make_unique<DefaultMemoryManagerStrategy>();
+}
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryManagerStrategy.h
+++ b/velox/common/memory/MemoryManagerStrategy.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+
+#pragma once
+
+#include <folly/futures/Future.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/MemoryUsageTracker.h"
+
+namespace facebook::velox::memory {
+class MemoryPool;
+class ScopedMemoryPool;
+
+enum class UsageLevel { kDefault, kProcess, kSpiller, kCache, kQuery };
+
+class MemoryConsumer {
+ public:
+  virtual ~MemoryConsumer() {}
+
+  virtual void updateMemoryUsageConfig(const MemoryUsageConfig& config) = 0;
+
+  // Returns the number of bytes that this memory consumer overcomitted.
+  virtual int64_t getOvercommittedMemory() const = 0;
+
+  // Returns the number of bytes that may be recoverable with
+  // tryRecoverMemory().
+  virtual int64_t getRecoverableMemory() const = 0;
+
+  //  Recovers memory. Implementations may for example spill or evict
+  //  caches. Returns the number of bytes actually freed.  size
+  //  specifies a target number of bytes to recover.
+  virtual int64_t recover(int64_t size) = 0;
+};
+
+class MemoryManagerStrategy {
+ public:
+  virtual ~MemoryManagerStrategy() {}
+
+  // returns true if this can resize initial limits of consumers.
+  virtual bool canResize() const = 0;
+
+  // Returns true if the memory manager allows overcommit for
+  // individual memory pool or mapped memory.
+  virtual bool allowOvercommit() const = 0;
+
+  // Returns true if the memory manager may change memory usage quota
+  // dynamically, depending on the number of queries/tasks in the system.
+  // We use this to implement a fair memory usage policy.
+  virtual bool canChangeLimitsDynamically() const = 0;
+
+  // Returns a shared pointer to the memory usage quota.
+  // UsageType specifies whether it is for Process, Query, Task or Operators
+  // If canChangeQuotaDynamically() returns true, quota may change dynamically
+  // as the number of MemoryConsumers changes and registered MemoryConsumers
+  // will be/ updated through 'updateMemoryUsageConfig()'.
+  virtual MemoryUsageConfig getDefaultMemoryUsageConfig(
+      UsageLevel Level) const = 0;
+
+  // To register a memory consumer with MemoryManager.
+  virtual void registerConsumer(
+      MemoryConsumer* consumer,
+      const std::weak_ptr<MemoryConsumer>& consumerPtr) = 0;
+
+  // To unregister a memory consumer with MemoryManager.
+  virtual void unregisterConsumer(MemoryConsumer* consumer) = 0;
+
+  // Tries to recover memory so that 'requester' can allocate 'size'
+  // bytes of new memory. Returns true if the limit of 'requester' was
+  // increased by at least 'size'.
+  virtual bool recover(
+      std::shared_ptr<MemoryConsumer> requester,
+      UsageType type,
+      int64_t size) = 0;
+
+  static MemoryManagerStrategy* instance();
+
+  using MemoryManagerStrategyFactory =
+      std::function<std::unique_ptr<MemoryManagerStrategy>()>;
+
+  static void registerFactory(MemoryManagerStrategyFactory factory) {
+    VELOX_CHECK(
+        !initialized_,
+        "Registering factory after creating MemoryManagerStrategy object");
+    factory_ = factory;
+  }
+
+ private:
+  static std::unique_ptr<MemoryManagerStrategy> createDefault();
+
+  static MemoryManagerStrategyFactory factory_;
+  static bool initialized_;
+};
+
+class MemoryManagerStrategyBase : public MemoryManagerStrategy {
+ public:
+  MemoryManagerStrategyBase() = default;
+
+  bool canResize() const override {
+    return false;
+  }
+
+  bool allowOvercommit() const override {
+    return true;
+  }
+
+  bool canChangeLimitsDynamically() const override {
+    return false;
+  }
+
+  MemoryUsageConfig getDefaultMemoryUsageConfig(
+      UsageLevel /*level*/) const override {
+  return MemoryUsageConfig();
+}
+
+void registerConsumer(
+    MemoryConsumer* consumer,
+    const std::weak_ptr<MemoryConsumer>& consumerPtr) override {
+  std::lock_guard<std::mutex> l(mutex_);
+  consumers_.emplace(consumer, consumerPtr);
+}
+
+void unregisterConsumer(MemoryConsumer* consumer) override {
+  std::lock_guard<std::mutex> l(mutex_);
+  consumers_.erase(consumer);
+}
+
+protected:
+using ConsumerMap =
+    std::unordered_map<MemoryConsumer*, std::weak_ptr<MemoryConsumer>>;
+
+std::mutex mutex_;
+ConsumerMap consumers_;
+}
+;
+
+class DefaultMemoryManagerStrategy : public MemoryManagerStrategyBase {
+ public:
+  // No op.
+  bool recover(
+      std::shared_ptr<MemoryConsumer> /*requester*/,
+      UsageType /*type*/,
+      int64_t /*size*/) override {
+    return false;
+  }
+};
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -15,20 +15,95 @@
  */
 
 #include "velox/common/memory/MemoryUsageTracker.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
 std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
     const std::shared_ptr<MemoryUsageTracker>& parent,
-    MemoryUsageTracker::UsageType type,
+    UsageType type,
     const MemoryUsageConfig& config) {
   struct SharedMemoryUsageTracker : public MemoryUsageTracker {
     SharedMemoryUsageTracker(
         const std::shared_ptr<MemoryUsageTracker>& parent,
-        MemoryUsageTracker::UsageType type,
+        UsageType type,
         const MemoryUsageConfig& config)
         : MemoryUsageTracker(parent, type, config) {}
   };
 
-  return std::make_shared<SharedMemoryUsageTracker>(parent, type, config);
+  // If it is not forMemoryManager and parent is null, set the parent
+  // to MemoryManager's usage tracker.
+  auto parentTracker = (!config.forMemoryManager && parent == nullptr)
+      ? MemoryManager<>::getProcessDefaultManager().getMemoryUsageTracker()
+      : parent;
+  return std::make_shared<SharedMemoryUsageTracker>(
+      parentTracker, type, config);
 }
+
+void MemoryUsageTracker::update(UsageType type, int64_t size) {
+  if (size > 0) {
+    ++numAllocs_[static_cast<int>(type)];
+    cumulativeBytes_[static_cast<int>(type)] += size;
+    ++numAllocs_[static_cast<int>(UsageType::kTotalMem)];
+    cumulativeBytes_[static_cast<int>(UsageType::kTotalMem)] += size;
+  }
+
+  auto currentOfType =
+      currentUsageInBytes_[static_cast<int32_t>(type)].fetch_add(size);
+  auto currentTotal =
+      currentUsageInBytes_[static_cast<int32_t>(UsageType::kTotalMem)]
+          .fetch_add(size);
+
+  try {
+    if (size > 0 &&
+        currentTotal > maxMemory_[static_cast<int>(UsageType::kTotalMem)]) {
+      if (growCallback_) {
+        if (growCallback_(type, size, this)) {
+          return;
+        }
+      }
+
+      VELOX_MEM_CAP_EXCEEDED();
+    }
+    if (parent_) {
+      parent_->update(type, size);
+    }
+  } catch (const std::exception& e) {
+    currentUsageInBytes_[static_cast<int32_t>(type)].fetch_sub(size);
+    currentUsageInBytes_[static_cast<int32_t>(UsageType::kTotalMem)].fetch_sub(
+        size);
+    std::rethrow_exception(std::current_exception());
+  }
+  maySetMax(type, currentOfType);
+  maySetMax(UsageType::kTotalMem, currentTotal);
+}
+
+namespace {
+
+std::string usageString(const std::array<std::atomic<int64_t>, 4>& usage) {
+  std::stringstream out;
+  const char* heading[] = {"user", "sys", "total", "revocable"};
+  for (auto i = 0; i < 4; ++i) {
+    if (usage[i]) {
+      out << heading[i] << usage[i] << " ";
+    }
+  }
+  return out.str();
+}
+
+} // namespace
+
+std::string MemoryUsageTracker::toString() const {
+  std::stringstream out;
+  out << "<tracker current:" << usageString(currentUsageInBytes_);
+  if (reservation_) {
+    out << " used/reserved " << usedReservation_ << "/" << reservation_;
+  }
+  auto max = getMaxTotalBytes();
+  if (max < kMaxMemory) {
+    out << " max " << max;
+  }
+  out << ">";
+  return out.str();
+}
+
 } // namespace facebook::velox::memory

--- a/velox/core/CancelPool.h
+++ b/velox/core/CancelPool.h
@@ -41,58 +41,164 @@ enum class StopReason {
   kAlreadyOnThread
 };
 
+// Represents a Driver's state. This is used for cancellation, forcing
+// release of and for waiting for memory. The fields are serialized on
+// the mutex of the Driver's CancelPool.
+struct ThreadState {
+  // The thread currently running this.
+  std::thread::id thread;
+  // The tid of 'thread'. Allows finding the thread in a debugger.
+  int32_t tid;
+  // True if queued on an executor but not on thread.
+  bool enqueued{false};
+  // True if being terminated or already terminated.
+  bool isTerminated{false};
+  // True if there is a future outstanding that will schedule this on an
+  // executor thread when some promise is realized.
+  bool hasBlockingFuture{false};
+  // True if on thread but in a section waiting for RPC or memory
+  // strategy decision. The thread is not supposed to access its
+  // memory, which a third party can revoke while the thread is in
+  // this state.
+  bool isCancelFree{false};
+  const char* continueFile = nullptr;
+  int32_t continueLine{0};
+
+  bool isOnThread() const {
+    return thread != std::thread::id();
+  }
+
+  void setThread() {
+    thread = std::this_thread::get_id();
+    tid = gettid();
+  }
+
+  void clearThread() {
+    thread = std::thread::id(); // no thread.
+    tid = 0;
+  }
+};
+
+#define SETCONT(state)             \
+  {                                \
+    state.continueLine = __LINE__; \
+    state.continueFile = __FILE__; \
+  }
+
 class CancelPool {
  public:
   // Returns kNone if no pause or terminate is requested. The thread count is
   // incremented if kNone is returned. If something else is returned the
   // calling tread should unwind and return itself to its pool.
-  StopReason enter(bool* isOnThread, bool* isTerminated) {
+  StopReason enter(ThreadState& state) {
     std::lock_guard<std::mutex> l(mutex_);
-    if (*isTerminated) {
+    VELOX_CHECK(state.enqueued);
+    state.enqueued = false;
+    if (state.isTerminated) {
       return StopReason::kAlreadyTerminated;
     }
-    if (*isOnThread) {
+    if (state.isOnThread()) {
       return StopReason::kAlreadyOnThread;
     }
     auto reason = shouldStopLocked();
     if (reason == StopReason::kTerminate) {
-      *isTerminated = true;
+      state.isTerminated = true;
     }
     if (reason == StopReason::kNone) {
       ++numThreads_;
-      *isOnThread = true;
+      state.setThread();
+      state.hasBlockingFuture = false;
     }
     return reason;
   }
 
-  StopReason enterForTerminate(bool* isOnThread, bool* isTerminated) {
+  StopReason enterForTerminate(ThreadState& state) {
     std::lock_guard<std::mutex> l(mutex_);
-    if (*isOnThread || *isTerminated) {
-      *isTerminated = true;
+    if (state.isOnThread() || state.isTerminated) {
+      state.isTerminated = true;
       return StopReason::kAlreadyOnThread;
     }
-    *isTerminated = true;
-    *isOnThread = true;
+    state.isTerminated = true;
+    state.setThread();
     return StopReason::kTerminate;
   }
 
-  StopReason leave(bool* isOnThread, bool* isTerminated) {
+  StopReason leave(ThreadState& state) {
     std::lock_guard<std::mutex> l(mutex_);
     if (--numThreads_ == 0) {
-      for (auto& promise : finishPromises_) {
-        promise.setValue(true);
-      }
-      finishPromises_.clear();
+      finished();
     }
-    *isOnThread = false;
-    if (*isTerminated) {
+    state.clearThread();
+    if (state.isTerminated) {
       return StopReason::kTerminate;
     }
     auto reason = shouldStopLocked();
     if (reason == StopReason::kTerminate) {
-      *isTerminated = true;
+      state.isTerminated = true;
     }
     return reason;
+  }
+
+  // Enters a cancel-free section where the caller stays on thread but
+  // is not accounted as being on the thread.  Returns kNone if no
+  // terminate is requested. The thread count is decremented if kNone
+  // is returned. If thread count goes to zero, waiting promises are
+  // realized. If kNone is not returned the calling tread should
+  // unwind and return itself to its pool.
+  StopReason enterCancelFree(ThreadState& state) {
+    VELOX_CHECK(!state.hasBlockingFuture);
+    VELOX_CHECK(state.isOnThread());
+    std::lock_guard<std::mutex> l(mutex_);
+    if (state.isTerminated) {
+      return StopReason::kAlreadyTerminated;
+    }
+    if (!state.isOnThread()) {
+      return StopReason::kAlreadyTerminated;
+    }
+    auto reason = shouldStopLocked();
+    if (reason == StopReason::kTerminate) {
+      state.isTerminated = true;
+    }
+    // A pause will not stop entering the cancel free section. It will
+    // just ack that the thread is no longer in inside the
+    // CancelPool. The pause can wait at the exit of the cancel free
+    // section.
+    if (reason == StopReason::kNone || reason == StopReason::kPause) {
+      state.isCancelFree = true;
+      if (--numThreads_ == 0) {
+        finished();
+      }
+    }
+    return StopReason::kNone;
+  }
+
+  StopReason leaveCancelFree(ThreadState& state) {
+    for (;;) {
+      {
+        std::lock_guard<std::mutex> l(mutex_);
+        ++numThreads_;
+        state.isCancelFree = false;
+        if (state.isTerminated) {
+          return StopReason::kAlreadyTerminated;
+        }
+        if (terminateRequested_) {
+          state.isTerminated = true;
+          return StopReason::kTerminate;
+        }
+        if (!pauseRequested_) {
+          // For yield or anything but pause  we return here.
+          return StopReason::kNone;
+        }
+        --numThreads_;
+        state.isCancelFree = true;
+      }
+      // If the pause flag is on when trying to reenter, sleep a while
+      // outside of the mutex and recheck. This is rare and not time
+      // critical. Can happen if memory interrupt sets pause while
+      // already inside a cancel free section for other reason, like
+      // IO.
+      std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+    }
   }
 
   // Returns a stop reason without synchronization. If the stop reason
@@ -113,6 +219,7 @@ class CancelPool {
   }
 
   void requestPause(bool pause) {
+    std::lock_guard<std::mutex> l(mutex_);
     pauseRequested_ = pause;
   }
 
@@ -127,6 +234,10 @@ class CancelPool {
 
   bool terminateRequested() const {
     return terminateRequested_;
+  }
+
+  bool pauseRequested() const {
+    return pauseRequested_;
   }
 
   // Returns a future that is completed when all threads have acknowledged
@@ -149,6 +260,13 @@ class CancelPool {
   }
 
  private:
+  void finished() {
+    for (auto& promise : finishPromises_) {
+      promise.setValue(true);
+    }
+    finishPromises_.clear();
+  }
+
   StopReason shouldStopLocked() {
     if (terminateRequested_) {
       return StopReason::kTerminate;

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <iostream>
+
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/executors/task_queue/UnboundedBlockingQueue.h>
 #include <folly/executors/thread_factory/InitThreadFactory.h>
@@ -73,7 +75,13 @@ DriverCtx::DriverCtx(
           std::make_unique<SimpleExpressionEvaluator>(execCtx.get())),
       driverId(_driverId),
       pipelineId(_pipelineId),
-      numDrivers(_numDrivers) {}
+      numDrivers(_numDrivers) {
+  auto parentTracker = task->pool()->getMemoryUsageTracker();
+  if (parentTracker) {
+    execCtx->pool()->setMemoryUsageTracker(
+        std::move(parentTracker->addChild()));
+  }
+}
 
 std::unique_ptr<connector::ConnectorQueryCtx>
 DriverCtx::createConnectorQueryCtx(const std::string& connectorId) const {
@@ -95,18 +103,34 @@ BlockingState::BlockingState(
       sinceMicros_(
           std::chrono::duration_cast<std::chrono::microseconds>(
               std::chrono::high_resolution_clock::now().time_since_epoch())
-              .count()) {}
+              .count()) {
+  // Set before leaving the thread.
+  driver_->state().hasBlockingFuture = true;
+}
 
 // static
 void BlockingState::setResume(
     std::shared_ptr<BlockingState> state,
     folly::Executor* executor) {
+  VELOX_CHECK(!state->driver_->isOnThread());
   auto& exec = folly::QueuedImmediateExecutor::instance();
   std::move(state->future_)
       .via(&exec)
       .thenValue([state, executor](bool /* unused */) {
         state->operator_->recordBlockingTime(state->sinceMicros_);
-        Driver::enqueue(state->driver_, executor);
+        auto driver = state->driver_;
+        {
+          std::lock_guard<std::mutex> l(*driver->cancelPool()->mutex());
+          VELOX_CHECK(!driver->state().isCancelFree);
+          VELOX_CHECK(driver->state().hasBlockingFuture);
+          driver->state().hasBlockingFuture = false;
+          if (driver->cancelPool()->pauseRequested()) {
+            // The thread will be enqueued at resume.
+            return;
+          }
+        }
+        SETCONT(state->driver_->state());
+        Driver::enqueue(state->driver_);
       })
       .thenError(
           folly::tag_t<std::exception>{}, [state](std::exception const& e) {
@@ -124,13 +148,9 @@ class CancelPoolGuard {
  public:
   CancelPoolGuard(
       core::CancelPool* cancelPool,
-      bool* isOnThread,
-      bool* isTerminated,
+      core::ThreadState* state,
       std::function<void(core::StopReason)> onTerminate)
-      : cancelPool_(cancelPool),
-        isOnThread_(isOnThread),
-        isTerminated_(isTerminated),
-        onTerminate_(onTerminate) {}
+      : cancelPool_(cancelPool), state_(state), onTerminate_(onTerminate) {}
 
   void notThrown() {
     isThrow_ = false;
@@ -140,11 +160,11 @@ class CancelPoolGuard {
     bool onTerminateCalled = false;
     if (isThrow_) {
       // Runtime error. Driver is on thread, hence safe.
-      *isTerminated_ = true;
+      state_->isTerminated = true;
       onTerminate_(core::StopReason::kNone);
       onTerminateCalled = true;
     }
-    auto reason = cancelPool_->leave(isOnThread_, isTerminated_);
+    auto reason = cancelPool_->leave(*state_);
     if (reason == core::StopReason::kTerminate) {
       // Terminate requested via cancelPool. The Driver is not on
       // thread but 'terminated_' is set, hence no other threads will
@@ -158,8 +178,7 @@ class CancelPoolGuard {
 
  private:
   core::CancelPool* cancelPool_;
-  bool* isOnThread_;
-  bool* isTerminated_;
+  core::ThreadState* state_;
   std::function<void(core::StopReason reason)> onTerminate_;
   bool isThrow_ = true;
 };
@@ -200,6 +219,9 @@ void Driver::testingJoinAndReinitializeExecutor(int32_t threads) {
 void Driver::enqueue(
     std::shared_ptr<Driver> driver,
     folly::Executor* executor) {
+  // This is expected to be called inside the Driver's CancelPool mutex.
+  VELOX_CHECK(!driver->state().enqueued);
+  driver->state().enqueued = true;
   auto currentExecutor = (executor ? executor : Driver::executor());
   currentExecutor->add(
       [driver, currentExecutor]() { Driver::run(driver, currentExecutor); });
@@ -219,7 +241,7 @@ Driver::Driver(
 core::StopReason Driver::runInternal(
     std::shared_ptr<Driver>& self,
     std::shared_ptr<BlockingState>* blockingState) {
-  auto stop = cancelPool_->enter(&isOnThread_, &isTerminated_);
+  auto stop = cancelPool_->enter(state_);
   if (stop != core::StopReason::kNone) {
     if (stop == core::StopReason::kTerminate) {
       task_->setError(std::make_exception_ptr(VeloxRuntimeError(
@@ -236,10 +258,7 @@ core::StopReason Driver::runInternal(
     return stop;
   }
   CancelPoolGuard guard(
-      cancelPool_.get(),
-      &isOnThread_,
-      &isTerminated_,
-      [this](core::StopReason reason) {
+      cancelPool_.get(), &state_, [this](core::StopReason reason) {
         auto task = task_.get();
         if (task && reason == core::StopReason::kTerminate) {
           task_->setError(std::make_exception_ptr(VeloxRuntimeError(
@@ -429,7 +448,7 @@ void Driver::close() {
 }
 
 bool Driver::terminate() {
-  auto stop = cancelPool_->enterForTerminate(&isOnThread_, &isTerminated_);
+  auto stop = cancelPool_->enterForTerminate(state_);
   if (stop == core::StopReason::kTerminate) {
     close();
     return true;
@@ -468,7 +487,7 @@ void Driver::setError(std::exception_ptr exception) {
 std::string Driver::toString() {
   std::stringstream out;
   out << "{Driver: ";
-  if (isOnThread_) {
+  if (state_.isOnThread()) {
     out << "running ";
   } else {
     out << "blocked " << static_cast<int>(blockingReason_) << " ";
@@ -478,6 +497,43 @@ std::string Driver::toString() {
   }
   out << "}";
   return out.str();
+}
+
+bool Driver::growTaskMemory(
+    memory::UsageType type,
+    int64_t size,
+    memory::MemoryUsageTracker* tracker) {
+  CancelFreeSection guard(this);
+  return memory::MemoryManagerStrategy::instance()->recover(
+      driverCtx()->task, type, size);
+}
+
+int64_t Driver::spill(int64_t size) {
+  int64_t spilled = 0;
+  if (size > 0) {
+    for (auto& op : operators_) {
+      spilled += op->spill(std::max(size - spilled, int64_t{}));
+    }
+  }
+  return spilled;
+}
+
+CancelFreeSection::CancelFreeSection(Driver* driver) : driver_(driver) {
+  if (driver->cancelPool()->enterCancelFree(driver->state()) !=
+      core::StopReason::kNone) {
+    VELOX_FAIL("Terminate detected when entering cancel-free");
+  }
+}
+
+CancelFreeSection::~CancelFreeSection() {
+  if (driver_->cancelPool()->leaveCancelFree(driver_->state()) !=
+      core::StopReason::kNone) {
+    VELOX_FAIL("Terminate detected when leaving cancel-free");
+  }
+}
+
+std::string Driver::label() {
+  return fmt::format("<Driver {}:{}>", ctx_->task->taskId(), ctx_->driverId);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -298,7 +298,9 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {
       operators.push_back(std::make_unique<Unnest>(id, ctx.get(), unnest));
     } else {
-      VELOX_FAIL("Unsupported plan node: {}", planNode->toString());
+      auto extended = Operator::fromPlanNode(ctx.get(), id, planNode);
+      VELOX_CHECK(extended, "Unsupported plan node: {}", planNode->toString());
+      operators.push_back(std::move(extended));
     }
   }
   if (consumerSupplier) {

--- a/velox/exec/tests/Cursor.cpp
+++ b/velox/exec/tests/Cursor.cpp
@@ -102,6 +102,8 @@ bool TaskQueue::hasNext() {
   return !queue_.empty();
 }
 
+int32_t TaskCursor::serial_;
+
 TaskCursor::TaskCursor(const CursorParameters& params) {
   std::shared_ptr<core::QueryCtx> queryCtx;
   if (params.queryCtx) {
@@ -114,7 +116,7 @@ TaskCursor::TaskCursor(const CursorParameters& params) {
   // Captured as a shared_ptr by the consumer callback of task_.
   auto queue = queue_;
   task_ = std::make_shared<exec::Task>(
-      "test_cursor",
+      fmt::format("test_cursor {}", ++serial_),
       params.planNode,
       params.destination,
       std::move(queryCtx),

--- a/velox/exec/tests/Cursor.h
+++ b/velox/exec/tests/Cursor.h
@@ -109,6 +109,7 @@ class TaskCursor {
   std::shared_ptr<TaskQueue> queue_;
   std::shared_ptr<exec::Task> task_;
   RowVectorPtr current_;
+  static int32_t serial_;
 };
 
 class RowCursor {

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -42,7 +42,8 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       int numDrivers) {
     auto queryCtx = core::QueryCtx::create();
     bufferManager_->removeTask(taskId);
-    auto task = std::make_shared<Task>(taskId, queryCtx);
+    auto task = std::make_shared<Task>(taskId, nullptr, 0, std::move(queryCtx));
+
     bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
     return task;
   }

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -181,6 +181,14 @@ class PlanBuilder {
     return planNode_;
   }
 
+  // Adds a user defined PlanNode as the root of the plan. 'func' takes
+  // the current root of the plan and returns the new root.
+  PlanBuilder& addNode(std::function<std::shared_ptr<core::PlanNode>(
+                           std::shared_ptr<const core::PlanNode>)> func) {
+    planNode_ = func(planNode_);
+    return *this;
+  }
+
  private:
   std::string nextPlanNodeId();
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -27,7 +27,7 @@ TEST_F(TaskTest, splitGroup) {
   auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
       "test", "file:/tmp/abc", 0, 100);
   core::PlanNodeId planNodeId{"0"};
-  exec::Task task("0", nullptr);
+  exec::Task task("0", nullptr, 0, nullptr);
 
   // This is the set of completed groups we expect.
   std::unordered_set<int32_t> completedSplitGroups;


### PR DESCRIPTION
- Add a grow callback to MemoryUsageTracker.

-Add interface to
- Task/Driver/Operator for inquiring over potentially spillable space
- and forcing spilling.

-Add MemoryManagerStrategy and a sample
- implementation that spills the largest task first.

- Add GrowCallback to memoryUsageTracker that may request for more
  space from MemoryManagerStrategy.