### PR TITLE
Optimize away the join after pushing down dynamic filter

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -241,7 +241,7 @@ void HiveDataSource::addDynamicFilter(
     const std::shared_ptr<common::Filter>& filter) {
   auto& fieldSpec = scanSpec_->getChildByChannel(outputChannel);
   if (fieldSpec.filter()) {
-    fieldSpec.filter()->mergeWith(filter.get());
+    fieldSpec.setFilter(fieldSpec.filter()->mergeWith(filter.get()));
   } else {
     fieldSpec.setFilter(filter->clone());
   }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -734,7 +734,7 @@ class PartitionedOutputNode : public PlanNode {
 
 enum class JoinType { kInner, kLeft, kRight, kFull, kSemi, kAnti };
 
-// Represents inner/outer/semi/antijoin hash
+// Represents inner/outer/semi/anti join hash
 // joins. Translates to an exec::HashBuild and exec::HashProbe. A
 // separate pipeline is produced for the build side when generating
 // exec::Operators.
@@ -748,30 +748,7 @@ class HashJoinNode : public PlanNode {
       std::shared_ptr<const ITypedExpr> filter,
       std::shared_ptr<const PlanNode> left,
       std::shared_ptr<const PlanNode> right,
-      const RowTypePtr outputType)
-      : PlanNode(id),
-        joinType_(joinType),
-        leftKeys_(leftKeys),
-        rightKeys_(rightKeys),
-        filter_(std::move(filter)),
-        sources_({std::move(left), std::move(right)}),
-        outputType_(outputType) {
-    VELOX_CHECK(!leftKeys_.empty());
-    VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
-    auto leftType = sources_[0]->outputType();
-    for (auto key : leftKeys_) {
-      VELOX_CHECK(leftType->containsChild(key->name()));
-    }
-    auto rightType = sources_[1]->outputType();
-    for (auto key : rightKeys_) {
-      VELOX_CHECK(rightType->containsChild(key->name()));
-    }
-    for (auto i = 0; i < outputType_->size(); ++i) {
-      auto name = outputType_->nameOf(i);
-      VELOX_CHECK(
-          leftType->containsChild(name) || rightType->containsChild(name));
-    }
-  }
+      const RowTypePtr outputType);
 
   const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
     return sources_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -40,6 +40,8 @@ class HashProbe : public Operator {
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
+  void clearDynamicFilters() override;
+
   void close() override {}
 
  private:
@@ -110,6 +112,12 @@ class HashProbe : public Operator {
   // List of DynamicFilterBuilders aligned with keyChannels_. Contains a valid
   // entry if the driver can push down a filter on the corresponding join key.
   std::vector<std::optional<DynamicFilterBuilder>> dynamicFilterBuilders_;
+
+  // True if the join can become a no-op starting with the next batch of input.
+  bool canReplaceWithDynamicFilter_{false};
+
+  // True if the join became a no-op after pushing down the filter.
+  bool replacedWithDynamicFilter_{false};
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -119,6 +119,9 @@ class BaseHashTable {
   /// side. This is used for sizing the internal hash table.
   virtual uint64_t numDistinct() const = 0;
 
+  /// Returns true if the hash table contains rows with duplicate keys.
+  virtual bool hasDuplicateKeys() const = 0;
+
   /// Returns the hash mode. This is needed for the caller to calculate
   /// the hash numbers using the appropriate method of the
   /// VectorHashers of 'this'.
@@ -255,6 +258,10 @@ class HashTable : public BaseHashTable {
 
   uint64_t numDistinct() const override {
     return numDistinct_;
+  }
+
+  bool hasDuplicateKeys() const override {
+    return hasDuplicates_;
   }
 
   HashMode hashMode() const override {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -104,6 +104,13 @@ class HashJoinTest : public HiveConnectorTestBase {
     return stats[operatorIndex].runtimeStats["dynamicFiltersAccepted"];
   }
 
+  static RuntimeMetric getReplacedWithFilterRows(
+      const std::shared_ptr<Task>& task,
+      int operatorIndex) {
+    auto stats = task->taskStats().pipelineStats.front().operatorStats;
+    return stats[operatorIndex].runtimeStats["replacedWithDynamicFilterRows"];
+  }
+
   static uint64_t getInputPositions(
       const std::shared_ptr<Task>& task,
       int operatorIndex) {
@@ -476,31 +483,42 @@ TEST_F(HashJoinTest, dynamicFilters) {
   }
 
   // 100 key values in [35, 233] range.
-  auto rightVectors = {makeRowVector(
-      {makeFlatVector<int32_t>(100, [](auto row) { return 35 + row * 2; })})};
+  auto rightKey =
+      makeFlatVector<int32_t>(100, [](auto row) { return 35 + row * 2; });
+  auto rightVectors = {makeRowVector({
+      rightKey,
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+  })};
 
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
   auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
 
+  auto buildSide = PlanBuilder(0)
+                       .values(rightVectors)
+                       .project({"c0", "c1"}, {"u_c0", "u_c1"})
+                       .planNode();
+  auto keyOnlyBuildSide = PlanBuilder(0)
+                              .values({makeRowVector({rightKey})})
+                              .project({"c0"}, {"u_c0"})
+                              .planNode();
+
   // Basic push-down.
   {
     auto op = PlanBuilder(10)
                   .tableScan(probeType)
-                  .hashJoin(
-                      {0},
-                      {0},
-                      PlanBuilder(0).values(rightVectors).planNode(),
-                      "",
-                      {1})
-                  .project({"c1 + 1"})
+                  .hashJoin({0}, {0}, buildSide, "", {0, 1, 3})
+                  .project({"c0", "c1 + 1", "c1 + u_c1"})
                   .planNode();
 
     auto task = assertQuery(
-        op, {{10, leftFiles}}, "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
+        op,
+        {{10, leftFiles}},
+        "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
     EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
   }
 
@@ -518,19 +536,17 @@ TEST_F(HashJoinTest, dynamicFilters) {
                 scanOutputType,
                 makeTableHandle(common::test::SubfieldFiltersBuilder().build()),
                 assignments)
-            .hashJoin(
-                {0},
-                {0},
-                PlanBuilder(0).values(rightVectors).planNode(),
-                "",
-                {1})
-            .project({"b + 1"})
+            .hashJoin({0}, {0}, buildSide, "", {0, 1, 3})
+            .project({"a", "b + 1", "b + u_c1"})
             .planNode();
 
     auto task = assertQuery(
-        op, {{10, leftFiles}}, "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
+        op,
+        {{10, leftFiles}},
+        "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
     EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
   }
 
@@ -543,12 +559,47 @@ TEST_F(HashJoinTest, dynamicFilters) {
                       probeType,
                       makeTableHandle(std::move(filters)),
                       allRegularColumns(probeType))
-                  .hashJoin(
-                      {0},
-                      {0},
-                      PlanBuilder(0).values(rightVectors).planNode(),
-                      "",
-                      {1})
+                  .hashJoin({0}, {0}, buildSide, "", {1, 3})
+                  .project({"c1 + u_c1"})
+                  .planNode();
+
+    auto task = assertQuery(
+        op,
+        {{10, leftFiles}},
+        "SELECT t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
+    EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
+    EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+  }
+
+  // Push-down that turns join into a no-op.
+  {
+    auto op = PlanBuilder(10)
+                  .tableScan(probeType)
+                  .hashJoin({0}, {0}, keyOnlyBuildSide, "", {0, 1})
+                  .project({"c0", "c1 + 1"})
+                  .planNode();
+
+    auto task = assertQuery(
+        op,
+        {{10, leftFiles}},
+        "SELECT t.c0, t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
+    EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
+    EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
+    EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
+  }
+
+  // Push-down that requires merging filters and turns join into a no-op.
+  {
+    auto filters =
+        common::test::singleSubfieldFilter("c0", common::test::lessThan(500));
+    auto op = PlanBuilder(10)
+                  .tableScan(
+                      probeType,
+                      makeTableHandle(std::move(filters)),
+                      allRegularColumns(probeType))
+                  .hashJoin({0}, {0}, keyOnlyBuildSide, "", {1})
                   .project({"c1 + 1"})
                   .planNode();
 
@@ -558,6 +609,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
         "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
   }
 
   // Disable filter push-down by using highly selective filter in the scan.
@@ -569,12 +621,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
                       probeType,
                       makeTableHandle(std::move(filters)),
                       allRegularColumns(probeType))
-                  .hashJoin(
-                      {0},
-                      {0},
-                      PlanBuilder(0).values(rightVectors).planNode(),
-                      "",
-                      {1})
+                  .hashJoin({0}, {0}, buildSide, "", {1})
                   .project({"c1 + 1"})
                   .planNode();
 
@@ -584,18 +631,14 @@ TEST_F(HashJoinTest, dynamicFilters) {
         "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 200");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
+    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
   }
 
   // Disable filter push-down by using values in place of scan.
   {
     auto op = PlanBuilder(10)
                   .values(leftVectors)
-                  .hashJoin(
-                      {0},
-                      {0},
-                      PlanBuilder(0).values(rightVectors).planNode(),
-                      "",
-                      {1})
+                  .hashJoin({0}, {0}, buildSide, "", {1})
                   .project({"c1 + 1"})
                   .planNode();
 
@@ -611,12 +654,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     auto op = PlanBuilder(10)
                   .tableScan(probeType)
                   .project({"c0 + 1", "c1"})
-                  .hashJoin(
-                      {0},
-                      {0},
-                      PlanBuilder(0).values(rightVectors).planNode(),
-                      "",
-                      {1})
+                  .hashJoin({0}, {0}, buildSide, "", {1})
                   .project({"p1 + 1"})
                   .planNode();
 


### PR DESCRIPTION
The join can be completely replaced with a pushed down filter when the following
conditions are met:
	* hash table has a single key with unique values,
	* build side has no dependent columns.