### PR TITLE
[velox] Add fuzzer simple test to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,15 @@ jobs:
           paths:
             - .ccache/
       - run:
-          name: Run Unit Tests
+          name: "Run Unit Tests"
           command: |
             make unittest NUM_THREADS=16
           no_output_timeout: 1h
+      - run:
+          name: "Run Fuzzer Tests"
+          command: |
+            make fuzzertest
+          no_output_timeout: 5m
 
   format-check:
     executor: check

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ release:				#: Build the release version
 unittest: debug			#: Build with debugging and run unit tests
 	cd $(BUILD_BASE_DIR)/debug && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
 
+fuzzertest: debug		#: Build with debugging and run expression fuzzer test.
+	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_main --steps 100000 --logtostderr=1 --minloglevel=0
+
 format-fix: 			#: Fix formatting issues in the current branch
 	scripts/check.py format branch --fix
 


### PR DESCRIPTION
Enable expression fuzzer to run in circleCI after linux unit tests finish. The currently configuration will run for about 50seconds. 