### PR TITLE
Refactor JoinBridge

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   HashProbe.cpp
   HashStringAllocator.cpp
   HashTable.cpp
+  JoinBridge.cpp
   Limit.cpp
   LocalPartition.cpp
   LocalPlanner.cpp

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -262,6 +262,17 @@ struct DriverFactory {
 
     return std::nullopt;
   }
+
+  std::vector<core::PlanNodeId> needsHashJoinBridges() const {
+    std::vector<core::PlanNodeId> planNodeIds;
+    for (const auto& planNode : planNodes) {
+      if (auto joinNode =
+              std::dynamic_pointer_cast<const core::HashJoinNode>(planNode)) {
+        planNodeIds.emplace_back(joinNode->id());
+      }
+    }
+    return planNodeIds;
+  }
 };
 
 // Begins and ends a section where a thread is running but not

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -177,7 +177,7 @@ BlockingReason HashProbe::isBlocked(ContinueFuture* future) {
   }
 
   auto hashBuildResult = operatorCtx_->task()
-                             ->findOrCreateJoinBridge(planNodeId())
+                             ->getHashJoinBridge(planNodeId())
                              ->tableOrFuture(future);
   if (!hashBuildResult.has_value()) {
     return BlockingReason::kWaitForJoinBuild;

--- a/velox/exec/JoinBridge.cpp
+++ b/velox/exec/JoinBridge.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/JoinBridge.h"
+
+namespace facebook::velox::exec {
+
+void JoinBridge::cancel() {
+  std::lock_guard<std::mutex> l(mutex_);
+  cancelled_ = true;
+  notifyConsumersLocked();
+}
+
+void JoinBridge::notifyConsumersLocked() {
+  for (auto& promise : promises_) {
+    promise.setValue(true);
+  }
+  promises_.clear();
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/JoinBridge.h
+++ b/velox/exec/JoinBridge.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/future/VeloxPromise.h"
+
+namespace facebook::velox::exec {
+
+class JoinBridge {
+ public:
+  virtual ~JoinBridge() = default;
+
+  // Sets this to a cancelled state and unblocks any waiting activity. This may
+  // happen asynchronously before or after the result has been set.
+  void cancel();
+
+ protected:
+  void notifyConsumersLocked();
+
+  std::mutex mutex_;
+  std::vector<VeloxPromise<bool>> promises_;
+  bool cancelled_{false};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -125,6 +125,8 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
       self->createLocalExchangeSources(exchangeId.value(), numDrivers);
     }
 
+    self->addHashJoinBridges(factory->needsHashJoinBridges());
+
     for (int32_t i = 0; i < numDrivers; ++i) {
       drivers.push_back(factory->createDriver(
           std::make_unique<DriverCtx>(self, i, pipeline, numDrivers),
@@ -444,14 +446,27 @@ bool Task::allPeersFinished(
   return false;
 }
 
-std::shared_ptr<JoinBridge> Task::findOrCreateJoinBridge(
+void Task::addHashJoinBridges(
+    const std::vector<core::PlanNodeId>& planNodeIds) {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (const auto& planNodeId : planNodeIds) {
+    bridges_.emplace(planNodeId, std::make_shared<HashJoinBridge>());
+  }
+}
+
+std::shared_ptr<HashJoinBridge> Task::getHashJoinBridge(
     const core::PlanNodeId& planNodeId) {
   std::lock_guard<std::mutex> l(mutex_);
-  auto& bridge = bridges_[planNodeId];
-  if (!bridge) {
-    bridge = std::make_shared<JoinBridge>();
-    bridges_[planNodeId] = bridge;
-  }
+  auto it = bridges_.find(planNodeId);
+  VELOX_CHECK(
+      it != bridges_.end(),
+      "Hash join bridge for plan node ID not found: {}",
+      planNodeId);
+  auto bridge = std::dynamic_pointer_cast<HashJoinBridge>(it->second);
+  VELOX_CHECK(
+      bridge,
+      "Join bridge for plan node ID is not a hash join bridge: {}",
+      planNodeId);
   return bridge;
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -63,6 +63,7 @@ struct TaskStats {
 };
 
 class JoinBridge;
+class HashJoinBridge;
 
 class Task {
  public:
@@ -257,12 +258,14 @@ class Task {
       std::vector<VeloxPromise<bool>>& promises,
       std::vector<std::shared_ptr<Driver>>& peers);
 
-  // Returns a JoinBridge for 'planNodeId'. This is used for synchronizing
+  // Adds HashJoinBridge's for all the specified plan node IDs.
+  void addHashJoinBridges(const std::vector<core::PlanNodeId>& planNodeIds);
+
+  // Returns a HashJoinBridge for 'planNodeId'. This is used for synchronizing
   // start of probe with completion of build for a join that has a
   // separate probe and build. 'id' is the PlanNodeId shared between
-  // the probe and build Operators of the join. The JoinBridge is
-  // created on first call with any given 'id'.
-  std::shared_ptr<JoinBridge> findOrCreateJoinBridge(
+  // the probe and build Operators of the join.
+  std::shared_ptr<HashJoinBridge> getHashJoinBridge(
       const core::PlanNodeId& planNodeId);
 
   // Sets the CancelPool of the QueryCtx to a terminate requested


### PR DESCRIPTION
Split JoinBridge into base class and HashJoinBridge derived class. Base class
JoinBridge will be used for a CrossJoinBridge which is similar to
HashJoinBridge but stores raw vectors instead of a hash table.