### PR TITLE
Remove passing step as an input parameter to Aggregate constructor

### DIFF
--- a/velox/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/aggregates/ApproxDistinctAggregate.cpp
@@ -109,10 +109,8 @@ inline uint64_t hashOne<StringView>(StringView value) {
 template <typename T>
 class ApproxDistinctAggregate : public exec::Aggregate {
  public:
-  ApproxDistinctAggregate(
-      core::AggregationNode::Step step,
-      const TypePtr& resultType)
-      : exec::Aggregate(step, resultType) {}
+  explicit ApproxDistinctAggregate(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(HllAccumulator);
@@ -357,10 +355,9 @@ class ApproxDistinctAggregate : public exec::Aggregate {
 
 template <TypeKind kind>
 std::unique_ptr<exec::Aggregate> createApproxDistinct(
-    core::AggregationNode::Step step,
     const TypePtr& resultType) {
   using T = typename TypeTraits<kind>::NativeType;
-  return std::make_unique<ApproxDistinctAggregate<T>>(step, resultType);
+  return std::make_unique<ApproxDistinctAggregate<T>>(resultType);
 }
 
 bool registerApproxDistinct(const std::string& name) {
@@ -396,7 +393,7 @@ bool registerApproxDistinct(const std::string& name) {
             ? std::dynamic_pointer_cast<const Type>(VARBINARY())
             : BIGINT();
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-            createApproxDistinct, type->kind(), step, aggResultType);
+            createApproxDistinct, type->kind(), aggResultType);
       });
   return true;
 }

--- a/velox/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/aggregates/ApproxPercentileAggregate.cpp
@@ -203,11 +203,8 @@ struct TDigestAccumulator {
 template <typename T>
 class ApproxPercentileAggregate : public exec::Aggregate {
  public:
-  ApproxPercentileAggregate(
-      core::AggregationNode::Step step,
-      bool hasWeight,
-      const TypePtr& resultType)
-      : exec::Aggregate(step, resultType), hasWeight_{hasWeight} {}
+  ApproxPercentileAggregate(bool hasWeight, const TypePtr& resultType)
+      : exec::Aggregate(resultType), hasWeight_{hasWeight} {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(TDigestAccumulator);
@@ -547,7 +544,7 @@ bool registerApproxPercentile(const std::string& name) {
 
         if (step == core::AggregationNode::Step::kIntermediate) {
           return std::make_unique<ApproxPercentileAggregate<double>>(
-              step, false, VARBINARY());
+              false, VARBINARY());
         }
 
         auto aggResultType =
@@ -556,22 +553,22 @@ bool registerApproxPercentile(const std::string& name) {
         switch (type->kind()) {
           case TypeKind::TINYINT:
             return std::make_unique<ApproxPercentileAggregate<int8_t>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           case TypeKind::SMALLINT:
             return std::make_unique<ApproxPercentileAggregate<int16_t>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           case TypeKind::INTEGER:
             return std::make_unique<ApproxPercentileAggregate<int32_t>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           case TypeKind::BIGINT:
             return std::make_unique<ApproxPercentileAggregate<int64_t>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           case TypeKind::REAL:
             return std::make_unique<ApproxPercentileAggregate<float>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           case TypeKind::DOUBLE:
             return std::make_unique<ApproxPercentileAggregate<double>>(
-                step, hasWeight, aggResultType);
+                hasWeight, aggResultType);
           default:
             VELOX_USER_FAIL(
                 "Unsupported input type for {} aggregation {}",

--- a/velox/aggregates/ArbitraryAggregate.cpp
+++ b/velox/aggregates/ArbitraryAggregate.cpp
@@ -32,10 +32,7 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
   using BaseAggregate = SimpleNumericAggregate<T, T, T>;
 
  public:
-  explicit ArbitraryAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType)
-      : BaseAggregate(step, resultType) {}
+  explicit ArbitraryAggregate(TypePtr resultType) : BaseAggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(T);
@@ -146,10 +143,8 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
 // seen. Arbitrary (x) will produce partial and final aggregations of type x.
 class NonNumericArbitrary : public exec::Aggregate {
  public:
-  explicit NonNumericArbitrary(
-      core::AggregationNode::Step step,
-      const TypePtr& resultType)
-      : exec::Aggregate(step, resultType) {}
+  explicit NonNumericArbitrary(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
 
   // We use singleValueAccumulator to save the results for each group. This
   // struct will allow us to save variable-width value.
@@ -283,27 +278,22 @@ bool registerArbitraryAggregate(const std::string& name) {
         auto inputType = argTypes[0];
         switch (inputType->kind()) {
           case TypeKind::TINYINT:
-            return std::make_unique<ArbitraryAggregate<int8_t>>(
-                step, inputType);
+            return std::make_unique<ArbitraryAggregate<int8_t>>(inputType);
           case TypeKind::SMALLINT:
-            return std::make_unique<ArbitraryAggregate<int16_t>>(
-                step, inputType);
+            return std::make_unique<ArbitraryAggregate<int16_t>>(inputType);
           case TypeKind::INTEGER:
-            return std::make_unique<ArbitraryAggregate<int32_t>>(
-                step, inputType);
+            return std::make_unique<ArbitraryAggregate<int32_t>>(inputType);
           case TypeKind::BIGINT:
-            return std::make_unique<ArbitraryAggregate<int64_t>>(
-                step, inputType);
+            return std::make_unique<ArbitraryAggregate<int64_t>>(inputType);
           case TypeKind::REAL:
-            return std::make_unique<ArbitraryAggregate<float>>(step, inputType);
+            return std::make_unique<ArbitraryAggregate<float>>(inputType);
           case TypeKind::DOUBLE:
-            return std::make_unique<ArbitraryAggregate<double>>(
-                step, inputType);
+            return std::make_unique<ArbitraryAggregate<double>>(inputType);
           case TypeKind::VARCHAR:
           case TypeKind::ARRAY:
           case TypeKind::MAP:
           case TypeKind::ROW:
-            return std::make_unique<NonNumericArbitrary>(step, inputType);
+            return std::make_unique<NonNumericArbitrary>(inputType);
           default:
             VELOX_FAIL(
                 "Unknown input type for {} aggregation {}",

--- a/velox/aggregates/ArrayAggAggregate.cpp
+++ b/velox/aggregates/ArrayAggAggregate.cpp
@@ -27,10 +27,7 @@ struct ArrayAccumulator {
 
 class ArrayAggAggregate : public exec::Aggregate {
  public:
-  explicit ArrayAggAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType)
-      : Aggregate(step, resultType) {}
+  explicit ArrayAggAggregate(TypePtr resultType) : Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(ArrayAccumulator);
@@ -181,7 +178,7 @@ bool registerArrayAggregate(const std::string& name) {
             argTypes.size(), 1, "{} takes at most one argument", name);
         auto rawInput = exec::isRawInput(step);
         TypePtr returnType = rawInput ? ARRAY(argTypes[0]) : argTypes[0];
-        return std::make_unique<ArrayAggAggregate>(step, returnType);
+        return std::make_unique<ArrayAggAggregate>(returnType);
       });
   return true;
 }

--- a/velox/aggregates/AverageAggregate.cpp
+++ b/velox/aggregates/AverageAggregate.cpp
@@ -34,8 +34,7 @@ struct SumCount {
 template <typename T>
 class AverageAggregate : public exec::Aggregate {
  public:
-  AverageAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : exec::Aggregate(step, resultType) {}
+  explicit AverageAggregate(TypePtr resultType) : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(SumCount);
@@ -305,20 +304,15 @@ bool registerAverageAggregate(const std::string& name) {
         if (exec::isRawInput(step)) {
           switch (inputType->kind()) {
             case TypeKind::SMALLINT:
-              return std::make_unique<AverageAggregate<int16_t>>(
-                  step, resultType);
+              return std::make_unique<AverageAggregate<int16_t>>(resultType);
             case TypeKind::INTEGER:
-              return std::make_unique<AverageAggregate<int32_t>>(
-                  step, resultType);
+              return std::make_unique<AverageAggregate<int32_t>>(resultType);
             case TypeKind::BIGINT:
-              return std::make_unique<AverageAggregate<int64_t>>(
-                  step, resultType);
+              return std::make_unique<AverageAggregate<int64_t>>(resultType);
             case TypeKind::REAL:
-              return std::make_unique<AverageAggregate<float>>(
-                  step, resultType);
+              return std::make_unique<AverageAggregate<float>>(resultType);
             case TypeKind::DOUBLE:
-              return std::make_unique<AverageAggregate<double>>(
-                  step, resultType);
+              return std::make_unique<AverageAggregate<double>>(resultType);
             default:
               VELOX_FAIL(
                   "Unknown input type for {} aggregation {}",
@@ -330,7 +324,7 @@ bool registerAverageAggregate(const std::string& name) {
           checkSumCountRowType(
               inputType,
               "Input type for final aggregation must be (sum:double, count:bigint) struct");
-          return std::make_unique<AverageAggregate<int64_t>>(step, resultType);
+          return std::make_unique<AverageAggregate<int64_t>>(resultType);
         }
       });
   return true;

--- a/velox/aggregates/BitwiseAggregates.cpp
+++ b/velox/aggregates/BitwiseAggregates.cpp
@@ -27,11 +27,8 @@ class BitwiseAndOrAggregate : public SimpleNumericAggregate<T, T, T> {
   using BaseAggregate = SimpleNumericAggregate<T, T, T>;
 
  public:
-  BitwiseAndOrAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType,
-      T initialValue)
-      : BaseAggregate(step, resultType), initialValue_(initialValue) {}
+  BitwiseAndOrAggregate(TypePtr resultType, T initialValue)
+      : BaseAggregate(resultType), initialValue_(initialValue) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(T);
@@ -83,11 +80,8 @@ class BitwiseAndOrAggregate : public SimpleNumericAggregate<T, T, T> {
 template <typename T>
 class BitwiseOrAggregate : public BitwiseAndOrAggregate<T> {
  public:
-  explicit BitwiseOrAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType)
+  explicit BitwiseOrAggregate(TypePtr resultType)
       : BitwiseAndOrAggregate<T>(
-            step,
             resultType,
             /* initialValue = */ 0) {}
 
@@ -124,11 +118,8 @@ class BitwiseOrAggregate : public BitwiseAndOrAggregate<T> {
 template <typename T>
 class BitwiseAndAggregate : public BitwiseAndOrAggregate<T> {
  public:
-  explicit BitwiseAndAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType)
+  explicit BitwiseAndAggregate(TypePtr resultType)
       : BitwiseAndOrAggregate<T>(
-            step,
             resultType,
             /* initialValue = */ -1) {}
 
@@ -175,13 +166,13 @@ bool registerBitwiseAggregate(const std::string& name) {
         auto inputType = argTypes[0];
         switch (inputType->kind()) {
           case TypeKind::TINYINT:
-            return std::make_unique<T<int8_t>>(step, inputType);
+            return std::make_unique<T<int8_t>>(inputType);
           case TypeKind::SMALLINT:
-            return std::make_unique<T<int16_t>>(step, inputType);
+            return std::make_unique<T<int16_t>>(inputType);
           case TypeKind::INTEGER:
-            return std::make_unique<T<int32_t>>(step, inputType);
+            return std::make_unique<T<int32_t>>(inputType);
           case TypeKind::BIGINT:
-            return std::make_unique<T<int64_t>>(step, inputType);
+            return std::make_unique<T<int64_t>>(inputType);
           default:
             VELOX_CHECK(
                 false,

--- a/velox/aggregates/BoolAggregates.cpp
+++ b/velox/aggregates/BoolAggregates.cpp
@@ -28,10 +28,8 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
   using BaseAggregate = SimpleNumericAggregate<bool, bool, bool>;
 
  public:
-  explicit BoolAndOrAggregate(
-      core::AggregationNode::Step step,
-      bool initialValue)
-      : BaseAggregate(step, BOOLEAN()), initialValue_(initialValue) {}
+  explicit BoolAndOrAggregate(bool initialValue)
+      : BaseAggregate(BOOLEAN()), initialValue_(initialValue) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(bool);
@@ -84,8 +82,7 @@ class BoolAndOrAggregate : public SimpleNumericAggregate<bool, bool, bool> {
 
 class BoolAndAggregate final : public BoolAndOrAggregate {
  public:
-  explicit BoolAndAggregate(core::AggregationNode::Step step)
-      : BoolAndOrAggregate(step, /* initialValue = */ true) {}
+  explicit BoolAndAggregate() : BoolAndOrAggregate(/* initialValue = */ true) {}
 
   void updatePartial(
       char** groups,
@@ -136,8 +133,7 @@ class BoolAndAggregate final : public BoolAndOrAggregate {
 
 class BoolOrAggregate final : public BoolAndOrAggregate {
  public:
-  explicit BoolOrAggregate(core::AggregationNode::Step step)
-      : BoolAndOrAggregate(step, /* initialValue = */ false) {}
+  explicit BoolOrAggregate() : BoolAndOrAggregate(/* initialValue = */ false) {}
 
   void updatePartial(
       char** groups,
@@ -203,7 +199,7 @@ bool registerBoolAggregate(const std::string& name) {
             "Unknown input type for {} aggregation {}",
             name,
             inputType->kindName());
-        return std::make_unique<T>(step);
+        return std::make_unique<T>();
       });
   return true;
 }

--- a/velox/aggregates/CountAggregate.cpp
+++ b/velox/aggregates/CountAggregate.cpp
@@ -24,8 +24,7 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
   using BaseAggregate = SimpleNumericAggregate<bool, int64_t, int64_t>;
 
  public:
-  explicit CountAggregate(core::AggregationNode::Step step)
-      : BaseAggregate(step, BIGINT()) {}
+  explicit CountAggregate() : BaseAggregate(BIGINT()) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(int64_t);
@@ -143,10 +142,10 @@ bool registerCountAggregate(const std::string& name) {
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         if (exec::isRawInput(step)) {
-          return std::make_unique<CountAggregate>(step);
+          return std::make_unique<CountAggregate>();
         } else {
           return std::make_unique<SumAggregate<int64_t, int64_t, int64_t>>(
-              step, BIGINT());
+              BIGINT());
         }
       });
   return true;

--- a/velox/aggregates/CountIfAggregate.cpp
+++ b/velox/aggregates/CountIfAggregate.cpp
@@ -24,8 +24,7 @@ namespace facebook::velox::aggregate {
 
 class CountIfAggregate : public exec::Aggregate {
  public:
-  explicit CountIfAggregate(core::AggregationNode::Step step)
-      : exec::Aggregate(step, BIGINT()) {}
+  explicit CountIfAggregate() : exec::Aggregate(BIGINT()) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(int64_t);
@@ -191,7 +190,7 @@ bool registerCountIfAggregate(const std::string& name) {
               name);
         }
 
-        return std::make_unique<CountIfAggregate>(step);
+        return std::make_unique<CountIfAggregate>();
       });
   return true;
 }

--- a/velox/aggregates/MapAggAggregate.cpp
+++ b/velox/aggregates/MapAggAggregate.cpp
@@ -29,8 +29,7 @@ struct MapAccumulator {
 // https://prestodb.io/docs/current/functions/aggregate.html
 class MapAggAggregate : public exec::Aggregate {
  public:
-  explicit MapAggAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : Aggregate(step, resultType) {}
+  explicit MapAggAggregate(TypePtr resultType) : Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(MapAccumulator);
@@ -279,7 +278,7 @@ bool registerMapAggAggregate(const std::string& name) {
             name);
         TypePtr returnType =
             rawInput ? MAP(argTypes[0], argTypes[1]) : argTypes[0];
-        return std::make_unique<MapAggAggregate>(step, returnType);
+        return std::make_unique<MapAggAggregate>(returnType);
       });
   return true;
 }

--- a/velox/aggregates/MinMaxAggregates.cpp
+++ b/velox/aggregates/MinMaxAggregates.cpp
@@ -44,8 +44,7 @@ class MinMaxAggregate : public SimpleNumericAggregate<T, T, ResultType> {
   using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
 
  public:
-  MinMaxAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : BaseAggregate(step, resultType) {}
+  explicit MinMaxAggregate(TypePtr resultType) : BaseAggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(T);
@@ -88,8 +87,8 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
   using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
 
  public:
-  MaxAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : MinMaxAggregate<T, ResultType>(step, resultType) {}
+  explicit MaxAggregate(TypePtr resultType)
+      : MinMaxAggregate<T, ResultType>(resultType) {}
 
   void initializeNewGroups(
       char** groups,
@@ -169,8 +168,8 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
   using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
 
  public:
-  MinAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : MinMaxAggregate<T, ResultType>(step, resultType) {}
+  explicit MinAggregate(TypePtr resultType)
+      : MinMaxAggregate<T, ResultType>(resultType) {}
 
   void initializeNewGroups(
       char** groups,
@@ -247,10 +246,8 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
 
 class NonNumericMinMaxAggregateBase : public exec::Aggregate {
  public:
-  NonNumericMinMaxAggregateBase(
-      core::AggregationNode::Step step,
-      const TypePtr& resultType)
-      : exec::Aggregate(step, resultType) {}
+  explicit NonNumericMinMaxAggregateBase(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(SingleValueAccumulator);
@@ -380,10 +377,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
 class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {
  public:
-  NonNumericMaxAggregate(
-      core::AggregationNode::Step step,
-      const TypePtr& resultType)
-      : NonNumericMinMaxAggregateBase(step, resultType) {}
+  explicit NonNumericMaxAggregate(const TypePtr& resultType)
+      : NonNumericMinMaxAggregateBase(resultType) {}
 
   void updatePartial(
       char** groups,
@@ -424,10 +419,8 @@ class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {
 
 class NonNumericMinAggregate : public NonNumericMinMaxAggregateBase {
  public:
-  NonNumericMinAggregate(
-      core::AggregationNode::Step step,
-      const TypePtr& resultType)
-      : NonNumericMinMaxAggregateBase(step, resultType) {}
+  explicit NonNumericMinAggregate(const TypePtr& resultType)
+      : NonNumericMinMaxAggregateBase(resultType) {}
 
   void updatePartial(
       char** groups,
@@ -469,21 +462,20 @@ class NonNumericMinAggregate : public NonNumericMinMaxAggregateBase {
 template <typename TInput, template <typename U, typename V> class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxIntegralAggregate(
     const std::string& name,
-    core::AggregationNode::Step step,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::TINYINT:
-      return std::make_unique<TNumeric<TInput, int8_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int8_t>>(resultType);
     case TypeKind::SMALLINT:
-      return std::make_unique<TNumeric<TInput, int16_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int16_t>>(resultType);
     case TypeKind::INTEGER:
-      return std::make_unique<TNumeric<TInput, int32_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int32_t>>(resultType);
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
     case TypeKind::REAL:
-      return std::make_unique<TNumeric<TInput, float>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, float>>(resultType);
     case TypeKind::DOUBLE:
-      return std::make_unique<TNumeric<TInput, double>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, double>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with integral input type: {}",
@@ -495,13 +487,12 @@ std::unique_ptr<exec::Aggregate> createMinMaxIntegralAggregate(
 template <typename TInput, template <typename U, typename V> class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxTimestampAggregate(
     const std::string& name,
-    core::AggregationNode::Step step,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
     case TypeKind::TIMESTAMP:
-      return std::make_unique<TNumeric<TInput, Timestamp>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, Timestamp>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with timestamp input type: {}",
@@ -513,15 +504,14 @@ std::unique_ptr<exec::Aggregate> createMinMaxTimestampAggregate(
 template <typename TInput, template <typename U, typename V> class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxFloatingPointAggregate(
     const std::string& name,
-    core::AggregationNode::Step step,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::REAL:
-      return std::make_unique<TNumeric<TInput, float>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, float>>(resultType);
     case TypeKind::DOUBLE:
-      return std::make_unique<TNumeric<TInput, double>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, double>>(resultType);
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(step, resultType);
+      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with floating point input type: {}",
@@ -550,34 +540,34 @@ bool registerMinMaxAggregate(const std::string& name) {
         switch (inputType->kind()) {
           case TypeKind::TINYINT:
             return createMinMaxIntegralAggregate<int8_t, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::SMALLINT:
             return createMinMaxIntegralAggregate<int16_t, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::INTEGER:
             return createMinMaxIntegralAggregate<int32_t, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::BIGINT:
             if (adjustedResultType->isTimestamp()) {
               return std::make_unique<TNumeric<int64_t, Timestamp>>(
-                  step, adjustedResultType);
+                  adjustedResultType);
             }
             return createMinMaxIntegralAggregate<int64_t, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::REAL:
             return createMinMaxFloatingPointAggregate<float, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::DOUBLE:
             return createMinMaxFloatingPointAggregate<double, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::TIMESTAMP:
             return createMinMaxTimestampAggregate<Timestamp, TNumeric>(
-                name, step, adjustedResultType);
+                name, adjustedResultType);
           case TypeKind::VARCHAR:
           case TypeKind::ARRAY:
           case TypeKind::MAP:
           case TypeKind::ROW:
-            return std::make_unique<TNonNumeric>(step, inputType);
+            return std::make_unique<TNonNumeric>(inputType);
           default:
             VELOX_CHECK(
                 false,

--- a/velox/aggregates/SimpleNumericAggregate.h
+++ b/velox/aggregates/SimpleNumericAggregate.h
@@ -26,10 +26,7 @@ namespace facebook::velox::aggregate {
 template <typename TInput, typename TAccumulator, typename TResult>
 class SimpleNumericAggregate : public exec::Aggregate {
  protected:
-  explicit SimpleNumericAggregate(
-      core::AggregationNode::Step step,
-      TypePtr resultType)
-      : Aggregate(step, resultType) {}
+  explicit SimpleNumericAggregate(TypePtr resultType) : Aggregate(resultType) {}
 
  public:
   void finalize(char** /* unused */, int32_t /* unused */) override {}

--- a/velox/aggregates/SumAggregate.h
+++ b/velox/aggregates/SumAggregate.h
@@ -26,8 +26,7 @@ class SumAggregate
       SimpleNumericAggregate<TInput, TAccumulator, ResultType>;
 
  public:
-  explicit SumAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : BaseAggregate(step, resultType) {}
+  explicit SumAggregate(TypePtr resultType) : BaseAggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(TAccumulator);
@@ -158,29 +157,23 @@ bool registerSumAggregate(const std::string& name) {
         auto inputType = argTypes[0];
         switch (inputType->kind()) {
           case TypeKind::TINYINT:
-            return std::make_unique<T<int8_t, int64_t, int64_t>>(
-                step, BIGINT());
+            return std::make_unique<T<int8_t, int64_t, int64_t>>(BIGINT());
           case TypeKind::SMALLINT:
-            return std::make_unique<T<int16_t, int64_t, int64_t>>(
-                step, BIGINT());
+            return std::make_unique<T<int16_t, int64_t, int64_t>>(BIGINT());
           case TypeKind::INTEGER:
-            return std::make_unique<T<int32_t, int64_t, int64_t>>(
-                step, BIGINT());
+            return std::make_unique<T<int32_t, int64_t, int64_t>>(BIGINT());
           case TypeKind::BIGINT:
-            return std::make_unique<T<int64_t, int64_t, int64_t>>(
-                step, BIGINT());
+            return std::make_unique<T<int64_t, int64_t, int64_t>>(BIGINT());
           case TypeKind::REAL:
             if (resultType->kind() == TypeKind::REAL) {
-              return std::make_unique<T<float, double, float>>(
-                  step, resultType);
+              return std::make_unique<T<float, double, float>>(resultType);
             }
-            return std::make_unique<T<float, double, double>>(step, DOUBLE());
+            return std::make_unique<T<float, double, double>>(DOUBLE());
           case TypeKind::DOUBLE:
             if (resultType->kind() == TypeKind::REAL) {
-              return std::make_unique<T<double, double, float>>(
-                  step, resultType);
+              return std::make_unique<T<double, double, float>>(resultType);
             }
-            return std::make_unique<T<double, double, double>>(step, DOUBLE());
+            return std::make_unique<T<double, double, double>>(DOUBLE());
           default:
             VELOX_CHECK(
                 false,

--- a/velox/aggregates/VarianceAggregates.cpp
+++ b/velox/aggregates/VarianceAggregates.cpp
@@ -133,8 +133,8 @@ struct VarSampResultAccessor {
 template <typename T, typename TResultAccessor>
 class VarianceAggregate : public exec::Aggregate {
  public:
-  VarianceAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : exec::Aggregate(step, resultType) {}
+  explicit VarianceAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(VarianceAccumulator);
@@ -419,8 +419,8 @@ template <typename T>
 class StdDevPopAggregate
     : public VarianceAggregate<T, StdDevPopResultAccessor> {
  public:
-  StdDevPopAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : VarianceAggregate<T, StdDevPopResultAccessor>(step, resultType) {}
+  explicit StdDevPopAggregate(TypePtr resultType)
+      : VarianceAggregate<T, StdDevPopResultAccessor>(resultType) {}
 };
 
 // Implements 'Sample Standard Deviation' aggregate.
@@ -429,8 +429,8 @@ template <typename T>
 class StdDevSampAggregate
     : public VarianceAggregate<T, StdDevSampResultAccessor> {
  public:
-  StdDevSampAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : VarianceAggregate<T, StdDevSampResultAccessor>(step, resultType) {}
+  explicit StdDevSampAggregate(TypePtr resultType)
+      : VarianceAggregate<T, StdDevSampResultAccessor>(resultType) {}
 };
 
 // Implements 'Population Variance' aggregate.
@@ -438,8 +438,8 @@ class StdDevSampAggregate
 template <typename T>
 class VarPopAggregate : public VarianceAggregate<T, VarPopResultAccessor> {
  public:
-  VarPopAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : VarianceAggregate<T, VarPopResultAccessor>(step, resultType) {}
+  explicit VarPopAggregate(TypePtr resultType)
+      : VarianceAggregate<T, VarPopResultAccessor>(resultType) {}
 };
 
 // Implements 'Sample Variance' aggregate.
@@ -447,8 +447,8 @@ class VarPopAggregate : public VarianceAggregate<T, VarPopResultAccessor> {
 template <typename T>
 class VarSampAggregate : public VarianceAggregate<T, VarSampResultAccessor> {
  public:
-  VarSampAggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : VarianceAggregate<T, VarSampResultAccessor>(step, resultType) {}
+  explicit VarSampAggregate(TypePtr resultType)
+      : VarianceAggregate<T, VarSampResultAccessor>(resultType) {}
 };
 
 // Registration code
@@ -486,15 +486,15 @@ bool registerVarianceAggregate(const std::string& name) {
         if (exec::isRawInput(step)) {
           switch (inputType->kind()) {
             case TypeKind::SMALLINT:
-              return std::make_unique<TClass<int16_t>>(step, resultType);
+              return std::make_unique<TClass<int16_t>>(resultType);
             case TypeKind::INTEGER:
-              return std::make_unique<TClass<int32_t>>(step, resultType);
+              return std::make_unique<TClass<int32_t>>(resultType);
             case TypeKind::BIGINT:
-              return std::make_unique<TClass<int64_t>>(step, resultType);
+              return std::make_unique<TClass<int64_t>>(resultType);
             case TypeKind::REAL:
-              return std::make_unique<TClass<float>>(step, resultType);
+              return std::make_unique<TClass<float>>(resultType);
             case TypeKind::DOUBLE:
-              return std::make_unique<TClass<double>>(step, resultType);
+              return std::make_unique<TClass<double>>(resultType);
             default:
               VELOX_FAIL(
                   "Unknown input type for {} aggregation {}",
@@ -507,7 +507,7 @@ bool registerVarianceAggregate(const std::string& name) {
               inputType,
               "Input type for final aggregation must be "
               "(count:bigint, mean:double, m2:double) struct");
-          return std::make_unique<TClass<int64_t>>(step, resultType);
+          return std::make_unique<TClass<int64_t>>(resultType);
         }
       });
   return true;

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -33,8 +33,7 @@ bool isPartialOutput(core::AggregationNode::Step step);
 
 class Aggregate {
  protected:
-  explicit Aggregate(core::AggregationNode::Step step, TypePtr resultType)
-      : isRawInput_{isRawInput(step)}, resultType_(resultType) {}
+  explicit Aggregate(TypePtr resultType) : resultType_(resultType) {}
 
  public:
   virtual ~Aggregate() {}
@@ -231,7 +230,6 @@ class Aggregate {
     }
   }
 
-  const bool isRawInput_;
   const TypePtr resultType_;
 
   // Byte position of null flag in group row.

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -50,9 +50,11 @@ GroupingSet::GroupingSet(
     std::vector<std::vector<ChannelIndex>>&& channelLists,
     std::vector<std::vector<VectorPtr>>&& constantLists,
     bool ignoreNullKeys,
+    bool isRawInput,
     OperatorCtx* operatorCtx)
     : hashers_(std::move(hashers)),
       isGlobal_(hashers_.empty()),
+      isRawInput_(isRawInput),
       aggregates_(std::move(aggregates)),
       aggrMaskChannels_(std::move(aggrMaskChannels)),
       channelLists_(std::move(channelLists)),
@@ -93,8 +95,13 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
       const SelectivityVector& rows = getSelectivityVector(i);
       const bool canPushdown =
           mayPushdown && mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
-      aggregates_[i]->updateSingleGroup(
-          lookup_->hits[0], rows, tempVectors_, canPushdown);
+      if (isRawInput_) {
+        aggregates_[i]->updateSingleGroupPartial(
+            lookup_->hits[0], rows, tempVectors_, canPushdown);
+      } else {
+        aggregates_[i]->updateSingleGroupFinal(
+            lookup_->hits[0], rows, tempVectors_, canPushdown);
+      }
     }
     tempVectors_.clear();
     return;
@@ -168,8 +175,13 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
     const bool canPushdown = (&rows != &activeRows_) && mayPushdown &&
         mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
     populateTempVectors(i, input);
-    aggregates_[i]->update(
-        lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    if (isRawInput_) {
+      aggregates_[i]->updatePartial(
+          lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    } else {
+      aggregates_[i]->updateFinal(
+          lookup_->hits.data(), rows, tempVectors_, canPushdown);
+    }
   }
   tempVectors_.clear();
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -31,6 +31,7 @@ class GroupingSet {
       std::vector<std::vector<ChannelIndex>>&& channelLists,
       std::vector<std::vector<VectorPtr>>&& constantLists,
       bool ignoreNullKeys,
+      bool isRawInput,
       OperatorCtx* driverCtx);
 
   void addInput(const RowVectorPtr& input, bool mayPushdown);
@@ -66,6 +67,7 @@ class GroupingSet {
   std::vector<ChannelIndex> keyChannels_;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   const bool isGlobal_;
+  const bool isRawInput_;
   std::vector<std::unique_ptr<Aggregate>> aggregates_;
   // For each aggregation, can hold an index to a boolean channel (projection in
   // the input row vector), that acts as row mask for the aggregation.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/HashAggregation.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -117,6 +118,7 @@ HashAggregation::HashAggregation(
       std::move(args),
       std::move(constantLists),
       aggregationNode->ignoreNullKeys(),
+      isRawInput(aggregationNode->step()),
       operatorCtx_.get());
 }
 


### PR DESCRIPTION
Summary: Remove passing step as an input parameter to Aggregate constructor as it's no longer needed.

Differential Revision: D31198316

