### PR TITLE
Consolidate VELOX_USER_FAIL and VELOX_USER_THROW macros

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -314,15 +314,6 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 
 DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
 
-#define VELOX_USER_THROW(...)                                    \
-  _VELOX_THROW_IMPL(                                             \
-      ::facebook::velox::VeloxUserError,                         \
-      "",                                                        \
-      ::facebook::velox::error_source::kErrorSourceUser.c_str(), \
-      ::facebook::velox::error_code::kInvalidArgument.c_str(),   \
-      /* isRetriable */ false,                                   \
-      ##__VA_ARGS__)
-
 // For all below macros, an additional message can be passed using a
 // format string and arguments, as with `fmt::format`.
 #define VELOX_USER_CHECK(expr, ...) \
@@ -373,7 +364,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
   _VELOX_THROW(                                                  \
       ::facebook::velox::VeloxUserError,                         \
       ::facebook::velox::error_source::kErrorSourceUser.c_str(), \
-      ::facebook::velox::error_code::kGenericUserError.c_str(),  \
+      ::facebook::velox::error_code::kInvalidArgument.c_str(),   \
       /* isRetriable */ false,                                   \
       ##__VA_ARGS__)
 

--- a/velox/common/tests/ExceptionTests.cpp
+++ b/velox/common/tests/ExceptionTests.cpp
@@ -432,7 +432,7 @@ TEST(ExceptionTests, ExceptionWithErrorCode) {
           "\nFile: ",
           "VeloxUserError",
           "USER",
-          "GENERIC_USER_ERROR",
+          "INVALID_ARGUMENT",
           "False",
           "operator()"));
 }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -350,7 +350,7 @@ void CastExpr::applyRow(
 
     if (matchNotFound) {
       if (nullOnFailure_) {
-        VELOX_USER_THROW(
+        VELOX_USER_FAIL(
             "Invalid complex cast the match is not found for the field {}",
             toFieldName)
       }

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -61,7 +61,7 @@ std::optional<T> getIfConstant(const BaseVector& v) {
 
 void checkForBadPattern(const RE2& re) {
   if (UNLIKELY(!re.ok())) {
-    VELOX_USER_THROW("invalid regular expression:{}", re.error());
+    VELOX_USER_FAIL("invalid regular expression:{}", re.error());
   }
 }
 
@@ -172,7 +172,7 @@ class Re2Match final : public VectorFunction {
 
 void checkForBadGroupId(int groupId, const RE2& re) {
   if (UNLIKELY(groupId < 0 || groupId > re.NumberOfCapturingGroups())) {
-    VELOX_USER_THROW("No group {} in regex '{}'", groupId, re.pattern());
+    VELOX_USER_FAIL("No group {} in regex '{}'", groupId, re.pattern());
   }
 }
 

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -230,7 +230,7 @@ class SubscriptImpl : public exec::VectorFunction {
     if constexpr (indexStartsAtOne) {
       // If it's zero, throw.
       if (UNLIKELY(index == 0)) {
-        VELOX_USER_THROW("SQL array indices start at 1");
+        VELOX_USER_FAIL("SQL array indices start at 1");
       }
 
       // If larger than zero, adjust it.
@@ -262,7 +262,7 @@ class SubscriptImpl : public exec::VectorFunction {
           index += arraySize;
         }
       } else {
-        VELOX_USER_THROW("Array subscript is negative.");
+        VELOX_USER_FAIL("Array subscript is negative.");
       }
     }
 
@@ -274,7 +274,7 @@ class SubscriptImpl : public exec::VectorFunction {
       }
       // Otherwise, throw.
       else {
-        VELOX_USER_THROW("Array subscript out of bounds.");
+        VELOX_USER_FAIL("Array subscript out of bounds.");
       }
     }
 

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -28,7 +28,7 @@ void ensureRegexIsCompatible(
     const VectorPtr& patternVector) {
   if (!patternVector ||
       patternVector->encoding() != VectorEncoding::Simple::CONSTANT) {
-    VELOX_USER_THROW("{} requires a constant pattern.", functionName);
+    VELOX_USER_FAIL("{} requires a constant pattern.", functionName);
   }
   if (patternVector->isNullAt(0)) {
     return;
@@ -43,8 +43,9 @@ void ensureRegexIsCompatible(
       ++c;
     } else if (*c == '[') {
       if (charClassStart) {
-        VELOX_USER_THROW(
-            "{} does not support character class union, intersection, or difference ([a[b]], [a&&[b]], [a&&[^b]])",
+        VELOX_USER_FAIL(
+            "{} does not support character class union, intersection, "
+            "or difference ([a[b]], [a&&[b]], [a&&[^b]])",
             functionName);
       }
       charClassStart = c;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -445,7 +445,7 @@ int32_t fromDate(int32_t year, int32_t month, int32_t day) {
   int32_t daysSinceEpoch = 0;
 
   if (!isValidDate(year, month, day)) {
-    VELOX_USER_THROW("Date out of range: {}-{}-{}", year, month, day);
+    VELOX_USER_FAIL("Date out of range: {}-{}-{}", year, month, day);
   }
   while (year < 1970) {
     year += kYearInterval;
@@ -467,7 +467,7 @@ int32_t fromDateString(const char* str, size_t len) {
   size_t pos = 0;
 
   if (!tryParseDateString(str, len, pos, daysSinceEpoch, true)) {
-    VELOX_USER_THROW(
+    VELOX_USER_FAIL(
         "Unable to parse date value: \"{}\", expected format is (YYYY-MM-DD)",
         std::string(str, len));
   }
@@ -489,7 +489,7 @@ int64_t fromTimeString(const char* str, size_t len) {
   size_t pos;
 
   if (!tryParseTimeString(str, len, pos, microsSinceMidnight, true)) {
-    VELOX_USER_THROW(
+    VELOX_USER_FAIL(
         "Unable to parse time value: \"{}\", "
         "expected format is (HH:MM:SS[.MS])",
         std::string(str, len));
@@ -508,7 +508,7 @@ Timestamp fromDatetime(int32_t daysSinceEpoch, int64_t microsSinceMidnight) {
 }
 
 void parserError(const char* str, size_t len) {
-  VELOX_USER_THROW(
+  VELOX_USER_FAIL(
       "Unable to parse timestamp value: \"{}\", "
       "expected format is (YYYY-MM-DD HH:MM:SS[.MS])",
       std::string(str, len));

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -62,7 +62,7 @@ TypeKind mapNameToTypeKind(const std::string& name) {
   auto found = typeStringMap.find(name);
 
   if (found == typeStringMap.end()) {
-    VELOX_USER_THROW("Specified element is not found : {}", name);
+    VELOX_USER_FAIL("Specified element is not found : {}", name);
   }
 
   return found->second;
@@ -91,7 +91,7 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   auto found = typeEnumMap.find(typeKind);
 
   if (found == typeEnumMap.end()) {
-    VELOX_USER_THROW("Specified element is not found : {}", (int32_t)typeKind);
+    VELOX_USER_FAIL("Specified element is not found : {}", (int32_t)typeKind);
   }
 
   return found->second;
@@ -201,7 +201,7 @@ const std::shared_ptr<const Type>& MapType::childAt(uint32_t idx) const {
   } else if (idx == 1) {
     return valueType();
   }
-  VELOX_USER_THROW("Map type should have only two children");
+  VELOX_USER_FAIL("Map type should have only two children");
 }
 
 MapType::MapType(
@@ -249,7 +249,7 @@ const std::shared_ptr<const Type>& RowType::findChild(
       return children_.at(i);
     }
   }
-  VELOX_USER_THROW("Field not found: {}", name);
+  VELOX_USER_FAIL("Field not found: {}", name);
 }
 
 bool RowType::containsChild(std::string_view name) const {
@@ -262,7 +262,7 @@ uint32_t RowType::getChildIdx(const std::string& name) const {
       return i;
     }
   }
-  VELOX_USER_THROW("Field not found: {}", name);
+  VELOX_USER_FAIL("Field not found: {}", name);
 }
 
 bool RowType::operator==(const Type& other) const {
@@ -553,7 +553,7 @@ template <>
 std::shared_ptr<const Type> createType<TypeKind::ROW>(
     std::vector<std::shared_ptr<const Type>>&& /*children*/) {
   std::string name{TypeTraits<TypeKind::ROW>::name};
-  VELOX_USER_THROW("Not supported for kind: {}", name);
+  VELOX_USER_FAIL("Not supported for kind: {}", name);
 }
 
 template <>
@@ -574,7 +574,7 @@ template <>
 std::shared_ptr<const Type> createType<TypeKind::OPAQUE>(
     std::vector<std::shared_ptr<const Type>>&& /*children*/) {
   std::string name{TypeTraits<TypeKind::OPAQUE>::name};
-  VELOX_USER_THROW("Not supported for kind: {}", name);
+  VELOX_USER_FAIL("Not supported for kind: {}", name);
 }
 
 bool Type::containsUnknown() const {


### PR DESCRIPTION
Summary:
We used to have two macros used in the same situation, when
unconditionally throwing an exception based on something related to the user
request:
- VELOX_USER_FAIL()
- VELOX_USER_THROW()
This diff makes two changes:
1. VELOX_USER_FAIL() now throws "invalid argument" instead of "generic user
error", which better describes the error condition.
2. VELOX_USER_TROW() removed and callsites where moved to VELOX_USER_FAIL().
_THROW() already used to throw "invalid argument", so no semantic changes
there.

Differential Revision: D30971608

