### PR TITLE
Instantiate LocalFileSystem only once

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -58,10 +58,6 @@ namespace {
 std::once_flag localFSRegistrationFlag;
 // Implement Local FileSystem.
 class LocalFileSystem : public FileSystem {
- private:
-  // Used to track a single Local FileSystem instance
-  static std::shared_ptr<FileSystem> lfs;
-
  public:
   explicit LocalFileSystem(std::shared_ptr<const Config> config)
       : FileSystem(config) {}
@@ -101,6 +97,7 @@ class LocalFileSystem : public FileSystem {
     return [](std::shared_ptr<const Config> properties) {
       // One instance of Local FileSystem is sufficient.
       // Initialize on first access and reuse after that.
+      static std::shared_ptr<FileSystem> lfs;
       std::call_once(localFSRegistrationFlag, [&properties]() {
         lfs = std::make_shared<LocalFileSystem>(properties);
       });
@@ -108,7 +105,6 @@ class LocalFileSystem : public FileSystem {
     };
   }
 };
-std::shared_ptr<FileSystem> LocalFileSystem::lfs = nullptr;
 } // namespace
 
 void registerLocalFileSystem() {


### PR DESCRIPTION
The goal here is to create the Local FileSystem object only once and re-use that.