### PR TITLE
modulus() on floating numbers

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -67,6 +67,14 @@ FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b)
 VELOX_UDF_END();
 
 template <typename T>
+VELOX_UDF_BEGIN(modulus)
+FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
+  result = modulus(a, b);
+  return true;
+}
+VELOX_UDF_END();
+
+template <typename T>
 VELOX_UDF_BEGIN(ceil)
 FOLLY_ALWAYS_INLINE bool call(T& result, const T& a) {
   result = ceil(a);

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -81,6 +81,16 @@ T divide(const T& a, const T& b)
   return result;
 }
 
+// This is used by Velox for floating points modulus.
+template <typename T>
+T modulus(const T a, const T b) {
+  if (b == 0) {
+    // Match Presto semantics
+    return std::numeric_limits<T>::quiet_NaN();
+  }
+  return std::fmod(a, b);
+}
+
 template <typename T>
 T negate(const T& arg) {
   T results = std::negate<std::remove_cv_t<T>>()(arg);

--- a/velox/functions/prestosql/RegisterArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterArithmetic.cpp
@@ -43,6 +43,7 @@ void registerArithmeticFunctions() {
   registerBinaryFloatingPoint<udf_minus>({});
   registerBinaryFloatingPoint<udf_multiply>({});
   registerBinaryFloatingPoint<udf_divide>({});
+  registerBinaryFloatingPoint<udf_modulus>({});
   registerUnaryNumeric<udf_ceil>({"ceil", "ceiling"});
   registerUnaryNumeric<udf_floor>({});
   registerUnaryNumeric<udf_abs>({});

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -79,6 +79,44 @@ __attribute__((__no_sanitize__("float-divide-by-zero")))
       "c0 / c1", {10.5, 9.2, 0.0}, {2, 0, 0}, {5.25, inf, nan});
 }
 
+TEST_F(ArithmeticTest, modulus) {
+  // Doubles as input.
+  std::vector<double> numerDouble = {0, 6, 0, -7, -1, -9, 9, 10.1};
+  std::vector<double> denomDouble = {1, 2, -1, 3, -1, -3, -3, -99.9};
+  std::vector<double> expectedDouble;
+
+  expectedDouble.reserve(numerDouble.size());
+  for (size_t i = 0; i < numerDouble.size(); i++) {
+    expectedDouble.emplace_back(std::fmod(numerDouble[i], denomDouble[i]));
+  }
+
+  double nan = std::nan("");
+  double inf = std::numeric_limits<double>::infinity();
+
+  // Check using function name and alias.
+  assertExpression<double>(
+      "modulus(c0, c1)", numerDouble, denomDouble, expectedDouble);
+  assertExpression<double>(
+      "modulus(c0, c1)",
+      {5.1, nan, 5.1, inf, 5.1},
+      {0.0, 5.1, nan, 5.1, inf},
+      {nan, nan, nan, nan, 5.1});
+
+  // Integers as input.
+  std::vector<int64_t> numerInt = {9, 10, 0, -9, -10, -11};
+  std::vector<int64_t> denomInt = {3, -3, 11, -1, 199999, 77};
+  std::vector<int64_t> expectedInt;
+  expectedInt.reserve(numerInt.size());
+
+  for (size_t i = 0; i < numerInt.size(); i++) {
+    expectedInt.emplace_back(numerInt[i] % denomInt[i]);
+  }
+
+  assertExpression<int64_t, int64_t>(
+      "modulus(c0, c1)", numerInt, denomInt, expectedInt);
+  assertError<int64_t>("modulus(c0, c1)", {10}, {0}, "Cannot divide by 0");
+}
+
 TEST_F(ArithmeticTest, power) {
   float inf = std::numeric_limits<float>::infinity();
 


### PR DESCRIPTION
Summary: Implement `modulus()` on floating numbers by `std::fmod`. Adding this to support TorchArrow's modulo operation in Python (D30902518).

Differential Revision: D30917653

