### PR TITLE
Track size of row in RowContainer

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -192,8 +192,13 @@ void GroupingSet::initializeGlobalAggregation() {
 
   // Row layout is:
   //  - null flags - one bit per aggregate,
+  // - uint32_t row size,
   //  - fixed-width accumulators - one per aggregate
-  int32_t offset = bits::nbytes(aggregates_.size());
+  //
+  // Here we always make space for a row size since we only have one
+  // row and no RowContainer.
+  int32_t rowSizeOffset = bits::nbytes(aggregates_.size());
+  int32_t offset = rowSizeOffset + sizeof(int32_t);
   int32_t nullOffset = 0;
 
   for (auto& aggregate : aggregates_) {
@@ -201,7 +206,8 @@ void GroupingSet::initializeGlobalAggregation() {
     aggregate->setOffsets(
         offset,
         RowContainer::nullByte(nullOffset),
-        RowContainer::nullMask(nullOffset));
+        RowContainer::nullMask(nullOffset),
+        rowSizeOffset);
     offset += aggregate->accumulatorFixedWidthSize();
     ++nullOffset;
   }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -363,3 +363,43 @@ TEST_F(RowContainerTest, erase) {
   EXPECT_EQ(rowSet.end(), rowSet.find(newRow));
   data->checkConsistency();
 }
+
+TEST_F(RowContainerTest, rowSize) {
+  constexpr int32_t kNumRows = 100;
+  auto data = makeRowContainer({SMALLINT()}, {VARCHAR()});
+
+  // The layout is expected to be smallint - 6 bytes of padding - 1 byte of bits
+  // - StringView - rowSize - next pointer. The bits are a null flag for the
+  // second smallint, a probed flag and a free flag.
+  EXPECT_EQ(25, data->rowSizeOffset());
+  EXPECT_EQ(29, data->nextOffset());
+  // 2nd bit in first byte of flags.
+  EXPECT_EQ(data->probedFlagOffset(), 8 * 8 + 1);
+  std::unordered_set<char*> rowSet;
+  std::vector<char*> rows;
+  for (int i = 0; i < kNumRows; ++i) {
+    rows.push_back(data->newRow());
+    rowSet.insert(rows.back());
+  }
+  EXPECT_EQ(kNumRows, data->numRows());
+  for (auto i = 0; i < rows.size(); ++i) {
+    data->incrementRowSize(rows[i], i * 1000);
+  }
+  // The first size overflows 32 bits.
+  data->incrementRowSize(rows[0], 2000000000);
+  data->incrementRowSize(rows[0], 2000000000);
+  data->incrementRowSize(rows[0], 2000000000);
+  std::vector<char*> rowsFromContainer(kNumRows);
+  RowContainerIterator iter;
+  // The first row is returned alone.
+  auto numRows =
+      data->listRows(&iter, kNumRows, 100000, rowsFromContainer.data());
+  EXPECT_EQ(1, numRows);
+  while (numRows < kNumRows) {
+    numRows += data->listRows(
+        &iter, kNumRows, 100000, rowsFromContainer.data() + numRows);
+  }
+  EXPECT_EQ(0, data->listRows(&iter, kNumRows, rows.data()));
+
+  EXPECT_EQ(rows, rowsFromContainer);
+}


### PR DESCRIPTION
Adds a uint32_t to the row for tracking width of out of line variable
length data. This is only added if there are variable lenght fields or
accumulators.

This allows controlling the output batch size for hash join or group
by and for getting predictable size chunks of data for spilling.

Follow-up PRs will add setting this in hash build, group by key insert
and when growing variable width accumulators.