### PR TITLE
Add vectorized functions to ExprFuzzer

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -160,12 +160,7 @@ void Expr::evalSimplified(
   if (remainingRows->hasSelections()) {
     evalSimplifiedImpl(*remainingRows, context, result);
   }
-
-  // If there's no output vector yet, return a null constant.
-  if (*result == nullptr) {
-    *result =
-        BaseVector::createNullConstant(type(), rows.size(), context->pool());
-  }
+  addNulls(rows, remainingRows->asRange().bits(), context, result);
 }
 
 void Expr::evalSimplifiedImpl(
@@ -215,8 +210,7 @@ void Expr::evalSimplifiedImpl(
   vectorFunction_->apply(remainingRows, inputValues_, this, context, result);
 
   // Make sure the returned vector has its null bitmap properly set.
-  (*result)->addNulls(
-      remainingRows.asRange().bits(), SelectivityVector((*result)->size()));
+  addNulls(rows, remainingRows.asRange().bits(), context, result);
   inputValues_.clear();
 }
 

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
 add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 
 target_link_libraries(velox_expression_fuzzer velox_type velox_vector_fuzzer
-                      velox_vector_test_lib)
+                      velox_vector_test_lib velox_function_registry)
 
 add_executable(velox_expression_fuzzer_main ExpressionFuzzerMain.cpp)
 

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -16,27 +16,14 @@
 
 #pragma once
 
-#include "velox/type/Type.h"
+#include "velox/functions/FunctionRegistry.h"
 
 namespace facebook::velox::test {
-
-// Represents one available function signature.
-struct CallableSignature {
-  // Function name.
-  std::string name;
-
-  // Input arguments and return type.
-  std::vector<TypePtr> args;
-  TypePtr returnType;
-
-  // Convenience print function.
-  std::string toString() const;
-};
 
 // Generates random expressions based on `signatures` and random input data (via
 // VectorFuzzer). Generates `steps` distinct expressions.
 void expressionFuzzer(
-    std::vector<CallableSignature> signatures,
+    FunctionSignatureMap signatureMap,
     size_t steps,
     size_t seed);
 

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -221,7 +221,7 @@ FOLLY_ALWAYS_INLINE void replaceInPlace(
     TInOutString& string,
     const TInString& replaced,
     const TInString& replacement) {
-  assert(replacement.size() <= replaced.size() && "invlaid inplace replace");
+  assert(replacement.size() <= replaced.size() && "invalid inplace replace");
 
   auto outputSize = stringCore::replace(
       string.data(),


### PR DESCRIPTION
Summary:
Extending ExprFuzzer to support FunctionRegistry, and thus exercise
vectorized functions as well. Still need to add new types of vectors to
VectorFuzzer to support complex types, but this already adds support for string
vectorized functions.
Found that replace and strpos crash at some point (so skipping them for now).

Reviewed By: funrollloops

Differential Revision: D31164276

