### PR TITLE
Fix ascii string benchmark test

### DIFF
--- a/velox/expression/tests/VectorFuzzer.cpp
+++ b/velox/expression/tests/VectorFuzzer.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/expression/tests/VectorFuzzer.h"
+#include <codecvt>
+#include <locale>
 #include "velox/type/Timestamp.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
@@ -69,47 +71,55 @@ Timestamp rand(folly::Random::DefaultGenerator& rng) {
   return Timestamp(folly::Random::rand32(rng), folly::Random::rand32(rng));
 }
 
+template <>
+uint32_t rand(folly::Random::DefaultGenerator& rng) {
+  return folly::Random::rand32(rng);
+}
+
 /// Unicode character ranges.
 /// Source: https://jrgraphix.net/research/unicode_blocks.php
-const std::map<UTF8CharList, std::vector<std::pair<char, char>>> kUTFChatSetMap{
-    {UTF8CharList::ASCII,
-     {
-         /*Numbers*/ {'0', '9'},
-         /*Upper*/ {'A', 'Z'},
-         /*Lower*/ {'a', 'z'},
-     }},
-    {UTF8CharList::UNICODE_CASE_SENSITIVE,
-     {
-         /*Basic Latin*/ {u'\u0020', u'\u007F'},
-         /*Cyrillic*/ {u'\u0400', u'\u04FF'},
-     }},
-    {UTF8CharList::EXTENDED_UNICODE,
-     {
-         /*Greek*/ {u'\u03F0', u'\u03FF'},
-         /*Latin Extended A*/ {u'\u0100', u'\u017F'},
-         /*Arabic*/ {u'\u0600', u'\u06FF'},
-         /*Devanagari*/ {u'\u0900', u'\u097F'},
-         /*Hebrew*/ {u'\u0600', u'\u06FF'},
-         /*Hiragana*/ {u'\u3040', u'\u309F'},
-         /*Punctuation*/ {u'\u2000', u'\u206F'},
-         /*Sub/Super Script*/ {u'\u2070', u'\u209F'},
-         /*Currency*/ {u'\u20A0', u'\u20CF'},
-     }},
-    {UTF8CharList::MATHEMATICAL_SYMBOLS,
-     {
-         /*Math Operators*/ {u'\u2200', u'\u22FF'},
-         /*Number Forms*/ {u'\u2150', u'\u218F'},
-         /*Geometric Shapes*/ {u'\u25A0', u'\u25FF'},
-         /*Math Sympols-A*/ {u'\u27C0', u'\u27EF'},
-         /*Supplemental*/ {u'\u2A00', u'\u2AFF'},
-     }}};
+const std::map<UTF8CharList, std::vector<std::pair<char16_t, char16_t>>>
+    kUTFChatSetMap{
+        {UTF8CharList::ASCII,
+         {
+             /*Numbers*/ {'0', '9'},
+             /*Upper*/ {'A', 'Z'},
+             /*Lower*/ {'a', 'z'},
+         }},
+        {UTF8CharList::UNICODE_CASE_SENSITIVE,
+         {
+             /*Basic Latin*/ {u'\u0020', u'\u007F'},
+             /*Cyrillic*/ {u'\u0400', u'\u04FF'},
+         }},
+        {UTF8CharList::EXTENDED_UNICODE,
+         {
+             /*Greek*/ {u'\u03F0', u'\u03FF'},
+             /*Latin Extended A*/ {u'\u0100', u'\u017F'},
+             /*Arabic*/ {u'\u0600', u'\u06FF'},
+             /*Devanagari*/ {u'\u0900', u'\u097F'},
+             /*Hebrew*/ {u'\u0600', u'\u06FF'},
+             /*Hiragana*/ {u'\u3040', u'\u309F'},
+             /*Punctuation*/ {u'\u2000', u'\u206F'},
+             /*Sub/Super Script*/ {u'\u2070', u'\u209F'},
+             /*Currency*/ {u'\u20A0', u'\u20CF'},
+         }},
+        {UTF8CharList::MATHEMATICAL_SYMBOLS,
+         {
+             /*Math Operators*/ {u'\u2200', u'\u22FF'},
+             /*Number Forms*/ {u'\u2150', u'\u218F'},
+             /*Geometric Shapes*/ {u'\u25A0', u'\u25FF'},
+             /*Math Symbols*/ {u'\u27C0', u'\u27EF'},
+             /*Supplemental*/ {u'\u2A00', u'\u2AFF'},
+         }}};
 
-FOLLY_ALWAYS_INLINE char getRandomChar(
+FOLLY_ALWAYS_INLINE char16_t getRandomChar(
     folly::Random::DefaultGenerator& rng,
-    const std::vector<std::pair<char, char>>& charSet) {
-  auto chars = charSet[rand<int32_t>(rng) % charSet.size()];
+    const std::vector<std::pair<char16_t, char16_t>>& charSet) {
+  const auto& chars = charSet[rand<uint32_t>(rng) % charSet.size()];
   auto size = chars.second - chars.first;
-  return chars.first + (rand<int32_t>(rng) % size);
+  auto inc = (rand<uint32_t>(rng) % size);
+  char16_t res = chars.first + inc;
+  return res;
 }
 
 /// Generates a random string (string size and encoding are passed through
@@ -117,17 +127,22 @@ FOLLY_ALWAYS_INLINE char getRandomChar(
 StringView randString(
     folly::Random::DefaultGenerator& rng,
     const VectorFuzzer::Options& opts,
-    std::string& buf) {
+    std::string& buf,
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t>& converter) {
+  buf.clear();
+  std::u16string wbuf;
   const size_t stringLength = opts.stringVariableLength
       ? folly::Random::rand32(rng) % opts.stringLength
       : opts.stringLength;
-  buf.resize(stringLength);
+  wbuf.resize(stringLength);
 
   for (size_t i = 0; i < stringLength; ++i) {
     auto encoding =
-        opts.charEncodings[rand<int32_t>(rng) % opts.charEncodings.size()];
-    buf[i] = getRandomChar(rng, kUTFChatSetMap.at(encoding));
+        opts.charEncodings[rand<uint32_t>(rng) % opts.charEncodings.size()];
+    wbuf[i] = getRandomChar(rng, kUTFChatSetMap.at(encoding));
   }
+
+  buf.append(converter.to_bytes(wbuf));
   return StringView(buf);
 }
 
@@ -137,8 +152,9 @@ variant randVariantImpl(
     const VectorFuzzer::Options& opts) {
   using TCpp = typename TypeTraits<kind>::NativeType;
   if constexpr (std::is_same_v<TCpp, StringView>) {
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
     std::string buf;
-    return variant(randString(rng, opts, buf));
+    return variant(randString(rng, opts, buf, converter));
   } else {
     return variant(rand<TCpp>(rng));
   }
@@ -153,12 +169,12 @@ void fuzzFlatImpl(
   using TCpp = typename TypeTraits<kind>::NativeType;
 
   auto flatVector = vector->as<TFlat>();
-  auto* rawValues = flatVector->mutableRawValues();
   std::string strBuf;
 
+  std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
   for (size_t i = 0; i < vector->size(); ++i) {
     if constexpr (std::is_same_v<TCpp, StringView>) {
-      flatVector->set(i, randString(rng, opts, strBuf));
+      flatVector->set(i, randString(rng, opts, strBuf, converter));
     } else {
       flatVector->set(i, rand<TCpp>(rng));
     }

--- a/velox/expression/tests/VectorFuzzer.h
+++ b/velox/expression/tests/VectorFuzzer.h
@@ -43,7 +43,8 @@ class VectorFuzzer {
     size_t nullChance{0};
 
     // Size of the generated strings. If `stringVariableLength` is true, the
-    // semantic of this option becomes "string maximum length".
+    // semantic of this option becomes "string maximum length". Here this
+    // represents number of characters and not bytes.
     size_t stringLength{50};
 
     // Vector of String charsets to choose from; bias a charset by including it


### PR DESCRIPTION
This PR fixes:
* Minor bug in string benchmark test that did not take into consideration utf or not
* Adds more unicode ranges. The unicode ranges are coarse grained for now and not exhaustive but cover a good range of unicode chars. 
In particular there is a UNICODE_CASE_SENSITIVE range since most scripts are not case aware except Latin, cyrillic etc. This is used in upper , lower testing. 

I will have another PR with more string functions in this benchmark. 