### PR TITLE
Add overload of initializeNewGroups() which takes partial result as input to Velox Aggregate

### DIFF
--- a/velox/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/aggregates/ApproxDistinctAggregate.cpp
@@ -128,6 +128,13 @@ class ApproxDistinctAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** /*groups*/, int32_t /*numGroups*/) override {
     // nothing to do
   }

--- a/velox/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/aggregates/ApproxPercentileAggregate.cpp
@@ -223,6 +223,13 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void destroy(folly::Range<char**> groups) override {
     for (auto group : groups) {
       auto accumulator = value<TDigestAccumulator>(group);

--- a/velox/aggregates/ArbitraryAggregate.cpp
+++ b/velox/aggregates/ArbitraryAggregate.cpp
@@ -47,6 +47,13 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
     exec::Aggregate::setAllNulls(groups, indices);
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
@@ -158,6 +165,13 @@ class NonNumericArbitrary : public exec::Aggregate {
     for (auto i : indices) {
       new (groups[i] + offset_) SingleValueAccumulator();
     }
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
   }
 
   void finalize(char** /* groups */, int32_t /* numGroups */) override {}

--- a/velox/aggregates/ArrayAggAggregate.cpp
+++ b/velox/aggregates/ArrayAggAggregate.cpp
@@ -44,6 +44,13 @@ class ArrayAggAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** groups, int32_t numGroups) override {
     for (auto i = 0; i < numGroups; i++) {
       value<ArrayAccumulator>(groups[i])->elements.finalize(allocator_);

--- a/velox/aggregates/AverageAggregate.cpp
+++ b/velox/aggregates/AverageAggregate.cpp
@@ -50,6 +50,13 @@ class AverageAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** /* unused */, int32_t /* unused */) override {}
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)

--- a/velox/aggregates/BitwiseAggregates.cpp
+++ b/velox/aggregates/BitwiseAggregates.cpp
@@ -46,6 +46,13 @@ class BitwiseAndOrAggregate : public SimpleNumericAggregate<T, T, T> {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {

--- a/velox/aggregates/BoolAggregates.cpp
+++ b/velox/aggregates/BoolAggregates.cpp
@@ -71,6 +71,13 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
  protected:
   const bool initialValue_;
 };

--- a/velox/aggregates/CountAggregate.cpp
+++ b/velox/aggregates/CountAggregate.cpp
@@ -40,6 +40,13 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {

--- a/velox/aggregates/CountIfAggregate.cpp
+++ b/velox/aggregates/CountIfAggregate.cpp
@@ -39,6 +39,13 @@ class CountIfAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** /* groups */, int32_t /* numGroups */) override {}
 
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)

--- a/velox/aggregates/MapAggAggregate.cpp
+++ b/velox/aggregates/MapAggAggregate.cpp
@@ -44,6 +44,13 @@ class MapAggAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** groups, int32_t numGroups) override {
     for (auto i = 0; i < numGroups; i++) {
       value<MapAccumulator>(groups[i])->keys.finalize(allocator_);

--- a/velox/aggregates/MinMaxAggregates.cpp
+++ b/velox/aggregates/MinMaxAggregates.cpp
@@ -100,6 +100,13 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void updatePartial(
       char** groups,
       const SelectivityVector& rows,
@@ -172,6 +179,13 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
     for (auto i : indices) {
       *exec::Aggregate::value<T>(groups[i]) = kInitialValue_;
     }
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
   }
 
   void updatePartial(
@@ -249,6 +263,13 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     for (auto i : indices) {
       new (groups[i] + offset_) SingleValueAccumulator();
     }
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
   }
 
   void finalize(char** /* groups */, int32_t /* numGroups */) override {

--- a/velox/aggregates/MinMaxByAggregates.cpp
+++ b/velox/aggregates/MinMaxByAggregates.cpp
@@ -53,6 +53,13 @@ class MinMaxByAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** /* unused */, int32_t /* unused */) override {}
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)

--- a/velox/aggregates/SumAggregate.h
+++ b/velox/aggregates/SumAggregate.h
@@ -42,6 +42,13 @@ class SumAggregate
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
     BaseAggregate::template doExtractValues<ResultType>(

--- a/velox/aggregates/VarianceAggregates.cpp
+++ b/velox/aggregates/VarianceAggregates.cpp
@@ -149,6 +149,13 @@ class VarianceAggregate : public exec::Aggregate {
     }
   }
 
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) override {
+    VELOX_NYI();
+  }
+
   void finalize(char** /* unused */, int32_t /* unused */) override {}
 
   void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -69,6 +69,16 @@ class Aggregate {
       char** groups,
       folly::Range<const vector_size_t*> indices) = 0;
 
+  // Initializes null flags and accumulators for newly encountered groups from
+  // partial results.
+  // @param groups Pointers to the start of the new group rows.
+  // @param indices Indices into 'groups' of the new entries.
+  // @param initialState Partial results extracted from `extractAccumulators`.
+  virtual void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/,
+      const VectorPtr& /*initialState*/) = 0;
+
   // Updates the accumulator in 'groups' with the values in 'args'.
   // @param groups Pointers to the start of the group rows. These are aligned
   // with the 'args', e.g. data in the i-th row of the 'args' goes to the i-th


### PR DESCRIPTION
Differential Revision: D30903533

