### PR TITLE
Mark FlatVector final to allow for inlining of FlatVector methods

### DIFF
--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -27,8 +27,11 @@
 namespace facebook {
 namespace velox {
 
+// FlatVector is marked final to allow for inlining on virtual methods called
+// on a pointer that has the static type FlatVector<T>; this can be a
+// significant performance win when these methods are called in loops.
 template <typename T>
-class FlatVector : public SimpleVector<T> {
+class FlatVector final : public SimpleVector<T> {
  public:
   using value_type = T;
 


### PR DESCRIPTION
Summary: This should, in some cases, allow e.g. `valueAt` calls to be inlined.

Reviewed By: pedroerp

Differential Revision: D31247763

