### PR TITLE
Add * and -> operators to LocalSelectivityVector and LocalDecodedVector

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -285,6 +285,26 @@ class LocalSelectivityVector {
     return vector_.get();
   }
 
+  SelectivityVector& operator*() {
+    VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
+    return *vector_;
+  }
+
+  const SelectivityVector& operator*() const {
+    VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
+    return *vector_;
+  }
+
+  SelectivityVector* operator->() {
+    VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
+    return vector_.get();
+  }
+
+  const SelectivityVector* operator->() const {
+    VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
+    return vector_.get();
+  }
+
  private:
   core::ExecCtx* const context_;
   std::unique_ptr<SelectivityVector> vector_ = nullptr;
@@ -326,11 +346,23 @@ class LocalDecodedVector {
   }
 
   // Must either use the constructor that provides data or call get() first.
-  DecodedVector* operator*() const {
+  DecodedVector& operator*() {
+    VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
+    return *vector_;
+  }
+
+  const DecodedVector& operator*() const {
+    VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
+    return *vector_;
+  }
+
+  DecodedVector* operator->() {
+    VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
     return vector_.get();
   }
 
-  DecodedVector* operator->() const {
+  const DecodedVector* operator->() const {
+    VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
     return vector_.get();
   }
 

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -124,19 +124,16 @@ class HashFunction final : public exec::VectorFunction {
     FlatVector<int32_t>& result = *(*resultRef)->as<FlatVector<int32_t>>();
     rows.applyToSelected([&](int row) { result.set(row, kSeed); });
 
-    std::optional<exec::LocalSelectivityVector> cached_local_selected;
+    exec::LocalSelectivityVector selectedMinusNulls(context);
 
     for (auto& arg : args) {
       exec::LocalDecodedVector decoded(context, *arg, rows);
       const SelectivityVector* selected = &rows;
       if (arg->mayHaveNulls()) {
-        if (!cached_local_selected) {
-          cached_local_selected.emplace(context, rows.end());
-        }
-        *cached_local_selected->get() = rows;
-        cached_local_selected->get()->deselectNulls(
+        *selectedMinusNulls.get(rows.end()) = rows;
+        selectedMinusNulls->deselectNulls(
             arg->flatRawNulls(rows), rows.begin(), rows.end());
-        selected = cached_local_selected->get();
+        selected = selectedMinusNulls.get();
       }
       switch (arg->type()->kind()) {
 #define CASE(typeEnum, hashFn, inputType)                                      \


### PR DESCRIPTION
Summary:
These allow you to conveniently access the wrapped SelectivityVector and
DecodedVector. I've added const overloads for completeness.

The * operator for DecodedVector had the wrong type; it's fixed here.

Reviewed By: pedroerp

Differential Revision: D31100587

