### PR TITLE
Use TYPED_TEST_SUITE framework for testing

### DIFF
--- a/velox/functions/common/tests/FunctionBaseTest.cpp
+++ b/velox/functions/common/tests/FunctionBaseTest.cpp
@@ -58,4 +58,224 @@ BufferPtr FunctionBaseTest::makeIndices(
 
   return indices;
 }
+
+template <typename T>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector() {
+  return nullptr;
+}
+
+template <typename T>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector() {
+  return nullptr;
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<int8_t>() {
+  return makeNullableArrayVector<int8_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, std::nullopt},
+       {std::nullopt, -1, -2, -3, -4},
+       {},
+       {std::nullopt}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<int8_t>() {
+  return makeArrayVector<int8_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, 105},
+       {}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<int16_t>() {
+  return makeNullableArrayVector<int16_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, std::nullopt},
+       {std::nullopt, -1, -2, -3, -4},
+       {},
+       {std::nullopt}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<int16_t>() {
+  return makeArrayVector<int16_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, 105},
+       {}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<int32_t>() {
+  return makeNullableArrayVector<int32_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, std::nullopt},
+       {std::nullopt, -1, -2, -3, -4},
+       {},
+       {std::nullopt}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<int32_t>() {
+  return makeArrayVector<int32_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, 105},
+       {}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<int64_t>() {
+  return makeNullableArrayVector<int64_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, std::nullopt},
+       {std::nullopt, -1, -2, -3, -4},
+       {},
+       {std::nullopt}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<int64_t>() {
+  return makeArrayVector<int64_t>(
+      {{-1, 0, 1, 2, 3, 4},
+       {4, 3, 2, 1, 0, -1, -2},
+       {-5, -4, -3, -2, -1},
+       {101, 102, 103, 104, 105},
+       {}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<StringView>() {
+  using S = StringView;
+  return makeNullableArrayVector<S>({
+      {S("red"), S("blue")},
+      {std::nullopt, S("blue"), S("yellow"), S("orange")},
+      {},
+      {S("red"), S("purple"), S("green")},
+  });
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<StringView>() {
+  using S = StringView;
+  return makeArrayVector<S>({
+      {S("red"), S("blue")},
+      {S("blue"), S("yellow"), S("orange")},
+      {},
+      {S("red"), S("purple"), S("green")},
+  });
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<bool>() {
+  return makeNullableArrayVector<bool>(
+      {{true, false},
+       {true},
+       {false},
+       {},
+       {true, false, true, std::nullopt},
+       {std::nullopt, true, false, true},
+       {false, false, false},
+       {true, true, true}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<bool>() {
+  return makeArrayVector<bool>(
+      {{true, false},
+       {true},
+       {false},
+       {},
+       {false, false, false},
+       {true, true, true}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<float>() {
+  return makeNullableArrayVector<float>(
+      {{0.0000, 0.00001},
+       {std::nullopt, 1.1, 1.11, -2.2, -1.0},
+       {-0.0001, -0.0002, -0.0003},
+       {},
+       {1.1, 1.22222, 1.33, std::nullopt},
+       {-0.00001, -0.0002, 0.0001}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<float>() {
+  return makeArrayVector<float>(
+      {{0.0000, 0.00001},
+       {1.1, 1.11, -2.2, -1.0},
+       {-0.0001, -0.0002, -0.0003},
+       {},
+       {1.1, 1.22222, 1.33},
+       {-0.00001, -0.0002, 0.0001}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableArrayVector<double>() {
+  return makeNullableArrayVector<double>(
+      {{0.0000, 0.00001},
+       {std::nullopt, 1.1, 1.11, -2.2, -1.0},
+       {-0.0001, -0.0002, -0.0003},
+       {},
+       {1.1, 1.22222, 1.33, std::nullopt},
+       {-0.00001, -0.0002, 0.0001}});
+}
+
+template <>
+ArrayVectorPtr FunctionBaseTest::makeSample1ArrayVector<double>() {
+  return makeArrayVector<double>(
+      {{0.0000, 0.00001},
+       {1.1, 1.11, -2.2, -1.0},
+       {-0.0001, -0.0002, -0.0003},
+       {},
+       {1.1, 1.22222, 1.33},
+       {-0.00001, -0.0002, 0.0001}});
+}
+
+ArrayVectorPtr FunctionBaseTest::makeSample1NullableLongVarcharArrayVector() {
+  using S = StringView;
+  // use > 12 length string to avoid inlining
+  return makeNullableArrayVector<S>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {std::nullopt,
+       S("blue clear sky above"),
+       S("yellow rose flowers"),
+       S("orange beautiful sunset")},
+      {},
+      {S("red shiny car ahead"),
+       S("purple is an elegant color"),
+       S("green plants make us happy")},
+  });
+}
+
+ArrayVectorPtr FunctionBaseTest::makeSample1LongVarcharArrayVector() {
+  using S = StringView;
+  // use > 12 length string to avoid inlining
+  return makeArrayVector<S>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {S("blue clear sky above"),
+       S("yellow rose flowers"),
+       S("orange beautiful sunset")},
+      {},
+      {S("red shiny car ahead"),
+       S("purple is an elegant color"),
+       S("green plants make us happy")},
+  });
+}
+
 } // namespace facebook::velox::functions::test

--- a/velox/functions/common/tests/FunctionBaseTest.h
+++ b/velox/functions/common/tests/FunctionBaseTest.h
@@ -25,6 +25,16 @@
 namespace facebook::velox::functions::test {
 
 class FunctionBaseTest : public testing::Test {
+ public:
+  class TypeNames {
+   public:
+    template <typename T>
+    static std::string GetName(int) {
+      T type;
+      return type.toString();
+    }
+  };
+
  protected:
   static void SetUpTestCase();
 
@@ -214,6 +224,14 @@ class FunctionBaseTest : public testing::Test {
       std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
     return vectorMaker_.arrayVector<T>(size, sizeAt, valueAt, isNullAt);
   }
+
+  template <typename T>
+  ArrayVectorPtr makeSample1NullableArrayVector();
+  ArrayVectorPtr makeSample1NullableLongVarcharArrayVector();
+
+  template <typename T>
+  ArrayVectorPtr makeSample1ArrayVector();
+  ArrayVectorPtr makeSample1LongVarcharArrayVector();
 
   template <typename TKey, typename TValue>
   MapVectorPtr makeMapVector(


### PR DESCRIPTION
This PR modifies the `ArrayMaxTest.cpp` to use TYPED_TEST_SUITE.
The motivation is as follow.
1) Be able to reuse the input data across multiple files.
2) Make it easy to add tests for all scalar types.
If this looks good, I will modify the other array tests to use a similar pattern.
3) Improve test coverage for all tests. We currently do not test all the Types.

Sample test output below
https://circleci.com/api/v1.1/project/github/facebookincubator/velox/1456/output/107/0?file=true&allocation-id=61270935c8f5fe7c2f6366cd-0-build%2FB95AD63