### PR TITLE
Add ltrim and rtrim Presto functions and improve trim function to support unicode encoding (#251)

### DIFF
--- a/velox/docs/functions/string.rst
+++ b/velox/docs/functions/string.rst
@@ -41,6 +41,10 @@ String Functions
 
     Converts ``string`` to lowercase.
 
+.. function:: ltrim(string) -> varchar
+
+    Removes leading whitespace from string.
+
 .. function:: replace(string, search) -> varchar
 
     Removes all instances of ``search`` from ``string``.
@@ -51,6 +55,10 @@ String Functions
 
     If ``search`` is an empty string, inserts ``replace`` in front of every
     character and at the end of the ``string``.
+
+.. function:: rtrim(string) -> varchar
+
+    Removes trailing whitespace from string.
 
 .. function:: strpos(string, substring) -> bigint
 

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -55,6 +55,8 @@ void registerVectorFunctions() {
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_substr, "substr");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, "lower");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_ltrim, "ltrim");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_rtrim, "rtrim");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_trim, "trim");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, "upper");


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/251

1. Add ltrim and rtrim Presto functions.
2. Improve trim function to support unicode encoding.
3. Merge reusable code.
4. Support both ascii and unicode whitespace. For pure ascii input, we run this in fast path without checking code point.
5. The function will stop processing the input when meet any invalid input encoding

Reviewed By: mbasmanova

Differential Revision: D31038967

