### PR TITLE
Adding support for aggregation masks.

### DIFF
--- a/velox/aggregates/SimpleNumerics.cpp
+++ b/velox/aggregates/SimpleNumerics.cpp
@@ -62,6 +62,7 @@ class SumAggregate : public SimpleNumericAggregate<T, ResultType, ResultType> {
           groups, rows, arg);
       return;
     }
+
     if (exec::Aggregate::numNulls_) {
       BaseAggregate::template updateGroups<true>(
           groups,

--- a/velox/aggregates/tests/MinMaxTest.cpp
+++ b/velox/aggregates/tests/MinMaxTest.cpp
@@ -48,14 +48,14 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     // Global partial aggregation.
     auto op = PlanBuilder()
                   .values(vectors)
-                  .partialAggregation({}, {agg(c1)}, {intermediateType})
+                  .partialAggregation({}, {agg(c1)}, {}, {intermediateType})
                   .planNode();
     assertQuery(op, fmt::format("SELECT {} FROM tmp", agg(c1)));
 
     // Global final aggregation.
     op = PlanBuilder()
              .values(vectors)
-             .partialAggregation({}, {agg(c1)}, {intermediateType})
+             .partialAggregation({}, {agg(c1)}, {}, {intermediateType})
              .finalAggregation({}, {agg(a0)}, {inputType})
              .planNode();
     assertQuery(op, fmt::format("SELECT {} FROM tmp", agg(c1)));
@@ -64,7 +64,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     op = PlanBuilder()
              .values(vectors)
              .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
-             .partialAggregation({0}, {agg(c1)}, {intermediateType})
+             .partialAggregation({0}, {agg(c1)}, {}, {intermediateType})
              .planNode();
     assertQuery(
         op, fmt::format("SELECT c0 % 10, {} FROM tmp GROUP BY 1", agg(c1)));
@@ -73,7 +73,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     op = PlanBuilder()
              .values(vectors)
              .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
-             .partialAggregation({0}, {agg(c1)}, {intermediateType})
+             .partialAggregation({0}, {agg(c1)}, {}, {intermediateType})
              .finalAggregation({0}, {agg(a0)}, {inputType})
              .planNode();
     assertQuery(
@@ -84,7 +84,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
              .values(vectors)
              .filter("c0 % 2 = 0")
              .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
-             .partialAggregation({0}, {agg(c1)}, {intermediateType})
+             .partialAggregation({0}, {agg(c1)}, {}, {intermediateType})
              .planNode();
 
     assertQuery(
@@ -96,7 +96,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     op = PlanBuilder()
              .values(vectors)
              .filter("c0 % 2 = 0")
-             .partialAggregation({}, {agg(c1)}, {inputType})
+             .partialAggregation({}, {agg(c1)}, {}, {inputType})
              .planNode();
     assertQuery(
         op, fmt::format("SELECT {} FROM tmp WHERE c0 % 2 = 0", agg(c1)));
@@ -276,7 +276,7 @@ TEST_F(MinMaxTest, minMaxTimestamp) {
   // Intermediate result type is BIGINT.
   auto agg = PlanBuilder()
                  .values(vectors)
-                 .partialAggregation({}, {"min(c0)", "max(c0)"}, {BIGINT()})
+                 .partialAggregation({}, {"min(c0)", "max(c0)"}, {}, {BIGINT()})
                  .finalAggregation({}, {"min(a0)", "max(a1)"}, {TIMESTAMP()})
                  .planNode();
   assertQuery(
@@ -286,7 +286,7 @@ TEST_F(MinMaxTest, minMaxTimestamp) {
   // Intermediate result type is TIMESTAMP.
   agg = PlanBuilder()
             .values(vectors)
-            .partialAggregation({}, {"min(c0)", "max(c0)"}, {TIMESTAMP()})
+            .partialAggregation({}, {"min(c0)", "max(c0)"}, {}, {TIMESTAMP()})
             .finalAggregation({}, {"min(a0)", "max(a1)"}, {TIMESTAMP()})
             .planNode();
   assertQuery(agg, "SELECT min(c0), max(c0) FROM tmp");
@@ -307,14 +307,14 @@ TEST_F(MinMaxTest, initialValue) {
   // Make sure they are not zero.
   auto agg = PlanBuilder()
                  .values({row})
-                 .partialAggregation({}, {"min(c0)"}, {BIGINT()})
+                 .partialAggregation({}, {"min(c0)"}, {}, {BIGINT()})
                  .finalAggregation({}, {"min(a0)"}, {TINYINT()})
                  .planNode();
   assertQuery(agg, "SELECT 1");
 
   agg = PlanBuilder()
             .values({row})
-            .partialAggregation({}, {"max(c1)"}, {BIGINT()})
+            .partialAggregation({}, {"max(c1)"}, {}, {BIGINT()})
             .finalAggregation({}, {"max(a0)"}, {TINYINT()})
             .planNode();
   assertQuery(agg, "SELECT -1");

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -415,24 +415,9 @@ class AggregationNode : public PlanNode {
           groupingKeys,
       const std::vector<std::string>& aggregateNames,
       const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
+      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& aggrMasks,
       bool ignoreNullKeys,
-      std::shared_ptr<const PlanNode> source)
-      : PlanNode(id),
-        step_(step),
-        groupingKeys_(groupingKeys),
-        aggregateNames_(aggregateNames),
-        aggregates_(aggregates),
-        ignoreNullKeys_(ignoreNullKeys),
-        sources_{source},
-        outputType_(
-            getOutputType(groupingKeys_, aggregateNames_, aggregates_)) {
-    // empty grouping keys are used in global aggregation: SELECT sum(c) FROM
-    // t empty aggregates are used in distinct:
-    //    SELECT distinct(b, c) FROM t GROUP BY a
-    VELOX_CHECK(
-        !groupingKeys.empty() || !aggregates.empty(),
-        "Aggregation must specify either grouping keys or aggregates");
-  }
+      std::shared_ptr<const PlanNode> source);
 
   const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
     return sources_;
@@ -457,6 +442,11 @@ class AggregationNode : public PlanNode {
 
   const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates() const {
     return aggregates_;
+  }
+
+  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& aggrMasks()
+      const {
+    return aggrMasks_;
   }
 
   bool ignoreNullKeys() const {
@@ -501,6 +491,9 @@ class AggregationNode : public PlanNode {
   const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> groupingKeys_;
   const std::vector<std::string> aggregateNames_;
   const std::vector<std::shared_ptr<const CallTypedExpr>> aggregates_;
+  // Keeps mask/'no mask' for every aggregation. Mask, if given, is a reference
+  // to a boolean projection column, used to mask out rows for the aggregation.
+  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> aggrMasks_;
   const bool ignoreNullKeys_;
   const std::vector<std::shared_ptr<const PlanNode>> sources_;
   const RowTypePtr outputType_;

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -236,6 +236,11 @@ class Aggregate {
   // is not needed.
   uint64_t numNulls_ = 0;
   HashStringAllocator* allocator_;
+
+  // When selectivity vector has holes, in the pushdown, we need to generate a
+  // different indices vector as the one we get from the DecodedVector is simply
+  // sequential.
+  std::vector<vector_size_t> pushdownCustomIndices_;
 };
 
 using AggregateFunctionRegistry = Registry<

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -27,18 +27,19 @@ class GroupingSet {
   GroupingSet(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       std::vector<std::unique_ptr<Aggregate>>&& aggregates,
+      std::vector<std::optional<ChannelIndex>>&& aggrMaskChannels,
       std::vector<std::vector<ChannelIndex>>&& channelLists,
       std::vector<std::vector<VectorPtr>>&& constantLists,
       bool ignoreNullKeys,
       OperatorCtx* driverCtx);
 
-  void addInput(RowVectorPtr input, bool mayPushdown);
+  void addInput(const RowVectorPtr& input, bool mayPushdown);
 
   bool getOutput(
       int32_t batchSize,
       bool isPartial,
       RowContainerIterator* iterator,
-      RowVectorPtr result);
+      RowVectorPtr& result);
 
   uint64_t allocatedBytes() const;
 
@@ -51,10 +52,21 @@ class GroupingSet {
 
   void populateTempVectors(int32_t aggregateIndex, const RowVectorPtr& input);
 
+  // If the given aggregation has mask, the method copies the activeRows_ to
+  // maskedActiveRows_, updates maskedActiveRows_ from the mask column and
+  // returns pointer to the maskedActiveRows_. Otherwise it simply returns
+  // pointer to activeRows_.
+  const SelectivityVector* prepareSelectivityVector(
+      size_t aggregateIndex,
+      const RowVectorPtr& input);
+
   std::vector<ChannelIndex> keyChannels_;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   const bool isGlobal_;
   std::vector<std::unique_ptr<Aggregate>> aggregates_;
+  // For each aggregation, can hold an index to a boolean channel (projection in
+  // the input row vector), that acts as row mask for the aggregation.
+  std::vector<std::optional<ChannelIndex>> aggrMaskChannels_;
   // Argument list for the corresponding element of 'aggregates_'.
   const std::vector<std::vector<ChannelIndex>> channelLists_;
   // Constant arguments to aggregates. Corresponds pairwise to
@@ -73,6 +85,14 @@ class GroupingSet {
   std::unique_ptr<HashLookup> lookup_;
   uint64_t numAdded_ = 0;
   SelectivityVector activeRows_;
+  // In case of an aggregation using a mask, this selectivity vector is updated
+  // from the mask boolean projection and is used to run aggregations, instead
+  // of the activeRows_.
+  SelectivityVector maskedActiveRows_;
+
+  // We use this vector to decode mask boolean projections to update aggregation
+  // masks.
+  DecodedVector decodedMask_;
 
   // Used to allocate memory for a single row accumulating results of global
   // aggregation
@@ -86,7 +106,7 @@ class HashAggregation : public Operator {
   HashAggregation(
       int32_t operatorId,
       DriverCtx* driverCtx,
-      std::shared_ptr<const core::AggregationNode> aggregationNode);
+      const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
   void addInput(RowVectorPtr input) override;
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -48,6 +48,7 @@ class AggregationTest : public AggregationTestBase {
                   .aggregation(
                       {rowType_->getChildIdx(keyName)},
                       aggregates,
+                      {},
                       core::AggregationNode::Step::kPartial,
                       ignoreNullKeys)
                   .planNode();
@@ -94,6 +95,7 @@ class AggregationTest : public AggregationTestBase {
                   .aggregation(
                       {0, 1, 6},
                       aggregates,
+                      {},
                       core::AggregationNode::Step::kPartial,
                       ignoreNullKeys)
                   .planNode();
@@ -220,6 +222,7 @@ TEST_F(AggregationTest, global) {
                      "max(c3)",
                      "max(c4)",
                      "max(c5)"},
+                    {},
                     core::AggregationNode::Step::kPartial,
                     false)
                 .planNode();
@@ -291,6 +294,7 @@ TEST_F(AggregationTest, aggregateOfNulls) {
                 .aggregation(
                     {0},
                     {"sum(c1)", "min(c1)", "max(c1)"},
+                    {},
                     core::AggregationNode::Step::kPartial,
                     false)
                 .planNode();
@@ -303,6 +307,7 @@ TEST_F(AggregationTest, aggregateOfNulls) {
            .aggregation(
                {},
                {"sum(c1)", "min(c1)", "max(c1)"},
+               {},
                core::AggregationNode::Step::kPartial,
                false)
            .planNode();

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -64,10 +64,12 @@ class PlanBuilder {
   PlanBuilder& partialAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
       const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks = {},
       const std::vector<TypePtr>& resultTypes = {}) {
     return aggregation(
         groupingKeys,
         aggregates,
+        masks,
         core::AggregationNode::Step::kPartial,
         false,
         resultTypes);
@@ -83,6 +85,7 @@ class PlanBuilder {
     return aggregation(
         groupingKeys,
         aggregates,
+        {},
         core::AggregationNode::Step::kFinal,
         false,
         resultTypes);
@@ -94,6 +97,7 @@ class PlanBuilder {
     return aggregation(
         groupingKeys,
         aggregates,
+        {},
         core::AggregationNode::Step::kIntermediate,
         false);
   }
@@ -105,6 +109,7 @@ class PlanBuilder {
     return aggregation(
         groupingKeys,
         aggregates,
+        {},
         core::AggregationNode::Step::kSingle,
         false,
         resultTypes);
@@ -113,6 +118,7 @@ class PlanBuilder {
   PlanBuilder& aggregation(
       const std::vector<ChannelIndex>& groupingKeys,
       const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
       bool ignoreNullKeys,
       const std::vector<TypePtr>& resultTypes = {});


### PR DESCRIPTION
Summary:
Supporting aggregation masks.
Aggregation mask is a reference to one of the boolean projections which contains true for all rows that should be aggregated and false for rows that should not be.
One of the examples is this query:
  SELECT count(1), sum(IF(linenumber = 7, partkey, null)) FROM lineitem
It will have two projections for aggregation operator:
  'equal' = (linenumber = 7)
  'partkey' = partkey
'partkey' is used as a channel for 'sum' aggregation, while 'equal' as a mask.
Aggregation 'count' does not need any channels and just counts all rows.

Differential Revision: D30624680

