### PR TITLE
Pass only one selectivity vector to applyFunction

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -875,7 +875,7 @@ void Expr::evalAll(
 
   if (!tryPeelArgs ||
       !applyFunctionWithPeeling(rows, *remainingRows, context, result)) {
-    applyFunction(rows, *remainingRows, context, result);
+    applyFunction(*remainingRows, context, result);
   }
   if (remainingRows != &rows) {
     addNulls(rows, remainingRows->asRange().bits(), context, result);
@@ -1007,21 +1007,20 @@ bool Expr::applyFunctionWithPeeling(
   }
 
   VectorPtr peeledResult;
-  applyFunction(*newRows, *newRows, context, &peeledResult);
+  applyFunction(*newRows, context, &peeledResult);
   context->setWrapped(this, peeledResult, rows, result);
   return true;
 }
 
 void Expr::applyFunction(
     const SelectivityVector& rows,
-    const SelectivityVector& applyRows,
     EvalCtx* context,
     VectorPtr* result) {
   scanVectorFunctionInputsStringEncoding(
       vectorFunction_.get(), inputValues_, context, rows);
   auto resultEncoding = getVectorFunctionResultStringEncoding(
       vectorFunction_.get(), inputValues_);
-  applyVectorFunction(applyRows, context, result);
+  applyVectorFunction(rows, context, result);
   if (resultEncoding.has_value()) {
     (*result)->as<SimpleVector<StringView>>()->setStringEncoding(
         *resultEncoding);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -258,7 +258,6 @@ class Expr {
   // 'inputValues_'. Handles cases of VectorFunction and VectorAdapter.
   void applyFunction(
       const SelectivityVector& rows,
-      const SelectivityVector& applyRows,
       EvalCtx* context,
       VectorPtr* result);
 


### PR DESCRIPTION
Currently we pass two SelectivityVectors to Expr::applyFunction , one for all input rows and the other with only for those inputs which are non null. For functions that specify a non default null behavior, both sets of rows were same. 