### PR TITLE
Extract SubfieldFiltersBuilder from TableScanTest.cpp

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -246,7 +246,7 @@ TEST_F(HashJoinTest, lazyVectors) {
 
   assertQuery(
       op,
-      {{0, rightFile}, {10, leftFile}},
+      {{0, {rightFile}}, {10, {leftFile}}},
       "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
 }
 

--- a/velox/exec/tests/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/HiveConnectorTestBase.cpp
@@ -86,7 +86,8 @@ std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
 
 std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,
-    const std::unordered_map<int, std::shared_ptr<TempFilePath>>& filePaths,
+    const std::unordered_map<int, std::vector<std::shared_ptr<TempFilePath>>>&
+        filePaths,
     const std::string& duckDbSql) {
   bool noMoreSplits = false;
   return test::assertQuery(
@@ -95,7 +96,9 @@ std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
         if (!noMoreSplits) {
           for (const auto& entry : filePaths) {
             auto planNodeId = fmt::format("{}", entry.first);
-            addSplit(task, planNodeId, makeHiveSplit(entry.second->path));
+            for (auto file : entry.second) {
+              addSplit(task, planNodeId, makeHiveSplit(file->path));
+            }
             task->noMoreSplits(planNodeId);
           }
           noMoreSplits = true;

--- a/velox/exec/tests/HiveConnectorTestBase.h
+++ b/velox/exec/tests/HiveConnectorTestBase.h
@@ -18,10 +18,14 @@
 #include "velox/exec/Operator.h"
 #include "velox/exec/tests/OperatorTestBase.h"
 #include "velox/exec/tests/TempFilePath.h"
+#include "velox/type/tests/SubfieldFiltersBuilder.h"
 
 namespace facebook::velox::exec::test {
 
 static const std::string kHiveConnectorId = "test-hive";
+
+using ColumnHandleMap =
+    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>;
 
 // A dummy cache that always misses. This class is for testing purpose only.
 class DummyDataCache : public DataCache {
@@ -89,7 +93,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   std::shared_ptr<exec::Task> assertQuery(
       const std::shared_ptr<const core::PlanNode>& plan,
-      const std::unordered_map<int, std::shared_ptr<TempFilePath>>& filePaths,
+      const std::unordered_map<int, std::vector<std::shared_ptr<TempFilePath>>>&
+          filePaths,
       const std::string& duckDbSql);
 
   static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);
@@ -108,6 +113,14 @@ class HiveConnectorTestBase : public OperatorTestBase {
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max());
 
+  static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
+      common::test::SubfieldFilters subfieldFilters,
+      const std::shared_ptr<const core::ITypedExpr>& remainingFilter =
+          nullptr) {
+    return std::make_shared<connector::hive::HiveTableHandle>(
+        true, std::move(subfieldFilters), remainingFilter);
+  }
+
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name);
 
@@ -116,6 +129,16 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> synthesizedColumn(
       const std::string& name);
+
+  static ColumnHandleMap allRegularColumns(
+      const std::shared_ptr<const RowType>& rowType) {
+    ColumnHandleMap assignments;
+    assignments.reserve(rowType->size());
+    for (auto& name : rowType->names()) {
+      assignments[name] = regularColumn(name);
+    }
+    return assignments;
+  }
 
   static void addConnectorSplit(
       Task* task,

--- a/velox/type/tests/FilterBuilder.h
+++ b/velox/type/tests/FilterBuilder.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "velox/type/Filter.h"
+
 namespace facebook::velox::common::test {
 
 inline std::unique_ptr<common::BigintRange> lessThan(

--- a/velox/type/tests/SubfieldFiltersBuilder.h
+++ b/velox/type/tests/SubfieldFiltersBuilder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/Subfield.h"
+
+namespace facebook::velox::common::test {
+
+using SubfieldFilters =
+    std::unordered_map<common::Subfield, std::unique_ptr<common::Filter>>;
+
+class SubfieldFiltersBuilder {
+ public:
+  SubfieldFiltersBuilder& add(
+      const std::string& path,
+      std::unique_ptr<common::Filter> filter) {
+    filters_[common::Subfield(path)] = std::move(filter);
+    return *this;
+  }
+
+  SubfieldFilters build() {
+    return std::move(filters_);
+  }
+
+ private:
+  SubfieldFilters filters_;
+};
+
+inline SubfieldFilters singleSubfieldFilter(
+    const std::string& path,
+    std::unique_ptr<common::Filter> filter) {
+  return SubfieldFiltersBuilder().add(path, std::move(filter)).build();
+}
+} // namespace facebook::velox::common::test


### PR DESCRIPTION
SubfieldFiltersBuilder utility class as well as helper methods makeTableHandle() and allRegularColumns() methods would be handy in other tests, e.g. HashJoinTest. 