### PR TITLE
Fix simple functions with rows of opaque types

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -976,6 +976,13 @@ struct VectorWriter<std::shared_ptr<T>> {
     vector_ = &vector;
   }
 
+  void ensureSize(size_t size) {
+    if (size != vector_->size()) {
+      vector_->resize(size);
+      init(*vector_);
+    }
+  }
+
   VectorWriter() {}
 
   exec_out_t& current() {


### PR DESCRIPTION
Summary:
VectorWriter for opaque types was missing an ensureSize() method. And
tests.

Reviewed By: mbasmanova

Differential Revision: D30721628

