### PR TITLE
Stop using kMaxElements in Hive connector

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -423,15 +423,13 @@ vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {
 void HiveDataSource::setConstantValue(
     common::ScanSpec* spec,
     const velox::variant& value) const {
-  spec->setConstantValue(
-      BaseVector::createConstant(value, BaseVector::kMaxElements, pool_));
+  spec->setConstantValue(BaseVector::createConstant(value, 1, pool_));
 }
 
 void HiveDataSource::setNullConstantValue(
     common::ScanSpec* spec,
     const TypePtr& type) const {
-  spec->setConstantValue(
-      BaseVector::createNullConstant(type, BaseVector::kMaxElements, pool_));
+  spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
 }
 
 HiveConnector::HiveConnector(

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -3934,7 +3934,8 @@ void SelectiveStructColumnReader::next(
     for (auto& childSpec : childSpecs) {
       VELOX_CHECK(childSpec->isConstant());
       auto channel = childSpec->channel();
-      resultRowVector->childAt(channel) = childSpec->constantValue();
+      resultRowVector->childAt(channel) =
+          BaseVector::wrapInConstant(numValues, 0, childSpec->constantValue());
     }
     return;
   }
@@ -4106,7 +4107,8 @@ void SelectiveStructColumnReader::getValues(RowSet rows, VectorPtr* result) {
     auto index = childSpec->subscript();
     auto channel = childSpec->channel();
     if (childSpec->isConstant()) {
-      resultRow->childAt(channel) = childSpec->constantValue();
+      resultRow->childAt(channel) = BaseVector::wrapInConstant(
+          rows.size(), 0, childSpec->constantValue());
     } else {
       if (!childSpec->extractValues() && !childSpec->filter()) {
         // LazyVector result.


### PR DESCRIPTION
Store constant values as ConstantVector of size 1 in ScanSpec and make properly-sized constant vectors from these when returning results.