### PR TITLE
Protect access to Task.taskStats_ with a lock

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -484,6 +484,7 @@ void Task::terminate(TaskState terminalState) {
 }
 
 void Task::addOperatorStats(OperatorStats& stats) {
+  std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(
       stats.pipelineId >= 0 &&
       stats.pipelineId < taskStats_.pipelineStats.size());


### PR DESCRIPTION
Differential Revision: D30596015

