### PR TITLE
Remove unused header include and dependency for velox_type

### DIFF
--- a/velox/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/aggregates/benchmarks/CMakeLists.txt
@@ -21,5 +21,6 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_lib
   velox_exec_test_util
+  velox_dwio_common_exception
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK})

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -19,11 +19,11 @@ include_directories(${CMAKE_BINARY_DIR})
 
 set(VELOX_LINK_LIBS
     velox_dwio_common
-    velox_dwio_common_exception
     velox_dwio_dwrf_reader
     velox_dwio_dwrf_common
     velox_dwio_dwrf_utils
     velox_dwio_dwrf_writer
+    velox_dwio_common_exception
     velox_dwio_type_fbhive
     velox_vector
     velox_exception
@@ -474,5 +474,11 @@ target_link_libraries(
 
 add_executable(velox_dwrf_float_column_writer_benchmark
                FloatColumnWriterBenchmark.cpp)
-target_link_libraries(velox_dwrf_float_column_writer_benchmark velox_vector
-                      velox_dwio_dwrf_writer ${FOLLY} ${FOLLY_BENCHMARK} ${FMT})
+target_link_libraries(
+  velox_dwrf_float_column_writer_benchmark
+  velox_vector
+  velox_dwio_common_exception
+  velox_dwio_dwrf_writer
+  ${FOLLY}
+  ${FOLLY_BENCHMARK}
+  ${FMT})

--- a/velox/dwio/dwrf/utils/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/utils/test/CMakeLists.txt
@@ -20,8 +20,8 @@ add_test(velox_dwio_dwrf_utils_test velox_dwio_dwrf_utils_test)
 target_link_libraries(
   velox_dwio_dwrf_utils_test
   velox_dwio_common
-  velox_dwio_common_exception
   velox_dwio_dwrf_utils
+  velox_dwio_common_exception
   velox_dwio_type_fbhive
   ${gflags_LIBRARIES}
   ${GTEST_BOTH_LIBRARIES}

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(
   velox_memory
   velox_parse_parser
   velox_dwio_type_fbhive
+  velox_dwio_common_exception
   velox_dwrf_test_utils
   velox_presto_serializer
   ${Boost_ATOMIC_LIBRARIES}

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   velox_vector
   velox_memory
   velox_dwio_type_fbhive
+  velox_dwio_common_exception
   velox_dwrf_test_utils
   velox_presto_serializer
   velox_transform_utils

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   velox_aggregates
   velox_hive_connector
   velox_dwio_common
+  velox_dwio_common_exception
   velox_exec_test_util
   velox_expression
   velox_functions_lib

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(
   velox_type
   velox_encode
   velox_exception
-  velox_dwio_common_exception
   velox_serialization
   velox_external_date
   ${Boost_REGEX_LIBRARIES}

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -26,7 +26,6 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SimdUtil.h"
-#include "velox/dwio/common/exception/Exception.h"
 #include "velox/type/StringView.h"
 
 namespace facebook ::velox::common {

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -17,7 +17,6 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include "velox/common/base/Exceptions.h"
-#include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook::velox::common {
 


### PR DESCRIPTION
For the velox decomposition, remove unused header include and dependency of velox_dwio_common_exception  from velox_type target to remove its dependency on dwio. And add velox_dwio_common_exception back to targets that get it from velox_type.