### PR TITLE
Add array_distinct Presto function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -20,6 +20,14 @@ Array Functions
         SELECT array_except(ARRAY [1, 2, 2], ARRAY [1, 3, 4]); -- [2]
         SELECT array_except(ARRAY [1, NULL, NULL], ARRAY [1, 1, NULL]); -- []
 
+.. function:: array_distinct(array(E)) -> array(E)
+
+    Remove duplicate values from the input array. ::
+
+        SELECT array_distinct(ARRAY [1, 2, 3]); -- [1, 2, 3]
+        SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
+        SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
+
 .. function:: array_max(array(E)) -> E
 
     Returns the maximum value of input array. ::

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/F14Set.h>
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at https://prestodb.io/docs/current/functions/array.html
+template <typename T>
+class ArrayDistinctFunction : public exec::VectorFunction {
+ public:
+  /// This class implements the array_distint query function.
+  ///
+  /// Along with the set, we maintain a `hasNull` flag that indicates whether
+  /// null is present in the array.
+  ///
+  /// Zero element copy:
+  ///
+  /// In order to prevent copies of array elements, the function reuses the
+  /// internal elements() vector from the original ArrayVector.
+  ///
+  /// First a new vector is created containing the indices of the elements
+  /// which will be present in the output, and wrapped into a DictionaryVector.
+  /// Next the `lengths` and `offsets` vectors that control where output arrays
+  /// start and end are wrapped into the output ArrayVector.
+
+  ArrayDistinctFunction() {}
+
+  // Execute function.
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      exec::Expr* caller,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    // Acquire the array elements vector.
+    auto arrayVector = args.front()->as<ArrayVector>();
+    auto elementsVector = arrayVector->elements();
+    auto elementsRows =
+        toElementRows(elementsVector->size(), rows, arrayVector);
+    exec::LocalDecodedVector elements(context, *elementsVector, elementsRows);
+
+    vector_size_t elementsCount = elementsRows.size();
+    vector_size_t rowCount = arrayVector->size();
+
+    // Allocate new vectors for indices, length and offsets.
+    memory::MemoryPool* pool = context->pool();
+    BufferPtr newIndices =
+        AlignedBuffer::allocate<vector_size_t>(elementsCount, pool);
+    BufferPtr newLengths =
+        AlignedBuffer::allocate<vector_size_t>(rowCount, pool);
+    BufferPtr newOffsets =
+        AlignedBuffer::allocate<vector_size_t>(rowCount, pool);
+
+    // Pointers and cursors to the raw data.
+    vector_size_t indicesCursor = 0;
+    auto* rawNewIndices = newIndices->asMutable<vector_size_t>();
+    auto* rawSizes = newLengths->asMutable<vector_size_t>();
+    auto* rawOffsets = newOffsets->asMutable<vector_size_t>();
+
+    // Process the rows: store unique values in the hash table.
+    folly::F14FastSet<T> uniqueSet;
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto size = arrayVector->sizeAt(row);
+      auto offset = arrayVector->offsetAt(row);
+
+      *rawOffsets = indicesCursor;
+      bool hasNulls = false;
+      for (vector_size_t i = offset; i < offset + size; ++i) {
+        if (elements->isNullAt(i)) {
+          if (!hasNulls) {
+            hasNulls = true;
+            rawNewIndices[indicesCursor++] = i;
+          }
+        } else {
+          auto value = elements->valueAt<T>(i);
+
+          if (uniqueSet.insert(value).second) {
+            rawNewIndices[indicesCursor++] = i;
+          }
+        }
+      }
+
+      uniqueSet.clear();
+      *rawSizes = indicesCursor - *rawOffsets;
+      ++rawSizes;
+      ++rawOffsets;
+    });
+
+    auto newElements =
+        BaseVector::transpose(newIndices, std::move(elementsVector));
+
+    // Prepare and return result set.
+    auto resultArray = std::make_shared<ArrayVector>(
+        pool,
+        caller->type(),
+        nullptr,
+        rowCount,
+        std::move(newOffsets),
+        std::move(newLengths),
+        std::move(newElements),
+        0);
+    context->moveOrCopyResult(resultArray, rows, result);
+  }
+};
+
+// Validate number of parameters and types.
+void validateType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_USER_CHECK_EQ(
+      inputArgs.size(), 1, "array_distinct requires exactly one parameter");
+
+  auto arrayType = inputArgs.front().type;
+  VELOX_USER_CHECK_EQ(
+      arrayType->kind(),
+      TypeKind::ARRAY,
+      "array_distinct requires arguments of type ARRAY");
+}
+
+// Create function template based on type.
+template <TypeKind kind>
+std::shared_ptr<exec::VectorFunction> createTyped(
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_CHECK_EQ(inputArgs.size(), 1);
+
+  using T = typename TypeTraits<kind>::NativeType;
+  return std::make_shared<ArrayDistinctFunction<T>>();
+}
+
+// Create function.
+std::shared_ptr<exec::VectorFunction> create(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  validateType(inputArgs);
+  auto elementType = inputArgs.front().type->childAt(0);
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      createTyped, elementType->kind(), inputArgs);
+}
+
+// Define function signature.
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  // array(T) -> array(T)
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .returnType("array(T)")
+              .argumentType("array(T)")
+              .build()};
+}
+
+} // namespace
+
+// Register function.
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_array_distinct,
+    signatures(),
+    create);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(
   Not.cpp
   ArrayConstructor.cpp
   ArrayContains.cpp
+  ArrayDistinct.cpp
   ArrayIntersectExcept.cpp
   ArrayMinMax.cpp
   FilterFunctions.cpp

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -35,6 +35,7 @@ void registerVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, "not");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_intersect, "array_intersect");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, "array_except");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_max, "array_max");

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+// Class to test the array_distinct operator.
+class ArrayDistinctTest : public FunctionBaseTest {
+ protected:
+  // Evaluate an expression.
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result = evaluate<ArrayVector>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  // Execute test for integer types.
+  template <typename T>
+  void testInt() {
+    auto array = makeNullableArrayVector<T>({
+        {},
+        {0},
+        {1},
+        {std::numeric_limits<T>::min()},
+        {std::numeric_limits<T>::max()},
+        {std::nullopt},
+        {-1},
+        {1, 2, 3},
+        {1, 2, 1},
+        {1, 1, 1},
+        {-1, -2, -3},
+        {-1, -2, -1},
+        {-1, -1, -1},
+        {std::nullopt, std::nullopt, std::nullopt},
+        {1, 2, -2, 1},
+        {1, 1, -2, -2, -2, 4, 8},
+        {3, 8, std::nullopt},
+        {1, 2, 3, std::nullopt, 4, 1, 2, std::nullopt},
+    });
+
+    auto expected = makeNullableArrayVector<T>({
+        {},
+        {0},
+        {1},
+        {std::numeric_limits<T>::min()},
+        {std::numeric_limits<T>::max()},
+        {std::nullopt},
+        {-1},
+        {1, 2, 3},
+        {1, 2},
+        {1},
+        {-1, -2, -3},
+        {-1, -2},
+        {-1},
+        {std::nullopt},
+        {1, 2, -2},
+        {1, -2, 4, 8},
+        {3, 8, std::nullopt},
+        {1, 2, 3, std::nullopt, 4},
+    });
+
+    testExpr(expected, "array_distinct(C0)", {array});
+  }
+
+  // Execute test for floating point types.
+  template <typename T>
+  void testFloatingPoint() {
+    auto array = makeNullableArrayVector<T>({
+        {},
+        {0.0},
+        {1.0001},
+        {-2.0},
+        {3.03},
+        {std::numeric_limits<T>::min()},
+        {std::numeric_limits<T>::max()},
+        {std::numeric_limits<T>::lowest()},
+        {std::numeric_limits<T>::infinity()},
+        {std::numeric_limits<T>::quiet_NaN()},
+        {std::numeric_limits<T>::signaling_NaN()},
+        {std::numeric_limits<T>::denorm_min()},
+        {std::nullopt},
+        {0.0, 0.0},
+        {0.0, 10.0},
+        {0.0, -10.0},
+        {std::numeric_limits<T>::quiet_NaN(),
+         std::numeric_limits<T>::quiet_NaN()},
+        {std::numeric_limits<T>::signaling_NaN(),
+         std::numeric_limits<T>::signaling_NaN()},
+        {std::numeric_limits<T>::lowest(), std::numeric_limits<T>::lowest()},
+        {std::nullopt, std::nullopt},
+        {1.0001, -2.0, 3.03, std::nullopt, 4.00004},
+        {std::numeric_limits<T>::min(), 2.02, -2.001, 1},
+        {std::numeric_limits<T>::max(), 8.0001, std::nullopt},
+        {9.0009,
+         std::numeric_limits<T>::infinity(),
+         std::numeric_limits<T>::max()},
+        {std::numeric_limits<T>::quiet_NaN(), 9.0009},
+    });
+    auto expected = makeNullableArrayVector<T>({
+        {},
+        {0.0},
+        {1.0001},
+        {-2.0},
+        {3.03},
+        {std::numeric_limits<T>::min()},
+        {std::numeric_limits<T>::max()},
+        {std::numeric_limits<T>::lowest()},
+        {std::numeric_limits<T>::infinity()},
+        {std::numeric_limits<T>::quiet_NaN()},
+        {std::numeric_limits<T>::signaling_NaN()},
+        {std::numeric_limits<T>::denorm_min()},
+        {std::nullopt},
+        {0.0},
+        {0.0, 10.0},
+        {0.0, -10.0},
+        {std::numeric_limits<T>::quiet_NaN(),
+         std::numeric_limits<T>::quiet_NaN()},
+        {std::numeric_limits<T>::signaling_NaN(),
+         std::numeric_limits<T>::signaling_NaN()},
+        {std::numeric_limits<T>::lowest()},
+        {std::nullopt},
+        {1.0001, -2.0, 3.03, std::nullopt, 4.00004},
+        {std::numeric_limits<T>::min(), 2.02, -2.001, 1},
+        {std::numeric_limits<T>::max(), 8.0001, std::nullopt},
+        {9.0009,
+         std::numeric_limits<T>::infinity(),
+         std::numeric_limits<T>::max()},
+        {std::numeric_limits<T>::quiet_NaN(), 9.0009},
+    });
+
+    testExpr(expected, "array_distinct(C0)", {array});
+  }
+};
+
+} // namespace
+
+// Test boolean arrays.
+TEST_F(ArrayDistinctTest, boolArrays) {
+  auto array = makeNullableArrayVector<bool>(
+      {{},
+       {true},
+       {false},
+       {std::nullopt},
+       {true, false},
+       {true, std::nullopt},
+       {true, true},
+       {false, false},
+       {std::nullopt, std::nullopt},
+       {true, false, true, std::nullopt},
+       {std::nullopt, true, false, true},
+       {false, true, false},
+       {true, false, true}});
+
+  auto expected = makeNullableArrayVector<bool>(
+      {{},
+       {true},
+       {false},
+       {std::nullopt},
+       {true, false},
+       {true, std::nullopt},
+       {true},
+       {false},
+       {std::nullopt},
+       {true, false, std::nullopt},
+       {std::nullopt, true, false},
+       {false, true},
+       {true, false}});
+
+  testExpr(expected, "array_distinct(C0)", {array});
+}
+
+// Test integer arrays.
+TEST_F(ArrayDistinctTest, integerArrays) {
+  testInt<int8_t>();
+  testInt<int16_t>();
+  testInt<int32_t>();
+  testInt<int64_t>();
+}
+
+// Test floating point arrays.
+TEST_F(ArrayDistinctTest, floatArrays) {
+  testFloatingPoint<float>();
+  testFloatingPoint<double>();
+}
+
+// Test inline (short) strings.
+TEST_F(ArrayDistinctTest, inlineStringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {},
+      {S("")},
+      {S(" ")},
+      {S("a")},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), S("A")},
+      {S("a"), S("a")},
+      {std::nullopt, std::nullopt},
+      {S("a"), std::nullopt, S("b")},
+      {S("a"), S("b"), S("a"), S("a")},
+      {std::nullopt, S("b"), std::nullopt},
+      {S("abc")},
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {},
+      {S("")},
+      {S(" ")},
+      {S("a")},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), S("A")},
+      {S("a")},
+      {std::nullopt},
+      {S("a"), std::nullopt, S("b")},
+      {S("a"), S("b")},
+      {std::nullopt, S("b")},
+      {S("abc")},
+  });
+
+  testExpr(expected, "array_distinct(C0)", {array});
+}
+
+// Test non-inline (> 12 character length) strings.
+TEST_F(ArrayDistinctTest, stringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {std::nullopt,
+       S("blue clear sky above"),
+       S("yellow rose flowers"),
+       S("blue clear sky above"),
+       S("orange beautiful sunset")},
+      {std::nullopt, std::nullopt},
+      {},
+      {S("red shiny car ahead"),
+       S("purple is an elegant color"),
+       S("green plants make us happy")},
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {std::nullopt,
+       S("blue clear sky above"),
+       S("yellow rose flowers"),
+       S("orange beautiful sunset")},
+      {std::nullopt},
+      {},
+      {S("red shiny car ahead"),
+       S("purple is an elegant color"),
+       S("green plants make us happy")},
+  });
+
+  testExpr(expected, "array_distinct(C0)", {array});
+}
+
+// Test for invalid signature and types.
+TEST_F(ArrayDistinctTest, invalidTypes) {
+  auto array = makeNullableArrayVector<int32_t>({{1}});
+  auto expected = makeNullableArrayVector<int32_t>({{1}});
+
+  EXPECT_THROW(
+      testExpr(expected, "array_distinct(1)", {array}), std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_distinct(C0, CO)", {array, array}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_distinct(ARRAY[1], 1)", {array}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_distinct(ARRAY[ARRAY[1]])", {array}),
+      facebook::velox::VeloxUserError);
+  EXPECT_THROW(
+      testExpr(expected, "array_distinct()", {array}), std::invalid_argument);
+
+  EXPECT_NO_THROW(testExpr(expected, "array_distinct(C0)", {array}));
+}

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   ArithmeticTest.cpp
   ArrayConstructorTest.cpp
   ArrayContainsTest.cpp
+  ArrayDistinctTest.cpp
   ArrayExceptTest.cpp
   ArrayFilterTest.cpp
   ArrayIntersectTest.cpp


### PR DESCRIPTION
Summary: This implements the array_distinct function in velox for arrays with scalar values. It also adds a new set of tests for the new array_distinct function.

Reviewed By: mbasmanova

Differential Revision: D31198914

