### PR TITLE
Fix outputType_->size() > 0

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -231,7 +231,6 @@ LocalPartition::LocalPartition(
           planNode->outputType())},
       blockingReasons_{numPartitions_} {
   VELOX_CHECK(numPartitions_ == 1 || !keyChannels_.empty());
-  VELOX_CHECK_GT(outputType_->size(), 0);
 
   for (auto& source : localExchangeSources_) {
     source->addProducer();

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -122,7 +122,6 @@ class PartitionedOutput : public Operator {
       VELOX_CHECK(keyChannels_.empty());
       VELOX_CHECK_NULL(partitionFunction_);
     }
-    VELOX_CHECK_GT(outputType_->size(), 0);
   }
 
   void addInput(RowVectorPtr input) override;

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -338,6 +338,23 @@ TEST_F(LocalPartitionTest, outputLayout) {
   task = assertQuery(
       op, std::vector<std::shared_ptr<TempFilePath>>{}, "SELECT 300, -71, 102");
   verifyExchangeSourceOperatorStats(task, 300);
+
+  op = PlanBuilder()
+           .localPartition(
+               {},
+               {
+                   valuesNode(0),
+                   valuesNode(1),
+                   valuesNode(2),
+               },
+               // Drop all columns.
+               {})
+           .singleAggregation({}, {"count(1)"})
+           .planNode();
+
+  task = assertQuery(
+      op, std::vector<std::shared_ptr<TempFilePath>>{}, "SELECT 300");
+  verifyExchangeSourceOperatorStats(task, 300);
 }
 
 TEST_F(LocalPartitionTest, multipleExchanges) {


### PR DESCRIPTION
Summary:
LocalPartition and PartitionedOutput may produce vectors with non-zero rows, but zero columns. This happens in queries like the following:

SELECT l.linenumber FROM lineitem l, orders o WHERE l.orderkey = o.orderkey AND o.orderkey = 14209 AND o.totalprice > 0

Fragment 1 [tpch:orders:15000]
    Output layout: [linenumber]
    Output partitioning: SINGLE []
    Stage Execution Strategy: UNGROUPED_EXECUTION
    - LimitPartial[10000] => [linenumber:integer]
            Estimates: {rows: 4 (20B), cpu: 2224980.23, memory: 0.00, network: 0.00}
        - CrossJoin => [linenumber:integer]
                Estimates: {rows: 4 (20B), cpu: 2224960.18, memory: 0.00, network: 0.00}
                Distribution: REPLICATED
            - ScanFilterProject[table = TableHandle {connectorId='tpch', connectorHandle='lineitem:sf0.01', layout='Optional[lineitem:sf0.01]'}, grouped = false, filterPredicate = (orderkey) = (BIGINT'14209'), projectLocality = LOCAL] => [linenumber:integer]
                    Estimates: {rows: 60175 (293.82kB), cpu: 842450.00, memory: 0.00, network: 0.00}/{rows: 4 (20B), cpu: 1684900.00, memory: 0.00, network: 0.00}/{rows: 4 (20B), cpu: 1684920.06, memory: 0.00, network: 0.00}
                    orderkey := tpch:orderkey
                    linenumber := tpch:linenumber
            - LocalExchange[SINGLE] () => []
                    Estimates: {rows: 1 (0B), cpu: 540000.00, memory: 0.00, network: 0.00}
                - RemoteSource[2] => []

Fragment 2 [tpch:orders:15000]
    Output layout: []
    Output partitioning: BROADCAST []
    Stage Execution Strategy: UNGROUPED_EXECUTION
    - ScanFilterProject[table = TableHandle {connectorId='tpch', connectorHandle='orders:sf0.01', layout='Optional[orders:sf0.01]'}, grouped = false, filterPredicate = ((totalprice) > (DOUBLE'0.0')) AND ((orderkey_0) = (BIGINT'14209')), projectLocality = LOCAL] => []
            Estimates: {rows: 15000 (0B), cpu: 270000.00, memory: 0.00, network: 0.00}/{rows: 1 (0B), cpu: 540000.00, memory: 0.00, network: 0.00}/{rows: 1 (0B), cpu: 540000.00, memory: 0.00, network: 0.00}
            orderkey_0 := tpch:orderkey
            totalprice := tpch:totalprice
            tpch:orderstatus
                :: [["F"], ["O"], ["P"]]

Differential Revision: D31258343

