### PR TITLE
Free resources in HashAggregation::close

### DIFF
--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -43,7 +43,10 @@ class HashAggregation : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
-  void close() override {}
+  void close() override {
+    Operator::close();
+    groupingSet_.reset();
+  }
 
  private:
   static constexpr int32_t kOutputBatchSize = 10'000;


### PR DESCRIPTION
All operators must free up memory used by any vectors on close(). This is to avoid freeing up memory after the MemoryPool is gone.