### PR TITLE
Fix lengthUnicode going into infinite loop

### DIFF
--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -186,7 +186,9 @@ lengthUnicode(const char* inputBuffer, size_t bufferLength) {
   auto currentChar = inputBuffer;
   int64_t size = 0;
   while (currentChar < buffEndAddress) {
-    currentChar += utf8proc_char_length(currentChar);
+    auto chrOffset = utf8proc_char_length(currentChar);
+    // Skip bad byte if we get utf length < 0.
+    currentChar += UNLIKELY(chrOffset < 0) ? 1 : chrOffset;
     size++;
   }
   return size;

--- a/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
@@ -110,17 +110,6 @@ BENCHMARK(utfUpper) {
 BENCHMARK_RELATIVE(asciiUpper) {
   StringAsciiUTFFunctionBenchmark benchmark;
   benchmark.runUpperLower("upper", false);
-  benchmark.runUpperLower("upper", false);
-}
-
-BENCHMARK(utfSubStr) {
-  StringAsciiUTFFunctionBenchmark benchmark;
-  benchmark.runSubStr(true);
-}
-
-BENCHMARK_RELATIVE(asciiSubStr) {
-  StringAsciiUTFFunctionBenchmark benchmark;
-  benchmark.runSubStr(false);
 }
 
 BENCHMARK(utfSubStr) {


### PR DESCRIPTION
This is the fix for lengthUnicode going into infinite loop when a unicode char has underflow (due to bad conversion) etc. 