### PR TITLE
Extend CMake to handle aws-sdk-cpp dependency needed for S3 connector

### DIFF
--- a/CMake/AWSSDKCPP.cmake
+++ b/CMake/AWSSDKCPP.cmake
@@ -17,7 +17,7 @@
 
 macro(build_awssdk)
     message("Configured to download and build AWS-SDK-CPP version " ${AWS_SDK_VERSION})
-    externalproject_add(aws-sdk
+    ExternalProject_Add(aws-sdk
             PREFIX aws-sdk-cpp
             GIT_REPOSITORY "https://github.com/aws/aws-sdk-cpp.git"
             GIT_TAG ${AWS_SDK_VERSION}
@@ -39,7 +39,7 @@ macro(build_awssdk)
             ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}aws-cpp-sdk-core${CMAKE_STATIC_LIBRARY_SUFFIX})
     set_target_properties(aws-sdk-s3   PROPERTIES IMPORTED_LOCATION
             ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}aws-cpp-sdk-s3${CMAKE_STATIC_LIBRARY_SUFFIX})
-    target_include_directories(aws-sdk-s3 PRIVATE ${AWS_INCLUDE_DIRS})
+    target_include_directories(aws-sdk-s3 PUBLIC ${AWS_INCLUDE_DIRS})
 endmacro()
 
 # S3 Reference  https://aws.amazon.com/blogs/developer/developer-experience-of-the-aws-sdk-for-c-now-simplified-by-cmake/

--- a/CMake/ThirdpartyDependencies.cmake
+++ b/CMake/ThirdpartyDependencies.cmake
@@ -14,6 +14,9 @@
 
 include(ExternalProject)
 
+# Set third-party dependency versions below
+set(AWS_SDK_VERSION "1.9.96")
+
 if (VELOX_ENABLE_S3)
     include(AWSSDKCPP)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,6 @@ endif()
 # Add all options below
 option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)
 
-# Set third-party dependency versions below
-set(AWS_SDK_VERSION "1.9.96")
-
 include(ThirdpartyDependencies)
 
 # If CODEGEN support isn't explicitly set, we guestimate the value based on the


### PR DESCRIPTION
This change currently extends the CMake script to find or download and install aws-sdk-cpp.
VELOX_ENABLE_S3 option is used to enable the S3 connector and is set by default to OFF.
The package (including headers, libraries, binaries) is installed in the directory specified by VELOX_DEPENDENCY_INSTALL_DIR. The default is the build directory.
If AWS SDK CPP is already installed but in a custom location, set AWS_SDK_CPP_INSTALL_DIR to the install location.
