### PR TITLE
Use std::copy instead of memcpy

### DIFF
--- a/velox/functions/UDFOutputString.h
+++ b/velox/functions/UDFOutputString.h
@@ -67,7 +67,7 @@ class UDFOutputString {
       typename = std::enable_if_t<std::is_base_of_v<UDFOutputString, T>>>
   static void assign(T& output, const std::string_view& input) {
     output.resize(input.size());
-    std::memcpy(output.data(), input.data(), input.size());
+    std::copy(input.begin(), input.end(), output.data());
   }
 
  protected:

--- a/velox/functions/prestosql/JsonExtractScalar.h
+++ b/velox/functions/prestosql/JsonExtractScalar.h
@@ -32,9 +32,7 @@ FOLLY_ALWAYS_INLINE bool call(
   const folly::StringPiece& jsonPathStringPiece = jsonPath;
   auto extractResult = jsonExtractScalar(jsonStringPiece, jsonPathStringPiece);
   if (extractResult.hasValue()) {
-    auto strValue = extractResult.value();
-    result.resize(strValue.size());
-    std::memcpy(result.data(), strValue.data(), strValue.size());
+    UDFOutputString::assign(result, *extractResult);
     return true;
 
   } else {

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -117,7 +117,7 @@ void DecodedVector::copyNulls(vector_size_t size) {
   auto numWords = bits::nwords(size);
   copiedNulls_.resize(numWords);
   if (nulls_) {
-    std::memcpy(copiedNulls_.data(), nulls_, numWords * 8);
+    std::copy(nulls_, nulls_ + numWords, copiedNulls_.data());
   } else {
     std::fill(copiedNulls_.begin(), copiedNulls_.end(), bits::kNotNull64);
   }


### PR DESCRIPTION
Summary:
I'm debugging a crash in DecodedVector where indices_ is unexpectedly null.  In
mode/dev, the program is killed before I get to the relevant crash if the src
parameter is null even if the size is zero. std::copy doesn't do this.

Performance of std::copy should be identical to memcpy.

Reviewed By: pedroerp

Differential Revision: D30978509

