### PR TITLE
Build velox_flag_definitions as static library

### DIFF
--- a/velox/flag_definitions/CMakeLists.txt
+++ b/velox/flag_definitions/CMakeLists.txt
@@ -11,5 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_flag_definitions SHARED flags.cpp)
+add_library(velox_flag_definitions OBJECT flags.cpp)
 target_link_libraries(velox_flag_definitions gflags)


### PR DESCRIPTION
Summary:
This allows other libarary depends on Velox to be
statically linked into a single `.so` without other shared
library dependencies, which could also help Velox adoption in other libs.

Differential Revision: D31222638

