### PR TITLE
Fix RowContainer::clear()

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -464,6 +464,7 @@ void RowContainer::hash(
 void RowContainer::clear() {
   rows_.clear();
   stringAllocator_.clear();
+  numRows_ = 0;
   numRowsWithNormalizedKey_ = 0;
   if (hasNormalizedKeys_) {
     normalizedKeySize_ = sizeof(normalized_key_t);


### PR DESCRIPTION
Summary: Set `numRows_ = 0;` when `clear()` is callled.

Reviewed By: mbasmanova

Differential Revision: D30903536

