### PR TITLE
Complete Task pausing and add Cancel-free section

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -16,7 +16,8 @@ add_subdirectory(tests)
 add_library(velox_config Context.cpp)
 target_link_libraries(velox_config ${FOLLY_WITH_DEPENDENCIES})
 
-add_library(velox_core FunctionRegistry.cpp PlanNode.cpp ScalarFunction.cpp)
+add_library(velox_core FunctionRegistry.cpp PlanNode.cpp ScalarFunction.cpp
+                       CancelPool.cpp)
 
 target_link_libraries(velox_core velox_config velox_type velox_serialization
                       velox_vector ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/core/CancelPool.cpp
+++ b/velox/core/CancelPool.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/CancelPool.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::core {
+
+StopReason CancelPool::enter(ThreadState& state) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(state.isEnqueued);
+  state.isEnqueued = false;
+  if (state.isTerminated) {
+    return StopReason::kAlreadyTerminated;
+  }
+  if (state.isOnThread()) {
+    return StopReason::kAlreadyOnThread;
+  }
+  auto reason = shouldStopLocked();
+  if (reason == StopReason::kTerminate) {
+    state.isTerminated = true;
+  }
+  if (reason == StopReason::kNone) {
+    ++numThreads_;
+    state.setThread();
+    state.hasBlockingFuture = false;
+  }
+  return reason;
+}
+
+StopReason CancelPool::enterForTerminate(ThreadState& state) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (state.isOnThread() || state.isTerminated) {
+    state.isTerminated = true;
+    return StopReason::kAlreadyOnThread;
+  }
+  state.isTerminated = true;
+  state.setThread();
+  return StopReason::kTerminate;
+}
+
+StopReason CancelPool::leave(ThreadState& state) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (--numThreads_ == 0) {
+    finished();
+  }
+  state.clearThread();
+  if (state.isTerminated) {
+    return StopReason::kTerminate;
+  }
+  auto reason = shouldStopLocked();
+  if (reason == StopReason::kTerminate) {
+    state.isTerminated = true;
+  }
+  return reason;
+}
+
+StopReason CancelPool::enterSuspended(ThreadState& state) {
+  VELOX_CHECK(!state.hasBlockingFuture);
+  VELOX_CHECK(state.isOnThread());
+  std::lock_guard<std::mutex> l(mutex_);
+  if (state.isTerminated) {
+    return StopReason::kAlreadyTerminated;
+  }
+  if (!state.isOnThread()) {
+    return StopReason::kAlreadyTerminated;
+  }
+  auto reason = shouldStopLocked();
+  if (reason == StopReason::kTerminate) {
+    state.isTerminated = true;
+  }
+  // A pause will not stop entering the suspended section. It will
+  // just ack that the thread is no longer in inside the
+  // CancelPool. The pause can wait at the exit of the suspended
+  // section.
+  if (reason == StopReason::kNone || reason == StopReason::kPause) {
+    state.isSuspended = true;
+    if (--numThreads_ == 0) {
+      finished();
+    }
+  }
+  return StopReason::kNone;
+}
+
+StopReason CancelPool::leaveSuspended(ThreadState& state) {
+  for (;;) {
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      ++numThreads_;
+      state.isSuspended = false;
+      if (state.isTerminated) {
+        return StopReason::kAlreadyTerminated;
+      }
+      if (terminateRequested_) {
+        state.isTerminated = true;
+        return StopReason::kTerminate;
+      }
+      if (!pauseRequested_) {
+        // For yield or anything but pause  we return here.
+        return StopReason::kNone;
+      }
+      --numThreads_;
+      state.isSuspended = true;
+    }
+    // If the pause flag is on when trying to reenter, sleep a while
+    // outside of the mutex and recheck. This is rare and not time
+    // critical. Can happen if memory interrupt sets pause while
+    // already inside a suspended section for other reason, like
+    // IO.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+  }
+}
+
+} // namespace facebook::velox::core

--- a/velox/core/CancelPool.h
+++ b/velox/core/CancelPool.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/futures/Future.h>
+#include <folly/portability/SysSyscall.h>
 #include <mutex>
 #include "velox/common/future/VeloxPromise.h"
 
@@ -41,60 +42,104 @@ enum class StopReason {
   kAlreadyOnThread
 };
 
+// Represents a Driver's state. This is used for cancellation, forcing
+// release of and for waiting for memory. The fields are serialized on
+// the mutex of the Driver's CancelPool.
+//
+// The Driver goes through the following states:
+// Not on thread. It is created and has not started. All flags are false.
+//
+// Enqueued - The Driver is added to an executor but does not yet have a thread.
+// isEnqueued is true. Next states are terminated or on thread.
+//
+// On thread - 'thread' is set to the thread that is running the Driver. Next
+// states are blocked, terminated, suspended, enqueued.
+//
+//  Blocked - The Driver is not on thread and is waiting for an external event.
+//  Next states are terminated, enqueud.
+//
+// Suspended - The Driver is on thread, 'thread' and 'isSuspended' are set. The
+// thread does not manipulate the Driver's state and is suspended as in waiting
+// for memory or out of process IO. This is different from Blocked in that here
+// we keep the stack so that when the wait is over the control stack is not
+// lost. Next states are on thread or terminated.
+//
+//  Terminated - 'isTerminated' is set. The Driver cannot run after this and
+// the state is final.
+//
+// CancelPool  allows terminating or pausing a set of Drivers. The Task API
+// allows starting or resuming Drivers. When terminate is requested the request
+// is successful when all Drivers are off thread, blocked or suspended. When
+// pause is requested, we have success when all Drivers are either enqueued,
+// suspended, off thread or blocked.
+struct ThreadState {
+  // The thread currently running this.
+  std::thread::id thread;
+  // The tid of 'thread'. Allows finding the thread in a debugger.
+  int32_t tid;
+  // True if queued on an executor but not on thread.
+  bool isEnqueued{false};
+  // True if being terminated or already terminated.
+  bool isTerminated{false};
+  // True if there is a future outstanding that will schedule this on an
+  // executor thread when some promise is realized.
+  bool hasBlockingFuture{false};
+  // True if on thread but in a section waiting for RPC or memory
+  // strategy decision. The thread is not supposed to access its
+  // memory, which a third party can revoke while the thread is in
+  // this state.
+  bool isSuspended{false};
+
+  bool isOnThread() const {
+    return thread != std::thread::id();
+  }
+
+  void setThread() {
+    thread = std::this_thread::get_id();
+#if !defined(__APPLE__)
+    // This is a debugging feature disabled on the Mac since syscall
+    // is deprecated on that platform.
+    tid = syscall(FOLLY_SYS_gettid);
+#endif
+  }
+
+  void clearThread() {
+    thread = std::thread::id(); // no thread.
+    tid = 0;
+  }
+};
+
 class CancelPool {
  public:
   // Returns kNone if no pause or terminate is requested. The thread count is
   // incremented if kNone is returned. If something else is returned the
-  // calling tread should unwind and return itself to its pool.
-  StopReason enter(bool* isOnThread, bool* isTerminated) {
-    std::lock_guard<std::mutex> l(mutex_);
-    if (*isTerminated) {
-      return StopReason::kAlreadyTerminated;
-    }
-    if (*isOnThread) {
-      return StopReason::kAlreadyOnThread;
-    }
-    auto reason = shouldStopLocked();
-    if (reason == StopReason::kTerminate) {
-      *isTerminated = true;
-    }
-    if (reason == StopReason::kNone) {
-      ++numThreads_;
-      *isOnThread = true;
-    }
-    return reason;
-  }
+  // calling thread should unwind and return itself to its pool.
+  StopReason enter(ThreadState& state);
 
-  StopReason enterForTerminate(bool* isOnThread, bool* isTerminated) {
-    std::lock_guard<std::mutex> l(mutex_);
-    if (*isOnThread || *isTerminated) {
-      *isTerminated = true;
-      return StopReason::kAlreadyOnThread;
-    }
-    *isTerminated = true;
-    *isOnThread = true;
-    return StopReason::kTerminate;
-  }
+  // Sets the state to terminated. Returns kAlreadyOnThread if the
+  // Driver is running. In this case, the Driver will free resources
+  // and the caller should not do anything. Returns kTerminate if the
+  // Driver was not on thread. When this happens, the Driver is on the
+  // caller thread wit isTerminated set and the caller is responsible
+  // for freeing resources.
+  StopReason enterForTerminate(ThreadState& state);
 
-  StopReason leave(bool* isOnThread, bool* isTerminated) {
-    std::lock_guard<std::mutex> l(mutex_);
-    if (--numThreads_ == 0) {
-      for (auto& promise : finishPromises_) {
-        promise.setValue(true);
-      }
-      finishPromises_.clear();
-    }
-    *isOnThread = false;
-    if (*isTerminated) {
-      return StopReason::kTerminate;
-    }
-    auto reason = shouldStopLocked();
-    if (reason == StopReason::kTerminate) {
-      *isTerminated = true;
-    }
-    return reason;
-  }
+  // Marks that the Driver is not on thread. If no more Drivers in the
+  // CancelPool are on thread, this realizes any finishFutures. The
+  // Driver may go off thread because of hasBlockingFuture or pause
+  // requested or terminate requested. The return value indicates the
+  // reason. If kTerminate is returned, the isTerminated flag is set.
+  StopReason leave(ThreadState& state);
 
+  // Enters a suspended section where the caller stays on thread but
+  // is not accounted as being on the thread.  Returns kNone if no
+  // terminate is requested. The thread count is decremented if kNone
+  // is returned. If thread count goes to zero, waiting promises are
+  // realized. If kNone is not returned the calling thread should
+  // unwind and return itself to its pool.
+  StopReason enterSuspended(ThreadState& state);
+
+  StopReason leaveSuspended(ThreadState& state);
   // Returns a stop reason without synchronization. If the stop reason
   // is yield, then atomically decrements the count of threads that
   // are to yield.
@@ -113,6 +158,11 @@ class CancelPool {
   }
 
   void requestPause(bool pause) {
+    std::lock_guard<std::mutex> l(mutex_);
+    requestPauseLocked(pause);
+  }
+
+  void requestPauseLocked(bool pause) {
     pauseRequested_ = pause;
   }
 
@@ -127,6 +177,13 @@ class CancelPool {
 
   bool terminateRequested() const {
     return terminateRequested_;
+  }
+
+  // Once 'pauseRequested_' is set, it will not be cleared until
+  // task::resume(). It is therefore OK to read it without a mutex
+  // from a thread that this flag concerns.
+  bool pauseRequested() const {
+    return pauseRequested_;
   }
 
   // Returns a future that is completed when all threads have acknowledged
@@ -149,6 +206,13 @@ class CancelPool {
   }
 
  private:
+  void finished() {
+    for (auto& promise : finishPromises_) {
+      promise.setValue(true);
+    }
+    finishPromises_.clear();
+  }
+
   StopReason shouldStopLocked() {
     if (terminateRequested_) {
       return StopReason::kTerminate;

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -33,7 +33,8 @@ enum class BlockingReason {
   kWaitForConsumer,
   kWaitForSplit,
   kWaitForExchange,
-  kWaitForJoinBuild
+  kWaitForJoinBuild,
+  kWaitForMemory
 };
 
 using ContinueFuture = folly::SemiFuture<bool>;
@@ -134,11 +135,21 @@ class Driver {
   static void testingJoinAndReinitializeExecutor(int32_t threads = 0);
 
   bool isOnThread() const {
-    return isOnThread_;
+    return state_.isOnThread();
   }
 
   bool isTerminated() const {
-    return isTerminated_;
+    return state_.isTerminated;
+  }
+
+  std::string label() const;
+
+  core::ThreadState& state() {
+    return state_;
+  }
+
+  core::CancelPool* cancelPool() const {
+    return cancelPool_.get();
   }
 
   // Frees the resources associated with this if this is
@@ -180,9 +191,8 @@ class Driver {
   std::shared_ptr<Task> task_;
   core::CancelPoolPtr cancelPool_;
 
-  // Set via cancelPool->enter()
-  bool isOnThread_ = false;
-  bool isTerminated_ = false;
+  // Set via 'cancelPool_' and serialized by 'cancelPool_'s mutex.
+  core::ThreadState state_;
 
   std::vector<std::unique_ptr<Operator>> operators_;
 
@@ -242,6 +252,25 @@ struct DriverFactory {
 
     return std::nullopt;
   }
+};
+
+// Begins and ends a section where a thread is running but not
+// counted in its CancelPool. Using this, a Driver thread can for
+// example stop its own Task. For arbitrating memory overbooking,
+// the contending threads go suspended and each in turn enters a
+// global critical section. When running the arbitration strategy, a
+// thread can stop and restart Tasks, including its own. When a Task
+// is stopped, its drivers are blocked or suspended and the strategy thread can
+// alter the Task's memory including spilling or killing the whole Task. Other
+// threads waiting to run the arbitration, are in a suspended state which also
+// means that they are instantaneously killable or spillable.
+class SuspendedSection {
+ public:
+  explicit SuspendedSection(Driver* FOLLY_NONNULL driver);
+  ~SuspendedSection();
+
+ private:
+  Driver* FOLLY_NONNULL driver_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -298,7 +298,9 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {
       operators.push_back(std::make_unique<Unnest>(id, ctx.get(), unnest));
     } else {
-      VELOX_FAIL("Unsupported plan node: {}", planNode->toString());
+      auto extended = Operator::fromPlanNode(ctx.get(), id, planNode);
+      VELOX_CHECK(extended, "Unsupported plan node: {}", planNode->toString());
+      operators.push_back(std::move(extended));
     }
   }
   if (consumerSupplier) {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -25,6 +25,25 @@ namespace facebook {
 namespace velox {
 namespace exec {
 
+std::vector<Operator::PlanNodeTranslator>& Operator::translators() {
+  static std::vector<PlanNodeTranslator> translators;
+  return translators;
+}
+
+// static
+std::unique_ptr<Operator> Operator::fromPlanNode(
+    DriverCtx* ctx,
+    int32_t id,
+    std::shared_ptr<const core::PlanNode> planNode) {
+  for (auto& translator : translators()) {
+    auto op = translator(ctx, id, planNode);
+    if (op) {
+      return op;
+    }
+  }
+  return nullptr;
+}
+
 memory::MappedMemory* OperatorCtx::mappedMemory() const {
   if (!mappedMemory_) {
     auto parent = driverCtx_->task->queryCtx()->mappedMemory();

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -35,7 +35,6 @@ struct IdentityProjection {
 
 struct MemoryStats {
   uint64_t userMemoryReservation = {};
-  // TODO: Populate revocableMemoryReservation as well.
   uint64_t revocableMemoryReservation = {};
   uint64_t systemMemoryReservation = {};
   uint64_t peakUserMemoryReservation = {};
@@ -194,11 +193,19 @@ class OperatorCtx {
   // These members are created on demand.
   mutable velox::memory::MemoryPool* systemMemPool_{nullptr};
   mutable std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  mutable std::shared_ptr<memory::MappedMemory> recoverableMappedMemory_;
 };
 
 // Query operator
 class Operator {
  public:
+  // Function for mapping a user-registered PlanNode into the corresponding
+  // Operator.
+  using PlanNodeTranslator = std::function<std::unique_ptr<Operator>(
+      DriverCtx* ctx,
+      int32_t id,
+      const std::shared_ptr<const core::PlanNode>& node)>;
+
   // 'operatorId' is the initial index of the 'this' in the Driver's
   // list of Operators. This is used as in index into OperatorStats
   // arrays in the Task. 'planNodeId' is a query-level unique
@@ -279,7 +286,23 @@ class Operator {
     return stats_.planNodeId;
   }
 
+  // Registers 'translator' for mapping user defined PlanNode subclass instances
+  // to user-defined Operators.
+  static void registerOperator(PlanNodeTranslator translator) {
+    translators().push_back(translator);
+  }
+
+  // Calls all the registered PlanNodeTranslators on 'planNode' and
+  // returns the the result of the first one that returns non-nullptr
+  // or nullptr if all return nullptr.
+  static std::unique_ptr<Operator> fromPlanNode(
+      DriverCtx* ctx,
+      int32_t id,
+      std::shared_ptr<const core::PlanNode> planNode);
+
  protected:
+  static std::vector<PlanNodeTranslator>& translators();
+
   // Clears the columns of 'output_' that are projected from
   // 'input_'. This should be done when preparing to produce a next
   // batch of output to drop any lingering references to row

--- a/velox/exec/tests/Cursor.cpp
+++ b/velox/exec/tests/Cursor.cpp
@@ -102,6 +102,8 @@ bool TaskQueue::hasNext() {
   return !queue_.empty();
 }
 
+int32_t TaskCursor::serial_;
+
 TaskCursor::TaskCursor(const CursorParameters& params) {
   std::shared_ptr<core::QueryCtx> queryCtx;
   if (params.queryCtx) {
@@ -114,7 +116,7 @@ TaskCursor::TaskCursor(const CursorParameters& params) {
   // Captured as a shared_ptr by the consumer callback of task_.
   auto queue = queue_;
   task_ = std::make_shared<exec::Task>(
-      "test_cursor",
+      fmt::format("test_cursor {}", ++serial_),
       params.planNode,
       params.destination,
       std::move(queryCtx),

--- a/velox/exec/tests/Cursor.h
+++ b/velox/exec/tests/Cursor.h
@@ -109,6 +109,7 @@ class TaskCursor {
   std::shared_ptr<TaskQueue> queue_;
   std::shared_ptr<exec::Task> task_;
   RowVectorPtr current_;
+  static int32_t serial_;
 };
 
 class RowCursor {

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -25,6 +25,31 @@ using namespace facebook::velox::exec::test;
 
 using facebook::velox::test::BatchMaker;
 
+// A PlanNode that passes its input to its output and makes variable
+// memory reservations.
+// A PlanNode that passes its input to its output and periodically
+// pauses and resumes other Tasks.
+class TestingPauserNode : public core::PlanNode {
+ public:
+  explicit TestingPauserNode(std::shared_ptr<const core::PlanNode> input)
+      : PlanNode("Pauser"), sources_{input} {}
+
+  const std::shared_ptr<const RowType>& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "Pauser";
+  }
+
+ private:
+  std::vector<std::shared_ptr<const core::PlanNode>> sources_;
+};
+
 class DriverTest : public OperatorTestBase {
  protected:
   enum class ResultOperation {
@@ -51,6 +76,14 @@ class DriverTest : public OperatorTestBase {
              BIGINT()});
   }
 
+  void TearDown() override {
+    if (wakeupInitialized_) {
+      wakeupCancelled_ = true;
+      wakeupThread_.join();
+    }
+    OperatorTestBase::TearDown();
+  }
+
   std::shared_ptr<const core::PlanNode> makeValuesFilterProject(
       const std::shared_ptr<const RowType>& rowType,
       const std::string& filter,
@@ -59,7 +92,8 @@ class DriverTest : public OperatorTestBase {
       int32_t rowsInBatch,
       // applies to second column
       std::function<bool(int64_t)> filterFunc = nullptr,
-      int32_t* filterHits = nullptr) {
+      int32_t* filterHits = nullptr,
+      bool addTestingPauser = false) {
     std::vector<RowVectorPtr> batches;
     for (int32_t i = 0; i < numBatches; ++i) {
       batches.push_back(std::dynamic_pointer_cast<RowVector>(
@@ -93,6 +127,12 @@ class DriverTest : public OperatorTestBase {
 
       planBuilder.project(expressions, projectNames);
     }
+    if (addTestingPauser) {
+      planBuilder.addNode([](std::shared_ptr<const core::PlanNode> input) {
+        return std::make_shared<TestingPauserNode>(input);
+      });
+    }
+
     return planBuilder.planNode();
   }
 
@@ -121,7 +161,6 @@ class DriverTest : public OperatorTestBase {
       if (operation == ResultOperation::kPause && paused) {
         if (!cursor->hasNext()) {
           paused = false;
-          cursor->cancelPool()->requestPause(false);
           Task::resume(cursor->task());
         }
       }
@@ -156,10 +195,87 @@ class DriverTest : public OperatorTestBase {
     }
   }
 
+ public:
+  // Sets 'future' to a future that will be realized within a random
+  // delay of a few ms.
+  void registerForWakeup(ContinueFuture* future) {
+    std::lock_guard<std::mutex> l(wakeupMutex_);
+    if (!wakeupInitialized_) {
+      wakeupInitialized_ = true;
+      wakeupThread_ = std::thread([&]() {
+        int32_t counter = 0;
+        for (;;) {
+          if (wakeupCancelled_) {
+            return;
+          }
+          // Wait a small interval and realize a small number of queued
+          // promises, if any.
+          auto units = 1 + (++counter % 5);
+          // NOLINT
+          std::this_thread::sleep_for(std::chrono::milliseconds(units));
+          auto count = 1 + (++counter % 4);
+          for (auto i = 0; i < count; ++i) {
+            if (wakeupPromises_.empty()) {
+              break;
+            }
+            wakeupPromises_.front().setValue(true);
+            wakeupPromises_.pop_front();
+          }
+        }
+      });
+    }
+    auto [promise, semiFuture] = makeVeloxPromiseContract<bool>("wakeup");
+    *future = std::move(semiFuture);
+    wakeupPromises_.push_back(std::move(promise));
+  }
+
+  // Registers a Task for use in randomTask().
+  void registerTask(std::shared_ptr<Task> task) {
+    std::lock_guard<std::mutex> l(taskMutex_);
+    if (std::find(allTasks_.begin(), allTasks_.end(), task) !=
+        allTasks_.end()) {
+      return;
+    }
+    allTasks_.push_back(task);
+  }
+
+  void unregisterTask(std::shared_ptr<Task> task) {
+    std::lock_guard<std::mutex> l(taskMutex_);
+    auto it = std::find(allTasks_.begin(), allTasks_.end(), task);
+    if (it == allTasks_.end()) {
+      return;
+    }
+    allTasks_.erase(it);
+  }
+
+  std::shared_ptr<Task> randomTask() {
+    std::lock_guard<std::mutex> l(taskMutex_);
+    if (allTasks_.empty()) {
+      return nullptr;
+    }
+    return allTasks_[folly::Random::rand32() % allTasks_.size()];
+  }
+
+ protected:
+  // State for registerForWakeup().
+  std::mutex wakeupMutex_;
+  std::thread wakeupThread_;
+  std::deque<folly::Promise<bool>> wakeupPromises_;
+  bool wakeupInitialized_{false};
+  // Set to true when it is time to exit 'wakeupThread_'.
+  bool wakeupCancelled_{false};
+
   std::shared_ptr<const RowType> rowType_;
   std::mutex mutex_;
   std::vector<std::shared_ptr<Task>> tasks_;
   std::unordered_map<int32_t, folly::Future<bool>> stateFutures_;
+
+  // Mutex for randomTask()
+  std::mutex taskMutex_;
+  // Tasks registered for randomTask()
+  std::vector<std::shared_ptr<Task>> allTasks_;
+
+  folly::Random::DefaultGenerator rng_;
 };
 
 TEST_F(DriverTest, error) {
@@ -321,6 +437,182 @@ TEST_F(DriverTest, yield) {
     EXPECT_EQ(counters[i], kThreadsPerTask * hits);
     EXPECT_TRUE(stateFutures_.at(i).isReady());
   }
+}
+
+// A testing Operator that periodically does one of the following:
+//
+// 1. Blocks and registers a resume that continues the Driver after a timed
+// pause. This simulates blocking to wait for exchange or consumer.
+//
+// 2. Enters a suspended section where the Driver is on thread but is not
+// counted as running and is therefore instantaneously cancellable and pausable.
+// Comes back on thread after a timed pause. This simulates an RPC to an out of
+// process service.
+//
+// 3.  Enters a suspended section where this pauses and resumes random Tasks,
+// including its own Task. This simulates making Tasks release memory under
+// memory contention, checkpointing Tasks for migration or fault tolerance and
+// other process-wide coordination activities.
+//
+// These situations will occur with arbitrary concurrency and sequence and must
+// therefore be in one test to check against deadlocks.
+class TestingPauser : public Operator {
+ public:
+  TestingPauser(
+      DriverCtx* ctx,
+      int32_t id,
+      std::shared_ptr<const TestingPauserNode> node,
+      DriverTest* test,
+      int32_t sequence)
+      : Operator(ctx, node->outputType(), id, node->id(), "Pauser"),
+        test_(test),
+        counter_(sequence),
+        future_(false) {
+    test_->registerTask(operatorCtx_->task());
+  }
+
+  bool needsInput() const override {
+    return !isFinishing_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+  }
+
+  RowVectorPtr getOutput() override {
+    if (!input_) {
+      return nullptr;
+    }
+    ++counter_;
+    auto label = operatorCtx_->driver()->label();
+    // Block for a time quantum evern 10th time.
+    if (counter_ % 10 == 0) {
+      test_->registerForWakeup(&future_);
+      hasFuture_ = true;
+      return nullptr;
+    }
+    {
+      SuspendedSection noCancel(operatorCtx_->driver());
+      sleep(1);
+      if (counter_ % 7 == 0) {
+        // Every 7th time, stop and resume other Tasks. This operation is
+        // globally serilized.
+        std::lock_guard<std::mutex> l(pauseMutex_);
+
+        for (auto i = 0; i <= counter_ % 3; ++i) {
+          auto task = test_->randomTask();
+          if (!task) {
+            continue;
+          }
+          auto cancelPool = task->cancelPool();
+          cancelPool->requestPause(true);
+          auto& executor = folly::QueuedImmediateExecutor::instance();
+          auto future = cancelPool->finishFuture().via(&executor);
+          future.wait();
+          sleep(2);
+          Task::resume(task);
+        }
+      }
+    }
+
+    return std::move(input_);
+  }
+
+  BlockingReason isBlocked(ContinueFuture* future) override {
+    VELOX_CHECK(!operatorCtx_->driver()->state().isSuspended);
+    if (hasFuture_) {
+      hasFuture_ = false;
+      *future = std::move(future_);
+      return BlockingReason::kWaitForConsumer;
+    }
+    return BlockingReason::kNotBlocked;
+  }
+
+  void finish() override {
+    test_->unregisterTask(operatorCtx_->task());
+    Operator::finish();
+  }
+
+ private:
+  void sleep(int32_t units) {
+    // NOLINT
+    std::this_thread::sleep_for(std::chrono::milliseconds(units));
+  }
+  // The DriverTest under which this is running. Used for global context.
+  DriverTest* test_;
+  // Mutex to serialize the pause/restart exercise so that only one instance
+  // does this at a time.
+  static std::mutex pauseMutex_;
+
+  // Counter deciding
+  // the next action in getOutput().
+  int32_t counter_;
+  bool hasFuture_{false};
+  ContinueFuture future_;
+};
+
+std::mutex TestingPauser ::pauseMutex_;
+
+TEST_F(DriverTest, pauserNode) {
+  constexpr int32_t kNumTasks = 20;
+  constexpr int32_t kThreadsPerTask = 5;
+  // Run with a fraction of the testing threads fitting in the executor.
+  Driver::testingJoinAndReinitializeExecutor(20);
+  static int32_t sequence = 0;
+  // Use a static variable to pass the test instance to the create
+  // function of the testing operator. The testing operator registers
+  // all its Tasks in the test instance to create inter-Task pauses.
+  static DriverTest* testInstance;
+  testInstance = this;
+  Operator::registerOperator(
+      [&](DriverCtx* ctx,
+          int32_t id,
+          const std::shared_ptr<const core::PlanNode>& node)
+          -> std::unique_ptr<TestingPauser> {
+        if (auto pauser =
+                std::dynamic_pointer_cast<const TestingPauserNode>(node)) {
+          return std::make_unique<TestingPauser>(
+              ctx, id, pauser, testInstance, ++sequence);
+        }
+        return nullptr;
+      });
+
+  std::vector<int32_t> counters;
+  counters.reserve(kNumTasks);
+  std::vector<CursorParameters> params;
+  params.resize(kNumTasks);
+  int32_t hits;
+  for (int32_t i = 0; i < kNumTasks; ++i) {
+    params[i].queryCtx = core::QueryCtx::create();
+    params[i].planNode = makeValuesFilterProject(
+        rowType_,
+        "m1 % 10 > 0",
+        "m1 % 3 + m2 % 5 + m3 % 7 + m4 % 11 + m5 % 13 + m6 % 17 + m7 % 19",
+        200,
+        2'000,
+        [](int64_t num) { return num % 10 > 0; },
+        &hits,
+        true);
+    params[i].numThreads = kThreadsPerTask;
+  }
+  std::vector<std::thread> threads;
+  threads.reserve(kNumTasks);
+  for (int32_t i = 0; i < kNumTasks; ++i) {
+    counters.push_back(0);
+    threads.push_back(std::thread([this, &params, &counters, i]() {
+      try {
+        readResults(params[i], ResultOperation::kRead, 10'000, &counters[i], i);
+      } catch (const std::exception& e) {
+        LOG(INFO) << "Pauser task errored out " << e.what();
+      }
+    }));
+  }
+  for (int32_t i = 0; i < kNumTasks; ++i) {
+    threads[i].join();
+    EXPECT_EQ(counters[i], kThreadsPerTask * hits);
+    EXPECT_TRUE(stateFutures_.at(i).isReady());
+  }
+  Driver::testingJoinAndReinitializeExecutor(10);
 }
 
 int main(int argc, char** argv) {

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -42,7 +42,8 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       int numDrivers) {
     auto queryCtx = core::QueryCtx::create();
     bufferManager_->removeTask(taskId);
-    auto task = std::make_shared<Task>(taskId, queryCtx);
+    auto task = std::make_shared<Task>(taskId, nullptr, 0, std::move(queryCtx));
+
     bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
     return task;
   }

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -187,6 +187,14 @@ class PlanBuilder {
     return planNode_;
   }
 
+  // Adds a user defined PlanNode as the root of the plan. 'func' takes
+  // the current root of the plan and returns the new root.
+  PlanBuilder& addNode(std::function<std::shared_ptr<core::PlanNode>(
+                           std::shared_ptr<const core::PlanNode>)> func) {
+    planNode_ = func(planNode_);
+    return *this;
+  }
+
  private:
   std::string nextPlanNodeId();
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -27,7 +27,8 @@ TEST_F(TaskTest, splitGroup) {
   auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
       "test", "file:/tmp/abc", 0, 100);
   core::PlanNodeId planNodeId{"0"};
-  exec::Task task("0", nullptr);
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  exec::Task task("0", nullptr, 0, queryCtx);
 
   // This is the set of completed groups we expect.
   std::unordered_set<int32_t> completedSplitGroups;


### PR DESCRIPTION
- Refactor driver on-thread state as a struct

- Explicitly represent enqueueing, running, pausing while on thread
- and waiting for a continue future.

- make all thread state transitions inside the CancelPool mutex,
- including initial and resume enqueuing, enqueueing from continue
- future etc.

- Add a CancelFreeSection where control is on thread but is not
- touching the Driver's data, so that other threads or self can
- manipulate the Driver as if it were stopped.

- Fix situation of pausing and restarting a Driver that is all the while waiting for a thread on an executor. This case used to enqueue the Driver twice.

- Add safety checks for on-thread flags.