### PR TITLE
Fix finding ScanSpec for dynamic pushdown

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -239,12 +239,11 @@ bool testFilters(
 void HiveDataSource::addDynamicFilter(
     ChannelIndex outputChannel,
     const std::shared_ptr<common::Filter>& filter) {
-  common::Subfield subfield{outputType_->nameOf(outputChannel)};
-  auto fieldSpec = scanSpec_->getOrCreateChild(subfield);
-  if (fieldSpec->filter()) {
-    fieldSpec->filter()->mergeWith(filter.get());
+  auto& fieldSpec = scanSpec_->getChildByChannel(outputChannel);
+  if (fieldSpec.filter()) {
+    fieldSpec.filter()->mergeWith(filter.get());
   } else {
-    fieldSpec->setFilter(filter->clone());
+    fieldSpec.setFilter(filter->clone());
   }
   scanSpec_->resetCachedValues();
 

--- a/velox/dwio/dwrf/reader/ScanSpec.cpp
+++ b/velox/dwio/dwrf/reader/ScanSpec.cpp
@@ -285,4 +285,13 @@ bool testFilter(
   return true;
 }
 
+ScanSpec& ScanSpec::getChildByChannel(ChannelIndex channel) {
+  for (auto& child : children_) {
+    if (child->channel_ == channel) {
+      return *child;
+    }
+  }
+  VELOX_FAIL("No ScanSpec produces channel {}", channel);
+}
+
 } // namespace facebook::velox::common

--- a/velox/dwio/dwrf/reader/ScanSpec.h
+++ b/velox/dwio/dwrf/reader/ScanSpec.h
@@ -248,6 +248,9 @@ class ScanSpec {
     enableFilterReorder_ = enableFilterReorder;
   }
 
+  // Returns the child which produces values for 'channel'. Throws if not found.
+  ScanSpec& getChildByChannel(ChannelIndex channel);
+
  private:
   void reorder();
 

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -4068,7 +4068,7 @@ void SelectiveStructColumnReader::read(
       continue;
     }
     auto fieldIndex = childSpec->subscript();
-    auto reader = children_[fieldIndex].get();
+    auto reader = children_.at(fieldIndex).get();
     advanceFieldReader(reader, offset);
     if (childSpec->filter()) {
       hasFilter = true;


### PR DESCRIPTION
Uses the output channel of the top level column's ScanSpec to find the
ScanSpec to update for dynamic filter pushdown. The name in the output
type may not match the name in the ScanSpec, hence we use the
channel number.