### PR TITLE
Destroy operators in Driver::close

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -506,6 +506,7 @@ void Driver::close() {
   for (auto& op : operators_) {
     op->close();
   }
+  operators_.clear();
   Task::removeDriver(task_, this);
   task_ = nullptr;
 }


### PR DESCRIPTION
Operators are supposed to free up any memory held by vectors in Operator::close
(). In case they don't, Driver::close destroys the operators to ensure memory
held by vectors is freed up before the corresponding MemoryPool is destroyed.