### PR TITLE
Properly use SelectivityVector in aggregations.

### DIFF
--- a/velox/aggregates/ApproxDistinct.cpp
+++ b/velox/aggregates/ApproxDistinct.cpp
@@ -225,12 +225,12 @@ class ApproxDistinctAggregate : public exec::Aggregate {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
-    decodeArguments(allRows, args);
+    decodeArguments(rows, args);
 
-    allRows.applyToSelected([&](auto row) {
+    rows.applyToSelected([&](auto row) {
       if (decodedValue_.isNullAt(row)) {
         return;
       }
@@ -247,12 +247,12 @@ class ApproxDistinctAggregate : public exec::Aggregate {
 
   void updateSingleGroupFinal(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& row,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
-    decodedHll_.decode(*args[0], allRows, true);
+    decodedHll_.decode(*args[0], row, true);
 
-    allRows.applyToSelected([&](auto row) {
+    row.applyToSelected([&](auto row) {
       if (decodedHll_.isNullAt(row)) {
         return;
       }

--- a/velox/aggregates/ArrayAgg.cpp
+++ b/velox/aggregates/ArrayAgg.cpp
@@ -113,20 +113,20 @@ class ArrayAggAggregate : public exec::Aggregate {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
     auto& values = value<ArrayAccumulator>(group)->elements;
 
-    decodedElements_.decode(*args[0], allRows);
-    allRows.applyToSelected([&](vector_size_t row) {
+    decodedElements_.decode(*args[0], rows);
+    rows.applyToSelected([&](vector_size_t row) {
       values.appendValue(decodedElements_, row, allocator_);
     });
   }
 
   void updateSingleGroupFinal(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
     auto& values = value<ArrayAccumulator>(group)->elements;
@@ -134,7 +134,7 @@ class ArrayAggAggregate : public exec::Aggregate {
     VELOX_CHECK_EQ(args[0]->encoding(), VectorEncoding::Simple::ARRAY);
     auto arrayVector = args[0]->as<ArrayVector>();
     auto elements = arrayVector->elements();
-    allRows.applyToSelected([&](vector_size_t row) {
+    rows.applyToSelected([&](vector_size_t row) {
       values.appendRange(
           elements,
           arrayVector->offsetAt(row),

--- a/velox/aggregates/BitwiseAggregates.cpp
+++ b/velox/aggregates/BitwiseAggregates.cpp
@@ -63,10 +63,10 @@ class BitwiseAndOrAggregate : public SimpleNumericAggregate<T, T, T> {
 
   void updateSingleGroupFinal(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    this->updateSingleGroupPartial(group, allRows, args, mayPushdown);
+    this->updateSingleGroupPartial(group, rows, args, mayPushdown);
   }
 
  protected:
@@ -99,12 +99,12 @@ class BitwiseOrAggregate : public BitwiseAndOrAggregate<T> {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     SimpleNumericAggregate<T, T, T>::updateOneGroup(
         group,
-        allRows,
+        rows,
         args[0],
         [](T& result, T value) { result |= value; },
         [](T& result, T value, int /* unused */
@@ -140,12 +140,12 @@ class BitwiseAndAggregate : public BitwiseAndOrAggregate<T> {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     SimpleNumericAggregate<T, T, T>::template updateOneGroup(
         group,
-        allRows,
+        rows,
         args[0],
         [](T& result, T value) { result &= value; },
         [](T& result, T value, int /* unused */

--- a/velox/aggregates/BoolAggregates.cpp
+++ b/velox/aggregates/BoolAggregates.cpp
@@ -103,12 +103,12 @@ class BoolAndAggregate final : public BoolAndOrAggregate {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     BaseAggregate::updateOneGroup(
         group,
-        allRows,
+        rows,
         args[0],
         [](bool& result, bool value) { result = result && value; },
         [](bool& result, bool value, int /* unused */) {
@@ -120,10 +120,10 @@ class BoolAndAggregate final : public BoolAndOrAggregate {
 
   void updateSingleGroupFinal(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    updateSingleGroupPartial(group, allRows, args, mayPushdown);
+    updateSingleGroupPartial(group, rows, args, mayPushdown);
   }
 };
 
@@ -155,12 +155,12 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 
   void updateSingleGroupPartial(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     BaseAggregate::updateOneGroup(
         group,
-        allRows,
+        rows,
         args[0],
         [](bool& result, bool value) { result = result || value; },
         [](bool& result, bool value, int /* unused */) {
@@ -172,10 +172,10 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 
   void updateSingleGroupFinal(
       char* group,
-      const SelectivityVector& allRows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    updateSingleGroupPartial(group, allRows, args, mayPushdown);
+    updateSingleGroupPartial(group, rows, args, mayPushdown);
   }
 };
 


### PR DESCRIPTION
Summary:
SelectivityVector in aggregations was only properly used in update() methods, but not updateSingleGroup() where it was assumed to be 'allRows'.
With the coming implementation of Aggregation Mask (when aggregations could have a boolean column as a mask to indicate what rows to aggregate), we need to assume that SelectivityVector might not have all rows selected.
This diff is to make that change.

Differential Revision: D30569720

