### PR TITLE
Cache masked selectivity vectors for aggregations.

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -52,13 +52,16 @@ class GroupingSet {
 
   void populateTempVectors(int32_t aggregateIndex, const RowVectorPtr& input);
 
-  // If the given aggregation has mask, the method copies the activeRows_ to
-  // maskedActiveRows_, updates maskedActiveRows_ from the mask column and
-  // returns pointer to the maskedActiveRows_. Otherwise it simply returns
-  // pointer to activeRows_.
-  const SelectivityVector* prepareSelectivityVector(
-      size_t aggregateIndex,
-      const RowVectorPtr& input);
+  // For each aggregation, if that aggregation has mask, the method prepares the
+  // selectivity vector by copying activeRows_ and then updating it from the
+  // mask column. The selectivity vectors are reused, if more than one
+  // aggregation is using it (we keep the map keyed by channel index).
+  void prepareMaskedSelectivityVectors(const RowVectorPtr& input);
+
+  // If the given aggregation has mask, the method returns reference to the
+  // selectivity vector from the maskedActiveRows_ (based on the mask channel
+  // index for this aggregation), otherwise it returns reference to activeRows_.
+  const SelectivityVector& getSelectivityVector(size_t aggregateIndex) const;
 
   std::vector<ChannelIndex> keyChannels_;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
@@ -85,10 +88,13 @@ class GroupingSet {
   std::unique_ptr<HashLookup> lookup_;
   uint64_t numAdded_ = 0;
   SelectivityVector activeRows_;
-  // In case of an aggregation using a mask, this selectivity vector is updated
-  // from the mask boolean projection and is used to run aggregations, instead
-  // of the activeRows_.
-  SelectivityVector maskedActiveRows_;
+  // For aggregations that use masks we keep selectivity vectors in this map,
+  // keyed by the channel index, so the selectivity vectors can be reused.
+  struct MaskedRows {
+    bool prepared{false}; // true, if already prepared for the current batch.
+    SelectivityVector rows;
+  };
+  std::unordered_map<ChannelIndex, MaskedRows> maskedActiveRows_;
 
   // We use this vector to decode mask boolean projections to update aggregation
   // masks.


### PR DESCRIPTION
Summary:
More than one aggregation can use one mask, so it makes sense to compute them before the aggregations and then reuse.
So, we cache masked selectivity vectors for aggregations.

Differential Revision: D30812650

