### PR TITLE
Add erase method to HashTable

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -65,7 +65,23 @@ HashTable<ignoreNullKeys>::HashTable(
 
 class ProbeState {
  public:
+  enum class Operation { kProbe, kInsert, kErase };
+  // Special tag for an erased entry. This counts as occupied for
+  // probe and as empty for insert. If a tag word with empties gets an
+  // erase, we make the erased tag empty. If the tag word getting the
+  // erase has no empties, the erase is marked with a tombstone. A
+  // probe always stops with a tag word with empties. Adding an empty
+  // to a tag word with no empties would break probes that needed to
+  // skip this tag word. This is standard practice for open addressing
+  // hash tables. F14 has more sophistication in this but we do not
+  // need it here since erase is very rare and is not expected to
+  // change the load factor by much in the expected uses.
+  static constexpr uint8_t kTombstoneTag = 0x7f;
   static constexpr int32_t kFullMask = 0xffff;
+  static constexpr BaseHashTable::TagVector kTombstoneGroup = {
+      0x7f7f7f7f7f7f7f7fUL,
+      0x7f7f7f7f7f7f7f7fUL};
+  static constexpr BaseHashTable::TagVector kEmptyGroup = {0, 0};
 
   static inline int32_t tagsByteOffset(uint64_t hash, uint64_t sizeMask) {
     return (hash & sizeMask) & ~(sizeof(BaseHashTable::TagVector) - 1);
@@ -85,19 +101,21 @@ class ProbeState {
     auto tag = BaseHashTable::hashTag(hash);
     wantedTags_ = _mm_set1_epi8(tag);
     group_ = nullptr;
+    indexInTags_ = kNotSet;
   }
 
   // Use one instruction to compare the tag being searched for to 16 tags
   // If there is a match, load corresponding data from the table
+  template <Operation op = Operation::kProbe>
   inline void firstProbe(char** table, int32_t firstKey) {
     auto tagMatches = _mm_cmpeq_epi8(tagsInTable_, wantedTags_);
     hits_ = _mm_movemask_epi8(tagMatches);
     if (hits_) {
-      loadNextHit(table, firstKey);
+      loadNextHit<op>(table, firstKey);
     }
   }
 
-  template <typename Compare, typename Insert>
+  template <Operation op, typename Compare, typename Insert>
   inline char* fullProbe(
       uint8_t* tags,
       char** table,
@@ -107,6 +125,9 @@ class ProbeState {
       Insert insert,
       bool extraCheck = false) {
     if (group_ && compare(group_, row_)) {
+      if (op == Operation::kErase) {
+        eraseHit(tags);
+      }
       return group_;
     }
 
@@ -117,18 +138,43 @@ class ProbeState {
       hits_ = _mm_movemask_epi8(tagMatches);
     }
 
+    int32_t insertTagIndex = -1;
     for (;;) {
       if (!hits_) {
-        auto occupied = _mm_movemask_epi8(tagsInTable_);
-        if (occupied != kFullMask) {
-          BaseHashTable::MaskType gaps = ~occupied & 0xffff;
-          auto pos = bits::getAndClearLastSetBit(gaps);
+        uint16_t empty =
+            _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kEmptyGroup)) &
+            kFullMask;
+        if (empty) {
+          if (op == Operation::kProbe) {
+            return nullptr;
+          }
+          if (op == Operation::kErase) {
+            VELOX_FAIL("Erasing non-existing entry");
+          }
+          if (indexInTags_ != kNotSet) {
+            // We came to the end of the probe without a hit. We replace the
+            // first tombstone on the way.
+            return insert(row_, insertTagIndex + indexInTags_);
+          }
+          auto pos = bits::getAndClearLastSetBit(empty);
           return insert(row_, tagIndex_ + pos);
+        } else if (op == Operation::kInsert && indexInTags_ == kNotSet) {
+          // We passed through a full group.
+          uint16_t tombstones =
+              _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kTombstoneGroup)) &
+              kFullMask;
+          if (tombstones) {
+            insertTagIndex = tagIndex_;
+            indexInTags_ = bits::getAndClearLastSetBit(tombstones);
+          }
         }
       } else {
-        loadNextHit(table, firstKey);
+        loadNextHit<op>(table, firstKey);
         if (!(extraCheck && group_ == alreadyChecked) &&
             compare(group_, row_)) {
+          if (op == Operation::kErase) {
+            eraseHit(tags);
+          }
           return group_;
         }
         continue;
@@ -141,10 +187,24 @@ class ProbeState {
   }
 
  private:
+  static constexpr uint8_t kNotSet = 0xff;
+
+  template <Operation op>
   inline void loadNextHit(char** table, int32_t firstKey) {
     int32_t hit = bits::getAndClearLastSetBit(hits_);
+
+    if (op == Operation::kErase) {
+      indexInTags_ = hit;
+    }
     group_ = BaseHashTable::loadRow(table, tagIndex_ + hit);
     __builtin_prefetch(group_ + firstKey);
+  }
+
+  void eraseHit(uint8_t* tags) {
+    auto empty = _mm_movemask_epi8(_mm_cmpeq_epi8(tagsInTable_, kEmptyGroup));
+
+    BaseHashTable::storeTag(
+        tags, tagIndex_ + indexInTags_, empty ? 0 : kTombstoneTag);
   }
 
   char* group_;
@@ -153,6 +213,16 @@ class ProbeState {
   int32_t row_;
   int32_t tagIndex_;
   BaseHashTable::MaskType hits_;
+
+  // If op is kErase, this is the index of the current hit within the
+  // group of 'tagIndex_'. If op is kInsert, this is the index of the
+  // first tombstone in the group of 'insertTagIndex_'. Insert
+  // replaces the first tombstone it finds. If it finds an empty
+  // before finding a tombstone, it replaces the empty as soon as it
+  // sees it. But the tombstone can be replaced only after finding an
+  // empty and thus determining that the item being inserted is not in
+  // the table.
+  uint8_t indexInTags_ = kNotSet;
 };
 
 template <bool ignoreNullKeys>
@@ -235,9 +305,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
     HashLookup& lookup,
     ProbeState& state,
     bool extraCheck) {
+  constexpr ProbeState::Operation op =
+      isJoin ? ProbeState::Operation::kProbe : ProbeState::Operation::kInsert;
   if (hashMode_ == HashMode::kNormalizedKey) {
-    // NOLINT
-    lookup.hits[state.row()] = state.fullProbe(
+    lookup.hits[state.row()] = state.fullProbe<op>(
         tags_,
         table_,
         sizeMask_,
@@ -252,8 +323,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
         !isJoin && extraCheck);
     return;
   }
-  // NOLINT
-  lookup.hits[state.row()] = state.fullProbe(
+  lookup.hits[state.row()] = state.fullProbe<op>(
       tags_,
       table_,
       sizeMask_,
@@ -316,10 +386,10 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
     state3.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
     row = rows[probeIndex + 3];
     state4.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
-    state2.firstProbe(table_, 0);
-    state3.firstProbe(table_, 0);
-    state4.firstProbe(table_, 0);
+    state1.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state2.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state3.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state4.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
     fullProbe<false>(lookup, state1, false);
     fullProbe<false>(lookup, state2, true);
     fullProbe<false>(lookup, state3, true);
@@ -613,11 +683,12 @@ bool HashTable<ignoreNullKeys>::arrayPushRow(char* row, int32_t index) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::pushNext(char* row, char* next) {
-  DCHECK(nextOffset_);
-  hasDuplicates_ = true;
-  auto previousNext = nextRow(row);
-  nextRow(row) = next;
-  nextRow(next) = previousNext;
+  if (nextOffset_) {
+    hasDuplicates_ = true;
+    auto previousNext = nextRow(row);
+    nextRow(row) = next;
+    nextRow(next) = previousNext;
+  }
 }
 
 template <bool ignoreNullKeys>
@@ -627,12 +698,12 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
     char* inserted,
     bool extraCheck) {
   if (hashMode_ == HashMode::kNormalizedKey) {
-    state.fullProbe(
+    state.fullProbe<ProbeState::Operation::kInsert>(
         tags_,
         table_,
         sizeMask_,
         -static_cast<int32_t>(sizeof(normalized_key_t)),
-        [&](char* group, int32_t /*row*/) {
+        [&](char* group, int32_t row) {
           if (RowContainer::normalizedKey(group) ==
               RowContainer::normalizedKey(inserted)) {
             if (nextOffset_) {
@@ -642,18 +713,18 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           }
           return false;
         },
-        [&](int32_t /*row*/, int32_t index) {
+        [&](int32_t row, int32_t index) {
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
         extraCheck);
   } else {
-    state.fullProbe(
+    state.fullProbe<ProbeState::Operation::kInsert>(
         tags_,
         table_,
         sizeMask_,
         0,
-        [&](char* group, int32_t /*row*/) {
+        [&](char* group, int32_t row) {
           if (compareKeys(group, inserted)) {
             if (nextOffset_) {
               pushNext(group, inserted);
@@ -662,7 +733,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           }
           return false;
         },
-        [&](int32_t /*row*/, int32_t index) {
+        [&](int32_t row, int32_t index) {
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
@@ -675,6 +746,15 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     char** groups,
     uint64_t* hashes,
     int32_t numGroups) {
+  if (hashMode_ == HashMode::kNormalizedKey) {
+    // Write the normalized key below each row. The key is only known
+    // at the time of insert, so cannot be filled in at the time of
+    // accumulating the build rows.
+    for (auto i = 0; i < numGroups; ++i) {
+      RowContainer::normalizedKey(groups[i]) = hashes[i];
+      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
+    }
+  }
   // The insertable rows are in the table, all get put in the hash
   // table or array.
   if (hashMode_ == HashMode::kArray) {
@@ -685,15 +765,7 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     }
     return;
   }
-  if (hashMode_ == HashMode::kNormalizedKey) {
-    // Write the normalized key below each row. The key is only known
-    // at the time of insert, so cannot be filled in at the time of
-    // accumulating the build rows.
-    for (auto i = 0; i < numGroups; ++i) {
-      RowContainer::normalizedKey(groups[i]) = hashes[i];
-      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
-    }
-  }
+
   ProbeState state1;
   for (auto i = 0; i < numGroups; ++i) {
     state1.preProbe(tags_, sizeMask_, hashes[i], i);
@@ -1067,6 +1139,69 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
     }
   }
   return numOut;
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::erase(folly::Range<char**> rows) {
+  auto numRows = rows.size();
+  std::vector<uint64_t> hashes;
+  hashes.resize(numRows);
+
+  for (int32_t i = 0; i < hashers_.size(); ++i) {
+    auto& hasher = hashers_[i];
+    if (hashMode_ == HashMode::kHash) {
+      rows_->hash(i, rows, i > 0, hashes.data());
+    } else {
+      if (!VALUE_ID_TYPE_DISPATCH(
+              valueIdRowsColumn,
+              hasher->typeKind(),
+              ignoreNullKeys,
+              hasher.get(),
+              rows.data(),
+              numRows,
+              rows_->columnAt(i),
+              hashes.data())) {
+        VELOX_FAIL("Value ids in erase must exist for all keys");
+      }
+    }
+  }
+  eraseWithHashes(rows, hashes.data());
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::eraseWithHashes(
+    folly::Range<char**> rows,
+    uint64_t* hashes) {
+  auto numRows = rows.size();
+  if (hashMode_ == HashMode::kArray) {
+    for (auto i = 0; i < numRows; ++i) {
+      DCHECK(hashes[i] < size_);
+      table_[hashes[i]] = nullptr;
+    }
+  } else {
+    if (hashMode_ == HashMode::kNormalizedKey) {
+      for (auto i = 0; i < numRows; ++i) {
+        hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
+      }
+    }
+
+    ProbeState state;
+    for (auto i = 0; i < numRows; ++i) {
+      state.preProbe(tags_, sizeMask_, hashes[i], i);
+
+      state.firstProbe<ProbeState::Operation::kErase>(table_, 0);
+      state.fullProbe<ProbeState::Operation::kErase>(
+          tags_,
+          table_,
+          sizeMask_,
+          0,
+          [&](char* group, int32_t row) { return rows[row] == group; },
+          [&](int32_t index, int32_t row) { return nullptr; },
+          false);
+    }
+  }
+  numDistinct_ -= numRows;
+  rows_->eraseRows(rows);
 }
 
 template class HashTable<true>;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -148,8 +148,16 @@ class BaseHashTable {
   /// distinct entries before needing to rehash.
   virtual void decideHashMode(int32_t numNew) = 0;
 
+  // Removes 'rows'  from the hash table and its RowContainer. 'rows' must exist
+  // and be unique.
+  virtual void erase(folly::Range<char**> rows) = 0;
+
   /// Returns a brief description for use in debugging.
   virtual std::string toString() = 0;
+
+  static void storeTag(uint8_t* tags, int32_t index, uint8_t tag) {
+    tags[index] = tag;
+  }
 
   const std::vector<std::unique_ptr<VectorHasher>>& hashers() const {
     return hashers_;
@@ -275,6 +283,8 @@ class HashTable : public BaseHashTable {
   void decideHashMode(int32_t numNew) override;
 
   // Moves the contents of 'tables' into 'this' and prepares 'this'
+
+  void erase(folly::Range<char**> rows) override;
   // for use in hash join probe. A hash join build side is prepared as
   // follows: 1. Each build side thread gets a random selection of the
   // build stream. Each accumulates rows into its own
@@ -370,6 +380,10 @@ class HashTable : public BaseHashTable {
   // content. Returns true if all hashers offer a mapping to value ids
   // for array or normalized key.
   bool analyze();
+  // Erases the entries of rows from the hash table and its RowContainer.
+  // 'hashes' must be computed according to 'hashMode_'.
+  void eraseWithHashes(folly::Range<char**> rows, uint64_t* hashes);
+
   const std::vector<std::unique_ptr<Aggregate>>& aggregates_;
   int8_t sizeBits_;
   bool isJoinBuild_ = false;

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -54,15 +54,17 @@ RowContainer::RowContainer(
       stringAllocator_(mappedMemory),
       serde_(serde) {
   // Compute the layout of the payload row.  The row has keys, null
-  // flags, accumulators, dependent fields. All fields are fixed width. If
-  // variable width data is referenced, this is done with StringView that
-  // inlines or points to the data.  The number of bytes used by each
-  // key is determined by keyTypes[i].  Null flags are one
-  // bit per field. If nullableKeys is true there is a null flag
-  // for each key. A null bit for each accumulator and dependent field follows.
-  // If hasProbedFlag is true, there is an extra bit to track if the row has
-  // been selected  by a hash join probe.  The accumulators come next, with size
-  // given by Aggregate::accumulatorFixedWidthSize(). Dependent fields follow.
+  // flags, accumulators, dependent fields. All fields are fixed
+  // width. If variable width data is referenced, this is done with
+  // StringView that inlines or points to the data.  The number of
+  // bytes used by each key is determined by keyTypes[i].  Null flags
+  // are one bit per field. If nullableKeys is true there is a null
+  // flag for each key. A null bit for each accumulator and dependent
+  // field follows.  If hasProbedFlag is true, there is an extra bit
+  // to track if the row has been selected by a hash join probe. This
+  // is followed by a free bit which is set if the row is in a free
+  // list. The accumulators come next, with size given by
+  // Aggregate::accumulatorFixedWidthSize(). Dependent fields follow.
   // These are non-key columns for hash join or order by.
   //
   // In most cases, rows are prefixed with a normalized_key_t at index
@@ -84,7 +86,9 @@ RowContainer::RowContainer(
       ++nullOffset;
     }
   }
-
+  // Make offset at least sizeof pointer so that there is space for a
+  // free list next pointer below the bit at 'freeFlagOffset_'.
+  offset = std::max<int32_t>(offset, sizeof(void*));
   int32_t firstAggregate = offsets_.size();
   int32_t firstAggregateOffset = offset;
   for (auto& aggregate : aggregates) {
@@ -103,9 +107,13 @@ RowContainer::RowContainer(
   }
   if (hasProbedFlag) {
     nullOffsets_.push_back(nullOffset);
-    probedFlagOffset_ = nullOffset;
+    probedFlagOffset_ = nullOffset + firstAggregateOffset * 8;
     ++nullOffset;
   }
+  // Free flag.
+  nullOffsets_.push_back(nullOffset);
+  freeFlagOffset_ = nullOffset + firstAggregateOffset * 8;
+  ++nullOffset;
   // Fixup nullOffsets_ to be the bit number from the start of the row.
   for (int32_t i = 0; i < nullOffsets_.size(); ++i) {
     nullOffsets_[i] += firstAggregateOffset * 8;
@@ -135,6 +143,9 @@ RowContainer::RowContainer(
   if (!nullOffsets_.empty()) {
     // Aggregates start life as null, join dependent columns as non-null.
     initialNulls_.resize(nullBytes, isJoinBuild_ ? 0x0 : 0xff);
+    // The free flag has an initial value of 0.
+    bits::clearBit(
+        initialNulls_.data(), freeFlagOffset_ - nullOffsets_.front());
     if (nullableKeys) {
       for (int32_t i = 0; i < keyTypes_.size(); ++i) {
         bits::clearBit(initialNulls_.data(), i);
@@ -151,11 +162,20 @@ RowContainer::RowContainer(
 }
 
 char* RowContainer::newRow() {
-  char* row = rows_.allocateFixed(fixedRowSize_ + normalizedKeySize_) +
-      normalizedKeySize_;
+  char* row;
   ++numRows_;
-  if (normalizedKeySize_) {
-    ++numRowsWithNormalizedKey_;
+
+  if (firstFreeRow_) {
+    row = firstFreeRow_;
+    VELOX_CHECK(bits::isBitSet(row, freeFlagOffset_));
+    firstFreeRow_ = nextFree(row);
+    --numFreeRows_;
+  } else {
+    row = rows_.allocateFixed(fixedRowSize_ + normalizedKeySize_) +
+        normalizedKeySize_;
+    if (normalizedKeySize_) {
+      ++numRowsWithNormalizedKey_;
+    }
   }
   return initializeRow(row, false /* reuse */);
 }
@@ -174,6 +194,19 @@ char* RowContainer::initializeRow(char* row, bool reuse) {
         initialNulls_.size());
   }
   return row;
+}
+
+void RowContainer::eraseRows(folly::Range<char**> rows) {
+  freeVariableWidthFields(rows);
+  freeAggregates(rows);
+  numRows_ -= rows.size();
+  for (auto* row : rows) {
+    VELOX_CHECK(!bits::isBitSet(row, freeFlagOffset_), "Double free of row");
+    bits::setBit(row, freeFlagOffset_);
+    nextFree(row) = firstFreeRow_;
+    firstFreeRow_ = row;
+  }
+  numFreeRows_ += rows.size();
 }
 
 void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
@@ -200,6 +233,33 @@ void RowContainer::freeVariableWidthFields(folly::Range<char**> rows) {
   }
 }
 
+void RowContainer::checkConsistency() {
+  constexpr int32_t kBatch = 1000;
+  std::vector<char*> rows(kBatch);
+  uint64_t count = 0;
+  RowContainerIterator iter;
+  int64_t allocatedRows = 0;
+  for (;;) {
+    int64_t numRows = listRows(&iter, kBatch, rows.data());
+    if (!numRows) {
+      break;
+    }
+    for (auto i = 0; i < numRows; ++i) {
+      auto row = rows[i];
+      VELOX_CHECK(!bits::isBitSet(row, freeFlagOffset_));
+      ++allocatedRows;
+    }
+  }
+
+  size_t numFree = 0;
+  for (auto free = firstFreeRow_; free; free = nextFree(free)) {
+    ++numFree;
+    VELOX_CHECK(bits::isBitSet(free, freeFlagOffset_));
+  }
+  VELOX_CHECK_EQ(numFree, numFreeRows_);
+  VELOX_CHECK_EQ(allocatedRows, numRows_);
+}
+
 void RowContainer::freeAggregates(folly::Range<char**> rows) {
   for (auto& aggregate : aggregates_) {
     aggregate->destroy(rows);
@@ -211,6 +271,7 @@ int32_t RowContainer::listRows(
     int32_t maxRows,
     char** rows) {
   int32_t count = 0;
+
   auto numAllocations = rows_.numAllocations();
   if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
       iter->rowOffset == 0) {
@@ -237,6 +298,10 @@ int32_t RowContainer::listRows(
         row += rowSize;
         if (--iter->normalizedKeysLeft == 0) {
           rowSize -= sizeof(normalized_key_t);
+        }
+        if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+          --count;
+          continue;
         }
         if (count == maxRows) {
           iter->rowOffset = row;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -127,6 +127,10 @@ class RowContainer {
   // Allocates a new row and initializes possible aggregates to null.
   char* newRow();
 
+  // Adds 'rows' to the free rows list and frees any associated
+  // variable length data.
+  void eraseRows(folly::Range<char**> rows);
+
   // Initialize row. 'reuse' specifies whether the 'row' is reused or
   // not. If it is reused, it will free memory associated with the row
   // elsewhere (such as in HashStringAllocator).
@@ -286,7 +290,14 @@ class RowContainer {
     }
   }
 
+  // Checks that row and free row counts match and that free list
+  // membership is consistent with free flag.
+  void checkConsistency();
+
  private:
+  // Offset of the pointer to the next free row on a free row.
+  static constexpr int32_t kNextFreeOffset = 0;
+
   static inline bool
   isNullAt(const char* row, int32_t nullByte, uint8_t nullMask) {
     return (row[nullByte] & nullMask) != 0;
@@ -323,6 +334,10 @@ class RowContainer {
       extractValuesWithNulls<T>(
           rows, numRows, offset, column.nullByte(), nullMask, flatResult);
     }
+  }
+
+  char*& nextFree(char* row) {
+    return *reinterpret_cast<char**>(row + kNextFreeOffset);
   }
 
   template <TypeKind Kind>
@@ -594,6 +609,8 @@ class RowContainer {
   std::vector<RowColumn> rowColumns_;
   // Bit position of probed flag, 0 if none.
   int32_t probedFlagOffset_ = 0;
+  // Bit position of free bit.
+  int32_t freeFlagOffset_{0};
   int32_t fixedRowSize_;
   // True if normalized keys are enabled in initial state.
   const bool hasNormalizedKeys_;
@@ -607,6 +624,10 @@ class RowContainer {
   // not null, aggregates are null.
   std::vector<uint8_t> initialNulls_;
   int64_t numRows_ = 0;
+  // Head of linked list of free rows.
+  char* firstFreeRow_ = nullptr;
+  uint64_t numFreeRows_ = 0;
+
   AllocationPool rows_;
   HashStringAllocator stringAllocator_;
   const RowSerde& serde_;


### PR DESCRIPTION
Adds erase to HashTable for use in spilling selected groups from a
group by hash table.

A deleted entry is marked by a tombstone in the tags. This counts as
occupied for probing and as empty for inserting. If a group of tags
has at least one empty, then an erase is represented by setting the
tag to empty. If all tags are non-empty, the erase is represented by
setting the tag to a tombstone. This is done so that an erased entry
will not interrupt the probing when a tag is not found in a group of
tags. Note that probing stops when there is no hit and there is at
least one free in a group of tags.

- Adds eraseRows method to RowContainer.

- Fixes offset of probedFlag bit in RowContainer.