### PR TITLE
Add erase method to HashTable

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -65,7 +65,15 @@ HashTable<ignoreNullKeys>::HashTable(
 
 class ProbeState {
  public:
+  enum class Operation { kProbe, kInsert, kErase };
+  // Special tag for an erased entry. This counts as occupied for probe and as
+  // empty for insert.
+  static constexpr uint8_t kTombstoneTag = 0x7f;
   static constexpr int32_t kFullMask = 0xffff;
+  static constexpr BaseHashTable::TagVector kTombstoneGroup = {
+      0x7f7f7f7f7f7f7f7fUL,
+      0x7f7f7f7f7f7f7f7fUL};
+  static constexpr BaseHashTable::TagVector kEmptyGroup = {0, 0};
 
   static inline int32_t tagsByteOffset(uint64_t hash, uint64_t sizeMask) {
     return (hash & sizeMask) & ~(sizeof(BaseHashTable::TagVector) - 1);
@@ -85,19 +93,21 @@ class ProbeState {
     auto tag = BaseHashTable::hashTag(hash);
     wantedTags_ = _mm_set1_epi8(tag);
     group_ = nullptr;
+    indexInTags_ = kNotSet;
   }
 
   // Use one instruction to compare the tag being searched for to 16 tags
   // If there is a match, load corresponding data from the table
+  template <Operation op = Operation::kProbe>
   inline void firstProbe(char** table, int32_t firstKey) {
     auto tagMatches = _mm_cmpeq_epi8(tagsInTable_, wantedTags_);
     hits_ = _mm_movemask_epi8(tagMatches);
     if (hits_) {
-      loadNextHit(table, firstKey);
+      loadNextHit<op>(table, firstKey);
     }
   }
 
-  template <typename Compare, typename Insert>
+  template <Operation op, typename Compare, typename Insert>
   inline char* fullProbe(
       uint8_t* tags,
       char** table,
@@ -107,6 +117,9 @@ class ProbeState {
       Insert insert,
       bool extraCheck = false) {
     if (group_ && compare(group_, row_)) {
+      if (op == Operation::kErase) {
+        eraseHit(tags);
+      }
       return group_;
     }
 
@@ -117,18 +130,43 @@ class ProbeState {
       hits_ = _mm_movemask_epi8(tagMatches);
     }
 
+    int32_t insertTagIndex = -1;
     for (;;) {
       if (!hits_) {
-        auto occupied = _mm_movemask_epi8(tagsInTable_);
-        if (occupied != kFullMask) {
-          BaseHashTable::MaskType gaps = ~occupied & 0xffff;
-          auto pos = bits::getAndClearLastSetBit(gaps);
+        uint16_t empty =
+            _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kEmptyGroup)) &
+            kFullMask;
+        if (empty) {
+          if (op == Operation::kProbe) {
+            return nullptr;
+          }
+          if (op == Operation::kErase) {
+            VELOX_FAIL("Erasing non-existing entry");
+          }
+          if (indexInTags_ != kNotSet) {
+            // We came to the end of the probe without a hit. We replace the
+            // first tombstone on the way.
+            return insert(row_, insertTagIndex + indexInTags_);
+          }
+          auto pos = bits::getAndClearLastSetBit(empty);
           return insert(row_, tagIndex_ + pos);
+        } else if (op == Operation::kInsert && indexInTags_ == kNotSet) {
+          // We passed through a full group.
+          uint16_t tombstones =
+              _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kTombstoneGroup)) &
+              kFullMask;
+          if (tombstones) {
+            insertTagIndex = tagIndex_;
+            indexInTags_ = bits::getAndClearLastSetBit(tombstones);
+          }
         }
       } else {
-        loadNextHit(table, firstKey);
+        loadNextHit<op>(table, firstKey);
         if (!(extraCheck && group_ == alreadyChecked) &&
             compare(group_, row_)) {
+          if (op == Operation::kErase) {
+            eraseHit(tags);
+          }
           return group_;
         }
         continue;
@@ -141,10 +179,24 @@ class ProbeState {
   }
 
  private:
+  static constexpr uint8_t kNotSet = 0xff;
+
+  template <Operation op>
   inline void loadNextHit(char** table, int32_t firstKey) {
     int32_t hit = bits::getAndClearLastSetBit(hits_);
+
+    if (op == Operation::kErase) {
+      indexInTags_ = hit;
+    }
     group_ = BaseHashTable::loadRow(table, tagIndex_ + hit);
     __builtin_prefetch(group_ + firstKey);
+  }
+
+  void eraseHit(uint8_t* tags) {
+    auto empty = _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kEmptyGroup));
+
+    BaseHashTable::storeTag(
+        tags, tagIndex_ + indexInTags_, empty ? 0 : kTombstoneTag);
   }
 
   char* group_;
@@ -153,6 +205,16 @@ class ProbeState {
   int32_t row_;
   int32_t tagIndex_;
   BaseHashTable::MaskType hits_;
+
+  // If op is kErase, this is the index of the current hit within the
+  // group of 'tagIndex_'. If op is kInsert, this is the index of the
+  // first tombstone in the group of 'insertTagIndex_'. Insert
+  // replaces the first tombstone it finds. If it finds an empty
+  // before finding a tombstone, it replaces the empty as soon as it
+  // sees it. But the tombstone can be replaced only after finding an
+  // empty and thus determining that the item being inserted is not in
+  // the table.
+  uint8_t indexInTags_ = kNotSet;
 };
 
 template <bool ignoreNullKeys>
@@ -235,9 +297,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
     HashLookup& lookup,
     ProbeState& state,
     bool extraCheck) {
+  constexpr ProbeState::Operation op =
+      isJoin ? ProbeState::Operation::kProbe : ProbeState::Operation::kInsert;
   if (hashMode_ == HashMode::kNormalizedKey) {
-    // NOLINT
-    lookup.hits[state.row()] = state.fullProbe(
+    lookup.hits[state.row()] = state.fullProbe<op>(
         tags_,
         table_,
         sizeMask_,
@@ -252,8 +315,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
         !isJoin && extraCheck);
     return;
   }
-  // NOLINT
-  lookup.hits[state.row()] = state.fullProbe(
+  lookup.hits[state.row()] = state.fullProbe<op>(
       tags_,
       table_,
       sizeMask_,
@@ -316,10 +378,10 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
     state3.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
     row = rows[probeIndex + 3];
     state4.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
-    state2.firstProbe(table_, 0);
-    state3.firstProbe(table_, 0);
-    state4.firstProbe(table_, 0);
+    state1.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state2.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state3.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state4.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
     fullProbe<false>(lookup, state1, false);
     fullProbe<false>(lookup, state2, true);
     fullProbe<false>(lookup, state3, true);
@@ -613,11 +675,12 @@ bool HashTable<ignoreNullKeys>::arrayPushRow(char* row, int32_t index) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::pushNext(char* row, char* next) {
-  DCHECK(nextOffset_);
-  hasDuplicates_ = true;
-  auto previousNext = nextRow(row);
-  nextRow(row) = next;
-  nextRow(next) = previousNext;
+  if (nextOffset_) {
+    hasDuplicates_ = true;
+    auto previousNext = nextRow(row);
+    nextRow(row) = next;
+    nextRow(next) = previousNext;
+  }
 }
 
 template <bool ignoreNullKeys>
@@ -627,12 +690,12 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
     char* inserted,
     bool extraCheck) {
   if (hashMode_ == HashMode::kNormalizedKey) {
-    state.fullProbe(
+    state.fullProbe<ProbeState::Operation::kInsert>(
         tags_,
         table_,
         sizeMask_,
         -static_cast<int32_t>(sizeof(normalized_key_t)),
-        [&](char* group, int32_t /*row*/) {
+        [&](char* group, int32_t row) {
           if (RowContainer::normalizedKey(group) ==
               RowContainer::normalizedKey(inserted)) {
             if (nextOffset_) {
@@ -642,18 +705,18 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           }
           return false;
         },
-        [&](int32_t /*row*/, int32_t index) {
+        [&](int32_t row, int32_t index) {
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
         extraCheck);
   } else {
-    state.fullProbe(
+    state.fullProbe<ProbeState::Operation::kInsert>(
         tags_,
         table_,
         sizeMask_,
         0,
-        [&](char* group, int32_t /*row*/) {
+        [&](char* group, int32_t row) {
           if (compareKeys(group, inserted)) {
             if (nextOffset_) {
               pushNext(group, inserted);
@@ -662,7 +725,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           }
           return false;
         },
-        [&](int32_t /*row*/, int32_t index) {
+        [&](int32_t row, int32_t index) {
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
@@ -675,6 +738,15 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     char** groups,
     uint64_t* hashes,
     int32_t numGroups) {
+  if (hashMode_ == HashMode::kNormalizedKey) {
+    // Write the normalized key below each row. The key is only known
+    // at the time of insert, so cannot be filled in at the time of
+    // accumulating the build rows.
+    for (auto i = 0; i < numGroups; ++i) {
+      RowContainer::normalizedKey(groups[i]) = hashes[i];
+      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
+    }
+  }
   // The insertable rows are in the table, all get put in the hash
   // table or array.
   if (hashMode_ == HashMode::kArray) {
@@ -685,15 +757,7 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     }
     return;
   }
-  if (hashMode_ == HashMode::kNormalizedKey) {
-    // Write the normalized key below each row. The key is only known
-    // at the time of insert, so cannot be filled in at the time of
-    // accumulating the build rows.
-    for (auto i = 0; i < numGroups; ++i) {
-      RowContainer::normalizedKey(groups[i]) = hashes[i];
-      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
-    }
-  }
+
   ProbeState state1;
   for (auto i = 0; i < numGroups; ++i) {
     state1.preProbe(tags_, sizeMask_, hashes[i], i);
@@ -1067,6 +1131,69 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
     }
   }
   return numOut;
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::erase(folly::Range<char**> rows) {
+  auto numRows = rows.size();
+  std::vector<uint64_t> hashes;
+  hashes.resize(numRows);
+
+  for (int32_t i = 0; i < hashers_.size(); ++i) {
+    auto& hasher = hashers_[i];
+    if (hashMode_ == HashMode::kHash) {
+      rows_->hash(i, rows, i > 0, hashes.data());
+    } else {
+      if (!VALUE_ID_TYPE_DISPATCH(
+              valueIdRowsColumn,
+              hasher->typeKind(),
+              ignoreNullKeys,
+              hasher.get(),
+              rows.data(),
+              numRows,
+              rows_->columnAt(i),
+              hashes.data())) {
+        VELOX_FAIL("Value ids in erase must exist for all keys");
+      }
+    }
+  }
+  eraseWithHashes(rows, hashes.data());
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::eraseWithHashes(
+    folly::Range<char**> rows,
+    uint64_t* hashes) {
+  auto numRows = rows.size();
+  if (hashMode_ == HashMode::kArray) {
+    for (auto i = 0; i < numRows; ++i) {
+      VELOX_CHECK(hashes[i] < size_);
+      table_[hashes[i]] = nullptr;
+    }
+  } else {
+    if (hashMode_ == HashMode::kNormalizedKey) {
+      for (auto i = 0; i < numRows; ++i) {
+        hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
+      }
+    }
+
+    ProbeState state;
+    for (auto i = 0; i < numRows; ++i) {
+      state.preProbe(tags_, sizeMask_, hashes[i], i);
+
+      state.firstProbe<ProbeState::Operation::kErase>(table_, 0);
+      state.fullProbe<ProbeState::Operation::kErase>(
+          tags_,
+          table_,
+          sizeMask_,
+          0,
+          [&](char* group, int32_t row) { return rows[row] == group; },
+          [&](int32_t index, int32_t row) { return nullptr; },
+          false);
+    }
+  }
+  numDistinct_ -= numRows;
+  rows_->eraseRows(rows);
 }
 
 template class HashTable<true>;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -144,8 +144,16 @@ class BaseHashTable {
   /// distinct entries before needing to rehash.
   virtual void decideHashMode(int32_t numNew) = 0;
 
+  // Removes 'rows'  from the hash table and its RowContainer. 'rows' must exist
+  // and be unique.
+  virtual void erase(folly::Range<char**> rows) = 0;
+
   /// Returns a brief description for use in debugging.
   virtual std::string toString() = 0;
+
+  static void storeTag(uint8_t* tags, int32_t index, uint8_t tag) {
+    tags[index] = tag;
+  }
 
   const std::vector<std::unique_ptr<VectorHasher>>& hashers() const {
     return hashers_;
@@ -271,6 +279,8 @@ class HashTable : public BaseHashTable {
   void decideHashMode(int32_t numNew) override;
 
   // Moves the contents of 'tables' into 'this' and prepares 'this'
+
+  void erase(folly::Range<char**> rows) override;
   // for use in hash join probe. A hash join build side is prepared as
   // follows: 1. Each build side thread gets a random selection of the
   // build stream. Each accumulates rows into its own
@@ -366,6 +376,10 @@ class HashTable : public BaseHashTable {
   // content. Returns true if all hashers offer a mapping to value ids
   // for array or normalized key.
   bool analyze();
+  // Erases the entries of rows from the hash table and its RowContainer.
+  // 'hashes' must be computed according to 'hashMode_'.
+  void eraseWithHashes(folly::Range<char**> rows, uint64_t* hashes);
+
   const std::vector<std::unique_ptr<Aggregate>>& aggregates_;
   int8_t sizeBits_;
   bool isJoinBuild_ = false;

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -84,7 +84,9 @@ RowContainer::RowContainer(
       ++nullOffset;
     }
   }
-
+  // Make offset at least sizeof pointer so that there is space for a
+  // free list next pointer below The bit at 'freeFlagOffset_'.
+  offset = std::max<int32_t>(offset, sizeof(void*));
   int32_t firstAggregate = offsets_.size();
   int32_t firstAggregateOffset = offset;
   for (auto& aggregate : aggregates) {
@@ -103,9 +105,13 @@ RowContainer::RowContainer(
   }
   if (hasProbedFlag) {
     nullOffsets_.push_back(nullOffset);
-    probedFlagOffset_ = nullOffset;
+    probedFlagOffset_ = nullOffset + firstAggregateOffset * 8;
     ++nullOffset;
   }
+  // Free flag.
+  nullOffsets_.push_back(nullOffset);
+  freeFlagOffset_ = nullOffset + firstAggregateOffset * 8;
+  ++nullOffset;
   // Fixup nullOffsets_ to be the bit number from the start of the row.
   for (int32_t i = 0; i < nullOffsets_.size(); ++i) {
     nullOffsets_[i] += firstAggregateOffset * 8;
@@ -135,6 +141,9 @@ RowContainer::RowContainer(
   if (!nullOffsets_.empty()) {
     // Aggregates start life as null, join dependent columns as non-null.
     initialNulls_.resize(nullBytes, isJoinBuild_ ? 0x0 : 0xff);
+    // The free flag has an initial value of 0.
+    bits::clearBit(
+        initialNulls_.data(), freeFlagOffset_ - nullOffsets_.front());
     if (nullableKeys) {
       for (int32_t i = 0; i < keyTypes_.size(); ++i) {
         bits::clearBit(initialNulls_.data(), i);
@@ -151,11 +160,20 @@ RowContainer::RowContainer(
 }
 
 char* RowContainer::newRow() {
-  char* row = rows_.allocateFixed(fixedRowSize_ + normalizedKeySize_) +
-      normalizedKeySize_;
+  char* row;
   ++numRows_;
-  if (normalizedKeySize_) {
-    ++numRowsWithNormalizedKey_;
+
+  if (firstFreeRow_) {
+    row = firstFreeRow_;
+    VELOX_CHECK(bits::isBitSet(row, freeFlagOffset_));
+    firstFreeRow_ = nextFree(row);
+    --numFreeRows_;
+  } else {
+    row = rows_.allocateFixed(fixedRowSize_ + normalizedKeySize_) +
+        normalizedKeySize_;
+    if (normalizedKeySize_) {
+      ++numRowsWithNormalizedKey_;
+    }
   }
   return initializeRow(row, false /* reuse */);
 }
@@ -174,6 +192,19 @@ char* RowContainer::initializeRow(char* row, bool reuse) {
         initialNulls_.size());
   }
   return row;
+}
+
+void RowContainer::eraseRows(folly::Range<char**> rows) {
+  freeVariableWidthFields(rows);
+  freeAggregates(rows);
+  numRows_ -= rows.size();
+  for (auto* row : rows) {
+    VELOX_CHECK(!bits::isBitSet(row, freeFlagOffset_), "Double free of row");
+    bits::setBit(row, freeFlagOffset_);
+    nextFree(row) = firstFreeRow_;
+    firstFreeRow_ = row;
+  }
+  numFreeRows_ += rows.size();
 }
 
 void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
@@ -200,6 +231,33 @@ void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
   }
 }
 
+void RowContainer::checkConsistency() {
+  constexpr int32_t kBatch = 1000;
+  std::vector<char*> rows(kBatch);
+  uint64_t count = 0;
+  RowContainerIterator iter;
+  int64_t allocatedRows = 0;
+  for (;;) {
+    int64_t numRows = listRows(&iter, kBatch, rows.data());
+    if (!numRows) {
+      break;
+    }
+    for (auto i = 0; i < numRows; ++i) {
+      auto row = rows[i];
+      VELOX_CHECK(!bits::isBitSet(row, freeFlagOffset_));
+      ++allocatedRows;
+    }
+  }
+
+  size_t numFree = 0;
+  for (auto free = firstFreeRow_; free; free = nextFree(free)) {
+    ++numFree;
+    VELOX_CHECK(bits::isBitSet(free, freeFlagOffset_));
+  }
+  VELOX_CHECK_EQ(numFree, numFreeRows_);
+  VELOX_CHECK_EQ(allocatedRows, numRows_);
+}
+
 void RowContainer::freeAggregates(folly::Range<char**> rows) {
   for (auto& aggregate : aggregates_) {
     aggregate->destroy(rows);
@@ -211,6 +269,7 @@ int32_t RowContainer::listRows(
     int32_t maxRows,
     char** rows) {
   int32_t count = 0;
+
   auto numAllocations = rows_.numAllocations();
   if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
       iter->rowOffset == 0) {
@@ -237,6 +296,10 @@ int32_t RowContainer::listRows(
         row += rowSize;
         if (--iter->normalizedKeysLeft == 0) {
           rowSize -= sizeof(normalized_key_t);
+        }
+        if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+          --count;
+          continue;
         }
         if (count == maxRows) {
           iter->rowOffset = row;

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -85,6 +85,89 @@ class HashTableTest : public testing::Test {
     EXPECT_EQ(topTable_->hashMode(), mode);
     LOG(INFO) << "Made table " << describeTable();
     testProbe();
+    testErase();
+    testProbe();
+    testErase();
+    testProbe();
+    testGroupBySpill(size, buildType, numKeys);
+  }
+
+  // Inserts and deletes rows in a HashTable, similarly to a group by
+  // that periodically spills a fraction of the groups.
+  void testGroupBySpill(int32_t size, TypePtr buildType, int32_t numKeys) {
+    constexpr int32_t kBatchSize = 1000;
+    constexpr int32_t kNumErasePerRound = 500;
+    int32_t sequence = 0;
+    std::vector<RowVectorPtr> batches;
+    std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+    for (auto channel = 0; channel < numKeys; ++channel) {
+      keyHashers.emplace_back(
+          std::make_unique<VectorHasher>(buildType->childAt(channel), channel));
+    }
+    auto table = HashTable<false>::createForAggregation(
+        std::move(keyHashers), {}, mappedMemory_);
+    auto lookup = std::make_unique<HashLookup>(table->hashers());
+    auto& hashers = table->hashers();
+    std::vector<char*> erased;
+    std::vector<char*> allInserted;
+    int32_t numErased = 0;
+    // We insert 1000 and delete 500.
+    for (auto round = 0; round < size; round += kBatchSize) {
+      makeRows(kBatchSize, 1, sequence, buildType, batches);
+      sequence += kBatchSize;
+      lookup->reset(kBatchSize);
+      insertGroups(*batches.back(), *lookup, *table);
+      for (auto i = 0; i < kBatchSize; ++i) {
+      }
+      allInserted.insert(
+          allInserted.end(), lookup->hits.begin(), lookup->hits.end());
+
+      table->erase(
+          folly::Range<char**>(&allInserted[numErased], kNumErasePerRound));
+      numErased += kNumErasePerRound;
+    }
+    int32_t batchStart = 0;
+    // We loop over the keys one more time. The first half will be all
+    // new rows, the second half will be hits of existing ones.
+    int32_t row = 0;
+    for (auto i = 0; i < batches.size(); ++i) {
+      insertGroups(*batches[0], *lookup, *table);
+      for (; row < batchStart + kBatchSize; ++row) {
+        if (row < numErased) {
+          ASSERT_NE(lookup->hits[row - batchStart], allInserted[row]);
+        } else {
+          ASSERT_EQ(lookup->hits[row - batchStart], allInserted[row]);
+        }
+      }
+    }
+  }
+
+  void
+  insertGroups(RowVector& input, HashLookup& lookup, HashTable<false>& table) {
+    auto& hashers = table.hashers();
+    SelectivityVector activeRows(input.size());
+    auto mode = table.hashMode();
+    bool rehash = false;
+    for (int32_t i = 0; i < hashers.size(); ++i) {
+      auto key = input.childAt(hashers[i]->channel());
+      if (mode != BaseHashTable::HashMode::kHash) {
+        if (!hashers[i]->computeValueIds(*key, activeRows, &lookup.hashes)) {
+          rehash = true;
+        }
+      } else {
+        hashers[i]->hash(*key, activeRows, i > 0, &lookup.hashes);
+      }
+    }
+    std::iota(lookup.rows.begin(), lookup.rows.end(), 0);
+
+    if (rehash) {
+      if (table.hashMode() != BaseHashTable::HashMode::kHash) {
+        table.decideHashMode(input.size());
+      }
+      insertGroups(input, lookup, table);
+      return;
+    }
+    table.groupProbe(lookup);
   }
 
   std::string describeTable() {
@@ -308,6 +391,19 @@ class HashTableTest : public testing::Test {
                hashTime.timeToDropValue() / numHashed,
                probeTime.timeToDropValue() / numProbed)
         << std::endl;
+  }
+
+  // Erases every third item in the hash table.
+  void testErase() {
+    std::vector<char*> toErase;
+    int32_t counter = 0;
+    for (auto i = 0; i < rowOfKey_.size(); ++i) {
+      if (rowOfKey_[i] && ++counter % 3 == 0) {
+        toErase.push_back(rowOfKey_[i]);
+        rowOfKey_[i] = nullptr;
+      }
+    }
+    topTable_->erase(folly::Range<char**>(toErase.data(), toErase.size()));
   }
 
   std::unique_ptr<memory::MemoryPool> pool_{


### PR DESCRIPTION
Adds erase to HashTable for use in spilling selected groups from a
group by hash table.

A deleted entry is marked by a tombstone in the tags. This counts as
occupied for probing and as empty for inserting.