### PR TITLE
Refactor json_extract_scalar() test and fix behavior

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -70,6 +70,9 @@ void compareExceptions(
                      << ve1.message() << "\nand\n\t" << ve2.message();
       }
       return;
+    } catch (const std::exception& e2) {
+      LOG(WARNING) << "Two different exceptions were thrown:\n\t"
+                   << ve1.message() << "\nand\n\t" << e2.what();
     }
   } catch (const std::exception& e1) {
     try {

--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -169,16 +169,9 @@ folly::Optional<folly::dynamic> jsonExtract(
     auto jsonObj = folly::parseJson(json);
     return jsonExtractInternal(&jsonObj, path);
   } catch (const folly::json::parse_error&) {
-  }
-  return folly::none;
-}
-
-folly::Optional<folly::dynamic> jsonExtract(
-    const folly::dynamic& json,
-    folly::StringPiece path) {
-  try {
-    return jsonExtractInternal(&json, path);
-  } catch (const folly::json::parse_error&) {
+  } catch (const folly::ConversionError&) {
+    // Folly might throw a conversion error while parsing the input json. In
+    // this case, let it return null.
   }
   return folly::none;
 }
@@ -186,9 +179,14 @@ folly::Optional<folly::dynamic> jsonExtract(
 folly::Optional<folly::dynamic> jsonExtract(
     const std::string& json,
     const std::string& path) {
+  return jsonExtract(folly::StringPiece(json), folly::StringPiece(path));
+}
+
+folly::Optional<folly::dynamic> jsonExtract(
+    const folly::dynamic& json,
+    folly::StringPiece path) {
   try {
-    auto jsonObj = folly::parseJson(json);
-    return jsonExtractInternal(&jsonObj, path);
+    return jsonExtractInternal(&json, path);
   } catch (const folly::json::parse_error&) {
   }
   return folly::none;


### PR DESCRIPTION
Summary:
Refactoring the test suite for json_extract_scalar() to make it consistent with other tests, more legible, and increase coverage.

Also fixing a behavior issue when a conversion error was slipping through the code, when it actually should return null.

Reviewed By: mbasmanova

Differential Revision: D31033096

