### PR TITLE
Add FileHandleTest to the build

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,12 +15,10 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp FileSystems.h)
-target_link_libraries(velox_file velox_exception ${FOLLY_WITH_DEPENDENCIES} ${FMT})
+target_link_libraries(velox_file velox_exception ${FOLLY_WITH_DEPENDENCIES}
+                      ${FMT})
 
 add_executable(velox_file_test FileTest.cpp)
 add_test(velox_file_test velox_file_test)
-target_link_libraries(
- velox_file_test
- velox_file
- velox_exec_test_lib
- ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(velox_file_test velox_file velox_exec_test_lib
+                      ${GTEST_BOTH_LIBRARIES})

--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,9 +15,12 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp FileSystems.h)
-target_link_libraries(velox_file velox_exception ${GTEST_BOTH_LIBRARIES}
-                      ${GLOG} ${FOLLY_WITH_DEPENDENCIES} ${FMT})
+target_link_libraries(velox_file velox_exception ${FOLLY_WITH_DEPENDENCIES} ${FMT})
 
 add_executable(velox_file_test FileTest.cpp)
 add_test(velox_file_test velox_file_test)
-target_link_libraries(velox_file_test velox_file)
+target_link_libraries(
+ velox_file_test
+ velox_file
+ velox_exec_test_lib
+ ${GTEST_BOTH_LIBRARIES})

--- a/velox/common/file/FileTest.cpp
+++ b/velox/common/file/FileTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/TempFilePath.h"
 
 #include "gtest/gtest.h"
 
@@ -77,8 +78,8 @@ TEST(InMemoryFile, writeAndRead) {
 }
 
 TEST(LocalFile, WriteAndRead) {
-  // TODO: use the appropriate test directory.
-  const char filename[] = "/tmp/test";
+  auto tempFile = ::exec::test::TempFilePath::create();
+  const auto& filename = tempFile->path.c_str();
   remove(filename);
   {
     LocalWriteFile writeFile(filename);

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp)
+add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp FileHandleTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(velox_hive_connector_test velox_hive_partition_function

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp FileHandleTest.cpp)
+add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp
+                                         FileHandleTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(
- velox_hive_connector_test
- velox_hive_connector
- velox_hive_partition_function
- velox_dwio_common_exception
- velox_vector_test_lib
- velox_exec
- velox_exec_test_lib
- ${GTEST_BOTH_LIBRARIES})
+  velox_hive_connector_test
+  velox_hive_connector
+  velox_hive_partition_function
+  velox_dwio_common_exception
+  velox_vector_test_lib
+  velox_exec
+  velox_exec_test_lib
+  ${GTEST_BOTH_LIBRARIES})

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -14,5 +14,12 @@
 add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp FileHandleTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
-target_link_libraries(velox_hive_connector_test velox_hive_partition_function
-                      velox_vector_test_lib ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(
+ velox_hive_connector_test
+ velox_hive_connector
+ velox_hive_partition_function
+ velox_dwio_common_exception
+ velox_vector_test_lib
+ velox_exec
+ velox_exec_test_lib
+ ${GTEST_BOTH_LIBRARIES})

--- a/velox/connectors/hive/tests/FileHandleTest.cpp
+++ b/velox/connectors/hive/tests/FileHandleTest.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/connectors/hive/FileHandle.h"
 
-#include <string>
 #include "gtest/gtest.h"
 #include "velox/common/caching/SimpleLRUCache.h"
 #include "velox/common/file/File.h"
@@ -28,14 +27,12 @@ using namespace facebook::velox;
 TEST(FileHandleTest, localFile) {
   filesystems::registerLocalFileSystem();
 
-  // TODO: use the appropriate test directory.
-  // Use unique name for each process/thread execution to prevent cross
-  // process/thread race condition
   auto pid = getpid();
   auto tid = pthread_self();
-  const std::string filename =
-      "/tmp/test" + std::to_string(pid) + "_" + std::to_string(tid);
-  remove(filename.data());
+  std::stringstream file;
+  file << "/tmp/test" << pid << "_" << tid;
+  const auto filename = file.str();
+  remove(filename.c_str());
 
   {
     LocalWriteFile writeFile(filename);

--- a/velox/connectors/hive/tests/FileHandleTest.cpp
+++ b/velox/connectors/hive/tests/FileHandleTest.cpp
@@ -21,17 +21,15 @@
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Arena.h"
+#include "velox/exec/tests/TempFilePath.h"
 
 using namespace facebook::velox;
 
 TEST(FileHandleTest, localFile) {
   filesystems::registerLocalFileSystem();
 
-  auto pid = getpid();
-  auto tid = pthread_self();
-  std::stringstream file;
-  file << "/tmp/test" << pid << "_" << tid;
-  const auto filename = file.str();
+  auto tempFile = ::exec::test::TempFilePath::create();
+  const auto& filename = tempFile->path;
   remove(filename.c_str());
 
   {
@@ -48,5 +46,5 @@ TEST(FileHandleTest, localFile) {
   ASSERT_EQ(fileHandle->file->pread(0, 3, &arena), "foo");
 
   // Clean up
-  remove(filename.data());
+  remove(filename.c_str());
 }

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_type_fbhive
   velox_dwrf_test_utils
-  velox_presto_serializer)
+  velox_presto_serializer
+  ${GTEST_BOTH_LIBRARIES})
 
 add_executable(
   velox_exec_test


### PR DESCRIPTION
This change includes the FileHandleTest in the build process.
It also improves the FileTest to use TempFilePath and the linkage.