### PR TITLE
Use AsyncDataCache and read-ahead with Hive

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/process/ProcessBase.h"
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 
@@ -67,8 +68,14 @@ void AsyncDataCacheEntry::addReference() {
 }
 
 void AsyncDataCacheEntry::ensureLoaded(bool wait) {
-  auto load = load_;
   VELOX_CHECK(isShared());
+  if (dataValid_) {
+    return;
+  }
+  // Copy the shared_ptr to 'load_' so that another loader will not clear
+  // it if it gets in first. Competing loaders get serialized on the
+  // mutex of 'load'.
+  auto load = load_;
   if (load) {
     if (wait) {
       folly::SemiFuture<bool> waitFuture(false);
@@ -127,6 +134,7 @@ CachePin CacheShard::findOrCreate(
       found->touch();
       // The entry is in a readable state. Add a pin.
       if (found->isPrefetch_) {
+        found->isFirstUse_ = true;
         found->setPrefetch(false);
       } else {
         ++numHit_;
@@ -196,8 +204,12 @@ CachePin CacheShard::initEntry(
   return pin;
 }
 
+//  static
+std::atomic<int32_t> FusedLoad::numFusedLoads_{0};
+
 FusedLoad::~FusedLoad() {
   cancel();
+  --numFusedLoads_;
 }
 
 bool FusedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
@@ -221,7 +233,8 @@ bool FusedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
   }
   // Outside of 'mutex_'.
   try {
-    loadData();
+    // If wait is not set this counts as prefetch.
+    loadData(!wait);
     for (auto& pin : pins_) {
       pin.entry()->setValid();
     }
@@ -405,8 +418,13 @@ void CacheShard::updateStats(CacheStats& stats) {
   stats.allocClocks += allocClocks_;
 }
 
-AsyncDataCache::AsyncDataCache(MappedMemory* mappedMemory, uint64_t maxBytes)
-    : mappedMemory_(mappedMemory), cachedPages_(0), maxBytes_(maxBytes) {
+AsyncDataCache::AsyncDataCache(
+    std::unique_ptr<MappedMemory> mappedMemory,
+    uint64_t maxBytes)
+    : fileIds_(fileIdsShared()),
+      mappedMemory_(std::move(mappedMemory)),
+      cachedPages_(0),
+      maxBytes_(maxBytes) {
   for (auto i = 0; i < kNumShards; ++i) {
     shards_.push_back(std::make_unique<CacheShard>(this));
   }

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -153,7 +153,6 @@ class AsyncDataCacheEntry {
   void setLoading(std::shared_ptr<FusedLoad> load) {
     VELOX_CHECK(isExclusive());
     load_ = std::move(load);
-    setExclusiveToShared();
   }
 
   // Call this after loading the data and before releasing the pin.
@@ -199,6 +198,15 @@ class AsyncDataCacheEntry {
 
   bool isPrefetch() const {
     return isPrefetch_;
+  }
+
+  // Distinguishes between a reuse of a cached entry from first
+  // retrieval of a prefetched entry. If this is false, we have an
+  // actual reuse of cached data.
+  bool getAndClearFirstUseFlag() {
+    bool value = isFirstUse_;
+    isFirstUse_ = false;
+    return value;
   }
 
   // True if 'data_' is fully loaded from the backing storage.
@@ -249,6 +257,11 @@ class AsyncDataCacheEntry {
   // hit. Allows catching a situation where prefetched entries get
   // evicted before they are hit.
   bool isPrefetch_{false};
+
+  // Set after first use of a prefetched entry. Cleared by
+  // getAndClearFirstUseFlag(). Does not require synchronization since used for
+  // statistics only.
+  bool isFirstUse_{false};
 
   // Represents a pending coalesced IO that is either loading this or
   // scheduled to load this. Setting/clearing requires the shard
@@ -332,7 +345,7 @@ enum class LoadState { kPlanned, kLoading, kCancelled, kLoaded };
 // thread gets there first, then the query thread will do the
 // IO. The IO is also cancelled as a unit. FusedLoad holds a pin on
 // all the entries it concerns. The pins are released after the IO
-// completes or is cancelled. An entry that references a FusedLoad
+// completes or is cpriancelled. An entry that references a FusedLoad
 // is not readable until the FusedLoad is complete.
 class FusedLoad : public std::enable_shared_from_this<FusedLoad> {
  public:
@@ -346,6 +359,17 @@ class FusedLoad : public std::enable_shared_from_this<FusedLoad> {
     pins_ = std::move(pins);
     for (auto& pin : pins_) {
       pin.entry()->setLoading(shared_from_this());
+    }
+    // All pins to be loaded together must be set in place before we
+    // make any available for other threads to load. Else a partial
+    // load could result. Do this inside the mutex so that when a load
+    // begins we do not have a mix of shared and exclusive pins. Note
+    // that a second reader will be continued right after the pin goes
+    // shared. The just continued thread will still have to get
+    // 'mutex_' before it can start a load.
+    std::lock_guard<std::mutex> l(mutex_);
+    for (auto& pin : pins_) {
+      pin.entry()->setExclusiveToShared();
     }
   }
 
@@ -366,6 +390,10 @@ class FusedLoad : public std::enable_shared_from_this<FusedLoad> {
   LoadState state() const {
     return state_;
   }
+  // Used for testing and server status.
+  static int32_t numFusedLoads() {
+    return numFusedLoads_;
+  }
 
  protected:
   // Performs the data transfer part of the load. Subclasses will
@@ -374,7 +402,7 @@ class FusedLoad : public std::enable_shared_from_this<FusedLoad> {
   // is that a normal return will have filled all the pins with valid
   // data. A throw means that the data in the pins is undefined.  The
   // caller will release the pins in due time.
-  virtual void loadData() = 0;
+  virtual void loadData(bool isPrefetch) = 0;
 
   // Sets a final state and resumes waiting threads.
   void setEndState(LoadState endState);
@@ -395,6 +423,7 @@ class FusedLoad : public std::enable_shared_from_this<FusedLoad> {
   // entries in shared mode. The entries will block other readers until 'this'
   // lets go of the entries because 'load_' of the entry is set.
   std::vector<CachePin> pins_;
+  static std::atomic<int32_t> numFusedLoads_;
 };
 
 // Struct for CacheShard stats. Stats from all shards are added into
@@ -446,7 +475,7 @@ class ClockTimer {
   explicit ClockTimer(uint64_t& total)
       : total_(&total), start_(folly::hardware_timestamp()) {}
   ~ClockTimer() {
-    *total_ += start_ - folly::hardware_timestamp();
+    *total_ += folly::hardware_timestamp() - start_;
   }
 
  private:
@@ -538,7 +567,9 @@ class CacheShard {
 class AsyncDataCache : public memory::MappedMemory,
                        public std::enable_shared_from_this<AsyncDataCache> {
  public:
-  AsyncDataCache(memory::MappedMemory* mappedMemory, uint64_t maxBytes);
+  AsyncDataCache(
+      std::unique_ptr<memory::MappedMemory> mappedMemory,
+      uint64_t maxBytes);
 
   // Finds or creates a cache entry corresponding to 'key'. The entry
   // is returned in 'pin'. If the entry is new, it is pinned in
@@ -604,7 +635,9 @@ class AsyncDataCache : public memory::MappedMemory,
  private:
   static constexpr int32_t kNumShards = 4; // Must be power of 2.
   static constexpr int32_t kShardMask = kNumShards - 1;
-  memory::MappedMemory* const mappedMemory_;
+  // Keeps the id to file map alive as long as 'this' is live.
+  std::shared_ptr<StringIdMap> fileIds_;
+  std::unique_ptr<memory::MappedMemory> mappedMemory_;
   std::vector<std::unique_ptr<CacheShard>> shards_;
   int32_t shardCounter_{};
   std::atomic<memory::MachinePageCount> cachedPages_{0};

--- a/velox/common/caching/FileIds.cpp
+++ b/velox/common/caching/FileIds.cpp
@@ -19,10 +19,13 @@
 #include <gflags/gflags.h>
 
 namespace facebook::velox {
-
 StringIdMap& fileIds() {
-  static std::unique_ptr<StringIdMap> ids = std::make_unique<StringIdMap>();
-  return *ids;
+  return *fileIdsShared();
+}
+
+const std::shared_ptr<StringIdMap>& fileIdsShared() {
+  static std::shared_ptr<StringIdMap> ids = std::make_shared<StringIdMap>();
+  return ids;
 }
 
 } // namespace facebook::velox

--- a/velox/common/caching/FileIds.h
+++ b/velox/common/caching/FileIds.h
@@ -21,4 +21,9 @@ namespace facebook::velox {
 // Returns a process-wide map of file path to id and id to file path.
 StringIdMap& fileIds();
 
+// Returns a shared_ptr to fileIds(). Needed to control destruction
+// order at end of process, so that caches that pin ids to names keep
+// the map alive.
+const std::shared_ptr<StringIdMap>& fileIdsShared();
+
 } // namespace facebook::velox

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -252,10 +252,15 @@ bool MappedMemoryImpl::checkConsistency() {
   throw std::runtime_error("Not implemented");
 }
 
+MappedMemory* MappedMemory::customInstance_;
 std::unique_ptr<MappedMemory> MappedMemory::instance_;
 std::mutex MappedMemory::initMutex_;
 
+// static
 MappedMemory* MappedMemory::getInstance() {
+  if (customInstance_) {
+    return customInstance_;
+  }
   if (instance_) {
     return instance_.get();
   }
@@ -263,9 +268,20 @@ MappedMemory* MappedMemory::getInstance() {
   if (instance_) {
     return instance_.get();
   }
-  instance_ = std::make_unique<MappedMemoryImpl>();
+  instance_ = createDefaultInstance();
   return instance_.get();
 }
+
+// static
+std::unique_ptr<MappedMemory> MappedMemory::createDefaultInstance() {
+  return std::make_unique<MappedMemoryImpl>();
+}
+
+// static
+void MappedMemory::setDefaultInstance(MappedMemory* instance) {
+  customInstance_ = instance;
+}
+
 std::shared_ptr<MappedMemory> MappedMemory::addChild(
     std::shared_ptr<MemoryUsageTracker> tracker) {
   return std::make_shared<ScopedMappedMemory>(this, tracker);

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -157,7 +157,20 @@ class MappedMemory {
   };
 
   virtual ~MappedMemory() {}
+
+  // Returns the process-wide default instance or an application-supplied custom
+  // instance set via setDefaultInstance().
   static MappedMemory* getInstance();
+
+  // Creates a default MappedMemory instance but does not set this to process
+  // default.
+  static std::unique_ptr<MappedMemory> createDefaultInstance();
+
+  // Overrides the process-wide default instance. The caller keeps
+  // ownership and must not destroy the instance until it is
+  // empty. Calling this with nullptr restores the initial
+  // process-wide default instance.
+  static void setDefaultInstance(MappedMemory* instance);
 
   /// Allocates one or more runs that add up to at least 'numPages',
   /// with the smallest run being at least 'minSizeClass'
@@ -197,6 +210,9 @@ class MappedMemory {
  private:
   // Singleton instance.
   static std::unique_ptr<MappedMemory> instance_;
+  // Application-supplied custom implementation of MappedMemory to be returned
+  // by getInstance().
+  static MappedMemory* customInstance_;
   static std::mutex initMutex_;
 };
 

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -73,4 +73,32 @@ std::shared_ptr<Connector> getConnector(const std::string& connectorId) {
   return it->second;
 }
 
+folly::Synchronized<
+    std::unordered_map<std::string_view, std::weak_ptr<cache::ScanTracker>>>
+    Connector::trackers_;
+
+// static
+void Connector::unregisterTracker(cache::ScanTracker* tracker) {
+  trackers_.withWLock([&](auto& trackers) { trackers.erase(tracker->id()); });
+}
+
+std::shared_ptr<cache::ScanTracker> Connector::getTracker(
+    const std::string& scanId) {
+  return trackers_.withWLock([&](auto& trackers) -> auto {
+    auto it = trackers.find(scanId);
+    if (it == trackers.end()) {
+      auto newTracker =
+          std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      trackers[newTracker->id()] = newTracker;
+      return newTracker;
+    }
+    std::shared_ptr tracker = it->second.lock();
+    if (!tracker) {
+      tracker = std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      trackers[tracker->id()] = tracker;
+    }
+    return tracker;
+  });
+}
+
 } // namespace facebook::velox::connector

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -26,11 +26,21 @@ uint64_t FileHandleSizer::operator()(const FileHandle& fileHandle) {
   return fileHandle.file->memoryUsage();
 }
 
+namespace {
+// The group tracking is at the level of the directory, i.e. Hive partition.
+std::string groupName(const std::string& filename) {
+  const char* slash = strrchr(filename.c_str(), '/');
+  return slash ? std::string(filename.data(), slash - filename.data())
+               : filename;
+}
+} // namespace
+
 std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
     const std::string& filename) {
   auto fileHandle = std::make_unique<FileHandle>();
   fileHandle->file = generateReadFile(filename);
   fileHandle->uuid = StringIdLease(fileIds(), filename);
+  fileHandle->groupId = StringIdLease(fileIds(), groupName(filename));
   VLOG(1) << "Generating file handle for: " << filename
           << " uuid: " << fileHandle->uuid.id();
   // TODO: build the hash map/etc per file type -- presumably after reading

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -32,6 +32,7 @@
 #include "velox/common/caching/CachedFactory.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/file/File.h"
+#include "velox/dwio/common/InputStream.h"
 
 namespace facebook::velox {
 
@@ -43,6 +44,11 @@ struct FileHandle {
   // the identifier in downstream data caching structures. This saves a lot of
   // memory compared to using the filename as the identifier.
   StringIdLease uuid;
+
+  // Id for the group of files this belongs to, e.g. its
+  // directory. Used for coarse granularity access tracking, for
+  // example to decide placing on SSD.
+  StringIdLease groupId;
 
   // We'll want to have a hash map here to record the identifier->byte range
   // mappings. Different formats may have different identifiers, so we may need

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,6 +16,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include <velox/dwio/dwrf/reader/SelectiveColumnReader.h>
 #include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/expression/ControlExpr.h"
 
 using namespace facebook::velox::dwrf;
@@ -25,9 +26,8 @@ DEFINE_int32(
     file_handle_cache_mb,
     1024,
     "Amount of space for the file handle cache in mb.");
-
+DEFINE_int32(max_io_threads, 10, "Number of threads for background prefetch");
 namespace facebook::velox::connector::hive {
-
 namespace {
 static const char* kPath = "$path";
 static const char* kBucket = "$bucket";
@@ -118,13 +118,19 @@ HiveDataSource::HiveDataSource(
     FileHandleFactory* fileHandleFactory,
     velox::memory::MemoryPool* pool,
     DataCache* dataCache,
-    ExpressionEvaluator* expressionEvaluator)
+    ExpressionEvaluator* expressionEvaluator,
+    memory::MappedMemory* mappedMemory,
+    const std::string& scanId,
+    folly::Executor* executor)
     : outputType_(outputType),
       fileHandleFactory_(fileHandleFactory),
       pool_(pool),
       readerOpts_(pool),
       dataCache_(dataCache),
-      expressionEvaluator_(expressionEvaluator) {
+      expressionEvaluator_(expressionEvaluator),
+      mappedMemory_(mappedMemory),
+      scanId_(scanId),
+      executor_(executor) {
   regularColumns_.reserve(outputType->size());
 
   std::vector<std::string> columnNames;
@@ -193,11 +199,10 @@ HiveDataSource::HiveDataSource(
       std::make_unique<dwrf::SelectiveColumnReaderFactory>(scanSpec_.get());
   rowReaderOpts_.setColumnReaderFactory(columnReaderFactory_.get());
 
-  ioStats_ = std::make_unique<dwio::common::IoStatistics>();
+  ioStats_ = std::make_shared<dwio::common::IoStatistics>();
 }
 
 namespace {
-
 bool testFilters(
     common::ScanSpec* scanSpec,
     dwrf::DwrfReader* reader,
@@ -234,6 +239,38 @@ bool testFilters(
 
   return true;
 }
+
+class InputStreamHolder : public dwrf::AbstractInputStreamHolder {
+ public:
+  InputStreamHolder(
+      FileHandleCachedPtr fileHandle,
+      std::shared_ptr<dwio::common::IoStatistics> stats)
+      : fileHandle_(std::move(fileHandle)), stats_(std::move(stats)) {
+    input_ = std::make_unique<dwio::common::ReadFileInputStream>(
+        fileHandle_->file.get(),
+        dwio::common::MetricsLog::voidLog(),
+        stats.get());
+  }
+
+  dwio::common::InputStream& get() override {
+    return *input_;
+  }
+
+ private:
+  FileHandleCachedPtr fileHandle_;
+  // Keeps the pointer alive also in case of cancellation while reads
+  // proceeding on different threads.
+  std::shared_ptr<dwio::common::IoStatistics> stats_;
+  std::unique_ptr<dwio::common::InputStream> input_;
+};
+
+std::unique_ptr<InputStreamHolder> makeStreamHolder(
+    FileHandleFactory* factory,
+    const std::string& path,
+    std::shared_ptr<dwio::common::IoStatistics> stats) {
+  return std::make_unique<InputStreamHolder>(factory->generate(path), stats);
+}
+
 } // namespace
 
 void HiveDataSource::addDynamicFilter(
@@ -263,13 +300,36 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   VLOG(1) << "Adding split " << split_->toString();
 
   fileHandle_ = fileHandleFactory_->generate(split_->filePath);
-  if (dataCache_) {
+  // Decide between AsyncDataCache, legacy DataCache and no cache. All
+  // three are supported to enable comparison.
+  if (auto asyncCache = dynamic_cast<cache::AsyncDataCache*>(mappedMemory_)) {
+    VELOX_CHECK(
+        !dataCache_,
+        "DataCache should not be present if the MappedMemory is AsyncDataCache");
+    // Make DataCacheConfig to pass the filenum and a null DataCache.
+    if (!readerOpts_.getDataCacheConfig()) {
+      auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();
+      readerOpts_.setDataCacheConfig(std::move(dataCacheConfig));
+    }
+    readerOpts_.getDataCacheConfig()->filenum = fileHandle_->uuid.id();
+    bufferedInputFactory_ = std::make_unique<dwrf::CachedBufferedInputFactory>(
+        (asyncCache),
+        Connector::getTracker(scanId_),
+        fileHandle_->groupId.id(),
+        [factory = fileHandleFactory_,
+         path = split_->filePath,
+         stats = ioStats_]() { return makeStreamHolder(factory, path, stats); },
+        ioStats_,
+        executor_);
+    readerOpts_.setBufferedInputFactory(bufferedInputFactory_.get());
+  } else if (dataCache_) {
     auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();
     dataCacheConfig->cache = dataCache_;
     dataCacheConfig->filenum = fileHandle_->uuid.id();
     readerOpts_.setDataCacheConfig(std::move(dataCacheConfig));
   }
-
+  // We run with the default BufferedInputFactory and no DataCacheConfig if
+  // there is no DataCache and the MappedMemory is not an AsyncDataCache.
   reader_ = dwrf::DwrfReader::create(
       std::make_unique<dwio::common::ReadFileInputStream>(
           fileHandle_->file.get(),
@@ -444,16 +504,33 @@ void HiveDataSource::setNullConstantValue(
   spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
 }
 
+std::unordered_map<std::string, int64_t> HiveDataSource::runtimeStats() {
+  return {
+      {"skippedSplits", skippedSplits_},
+      {"skippedSplitBytes", skippedSplitBytes_},
+      {"skippedStrides", skippedStrides_},
+      {"numPrefetch", ioStats_->prefetch().count()},
+      {"prefetchBytes", ioStats_->prefetch().bytes()},
+      {"numStorageRead", ioStats_->read().count()},
+      {"storageReadBytes", ioStats_->read().bytes()},
+      {"numLocalRead", ioStats_->ssdRead().count()},
+      {"localReadBytes", ioStats_->ssdRead().bytes()},
+      {"numRamRead", ioStats_->ramHit().count()},
+      {"ramReadBytes", ioStats_->ramHit().bytes()}};
+}
+
 HiveConnector::HiveConnector(
     const std::string& id,
-    std::unique_ptr<DataCache> dataCache)
+    std::unique_ptr<DataCache> dataCache,
+    folly::Executor* executor)
     : Connector(id),
       dataCache_(std::move(dataCache)),
       fileHandleFactory_(
           std::make_unique<SimpleLRUCache<std::string, FileHandle>>(
               FLAGS_file_handle_cache_mb << 20),
-          std::make_unique<FileHandleGenerator>()) {}
+          std::make_unique<FileHandleGenerator>()),
+      executor_(executor) {}
 
 VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<HiveConnectorFactory>())
-
 } // namespace facebook::velox::connector::hive
+  // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -18,6 +18,7 @@
 #include "velox/common/caching/DataCache.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/reader/ScanSpec.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
@@ -102,7 +103,7 @@ class HiveDataSink : public DataSink {
   explicit HiveDataSink(
       std::shared_ptr<const RowType> inputType,
       const std::string& filePath,
-      velox::memory::MemoryPool* memoryPool);
+      velox::memory::MemoryPool* FOLLY_NONNULL memoryPool);
 
   void appendData(VectorPtr input) override;
 
@@ -113,6 +114,8 @@ class HiveDataSink : public DataSink {
   std::unique_ptr<facebook::velox::dwrf::Writer> writer_;
 };
 
+class HiveConnector;
+
 class HiveDataSource : public DataSource {
  public:
   HiveDataSource(
@@ -121,10 +124,13 @@ class HiveDataSource : public DataSource {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      FileHandleFactory* fileHandleFactory,
-      velox::memory::MemoryPool* pool,
-      DataCache* dataCache,
-      ExpressionEvaluator* expressionEvaluator);
+      FileHandleFactory* FOLLY_NONNULL fileHandleFactory,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool,
+      DataCache* FOLLY_NULLABLE dataCache,
+      ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
+      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      const std::string& scanId,
+      folly::Executor* FOLLY_NULLABLE executor);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
@@ -142,12 +148,7 @@ class HiveDataSource : public DataSource {
     return ioStats_->rawBytesRead();
   }
 
-  std::unordered_map<std::string, int64_t> runtimeStats() override {
-    return {
-        {"skippedSplits", skippedSplits_},
-        {"skippedSplitBytes", skippedSplitBytes_},
-        {"skippedStrides", skippedStrides_}};
-  }
+  std::unordered_map<std::string, int64_t> runtimeStats() override;
 
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
@@ -156,21 +157,25 @@ class HiveDataSource : public DataSource {
   // filterEvalCtx_.selectedIndices and selectedBits are not updated.
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 
-  void setConstantValue(common::ScanSpec* spec, const velox::variant& value)
-      const;
+  void setConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const velox::variant& value) const;
 
-  void setNullConstantValue(common::ScanSpec* spec, const TypePtr& type) const;
+  void setNullConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const TypePtr& type) const;
 
   const std::shared_ptr<const RowType> outputType_;
-  FileHandleFactory* fileHandleFactory_;
-  velox::memory::MemoryPool* pool_;
+  FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
+  velox::memory::MemoryPool* FOLLY_NONNULL pool_;
   std::vector<std::string> regularColumns_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
+  std::unique_ptr<dwrf::BufferedInputFactory> bufferedInputFactory_;
   std::unique_ptr<dwrf::ColumnReaderFactory> columnReaderFactory_;
   std::unique_ptr<common::ScanSpec> scanSpec_;
   std::shared_ptr<HiveConnectorSplit> split_;
   dwio::common::ReaderOptions readerOpts_;
   dwio::common::RowReaderOptions rowReaderOpts_;
-  std::unique_ptr<dwio::common::IoStatistics> ioStats_;
   std::unique_ptr<dwrf::DwrfReader> reader_;
   std::unique_ptr<dwrf::DwrfRowReader> rowReader_;
   std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
@@ -188,21 +193,26 @@ class HiveDataSource : public DataSource {
 
   VectorPtr output_;
   FileHandleCachedPtr fileHandle_;
-  DataCache* dataCache_;
-  ExpressionEvaluator* expressionEvaluator_;
+  DataCache* FOLLY_NULLABLE dataCache_;
+  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator_;
   uint64_t completedRows_ = 0;
 
   // Reusable memory for remaining filter evaluation
   VectorPtr filterResult_;
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
+
+  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  const std::string& scanId_;
+  folly::Executor* FOLLY_NULLABLE executor_;
 };
 
 class HiveConnector final : public Connector {
  public:
   explicit HiveConnector(
       const std::string& id,
-      std::unique_ptr<DataCache> dataCache);
+      std::unique_ptr<DataCache> dataCache,
+      folly::Executor* FOLLY_NONNULL executor);
 
   std::shared_ptr<DataSource> createDataSource(
       const std::shared_ptr<const RowType>& outputType,
@@ -210,7 +220,7 @@ class HiveConnector final : public Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     return std::make_shared<HiveDataSource>(
         outputType,
         tableHandle,
@@ -222,13 +232,16 @@ class HiveConnector final : public Connector {
                 kNodeSelectionStrategySoftAffinity
             ? dataCache_.get()
             : nullptr,
-        connectorQueryCtx->expressionEvaluator());
+        connectorQueryCtx->expressionEvaluator(),
+        connectorQueryCtx->mappedMemory(),
+        connectorQueryCtx->scanId().value(),
+        executor_);
   }
 
   std::shared_ptr<DataSink> createDataSink(
       std::shared_ptr<const RowType> inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
         connectorInsertTableHandle);
     VELOX_CHECK(
@@ -240,16 +253,21 @@ class HiveConnector final : public Connector {
         connectorQueryCtx->memoryPool());
   }
 
+  folly::Executor* FOLLY_NULLABLE executor() {
+    return executor_;
+  }
+
  private:
   std::unique_ptr<DataCache> dataCache_;
   FileHandleFactory fileHandleFactory_;
+  folly::Executor* FOLLY_NULLABLE executor_;
 
-  static constexpr const char* kNodeSelectionStrategy =
+  static constexpr const char* FOLLY_NONNULL kNodeSelectionStrategy =
       "node_selection_strategy";
-  static constexpr const char* kNodeSelectionStrategyNoPreference =
-      "NO_PREFERENCE";
-  static constexpr const char* kNodeSelectionStrategySoftAffinity =
-      "SOFT_AFFINITY";
+  static constexpr const char* FOLLY_NONNULL
+      kNodeSelectionStrategyNoPreference = "NO_PREFERENCE";
+  static constexpr const char* FOLLY_NONNULL
+      kNodeSelectionStrategySoftAffinity = "SOFT_AFFINITY";
 };
 
 class HiveConnectorFactory : public ConnectorFactory {
@@ -260,8 +278,9 @@ class HiveConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::unique_ptr<DataCache> dataCache = nullptr) override {
-    return std::make_shared<HiveConnector>(id, std::move(dataCache));
+      std::unique_ptr<DataCache> dataCache = nullptr,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) override {
+    return std::make_shared<HiveConnector>(id, std::move(dataCache), executor);
   }
 };
 

--- a/velox/core/ScalarFunction.h
+++ b/velox/core/ScalarFunction.h
@@ -36,6 +36,8 @@ class ArgumentsCtx {
   }
 
   bool operator==(const ArgumentsCtx& rhs) const {
+    if (types_.size() != rhs.types_.size())
+      return false;
     return std::equal(
         std::begin(types_),
         std::end(types_),

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -36,6 +36,26 @@ struct OperationCounters {
   uint64_t delayInjectedInSecs{0};
 };
 
+class IoCounter {
+ public:
+  uint64_t count() const {
+    return count_;
+  }
+
+  uint64_t bytes() const {
+    return bytes_;
+  }
+
+  void increment(uint64_t bytes) {
+    ++count_;
+    bytes_ += bytes;
+  }
+
+ private:
+  std::atomic<uint64_t> count_;
+  std::atomic<uint64_t> bytes_;
+};
+
 class IoStatistics {
  public:
   uint64_t rawBytesRead() const;
@@ -49,6 +69,22 @@ class IoStatistics {
   uint64_t incRawBytesWritten(int64_t);
   uint64_t incInputBatchSize(int64_t);
   uint64_t incOutputBatchSize(int64_t);
+
+  IoCounter& prefetch() {
+    return prefetch_;
+  }
+
+  IoCounter& read() {
+    return read_;
+  }
+
+  IoCounter& ssdRead() {
+    return ssdRead_;
+  }
+
+  IoCounter& ramHit() {
+    return ramHit_;
+  }
 
   void incOperationCounters(
       const std::string& operation,
@@ -67,6 +103,19 @@ class IoStatistics {
   std::atomic<uint64_t> inputBatchSize_{0};
   std::atomic<uint64_t> outputBatchSize_{0};
   std::atomic<uint64_t> rawOverreadBytes_{0};
+
+  // Planned read from storage or SSD.
+  IoCounter prefetch_;
+
+  // Read from storage, for sparsely accessed columns.
+  IoCounter read_;
+
+  // Hits from RAM cache. Does not include first use of prefetched data.
+  IoCounter ramHit_;
+
+  // Read from SSD cache instead of storage. Includes both random and planned
+  // reads.
+  IoCounter ssdRead_;
 
   std::unordered_map<std::string, OperationCounters> operationStats_;
   mutable std::mutex operationStatsMutex_;

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -282,9 +282,8 @@ enum class PrefetchMode {
  * PReads into the same |cache|.
  */
 struct DataCacheConfig {
-  velox::DataCache* cache;
-  // We identify the file the data belongs to by a 64 bit integer. One
-  // practical option is to use an external filename->incrementing integer map.
+  velox::DataCache* cache{nullptr};
+  // We identify the file the data belongs to by an id from StringIdMap.
   uint64_t filenum;
 };
 

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -80,6 +80,14 @@ class BufferedInput {
     return false;
   }
 
+  // True if caller should enqueue and load regions for stripe
+  // metadata after reading a file footer. The stripe footers are
+  // likely to be hit and should be read ahead of demand if
+  // BufferedInput has background load.
+  virtual bool shouldPrefetchStripes() const {
+    return false;
+  }
+
  protected:
   dwio::common::InputStream& input_;
 

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -25,6 +25,7 @@ using velox::memory::MappedMemory;
 
 CacheInputStream::CacheInputStream(
     cache::AsyncDataCache* cache,
+    dwio::common::IoStatistics* ioStats,
     const dwio::common::Region& region,
     dwio::common::InputStream& input,
     uint64_t fileNum,
@@ -32,6 +33,7 @@ CacheInputStream::CacheInputStream(
     TrackingId trackingId,
     uint64_t groupId)
     : cache_(cache),
+      ioStats_(ioStats),
       input_(input),
       region_(region),
       fileNum_(fileNum),
@@ -137,10 +139,17 @@ void CacheInputStream::loadSync(dwio::common::Region region) {
     if (pin_.entry()->isExclusive()) {
       auto ranges = makeRanges(pin_.entry(), region.length);
       input_.read(ranges, region.offset, dwio::common::LogType::FILE);
+      ioStats_->read().increment(region.length);
       pin_.entry()->setValid(true);
       pin_.entry()->setExclusiveToShared();
     } else {
-      pin_.entry()->ensureLoaded(true);
+      if (pin_.entry()->dataValid()) {
+        if (!pin_.entry()->getAndClearFirstUseFlag()) {
+          ioStats_->ramHit().increment(pin_.entry()->size());
+        }
+      } else {
+        pin_.entry()->ensureLoaded(true);
+      }
     }
   } while (pin_.empty());
 }
@@ -149,9 +158,12 @@ void CacheInputStream::loadPosition() {
   auto offset = region_.offset;
   if (pin_.empty()) {
     auto loadRegion = region_;
+    // Quantize position to previous multiple of 'loadQuantum_'.
     loadRegion.offset += (position_ / loadQuantum_) * loadQuantum_;
-    loadRegion.length =
-        std::min<int32_t>(loadQuantum_, region_.length - position_);
+    // Set length to be the lesser of 'loadQuantum_' and distance to end of
+    // 'region_'
+    loadRegion.length = std::min<int32_t>(
+        loadQuantum_, region_.length - (loadRegion.offset - region_.offset));
     loadSync(loadRegion);
   }
   auto* entry = pin_.entry();

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -42,6 +42,7 @@ class CacheInputStream : public SeekableInputStream {
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
   CacheInputStream(
       cache::AsyncDataCache* cache,
+      dwio::common::IoStatistics* ioStats,
       const dwio::common::Region& region,
       dwio::common::InputStream& input,
       uint64_t fileNum,
@@ -62,6 +63,7 @@ class CacheInputStream : public SeekableInputStream {
   void loadPosition();
   void loadSync(dwio::common::Region region);
   cache::AsyncDataCache* const cache_;
+  dwio::common::IoStatistics* ioStats_;
   dwio::common::InputStream& input_;
   // The region of 'input' 'this' ranges over.
   const dwio::common::Region region_;

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
       RawFileCacheKey{fileNum_, region.offset}, region.length, id, CachePin()});
   tracker_->recordReference(id, region.length, groupId_);
   return std::make_unique<CacheInputStream>(
-      cache_, region, input_, fileNum_, tracker_, id, groupId_);
+      cache_, ioStats_.get(), region, input_, fileNum_, tracker_, id, groupId_);
 }
 
 bool CachedBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)
@@ -78,7 +78,8 @@ void CachedBufferedInput::load(const dwio::common::LogType) {
   int32_t numNewLoads = 0;
   auto requests = std::move(requests_);
   for (auto& request : requests) {
-    if (tracker_->shouldPrefetch(request.trackingId, 3)) {
+    if (request.trackingId.empty() ||
+        tracker_->shouldPrefetch(request.trackingId, prefetchThreshold_)) {
       request.pin = cache_->findOrCreate(request.key, request.size, nullptr);
       if (request.pin.empty()) {
         // Already loading for another thread.
@@ -154,8 +155,11 @@ bool CachedBufferedInput::tryMerge(
 
     if (extension > 0) {
       first.length += extension;
-      if ((input_.getStats() != nullptr) && gap > 0) {
-        input_.getStats()->incRawOverreadBytes(gap);
+      if (gap > 0) {
+        ioStats_->incRawOverreadBytes(gap);
+        if (input_.getStats() != nullptr) {
+          input_.getStats()->incRawOverreadBytes(gap);
+        }
       }
     }
 
@@ -170,19 +174,25 @@ class DwrfFusedLoad : public cache::FusedLoad {
  public:
   void initialize(
       std::vector<CachePin>&& pins,
-      std::unique_ptr<AbstractInputStreamHolder> input) {
+      std::unique_ptr<AbstractInputStreamHolder> input,
+      std::shared_ptr<dwio::common::IoStatistics> ioStats) {
     input_ = std::move(input);
+    ioStats_ = std::move(ioStats);
+    // Initialize the base class last because as soon as the pins are
+    // placed and set to shared mode other threads can load 'this'.
     cache::FusedLoad::initialize(std::move(pins));
   }
 
-  void loadData() override {
+  void loadData(bool isPrefetch) override {
     auto& stream = input_->get();
     std::vector<folly::Range<char*>> buffers;
     uint64_t start = pins_[0].entry()->offset();
     uint64_t lastOffset = start;
+    uint64_t totalRead = 0;
     for (auto& pin : pins_) {
       auto& buffer = pin.entry()->data();
       uint64_t startOffset = pin.entry()->offset();
+      totalRead += pin.entry()->size();
       if (lastOffset < startOffset) {
         buffers.push_back(
             folly::Range<char*>(nullptr, startOffset - lastOffset));
@@ -205,18 +215,23 @@ class DwrfFusedLoad : public cache::FusedLoad {
       DWIO_ENSURE(offsetInRuns == size);
       lastOffset = startOffset + size;
     }
-
+    if (isPrefetch) {
+      ioStats_->prefetch().increment(totalRead);
+    } else {
+      ioStats_->read().increment(totalRead);
+    }
     stream.read(buffers, start, dwio::common::LogType::FILE);
   }
 
  private:
   std::unique_ptr<AbstractInputStreamHolder> input_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
 };
 } // namespace
 
 void CachedBufferedInput::readRegion(std::vector<CachePin> pins) {
   auto load = std::make_shared<DwrfFusedLoad>();
-  load->initialize(std::move(pins), streamSource_());
+  load->initialize(std::move(pins), streamSource_(), ioStats_);
   fusedLoads_.push_back(load);
 }
 
@@ -226,6 +241,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
     dwio::common::LogType /*logType*/) const {
   return std::make_unique<CacheInputStream>(
       cache_,
+      ioStats_.get(),
       dwio::common::Region{offset, length},
       input_,
       fileNum_,

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -21,7 +21,7 @@
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/dwrf/common/BufferedInput.h"
 
-#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/Executor.h>
 
 namespace facebook::velox::dwrf {
 
@@ -52,13 +52,15 @@ class CachedBufferedInput : public BufferedInput {
       std::shared_ptr<cache::ScanTracker> tracker,
       uint64_t groupId,
       StreamSource streamSource,
-      folly::IOThreadPoolExecutor* executor)
+      std::shared_ptr<dwio::common::IoStatistics> ioStats,
+      folly::Executor* executor)
       : BufferedInput(input, pool, dataCacheConfig),
         cache_(cache),
         fileNum_(dataCacheConfig->filenum),
         tracker_(std::move(tracker)),
         groupId_(groupId),
         streamSource_(streamSource),
+        ioStats_(std::move(ioStats)),
         executor_(executor) {}
 
   ~CachedBufferedInput() override {
@@ -85,6 +87,10 @@ class CachedBufferedInput : public BufferedInput {
       dwio::common::LogType logType) const override;
 
   bool shouldPreload() override;
+
+  bool shouldPrefetchStripes() const override {
+    return true;
+  }
 
  private:
   struct CacheRequest {
@@ -114,9 +120,15 @@ class CachedBufferedInput : public BufferedInput {
   std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
   StreamSource streamSource_;
-  folly::IOThreadPoolExecutor* const executor_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
+  folly::Executor* const executor_;
 
-  // Pins that are candidates for loading.
+  //  Percentage of reads over enqueues that qualifies a stream to be
+  //  coalesced with nearby streams and prefetched. Anything read less
+  //  frequently will be synchronously read on first use.
+  int32_t prefetchThreshold_ = 60;
+
+  // Regions that are candidates for loading.
   std::vector<CacheRequest> requests_;
   // Coalesced loads spanning multiple cache entries in one IO.
   std::vector<std::shared_ptr<cache::FusedLoad>> fusedLoads_;
@@ -129,11 +141,13 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
       std::shared_ptr<cache::ScanTracker> tracker,
       uint64_t groupId,
       StreamSource streamSource,
-      folly::IOThreadPoolExecutor* executor)
+      std::shared_ptr<dwio::common::IoStatistics> ioStats,
+      folly::Executor* executor)
       : cache_(cache),
         tracker_(std::move(tracker)),
         groupId_(groupId),
         streamSource_(streamSource),
+        ioStats_(ioStats),
         executor_(executor) {}
 
   std::unique_ptr<BufferedInput> create(
@@ -148,6 +162,7 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
         tracker_,
         groupId_,
         streamSource_,
+        ioStats_,
         executor_);
   }
 
@@ -163,6 +178,7 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
   std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
   StreamSource streamSource_;
-  folly::IOThreadPoolExecutor* executor_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
+  folly::Executor* executor_;
 };
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -94,6 +94,7 @@ class CacheTest : public testing::Test {
   void SetUp() override {
     executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
     rng_.seed(1);
+    ioStats_ = std::make_shared<common::IoStatistics>();
   }
 
   void TearDown() override {
@@ -101,8 +102,8 @@ class CacheTest : public testing::Test {
   }
 
   void initializeCache(int64_t maxBytes) {
-    cache_ =
-        std::make_unique<AsyncDataCache>(MappedMemory::getInstance(), maxBytes);
+    cache_ = std::make_unique<AsyncDataCache>(
+        MappedMemory::createDefaultInstance(), maxBytes);
     for (auto i = 0; i < kMaxStreams; ++i) {
       streamIds_.push_back(std::make_unique<dwrf::StreamIdentifier>(
           i, i, 0, dwrf::StreamKind_DATA));
@@ -162,6 +163,7 @@ class CacheTest : public testing::Test {
         [inputStream]() {
           return std::make_unique<TestInputStreamHolder>(inputStream);
         },
+        ioStats_,
         executor_.get());
     data->file = dynamic_cast<TestInputStream*>(inputStream.get());
     for (auto i = 0; i < streamStarts_.size() - 1; ++i) {
@@ -287,6 +289,7 @@ class CacheTest : public testing::Test {
       pathToInput_;
   common::DataCacheConfig config_;
   std::unique_ptr<AsyncDataCache> cache_;
+  std::shared_ptr<common::IoStatistics> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -82,11 +82,15 @@ DriverCtx::DriverCtx(
 }
 
 std::unique_ptr<connector::ConnectorQueryCtx>
-DriverCtx::createConnectorQueryCtx(const std::string& connectorId) const {
+DriverCtx::createConnectorQueryCtx(
+    const std::string& connectorId,
+    const std::string& planNodeId) const {
   return std::make_unique<connector::ConnectorQueryCtx>(
       execCtx->pool(),
       task->queryCtx()->getConnectorConfig(connectorId),
-      expressionEvaluator.get());
+      expressionEvaluator.get(),
+      task->queryCtx()->mappedMemory(),
+      fmt::format("{}.{}", task->taskId(), planNodeId));
 }
 
 BlockingState::BlockingState(

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -97,9 +97,12 @@ struct DriverCtx {
 
     return pool;
   }
-
+  // Makes an extract of QueryCtx for use in a connector. 'planNodeId'
+  // is the id of the calling TableScan. This and the task id identify
+  // the scan for column access tracking.
   std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
-      const std::string& connectorId) const;
+      const std::string& connectorId,
+      const std::string& planNodeId) const;
 
  private:
   // Lifetime of operator memory pools is same as the driverCtx, since some

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -68,8 +68,8 @@ RowVectorPtr TableScan::getOutput() {
 
       if (!connector_) {
         connector_ = connector::getConnector(connectorSplit->connectorId);
-        connectorQueryCtx_ =
-            driverCtx_->createConnectorQueryCtx(connectorSplit->connectorId);
+        connectorQueryCtx_ = driverCtx_->createConnectorQueryCtx(
+            connectorSplit->connectorId, planNodeId_);
         dataSource_ = connector_->createDataSource(
             outputType_,
             tableHandle_,

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -41,7 +41,8 @@ TableWriter::TableWriter(
   // partition
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
   connector_ = connector::getConnector(connectorId);
-  connectorQueryCtx_ = driverCtx_->createConnectorQueryCtx(connectorId);
+  connectorQueryCtx_ =
+      driverCtx_->createConnectorQueryCtx(connectorId, "TableWriter");
 
   auto names = tableWriteNode->columnNames();
   auto types = tableWriteNode->columns()->children();

--- a/velox/exec/tests/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/HiveConnectorTestBase.cpp
@@ -19,20 +19,31 @@
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/QueryAssertions.h"
+DEFINE_int32(cache_mb, 1024, "File cache size for testing");
 
 namespace facebook::velox::exec::test {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
-  auto dummyDataCache = std::make_unique<DummyDataCache>();
-  dataCache = dummyDataCache.get();
-  auto hiveConnector =
-      connector::getConnectorFactory(connector::hive::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, std::move(dummyDataCache));
-  connector::registerConnector(hiveConnector);
+  if (useAsyncCache_) {
+    executor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+    auto hiveConnector =
+        connector::getConnectorFactory(connector::hive::kHiveConnectorName)
+            ->newConnector(kHiveConnectorId, nullptr, executor_.get());
+    connector::registerConnector(hiveConnector);
+  } else {
+    auto dataCache = std::make_unique<SimpleLRUDataCache>(1UL << 30);
+    auto hiveConnector =
+        connector::getConnectorFactory(connector::hive::kHiveConnectorName)
+            ->newConnector(kHiveConnectorId, std::move(dataCache));
+    connector::registerConnector(hiveConnector);
+  }
 }
 
 void HiveConnectorTestBase::TearDown() {
+  if (executor_) {
+    executor_->join();
+  }
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }
@@ -47,9 +58,10 @@ void HiveConnectorTestBase::writeToFile(
 void HiveConnectorTestBase::writeToFile(
     const std::string& filePath,
     const std::string& name,
-    const std::vector<RowVectorPtr>& vectors) {
+    const std::vector<RowVectorPtr>& vectors,
+    std::shared_ptr<dwrf::Config> config) {
   facebook::velox::dwrf::WriterOptions options;
-  options.config = std::make_shared<facebook::velox::dwrf::Config>();
+  options.config = config;
   options.schema = vectors[0]->type();
   auto sink = std::make_unique<facebook::dwio::common::FileSink>(filePath);
   facebook::velox::dwrf::Writer writer{

--- a/velox/exec/tests/HiveConnectorTestBase.h
+++ b/velox/exec/tests/HiveConnectorTestBase.h
@@ -20,6 +20,8 @@
 #include "velox/exec/tests/TempFilePath.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 
+#include <folly/executors/IOThreadPoolExecutor.h>
+
 namespace facebook::velox::exec::test {
 
 static const std::string kHiveConnectorId = "test-hive";
@@ -27,41 +29,11 @@ static const std::string kHiveConnectorId = "test-hive";
 using ColumnHandleMap =
     std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>;
 
-// A dummy cache that always misses. This class is for testing purpose only.
-class DummyDataCache : public DataCache {
- public:
-  bool put(std::string_view /* key */, std::string_view /* value */) override {
-    putCount++;
-    return false;
-  }
-
-  bool get(std::string_view /* key */, uint64_t /* size */, void* /* buf */)
-      override {
-    getCount++;
-    return false;
-  }
-
-  bool get(std::string_view /* key */, std::string* /* value */) override {
-    getCount++;
-    return false;
-  }
-
-  int64_t currentSize() const final {
-    return 0;
-  }
-
-  int64_t maxSize() const final {
-    return 0;
-  }
-
-  size_t putCount{0};
-  size_t getCount{0};
-};
-
 class HiveConnectorTestBase : public OperatorTestBase {
  public:
   void SetUp() override;
 
+ public:
   void TearDown() override;
 
   void writeToFile(
@@ -72,7 +44,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
   void writeToFile(
       const std::string& filePath,
       const std::string& name,
-      const std::vector<RowVectorPtr>& vectors);
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwrf::Config> config =
+          std::make_shared<facebook::velox::dwrf::Config>());
 
   std::vector<RowVectorPtr> makeVectors(
       const std::shared_ptr<const RowType>& rowType,
@@ -148,7 +122,12 @@ class HiveConnectorTestBase : public OperatorTestBase {
   static void
   addSplit(Task* task, const core::PlanNodeId& planNodeId, exec::Split&& split);
 
-  DummyDataCache* dataCache;
+  memory::MappedMemory* mappedMemory() {
+    return memory::MappedMemory::getInstance();
+  }
+
+  SimpleLRUDataCache* dataCache;
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/tests/QueryAssertions.h"
@@ -28,6 +29,8 @@ class OperatorTestBase : public testing::Test {
  protected:
   OperatorTestBase();
   ~OperatorTestBase() override;
+
+  void SetUp() override;
 
   static void SetUpTestCase();
 
@@ -216,5 +219,12 @@ class OperatorTestBase : public testing::Test {
       memory::getDefaultScopedMemoryPool()};
   DuckDbQueryRunner duckDbQueryRunner_;
   velox::test::VectorMaker vectorMaker_{pool_.get()};
+
+  // Parametrized subclasses set this to choose the cache code path.
+  bool useAsyncCache_{true};
+
+  // Used as default MappedMemory if 'useAsyncCache_' is true. Created on first
+  // use.
+  static std::unique_ptr<cache::AsyncDataCache> asyncDataCache_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -318,7 +318,7 @@ TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  initializeTask(taskId, 5, 1);
+  auto task = initializeTask(taskId, 5, 1);
 
   enqueue(taskId, 0, rowType, size);
   for (int i = 0; i < 10; i++) {
@@ -341,6 +341,8 @@ TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
 
   noMoreData(taskId);
   fetchEndMarker(taskId, 1, 10);
+  task->terminate(TaskState::kCanceled);
+  bufferManager_->removeTask(taskId);
 }
 
 TEST_F(PartitionedOutputBufferManagerTest, errorInQueue) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/test_utils/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/dwrf/test/utils/DataFiles.h"
@@ -40,9 +41,11 @@ static const std::string kNodeSelectionStrategy = "node_selection_strategy";
 static const std::string kSoftAffinity = "SOFT_AFFINITY";
 static const std::string kTableScanTest = "TableScanTest.Writer";
 
-class TableScanTest : public HiveConnectorTestBase {
+class TableScanTest : public virtual HiveConnectorTestBase,
+                      public testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
+    useAsyncCache_ = GetParam();
     HiveConnectorTestBase::SetUp();
     rowType_ =
         ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
@@ -53,6 +56,10 @@ class TableScanTest : public HiveConnectorTestBase {
              DOUBLE(),
              VARCHAR(),
              TINYINT()});
+  }
+
+  static void SetUpTestCase() {
+    HiveConnectorTestBase::SetUpTestCase();
   }
 
   std::vector<RowVectorPtr> makeVectors(
@@ -156,7 +163,7 @@ class TableScanTest : public HiveConnectorTestBase {
           {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
 };
 
-TEST_F(TableScanTest, allColumns) {
+TEST_P(TableScanTest, allColumns) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -165,7 +172,7 @@ TEST_F(TableScanTest, allColumns) {
   assertQuery(tableScanNode(), {filePath}, "SELECT * FROM tmp");
 }
 
-TEST_F(TableScanTest, columnAliases) {
+TEST_P(TableScanTest, columnAliases) {
   auto vectors = makeVectors(1, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -199,7 +206,7 @@ TEST_F(TableScanTest, columnAliases) {
   assertQuery(op, {filePath}, "SELECT c0 FROM tmp WHERE c0 % 2 = 1");
 }
 
-TEST_F(TableScanTest, columnPruning) {
+TEST_P(TableScanTest, columnPruning) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -226,7 +233,7 @@ TEST_F(TableScanTest, columnPruning) {
 
 // Test reading files written before schema change, e.g. missing newly added
 // columns.
-TEST_F(TableScanTest, missingColumns) {
+TEST_P(TableScanTest, missingColumns) {
   // Simulate schema change of adding a new column.
   // - Create an "old" file with one column.
   // - Create a "new" file with two columns.
@@ -277,7 +284,7 @@ TEST_F(TableScanTest, missingColumns) {
 }
 
 // Tests queries that use Lazy vectors with multiple layers of wrapping.
-TEST_F(TableScanTest, constDictLazy) {
+TEST_P(TableScanTest, constDictLazy) {
   vector_size_t size = 1'000;
   auto rowVector = makeRowVector(
       {makeFlatVector<int64_t>(size, [](auto row) { return row; }),
@@ -329,7 +336,7 @@ TEST_F(TableScanTest, constDictLazy) {
   assertQuery(op, {filePath}, "SELECT 2 FROM tmp WHERE c0 = 5");
 }
 
-TEST_F(TableScanTest, count) {
+TEST_P(TableScanTest, count) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -354,7 +361,7 @@ TEST_F(TableScanTest, count) {
 
 // Test that adding the same split with the same sequence id does not cause
 // double read and the 2nd split is ignored.
-TEST_F(TableScanTest, sequentialSplitNoDoubleRead) {
+TEST_P(TableScanTest, sequentialSplitNoDoubleRead) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -384,7 +391,7 @@ TEST_F(TableScanTest, sequentialSplitNoDoubleRead) {
 
 // Test that adding the splits out of order does not result in splits being
 // ignored.
-TEST_F(TableScanTest, outOfOrderSplits) {
+TEST_P(TableScanTest, outOfOrderSplits) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -414,7 +421,7 @@ TEST_F(TableScanTest, outOfOrderSplits) {
 
 // Test that adding the same split, disregarding the sequence id, causes
 // double read, as expected.
-TEST_F(TableScanTest, splitDoubleRead) {
+TEST_P(TableScanTest, splitDoubleRead) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -441,7 +448,7 @@ TEST_F(TableScanTest, splitDoubleRead) {
   }
 }
 
-TEST_F(TableScanTest, multipleSplits) {
+TEST_P(TableScanTest, multipleSplits) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(10, 1'000);
   for (int32_t i = 0; i < vectors.size(); i++) {
@@ -452,7 +459,7 @@ TEST_F(TableScanTest, multipleSplits) {
   assertQuery(tableScanNode(), filePaths, "SELECT * FROM tmp");
 }
 
-TEST_F(TableScanTest, waitForSplit) {
+TEST_P(TableScanTest, waitForSplit) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(10, 1'000);
   for (int32_t i = 0; i < vectors.size(); i++) {
@@ -475,7 +482,7 @@ TEST_F(TableScanTest, waitForSplit) {
       duckDbQueryRunner_);
 }
 
-TEST_F(TableScanTest, splitOffsetAndLength) {
+TEST_P(TableScanTest, splitOffsetAndLength) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -492,7 +499,7 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       "SELECT * FROM tmp LIMIT 0");
 }
 
-TEST_F(TableScanTest, fileNotFound) {
+TEST_P(TableScanTest, fileNotFound) {
   CursorParameters params;
   params.planNode = tableScanNode();
 
@@ -502,7 +509,7 @@ TEST_F(TableScanTest, fileNotFound) {
 }
 
 // A valid ORC file (containing headers) but no data.
-TEST_F(TableScanTest, validFileNoData) {
+TEST_P(TableScanTest, validFileNoData) {
   auto rowType = ROW({"c0", "c1", "c2"}, {DOUBLE(), VARCHAR(), BIGINT()});
 
   auto filePath = facebook::velox::test::getDataFilePath(
@@ -519,7 +526,7 @@ TEST_F(TableScanTest, validFileNoData) {
 }
 
 // An invalid (size = 0) file.
-TEST_F(TableScanTest, emptyFile) {
+TEST_P(TableScanTest, emptyFile) {
   auto filePath = TempFilePath::create();
 
   try {
@@ -531,54 +538,7 @@ TEST_F(TableScanTest, emptyFile) {
   }
 }
 
-TEST_F(TableScanTest, cacheEnabled) {
-  // DataCache not enabled
-  auto rowType = ROW({"c0", "c1", "c2"}, {DOUBLE(), VARCHAR(), BIGINT()});
-  auto vectors = makeVectors(10, 1'000, rowType);
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->path, kTableScanTest, vectors);
-
-  CursorParameters params;
-  params.planNode = tableScanNode(rowType);
-
-  auto cursor = std::make_unique<TaskCursor>(params);
-
-  addSplit(cursor->task().get(), "0", makeHiveSplit(filePath->path));
-  cursor->task()->noMoreSplits("0");
-
-  while (cursor->moveNext()) {
-    cursor->current();
-  }
-
-  EXPECT_EQ(dataCache->getCount, 0);
-  EXPECT_EQ(dataCache->putCount, 0);
-
-  // DataCache enabled
-  std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs;
-  std::unordered_map<std::string, std::string> hiveConnectorConfigs;
-  hiveConnectorConfigs.insert({kNodeSelectionStrategy, kSoftAffinity});
-  connectorConfigs.insert(
-      {kHiveConnectorId,
-       std::make_shared<core::MemConfig>(std::move(hiveConnectorConfigs))});
-  params.queryCtx = core::QueryCtx::create(
-      std::make_shared<core::MemConfig>(),
-      connectorConfigs,
-      memory::MappedMemory::getInstance());
-
-  cursor = std::make_unique<TaskCursor>(params);
-
-  addSplit(cursor->task().get(), "0", makeHiveSplit(filePath->path));
-  cursor->task()->noMoreSplits("0");
-
-  while (cursor->moveNext()) {
-    cursor->current();
-  }
-
-  EXPECT_NE(dataCache->getCount, 0);
-  EXPECT_NE(dataCache->putCount, 0);
-}
-
-TEST_F(TableScanTest, partitionedTable) {
+TEST_P(TableScanTest, partitionedTable) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);
   auto filePath = TempFilePath::create();
@@ -597,7 +557,7 @@ std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
   return views;
 }
 
-TEST_F(TableScanTest, statsBasedSkippingBool) {
+TEST_P(TableScanTest, statsBasedSkippingBool) {
   auto rowType = ROW({"c0", "c1"}, {INTEGER(), BOOLEAN()});
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
@@ -631,7 +591,7 @@ TEST_F(TableScanTest, statsBasedSkippingBool) {
   EXPECT_EQ(2, getSkippedStridesStat(task));
 }
 
-TEST_F(TableScanTest, statsBasedSkippingDouble) {
+TEST_P(TableScanTest, statsBasedSkippingDouble) {
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
   auto rowVector = makeRowVector({makeFlatVector<double>(
@@ -684,7 +644,7 @@ TEST_F(TableScanTest, statsBasedSkippingDouble) {
   EXPECT_EQ(3, getSkippedStridesStat(task));
 }
 
-TEST_F(TableScanTest, statsBasedSkippingFloat) {
+TEST_P(TableScanTest, statsBasedSkippingFloat) {
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
   auto rowVector = makeRowVector({makeFlatVector<float>(
@@ -737,7 +697,7 @@ TEST_F(TableScanTest, statsBasedSkippingFloat) {
 }
 
 // Test skipping whole file based on statistics
-TEST_F(TableScanTest, statsBasedSkipping) {
+TEST_P(TableScanTest, statsBasedSkipping) {
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
   std::vector<std::string> fruits = {"apple", "banana", "cherry", "grapes"};
@@ -866,7 +826,7 @@ TEST_F(TableScanTest, statsBasedSkipping) {
 
 // Test skipping files and row groups containing constant values based on
 // statistics
-TEST_F(TableScanTest, statsBasedSkippingConstants) {
+TEST_P(TableScanTest, statsBasedSkippingConstants) {
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
   std::vector<std::string> fruits = {"apple", "banana", "cherry", "grapes"};
@@ -927,7 +887,7 @@ TEST_F(TableScanTest, statsBasedSkippingConstants) {
 }
 
 // Test stats-based skipping for the IS NULL filter.
-TEST_F(TableScanTest, statsBasedSkippingNulls) {
+TEST_P(TableScanTest, statsBasedSkippingNulls) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), INTEGER()});
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
@@ -982,7 +942,7 @@ TEST_F(TableScanTest, statsBasedSkippingNulls) {
 }
 
 // Test skipping whole compression blocks without decompressing these.
-TEST_F(TableScanTest, statsBasedSkippingWithoutDecompression) {
+TEST_P(TableScanTest, statsBasedSkippingWithoutDecompression) {
   const vector_size_t size = 31'234;
 
   // Use long, non-repeating strings to ensure there will be multiple
@@ -1037,7 +997,7 @@ TEST_F(TableScanTest, statsBasedSkippingWithoutDecompression) {
 }
 
 // Test skipping whole compression blocks without decompressing these.
-TEST_F(TableScanTest, filterBasedSkippingWithoutDecompression) {
+TEST_P(TableScanTest, filterBasedSkippingWithoutDecompression) {
   const vector_size_t size = 31'234;
 
   // Use long, non-repeating strings to ensure there will be multiple
@@ -1077,7 +1037,7 @@ TEST_F(TableScanTest, filterBasedSkippingWithoutDecompression) {
 // Test stats-based skipping for numeric columns (integers, floats and booleans)
 // that don't have filters themselves. Skipping is driven by a single bigint
 // column.
-TEST_F(TableScanTest, statsBasedSkippingNumerics) {
+TEST_P(TableScanTest, statsBasedSkippingNumerics) {
   const vector_size_t size = 31'234;
 
   // Make a vector of all possible integer and floating point types.
@@ -1147,7 +1107,7 @@ TEST_F(TableScanTest, statsBasedSkippingNumerics) {
 
 // Test stats-based skipping for list and map columns that don't have
 // filters themselves. Skipping is driven by a single bigint column.
-TEST_F(TableScanTest, statsBasedSkippingComplexTypes) {
+TEST_P(TableScanTest, statsBasedSkippingComplexTypes) {
   const vector_size_t size = 31'234;
 
   // Make a vector of all possible integer and floating point types.
@@ -1232,7 +1192,7 @@ TEST_F(TableScanTest, statsBasedSkippingComplexTypes) {
 
 /// Test the interaction between stats-based and regular skipping for lists and
 /// maps.
-TEST_F(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
+TEST_P(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
   const vector_size_t size = 31'234;
 
   // Orchestrate the case where the nested reader of a list/map gets behind the
@@ -1289,7 +1249,7 @@ TEST_F(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
       "SELECT * FROM tmp WHERE c0 <= 10 OR c0 between 600 AND 650 OR c0 >= 21234");
 }
 
-TEST_F(TableScanTest, filterPushdown) {
+TEST_P(TableScanTest, filterPushdown) {
   auto rowType =
       ROW({"c0", "c1", "c2", "c3"}, {TINYINT(), BIGINT(), DOUBLE(), BOOLEAN()});
   auto filePaths = makeFilePaths(10);
@@ -1356,7 +1316,7 @@ TEST_F(TableScanTest, filterPushdown) {
       "SELECT count(*) FROM tmp");
 }
 
-TEST_F(TableScanTest, path) {
+TEST_P(TableScanTest, path) {
   auto rowType = ROW({"a"}, {BIGINT()});
   auto filePath = makeFilePaths(1)[0];
   auto vector = makeVectors(1, 1'000, rowType)[0];
@@ -1394,7 +1354,7 @@ TEST_F(TableScanTest, path) {
       op, {filePath}, fmt::format("SELECT '{}', * FROM tmp", pathValue));
 }
 
-TEST_F(TableScanTest, bucket) {
+TEST_P(TableScanTest, bucket) {
   vector_size_t size = 1'000;
   int numBatches = 5;
 
@@ -1472,7 +1432,7 @@ TEST_F(TableScanTest, bucket) {
   }
 }
 
-TEST_F(TableScanTest, remainingFilter) {
+TEST_P(TableScanTest, remainingFilter) {
   auto rowType = ROW(
       {"c0", "c1", "c2", "c3"}, {INTEGER(), INTEGER(), DOUBLE(), BOOLEAN()});
   auto filePaths = makeFilePaths(10);
@@ -1539,7 +1499,7 @@ TEST_F(TableScanTest, remainingFilter) {
       "SELECT c1, c2 FROM tmp WHERE c1 > c0");
 }
 
-TEST_F(TableScanTest, aggregationPushdown) {
+TEST_P(TableScanTest, aggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -1620,7 +1580,7 @@ TEST_F(TableScanTest, aggregationPushdown) {
       op, {filePath}, "SELECT c5, min(c0), max(c0 + c1) FROM tmp GROUP BY 1");
 }
 
-TEST_F(TableScanTest, bitwiseAggregationPushdown) {
+TEST_P(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -1659,3 +1619,8 @@ TEST_F(TableScanTest, bitwiseAggregationPushdown) {
       {filePath},
       "SELECT c5, bit_or(c0), bit_or(c1), bit_or(c2), bit_or(c6) FROM tmp group by c5");
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    TableScanTests,
+    TableScanTest,
+    testing::Values(true, false));


### PR DESCRIPTION
Uses AsyncDataCache and ScanTracker with Hive if the MappedMemory
given to the reader is a AsyncDataCache. If this is a regular
MappedMemory, uses BufferedInput without caching

. Sets most tests to use AsyncDataCache as MappedMemory also if no
affinity.

Makes AsyncDataCache take ownership of MappedMemory.