### PR TITLE
Fixed fromUnixTime() crash when it gets NaN or inf

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerMain.cpp
+++ b/velox/expression/tests/ExpressionFuzzerMain.cpp
@@ -35,7 +35,7 @@ std::vector<CallableSignature> getAllSignatures() {
   std::vector<CallableSignature> functions;
 
   // TODO: Skipping buggy functions for now.
-  std::unordered_set<std::string> skipFunctions = {"from_unixtime"};
+  std::unordered_set<std::string> skipFunctions = {};
   auto keys = exec::AdaptedVectorFunctions().Keys();
 
   for (const auto& key : keys) {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -31,8 +31,12 @@ VELOX_UDF_BEGIN(from_unixtime)
 FOLLY_ALWAYS_INLINE bool call(
     Timestamp& result,
     const arg_type<double>& unixtime) {
-  result = fromUnixtime(unixtime);
-  return true;
+  auto resultOptional = fromUnixtime(unixtime);
+  if (LIKELY(resultOptional.has_value())) {
+    result = resultOptional.value();
+    return true;
+  }
+  return false;
 }
 VELOX_UDF_END();
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -15,12 +15,13 @@
  */
 #pragma once
 
+#include <optional>
 #include "velox/type/Timestamp.h"
 
 namespace facebook::velox::functions {
 namespace {
 constexpr double kNanosecondsInSecond = 1'000'000'000;
-}
+} // namespace
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {
   double result = timestamp.getSeconds();
@@ -28,7 +29,11 @@ FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {
   return result;
 }
 
-FOLLY_ALWAYS_INLINE Timestamp fromUnixtime(double unixtime) {
+FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
+  if (UNLIKELY(std::isinf(unixtime) || std::isnan(unixtime))) {
+    return std::nullopt;
+  }
+
   auto seconds = std::floor(unixtime);
   auto nanos = unixtime - seconds;
   return Timestamp(seconds, nanos * kNanosecondsInSecond);


### PR DESCRIPTION
Reviewed By: pedroerp

Differential Revision: D31094955

