### PR TITLE
Add EnforceSingleRow operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1042,4 +1042,30 @@ class UnnestNode : public PlanNode {
   RowTypePtr outputType_;
 };
 
+/// Checks that input contains at most one row. Return that row as is. If input
+/// is empty, returns a single row with all values set to null. If input
+/// contains more than one row raises an exception.
+class EnforceSingleRowNode : public PlanNode {
+ public:
+  EnforceSingleRowNode(
+      const PlanNodeId& id,
+      std::shared_ptr<const PlanNode> source)
+      : PlanNode(id), sources_{std::move(source)} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "enforce single row";
+  }
+
+ private:
+  const std::vector<std::shared_ptr<const PlanNode>> sources_;
+};
+
 } // namespace facebook::velox::core

--- a/velox/exec/AddOperatorChecklist.md
+++ b/velox/exec/AddOperatorChecklist.md
@@ -1,0 +1,9 @@
+# A list of steps to add a new operator
+
+- Add new plan node to core/PlanNode.h
+- Add new operator to exec/Xxx.h and exec/Xxx.cpp
+- Add translation from the new plan node to an instance of the new operator to exec/LocalPlanner.cpp
+- Add new method to PlanBuilder
+- Add new test to exec/XxxTest.cpp
+
+See Limit and EnforceSingleRow operators for examples of very simple operators.

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   AllocationPool.cpp
   ContainerRowSerde.cpp
   Driver.cpp
+  EnforceSingleRow.cpp
   Exchange.cpp
   FilterProject.cpp
   GroupingSet.cpp

--- a/velox/exec/EnforceSingleRow.cpp
+++ b/velox/exec/EnforceSingleRow.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/EnforceSingleRow.h"
+
+namespace facebook::velox::exec {
+
+EnforceSingleRow::EnforceSingleRow(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::EnforceSingleRowNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "EnforceSingleRow") {
+  isIdentityProjection_ = true;
+}
+
+void EnforceSingleRow::addInput(RowVectorPtr input) {
+  auto numInput = input->size();
+  VELOX_CHECK_NE(
+      numInput, 0, "EnforceSingleRow::addInput received empty set of rows")
+  if (input_ == nullptr) {
+    VELOX_USER_CHECK_EQ(
+        numInput,
+        1,
+        "Expected single row of input. Received {} rows.",
+        numInput);
+    input_ = std::move(input);
+  } else {
+    VELOX_USER_FAIL(
+        "Expected single row of input. Received {} extra rows.", numInput);
+  }
+}
+
+RowVectorPtr EnforceSingleRow::getOutput() {
+  if (!isFinishing()) {
+    return nullptr;
+  }
+
+  return std::move(input_);
+}
+
+void EnforceSingleRow::finish() {
+  if (!isFinishing_ && input_ == nullptr) {
+    // We have not seen any data. Return a single row of all nulls.
+    input_ = std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(outputType_, 1, pool()));
+    for (auto& child : input_->children()) {
+      child->resize(1);
+      child->setNull(0, true);
+    }
+  }
+  Operator::finish();
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/EnforceSingleRow.h
+++ b/velox/exec/EnforceSingleRow.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+class EnforceSingleRow : public Operator {
+ public:
+  EnforceSingleRow(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::EnforceSingleRowNode>& planNode);
+
+  bool isFilter() const override {
+    return true;
+  }
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  void finish() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/LocalPlanner.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/CallbackSink.h"
+#include "velox/exec/EnforceSingleRow.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/FilterProject.h"
 #include "velox/exec/HashAggregation.h"
@@ -297,6 +298,12 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         auto unnest =
             std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {
       operators.push_back(std::make_unique<Unnest>(id, ctx.get(), unnest));
+    } else if (
+        auto enforceSingleRow =
+            std::dynamic_pointer_cast<const core::EnforceSingleRowNode>(
+                planNode)) {
+      operators.push_back(
+          std::make_unique<EnforceSingleRow>(id, ctx.get(), enforceSingleRow));
     } else {
       auto extended = Operator::fromPlanNode(ctx.get(), id, planNode);
       VELOX_CHECK(extended, "Unsupported plan node: {}", planNode->toString());

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(
 add_executable(
   velox_exec_test
   DriverTest.cpp
+  EnforceSingleRowTest.cpp
   FilterProjectTest.cpp
   TableScanTest.cpp
   TaskTest.cpp

--- a/velox/exec/tests/EnforceSingleRowTest.cpp
+++ b/velox/exec/tests/EnforceSingleRowTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/OperatorTestBase.h"
+#include "velox/exec/tests/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+class EnforceSingleRowTest : public OperatorTestBase {
+ protected:
+  void assertQueryFails(
+      const std::shared_ptr<const core::PlanNode>& plan,
+      const std::string& errorMessage) {
+    CursorParameters params;
+    params.planNode = plan;
+    try {
+      readCursor(params, [](auto /*task*/) {});
+      FAIL() << "Expected query to fail, but it succeeded";
+    } catch (const VeloxException& e) {
+      ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos)
+          << "Expected query to fail with error message: " << errorMessage
+          << ". The query failed with a different error message: "
+          << e.message();
+    }
+  }
+};
+
+TEST_F(EnforceSingleRowTest, basic) {
+  auto singleRow =
+      makeRowVector({makeFlatVector<int32_t>(1, [](auto row) { return row; })});
+  auto multipleRows = makeRowVector(
+      {makeFlatVector<int32_t>(27, [](auto row) { return row; })});
+
+  createDuckDbTable({singleRow});
+
+  // Single row of input. The query should pass.
+  auto plan = PlanBuilder().values({singleRow}).enforceSingleRow().planNode();
+  assertQuery(plan, "SELECT * FROM tmp");
+
+  // Two rows of input in two separate single-row batches. The query should
+  // fail.
+  assertQueryFails(
+      PlanBuilder()
+          .values({singleRow, singleRow})
+          .enforceSingleRow()
+          .planNode(),
+      "Expected single row of input. Received 1 extra rows.");
+
+  // Multiple rows of input in a single batch. The query should fail.
+  assertQueryFails(
+      PlanBuilder().values({multipleRows}).enforceSingleRow().planNode(),
+      "Expected single row of input. Received 27 rows.");
+
+  // Empty input. The query should pass and return a single row of nulls.
+  plan = PlanBuilder()
+             .values({singleRow})
+             .filter("c0 = 12345")
+             .enforceSingleRow()
+             .planNode();
+  assertQuery(plan, "SELECT null");
+}

--- a/velox/exec/tests/PlanBuilder.cpp
+++ b/velox/exec/tests/PlanBuilder.cpp
@@ -316,6 +316,12 @@ PlanBuilder& PlanBuilder::limit(int32_t count, bool isPartial) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::enforceSingleRow() {
+  planNode_ =
+      std::make_shared<core::EnforceSingleRowNode>(nextPlanNodeId(), planNode_);
+  return *this;
+}
+
 namespace {
 RowTypePtr toRowType(
     RowTypePtr inputType,

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -142,6 +142,8 @@ class PlanBuilder {
 
   PlanBuilder& limit(int32_t count, bool isPartial);
 
+  PlanBuilder& enforceSingleRow();
+
   std::shared_ptr<const core::FieldAccessTypedExpr> field(int index);
 
   std::shared_ptr<const core::FieldAccessTypedExpr> field(


### PR DESCRIPTION
This operator enforces that input has no more than one row and returns that row
unmodified. If input is empty, this operator returns a single row with all
values set to null. If input has more than one row, this operator throws an
exception and aborts the query.

This operator is used in query plans that have non-correlated sub-queries, e.g.

	SELECT name
	FROM tpch.tiny.nation
	WHERE regionkey = (SELECT max(regionkey) FROM tpch.tiny.region)