### PR TITLE
Add query parameter to use simplified eval path

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -171,6 +171,10 @@ class QueryCtx : public Context {
     return get<std::string>(kSessionTimezone, "");
   }
 
+  bool exprEvalSimplified() const {
+    return get<bool>(kExprEvalSimplified, false);
+  }
+
   static constexpr const char* kCodegenEnabled = "driver.codegen.enabled";
   static constexpr const char* kCodegenConfigurationFilePath =
       "driver.codegen.configuration_file_path";
@@ -193,6 +197,10 @@ class QueryCtx : public Context {
   // False by default.
   static constexpr const char* kAdjustTimestampToTimezone =
       "driver.session.adjust_timestamp_to_timezone";
+
+  // Whether to use the simplified expression evaluation path. False by default.
+  static constexpr const char* kExprEvalSimplified =
+      "driver.expr_eval.simplified";
 
   // Flags used to configure the CAST operator:
 

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -71,8 +71,7 @@ FilterProject::FilterProject(
     isIdentityProjection_ = true;
   }
   numExprs_ = allExprs.size();
-  exprs_ =
-      std::make_unique<ExprSet>(std::move(allExprs), operatorCtx_->execCtx());
+  exprs_ = ExprSet::makeExprSet(std::move(allExprs), operatorCtx_->execCtx());
 }
 
 void FilterProject::addInput(RowVectorPtr input) {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -358,6 +358,15 @@ class ExprSet {
       core::ExecCtx* execCtx,
       bool enableConstantFolding = true);
 
+  virtual ~ExprSet() {}
+
+  // Factory method that takes `kExprEvalSimplified` (query parameter) into
+  // account and instantiates the correct ExprSet class.
+  static std::unique_ptr<ExprSet> makeExprSet(
+      std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
+      core::ExecCtx* execCtx,
+      bool enableConstantFolding = true);
+
   // Initialize and evaluate all expressions available in this ExprSet.
   void eval(
       const SelectivityVector& rows,
@@ -367,7 +376,7 @@ class ExprSet {
   }
 
   // Evaluate from expression `begin` to `end`.
-  void eval(
+  virtual void eval(
       int32_t begin,
       int32_t end,
       bool initialize,
@@ -421,6 +430,8 @@ class ExprSetSimplified : public ExprSet {
       core::ExecCtx* execCtx)
       : ExprSet(std::move(source), execCtx, /*enableConstantFolding*/ false) {}
 
+  virtual ~ExprSetSimplified() override {}
+
   // Initialize and evaluate all expressions available in this ExprSet.
   void eval(
       const SelectivityVector& rows,
@@ -435,7 +446,7 @@ class ExprSetSimplified : public ExprSet {
       bool initialize,
       const SelectivityVector& rows,
       EvalCtx* ctx,
-      std::vector<VectorPtr>* result);
+      std::vector<VectorPtr>* result) override;
 };
 
 /// Enabled for string vectors. Computes the ascii status of the vector by

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -140,3 +140,17 @@ TEST_F(EvalSimplifiedTest, strings) {
 TEST_F(EvalSimplifiedTest, doubles) {
   runTest("ceil(c1) * c0", ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
 }
+
+// Ensure that the right exprSet object is instantiated if `kExprEvalSimplified`
+// is specified.
+TEST_F(EvalSimplifiedTest, queryParameter) {
+  queryCtx_->setConfigOverridesUnsafe({
+      {core::QueryCtx::kExprEvalSimplified, "true"},
+  });
+
+  auto expr = makeTypedExpr("1 + 1", nullptr);
+  auto exprSet = exec::ExprSet::makeExprSet({expr}, &execCtx_);
+
+  auto* ptr = dynamic_cast<exec::ExprSetSimplified*>(exprSet.get());
+  EXPECT_TRUE(ptr != nullptr) << "expected ExprSetSimplified derived object.";
+}


### PR DESCRIPTION
Summary:
Adding query parameter to use simplified eval path. Also adding a
gflag to force to use simplified path.

Differential Revision: D30598320

