### PR TITLE
Add like function.

### DIFF
--- a/velox/docs/functions/regexp.rst
+++ b/velox/docs/functions/regexp.rst
@@ -33,3 +33,20 @@ See https://github.com/google/re2/wiki/Syntax for more information.
     the entire string by anchoring the pattern using ``^`` and ``$``::
 
         SELECT regexp_like('1a 2b 14m', '\d+b'); -- true
+
+.. function:: like(string, pattern) -> varchar
+              like(string, pattern, escape) -> varchar
+
+   Evaluates a regular expression from ``pattern`` and returns if the
+   ``string`` matches it.
+
+   This function is used for the ``LIKE`` operator. Patterns can contain
+   regular characters as well as wildcards. Wildcard characters can be
+   escaped using the single character specified for the ESCAPE parameter.
+   Matching is case sensitive.
+
+   Note: The wildcard '%' represents 0, 1 or multiple characters and the
+   wildcard '_' represents exactly one character.
+
+   SELECT like('abc', '%b%'); -- 'abc'
+   SELECT like('a_c', '%#_%', '#'); -- 'a_c'

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -73,4 +73,10 @@ std::shared_ptr<exec::VectorFunction> makeRe2Extract(
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures();
 
+std::shared_ptr<exec::VectorFunction> makeLike(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> likeSignatures();
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -15,16 +15,11 @@
  */
 #include "velox/functions/prestosql/VectorFunctions.h"
 #include "velox/functions/lib/Re2Functions.h"
-#include "velox/functions/prestosql/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/WidthBucketArray.h"
 
 namespace facebook::velox::functions {
 
 void registerVectorFunctions() {
-  registerType("timestamp with time zone", [](auto /*childTypes*/) {
-    return TIMESTAMP_WITH_TIME_ZONE();
-  });
-
   VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, "element_at");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, "subscript");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, "transform");
@@ -54,8 +49,6 @@ void registerVectorFunctions() {
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_substr, "substr");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, "lower");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_trim, "trim");
-
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, "upper");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_strpos, "strpos");
@@ -64,14 +57,13 @@ void registerVectorFunctions() {
   exec::registerStatefulVectorFunction(
       "width_bucket", widthBucketArraySignature(), makeWidthBucketArray);
 
+  exec::registerStatefulVectorFunction("like", likeSignatures(), makeLike);
   exec::registerStatefulVectorFunction(
       "regexp_extract", re2ExtractSignatures(), makeRe2Extract);
   exec::registerStatefulVectorFunction(
       "regexp_like", re2SearchSignatures(), makeRe2Search);
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, "to_utf8");
-
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_from_unixtime, "from_unixtime");
 
   // TODO Fix Koski parser and clean this up.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "ROW");


### PR DESCRIPTION
This function will be used to implement the LIKE operator in presto_cpp.
The LIKE operator is used in TPC-H queries 14 and 16.

Note: This version is for early feedback. I'm working on changing the null handling and more detailed tests.