### PR TITLE
Untangle Spark and Presto hashing functions

### DIFF
--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -152,7 +152,7 @@ TEST_F(EvalSimplifiedTest, constantAndInput) {
 }
 
 TEST_F(EvalSimplifiedTest, strings) {
-  runTest("md5(c0)", ROW({"c0"}, {VARCHAR()}));
+  runTest("lower(upper(c0))", ROW({"c0"}, {VARCHAR()}));
 }
 
 TEST_F(EvalSimplifiedTest, doubles) {

--- a/velox/expression/tests/ExpressionFuzzerMain.cpp
+++ b/velox/expression/tests/ExpressionFuzzerMain.cpp
@@ -35,7 +35,7 @@ std::vector<CallableSignature> getAllSignatures() {
   std::vector<CallableSignature> functions;
 
   // TODO: Skipping buggy functions for now.
-  std::unordered_set<std::string> skipFunctions = {"xxhash64", "from_unixtime"};
+  std::unordered_set<std::string> skipFunctions = {"from_unixtime"};
   auto keys = exec::AdaptedVectorFunctions().Keys();
 
   for (const auto& key : keys) {

--- a/velox/functions/prestosql/CoreFunctions.cpp
+++ b/velox/functions/prestosql/CoreFunctions.cpp
@@ -33,29 +33,16 @@ void registerFunctions() {
 
   registerFunction<udf_rand, double>(EMPTY);
 
-  registerUnaryScalar<udf_hash, int64_t>(EMPTY);
-
   registerFunction<udf_json_extract_scalar, Varchar, Varchar, Varchar>();
 
   // Register string functions.
   registerFunction<udf_chr, Varchar, int64_t>();
   registerFunction<udf_codepoint, int32_t, Varchar>();
-  registerFunction<
-      udf_xxhash64int<int64_t, Varchar>,
-      int64_t,
-      Varchar,
-      int64_t>({"xxhash64"});
-  registerFunction<udf_xxhash64int<int64_t, Varchar>, int64_t, Varchar>(
-      {"xxhash64"});
-  registerFunction<udf_xxhash64<Varbinary, Varbinary>, Varbinary, Varbinary>(
-      {"xxhash64"});
+
+  // Register hash functions
+  registerFunction<udf_xxhash64, Varbinary, Varbinary>({"xxhash64"});
   registerFunction<udf_md5<Varbinary, Varbinary>, Varbinary, Varbinary>(
       {"md5"});
-  registerFunction<udf_md5_radix<Varchar, Varchar>, Varchar, Varchar, int32_t>(
-      {"md5"});
-  registerFunction<udf_md5_radix<Varchar, Varchar>, Varchar, Varchar, int64_t>(
-      {"md5"});
-  registerFunction<udf_md5_radix<Varchar, Varchar>, Varchar, Varchar>({"md5"});
 
   registerFunction<udf_to_hex, Varchar, Varbinary>();
   registerFunction<udf_from_hex, Varbinary, Varchar>();

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -23,6 +23,7 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions {
+
 namespace {
 
 /// Check if the input vector's  buffers are single referenced

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -20,7 +20,6 @@
 #include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonExtractScalar.h"
 #include "velox/functions/prestosql/Rand.h"
-#include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/sparksql/Hash.h"
 #include "velox/functions/sparksql/LeastGreatest.h"
 #include "velox/functions/sparksql/RegexFunctions.h"
@@ -67,19 +66,12 @@ void registerFunctions(const std::string& prefix) {
   // Register string functions.
   registerFunction<udf_chr, Varchar, int64_t>();
   registerFunction<udf_ascii, int32_t, Varchar>();
-  registerFunction<
-      udf_xxhash64int<int64_t, Varchar>,
-      int64_t,
-      Varchar,
-      int64_t>({prefix + "xxhash64"});
-  registerFunction<udf_xxhash64int<int64_t, Varchar>, int64_t, Varchar>(
-      {prefix + "xxhash64"});
-  registerFunction<udf_xxhash64<Varbinary, Varbinary>, Varbinary, Varbinary>(
-      {prefix + "xxhash64"});
+
   exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(
       "length", lengthSignatures(), makeLength);
-  registerFunction<udf_md5_radix<Varchar, Varbinary>, Varchar, Varbinary>(
+
+  registerFunction<udf_md5<Varchar, Varbinary>, Varchar, Varbinary>(
       {prefix + "md5"});
 
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/UDFOutputString.h"
+#include "velox/functions/lib/string/StringImpl.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -34,6 +37,15 @@ FOLLY_ALWAYS_INLINE bool call(out_type<Varchar>& result, int64_t ord) {
     result.resize(1);
     *result.data() = ord;
   }
+  return true;
+}
+VELOX_UDF_END();
+
+template <typename To, typename From>
+VELOX_UDF_BEGIN(md5)
+FOLLY_ALWAYS_INLINE
+    bool call(out_type<To>& result, const arg_type<From>& input) {
+  stringImpl::md5_radix(result, input, 16);
   return true;
 }
 VELOX_UDF_END();

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -47,12 +47,12 @@ class StringTest : public SparkFunctionBaseTest {
 
   std::optional<int32_t> length_bytes(std::optional<std::string> arg) {
     return evaluateOnce<int32_t, std::string>(
-        "length(c0)", {arg}, {VarbinaryType::create()});
+        "length(c0)", {arg}, {VARBINARY()});
   }
 
   std::optional<std::string> md5(std::optional<std::string> arg) {
     return evaluateOnce<std::string, std::string>(
-        "md5(c0)", {arg}, {VarbinaryType::create()});
+        "md5(c0)", {arg}, {VARBINARY()});
   }
 };
 


### PR DESCRIPTION
Summary:
MD5 and XXHASH functions have similar behavior but not the same
between Spark and Presto. Re-organizing the code to implement the expected
semantic.

Reviewed By: funrollloops

Differential Revision: D30883888

