### PR TITLE
Fix key channel indices in PartitionedOutput

### DIFF
--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -47,7 +47,7 @@ class Destination {
   BlockingReason advance(
       uint64_t maxBytes,
       const std::vector<vector_size_t>& sizes,
-      const RowVectorPtr& input,
+      const RowVectorPtr& output,
       PartitionedOutputBufferManager& bufferManager,
       bool* atEnd,
       ContinueFuture* future);

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -381,6 +381,35 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     assertQuery(
         op, {leafTaskId}, "SELECT c0, c1, c2, c3, c4, c3, c2, c1, c0 FROM tmp");
   }
+
+  // Test dropping the partitioning key
+  {
+    constexpr int32_t kFanout = 4;
+    auto leafTaskId = makeTaskId("leaf", 0);
+    auto leafPlan = PlanBuilder()
+                        .values(vectors_)
+                        .partitionedOutput({5}, kFanout, {2, 0, 3})
+                        .planNode();
+    auto leafTask = makeTask(leafTaskId, leafPlan, 0);
+    Task::start(leafTask, 4);
+
+    auto intermediatePlan = PlanBuilder()
+                                .exchange(leafPlan->outputType())
+                                .partitionedOutput({}, 1, {2, 1, 0})
+                                .planNode();
+    std::vector<std::string> intermediateTaskIds;
+    for (auto i = 0; i < kFanout; ++i) {
+      intermediateTaskIds.push_back(makeTaskId("intermediate", i));
+      auto intermediateTask =
+          makeTask(intermediateTaskIds.back(), intermediatePlan, i);
+      Task::start(intermediateTask, 1);
+      addRemoteSplits(intermediateTask, {leafTaskId});
+    }
+
+    auto op = PlanBuilder().exchange(intermediatePlan->outputType()).planNode();
+
+    assertQuery(op, intermediateTaskIds, "SELECT c3, c0, c2 FROM tmp");
+  }
 }
 
 TEST_F(MultiFragmentTest, broadcast) {


### PR DESCRIPTION
Key channel indices are relative to the channels in the input
RowVector. The composition and order of the output may be different
and may not include the partitioning channels. Therefore interpret
'keyChannels_' in terms of the original input and do the rest of the
processing in terms of the rearranged input vectors stored in
'output_'.

Rename input to output where applicable. Add a test that drops the
partitioning column and triggers and error before the fix.