### PR TITLE
Reuse buffers only if singly-referenced

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -120,7 +120,8 @@ static inline void ensureCapacity(
     BufferPtr& data,
     size_t capacity,
     velox::memory::MemoryPool* pool) {
-  if (!data || data->capacity() < BaseVector::byteSize<T>(capacity)) {
+  if (!data || !data->unique() ||
+      data->capacity() < BaseVector::byteSize<T>(capacity)) {
     data = AlignedBuffer::allocate<T>(capacity, pool);
   }
 }

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -124,7 +124,7 @@ void SelectiveColumnReader::seekTo(vector_size_t offset, bool readsNullsOnly) {
 
 template <typename T>
 void SelectiveColumnReader::ensureValuesCapacity(vector_size_t numRows) {
-  if (values_ &&
+  if (values_ && values_->unique() &&
       values_->capacity() >=
           BaseVector::byteSize<T>(numRows) + simd::kPadding) {
     return;
@@ -203,11 +203,6 @@ void SelectiveColumnReader::prepareRead(
   }
   ensureValuesCapacity<T>(rows.size());
   if (scanSpec_->keepValues() && !scanSpec_->valueHook()) {
-    // Can't re-use if someone else has a reference
-    if (values_ && !values_->unique()) {
-      values_.reset();
-    }
-    ensureValuesCapacity<T>(rows.size());
     valueRows_.clear();
     prepareNulls(rows, nullsInReadRange_ != nullptr);
   }


### PR DESCRIPTION
Buffers can be reused only if they are singly-referenced. SelectiveColumnReader
didn't check reference counts before reusing which caused corruptions in
LocalPartition operator.