### PR TITLE
Small refactor in FunctionSignature and SignatureBinder

### DIFF
--- a/velox/exec/tests/ParseTypeSignatureTest.cpp
+++ b/velox/exec/tests/ParseTypeSignatureTest.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/expression/FunctionSignature.h"
+#include "velox/type/Type.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/FunctionSignature.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include "velox/common/base/Exceptions.h"
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::exec {
@@ -172,4 +173,14 @@ FunctionSignature::FunctionSignature(
       variableArity_{variableArity} {
   validate(typeVariableConstants_, returnType_, argumentTypes_);
 }
+
+std::shared_ptr<FunctionSignature> FunctionSignatureBuilder::build() {
+  VELOX_CHECK(returnType_.has_value());
+  return std::make_shared<FunctionSignature>(
+      std::move(typeVariableConstants_),
+      returnType_.value(),
+      std::move(argumentTypes_),
+      variableArity_);
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -15,9 +15,13 @@
  */
 #pragma once
 
-#include <velox/type/Type.h>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace facebook::velox::exec {
+
 // A type name (e.g. K or V in map(K, V)) and optionally constraints, e.g.
 // orderable, sortable, etc.
 class TypeVariableConstraint {
@@ -149,14 +153,7 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
-  std::shared_ptr<FunctionSignature> build() {
-    VELOX_CHECK(returnType_.has_value());
-    return std::make_shared<FunctionSignature>(
-        std::move(typeVariableConstants_),
-        returnType_.value(),
-        std::move(argumentTypes_),
-        variableArity_);
-  }
+  std::shared_ptr<FunctionSignature> build();
 
  private:
   std::vector<TypeVariableConstraint> typeVariableConstants_;

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -103,20 +103,27 @@ bool SignatureBinder::tryBind(
 
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature) const {
+  return tryResolveType(typeSignature, bindings_);
+}
+
+// static
+TypePtr SignatureBinder::tryResolveType(
+    const exec::TypeSignature& typeSignature,
+    const std::unordered_map<std::string, TypePtr>& bindings) {
   const auto& params = typeSignature.parameters();
 
   std::vector<TypePtr> children;
   children.reserve(params.size());
   for (auto& param : params) {
-    auto type = tryResolveType(param);
+    auto type = tryResolveType(param, bindings);
     if (!type) {
       return nullptr;
     }
     children.emplace_back(type);
   }
 
-  auto it = bindings_.find(typeSignature.baseType());
-  if (it == bindings_.end()) {
+  auto it = bindings.find(typeSignature.baseType());
+  if (it == bindings.end()) {
     // concrete type
     auto typeName = boost::algorithm::to_upper_copy(typeSignature.baseType());
 

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/expression/FunctionSignature.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::exec {
 
@@ -42,12 +43,16 @@ class SignatureBinder {
     return tryResolveType(signature_.returnType());
   }
 
+  TypePtr tryResolveType(const exec::TypeSignature& typeSignature) const;
+
+  static TypePtr tryResolveType(
+      const exec::TypeSignature& typeSignature,
+      const std::unordered_map<std::string, TypePtr>& bindings);
+
  private:
   bool tryBind(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);
-
-  TypePtr tryResolveType(const exec::TypeSignature& typeSignature) const;
 
   const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;


### PR DESCRIPTION
Summary:
Reducing the number of unecessary header dependency, and exposing
tryResolveType() function in SignatureBinder. This function will be used in the
next diff by ExpressionFuzzer to resolve a TypeSignature into a TypePtr given a
custom bindings map, which will be used to generate all possible supported
signatures.

Reviewed By: funrollloops

Differential Revision: D31161580

