### PR TITLE
Fix crash when partition key is null

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -301,7 +301,10 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
     auto keyIt = split_->partitionKeys.find(fieldName);
     if (keyIt != split_->partitionKeys.end()) {
-      setConstantValue(scanChildSpec, velox::variant(keyIt->second));
+      setConstantValue(
+          scanChildSpec,
+          keyIt->second.has_value() ? velox::variant(*(keyIt->second))
+                                    : velox::variant(TypeKind::VARCHAR));
     } else if (fieldName == kPath) {
       setConstantValue(scanChildSpec, velox::variant(split_->filePath));
     } else if (fieldName == kBucket) {
@@ -322,7 +325,10 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   for (const auto& entry : split_->partitionKeys) {
     auto childSpec = scanSpec_->childByName(entry.first);
     if (childSpec) {
-      setConstantValue(childSpec, velox::variant(entry.second));
+      setConstantValue(
+          childSpec,
+          entry.second.has_value() ? velox::variant(*(entry.second))
+                                   : velox::variant(TypeKind::VARCHAR));
     }
   }
 

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -29,7 +29,8 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
   dwio::common::FileFormat fileFormat;
   const uint64_t start;
   const uint64_t length;
-  const std::unordered_map<std::string, std::string> partitionKeys;
+  const std::unordered_map<std::string, std::optional<std::string>>
+      partitionKeys;
   std::optional<int32_t> tableBucketNumber;
 
   HiveConnectorSplit(
@@ -38,7 +39,8 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
       dwio::common::FileFormat _fileFormat,
       uint64_t _start = 0,
       uint64_t _length = std::numeric_limits<uint64_t>::max(),
-      const std::unordered_map<std::string, std::string>& _partitionKeys = {},
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          _partitionKeys = {},
       std::optional<int32_t> _tableBucketNumber = std::nullopt)
       : ConnectorSplit(connectorId),
         filePath(_filePath),

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -115,8 +115,8 @@ class TableScanTest : public HiveConnectorTestBase {
         {"c0", regularColumn("c0")},
         {"c1", regularColumn("c1")}};
 
-    std::unordered_map<std::string, std::string> partitionKeys = {
-        {"ds", "2020-11-01"}};
+    std::unordered_map<std::string, std::optional<std::string>> partitionKeys =
+        {{"ds", {"2020-11-01"}}};
     auto split = std::make_shared<HiveConnectorSplit>(
         kHiveConnectorId,
         filePath,
@@ -1423,7 +1423,7 @@ TEST_F(TableScanTest, bucket) {
         facebook::dwio::common::FileFormat::ORC,
         0,
         fs::file_size(filePaths[i]->path),
-        std::unordered_map<std::string, std::string>(),
+        std::unordered_map<std::string, std::optional<std::string>>(),
         bucket));
   }
 


### PR DESCRIPTION
Summary: Velox crashes when partition key is null.

Differential Revision: D31226796

