### PR TITLE
Keep operator memory pools alive for the duration of the task

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -75,6 +75,10 @@ DriverCtx::DriverCtx(
       pipelineId(_pipelineId),
       numDrivers(_numDrivers) {}
 
+velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
+  return task->addOperatorPool(execCtx->pool());
+}
+
 std::unique_ptr<connector::ConnectorQueryCtx>
 DriverCtx::createConnectorQueryCtx(const std::string& connectorId) const {
   return std::make_unique<connector::ConnectorQueryCtx>(

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -82,19 +82,10 @@ struct DriverCtx {
       int _pipelineId,
       int32_t numDrivers);
 
-  velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool() {
-    opMemPools_.push_back(execCtx->pool()->addScopedChild("operator_ctx"));
-    return opMemPools_.back().get();
-  }
+  velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool();
 
   std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
       const std::string& connectorId) const;
-
- private:
-  // Lifetime of operator memory pools is same as the driverCtx, since some
-  // buffers allocated within an operator context may still be referenced by
-  // other operators.
-  std::vector<std::unique_ptr<velox::memory::MemoryPool>> opMemPools_;
 };
 
 class Driver {
@@ -270,10 +261,10 @@ struct DriverFactory {
 // the contending threads go suspended and each in turn enters a
 // global critical section. When running the arbitration strategy, a
 // thread can stop and restart Tasks, including its own. When a Task
-// is stopped, its drivers are blocked or suspended and the strategy thread can
-// alter the Task's memory including spilling or killing the whole Task. Other
-// threads waiting to run the arbitration, are in a suspended state which also
-// means that they are instantaneously killable or spillable.
+// is stopped, its drivers are blocked or suspended and the strategy thread
+// can alter the Task's memory including spilling or killing the whole Task.
+// Other threads waiting to run the arbitration, are in a suspended state
+// which also means that they are instantaneously killable or spillable.
 class SuspendedSection {
  public:
   explicit SuspendedSection(Driver* FOLLY_NONNULL driver);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -22,6 +22,9 @@
 
 namespace facebook::velox::exec {
 
+OperatorCtx::OperatorCtx(DriverCtx* driverCtx)
+    : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorPool()) {}
+
 std::vector<Operator::PlanNodeTranslator>& Operator::translators() {
   static std::vector<PlanNodeTranslator> translators;
   return translators;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -153,8 +153,7 @@ struct OperatorStats {
 
 class OperatorCtx {
  public:
-  explicit OperatorCtx(DriverCtx* driverCtx)
-      : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorPool()) {}
+  explicit OperatorCtx(DriverCtx* driverCtx);
 
   velox::memory::MemoryPool* pool() const {
     return pool_;


### PR DESCRIPTION
We need to keep driver and operator memory pools alive for the duration of the
task to allow for passing vectors between operators without copy. #295 extended
lifetime of the drivers. This commit extends lifetime of the operators.