### PR TITLE
Increase compile, link, and test parallelism on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: Run Unit Tests
           command: |
-            make unittest NUM_THREADS=8
+            make unittest NUM_THREADS=16
           no_output_timeout: 1h
 
   format-check:


### PR DESCRIPTION
This PR doubles the container size and sets all parallelism flags (compile, high-mem compile, link, and test) to match the number of CPUs available.

I did not do this before because a lot of the build latency was coming from building duckdb, and increasing parallelism wouldn't have helped. This is no longer seems to be true.