### PR TITLE
Validate return type on simple functions

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -337,6 +337,14 @@ ExprPtr compileExpression(
     } else if (
         auto adapterFunc =
             AdaptedVectorFunctions().Create({call->name(), inputTypes})) {
+      VELOX_USER_CHECK(
+          resultType->kindEquals(adapterFunc->returnType()),
+          "Found incompatible return types for '{}' ({} vs. {}) "
+          "for input types ({}).",
+          call->name(),
+          adapterFunc->returnType(),
+          resultType,
+          folly::join(", ", inputTypes));
       result = std::make_shared<Expr>(
           resultType,
           std::move(compiledInputs),

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -124,6 +124,7 @@ class VectorAdapterFactory {
  public:
   virtual std::unique_ptr<VectorFunction> getVectorInterpreter() const = 0;
   virtual ~VectorAdapterFactory() = default;
+  virtual const TypePtr returnType() const = 0;
 };
 
 /// Returns a list of signatured supposed by VectorFunction with the specified

--- a/velox/expression/VectorFunctionAdapter.h
+++ b/velox/expression/VectorFunctionAdapter.h
@@ -315,6 +315,10 @@ class VectorAdapterFactoryImpl : public VectorAdapterFactory {
     return std::make_unique<VectorAdapter<FUNC>>(returnType_);
   }
 
+  const std::shared_ptr<const Type> returnType() const override {
+    return returnType_;
+  }
+
   bool isDeterministic() {
     return FUNC::isDeterministic;
   }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1451,6 +1451,14 @@ bool typeExists(const std::string& name);
 /// child types.
 TypePtr getType(const std::string& name, std::vector<TypePtr> childTypes);
 
+// Allows us to transparently use folly::toAppend(), folly::join(), etc.
+template <class TString>
+void toAppend(
+    const std::shared_ptr<const facebook::velox::Type>& type,
+    TString* result) {
+  result->append(type->toString());
+}
+
 } // namespace facebook::velox
 
 namespace folly {


### PR DESCRIPTION
Summary:
Expr execution used to crash if the type specified by the user didn't
match the expected function signature. Adding a check so that we throw a nice
exception. Note that this only works for simple functions; vectorized functions
will need a more complicated fix since we need to try to bind the available signatures.

Reviewed By: mbasmanova

Differential Revision: D31257222

