### PR TITLE
Refactor PartitionedOutput to extract partition function

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   GroupingSet.cpp
   HashAggregation.cpp
   HashBuild.cpp
+  HashPartitionFunction.cpp
   HashProbe.cpp
   HashStringAllocator.cpp
   HashTable.cpp

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <velox/exec/HashPartitionFunction.h>
+#include <velox/exec/VectorHasher.h>
+
+namespace facebook::velox::exec {
+HashPartitionFunction::HashPartitionFunction(
+    int numPartitions,
+    RowTypePtr inputType,
+    std::vector<ChannelIndex> keyChannels)
+    : numPartitions_{numPartitions}, keyChannels_{std::move(keyChannels)} {
+  hashers_.reserve(keyChannels_.size());
+  for (auto channel : keyChannels_) {
+    hashers_.emplace_back(
+        VectorHasher::create(inputType->childAt(channel), channel));
+  }
+}
+
+void HashPartitionFunction::partition(
+    const RowVector& input,
+    std::vector<uint32_t>& partitions) {
+  auto size = input.size();
+
+  rows_.resize(size);
+  rows_.setAll();
+
+  hashes_.resize(size);
+  for (auto i = 0; i < keyChannels_.size(); ++i) {
+    hashers_[i]->hash(*input.childAt(keyChannels_[i]), rows_, i > 0, &hashes_);
+  }
+
+  partitions.resize(size);
+  for (auto i = 0; i < size; ++i) {
+    partitions[i] = hashes_[i] % numPartitions_;
+  }
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <velox/exec/VectorHasher.h>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::exec {
+
+class HashPartitionFunction : public core::PartitionFunction {
+ public:
+  HashPartitionFunction(
+      int numPartitions,
+      RowTypePtr inputType,
+      std::vector<ChannelIndex> keyChannels);
+
+  ~HashPartitionFunction() override = default;
+
+  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
+      override;
+
+ private:
+  const int numPartitions_;
+  const std::vector<ChannelIndex> keyChannels_;
+  std::vector<std::unique_ptr<VectorHasher>> hashers_;
+
+  // Reusable memory.
+  SelectivityVector rows_;
+  std::vector<uint64_t> hashes_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -17,7 +17,6 @@
 
 #include "velox/exec/Operator.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
-#include "velox/exec/VectorHasher.h"
 
 namespace facebook::velox::exec {
 
@@ -109,13 +108,23 @@ class PartitionedOutput : public Operator {
         keyChannels_(toChannels(planNode->inputType(), planNode->keys())),
         numDestinations_(planNode->numPartitions()),
         replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
+        partitionFunction_(
+            numDestinations_ == 1
+                ? nullptr
+                : std::move(planNode->partitionFunctionFactory()())),
         outputChannels_(calculateOutputChannels(
             planNode->inputType(),
             planNode->outputType())),
         future_(false),
         bufferManager_(PartitionedOutputBufferManager::getInstance(
             operatorCtx_->task()->queryCtx()->host())) {
-    VELOX_CHECK(numDestinations_ > 1 || keyChannels_.empty());
+    if (numDestinations_ > 1) {
+      VELOX_CHECK(!keyChannels_.empty());
+      VELOX_CHECK_NOT_NULL(partitionFunction_);
+    } else {
+      VELOX_CHECK(keyChannels_.empty());
+      VELOX_CHECK_NULL(partitionFunction_);
+    }
     VELOX_CHECK_GT(outputType_->size(), 0);
   }
 
@@ -152,12 +161,10 @@ class PartitionedOutput : public Operator {
 
   void initializeSizeBuffers();
 
-  void calculateHashes();
-
   void estimateRowSizes();
 
-  /// Collect all rows with null keys into the provided SelectivityVector.
-  void collectNullRows(SelectivityVector& nullRows);
+  /// Collect all rows with null keys into nullRows_.
+  void collectNullRows();
 
   static constexpr uint64_t kMaxDestinationSize = 1024 * 1024; // 1MB
   static constexpr uint64_t kMinDestinationSize = 16 * 1024; // 16 KB
@@ -165,25 +172,26 @@ class PartitionedOutput : public Operator {
   const std::vector<ChannelIndex> keyChannels_;
   const int numDestinations_;
   const bool replicateNullsAndAny_;
+  std::unique_ptr<core::PartitionFunction> partitionFunction_;
   // Empty if column order in the output is exactly the same as in input.
   const std::vector<ChannelIndex> outputChannels_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
   ContinueFuture future_;
   bool isFinished_{false};
-  std::vector<std::unique_ptr<VectorHasher>> hashers_;
   // top-level row numbers used as input to
   // VectorStreamGroup::estimateSerializedSize member variable is used to avoid
   // re-allocating memory
   std::vector<IndexRange> topLevelRanges_;
   std::vector<vector_size_t*> sizePointers_;
   std::vector<vector_size_t> rowSize_;
-  std::vector<uint64_t> hashes_;
   std::vector<std::unique_ptr<Destination>> destinations_;
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
 
   // Reusable memory.
   SelectivityVector rows_;
+  SelectivityVector nullRows_;
+  std::vector<uint32_t> partitions_;
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Extract PartitionFunction logic from PartitionedOutput to allow for different
partition functions. An upcoming change will introduce partition function that
uses Hive bucketing. Partitioning using Hive bucketing is useful when joining
bucketed table on a bucket-by key with a non-bucketed table. 