### PR TITLE
Initial flatVector conversion to Arrow C data interface

### DIFF
--- a/velox/vector/arrow/Abi.h
+++ b/velox/vector/arrow/Abi.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is a drop-in copy of Arrow's C Data Interface, as defined in:
+//   https://arrow.apache.org/docs/format/CDataInterface.html
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+// EXPERIMENTAL: C stream interface
+
+struct ArrowArrayStream {
+  // Callback to get the stream type
+  // (will be the same for all arrays in the stream).
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowSchema must be released independently from the
+  // stream.
+  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
+
+  // Callback to get the next array
+  // (if no error and the array is released, the stream has ended)
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowArray must be released independently from the
+  // stream.
+  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
+
+  // Callback to get optional detailed error information.
+  // This must only be called if the last stream operation failed
+  // with a non-0 return code.
+  //
+  // Return value: pointer to a null-terminated character array describing
+  // the last error, or NULL if no description is available.
+  //
+  // The returned pointer is only valid until the next operation on this stream
+  // (including release).
+  const char* (*get_last_error)(struct ArrowArrayStream*);
+
+  // Release callback: release the stream's own resources.
+  // Note that arrays returned by `get_next` must be individually released.
+  void (*release)(struct ArrowArrayStream*);
+
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/arrow/Bridge.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::arrow {
+
+namespace {
+
+// TODO: The initial supported conversions only use one buffer for nulls and
+// one for value, but we'll need more once we support strings and complex types.
+static constexpr size_t kMaxBuffers{2};
+
+// Structure that will hold the buffers needed by ArrowArray. This is opaquely
+// carried by ArrowArray.private_data
+struct VeloxToArrowBridgeHolder {
+  // Holds a shared_ptr to the vector being bridged, to ensure its lifetime.
+  VectorPtr vector;
+
+  // Holds the pointers to buffers.
+  const void* buffers[kMaxBuffers];
+};
+
+// Main release function. Arrow standard requires it to recurse down to children
+// and dictionary arrays, and set release and private_data to null to signal it
+// has been released.
+static void bridgeRelease(ArrowArray* arrowArray) {
+  if (!arrowArray || !arrowArray->release) {
+    return;
+  }
+
+  // Recurse down to release children arrays.
+  for (int64_t i = 0; i < arrowArray->n_children; ++i) {
+    ArrowArray* child = arrowArray->children[i];
+    if (child != nullptr && child->release != nullptr) {
+      child->release(child);
+      VELOX_CHECK_NULL(child->release);
+    }
+  }
+
+  // Release dictionary.
+  ArrowArray* dict = arrowArray->dictionary;
+  if (dict != nullptr && dict->release != nullptr) {
+    dict->release(dict);
+    VELOX_CHECK_NULL(dict->release);
+  }
+
+  // Destroy the current holder.
+  auto* bridgeHolder =
+      static_cast<VeloxToArrowBridgeHolder*>(arrowArray->private_data);
+  delete bridgeHolder;
+
+  // Finally, mark the array as released.
+  arrowArray->release = nullptr;
+  arrowArray->private_data = nullptr;
+}
+
+void exportFlatVector(const VectorPtr& vector, ArrowArray& arrowArray) {
+  switch (vector->typeKind()) {
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+      arrowArray.buffers[1] = vector->valuesAsVoid();
+      break;
+
+    default:
+      VELOX_NYI(
+          "Conversion of FlatVector of {} is not supported yet.",
+          vector->typeKind());
+  }
+}
+
+} // namespace
+
+void exportToArrow(const VectorPtr& vector, ArrowArray& arrowArray) {
+  // Bridge holder is stored in private_data, which is a C-compatible naked
+  // pointer. However, since this function can throw (unsupported conversion
+  // type, for instance), we temporarily use a unique_ptr to ensure the bridge
+  // holder is released in case this function fails.
+  //
+  // Since this unique_ptr dies with this function and we'll need this bridge
+  // alive, the last step in this function is to release this unique_ptr.
+  auto bridgeHolder = std::make_unique<VeloxToArrowBridgeHolder>();
+  bridgeHolder->vector = vector;
+  arrowArray.n_buffers = kMaxBuffers;
+  arrowArray.buffers = bridgeHolder->buffers;
+  arrowArray.release = bridgeRelease;
+  arrowArray.length = vector->size();
+
+  // getNullCount() returns a std::optional. -1 means we don't have the count
+  // available yet (and we don't want to count it here).
+  arrowArray.null_count = vector->getNullCount().value_or(-1);
+
+  // Velox does not support offset'ed vectors yet.
+  arrowArray.offset = 0;
+
+  // Setting up buffer pointers. First one is always nulls.
+  arrowArray.buffers[0] = vector->rawNulls();
+
+  // Second buffer is values. Only support flat for now.
+  switch (vector->encoding()) {
+    case VectorEncoding::Simple::FLAT:
+      exportFlatVector(vector, arrowArray);
+      break;
+
+    default:
+      VELOX_NYI("Only FlatVectors can be exported to Arrow for now.");
+      break;
+  }
+
+  // TODO: No nested types, strings, or dictionaries for now.
+  arrowArray.n_children = 0;
+  arrowArray.children = nullptr;
+  arrowArray.dictionary = nullptr;
+
+  // We release the unique_ptr since bridgeHolder will now be carried inside
+  // ArrowArray.
+  arrowArray.private_data = bridgeHolder.release();
+}
+
+} // namespace facebook::velox::arrow

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/arrow/Abi.h"
+
+namespace facebook::velox::arrow {
+
+/// Export a generic Velox Vector to an ArrowArray, as defined by Arrow's C data
+/// interface:
+///
+///   https://arrow.apache.org/docs/format/CDataInterface.html
+///
+/// The output ArrowArray needs to be allocated by the consumer (either in the
+/// heap or stack), and after usage, the standard REQUIRES the client to call
+/// the release() function (or memory will leak).
+///
+/// After exporting, the ArrowArray will hold ownership to the underlying Vector
+/// being referenced, so the consumer don't need to explicitly hold on to the
+/// input Vector shared_ptr.
+///
+/// The function throws in case the conversion is not implemented yet.
+///
+/// Example usage:
+///
+///   ArrowArray arrowArray;
+///   arrow::exportToArrow(inputVector, arrowArray);
+///   inputVector.reset(); // don't need to hold on to this shared_ptr.
+///
+///   (use arrowArray)
+///
+///   arrowArray.release(&arrowArray);
+///
+void exportToArrow(const VectorPtr& vector, ArrowArray& arrowArray);
+
+} // namespace facebook::velox::arrow

--- a/velox/vector/arrow/tests/ArrowBridgeTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeTest.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/common/base/Nulls.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/vector/arrow/Bridge.h"
+#include "velox/vector/tests/VectorMaker.h"
+
+namespace {
+
+using namespace facebook::velox;
+
+class ArrowBridgeTest : public testing::Test {
+ protected:
+  template <typename T>
+  void testFlatVector(const std::vector<std::optional<T>>& inputData) {
+    auto flatVector = vectorMaker_.flatVectorNullable(inputData);
+    ArrowArray arrowArray;
+    arrow::exportToArrow(flatVector, arrowArray);
+
+    size_t nullCount =
+        std::count(inputData.begin(), inputData.end(), std::nullopt);
+    EXPECT_EQ(inputData.size(), arrowArray.length);
+    EXPECT_EQ(nullCount, arrowArray.null_count);
+    EXPECT_EQ(0, arrowArray.offset);
+    EXPECT_EQ(0, arrowArray.n_children);
+
+    EXPECT_EQ(nullptr, arrowArray.children);
+    EXPECT_EQ(nullptr, arrowArray.dictionary);
+
+    // Validate buffers.
+    EXPECT_EQ(2, arrowArray.n_buffers); // null and values buffers.
+
+    const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
+    const T* values = static_cast<const T*>(arrowArray.buffers[1]);
+
+    for (size_t i = 0; i < inputData.size(); ++i) {
+      if (inputData[i] == std::nullopt) {
+        EXPECT_TRUE(bits::isBitNull(nulls, i));
+      } else {
+        EXPECT_FALSE(bits::isBitNull(nulls, i));
+        EXPECT_EQ(inputData[i], values[i]);
+      }
+    }
+
+    arrowArray.release(&arrowArray);
+    EXPECT_EQ(nullptr, arrowArray.release);
+    EXPECT_EQ(nullptr, arrowArray.private_data);
+  }
+
+  // Boiler plate structures required by vectorMaker.
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
+};
+
+TEST_F(ArrowBridgeTest, flatNotNull) {
+  std::vector<int64_t> inputData = {1, 2, 3, 4, 5};
+  ArrowArray arrowArray;
+  {
+    // Make sure that ArrowArray is correctly acquiring ownership, even after
+    // the initial vector shared_ptr is gone.
+    auto flatVector = vectorMaker_.flatVector(inputData);
+    arrow::exportToArrow(flatVector, arrowArray);
+  }
+
+  EXPECT_EQ(inputData.size(), arrowArray.length);
+  EXPECT_EQ(0, arrowArray.null_count);
+  EXPECT_EQ(0, arrowArray.offset);
+  EXPECT_EQ(0, arrowArray.n_children);
+
+  EXPECT_EQ(nullptr, arrowArray.children);
+  EXPECT_EQ(nullptr, arrowArray.dictionary);
+
+  // Validate buffers.
+  EXPECT_EQ(2, arrowArray.n_buffers); // null and values buffers.
+  EXPECT_EQ(nullptr, arrowArray.buffers[0]); // no nulls.
+
+  const int64_t* values = static_cast<const int64_t*>(arrowArray.buffers[1]);
+
+  for (size_t i = 0; i < inputData.size(); ++i) {
+    EXPECT_EQ(inputData[i], values[i]);
+  }
+
+  // Consumers are required to call release. Ensure release and private_data
+  // are null after releasing it.
+  arrowArray.release(&arrowArray);
+  EXPECT_EQ(nullptr, arrowArray.release);
+  EXPECT_EQ(nullptr, arrowArray.private_data);
+}
+
+TEST_F(ArrowBridgeTest, flatTinyint) {
+  testFlatVector<int8_t>({
+      1,
+      std::numeric_limits<int8_t>::min(),
+      std::nullopt,
+      std::numeric_limits<int8_t>::max(),
+      std::nullopt,
+      4,
+  });
+}
+
+TEST_F(ArrowBridgeTest, flatSmallint) {
+  testFlatVector<int16_t>({
+      std::numeric_limits<int16_t>::min(),
+      1000,
+      std::nullopt,
+      std::numeric_limits<int16_t>::max(),
+  });
+}
+
+TEST_F(ArrowBridgeTest, flatInteger) {
+  testFlatVector<int32_t>({
+      std::numeric_limits<int32_t>::min(),
+      std::nullopt,
+      std::numeric_limits<int32_t>::max(),
+      std::numeric_limits<int32_t>::max(),
+      std::nullopt,
+      std::nullopt,
+  });
+}
+
+TEST_F(ArrowBridgeTest, flatBigint) {
+  testFlatVector<int64_t>({
+      std::nullopt,
+      99876,
+      std::nullopt,
+      12345678,
+      std::numeric_limits<int64_t>::max(),
+      std::numeric_limits<int64_t>::min(),
+      std::nullopt,
+  });
+}
+
+TEST_F(ArrowBridgeTest, flatReal) {
+  testFlatVector<float>({
+      std::nullopt,
+      std::numeric_limits<float>::infinity(),
+      std::numeric_limits<float>::lowest(),
+      std::numeric_limits<float>::max(),
+      std::nullopt,
+      77.8,
+      12.34,
+  });
+}
+
+TEST_F(ArrowBridgeTest, flatDouble) {
+  testFlatVector<double>({
+      1.1,
+      std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::lowest(),
+      std::nullopt,
+      std::numeric_limits<double>::max(),
+      std::nullopt,
+      99.4,
+  });
+}
+
+TEST_F(ArrowBridgeTest, unsupported) {
+  ArrowArray arrowArray;
+  VectorPtr vector;
+
+  // Strings.
+  vector = vectorMaker_.flatVectorNullable<std::string>({});
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Timestamps.
+  vector = vectorMaker_.flatVectorNullable<Timestamp>({});
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Arrays.
+  vector = vectorMaker_.arrayVector<int64_t>({{1, 2, 3}, {4, 5}});
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Maps.
+  auto lambda = [](vector_size_t /* row */) { return 1; };
+  vector = vectorMaker_.mapVector<int64_t, int64_t>(2, lambda, lambda, lambda);
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Row vectors.
+  vector =
+      vectorMaker_.rowVector({vectorMaker_.flatVector<int64_t>({1, 2, 3})});
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Constant encoding.
+  vector = BaseVector::createConstant(variant(10), 10, pool_.get());
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+
+  // Dictionary encoding.
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(3, pool_.get());
+  vector = BaseVector::wrapInDictionary(
+      BufferPtr(), indices, 3, vectorMaker_.flatVector<int64_t>({1, 2, 3}));
+  EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
Adding initial flatVector conversion to Arrow C data interface. Will
add more types and tests in the next diffs/PRs in the stack in order to prevent
this diff from growing too large.
Also adds a copy or Arrow's C Abi header file.

Differential Revision: D31189020

