### PR TITLE
Keep driver memory pools alive for the duration of the task

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -262,13 +262,11 @@ class QueryCtx : public Context {
 // Represents the state of one thread of query execution.
 class ExecCtx : public Context {
  public:
-  ExecCtx(std::unique_ptr<velox::memory::MemoryPool> pool, QueryCtx* queryCtx)
-      : Context{ContextScope::QUERY},
-        pool_(std::move(pool)),
-        queryCtx_(queryCtx) {}
+  ExecCtx(memory::MemoryPool* pool, QueryCtx* queryCtx)
+      : Context{ContextScope::QUERY}, pool_(pool), queryCtx_(queryCtx) {}
 
-  velox::memory::MemoryPool* pool() {
-    return pool_.get();
+  velox::memory::MemoryPool* pool() const {
+    return pool_;
   }
 
   QueryCtx* queryCtx() const {
@@ -310,7 +308,7 @@ class ExecCtx : public Context {
 
  private:
   // Pool for all Buffers for this thread
-  std::unique_ptr<velox::memory::MemoryPool> pool_;
+  memory::MemoryPool* pool_;
   QueryCtx* queryCtx_;
   // A pool of preallocated DecodedVectors for use by expressions and operators.
   std::vector<std::unique_ptr<DecodedVector>> decodedVectorPool_;

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -21,13 +21,6 @@ using namespace facebook::velox::duckdb;
 
 class BaseDuckWrapperTest : public testing::Test {
  public:
-  void SetUp() override {
-    queryCtx_ = core::QueryCtx::create();
-    execCtx_ = std::make_unique<core::ExecCtx>(
-        memory::getDefaultScopedMemoryPool(), queryCtx_.get());
-    db_ = std::make_unique<DuckDBWrapper>(execCtx_.get());
-  }
-
   template <class T>
   void verifyUnaryResult(
       const std::string& query,
@@ -71,9 +64,13 @@ class BaseDuckWrapperTest : public testing::Test {
         << "Query failed: " << result->errorMessage();
   }
 
-  std::unique_ptr<DuckDBWrapper> db_;
-  std::shared_ptr<core::QueryCtx> queryCtx_;
-  std::unique_ptr<core::ExecCtx> execCtx_;
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  std::unique_ptr<DuckDBWrapper> db_{
+      std::make_unique<DuckDBWrapper>(execCtx_.get())};
 };
 
 TEST_F(BaseDuckWrapperTest, simpleSelect) {

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -67,19 +67,13 @@ DriverCtx::DriverCtx(
     int32_t _numDrivers)
     : task(_task),
       execCtx(std::make_unique<core::ExecCtx>(
-          task->pool()->addScopedChild("driver_root"),
+          task->addDriverPool(),
           task->queryCtx().get())),
       expressionEvaluator(
           std::make_unique<SimpleExpressionEvaluator>(execCtx.get())),
       driverId(_driverId),
       pipelineId(_pipelineId),
-      numDrivers(_numDrivers) {
-  auto parentTracker = task->pool()->getMemoryUsageTracker();
-  if (parentTracker) {
-    execCtx->pool()->setMemoryUsageTracker(
-        std::move(parentTracker->addChild()));
-  }
-}
+      numDrivers(_numDrivers) {}
 
 std::unique_ptr<connector::ConnectorQueryCtx>
 DriverCtx::createConnectorQueryCtx(const std::string& connectorId) const {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -82,20 +82,9 @@ struct DriverCtx {
       int _pipelineId,
       int32_t numDrivers);
 
-  velox::memory::MemoryPool* FOLLY_NONNULL addOperatorUserPool() {
+  velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool() {
     opMemPools_.push_back(execCtx->pool()->addScopedChild("operator_ctx"));
     return opMemPools_.back().get();
-  }
-
-  velox::memory::MemoryPool* FOLLY_NONNULL
-  addOperatorSystemPool(velox::memory::MemoryPool* FOLLY_NONNULL userPool) {
-    auto poolPtr = userPool->addScopedChild("operator_ctx");
-    poolPtr->setMemoryUsageTracker(
-        userPool->getMemoryUsageTracker()->addChild(true));
-    auto pool = poolPtr.get();
-    opMemPools_.push_back(std::move(poolPtr));
-
-    return pool;
   }
 
   std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -154,17 +154,10 @@ struct OperatorStats {
 class OperatorCtx {
  public:
   explicit OperatorCtx(DriverCtx* driverCtx)
-      : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorUserPool()) {}
+      : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorPool()) {}
 
   velox::memory::MemoryPool* pool() const {
     return pool_;
-  }
-
-  velox::memory::MemoryPool* systemPool() const {
-    if (!systemMemPool_) {
-      systemMemPool_ = driverCtx_->addOperatorSystemPool(pool_);
-    }
-    return systemMemPool_;
   }
 
   memory::MappedMemory* mappedMemory() const;
@@ -196,9 +189,7 @@ class OperatorCtx {
   velox::memory::MemoryPool* pool_;
 
   // These members are created on demand.
-  mutable velox::memory::MemoryPool* systemMemPool_{nullptr};
   mutable std::shared_ptr<memory::MappedMemory> mappedMemory_;
-  mutable std::shared_ptr<memory::MappedMemory> recoverableMappedMemory_;
 };
 
 // Query operator

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -95,10 +95,8 @@ RowVectorPtr TableWriter::getOutput() {
   }
   finished_ = true;
 
-  auto pool = driverCtx_->execCtx->pool();
-
   auto rowsWritten = std::dynamic_pointer_cast<FlatVector<int64_t>>(
-      BaseVector::create(BIGINT(), 1, pool));
+      BaseVector::create(BIGINT(), 1, pool()));
   rowsWritten->set(0, numWrittenRows_);
 
   std::vector<VectorPtr> columns = {rowsWritten};
@@ -106,7 +104,7 @@ RowVectorPtr TableWriter::getOutput() {
   // TODO Find a way to not have this Presto-specific logic in here.
   if (outputType_->size() > 1) {
     auto fragments = std::dynamic_pointer_cast<FlatVector<StringView>>(
-        BaseVector::create(VARBINARY(), 1, pool));
+        BaseVector::create(VARBINARY(), 1, pool()));
     fragments->setNull(0, true);
     columns.emplace_back(fragments);
 
@@ -120,11 +118,11 @@ RowVectorPtr TableWriter::getOutput() {
     // clang-format on
 
     auto commitContext = std::make_shared<ConstantVector<StringView>>(
-        pool, 1, false, VARBINARY(), StringView(commitContextJson));
+        pool(), 1, false, VARBINARY(), StringView(commitContextJson));
     columns.emplace_back(commitContext);
   }
 
   return std::make_shared<RowVector>(
-      pool, outputType_, BufferPtr(nullptr), 1, columns);
+      pool(), outputType_, BufferPtr(nullptr), 1, columns);
 }
 } // namespace facebook::velox::exec

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -124,12 +124,13 @@ class CodegenBenchmark : public CodegenTestCore {
   CodegenBenchmark() {
     CodegenTestCore::init();
     queryCtx = std::make_shared<core::QueryCtx>();
-    execCtx = std::make_unique<core::ExecCtx>(
-        memory::getDefaultScopedMemoryPool(), queryCtx_.get());
+    pool = memory::getDefaultScopedMemoryPool();
+    execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
 
   std::vector<BenchmarkInfo> templateBenchmarkInfo;
   std::shared_ptr<core::QueryCtx> queryCtx;
+  std::unique_ptr<memory::MemoryPool> pool;
   std::unique_ptr<core::ExecCtx> execCtx;
   std::vector<BenchmarkInfo> benchmarkInfos;
   bool reusePlanNode = true;

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -492,9 +492,6 @@ class ExpressionCodegenTestBase : public testing::Test {
   UDFManager udfManager;
 
   virtual void SetUp() override {
-    queryCtx_ = std::make_shared<core::QueryCtx>();
-    execCtx_ = std::make_unique<facebook::velox::core::ExecCtx>(
-        memory::getDefaultScopedMemoryPool(), queryCtx_.get());
     codeManager_ =
         std::make_unique<CodeManager>(getCompilerOptions(), eventSequence_);
     generator_ = std::make_unique<ExprCodeGenerator>(
@@ -582,8 +579,13 @@ class ExpressionCodegenTestBase : public testing::Test {
         core::ConcatTypedExpr({"c0"}, {typedExpr}));
   }
 
-  std::unique_ptr<core::ExecCtx> execCtx_;
-  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<facebook::velox::core::ExecCtx>(
+          pool_.get(),
+          queryCtx_.get())};
   std::unique_ptr<CodeManager> codeManager_;
   std::unique_ptr<ExprCodeGenerator> generator_;
   DefaultScopedTimer::EventSequence eventSequence_;

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -105,8 +105,7 @@ class CodegenTestCore {
             eventSequence_);
     pool_ = memory::getDefaultScopedMemoryPool();
     queryCtx_ = std::make_shared<core::QueryCtx>();
-    execCtx_ = std::make_unique<core::ExecCtx>(
-        memory::getDefaultScopedMemoryPool(), queryCtx_.get());
+    execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
     exec::test::registerTypeResolver();
     functions::registerFunctions();

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -103,11 +103,9 @@ TEST(TestConcat, EvalConcatFunction) {
   in2->addNulls(nullptr, rows);
 
   std::vector<VectorPtr> in{in1, in2};
-  auto queryCtx_ = std::make_shared<core::QueryCtx>();
-  auto execCtx_ = std::make_unique<core::ExecCtx>(
-      memory::getDefaultScopedMemoryPool(), queryCtx_.get());
-  exec::EvalCtx context(execCtx_.get(), nullptr, inRowVector->as<RowVector>());
-
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+  exec::EvalCtx context(execCtx.get(), nullptr, inRowVector->as<RowVector>());
   GeneratedVectorFunction<GeneratedVectorFunctionConfigDouble> vectorFunction;
 
   vectorFunction.setRowType(outRowType);
@@ -197,9 +195,8 @@ TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   auto pool_ = memory::getDefaultScopedMemoryPool();
   auto pool = pool_.get();
   const size_t vectorSize = 1000;
-  auto queryCtx_ = std::make_shared<core::QueryCtx>();
-  auto execCtx_ = std::make_unique<core::ExecCtx>(
-      memory::getDefaultScopedMemoryPool(), queryCtx_.get());
+  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto execCtx = std::make_unique<core::ExecCtx>(pool, queryCtx.get());
 
   auto inRowType =
       ROW({"a", "b"},
@@ -237,7 +234,7 @@ TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   vectorFunction.setRowType(outRowType);
 
   // Eval
-  exec::EvalCtx context(execCtx_.get(), nullptr, inRowVector->as<RowVector>());
+  exec::EvalCtx context(execCtx.get(), nullptr, inRowVector->as<RowVector>());
   std::vector<VectorPtr> inputs{inputVector1, inputVector2};
   vectorFunction.apply(rows, inputs, nullptr, &context, &outRowVector);
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -114,10 +114,7 @@ class TestingVectorLoader : public VectorLoader {
 class ExprTest : public testing::Test {
  protected:
   void SetUp() override {
-    queryCtx_ = core::QueryCtx::create();
-    execCtx_ = std::make_unique<core::ExecCtx>(
-        memory::getDefaultScopedMemoryPool(), queryCtx_.get());
-    vectorMaker_ = std::make_unique<test::VectorMaker>(execCtx_->pool());
+    vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
 
     functions::registerFunctions();
     functions::registerVectorFunctions();
@@ -706,10 +703,11 @@ class ExprTest : public testing::Test {
     return indicesBuffer;
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_;
-  // execCtx is declared first and destroyed last because it owns the MemoryPool
-  // from which the rest is allocated.
-  std::unique_ptr<core::ExecCtx> execCtx_;
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   TestData testData_;
   std::shared_ptr<const RowType> testDataType_;
   std::unique_ptr<exec::ExprSet> exprs_;

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -339,7 +339,9 @@ class ExpressionFuzzer {
       signaturesMap_;
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
-  core::ExecCtx execCtx_{memory::getDefaultScopedMemoryPool(), queryCtx_.get()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 
   test::VectorMaker vectorMaker_{execCtx_.pool()};
   VectorFuzzer vectorFuzzer_;

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -56,7 +56,9 @@ class FunctionBenchmarkBase {
 
  protected:
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
-  core::ExecCtx execCtx_{memory::getDefaultScopedMemoryPool(), queryCtx_.get()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
 } // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -466,13 +466,15 @@ class FunctionBaseTest : public testing::Test {
         name, signature, rowType, parse::parseExpr(body), execCtx_.pool());
   }
 
-  memory::MemoryPool* pool() {
-    return execCtx_.pool();
+  memory::MemoryPool* pool() const {
+    return pool_.get();
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
-  core::ExecCtx execCtx_{memory::getDefaultScopedMemoryPool(), queryCtx_.get()};
-  velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  velox::test::VectorMaker vectorMaker_{pool_.get()};
 };
 
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
This would allows for sharing vectors across drivers without copy.