### PR TITLE
evalWithMemo() shouldn't bypass null optimizations

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -717,7 +717,7 @@ void Expr::evalWithMemo(
       VarSetter isFinalSelectionMemo(
           context->mutableIsFinalSelection(), false, updateFinalSelection);
 
-      evalAll(*uncached, context, result);
+      evalWithNulls(*uncached, context, result);
       deselectErrors(context, *uncached);
       context->exprSet()->addToMemo(this);
       auto newCacheSize = uncached->end();
@@ -744,7 +744,7 @@ void Expr::evalWithMemo(
     return;
   }
   baseDictionary_ = base;
-  evalAll(rows, context, result);
+  evalWithNulls(rows, context, result);
   dictionaryCache_ = *result;
   if (!cachedDictionaryIndices_) {
     cachedDictionaryIndices_ =


### PR DESCRIPTION
Summary:
For subexpressions where memoization is enabled, the eval follows the
evalWithMemo() path, and that ends up calling evalAll() directly, bypassing the
null optimizations in evalWithNull().
.
Results are mostly the same, except for the case where the expression
deterministically throws, and the null optimization would make the eval skip
the processing of this expression altogether.

Differential Revision: D31008389

