### PR TITLE
Optimize writer for ConstantVector

### DIFF
--- a/velox/dwio/dwrf/common/Range.h
+++ b/velox/dwio/dwrf/common/Range.h
@@ -34,6 +34,7 @@ class Ranges {
   void add(size_t begin, size_t end) {
     DWIO_ENSURE_LT(begin, end);
     size_ += (end - begin);
+    max_ = std::max(max_, end);
     if (ranges_.size()) {
       // try merge with last
       auto& last = ranges_.back();
@@ -101,9 +102,14 @@ class Ranges {
     return size_;
   }
 
+  size_t max() const {
+    return max_;
+  }
+
   void clear() {
     ranges_.clear();
     size_ = 0;
+    max_ = 0;
   }
 
   const std::vector<std::tuple<size_t, size_t>>& getRanges() const {
@@ -119,6 +125,7 @@ class Ranges {
  private:
   std::vector<std::tuple<size_t, size_t>> ranges_;
   size_t size_{0};
+  size_t max_{0};
 
   FRIEND_TEST(RangeTests, Add);
   FRIEND_TEST(RangeTests, Filter);

--- a/velox/dwio/dwrf/test/RangeTests.cpp
+++ b/velox/dwio/dwrf/test/RangeTests.cpp
@@ -25,20 +25,25 @@ namespace facebook::velox::dwrf {
 
 TEST(RangeTests, Add) {
   Ranges ranges;
+  ASSERT_EQ(ranges.size(), 0);
+  ASSERT_EQ(ranges.max(), 0);
   ASSERT_THROW(ranges.add(2, 1), exception::LoggedException);
   ASSERT_THROW(ranges.add(2, 2), exception::LoggedException);
   ranges.add(1, 3);
   ASSERT_THAT(ranges.ranges_, ElementsAre(std::tuple<size_t, size_t>{1, 3}));
   ASSERT_EQ(ranges.size(), 2);
+  ASSERT_EQ(ranges.max(), 3);
   ranges.add(3, 5);
   ASSERT_THAT(ranges.ranges_, ElementsAre(std::tuple<size_t, size_t>{1, 5}));
   ASSERT_EQ(ranges.size(), 4);
+  ASSERT_EQ(ranges.max(), 5);
   ranges.add(6, 9);
   ASSERT_THAT(
       ranges.ranges_,
       ElementsAre(
           std::tuple<size_t, size_t>{1, 5}, std::tuple<size_t, size_t>{6, 9}));
   ASSERT_EQ(ranges.size(), 7);
+  ASSERT_EQ(ranges.max(), 9);
   ranges.add(8, 10);
   ASSERT_THAT(
       ranges.ranges_,
@@ -46,8 +51,11 @@ TEST(RangeTests, Add) {
           std::tuple<size_t, size_t>{1, 5},
           std::tuple<size_t, size_t>{6, 9},
           std::tuple<size_t, size_t>{8, 10}));
+  ASSERT_EQ(ranges.size(), 9);
+  ASSERT_EQ(ranges.max(), 10);
   ranges.clear();
   ASSERT_EQ(ranges.size(), 0);
+  ASSERT_EQ(ranges.max(), 0);
 }
 
 TEST(RangeTests, ForEach) {


### PR DESCRIPTION
Summary: Eval always creates constant vector of size kMaxElements. Writer tries to create selectivity vector of `vector->size()`, which is significantly larger than the actual range needs to be written. It's sufficient to just create selectivity vector with a size large enough to hold the max index.

Differential Revision: D30692957

