### PR TITLE
Fix 'Write past Buffer capacity()' Bug

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -476,13 +476,12 @@ void BaseVector::ensureWritable(
   // The copy-on-write size is the max of the writable row set and the
   // vector.
   //
-  // If the vector is constant, this logic is tricky: we first try to use the
-  // vector size (in case the size is not set to kMaxElements), otherwise we
-  // fallback to the 'rows' size. We don't use rows.size() inadvertently because
-  // in many cases this function is used with SelectivityVector::empty().
-  auto targetSize = (*result)->isConstantEncoding()
-      ? (((*result)->size() != kMaxElements) ? (*result)->size() : rows.size())
-      : (std::max<vector_size_t>(rows.size(), (*result)->size()));
+  // If the vector size is kMaxElements then this is a constant vector's special
+  // case. In this case we use the selectivity vector size no matter if its
+  // empty. Otherwise we use the larger one as target size.
+  auto targetSize = (*result)->size() == kMaxElements
+      ? rows.size()
+      : std::max<vector_size_t>(rows.size(), (*result)->size());
 
   auto copy =
       BaseVector::create(isUnknownType ? type : resultType, targetSize, pool);

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -389,6 +389,39 @@ TEST_F(EnsureWritableVectorTest, constant) {
     EXPECT_EQ(size, constant->size());
   }
 
+  // If constant has smaller size, check that we follow the selectivity vector
+  // size.
+  {
+    const vector_size_t selectivityVectorSize = 100;
+    auto constant = BaseVector::createConstant(
+        variant::create<TypeKind::BIGINT>(123), 1, pool_.get());
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(selectivityVectorSize),
+        BIGINT(),
+        pool_.get(),
+        &constant);
+    EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
+    EXPECT_EQ(selectivityVectorSize, constant->size());
+  }
+
+  // If constant has larger size, check that we follow the constant vector
+  // size.
+  {
+    const vector_size_t selectivityVectorSize = 100;
+    const vector_size_t constantVectorSize = 200;
+    auto constant = BaseVector::createConstant(
+        variant::create<TypeKind::BIGINT>(123),
+        constantVectorSize,
+        pool_.get());
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(selectivityVectorSize),
+        BIGINT(),
+        pool_.get(),
+        &constant);
+    EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
+    EXPECT_EQ(constantVectorSize, constant->size());
+  }
+
   // If constant has max size, check that we follow the selectivity vector size.
   {
     const vector_size_t selectivityVectorSize = 100;


### PR DESCRIPTION
When a constant vector size is smaller than the selectivity vector size, the ensuring of writing buffer used to use the constant vector's size as the target vector size. This caused subsequent write to the raw buffer of the vector exceeding its allocated memory, causing the 'write past buffer capacity()' error.

Added unit tests to guard this situation.