### PR TITLE
Fixing markdown rendering issue in CODING_STYLE.md

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -194,7 +194,7 @@ About comment style:
   * Avoid `const char* const` and `const char*` - these are less efficient to
     convert to `std::string` later on in your program if you ever need to
     because `std::string_view`/`folly::StringPiece` knows its size and can use
-    a more efficient constructor. `std::string_view`/`folly::StringPiece` also
+    a more efficient constructor. `std::string_view`/ `folly::StringPiece` also
     has richer interfaces and often works as a drop-in replacement to
     `std::string`.
   * Need compile-time string concatenation? You can use `folly::FixedString`

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -193,7 +193,7 @@ About comment style:
   * **NEVER** use `std::string` - this makes your code more prone to SIOF bugs.
   * Avoid `const char* const` and `const char*` - these are less efficient to
     convert to `std::string` later on in your program if you ever need to
-    because `std::string_view`/`folly::StringPiece` knows its size and can use
+    because `std::string_view`/ `folly::StringPiece` knows its size and can use
     a more efficient constructor. `std::string_view`/ `folly::StringPiece` also
     has richer interfaces and often works as a drop-in replacement to
     `std::string`.


### PR DESCRIPTION
Insert a space between / and ' to  render the inline code snippet properly