### PR TITLE
Fix CacheInputTest and FusedLoad

### DIFF
--- a/velox/common/caching/FileIds.cpp
+++ b/velox/common/caching/FileIds.cpp
@@ -19,10 +19,13 @@
 #include <gflags/gflags.h>
 
 namespace facebook::velox {
-
 StringIdMap& fileIds() {
-  static std::unique_ptr<StringIdMap> ids = std::make_unique<StringIdMap>();
-  return *ids;
+  return *fileIdsShared();
+}
+
+const std::shared_ptr<StringIdMap>& fileIdsShared() {
+  static std::shared_ptr<StringIdMap> ids = std::make_shared<StringIdMap>();
+  return ids;
 }
 
 } // namespace facebook::velox

--- a/velox/common/caching/FileIds.h
+++ b/velox/common/caching/FileIds.h
@@ -21,4 +21,9 @@ namespace facebook::velox {
 // Returns a process-wide map of file path to id and id to file path.
 StringIdMap& fileIds();
 
+// Returns a shared_ptr to fileIds(). Needed to control destruction
+// order at end of process, so that caches that pin ids to names keep
+// the map alive.
+const std::shared_ptr<StringIdMap>& fileIdsShared();
+
 } // namespace facebook::velox

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -263,9 +263,15 @@ MappedMemory* MappedMemory::getInstance() {
   if (instance_) {
     return instance_.get();
   }
-  instance_ = std::make_unique<MappedMemoryImpl>();
+  instance_ = createDefaultInstance();
   return instance_.get();
 }
+
+// static
+std::unique_ptr<MappedMemory> MappedMemory::createDefaultInstance() {
+  return std::make_unique<MappedMemoryImpl>();
+}
+
 std::shared_ptr<MappedMemory> MappedMemory::addChild(
     std::shared_ptr<MemoryUsageTracker> tracker) {
   return std::make_shared<ScopedMappedMemory>(this, tracker);

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -159,6 +159,10 @@ class MappedMemory {
   virtual ~MappedMemory() {}
   static MappedMemory* getInstance();
 
+  // Creates a default MappedMemory instance but does not set this to process
+  // default.
+  static std::unique_ptr<MappedMemory> createDefaultInstance();
+
   /// Allocates one or more runs that add up to at least 'numPages',
   /// with the smallest run being at least 'minSizeClass'
   /// pages. 'minSizeClass' must be <= the size of the largest size

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -36,6 +36,26 @@ struct OperationCounters {
   uint64_t delayInjectedInSecs{0};
 };
 
+class IoCounter {
+ public:
+  uint64_t count() const {
+    return count_;
+  }
+
+  uint64_t bytes() const {
+    return bytes_;
+  }
+
+  void increment(uint64_t bytes) {
+    ++count_;
+    bytes_ += bytes;
+  }
+
+ private:
+  std::atomic<uint64_t> count_;
+  std::atomic<uint64_t> bytes_;
+};
+
 class IoStatistics {
  public:
   uint64_t rawBytesRead() const;
@@ -49,6 +69,22 @@ class IoStatistics {
   uint64_t incRawBytesWritten(int64_t);
   uint64_t incInputBatchSize(int64_t);
   uint64_t incOutputBatchSize(int64_t);
+
+  IoCounter& prefetch() {
+    return prefetch_;
+  }
+
+  IoCounter& read() {
+    return read_;
+  }
+
+  IoCounter& ssdRead() {
+    return ssdRead_;
+  }
+
+  IoCounter& ramHit() {
+    return ramHit_;
+  }
 
   void incOperationCounters(
       const std::string& operation,
@@ -67,6 +103,19 @@ class IoStatistics {
   std::atomic<uint64_t> inputBatchSize_{0};
   std::atomic<uint64_t> outputBatchSize_{0};
   std::atomic<uint64_t> rawOverreadBytes_{0};
+
+  // Planned read from storage or SSD.
+  IoCounter prefetch_;
+
+  // Read from storage, for sparsely accessed columns.
+  IoCounter read_;
+
+  // Hits from RAM cache. Does not include first use of prefetched data.
+  IoCounter ramHit_;
+
+  // Read from SSD cache instead of storage. Includes both random and planned
+  // reads.
+  IoCounter ssdRead_;
 
   std::unordered_map<std::string, OperationCounters> operationStats_;
   mutable std::mutex operationStatsMutex_;

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -25,6 +25,7 @@ using velox::memory::MappedMemory;
 
 CacheInputStream::CacheInputStream(
     cache::AsyncDataCache* cache,
+    dwio::common::IoStatistics* ioStats,
     const dwio::common::Region& region,
     dwio::common::InputStream& input,
     uint64_t fileNum,
@@ -32,6 +33,7 @@ CacheInputStream::CacheInputStream(
     TrackingId trackingId,
     uint64_t groupId)
     : cache_(cache),
+      ioStats_(ioStats),
       input_(input),
       region_(region),
       fileNum_(fileNum),
@@ -137,10 +139,17 @@ void CacheInputStream::loadSync(dwio::common::Region region) {
     if (pin_.entry()->isExclusive()) {
       auto ranges = makeRanges(pin_.entry(), region.length);
       input_.read(ranges, region.offset, dwio::common::LogType::FILE);
+      ioStats_->read().increment(region.length);
       pin_.entry()->setValid(true);
       pin_.entry()->setExclusiveToShared();
     } else {
-      pin_.entry()->ensureLoaded(true);
+      if (pin_.entry()->dataValid()) {
+        if (!pin_.entry()->getAndClearFirstUseFlag()) {
+          ioStats_->ramHit().increment(pin_.entry()->size());
+        }
+      } else {
+        pin_.entry()->ensureLoaded(true);
+      }
     }
   } while (pin_.empty());
 }
@@ -149,9 +158,12 @@ void CacheInputStream::loadPosition() {
   auto offset = region_.offset;
   if (pin_.empty()) {
     auto loadRegion = region_;
+    // Quantize position to previous multiple of 'loadQuantum_'.
     loadRegion.offset += (position_ / loadQuantum_) * loadQuantum_;
-    loadRegion.length =
-        std::min<int32_t>(loadQuantum_, region_.length - position_);
+    // Set length to be the lesser of 'loadQuantum_' and distance to end of
+    // 'region_'
+    loadRegion.length = std::min<int32_t>(
+        loadQuantum_, region_.length - (loadRegion.offset - region_.offset));
     loadSync(loadRegion);
   }
   auto* entry = pin_.entry();

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -42,6 +42,7 @@ class CacheInputStream : public SeekableInputStream {
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
   CacheInputStream(
       cache::AsyncDataCache* cache,
+      dwio::common::IoStatistics* ioStats,
       const dwio::common::Region& region,
       dwio::common::InputStream& input,
       uint64_t fileNum,
@@ -62,6 +63,7 @@ class CacheInputStream : public SeekableInputStream {
   void loadPosition();
   void loadSync(dwio::common::Region region);
   cache::AsyncDataCache* const cache_;
+  dwio::common::IoStatistics* ioStats_;
   dwio::common::InputStream& input_;
   // The region of 'input' 'this' ranges over.
   const dwio::common::Region region_;

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
       RawFileCacheKey{fileNum_, region.offset}, region.length, id, CachePin()});
   tracker_->recordReference(id, region.length, groupId_);
   return std::make_unique<CacheInputStream>(
-      cache_, region, input_, fileNum_, tracker_, id, groupId_);
+      cache_, ioStats_.get(), region, input_, fileNum_, tracker_, id, groupId_);
 }
 
 bool CachedBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)
@@ -78,7 +78,8 @@ void CachedBufferedInput::load(const dwio::common::LogType) {
   int32_t numNewLoads = 0;
   auto requests = std::move(requests_);
   for (auto& request : requests) {
-    if (tracker_->shouldPrefetch(request.trackingId, 3)) {
+    if (request.trackingId.empty() ||
+        tracker_->shouldPrefetch(request.trackingId, prefetchThreshold_)) {
       request.pin = cache_->findOrCreate(request.key, request.size, nullptr);
       if (request.pin.empty()) {
         // Already loading for another thread.
@@ -154,8 +155,11 @@ bool CachedBufferedInput::tryMerge(
 
     if (extension > 0) {
       first.length += extension;
-      if ((input_.getStats() != nullptr) && gap > 0) {
-        input_.getStats()->incRawOverreadBytes(gap);
+      if (gap > 0) {
+        ioStats_->incRawOverreadBytes(gap);
+        if (input_.getStats() != nullptr) {
+          input_.getStats()->incRawOverreadBytes(gap);
+        }
       }
     }
 
@@ -170,19 +174,25 @@ class DwrfFusedLoad : public cache::FusedLoad {
  public:
   void initialize(
       std::vector<CachePin>&& pins,
-      std::unique_ptr<AbstractInputStreamHolder> input) {
+      std::unique_ptr<AbstractInputStreamHolder> input,
+      std::shared_ptr<dwio::common::IoStatistics> ioStats) {
     input_ = std::move(input);
+    ioStats_ = std::move(ioStats);
+    // Initialize the base class last because as soon as the pins are
+    // placed and set to shared mode other threads can load 'this'.
     cache::FusedLoad::initialize(std::move(pins));
   }
 
-  void loadData() override {
+  void loadData(bool isPrefetch) override {
     auto& stream = input_->get();
     std::vector<folly::Range<char*>> buffers;
     uint64_t start = pins_[0].entry()->offset();
     uint64_t lastOffset = start;
+    uint64_t totalRead = 0;
     for (auto& pin : pins_) {
       auto& buffer = pin.entry()->data();
       uint64_t startOffset = pin.entry()->offset();
+      totalRead += pin.entry()->size();
       if (lastOffset < startOffset) {
         buffers.push_back(
             folly::Range<char*>(nullptr, startOffset - lastOffset));
@@ -205,18 +215,23 @@ class DwrfFusedLoad : public cache::FusedLoad {
       DWIO_ENSURE(offsetInRuns == size);
       lastOffset = startOffset + size;
     }
-
+    if (isPrefetch) {
+      ioStats_->prefetch().increment(totalRead);
+    } else {
+      ioStats_->read().increment(totalRead);
+    }
     stream.read(buffers, start, dwio::common::LogType::FILE);
   }
 
  private:
   std::unique_ptr<AbstractInputStreamHolder> input_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
 };
 } // namespace
 
 void CachedBufferedInput::readRegion(std::vector<CachePin> pins) {
   auto load = std::make_shared<DwrfFusedLoad>();
-  load->initialize(std::move(pins), streamSource_());
+  load->initialize(std::move(pins), streamSource_(), ioStats_);
   fusedLoads_.push_back(load);
 }
 
@@ -226,6 +241,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
     dwio::common::LogType /*logType*/) const {
   return std::make_unique<CacheInputStream>(
       cache_,
+      ioStats_.get(),
       dwio::common::Region{offset, length},
       input_,
       fileNum_,


### PR DESCRIPTION
- Add synchronization to threaded CacheTest.
- Fix initialization order of FusedLoad.
- Add IoStatistics members for tracking cache usage.
- Fix destruction order of caches and FileIds. FileIds must be live
  on destruction of caches that hold StringIdLeases.