### PR TITLE
Add HivePartitionFunction

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/HivePartitionFunction.h"
+
+namespace facebook::velox::connector::hive {
+
+namespace {
+template <TypeKind kind>
+void hashTyped(
+    const DecodedVector& /* values */,
+    vector_size_t /* size */,
+    bool /* mix */,
+    std::vector<int32_t>& /* hashes */) {
+  VELOX_UNSUPPORTED(
+      "Hive partitioning function doesn't support {} type",
+      TypeTraits<kind>::name);
+}
+
+template <>
+void hashTyped<TypeKind::BOOLEAN>(
+    const DecodedVector& values,
+    vector_size_t size,
+    bool mix,
+    std::vector<int32_t>& hashes) {
+  for (auto i = 0; i < size; ++i) {
+    uint32_t hash;
+    if (values.isNullAt(i)) {
+      hash = 0;
+    } else {
+      hash = values.valueAt<bool>(i) ? 1 : 0;
+    }
+
+    hashes[i] = mix ? hashes[i] * 31 + hash : hash;
+  }
+}
+
+int32_t hashInt64(int64_t value) {
+  return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
+}
+
+template <>
+void hashTyped<TypeKind::BIGINT>(
+    const DecodedVector& values,
+    vector_size_t size,
+    bool mix,
+    std::vector<int32_t>& hashes) {
+  for (auto i = 0; i < size; ++i) {
+    int32_t hash;
+    if (values.isNullAt(i)) {
+      hash = 0;
+    } else {
+      hash = hashInt64(values.valueAt<int64_t>(i));
+    }
+
+    hashes[i] = mix ? hashes[i] * 31 + hash : hash;
+  }
+}
+
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+__attribute__((no_sanitize("integer")))
+#endif
+#endif
+int32_t
+hashBytes(StringView bytes, int32_t initialValue) {
+  int32_t hash = initialValue;
+  auto* data = bytes.data();
+  for (auto i = 0; i < bytes.size(); ++i) {
+    hash = hash * 31 + *reinterpret_cast<const int8_t*>(data + i);
+  }
+  return hash;
+}
+
+template <>
+void hashTyped<TypeKind::VARCHAR>(
+    const DecodedVector& values,
+    vector_size_t size,
+    bool mix,
+    std::vector<int32_t>& hashes) {
+  for (auto i = 0; i < size; ++i) {
+    int32_t hash;
+    if (values.isNullAt(i)) {
+      hash = 0;
+    } else {
+      hash = hashBytes(values.valueAt<StringView>(i), 0);
+    }
+
+    hashes[i] = mix ? hashes[i] * 31 + hash : hash;
+  }
+}
+
+void hash(
+    const DecodedVector& values,
+    TypeKind typeKind,
+    vector_size_t size,
+    bool mix,
+    std::vector<int32_t>& hashes) {
+  // This function mirrors the behavior of function hashCode in
+  // HIVE-12025 ba83fd7bff
+  // serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+  // https://github.com/apache/hive/blob/ba83fd7bff/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+
+  // HIVE-7148 proposed change to bucketing hash algorithms. If that gets
+  // implemented, this function will need to change significantly.
+
+  VELOX_DYNAMIC_TYPE_DISPATCH(hashTyped, typeKind, values, size, mix, hashes);
+}
+} // namespace
+
+HivePartitionFunction::HivePartitionFunction(
+    int numBuckets,
+    std::vector<int> bucketToPartition,
+    std::vector<ChannelIndex> keyChannels)
+    : numBuckets_{numBuckets},
+      bucketToPartition_{bucketToPartition},
+      keyChannels_{std::move(keyChannels)} {
+  decodedVectors_.resize(keyChannels_.size());
+}
+
+void HivePartitionFunction::partition(
+    const RowVector& input,
+    std::vector<uint32_t>& partitions) {
+  auto size = input.size();
+
+  if (size > hashes_.size()) {
+    rows_.resize(size);
+    rows_.setAll();
+    hashes_.resize(size);
+  }
+
+  partitions.resize(size);
+  for (auto i = 0; i < keyChannels_.size(); ++i) {
+    auto keyVector = input.childAt(keyChannels_[i]);
+    decodedVectors_[i].decode(*keyVector, rows_);
+    hash(
+        decodedVectors_[i],
+        keyVector->typeKind(),
+        keyVector->size(),
+        i > 0,
+        hashes_);
+  }
+
+  static const int32_t kInt32Max = std::numeric_limits<int32_t>::max();
+
+  for (auto i = 0; i < size; ++i) {
+    partitions[i] =
+        bucketToPartition_[((hashes_[i] & kInt32Max) % numBuckets_)];
+  }
+}
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::connector::hive {
+
+class HivePartitionFunction : public core::PartitionFunction {
+ public:
+  HivePartitionFunction(
+      int numBuckets,
+      std::vector<int> bucketToPartition,
+      std::vector<ChannelIndex> keyChannels);
+
+  ~HivePartitionFunction() override = default;
+
+  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
+      override;
+
+ private:
+  const int numBuckets_;
+  const std::vector<int> bucketToPartition_;
+  const std::vector<ChannelIndex> keyChannels_;
+
+  // Reusable memory.
+  std::vector<int32_t> hashes_;
+  SelectivityVector rows_;
+  std::vector<DecodedVector> decodedVectors_;
+};
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -11,14 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp)
+add_test(velox_hive_connector_test velox_hive_connector_test)
 
-add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp)
-
-target_link_libraries(velox_hive_connector velox_connector
-                      velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)
-
-add_library(velox_hive_partition_function HivePartitionFunction.cpp)
-
-target_link_libraries(velox_hive_partition_function velox_core)
-
-add_subdirectory(tests)
+target_link_libraries(velox_hive_connector_test velox_hive_partition_function
+                      velox_vector_test_lib ${GTEST_BOTH_LIBRARIES})

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/HivePartitionFunction.h"
+#include "gtest/gtest.h"
+#include "velox/vector/tests/VectorMaker.h"
+
+using namespace facebook::velox;
+
+class HivePartitionFunctionTest : public ::testing::Test {
+ protected:
+  void assertPartitions(
+      const VectorPtr& vector,
+      int bucketCount,
+      const std::vector<uint32_t>& expectedPartitions) {
+    auto rowVector = vm_.rowVector({vector});
+
+    auto size = rowVector->size();
+
+    std::vector<int> bucketToPartition(bucketCount);
+    std::iota(bucketToPartition.begin(), bucketToPartition.end(), 0);
+    std::vector<ChannelIndex> keyChannels;
+    keyChannels.emplace_back(0);
+    connector::hive::HivePartitionFunction partitionFunction(
+        bucketCount, bucketToPartition, keyChannels);
+
+    std::vector<uint32_t> partitions(size);
+    partitionFunction.partition(*rowVector, partitions);
+    for (auto i = 0; i < size; ++i) {
+      EXPECT_EQ(expectedPartitions[i], partitions[i])
+          << "at " << i << ": " << vector->toString(i);
+    }
+  }
+
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vm_{pool_.get()};
+};
+
+TEST_F(HivePartitionFunctionTest, int64) {
+  auto values = vm_.flatVectorNullable<int64_t>(
+      {std::nullopt,
+       300'000'000'000,
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 1, 0, 0});
+  assertPartitions(values, 500, {0, 497, 0, 0});
+  assertPartitions(values, 997, {0, 852, 0, 0});
+}
+
+TEST_F(HivePartitionFunctionTest, string) {
+  // TODO Fix flatVectorNullable to set stringBuffers.
+  std::vector<std::optional<std::string>> values = {
+      std::nullopt, "", "test string", "\u5f3a\u5927\u7684Presto\u5f15\u64ce"};
+  auto vector = vm_.flatVectorNullable(values);
+
+  assertPartitions(vector, 1, {0, 0, 0, 0});
+  assertPartitions(vector, 2, {0, 0, 1, 0});
+  assertPartitions(vector, 500, {0, 0, 211, 454});
+  assertPartitions(vector, 997, {0, 0, 894, 831});
+}

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -168,4 +168,13 @@ HashJoinNode::HashJoinNode(
     }
   }
 }
+
+CrossJoinNode::CrossJoinNode(
+    const PlanNodeId& id,
+    std::shared_ptr<const PlanNode> left,
+    std::shared_ptr<const PlanNode> right,
+    RowTypePtr outputType)
+    : PlanNode(id),
+      sources_({std::move(left), std::move(right)}),
+      outputType_(std::move(outputType)) {}
 } // namespace facebook::velox::core

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -841,6 +841,32 @@ class HashJoinNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
+// Cross join.
+class CrossJoinNode : public PlanNode {
+ public:
+  CrossJoinNode(
+      const PlanNodeId& id,
+      std::shared_ptr<const PlanNode> left,
+      std::shared_ptr<const PlanNode> right,
+      RowTypePtr outputType);
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  std::string_view name() const override {
+    return "cross join";
+  }
+
+ private:
+  const std::vector<std::shared_ptr<const PlanNode>> sources_;
+  const RowTypePtr outputType_;
+};
+
 // Represents the 'SortBy' node in the plan.
 class OrderByNode : public PlanNode {
  public:

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(
   Aggregate.cpp
   AllocationPool.cpp
   ContainerRowSerde.cpp
+  CrossJoinBuild.cpp
+  CrossJoinProbe.cpp
   Driver.cpp
   EnforceSingleRow.cpp
   Exchange.cpp

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   GroupingSet.cpp
   HashAggregation.cpp
   HashBuild.cpp
+  HashPartitionFunction.cpp
   HashProbe.cpp
   HashStringAllocator.cpp
   HashTable.cpp

--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/CrossJoinBuild.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+void CrossJoinBridge::setData(std::vector<VectorPtr> data) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(!data_.has_value(), "setData may be called only once");
+  data_ = std::move(data);
+  notifyConsumersLocked();
+}
+
+std::optional<std::vector<VectorPtr>> CrossJoinBridge::dataOrFuture(
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");
+  if (data_.has_value()) {
+    return std::move(data_);
+  }
+  promises_.emplace_back("CrossJoinBridge::tableOrFuture");
+  *future = promises_.back().getSemiFuture();
+  return std::nullopt;
+}
+
+CrossJoinBuild::CrossJoinBuild(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    std::shared_ptr<const core::CrossJoinNode> joinNode)
+    : Operator(
+          driverCtx,
+          nullptr,
+          operatorId,
+          joinNode->id(),
+          "CrossJoinBuild") {}
+
+void CrossJoinBuild::addInput(RowVectorPtr input) {
+  if (input->size() > 0) {
+    // Load lazy vectors before storing.
+    for (auto& child : input->children()) {
+      child->loadedVector();
+    }
+    data_.emplace_back(std::move(input));
+  }
+}
+
+BlockingReason CrossJoinBuild::isBlocked(ContinueFuture* future) {
+  if (!hasFuture_) {
+    return BlockingReason::kNotBlocked;
+  }
+  *future = std::move(future_);
+  hasFuture_ = false;
+  return BlockingReason::kWaitForJoinBuild;
+}
+
+void CrossJoinBuild::finish() {
+  Operator::finish();
+  std::vector<VeloxPromise<bool>> promises;
+  std::vector<std::shared_ptr<Driver>> peers;
+  // The last Driver to hit CrossJoinBuild::finish gathers the data from
+  // all build Drivers and hands it over to the probe side. At this
+  // point all build Drivers are continued and will free their
+  // state. allPeersFinished is true only for the last Driver of the
+  // build pipeline.
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    hasFuture_ = true;
+    return;
+  }
+
+  for (auto& peer : peers) {
+    auto op = peer->findOperator(planNodeId());
+    auto* build = dynamic_cast<CrossJoinBuild*>(op);
+    VELOX_CHECK(build);
+    data_.insert(data_.begin(), build->data_.begin(), build->data_.end());
+  }
+
+  // Realize the promises so that the other Drivers (which were not
+  // the last to finish) can continue from the barrier and finish.
+  peers.clear();
+  for (auto& promise : promises) {
+    promise.setValue(true);
+  }
+
+  operatorCtx_->task()
+      ->getCrossJoinBridge(planNodeId())
+      ->setData(std::move(data_));
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/CrossJoinBuild.h
+++ b/velox/exec/CrossJoinBuild.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/JoinBridge.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class CrossJoinBridge : public JoinBridge {
+ public:
+  void setData(std::vector<VectorPtr> data);
+
+  std::optional<std::vector<VectorPtr>> dataOrFuture(ContinueFuture* future);
+
+ private:
+  std::optional<std::vector<VectorPtr>> data_;
+};
+
+class CrossJoinBuild : public Operator {
+ public:
+  CrossJoinBuild(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      std::shared_ptr<const core::CrossJoinNode> joinNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override {
+    return nullptr;
+  }
+
+  bool needsInput() const override {
+    return !isFinishing_;
+  }
+
+  void finish() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  void close() override {
+    data_.clear();
+    Operator::close();
+  }
+
+ private:
+  std::vector<VectorPtr> data_;
+
+  // Future for synchronizing with other Drivers of the same pipeline. All build
+  // Drivers must be completed before making data available for the probe side.
+  ContinueFuture future_{false};
+  bool hasFuture_ = false;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/CrossJoinProbe.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+CrossJoinProbe::CrossJoinProbe(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::CrossJoinNode>& joinNode)
+    : Operator(
+          driverCtx,
+          joinNode->outputType(),
+          operatorId,
+          joinNode->id(),
+          "CrossJoinProbe") {
+  bool isIdentityProjection = true;
+
+  auto probeType = joinNode->sources()[0]->outputType();
+  for (auto i = 0; i < probeType->size(); ++i) {
+    auto name = probeType->nameOf(i);
+    auto outIndex = outputType_->getChildIdxIfExists(name);
+    if (outIndex.has_value()) {
+      identityProjections_.emplace_back(i, outIndex.value());
+      if (outIndex != i) {
+        isIdentityProjection = false;
+      }
+    }
+  }
+
+  auto buildType = joinNode->sources()[1]->outputType();
+  for (auto i = 0; i < outputType_->size(); ++i) {
+    auto tableChannel = buildType->getChildIdxIfExists(outputType_->nameOf(i));
+    if (tableChannel.has_value()) {
+      buildProjections_.emplace_back(tableChannel.value(), i);
+    }
+  }
+
+  if (isIdentityProjection && buildProjections_.empty()) {
+    isIdentityProjection_ = true;
+  }
+}
+
+BlockingReason CrossJoinProbe::isBlocked(ContinueFuture* future) {
+  if (buildData_.has_value()) {
+    return BlockingReason::kNotBlocked;
+  }
+
+  auto buildData = operatorCtx_->task()
+                       ->getCrossJoinBridge(planNodeId())
+                       ->dataOrFuture(future);
+  if (!buildData.has_value()) {
+    return BlockingReason::kWaitForJoinBuild;
+  }
+
+  buildData_ = std::move(buildData);
+
+  if (buildData_->empty()) {
+    // Build side is empty. Return empty set of rows and  terminate the pipeline
+    // early.
+    isFinishing_ = true;
+  }
+
+  return BlockingReason::kNotBlocked;
+}
+
+void CrossJoinProbe::addInput(RowVectorPtr input) {
+  // In getOutput(), we are going to wrap input in dictionaries a few rows at a
+  // time. Since lazy vectors cannot be wrapped in different dictionaries, we
+  // are going to load them here.
+  for (auto& child : input->children()) {
+    child->loadedVector();
+  }
+  input_ = std::move(input);
+}
+
+RowVectorPtr CrossJoinProbe::getOutput() {
+  if (!input_) {
+    return nullptr;
+  }
+
+  // TODO Use query-level configuration property.
+  static const vector_size_t kOutputBatchSize = 1'000;
+
+  auto buildSize = buildData_.value()[buildIndex_]->size();
+  vector_size_t probeCnt;
+  if (buildSize > kOutputBatchSize) {
+    probeCnt = 1;
+  } else {
+    probeCnt =
+        std::min(kOutputBatchSize / buildSize, input_->size() - probeRow_);
+  }
+
+  auto size = probeCnt * buildSize;
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool());
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < probeCnt; ++i) {
+    std::fill(
+        rawIndices + i * buildSize,
+        rawIndices + (i + 1) * buildSize,
+        probeRow_ + i);
+  }
+  fillOutput(size, indices);
+
+  BufferPtr buildIndices = nullptr;
+  if (probeCnt > 1) {
+    buildIndices = AlignedBuffer::allocate<vector_size_t>(size, pool());
+    auto* rawBuildIndices = buildIndices->asMutable<vector_size_t>();
+    for (auto i = 0; i < probeCnt; ++i) {
+      std::iota(
+          rawBuildIndices + i * buildSize,
+          rawBuildIndices + (i + 1) * buildSize,
+          0);
+    }
+  }
+
+  auto buildRowVector =
+      buildData_.value()[buildIndex_]->asUnchecked<RowVector>();
+  for (const auto& projection : buildProjections_) {
+    VectorPtr buildVector = buildRowVector->childAt(projection.inputChannel);
+
+    if (buildIndices) {
+      buildVector = BaseVector::wrapInDictionary(
+          BufferPtr(nullptr), buildIndices, size, buildVector);
+    }
+    output_->childAt(projection.outputChannel) = buildVector;
+  }
+
+  probeRow_ += probeCnt;
+  if (probeRow_ == input_->size()) {
+    probeRow_ = 0;
+    ++buildIndex_;
+    if (buildIndex_ == buildData_->size()) {
+      buildIndex_ = 0;
+      input_.reset();
+    }
+  }
+  return output_;
+}
+
+void CrossJoinProbe::close() {
+  buildData_.reset();
+  Operator::close();
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/CrossJoinProbe.h
+++ b/velox/exec/CrossJoinProbe.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/CrossJoinBuild.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+class CrossJoinProbe : public Operator {
+ public:
+  CrossJoinProbe(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::CrossJoinNode>& hashJoinNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  bool needsInput() const override {
+    return !isFinishing_ && !input_;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  void close() override;
+
+ private:
+  std::vector<IdentityProjection> buildProjections_;
+
+  std::optional<std::vector<VectorPtr>> buildData_;
+
+  // Index into buildData_ for the build side vector to process on next call to
+  // getOutput().
+  size_t buildIndex_{0};
+
+  // Input row to process on next call to getOutput().
+  vector_size_t probeRow_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -243,6 +243,7 @@ struct DriverFactory {
     return std::nullopt;
   }
 
+  /// Returns plan node IDs of all HashJoinNode's in the pipeline.
   std::vector<core::PlanNodeId> needsHashJoinBridges() const {
     std::vector<core::PlanNodeId> planNodeIds;
     for (const auto& planNode : planNodes) {
@@ -252,6 +253,19 @@ struct DriverFactory {
       }
     }
     return planNodeIds;
+  }
+
+  /// Returns plan node IDs of all CrossJoinNode's in the pipeline.
+  std::vector<core::PlanNodeId> needsCrossJoinBridges() const {
+    std::vector<core::PlanNodeId> joinNodeIds;
+    for (const auto& planNode : planNodes) {
+      if (auto joinNode =
+              std::dynamic_pointer_cast<const core::CrossJoinNode>(planNode)) {
+        joinNodeIds.emplace_back(joinNode->id());
+      }
+    }
+
+    return joinNodeIds;
   }
 };
 

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <velox/exec/HashPartitionFunction.h>
+#include <velox/exec/VectorHasher.h>
+
+namespace facebook::velox::exec {
+HashPartitionFunction::HashPartitionFunction(
+    int numPartitions,
+    RowTypePtr inputType,
+    std::vector<ChannelIndex> keyChannels)
+    : numPartitions_{numPartitions}, keyChannels_{std::move(keyChannels)} {
+  hashers_.reserve(keyChannels_.size());
+  for (auto channel : keyChannels_) {
+    hashers_.emplace_back(
+        VectorHasher::create(inputType->childAt(channel), channel));
+  }
+}
+
+void HashPartitionFunction::partition(
+    const RowVector& input,
+    std::vector<uint32_t>& partitions) {
+  auto size = input.size();
+
+  rows_.resize(size);
+  rows_.setAll();
+
+  hashes_.resize(size);
+  for (auto i = 0; i < keyChannels_.size(); ++i) {
+    hashers_[i]->hash(*input.childAt(keyChannels_[i]), rows_, i > 0, &hashes_);
+  }
+
+  partitions.resize(size);
+  for (auto i = 0; i < size; ++i) {
+    partitions[i] = hashes_[i] % numPartitions_;
+  }
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <velox/exec/VectorHasher.h>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::exec {
+
+class HashPartitionFunction : public core::PartitionFunction {
+ public:
+  HashPartitionFunction(
+      int numPartitions,
+      RowTypePtr inputType,
+      std::vector<ChannelIndex> keyChannels);
+
+  ~HashPartitionFunction() override = default;
+
+  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
+      override;
+
+ private:
+  const int numPartitions_;
+  const std::vector<ChannelIndex> keyChannels_;
+  std::vector<std::unique_ptr<VectorHasher>> hashers_;
+
+  // Reusable memory.
+  SelectivityVector rows_;
+  std::vector<uint64_t> hashes_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/Task.h"
 #include "velox/codegen/Codegen.h"
 #include "velox/common/time/Timer.h"
+#include "velox/exec/CrossJoinBuild.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/LocalPlanner.h"
@@ -126,6 +127,7 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
     }
 
     self->addHashJoinBridges(factory->needsHashJoinBridges());
+    self->addCrossJoinBridges(factory->needsCrossJoinBridges());
 
     for (int32_t i = 0; i < numDrivers; ++i) {
       drivers.push_back(factory->createDriver(
@@ -454,6 +456,14 @@ void Task::addHashJoinBridges(
   }
 }
 
+void Task::addCrossJoinBridges(
+    const std::vector<core::PlanNodeId>& planNodeIds) {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (const auto& planNodeId : planNodeIds) {
+    bridges_.emplace(planNodeId, std::make_shared<CrossJoinBridge>());
+  }
+}
+
 std::shared_ptr<HashJoinBridge> Task::getHashJoinBridge(
     const core::PlanNodeId& planNodeId) {
   std::lock_guard<std::mutex> l(mutex_);
@@ -466,6 +476,22 @@ std::shared_ptr<HashJoinBridge> Task::getHashJoinBridge(
   VELOX_CHECK_NOT_NULL(
       bridge,
       "Join bridge for plan node ID is not a hash join bridge: {}",
+      planNodeId);
+  return bridge;
+}
+
+std::shared_ptr<CrossJoinBridge> Task::getCrossJoinBridge(
+    const core::PlanNodeId& planNodeId) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto it = bridges_.find(planNodeId);
+  VELOX_CHECK(
+      it != bridges_.end(),
+      "Join bridge for plan node ID not found:{}",
+      planNodeId);
+  auto bridge = std::dynamic_pointer_cast<CrossJoinBridge>(it->second);
+  VELOX_CHECK_NOT_NULL(
+      bridge,
+      "Join bridge for plan node ID is not a cross join bridge: {}",
       planNodeId);
   return bridge;
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -64,6 +64,7 @@ struct TaskStats {
 
 class JoinBridge;
 class HashJoinBridge;
+class CrossJoinBridge;
 
 class Task {
  public:
@@ -278,11 +279,18 @@ class Task {
   // Adds HashJoinBridge's for all the specified plan node IDs.
   void addHashJoinBridges(const std::vector<core::PlanNodeId>& planNodeIds);
 
+  // Adds CrossJoinBridge's for all the specified plan node IDs.
+  void addCrossJoinBridges(const std::vector<core::PlanNodeId>& planNodeIds);
+
   // Returns a HashJoinBridge for 'planNodeId'. This is used for synchronizing
   // start of probe with completion of build for a join that has a
   // separate probe and build. 'id' is the PlanNodeId shared between
   // the probe and build Operators of the join.
   std::shared_ptr<HashJoinBridge> getHashJoinBridge(
+      const core::PlanNodeId& planNodeId);
+
+  // Returns a CrossJoinBridge for 'planNodeId'.
+  std::shared_ptr<CrossJoinBridge> getCrossJoinBridge(
       const core::PlanNodeId& planNodeId);
 
   // Sets the CancelPool of the QueryCtx to a terminate requested

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
 
 add_executable(
   velox_exec_test
+  CrossJoinTest.cpp
   DriverTest.cpp
   EnforceSingleRowTest.cpp
   FilterProjectTest.cpp

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/HiveConnectorTestBase.h"
+#include "velox/exec/tests/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class CrossJoinTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+  }
+
+  template <typename T>
+  VectorPtr sequence(vector_size_t size, T start = 0) {
+    return makeFlatVector<int32_t>(
+        size, [start](auto row) { return start + row; });
+  }
+
+  template <typename T>
+  VectorPtr lazySequence(vector_size_t size, T start = 0) {
+    return vectorMaker_.lazyFlatVector<int32_t>(
+        size, [start](auto row) { return start + row; });
+  }
+};
+
+TEST_F(CrossJoinTest, basic) {
+  auto leftVectors = {
+      makeRowVector({sequence<int32_t>(10)}),
+      makeRowVector({sequence<int32_t>(100, 10)}),
+      makeRowVector({sequence<int32_t>(1'000, 10 + 100)}),
+      makeRowVector({sequence<int32_t>(7, 10 + 100 + 1'000)}),
+  };
+
+  auto rightVectors = {
+      makeRowVector({sequence<int32_t>(10)}),
+      makeRowVector({sequence<int32_t>(100, 10)}),
+      makeRowVector({sequence<int32_t>(1'000, 10 + 100)}),
+      makeRowVector({sequence<int32_t>(11, 10 + 100 + 1'000)}),
+  };
+
+  createDuckDbTable("t", {leftVectors});
+  createDuckDbTable("u", {rightVectors});
+
+  // All x 13. Join output vectors contains multiple probe rows each.
+  auto op = PlanBuilder(10)
+                .values({leftVectors})
+                .crossJoin(
+                    PlanBuilder(0)
+                        .values({rightVectors})
+                        .filter("c0 < 13")
+                        .project({"c0"}, {"u_c0"})
+                        .planNode(),
+                    {0, 1})
+                .planNode();
+
+  assertQuery(op, "SELECT * FROM t, u WHERE u.c0 < 13");
+
+  // 13 x all. Join output vectors contains single probe row each.
+  op = PlanBuilder(10)
+           .values({leftVectors})
+           .filter("c0 < 13")
+           .crossJoin(
+               PlanBuilder(0)
+                   .values({rightVectors})
+                   .project({"c0"}, {"u_c0"})
+                   .planNode(),
+               {0, 1})
+           .planNode();
+
+  assertQuery(op, "SELECT * FROM t, u WHERE t.c0 < 13");
+
+  // All x 13. No columns on the build side.
+  op = PlanBuilder(10)
+           .values({leftVectors})
+           .crossJoin(
+               PlanBuilder(0)
+                   .values({vectorMaker_.rowVector(ROW({}, {}), 13)})
+                   .planNode(),
+               {0})
+           .planNode();
+
+  assertQuery(op, "SELECT t.* FROM t, (SELECT * FROM u LIMIT 13) u");
+
+  // 13 x All. No columns on the build side.
+  op = PlanBuilder(10)
+           .values({leftVectors})
+           .filter("c0 < 13")
+           .crossJoin(
+               PlanBuilder(0)
+                   .values({vectorMaker_.rowVector(ROW({}, {}), 1121)})
+                   .planNode(),
+               {0})
+           .planNode();
+
+  assertQuery(
+      op,
+      "SELECT t.* FROM (SELECT * FROM t WHERE c0 < 13) t, (SELECT * FROM u LIMIT 1121) u");
+
+  // Empty build side.
+  op = PlanBuilder(10)
+           .values({leftVectors})
+           .crossJoin(
+               PlanBuilder(0)
+                   .values({rightVectors})
+                   .filter("c0 < 0")
+                   .project({"c0"}, {"u_c0"})
+                   .planNode(),
+               {0, 1})
+           .planNode();
+
+  assertQuery(op, "SELECT null, null LIMIT 0");
+
+  // Multi-threaded build side.
+  CursorParameters params;
+  params.maxDrivers = 4;
+  params.numResultDrivers = 1;
+  params.planNode = PlanBuilder(10)
+                        .values({leftVectors})
+                        .crossJoin(
+                            PlanBuilder(0)
+                                .values({rightVectors}, true)
+                                .filter("c0 in (10, 17)")
+                                .project({"c0"}, {"u_c0"})
+                                .planNode(),
+                            {0, 1})
+                        .limit(100'000, false)
+                        .planNode();
+
+  OperatorTestBase::assertQuery(
+      params,
+      "SELECT * FROM t, (SELECT * FROM UNNEST (ARRAY[10, 17, 10, 17, 10, 17, 10, 17])) u");
+}
+
+TEST_F(CrossJoinTest, lazyVectors) {
+  auto leftVectors = {
+      makeRowVector({lazySequence<int32_t>(10)}),
+      makeRowVector({lazySequence<int32_t>(100, 10)}),
+      makeRowVector({lazySequence<int32_t>(1'000, 10 + 100)}),
+      makeRowVector({lazySequence<int32_t>(7, 10 + 100 + 1'000)}),
+  };
+
+  auto rightVectors = {
+      makeRowVector({lazySequence<int32_t>(10)}),
+      makeRowVector({lazySequence<int32_t>(100, 10)}),
+      makeRowVector({lazySequence<int32_t>(1'000, 10 + 100)}),
+      makeRowVector({lazySequence<int32_t>(11, 10 + 100 + 1'000)}),
+  };
+
+  createDuckDbTable("t", {makeRowVector({sequence<int32_t>(1117)})});
+  createDuckDbTable("u", {makeRowVector({sequence<int32_t>(1121)})});
+
+  auto op = PlanBuilder(10)
+                .values({leftVectors})
+                .crossJoin(
+                    PlanBuilder(0)
+                        .values({rightVectors})
+                        .project({"c0"}, {"u_c0"})
+                        .planNode(),
+                    {0, 1})
+                .filter("c0 + u_c0 < 100")
+                .planNode();
+
+  assertQuery(op, "SELECT * FROM t, u WHERE t.c0 + u.c0 < 100");
+}

--- a/velox/exec/tests/Cursor.cpp
+++ b/velox/exec/tests/Cursor.cpp
@@ -112,7 +112,10 @@ TaskCursor::TaskCursor(const CursorParameters& params)
   } else {
     queryCtx = core::QueryCtx::create();
   }
-  queue_ = std::make_shared<TaskQueue>(maxDrivers_, params.bufferedBytes);
+  auto numProducers = params.numResultDrivers.has_value()
+      ? params.numResultDrivers.value()
+      : params.maxDrivers;
+  queue_ = std::make_shared<TaskQueue>(numProducers, params.bufferedBytes);
   // Captured as a shared_ptr by the consumer callback of task_.
   auto queue = queue_;
   task_ = std::make_shared<exec::Task>(

--- a/velox/exec/tests/Cursor.h
+++ b/velox/exec/tests/Cursor.h
@@ -26,6 +26,9 @@ struct CursorParameters {
   int32_t destination = 0;
   // Maximum number of drivers per pipeline.
   int32_t maxDrivers = 1;
+  // Number of drivers for the pipeline that produces task results. Cannot
+  // exceed numThreads, but can be less.
+  std::optional<int32_t> numResultDrivers;
   // Optional, created if not present.
   std::shared_ptr<core::QueryCtx> queryCtx;
   uint64_t bufferedBytes = 512 * 1024;

--- a/velox/exec/tests/PlanBuilder.cpp
+++ b/velox/exec/tests/PlanBuilder.cpp
@@ -448,6 +448,17 @@ PlanBuilder& PlanBuilder::hashJoin(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::crossJoin(
+    const std::shared_ptr<core::PlanNode>& build,
+    const std::vector<ChannelIndex>& output) {
+  auto resultType = concat(planNode_->outputType(), build->outputType());
+  auto outputType = extract(resultType, output);
+
+  planNode_ = std::make_shared<core::CrossJoinNode>(
+      nextPlanNodeId(), std::move(planNode_), build, outputType);
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::unnest(
     const std::vector<std::string>& replicateColumns,
     const std::vector<std::string>& unnestColumns,

--- a/velox/exec/tests/PlanBuilder.h
+++ b/velox/exec/tests/PlanBuilder.h
@@ -182,6 +182,10 @@ class PlanBuilder {
       const std::vector<ChannelIndex>& output,
       core::JoinType joinType = core::JoinType::kInner);
 
+  PlanBuilder& crossJoin(
+      const std::shared_ptr<core::PlanNode>& build,
+      const std::vector<ChannelIndex>& output);
+
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,


### PR DESCRIPTION
HivePartitionFunction is compatible with Hive bucketing and allows to
efficiently join bucketed and non-bucketed tables on bucket-by join keys by
partitioning non-bucketed table into partitions made of whole buckets.

This commits includes support for BIGINT and VARCHAR types. Future 
commits will add support for other types.