### PR TITLE
Expose updatePartial/Final as public API and remove update

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -50,9 +50,11 @@ GroupingSet::GroupingSet(
     std::vector<std::vector<ChannelIndex>>&& channelLists,
     std::vector<std::vector<VectorPtr>>&& constantLists,
     bool ignoreNullKeys,
+    bool isRawInput,
     OperatorCtx* operatorCtx)
     : hashers_(std::move(hashers)),
       isGlobal_(hashers_.empty()),
+      isRawInput_(isRawInput),
       aggregates_(std::move(aggregates)),
       aggrMaskChannels_(std::move(aggrMaskChannels)),
       channelLists_(std::move(channelLists)),
@@ -93,8 +95,13 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
       const SelectivityVector& rows = getSelectivityVector(i);
       const bool canPushdown =
           mayPushdown && mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
-      aggregates_[i]->updateSingleGroup(
-          lookup_->hits[0], rows, tempVectors_, canPushdown);
+      if (isRawInput_) {
+        aggregates_[i]->updateSingleGroupPartial(
+            lookup_->hits[0], rows, tempVectors_, canPushdown);
+      } else {
+        aggregates_[i]->updateSingleGroupFinal(
+            lookup_->hits[0], rows, tempVectors_, canPushdown);
+      }
     }
     tempVectors_.clear();
     return;
@@ -168,8 +175,13 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
     const bool canPushdown = (&rows != &activeRows_) && mayPushdown &&
         mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
     populateTempVectors(i, input);
-    aggregates_[i]->update(
-        lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    if (isRawInput_) {
+      aggregates_[i]->updatePartial(
+          lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    } else {
+      aggregates_[i]->updateFinal(
+          lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    }
   }
   tempVectors_.clear();
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -31,6 +31,7 @@ class GroupingSet {
       std::vector<std::vector<ChannelIndex>>&& channelLists,
       std::vector<std::vector<VectorPtr>>&& constantLists,
       bool ignoreNullKeys,
+      bool isRawInput,
       OperatorCtx* driverCtx);
 
   void addInput(const RowVectorPtr& input, bool mayPushdown);
@@ -66,6 +67,7 @@ class GroupingSet {
   std::vector<ChannelIndex> keyChannels_;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   const bool isGlobal_;
+  const bool isRawInput_;
   std::vector<std::unique_ptr<Aggregate>> aggregates_;
   // For each aggregation, can hold an index to a boolean channel (projection in
   // the input row vector), that acts as row mask for the aggregation.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/HashAggregation.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -117,6 +118,7 @@ HashAggregation::HashAggregation(
       std::move(args),
       std::move(constantLists),
       aggregationNode->ignoreNullKeys(),
+      isRawInput(aggregationNode->step()),
       operatorCtx_.get());
 }
 


### PR DESCRIPTION
Summary:
1.Make `updatePartial`, `updateFinal`, `updateSingleGroupFinal`, `updateSingleGroupPartial` public API.
2.Make the caller aggregate call corresponding method depending on the input type instead of doing that inside aggregate.

Differential Revision: D31184583

