### PR TITLE
Use AsyncDataCache and read-ahead with Hive

### DIFF
--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -252,10 +252,15 @@ bool MappedMemoryImpl::checkConsistency() {
   throw std::runtime_error("Not implemented");
 }
 
+MappedMemory* MappedMemory::customInstance_;
 std::unique_ptr<MappedMemory> MappedMemory::instance_;
 std::mutex MappedMemory::initMutex_;
 
+// static
 MappedMemory* MappedMemory::getInstance() {
+  if (customInstance_) {
+    return customInstance_;
+  }
   if (instance_) {
     return instance_.get();
   }
@@ -270,6 +275,11 @@ MappedMemory* MappedMemory::getInstance() {
 // static
 std::unique_ptr<MappedMemory> MappedMemory::createDefaultInstance() {
   return std::make_unique<MappedMemoryImpl>();
+}
+
+// static
+void MappedMemory::setDefaultInstance(MappedMemory* instance) {
+  customInstance_ = instance;
 }
 
 std::shared_ptr<MappedMemory> MappedMemory::addChild(

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -157,11 +157,20 @@ class MappedMemory {
   };
 
   virtual ~MappedMemory() {}
+
+  // Returns the process-wide default instance or an application-supplied custom
+  // instance set via setDefaultInstance().
   static MappedMemory* getInstance();
 
   // Creates a default MappedMemory instance but does not set this to process
   // default.
   static std::unique_ptr<MappedMemory> createDefaultInstance();
+
+  // Overrides the process-wide default instance. The caller keeps
+  // ownership and must not destroy the instance until it is
+  // empty. Calling this with nullptr restores the initial
+  // process-wide default instance.
+  static void setDefaultInstance(MappedMemory* instance);
 
   /// Allocates one or more runs that add up to at least 'numPages',
   /// with the smallest run being at least 'minSizeClass'
@@ -201,6 +210,9 @@ class MappedMemory {
  private:
   // Singleton instance.
   static std::unique_ptr<MappedMemory> instance_;
+  // Application-supplied custom implementation of MappedMemory to be returned
+  // by getInstance().
+  static MappedMemory* customInstance_;
   static std::mutex initMutex_;
 };
 

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -73,4 +73,32 @@ std::shared_ptr<Connector> getConnector(const std::string& connectorId) {
   return it->second;
 }
 
+folly::Synchronized<
+    std::unordered_map<std::string_view, std::weak_ptr<cache::ScanTracker>>>
+    Connector::trackers_;
+
+// static
+void Connector::unregisterTracker(cache::ScanTracker* tracker) {
+  trackers_.withWLock([&](auto& trackers) { trackers.erase(tracker->id()); });
+}
+
+std::shared_ptr<cache::ScanTracker> Connector::getTracker(
+    const std::string& scanId) {
+  return trackers_.withWLock([&](auto& trackers) -> auto {
+    auto it = trackers.find(scanId);
+    if (it == trackers.end()) {
+      auto newTracker =
+          std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      trackers[newTracker->id()] = newTracker;
+      return newTracker;
+    }
+    std::shared_ptr<cache::ScanTracker> tracker = it->second.lock();
+    if (!tracker) {
+      tracker = std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      trackers[tracker->id()] = tracker;
+    }
+    return tracker;
+  });
+}
+
 } // namespace facebook::velox::connector

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -33,6 +33,7 @@
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/file/File.h"
 #include "velox/core/Context.h"
+#include "velox/dwio/common/InputStream.h"
 
 namespace facebook::velox {
 
@@ -44,6 +45,11 @@ struct FileHandle {
   // the identifier in downstream data caching structures. This saves a lot of
   // memory compared to using the filename as the identifier.
   StringIdLease uuid;
+
+  // Id for the group of files this belongs to, e.g. its
+  // directory. Used for coarse granularity access tracking, for
+  // example to decide placing on SSD.
+  StringIdLease groupId;
 
   // We'll want to have a hash map here to record the identifier->byte range
   // mappings. Different formats may have different identifiers, so we may need

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,6 +16,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include <velox/dwio/dwrf/reader/SelectiveColumnReader.h>
 #include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/expression/ControlExpr.h"
 
 using namespace facebook::velox::dwrf;
@@ -27,7 +28,6 @@ DEFINE_int32(
     "Amount of space for the file handle cache in mb.");
 
 namespace facebook::velox::connector::hive {
-
 namespace {
 static const char* kPath = "$path";
 static const char* kBucket = "$bucket";
@@ -118,13 +118,19 @@ HiveDataSource::HiveDataSource(
     FileHandleFactory* fileHandleFactory,
     velox::memory::MemoryPool* pool,
     DataCache* dataCache,
-    ExpressionEvaluator* expressionEvaluator)
+    ExpressionEvaluator* expressionEvaluator,
+    memory::MappedMemory* mappedMemory,
+    const std::string& scanId,
+    folly::Executor* executor)
     : outputType_(outputType),
       fileHandleFactory_(fileHandleFactory),
       pool_(pool),
       readerOpts_(pool),
       dataCache_(dataCache),
-      expressionEvaluator_(expressionEvaluator) {
+      expressionEvaluator_(expressionEvaluator),
+      mappedMemory_(mappedMemory),
+      scanId_(scanId),
+      executor_(executor) {
   regularColumns_.reserve(outputType->size());
 
   std::vector<std::string> columnNames;
@@ -193,11 +199,10 @@ HiveDataSource::HiveDataSource(
       std::make_unique<dwrf::SelectiveColumnReaderFactory>(scanSpec_.get());
   rowReaderOpts_.setColumnReaderFactory(columnReaderFactory_.get());
 
-  ioStats_ = std::make_unique<dwio::common::IoStatistics>();
+  ioStats_ = std::make_shared<dwio::common::IoStatistics>();
 }
 
 namespace {
-
 bool testFilters(
     common::ScanSpec* scanSpec,
     dwrf::DwrfReader* reader,
@@ -234,6 +239,38 @@ bool testFilters(
 
   return true;
 }
+
+class InputStreamHolder : public dwrf::AbstractInputStreamHolder {
+ public:
+  InputStreamHolder(
+      FileHandleCachedPtr fileHandle,
+      std::shared_ptr<dwio::common::IoStatistics> stats)
+      : fileHandle_(std::move(fileHandle)), stats_(std::move(stats)) {
+    input_ = std::make_unique<dwio::common::ReadFileInputStream>(
+        fileHandle_->file.get(),
+        dwio::common::MetricsLog::voidLog(),
+        stats.get());
+  }
+
+  dwio::common::InputStream& get() override {
+    return *input_;
+  }
+
+ private:
+  FileHandleCachedPtr fileHandle_;
+  // Keeps the pointer alive also in case of cancellation while reads
+  // proceeding on different threads.
+  std::shared_ptr<dwio::common::IoStatistics> stats_;
+  std::unique_ptr<dwio::common::InputStream> input_;
+};
+
+std::unique_ptr<InputStreamHolder> makeStreamHolder(
+    FileHandleFactory* factory,
+    const std::string& path,
+    std::shared_ptr<dwio::common::IoStatistics> stats) {
+  return std::make_unique<InputStreamHolder>(factory->generate(path), stats);
+}
+
 } // namespace
 
 void HiveDataSource::addDynamicFilter(
@@ -263,14 +300,36 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   VLOG(1) << "Adding split " << split_->toString();
 
   fileHandle_ = fileHandleFactory_->generate(split_->filePath);
-
-  if (dataCache_) {
+  // Decide between AsyncDataCache, legacy DataCache and no cache. All
+  // three are supported to enable comparison.
+  if (auto asyncCache = dynamic_cast<cache::AsyncDataCache*>(mappedMemory_)) {
+    VELOX_CHECK(
+        !dataCache_,
+        "DataCache should not be present if the MappedMemory is AsyncDataCache");
+    // Make DataCacheConfig to pass the filenum and a null DataCache.
+    if (!readerOpts_.getDataCacheConfig()) {
+      auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();
+      readerOpts_.setDataCacheConfig(std::move(dataCacheConfig));
+    }
+    readerOpts_.getDataCacheConfig()->filenum = fileHandle_->uuid.id();
+    bufferedInputFactory_ = std::make_unique<dwrf::CachedBufferedInputFactory>(
+        (asyncCache),
+        Connector::getTracker(scanId_),
+        fileHandle_->groupId.id(),
+        [factory = fileHandleFactory_,
+         path = split_->filePath,
+         stats = ioStats_]() { return makeStreamHolder(factory, path, stats); },
+        ioStats_,
+        executor_);
+    readerOpts_.setBufferedInputFactory(bufferedInputFactory_.get());
+  } else if (dataCache_) {
     auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();
     dataCacheConfig->cache = dataCache_;
     dataCacheConfig->filenum = fileHandle_->uuid.id();
     readerOpts_.setDataCacheConfig(std::move(dataCacheConfig));
   }
-
+  // We run with the default BufferedInputFactory and no DataCacheConfig if
+  // there is no DataCache and the MappedMemory is not an AsyncDataCache.
   reader_ = dwrf::DwrfReader::create(
       std::make_unique<dwio::common::ReadFileInputStream>(
           fileHandle_->file.get(),
@@ -445,17 +504,33 @@ void HiveDataSource::setNullConstantValue(
   spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
 }
 
+std::unordered_map<std::string, int64_t> HiveDataSource::runtimeStats() {
+  return {
+      {"skippedSplits", skippedSplits_},
+      {"skippedSplitBytes", skippedSplitBytes_},
+      {"skippedStrides", skippedStrides_},
+      {"numPrefetch", ioStats_->prefetch().count()},
+      {"prefetchBytes", ioStats_->prefetch().bytes()},
+      {"numStorageRead", ioStats_->read().count()},
+      {"storageReadBytes", ioStats_->read().bytes()},
+      {"numLocalRead", ioStats_->ssdRead().count()},
+      {"localReadBytes", ioStats_->ssdRead().bytes()},
+      {"numRamRead", ioStats_->ramHit().count()},
+      {"ramReadBytes", ioStats_->ramHit().bytes()}};
+}
+
 HiveConnector::HiveConnector(
     const std::string& id,
     std::shared_ptr<const Config> properties,
-    std::unique_ptr<DataCache> dataCache)
+    std::unique_ptr<DataCache> dataCache,
+    folly::Executor* FOLLY_NULLABLE executor)
     : Connector(id, properties),
       dataCache_(std::move(dataCache)),
       fileHandleFactory_(
           std::make_unique<SimpleLRUCache<std::string, FileHandle>>(
               FLAGS_file_handle_cache_mb << 20),
-          std::make_unique<FileHandleGenerator>(properties)) {}
+          std::make_unique<FileHandleGenerator>()),
+      executor_(executor) {}
 
 VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<HiveConnectorFactory>())
-
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -18,6 +18,7 @@
 #include "velox/common/caching/DataCache.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/reader/ScanSpec.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
@@ -102,7 +103,7 @@ class HiveDataSink : public DataSink {
   explicit HiveDataSink(
       std::shared_ptr<const RowType> inputType,
       const std::string& filePath,
-      velox::memory::MemoryPool* memoryPool);
+      velox::memory::MemoryPool* FOLLY_NONNULL memoryPool);
 
   void appendData(VectorPtr input) override;
 
@@ -113,6 +114,8 @@ class HiveDataSink : public DataSink {
   std::unique_ptr<facebook::velox::dwrf::Writer> writer_;
 };
 
+class HiveConnector;
+
 class HiveDataSource : public DataSource {
  public:
   HiveDataSource(
@@ -121,10 +124,13 @@ class HiveDataSource : public DataSource {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      FileHandleFactory* fileHandleFactory,
-      velox::memory::MemoryPool* pool,
-      DataCache* dataCache,
-      ExpressionEvaluator* expressionEvaluator);
+      FileHandleFactory* FOLLY_NONNULL fileHandleFactory,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool,
+      DataCache* FOLLY_NULLABLE dataCache,
+      ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
+      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      const std::string& scanId,
+      folly::Executor* FOLLY_NULLABLE executor);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
@@ -142,12 +148,7 @@ class HiveDataSource : public DataSource {
     return ioStats_->rawBytesRead();
   }
 
-  std::unordered_map<std::string, int64_t> runtimeStats() override {
-    return {
-        {"skippedSplits", skippedSplits_},
-        {"skippedSplitBytes", skippedSplitBytes_},
-        {"skippedStrides", skippedStrides_}};
-  }
+  std::unordered_map<std::string, int64_t> runtimeStats() override;
 
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
@@ -156,21 +157,25 @@ class HiveDataSource : public DataSource {
   // filterEvalCtx_.selectedIndices and selectedBits are not updated.
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 
-  void setConstantValue(common::ScanSpec* spec, const velox::variant& value)
-      const;
+  void setConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const velox::variant& value) const;
 
-  void setNullConstantValue(common::ScanSpec* spec, const TypePtr& type) const;
+  void setNullConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const TypePtr& type) const;
 
   const std::shared_ptr<const RowType> outputType_;
-  FileHandleFactory* fileHandleFactory_;
-  velox::memory::MemoryPool* pool_;
+  FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
+  velox::memory::MemoryPool* FOLLY_NONNULL pool_;
   std::vector<std::string> regularColumns_;
+  std::shared_ptr<dwio::common::IoStatistics> ioStats_;
+  std::unique_ptr<dwrf::BufferedInputFactory> bufferedInputFactory_;
   std::unique_ptr<dwrf::ColumnReaderFactory> columnReaderFactory_;
   std::unique_ptr<common::ScanSpec> scanSpec_;
   std::shared_ptr<HiveConnectorSplit> split_;
   dwio::common::ReaderOptions readerOpts_;
   dwio::common::RowReaderOptions rowReaderOpts_;
-  std::unique_ptr<dwio::common::IoStatistics> ioStats_;
   std::unique_ptr<dwrf::DwrfReader> reader_;
   std::unique_ptr<dwrf::DwrfRowReader> rowReader_;
   std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
@@ -188,14 +193,18 @@ class HiveDataSource : public DataSource {
 
   VectorPtr output_;
   FileHandleCachedPtr fileHandle_;
-  DataCache* dataCache_;
-  ExpressionEvaluator* expressionEvaluator_;
+  DataCache* FOLLY_NULLABLE dataCache_;
+  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator_;
   uint64_t completedRows_ = 0;
 
   // Reusable memory for remaining filter evaluation
   VectorPtr filterResult_;
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
+
+  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  const std::string& scanId_;
+  folly::Executor* FOLLY_NULLABLE executor_;
 };
 
 class HiveConnector final : public Connector {
@@ -203,7 +212,8 @@ class HiveConnector final : public Connector {
   explicit HiveConnector(
       const std::string& id,
       std::shared_ptr<const Config> properties,
-      std::unique_ptr<DataCache> dataCache);
+      std::unique_ptr<DataCache> dataCache,
+      folly::Executor* FOLLY_NULLABLE executor);
 
   std::shared_ptr<DataSource> createDataSource(
       const std::shared_ptr<const RowType>& outputType,
@@ -211,7 +221,7 @@ class HiveConnector final : public Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     return std::make_shared<HiveDataSource>(
         outputType,
         tableHandle,
@@ -223,13 +233,16 @@ class HiveConnector final : public Connector {
                 kNodeSelectionStrategySoftAffinity
             ? dataCache_.get()
             : nullptr,
-        connectorQueryCtx->expressionEvaluator());
+        connectorQueryCtx->expressionEvaluator(),
+        connectorQueryCtx->mappedMemory(),
+        connectorQueryCtx->scanId(),
+        executor_);
   }
 
   std::shared_ptr<DataSink> createDataSink(
       std::shared_ptr<const RowType> inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
         connectorInsertTableHandle);
     VELOX_CHECK(
@@ -241,16 +254,21 @@ class HiveConnector final : public Connector {
         connectorQueryCtx->memoryPool());
   }
 
+  folly::Executor* FOLLY_NULLABLE executor() {
+    return executor_;
+  }
+
  private:
   std::unique_ptr<DataCache> dataCache_;
   FileHandleFactory fileHandleFactory_;
+  folly::Executor* FOLLY_NULLABLE executor_;
 
-  static constexpr const char* kNodeSelectionStrategy =
+  static constexpr const char* FOLLY_NONNULL kNodeSelectionStrategy =
       "node_selection_strategy";
-  static constexpr const char* kNodeSelectionStrategyNoPreference =
-      "NO_PREFERENCE";
-  static constexpr const char* kNodeSelectionStrategySoftAffinity =
-      "SOFT_AFFINITY";
+  static constexpr const char* FOLLY_NONNULL
+      kNodeSelectionStrategyNoPreference = "NO_PREFERENCE";
+  static constexpr const char* FOLLY_NONNULL
+      kNodeSelectionStrategySoftAffinity = "SOFT_AFFINITY";
 };
 
 class HiveConnectorFactory : public ConnectorFactory {
@@ -262,9 +280,10 @@ class HiveConnectorFactory : public ConnectorFactory {
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
       std::shared_ptr<const Config> properties,
-      std::unique_ptr<DataCache> dataCache = nullptr) override {
+      std::unique_ptr<DataCache> dataCache = nullptr,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) override {
     return std::make_shared<HiveConnector>(
-        id, properties, std::move(dataCache));
+        id, properties, std::move(dataCache), executor);
   }
 };
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -282,9 +282,8 @@ enum class PrefetchMode {
  * PReads into the same |cache|.
  */
 struct DataCacheConfig {
-  velox::DataCache* cache;
-  // We identify the file the data belongs to by a 64 bit integer. One
-  // practical option is to use an external filename->incrementing integer map.
+  velox::DataCache* cache{nullptr};
+  // We identify the file the data belongs to by an id from StringIdMap.
   uint64_t filenum;
 };
 

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -80,6 +80,14 @@ class BufferedInput {
     return false;
   }
 
+  // True if caller should enqueue and load regions for stripe
+  // metadata after reading a file footer. The stripe footers are
+  // likely to be hit and should be read ahead of demand if
+  // BufferedInput has background load.
+  virtual bool shouldPrefetchStripes() const {
+    return false;
+  }
+
  protected:
   dwio::common::InputStream& input_;
 

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -29,6 +29,11 @@ using memory::MappedMemory;
 std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
     dwio::common::Region region,
     const StreamIdentifier* si = nullptr) {
+  if (region.length == 0) {
+    return std::make_unique<SeekableArrayInputStream>(
+        static_cast<const char*>(nullptr), 0);
+  }
+
   TrackingId id;
   if (si) {
     id = TrackingId(si->node, si->kind);

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -88,6 +88,10 @@ class CachedBufferedInput : public BufferedInput {
 
   bool shouldPreload() override;
 
+  bool shouldPrefetchStripes() const override {
+    return true;
+  }
+
  private:
   struct CacheRequest {
     cache::RawFileCacheKey key;

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -80,11 +80,15 @@ velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
 }
 
 std::unique_ptr<connector::ConnectorQueryCtx>
-DriverCtx::createConnectorQueryCtx(const std::string& connectorId) const {
+DriverCtx::createConnectorQueryCtx(
+    const std::string& connectorId,
+    const std::string& planNodeId) const {
   return std::make_unique<connector::ConnectorQueryCtx>(
       execCtx->pool(),
       task->queryCtx()->getConnectorConfig(connectorId),
-      expressionEvaluator.get());
+      expressionEvaluator.get(),
+      task->queryCtx()->mappedMemory(),
+      fmt::format("{}.{}", task->taskId(), planNodeId));
 }
 
 BlockingState::BlockingState(

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -84,8 +84,12 @@ struct DriverCtx {
 
   velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool();
 
+  // Makes an extract of QueryCtx for use in a connector. 'planNodeId'
+  // is the id of the calling TableScan. This and the task id identify
+  // the scan for column access tracking.
   std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
-      const std::string& connectorId) const;
+      const std::string& connectorId,
+      const std::string& planNodeId) const;
 };
 
 class Driver {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -68,8 +68,8 @@ RowVectorPtr TableScan::getOutput() {
 
       if (!connector_) {
         connector_ = connector::getConnector(connectorSplit->connectorId);
-        connectorQueryCtx_ =
-            driverCtx_->createConnectorQueryCtx(connectorSplit->connectorId);
+        connectorQueryCtx_ = driverCtx_->createConnectorQueryCtx(
+            connectorSplit->connectorId, planNodeId_);
         dataSource_ = connector_->createDataSource(
             outputType_,
             tableHandle_,

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -29,7 +29,7 @@ TableWriter::TableWriter(
           tableWriteNode->outputType(),
           operatorId,
           tableWriteNode->id(),
-          "TableWriter"),
+          stats_.planNodeId),
       numWrittenRows_(0),
       finished_(false),
       closed_(false),
@@ -41,7 +41,8 @@ TableWriter::TableWriter(
   // partition
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
   connector_ = connector::getConnector(connectorId);
-  connectorQueryCtx_ = driverCtx_->createConnectorQueryCtx(connectorId);
+  connectorQueryCtx_ =
+      driverCtx_->createConnectorQueryCtx(connectorId, "TableWriter");
 
   auto names = tableWriteNode->columnNames();
   auto types = tableWriteNode->columns()->children();

--- a/velox/exec/tests/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/HiveConnectorTestBase.cpp
@@ -20,7 +20,6 @@
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/QueryAssertions.h"
-
 namespace facebook::velox::exec::test {
 
 HiveConnectorTestBase::HiveConnectorTestBase() {
@@ -29,15 +28,25 @@ HiveConnectorTestBase::HiveConnectorTestBase() {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
-  auto dummyDataCache = std::make_unique<DummyDataCache>();
-  dataCache = dummyDataCache.get();
-  auto hiveConnector =
-      connector::getConnectorFactory(connector::hive::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, nullptr, std::move(dummyDataCache));
-  connector::registerConnector(hiveConnector);
+  if (useAsyncCache_) {
+    executor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+    auto hiveConnector =
+        connector::getConnectorFactory(connector::hive::kHiveConnectorName)
+            ->newConnector(kHiveConnectorId, nullptr, nullptr, executor_.get());
+    connector::registerConnector(hiveConnector);
+  } else {
+    auto dataCache = std::make_unique<SimpleLRUDataCache>(1UL << 30);
+    auto hiveConnector =
+        connector::getConnectorFactory(connector::hive::kHiveConnectorName)
+            ->newConnector(kHiveConnectorId, nullptr, std::move(dataCache));
+    connector::registerConnector(hiveConnector);
+  }
 }
 
 void HiveConnectorTestBase::TearDown() {
+  if (executor_) {
+    executor_->join();
+  }
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }
@@ -52,9 +61,10 @@ void HiveConnectorTestBase::writeToFile(
 void HiveConnectorTestBase::writeToFile(
     const std::string& filePath,
     const std::string& name,
-    const std::vector<RowVectorPtr>& vectors) {
+    const std::vector<RowVectorPtr>& vectors,
+    std::shared_ptr<dwrf::Config> config) {
   facebook::velox::dwrf::WriterOptions options;
-  options.config = std::make_shared<facebook::velox::dwrf::Config>();
+  options.config = config;
   options.schema = vectors[0]->type();
   auto sink = std::make_unique<facebook::dwio::common::FileSink>(filePath);
   facebook::velox::dwrf::Writer writer{

--- a/velox/exec/tests/OperatorTestBase.h
+++ b/velox/exec/tests/OperatorTestBase.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/tests/QueryAssertions.h"
@@ -28,6 +29,8 @@ class OperatorTestBase : public testing::Test {
  protected:
   OperatorTestBase();
   ~OperatorTestBase() override;
+
+  void SetUp() override;
 
   static void SetUpTestCase();
 
@@ -216,5 +219,12 @@ class OperatorTestBase : public testing::Test {
       memory::getDefaultScopedMemoryPool()};
   DuckDbQueryRunner duckDbQueryRunner_;
   velox::test::VectorMaker vectorMaker_{pool_.get()};
+
+  // Parametrized subclasses set this to choose the cache code path.
+  bool useAsyncCache_{true};
+
+  // Used as default MappedMemory if 'useAsyncCache_' is true. Created on first
+  // use.
+  static std::unique_ptr<cache::AsyncDataCache> asyncDataCache_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/test_utils/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/dwrf/test/utils/DataFiles.h"
@@ -40,9 +41,11 @@ static const std::string kNodeSelectionStrategy = "node_selection_strategy";
 static const std::string kSoftAffinity = "SOFT_AFFINITY";
 static const std::string kTableScanTest = "TableScanTest.Writer";
 
-class TableScanTest : public HiveConnectorTestBase {
+class TableScanTest : public virtual HiveConnectorTestBase,
+                      public testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
+    useAsyncCache_ = GetParam();
     HiveConnectorTestBase::SetUp();
     rowType_ =
         ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
@@ -53,6 +56,10 @@ class TableScanTest : public HiveConnectorTestBase {
              DOUBLE(),
              VARCHAR(),
              TINYINT()});
+  }
+
+  static void SetUpTestCase() {
+    HiveConnectorTestBase::SetUpTestCase();
   }
 
   std::vector<RowVectorPtr> makeVectors(
@@ -156,7 +163,7 @@ class TableScanTest : public HiveConnectorTestBase {
           {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
 };
 
-TEST_F(TableScanTest, allColumns) {
+TEST_P(TableScanTest, allColumns) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -165,7 +172,7 @@ TEST_F(TableScanTest, allColumns) {
   assertQuery(tableScanNode(), {filePath}, "SELECT * FROM tmp");
 }
 
-TEST_F(TableScanTest, columnAliases) {
+TEST_P(TableScanTest, columnAliases) {
   auto vectors = makeVectors(1, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -199,7 +206,7 @@ TEST_F(TableScanTest, columnAliases) {
   assertQuery(op, {filePath}, "SELECT c0 FROM tmp WHERE c0 % 2 = 1");
 }
 
-TEST_F(TableScanTest, columnPruning) {
+TEST_P(TableScanTest, columnPruning) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -226,7 +233,7 @@ TEST_F(TableScanTest, columnPruning) {
 
 // Test reading files written before schema change, e.g. missing newly added
 // columns.
-TEST_F(TableScanTest, missingColumns) {
+TEST_P(TableScanTest, missingColumns) {
   // Simulate schema change of adding a new column.
   // - Create an "old" file with one column.
   // - Create a "new" file with two columns.
@@ -277,7 +284,7 @@ TEST_F(TableScanTest, missingColumns) {
 }
 
 // Tests queries that use Lazy vectors with multiple layers of wrapping.
-TEST_F(TableScanTest, constDictLazy) {
+TEST_P(TableScanTest, constDictLazy) {
   vector_size_t size = 1'000;
   auto rowVector = makeRowVector(
       {makeFlatVector<int64_t>(size, [](auto row) { return row; }),
@@ -329,7 +336,7 @@ TEST_F(TableScanTest, constDictLazy) {
   assertQuery(op, {filePath}, "SELECT 2 FROM tmp WHERE c0 = 5");
 }
 
-TEST_F(TableScanTest, count) {
+TEST_P(TableScanTest, count) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -354,7 +361,7 @@ TEST_F(TableScanTest, count) {
 
 // Test that adding the same split with the same sequence id does not cause
 // double read and the 2nd split is ignored.
-TEST_F(TableScanTest, sequentialSplitNoDoubleRead) {
+TEST_P(TableScanTest, sequentialSplitNoDoubleRead) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -384,7 +391,7 @@ TEST_F(TableScanTest, sequentialSplitNoDoubleRead) {
 
 // Test that adding the splits out of order does not result in splits being
 // ignored.
-TEST_F(TableScanTest, outOfOrderSplits) {
+TEST_P(TableScanTest, outOfOrderSplits) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -414,7 +421,7 @@ TEST_F(TableScanTest, outOfOrderSplits) {
 
 // Test that adding the same split, disregarding the sequence id, causes
 // double read, as expected.
-TEST_F(TableScanTest, splitDoubleRead) {
+TEST_P(TableScanTest, splitDoubleRead) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -441,7 +448,7 @@ TEST_F(TableScanTest, splitDoubleRead) {
   }
 }
 
-TEST_F(TableScanTest, multipleSplits) {
+TEST_P(TableScanTest, multipleSplits) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(10, 1'000);
   for (int32_t i = 0; i < vectors.size(); i++) {
@@ -452,7 +459,7 @@ TEST_F(TableScanTest, multipleSplits) {
   assertQuery(tableScanNode(), filePaths, "SELECT * FROM tmp");
 }
 
-TEST_F(TableScanTest, waitForSplit) {
+TEST_P(TableScanTest, waitForSplit) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(10, 1'000);
   for (int32_t i = 0; i < vectors.size(); i++) {
@@ -475,7 +482,7 @@ TEST_F(TableScanTest, waitForSplit) {
       duckDbQueryRunner_);
 }
 
-TEST_F(TableScanTest, splitOffsetAndLength) {
+TEST_P(TableScanTest, splitOffsetAndLength) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -492,7 +499,7 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       "SELECT * FROM tmp LIMIT 0");
 }
 
-TEST_F(TableScanTest, fileNotFound) {
+TEST_P(TableScanTest, fileNotFound) {
   CursorParameters params;
   params.planNode = tableScanNode();
 
@@ -502,7 +509,7 @@ TEST_F(TableScanTest, fileNotFound) {
 }
 
 // A valid ORC file (containing headers) but no data.
-TEST_F(TableScanTest, validFileNoData) {
+TEST_P(TableScanTest, validFileNoData) {
   auto rowType = ROW({"c0", "c1", "c2"}, {DOUBLE(), VARCHAR(), BIGINT()});
 
   auto filePath = facebook::velox::test::getDataFilePath(
@@ -519,7 +526,7 @@ TEST_F(TableScanTest, validFileNoData) {
 }
 
 // An invalid (size = 0) file.
-TEST_F(TableScanTest, emptyFile) {
+TEST_P(TableScanTest, emptyFile) {
   auto filePath = TempFilePath::create();
 
   try {
@@ -531,54 +538,7 @@ TEST_F(TableScanTest, emptyFile) {
   }
 }
 
-TEST_F(TableScanTest, cacheEnabled) {
-  // DataCache not enabled
-  auto rowType = ROW({"c0", "c1", "c2"}, {DOUBLE(), VARCHAR(), BIGINT()});
-  auto vectors = makeVectors(10, 1'000, rowType);
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->path, kTableScanTest, vectors);
-
-  CursorParameters params;
-  params.planNode = tableScanNode(rowType);
-
-  auto cursor = std::make_unique<TaskCursor>(params);
-
-  addSplit(cursor->task().get(), "0", makeHiveSplit(filePath->path));
-  cursor->task()->noMoreSplits("0");
-
-  while (cursor->moveNext()) {
-    cursor->current();
-  }
-
-  EXPECT_EQ(dataCache->getCount, 0);
-  EXPECT_EQ(dataCache->putCount, 0);
-
-  // DataCache enabled
-  std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs;
-  std::unordered_map<std::string, std::string> hiveConnectorConfigs;
-  hiveConnectorConfigs.insert({kNodeSelectionStrategy, kSoftAffinity});
-  connectorConfigs.insert(
-      {kHiveConnectorId,
-       std::make_shared<core::MemConfig>(std::move(hiveConnectorConfigs))});
-  params.queryCtx = core::QueryCtx::create(
-      std::make_shared<core::MemConfig>(),
-      connectorConfigs,
-      memory::MappedMemory::getInstance());
-
-  cursor = std::make_unique<TaskCursor>(params);
-
-  addSplit(cursor->task().get(), "0", makeHiveSplit(filePath->path));
-  cursor->task()->noMoreSplits("0");
-
-  while (cursor->moveNext()) {
-    cursor->current();
-  }
-
-  EXPECT_NE(dataCache->getCount, 0);
-  EXPECT_NE(dataCache->putCount, 0);
-}
-
-TEST_F(TableScanTest, partitionedTable) {
+TEST_P(TableScanTest, partitionedTable) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);
   auto filePath = TempFilePath::create();
@@ -597,7 +557,7 @@ std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
   return views;
 }
 
-TEST_F(TableScanTest, statsBasedSkippingBool) {
+TEST_P(TableScanTest, statsBasedSkippingBool) {
   auto rowType = ROW({"c0", "c1"}, {INTEGER(), BOOLEAN()});
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
@@ -631,7 +591,7 @@ TEST_F(TableScanTest, statsBasedSkippingBool) {
   EXPECT_EQ(2, getSkippedStridesStat(task));
 }
 
-TEST_F(TableScanTest, statsBasedSkippingDouble) {
+TEST_P(TableScanTest, statsBasedSkippingDouble) {
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
   auto rowVector = makeRowVector({makeFlatVector<double>(
@@ -684,7 +644,7 @@ TEST_F(TableScanTest, statsBasedSkippingDouble) {
   EXPECT_EQ(3, getSkippedStridesStat(task));
 }
 
-TEST_F(TableScanTest, statsBasedSkippingFloat) {
+TEST_P(TableScanTest, statsBasedSkippingFloat) {
   auto filePaths = makeFilePaths(1);
   auto size = 31'234;
   auto rowVector = makeRowVector({makeFlatVector<float>(
@@ -737,7 +697,7 @@ TEST_F(TableScanTest, statsBasedSkippingFloat) {
 }
 
 // Test skipping whole file based on statistics
-TEST_F(TableScanTest, statsBasedSkipping) {
+TEST_P(TableScanTest, statsBasedSkipping) {
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
   std::vector<std::string> fruits = {"apple", "banana", "cherry", "grapes"};
@@ -866,7 +826,7 @@ TEST_F(TableScanTest, statsBasedSkipping) {
 
 // Test skipping files and row groups containing constant values based on
 // statistics
-TEST_F(TableScanTest, statsBasedSkippingConstants) {
+TEST_P(TableScanTest, statsBasedSkippingConstants) {
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
   std::vector<std::string> fruits = {"apple", "banana", "cherry", "grapes"};
@@ -927,7 +887,7 @@ TEST_F(TableScanTest, statsBasedSkippingConstants) {
 }
 
 // Test stats-based skipping for the IS NULL filter.
-TEST_F(TableScanTest, statsBasedSkippingNulls) {
+TEST_P(TableScanTest, statsBasedSkippingNulls) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), INTEGER()});
   auto filePaths = makeFilePaths(1);
   const vector_size_t size = 31'234;
@@ -982,7 +942,7 @@ TEST_F(TableScanTest, statsBasedSkippingNulls) {
 }
 
 // Test skipping whole compression blocks without decompressing these.
-TEST_F(TableScanTest, statsBasedSkippingWithoutDecompression) {
+TEST_P(TableScanTest, statsBasedSkippingWithoutDecompression) {
   const vector_size_t size = 31'234;
 
   // Use long, non-repeating strings to ensure there will be multiple
@@ -1037,7 +997,7 @@ TEST_F(TableScanTest, statsBasedSkippingWithoutDecompression) {
 }
 
 // Test skipping whole compression blocks without decompressing these.
-TEST_F(TableScanTest, filterBasedSkippingWithoutDecompression) {
+TEST_P(TableScanTest, filterBasedSkippingWithoutDecompression) {
   const vector_size_t size = 31'234;
 
   // Use long, non-repeating strings to ensure there will be multiple
@@ -1077,7 +1037,7 @@ TEST_F(TableScanTest, filterBasedSkippingWithoutDecompression) {
 // Test stats-based skipping for numeric columns (integers, floats and booleans)
 // that don't have filters themselves. Skipping is driven by a single bigint
 // column.
-TEST_F(TableScanTest, statsBasedSkippingNumerics) {
+TEST_P(TableScanTest, statsBasedSkippingNumerics) {
   const vector_size_t size = 31'234;
 
   // Make a vector of all possible integer and floating point types.
@@ -1147,7 +1107,7 @@ TEST_F(TableScanTest, statsBasedSkippingNumerics) {
 
 // Test stats-based skipping for list and map columns that don't have
 // filters themselves. Skipping is driven by a single bigint column.
-TEST_F(TableScanTest, statsBasedSkippingComplexTypes) {
+TEST_P(TableScanTest, statsBasedSkippingComplexTypes) {
   const vector_size_t size = 31'234;
 
   // Make a vector of all possible integer and floating point types.
@@ -1232,7 +1192,7 @@ TEST_F(TableScanTest, statsBasedSkippingComplexTypes) {
 
 /// Test the interaction between stats-based and regular skipping for lists and
 /// maps.
-TEST_F(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
+TEST_P(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
   const vector_size_t size = 31'234;
 
   // Orchestrate the case where the nested reader of a list/map gets behind the
@@ -1289,7 +1249,7 @@ TEST_F(TableScanTest, statsBasedAndRegularSkippingComplexTypes) {
       "SELECT * FROM tmp WHERE c0 <= 10 OR c0 between 600 AND 650 OR c0 >= 21234");
 }
 
-TEST_F(TableScanTest, filterPushdown) {
+TEST_P(TableScanTest, filterPushdown) {
   auto rowType =
       ROW({"c0", "c1", "c2", "c3"}, {TINYINT(), BIGINT(), DOUBLE(), BOOLEAN()});
   auto filePaths = makeFilePaths(10);
@@ -1356,7 +1316,7 @@ TEST_F(TableScanTest, filterPushdown) {
       "SELECT count(*) FROM tmp");
 }
 
-TEST_F(TableScanTest, path) {
+TEST_P(TableScanTest, path) {
   auto rowType = ROW({"a"}, {BIGINT()});
   auto filePath = makeFilePaths(1)[0];
   auto vector = makeVectors(1, 1'000, rowType)[0];
@@ -1394,7 +1354,7 @@ TEST_F(TableScanTest, path) {
       op, {filePath}, fmt::format("SELECT '{}', * FROM tmp", pathValue));
 }
 
-TEST_F(TableScanTest, bucket) {
+TEST_P(TableScanTest, bucket) {
   vector_size_t size = 1'000;
   int numBatches = 5;
 
@@ -1472,7 +1432,7 @@ TEST_F(TableScanTest, bucket) {
   }
 }
 
-TEST_F(TableScanTest, remainingFilter) {
+TEST_P(TableScanTest, remainingFilter) {
   auto rowType = ROW(
       {"c0", "c1", "c2", "c3"}, {INTEGER(), INTEGER(), DOUBLE(), BOOLEAN()});
   auto filePaths = makeFilePaths(10);
@@ -1539,7 +1499,7 @@ TEST_F(TableScanTest, remainingFilter) {
       "SELECT c1, c2 FROM tmp WHERE c1 > c0");
 }
 
-TEST_F(TableScanTest, aggregationPushdown) {
+TEST_P(TableScanTest, aggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -1620,7 +1580,7 @@ TEST_F(TableScanTest, aggregationPushdown) {
       op, {filePath}, "SELECT c5, min(c0), max(c0 + c1) FROM tmp GROUP BY 1");
 }
 
-TEST_F(TableScanTest, bitwiseAggregationPushdown) {
+TEST_P(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
@@ -1659,3 +1619,8 @@ TEST_F(TableScanTest, bitwiseAggregationPushdown) {
       {filePath},
       "SELECT c5, bit_or(c0), bit_or(c1), bit_or(c2), bit_or(c6) FROM tmp group by c5");
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    TableScanTests,
+    TableScanTest,
+    testing::Values(true, false));


### PR DESCRIPTION
Uses AsyncDataCache and ScanTracker with Hive if the MappedMemory
given to the reader is a AsyncDataCache. If this is a regular
MappedMemory, uses BufferedInput with the given DataCache, if any.

Sets most tests to use AsyncDataCache as MappedMemory also if no
affinity.

Tests TableScan with both AsyncDataCache and regular MappedMemory +
SimpleLruDataCache.