### PR TITLE
Require protobuf minimum version as aleast 3.0.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf 3.0.0 REQUIRED)
 include_directories(SYSTEM ${Protobuf_INCLUDE_DIRS})
 
 # GCC needs to link a library to enable std::filesystem.


### PR DESCRIPTION
This is becasue that since protobuf 3.0.0, cc_enable_arenas became available:  https://github.com/protocolbuffers/protobuf/releases?after=v3.0.0-alpha-3.