### PR TITLE
Fix function signature comparison

### DIFF
--- a/velox/core/ScalarFunction.h
+++ b/velox/core/ScalarFunction.h
@@ -36,12 +36,19 @@ class ArgumentsCtx {
   }
 
   bool operator==(const ArgumentsCtx& rhs) const {
+    if (types_.size() != rhs.types_.size()) {
+      return false;
+    }
     return std::equal(
         std::begin(types_),
         std::end(types_),
         std::begin(rhs.types()),
         [](const std::shared_ptr<const Type>& l,
            const std::shared_ptr<const Type>& r) { return l->kindEquals(r); });
+  }
+
+  bool operator!=(const ArgumentsCtx& rhs) const {
+    return !(*this == rhs);
   }
 
  private:

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_core_test TestMap.cpp TestMetafunctions.cpp TestString.cpp)
+add_executable(velox_core_test TestMap.cpp TestMetafunctions.cpp TestString.cpp
+                               ScalarFunctionTest.cpp)
 add_test(velox_core_test velox_core_test)
 
 target_link_libraries(velox_core_test velox_core ${GTEST_BOTH_LIBRARIES})

--- a/velox/core/tests/ScalarFunctionTest.cpp
+++ b/velox/core/tests/ScalarFunctionTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/ScalarFunction.h"
+#include <gtest/gtest.h>
+#include "velox/type/Type.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+
+TEST(ScalarFunctionTest, compare) {
+  ArgumentsCtx one({VARCHAR()});
+  ArgumentsCtx two({VARCHAR(), VARCHAR()});
+  // Verifies that comparison between different length data does not read out of
+  // bounds.
+  EXPECT_EQ(two, two);
+  EXPECT_NE(two, one);
+  EXPECT_NE(one, two);
+}


### PR DESCRIPTION
Comparing a shorter to a longer signature reads out of bounds if
lengths are not checked.