### PR TITLE
Support for ascii encoding for a subset of rows.

### DIFF
--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -65,7 +65,7 @@ class CodegenBenchmark : public CodegenTestCore {
       for (auto& rowVector : inputVector) {
         for (auto& columns : rowVector->children()) {
           if (auto stringVector = columns->asFlatVector<StringView>()) {
-            stringVector->invalidateStringEncoding();
+            stringVector->invalidateIsAscii();
           }
         }
       }

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -38,7 +38,7 @@ void ConstantExpr::evalSpecialForm(
   if (isString()) {
     auto* vector =
         sharedSubexprValues_->asUnchecked<SimpleVector<StringView>>();
-    determineStringEncoding(context, vector, rows);
+    vector->computeAndSetIsAscii(rows);
   }
 
   if (result->get()) {
@@ -46,11 +46,6 @@ void ConstantExpr::evalSpecialForm(
     BaseVector::ensureWritable(
         rows, (*result)->type(), context->execCtx()->pool(), result);
     (*result)->copy(sharedSubexprValues_.get(), rows, nullptr);
-    if (isString()) {
-      (*result)
-          ->asUnchecked<SimpleVector<StringView>>()
-          ->copyStringEncodingFrom(sharedSubexprValues_.get());
-    }
     return;
   }
   *result = sharedSubexprValues_;
@@ -118,10 +113,6 @@ void FieldReference::evalSpecialForm(
     auto indices = useDecode ? decoded.indices() : nullptr;
     (*result)->copy(child.get(), rows, indices);
 
-    if (isString()) {
-      (*result)->as<SimpleVector<StringView>>()->copyStringEncodingFrom(
-          child.get());
-    }
 
   } else {
     if (child->encoding() == VectorEncoding::Simple::LAZY) {
@@ -141,39 +132,6 @@ void FieldReference::evalSpecialFormSimplified(
   BaseVector::flattenVector(result, rows.end());
 }
 
-namespace {
-
-/// Calculates the string encoding of the result of a switch expression by
-/// combining string encodings of the results of individual "then" clauses and
-/// an optional "else" clause.
-class StringEncodingTracker {
- public:
-  /// Accepts the result of a "then" or "else" clause.
-  void addEncoding(const VectorPtr& source) {
-    if (encoding_.has_value()) {
-      auto encoding =
-          source->asUnchecked<SimpleVector<StringView>>()->getStringEncoding();
-      if (encoding.has_value()) {
-        encoding_ = maxEncoding(encoding_.value(), encoding.value());
-      } else {
-        encoding_.reset();
-      }
-    }
-  }
-
-  /// Updates input vector with the final encoding of the "switch" expression.
-  void setEncoding(const VectorPtr& vector) const {
-    if (encoding_.has_value()) {
-      vector->asUnchecked<SimpleVector<StringView>>()->setStringEncoding(
-          encoding_.value());
-    }
-  }
-
- private:
-  folly::Optional<StringEncodingMode> encoding_{StringEncodingMode::ASCII};
-};
-} // namespace
-
 void SwitchExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
@@ -192,7 +150,6 @@ void SwitchExpr::evalSpecialForm(
   VarSetter isFinalSelection(context->mutableIsFinalSelection(), false);
 
   const bool isString = type()->kind() == TypeKind::VARCHAR;
-  StringEncodingTracker stringEncodingTracker;
 
   for (auto i = 0; i < numCases_; i++) {
     if (!remainingRows.get()->hasSelections()) {
@@ -214,10 +171,6 @@ void SwitchExpr::evalSpecialForm(
     switch (booleanMix) {
       case BooleanMix::kAllTrue:
         inputs_[2 * i + 1]->eval(*remainingRows.get(), context, result);
-        if (isString) {
-          stringEncodingTracker.addEncoding(*result);
-          stringEncodingTracker.setEncoding(*result);
-        }
         return;
       case BooleanMix::kAllNull:
       case BooleanMix::kAllFalse:
@@ -240,9 +193,6 @@ void SwitchExpr::evalSpecialForm(
           inputs_[2 * i + 1]->eval(*thenRows.get(), context, result);
           remainingRows.get()->deselect(*thenRows.get());
 
-          if (isString) {
-            stringEncodingTracker.addEncoding(*result);
-          }
         }
       }
     }
@@ -258,9 +208,6 @@ void SwitchExpr::evalSpecialForm(
     if (hasElseClause_) {
       inputs_.back()->eval(*remainingRows.get(), context, result);
 
-      if (isString) {
-        stringEncodingTracker.addEncoding(*result);
-      }
     } else {
       // fill in nulls for remainingRows
       remainingRows.get()->applyToSelected(
@@ -268,9 +215,6 @@ void SwitchExpr::evalSpecialForm(
     }
   }
 
-  if (isString) {
-    stringEncodingTracker.setEncoding(*result);
-  }
 }
 
 bool SwitchExpr::propagatesNulls() const {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -448,12 +448,10 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
     core::ExecCtx* execCtx);
 
-/// Enabled for string vectors. Computes the ascii status of the vector by
-/// scanning all the vector values. No-op if rows doesn't include all rows in
-/// the vector.
-void determineStringEncoding(
-    exec::EvalCtx* context,
-    SimpleVector<StringView>* vector,
-    const SelectivityVector& rows);
+// Factory method that takes `kExprEvalSimplified` (query parameter) into
+// account and instantiates the correct ExprSet class.
+std::unique_ptr<ExprSet> makeExprSetFromFlag(
+    std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
+    core::ExecCtx* execCtx);
 
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/Length.cpp
+++ b/velox/functions/prestosql/Length.cpp
@@ -64,7 +64,7 @@ class LengthFunction : public exec::VectorFunction {
     auto* resultFlatVector = (*result)->as<FlatVector<int64_t>>();
 
     if (inputArg->typeKind() == TypeKind::VARCHAR) {
-      auto stringEncoding = getStringEncodingOrUTF8(inputArg.get());
+      auto stringEncoding = getStringEncodingOrUTF8(inputArg.get(), rows);
       StringEncodingTemplateWrapper<ApplyInternalString>::apply(
           stringEncoding, rows, decodedInput, resultFlatVector);
       return;

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -198,7 +198,7 @@ class SubstrFunction : public exec::VectorFunction {
     BaseVector* stringsVector = args[0].get();
     BaseVector* startsVector = args[1].get();
     BaseVector* lengthsVector = noLengthVector ? nullptr : args[2].get();
-    auto stringArgStringEncoding = getStringEncodingOrUTF8(stringsVector);
+    auto stringArgStringEncoding = getStringEncodingOrUTF8(stringsVector, rows);
 
     auto stringArgVectorEncoding = stringsVector->encoding();
     auto startArgVectorEncoding = startsVector->encoding();
@@ -390,7 +390,7 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
     exec::LocalDecodedVector inputHolder(context, *inputStringsVector, rows);
     auto decodedInput = inputHolder.get();
 
-    auto stringEncoding = getStringEncodingOrUTF8(inputStringsVector);
+    auto stringEncoding = getStringEncodingOrUTF8(inputStringsVector, rows);
 
     bool inPlace = (stringEncoding == StringEncodingMode::ASCII) &&
         (inputStringsVector->encoding() == VectorEncoding::Simple::FLAT) &&
@@ -549,7 +549,8 @@ class StringPosition : public exec::VectorFunction {
       }
     }
 
-    auto stringArgStringEncoding = getStringEncodingOrUTF8(args.at(0).get());
+    auto stringArgStringEncoding =
+        getStringEncodingOrUTF8(args.at(0).get(), rows);
     BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
 
     auto* resultFlatVector = (*result)->as<FlatVector<int64_t>>();

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -148,10 +148,6 @@ class StringFunctionsTest : public FunctionBaseTest {
       inputsFlatVector->set(i, StringView(std::get<0>(tests[i])));
     }
 
-    if (stringEncoding.has_value()) {
-      inputsFlatVector->setStringEncoding(stringEncoding.value());
-    }
-
     auto crossRefVector = std::dynamic_pointer_cast<FlatVector<StringView>>(
         BaseVector::create(VARCHAR(), 1, execCtx_.pool()));
 
@@ -161,8 +157,6 @@ class StringFunctionsTest : public FunctionBaseTest {
 
     auto result = evaluate<FlatVector<StringView>>(
         "upper(c0)", makeRowVector({inputsFlatVector}));
-
-    ASSERT_EQ(result->getStringEncoding().value(), expectedResultEncoding);
 
     for (int32_t i = 0; i < tests.size(); ++i) {
       ASSERT_EQ(result->valueAt(i), StringView(std::get<1>(tests[i])));
@@ -181,10 +175,6 @@ class StringFunctionsTest : public FunctionBaseTest {
       inputsFlatVector->set(i, StringView(std::get<0>(tests[i])));
     }
 
-    if (stringEncoding.has_value()) {
-      inputsFlatVector->setStringEncoding(stringEncoding.value());
-    }
-
     auto crossRefVector = std::dynamic_pointer_cast<FlatVector<StringView>>(
         BaseVector::create(VARCHAR(), 1, execCtx_.pool()));
 
@@ -194,7 +184,6 @@ class StringFunctionsTest : public FunctionBaseTest {
     auto testQuery = [&](const std::string& query) {
       auto result = evaluate<FlatVector<StringView>>(
           query, makeRowVector({inputsFlatVector}));
-      ASSERT_EQ(result->getStringEncoding().value(), expectedResultEncoding);
 
       for (int32_t i = 0; i < tests.size(); ++i) {
         ASSERT_EQ(result->valueAt(i), StringView(std::get<1>(tests[i])));
@@ -257,9 +246,6 @@ class StringFunctionsTest : public FunctionBaseTest {
     for (int i = 0; i < tests.size(); i++) {
       inputsFlatVector->set(i, StringView(std::get<0>(tests[i])));
     }
-    if (stringEncoding.has_value()) {
-      inputsFlatVector->setStringEncoding(stringEncoding.value());
-    }
     auto result = evaluate<FlatVector<int64_t>>(
         "length(c0)", makeRowVector({inputsFlatVector}));
 
@@ -267,6 +253,31 @@ class StringFunctionsTest : public FunctionBaseTest {
       ASSERT_EQ(result->valueAt(i), std::get<1>(tests[i]));
     }
   }
+
+  void testAsciiPropogation(
+      std::vector<std::string> firstColumn,
+      std::vector<std::string> secondColumn,
+      std::vector<std::string> thirdColumn,
+      SelectivityVector rows,
+      bool isAscii,
+      std::string function = "testing_string",
+      bool computeAsciness = true) {
+    auto argFirst = makeFlatVector<std::string>(firstColumn);
+    auto argSecond = makeFlatVector<std::string>(secondColumn);
+    auto argThird = makeFlatVector<std::string>(thirdColumn);
+
+    // Compute asciiness on first and second column.
+    if (computeAsciness) {
+      (argFirst->as<SimpleVector<StringView>>())->computeAndSetIsAscii(rows);
+      (argSecond->as<SimpleVector<StringView>>())->computeAndSetIsAscii(rows);
+    }
+
+    auto result = evaluate<SimpleVector<StringView>>(
+        fmt::format("{}(c0, c1, c2)", function),
+        makeRowVector({argFirst, argSecond, argThird}));
+    auto ascii = result->isAscii(rows);
+    ASSERT_EQ(ascii && ascii.value(), isAscii);
+  };
 
   using strpos_input_test_t = std::vector<
       std::pair<std::tuple<std::string, std::string, int64_t>, int64_t>>;
@@ -304,7 +315,7 @@ class StringFunctionsTest : public FunctionBaseTest {
   void testStringEncodingResolution(
       const std::vector<std::vector<std::string>>& content,
       const std::vector<folly::Optional<StringEncodingMode>>& encodings,
-      StringEncodingMode expectedResolvedEncoding);
+      bool isAscii);
 
   void testXXHash64(
       const std::vector<std::tuple<std::string, int64_t, int64_t>>& tests);
@@ -771,14 +782,6 @@ TEST_F(StringFunctionsTest, concat) {
     EXPECT_EQ(result->valueAt(i), StringView(c0 + c1));
   }
 
-  // Test string encoding propagation
-  result =
-      evaluate<SimpleVector<StringView>>("concat('ali', 'ali','ali')", rows);
-  EXPECT_EQ(result->getStringEncoding().value(), StringEncodingMode::ASCII);
-
-  result = evaluate<SimpleVector<StringView>>(
-      "concat('ali', 'àáâãäåæçè','ali')", rows);
-  EXPECT_EQ(result->getStringEncoding().value(), StringEncodingMode::UTF8);
 }
 
 // Test length vector function
@@ -843,12 +846,6 @@ void StringFunctionsTest::testStringPositionAllFlatVector(
     }
   }
 
-  if (stringEncodings[0].has_value()) {
-    stringVector->setStringEncoding(stringEncodings[0].value());
-  }
-  if (stringEncodings[1].has_value()) {
-    subStringVector->setStringEncoding(stringEncodings[1].value());
-  }
 
   FlatVectorPtr<int64_t> result;
   if (withInstanceArgument) {
@@ -1138,7 +1135,7 @@ TEST_F(StringFunctionsTest, replace) {
 void StringFunctionsTest::testStringEncodingResolution(
     const std::vector<std::vector<std::string>>& content,
     const std::vector<folly::Optional<StringEncodingMode>>& encodings,
-    StringEncodingMode expectedResolvedEncoding) {
+    bool isAscii) {
   std::vector<FlatVectorPtr<StringView>> inputVectors;
   inputVectors.resize(content.size());
 
@@ -1149,11 +1146,6 @@ void StringFunctionsTest::testStringEncodingResolution(
     }
   }
 
-  for (int i = 0; i < encodings.size(); i++) {
-    if (encodings[i].has_value()) {
-      inputVectors[i]->setStringEncoding(encodings[i].value());
-    }
-  }
 
   SelectivityVector rows(content[0].size());
   rows.setAll();
@@ -1163,29 +1155,26 @@ void StringFunctionsTest::testStringEncodingResolution(
     baseVectors.push_back(vector.get());
   }
 
-  // A dummy context used to call determineStringEncoding
-  exec::EvalCtx evalCtx(
-      &execCtx_, nullptr, makeRowVector(ROW({}, {}), 0).get());
-
   auto resolvedEncoding = StringEncodingMode::ASCII;
   for (auto vector : baseVectors) {
     auto simpleVector = vector->as<SimpleVector<StringView>>();
-    if (!simpleVector->getStringEncoding().has_value()) {
-      SelectivityVector allRows(simpleVector->size());
-      determineStringEncoding(&evalCtx, simpleVector, allRows);
-    }
-
+    SelectivityVector allRows(simpleVector->size());
+    simpleVector->computeAndSetIsAscii(rows);
     resolvedEncoding = functions::maxEncoding(
-        resolvedEncoding, simpleVector->getStringEncoding().value());
+        resolvedEncoding,
+        simpleVector->isAscii(allRows).value() ? StringEncodingMode::ASCII
+                                               : StringEncodingMode::UTF8);
   }
-  ASSERT_EQ(resolvedEncoding, expectedResolvedEncoding);
+  ASSERT_EQ(
+      resolvedEncoding,
+      isAscii ? StringEncodingMode::ASCII : StringEncodingMode::UTF8);
 }
 
 TEST_F(StringFunctionsTest, controlExprEncodingPropagation) {
   std::vector<std::string> dataASCII({"ali", "ali", "ali"});
   std::vector<std::string> dataUTF8({"àáâãäåæçè", "àáâãäåæçè", "àáâãäå"});
 
-  auto test = [&](std::string query, StringEncodingMode expectedEncoding) {
+  auto test = [&](std::string query, bool expectedEncoding) {
     auto conditionVector = makeFlatVector<bool>({false, true, false});
 
     auto result = evaluate<SimpleVector<StringView>>(
@@ -1195,71 +1184,16 @@ TEST_F(StringFunctionsTest, controlExprEncodingPropagation) {
             makeFlatVector(dataASCII),
             makeFlatVector(dataUTF8),
         }));
-    ASSERT_TRUE(result->getStringEncoding().has_value());
-    ASSERT_EQ(result->getStringEncoding().value(), expectedEncoding);
-  };
-
-  auto testEncodingNotSet = [&](std::string query) {
-    auto conditionVector = makeFlatVector<bool>({false, true, false});
-
-    auto result = evaluate<SimpleVector<StringView>>(
-        query,
-        makeRowVector({
-            conditionVector,
-            makeFlatVector(dataASCII),
-            makeFlatVector(dataUTF8),
-        }));
-    ASSERT_EQ(result->getStringEncoding(), folly::none);
+    SelectivityVector all(result->size());
+    auto ascii = result->isAscii(all);
+    ASSERT_EQ(ascii && ascii.value(), expectedEncoding);
   };
 
   // Test if expressions
 
-  // Setting encoding on partially populated vector is not yet supported.
-  testEncodingNotSet("if(C0, lower(C1), lower(C2))");
+  test("if(1=1, lower(C1), lower(C2))", true);
 
-  // always then path
-  test("if(1=1, lower(C1), lower(C2))", StringEncodingMode::ASCII);
-
-  test("if(1!=1, lower(C1), lower(C2))", StringEncodingMode::UTF8);
-
-  // if and shared expression
-
-  // Setting encoding on partially populated vector is not yet supported.
-  testEncodingNotSet("if(C0, lower(C1), lower(C1))");
-
-  // Test const expressions ascii
-  test("if(C0, 'ali', 'àáâãäåæçè')", StringEncodingMode::UTF8);
-
-  test("if(C0, 'ali' ,'ali')", StringEncodingMode::ASCII);
-
-  // Test some more complicated expression
-  test(
-      "if(C0, upper('ali'), if(C0,'ali','àáâãäåæçè'))",
-      StringEncodingMode::UTF8);
-
-  // Test field reference expression
-  testEncodingNotSet("if(C0, C1, C2)");
-
-  testEncodingNotSet("if(1=1, C1, C2)");
-  testEncodingNotSet("if(1=1, C1, C1)");
-
-  auto testWithEncodingPreset = [&](std::string query,
-                                    StringEncodingMode expectedEncoding) {
-    auto conditionVector = makeFlatVector<bool>({false, true, false});
-    auto argASCII = makeFlatVector<std::string>({"ali", "ali", "ali"});
-    argASCII->setStringEncoding(StringEncodingMode::ASCII);
-
-    auto argUTF8 =
-        makeFlatVector<std::string>({"àáâãäåæçè", "àáâãäåæçè", "àáâãäå"});
-    argUTF8->setStringEncoding(StringEncodingMode::UTF8);
-
-    auto result = evaluate<FlatVector<StringView>>(
-        query, makeRowVector({conditionVector, argASCII, argUTF8}));
-    ASSERT_EQ(result->getStringEncoding().value(), expectedEncoding);
-  };
-
-  testWithEncodingPreset("if(C0, C1, C1)", StringEncodingMode::ASCII);
-  testWithEncodingPreset("if(C0, C2, C2)", StringEncodingMode::UTF8);
+  test("if(1!=1, lower(C1), lower(C2))", false);
 }
 
 // Test the string encoding reselution
@@ -1317,66 +1251,41 @@ TEST_F(StringFunctionsTest, findCommonEncoding) {
   };
 
   // Test identifying ascii
-  testStringEncodingResolution(
-      {asciiCol}, {folly::none}, StringEncodingMode::ASCII);
+  testStringEncodingResolution({asciiCol}, {folly::none}, true);
+
+  testStringEncodingResolution({asciiCol}, {StringEncodingMode::ASCII}, true);
 
   testStringEncodingResolution(
-      {asciiCol}, {StringEncodingMode::ASCII}, StringEncodingMode::ASCII);
-
-  testStringEncodingResolution(
-      {asciiCol, asciiCol},
-      {folly::none, folly::none},
-      StringEncodingMode::ASCII);
+      {asciiCol, asciiCol}, {folly::none, folly::none}, true);
 
   testStringEncodingResolution(
       {asciiCol, asciiCol, asciiCol},
       {folly::none, folly::none, folly::none},
-      StringEncodingMode::ASCII);
-
-  // Test identifying likely ascii
-  testStringEncodingResolution(
-      {mostlyAsciiCol}, {folly::none}, StringEncodingMode::MOSTLY_ASCII);
-
-  testStringEncodingResolution(
-      {asciiCol, mostlyAsciiCol},
-      {folly::none, folly::none},
-      StringEncodingMode::MOSTLY_ASCII);
-
-  testStringEncodingResolution(
-      {asciiCol, mostlyAsciiCol},
-      {StringEncodingMode::ASCII, StringEncodingMode::MOSTLY_ASCII},
-      StringEncodingMode::MOSTLY_ASCII);
-
-  testStringEncodingResolution(
-      {asciiCol, asciiCol},
-      {StringEncodingMode::MOSTLY_ASCII, StringEncodingMode::ASCII},
-      StringEncodingMode::MOSTLY_ASCII);
+      true);
 
   // Test identifying UTF8
-  testStringEncodingResolution(
-      {utf8Col}, {folly::none}, StringEncodingMode::UTF8);
+  testStringEncodingResolution({utf8Col}, {folly::none}, false);
 
-  testStringEncodingResolution(
-      {mixUTF8Col}, {folly::none}, StringEncodingMode::UTF8);
+  testStringEncodingResolution({mixUTF8Col}, {folly::none}, false);
 
   testStringEncodingResolution(
       {asciiCol, mostlyAsciiCol, utf8Col},
       {folly::none, folly::none, folly::none},
-      StringEncodingMode::UTF8);
+      false);
 
   testStringEncodingResolution(
       {asciiCol, mostlyAsciiCol, utf8Col},
       {StringEncodingMode::ASCII,
        StringEncodingMode::MOSTLY_ASCII,
        folly::none},
-      StringEncodingMode::UTF8);
+      false);
 
   testStringEncodingResolution(
       {asciiCol, mostlyAsciiCol, utf8Col},
       {StringEncodingMode::ASCII,
        StringEncodingMode::MOSTLY_ASCII,
        StringEncodingMode::UTF8},
-      StringEncodingMode::UTF8);
+      false);
 }
 
 void StringFunctionsTest::testXXHash64(
@@ -1453,4 +1362,285 @@ TEST_F(StringFunctionsTest, xxhash64) {
     // Default value seed for string inputs
     testXXHash64(validInputTest, true);
   }
+}
+
+namespace {
+
+class TestingStringFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      exec::Expr* /*caller*/,
+      exec::EvalCtx* /*context*/,
+      VectorPtr* result) const override {
+    *result = BaseVector::wrapInConstant(rows.size(), 0, args[0]);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {
+        // varchar, varchar, varchar -> varchar
+        exec::FunctionSignatureBuilder()
+            .returnType("varchar")
+            .argumentType("varchar")
+            .argumentType("varchar")
+            .argumentType("varchar")
+            .build(),
+    };
+  }
+
+  bool ensureStringEncodingSetAtAllInputs() const override {
+    return true;
+  }
+
+  bool propagateStringEncodingFromAllInputs() const override {
+    return true;
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_testing_string_function,
+    TestingStringFunction::signatures(),
+    std::make_unique<TestingStringFunction>());
+
+TEST_F(StringFunctionsTest, ascinessOnDictionary) {
+  using S = StringView;
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_testing_string_function, "testing_string")
+  vector_size_t size = 5;
+  auto flatVector = makeFlatVector<StringView>(
+      {S("hello how do"),
+       S("how are"),
+       S("is this how"),
+       S("abcd"),
+       S("yes no")});
+
+  auto searchVector = makeFlatVector<StringView>(
+      {S("hello"), S("how"), S("is"), S("abc"), S("yes")});
+  auto replaceVector = makeFlatVector<StringView>(
+      {S("hi"), S("hmm"), S("it"), S("mno"), S("xyz")});
+  BufferPtr nulls = nullptr;
+
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (int i = 0; i < size; i++) {
+    rawIndices[i] = i;
+  }
+
+  auto dictionaryVector =
+      BaseVector::wrapInDictionary(nulls, indices, size, flatVector);
+
+  auto result = evaluate<SimpleVector<StringView>>(
+      fmt::format("testing_string(c0, c1, c2)"),
+      makeRowVector({dictionaryVector, searchVector, replaceVector}));
+  SelectivityVector all(size);
+  auto ascii = result->isAscii(all);
+  ASSERT_EQ(ascii && ascii.value(), true);
+}
+
+TEST_F(StringFunctionsTest, vectorAccessCheck) {
+  using S = StringView;
+
+  auto flatVectorWithNulls = makeNullableFlatVector<StringView>(
+      std::vector<std::optional<StringView>>{
+          S("hello"), std::nullopt, S("world")},
+      VARCHAR());
+
+  exec::EvalCtx evalCtx(
+      &execCtx_, nullptr, makeRowVector(ROW({}, {}), 0).get());
+
+  auto vectorWithNulls = flatVectorWithNulls->as<SimpleVector<StringView>>();
+  SelectivityVector rows(vectorWithNulls->size());
+  rows.setValid(1, false); // Dont access the middle element.
+  vectorWithNulls->computeAndSetIsAscii(rows);
+  auto ascii = vectorWithNulls->isAscii(rows);
+  ASSERT_TRUE(ascii && ascii.value());
+}
+
+TEST_F(StringFunctionsTest, switchCaseCheck) {
+  auto testWithEncodingPreset = [&](std::vector<bool> conditionColumn,
+                                    std::vector<std::string> firstColumn,
+                                    std::vector<std::string> secondColumn,
+                                    SelectivityVector rows,
+                                    std::string query,
+                                    bool isAscii) {
+    auto conditionVector = makeFlatVector<bool>(conditionColumn);
+    auto argASCII = makeFlatVector<std::string>(firstColumn);
+    auto asciiVector = argASCII->as<SimpleVector<StringView>>();
+    asciiVector->computeAndSetIsAscii(rows);
+
+    auto argUTF8 = makeFlatVector<std::string>(secondColumn);
+    auto utfVector = argUTF8->as<SimpleVector<StringView>>();
+    utfVector->computeAndSetIsAscii(rows);
+
+    auto result = evaluate<FlatVector<StringView>>(
+        query, makeRowVector({conditionVector, argASCII, argUTF8}));
+    auto ascii = result->isAscii(rows);
+    ASSERT_EQ(ascii && ascii.value(), isAscii);
+  };
+
+  auto condition = std::vector<bool>{false, true, false};
+  auto c1 = std::vector<std::string>{"ali", "ali", "ali"};
+  auto c2 = std::vector<std::string>{"àáâãäåæçè", "àáâãäåæçè", "àáâãäå"};
+  SelectivityVector rows(condition.size());
+  testWithEncodingPreset(
+      condition, c1, c2, rows, "if(C0, upper(C1), lower(C1))", true);
+  testWithEncodingPreset(
+      condition, c1, c2, rows, "lower(if(C0, C2, C2))", false);
+  testWithEncodingPreset(
+      condition, c1, c2, rows, "lower(if(C0, C1, C1))", true);
+  // Encoding not computed if not required
+  testWithEncodingPreset(condition, c1, c2, rows, "if(C0, C1, C1)", false);
+}
+
+TEST_F(StringFunctionsTest, asciiPropogation) {
+  /// This test case catches case where we ensure that ascii propagation is
+  /// the AND of all input vectors.
+
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_testing_string_function, "testing_string")
+
+  auto c1 = std::vector<std::string>{"a", "a", "a"};
+  auto c2 = std::vector<std::string>{"à", "b", "å"};
+  auto c3 = std::vector<std::string>{"a", "a", "a"};
+
+  SelectivityVector rows(c1.size(), false);
+  rows.setValid(2, true);
+  rows.updateBounds();
+  testAsciiPropogation(c1, c2, c3, rows, false);
+
+  // We dont do row level asciiness anymore, thus even the middle element will
+  // be false.
+  rows.clearAll();
+  rows.setValid(1, true);
+  rows.updateBounds();
+  testAsciiPropogation(c1, c2, c3, rows, false);
+}
+
+namespace {
+
+class InputModifyingFunction : public TestingStringFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      exec::Expr* expr,
+      exec::EvalCtx* ctx,
+      VectorPtr* result) const override {
+    TestingStringFunction::apply(rows, args, expr, ctx, result);
+
+    // Modify args and remove its asciness
+    for (auto& arg : args) {
+      auto input = arg->as<SimpleVector<StringView>>();
+      input->invalidateIsAscii();
+    }
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_input_modifying_string_function,
+    InputModifyingFunction::signatures(),
+    std::make_unique<InputModifyingFunction>());
+
+TEST_F(StringFunctionsTest, asciiPropogationOnInputModification) {
+  /// This test case catches case where we ensure that ascii propagation is
+  /// the AND of all input vectors.
+
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_input_modifying_string_function, "modifying_string_input")
+
+  auto c1 = std::vector<std::string>{"a", "a", "a"};
+  auto c2 = std::vector<std::string>{"à", "b", "å"};
+  auto c3 = std::vector<std::string>{"a", "a", "a"};
+
+  SelectivityVector rows(c1.size(), false);
+  rows.setValid(2, true);
+  rows.updateBounds();
+  testAsciiPropogation(c1, c2, c3, rows, false, "modifying_string_input");
+}
+
+namespace {
+class AsciiPropagationCheckFn : public TestingStringFunction {
+ public:
+  folly::Optional<std::vector<size_t>> propagateStringEncodingFrom()
+      const override {
+    return {{0, 1}};
+    ;
+  }
+
+  bool propagateStringEncodingFromAllInputs() const override {
+    return false;
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_ascii_propagation_check,
+    AsciiPropagationCheckFn::signatures(),
+    std::make_unique<AsciiPropagationCheckFn>());
+
+TEST_F(StringFunctionsTest, asciiPropagationForSpecificInput) {
+  /// This test case catches case where we ensure that ascii propagation is
+  /// AND of first two input vectors.
+
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_ascii_propagation_check, "index_ascii_propagation")
+
+  auto c1 = std::vector<std::string>{"a", "a", "a"};
+  auto c2 = std::vector<std::string>{"à", "à", "å"};
+  auto c3 = std::vector<std::string>{"a", "a", "a"};
+
+  SelectivityVector all(c1.size());
+  testAsciiPropogation(c1, c2, c3, all, false, "index_ascii_propagation");
+
+  testAsciiPropogation(c1, c3, c2, all, true, "index_ascii_propagation");
+}
+
+namespace {
+class AsciiPropagationTestFn : public TestingStringFunction {
+ public:
+  folly::Optional<std::vector<size_t>> propagateStringEncodingFrom()
+      const override {
+    return {{0, 1}};
+    ;
+  }
+
+  bool propagateStringEncodingFromAllInputs() const override {
+    return false;
+  }
+
+  bool ensureStringEncodingSetAtAllInputs() const override {
+    return false;
+  }
+
+  std::vector<size_t> ensureStringEncodingSetAt() const override {
+    return {1};
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_ascii_propagation_input_check,
+    InputModifyingFunction::signatures(),
+    std::make_unique<AsciiPropagationTestFn>());
+
+TEST_F(StringFunctionsTest, asciiPropagationWithDisparateInput) {
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_ascii_propagation_check, "ascii_propagation_check")
+
+  auto c1 = std::vector<std::string>{"a", "a", "a"};
+  auto c2 = std::vector<std::string>{"à", "à", "å"};
+  auto c3 = std::vector<std::string>{"a", "a", "a"};
+
+  // Compute Asciness for inputs 2,3 explicitly.
+  SelectivityVector all(c1.size());
+  testAsciiPropogation(c1, c2, c3, all, false, "ascii_propagation_check");
+
+  testAsciiPropogation(c1, c3, c2, all, true, "ascii_propagation_check");
+
+  // Do not compute asciness explicitly.
+  testAsciiPropogation(
+      c1, c2, c3, all, false, "ascii_propagation_check", false);
+
+  testAsciiPropogation(c1, c3, c2, all, true, "ascii_propagation_check", false);
 }

--- a/velox/functions/sparksql/String.cpp
+++ b/velox/functions/sparksql/String.cpp
@@ -51,7 +51,8 @@ class Instr : public exec::VectorFunction {
     BaseVector::ensureWritable(selected, INTEGER(), context->pool(), result);
     auto* output = (*result)->as<FlatVector<int32_t>>();
 
-    if (getStringEncodingOrUTF8(args[0].get()) == StringEncodingMode::ASCII) {
+    if (getStringEncodingOrUTF8(args[0].get(), selected) ==
+        StringEncodingMode::ASCII) {
       selected.applyToSelected([&](vector_size_t row) {
         output->set(
             row,
@@ -91,7 +92,8 @@ class Length : public exec::VectorFunction {
     auto* output = (*result)->as<FlatVector<int32_t>>();
 
     if (args[0]->typeKind() == TypeKind::VARCHAR &&
-        getStringEncodingOrUTF8(args[0].get()) != StringEncodingMode::ASCII) {
+        getStringEncodingOrUTF8(args[0].get(), selected) !=
+            StringEncodingMode::ASCII) {
       selected.applyToSelected([&](vector_size_t row) {
         const StringView str = input->valueAt<StringView>(row);
         output->set(row, lengthUnicode(str.data(), str.size()));

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -335,11 +335,11 @@ class ConstantVector : public SimpleVector<T> {
       }
       valueVector_ = nullptr;
 
-      // Preserve string encoding
       if constexpr (std::is_same_v<T, StringView>) {
-        if (simple->getStringEncoding().has_value()) {
-          SimpleVector<T>::setStringEncoding(
-              simple->getStringEncoding().value());
+        SelectivityVector rows(simple->size());
+        auto vec = simple->template as<SimpleVector<StringView>>();
+        if (vec->isAscii(rows)) {
+          SimpleVector<T>::setIsAscii(vec->isAscii(rows).value(), rows);
         }
       }
     }

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -295,6 +295,10 @@ void FlatVector<T>::resize(vector_size_t size) {
   values_->setSize(minBytes);
 
   if (std::is_same<T, StringView>::value) {
+    if (size < previousSize) {
+      auto vector = this->template as<SimpleVector<StringView>>();
+      vector->invalidateIsAscii();
+    }
     if (size == 0) {
       stringBuffers_.clear();
     }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -999,6 +999,18 @@ TEST_F(VectorTest, resizeAtConstruction) {
   EXPECT_EQ(oldByteSize, flat->values()->size());
 }
 
+TEST_F(VectorTest, resizeStringAsciiness) {
+  auto vectorMaker = std::make_unique<test::VectorMaker>(pool_.get());
+  std::vector<std::string> stringInput = {"hellow", "how", "are"};
+  auto flatVector = vectorMaker->flatVector(stringInput);
+  auto stringVector = flatVector->as<SimpleVector<StringView>>();
+  SelectivityVector rows(stringInput.size());
+  stringVector->computeAndSetIsAscii(rows);
+  ASSERT_TRUE(stringVector->isAscii(rows).value());
+  stringVector->resize(2);
+  ASSERT_FALSE(stringVector->isAscii(rows));
+}
+
 TEST_F(VectorTest, compareNan) {
   auto vectorMaker = std::make_unique<test::VectorMaker>(pool_.get());
 

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -41,6 +41,11 @@ inline std::vector<VectorEncoding::Simple> kAllTypes = {
     VectorEncoding::Simple::BIASED,
     VectorEncoding::Simple::CONSTANT};
 
+inline std::vector<VectorEncoding::Simple> kAsciiTestTypes = {
+    VectorEncoding::Simple::DICTIONARY,
+    VectorEncoding::Simple::FLAT,
+    VectorEncoding::Simple::SEQUENCE};
+
 template <typename T>
 using ExpectedData = std::vector<std::optional<T>>;
 


### PR DESCRIPTION
NOTE: This PR is the same as #32 only created in a new branch against main so that there is only one commit. 

Currently for any String vector we store state on whether its fully ascii or not. When a vector is fully ascii it allows us to use the ascii fast path for any string computation. Most datasets are predominantly ascii , and we optimize for that use case. This PR now adds support to use asciiness based on subset of rows that are processed.
