### PR TITLE
Fix the "brew --prefix openssl" returning a wrong path issue

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -121,7 +121,7 @@ function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
   OPENSSL_DIR=$(brew --prefix openssl)
 
-  if [[ ! -d "$DIRECTORY" ]]
+  if [[ ! -d "$OPENSSL_DIR" ]]
   then
     OPENSSL_DIR="/usr/local/opt/openssl"
   fi

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -119,7 +119,7 @@ function install_fmt {
 
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="$(brew --prefix openssl)"
+  cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="/usr/local/opt/openssl"
 }
 
 function install_ranges_v3 {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -119,7 +119,14 @@ function install_fmt {
 
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="/usr/local/opt/openssl"
+  OPENSSL_DIR=$(brew --prefix openssl)
+
+  if [[ ! -d "$DIRECTORY" ]]
+  then
+    OPENSSL_DIR="/usr/local/opt/openssl"
+  fi
+
+  cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="${OPENSSL_DIR}"
 }
 
 function install_ranges_v3 {


### PR DESCRIPTION
'brew --prefix openssl' would return something like "/usr/local/opt/openssl@3" which does not exist. The openssl is actually installed at /usr/local/opt/openssl.
Fix it by falling back to a hard-coded directory @ "/usr/local/opt/openssl" if brew does not return the correct dir