### PR TITLE
Allow TableWrite to decide parallelism based on connector capability

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -68,6 +68,12 @@ class ConnectorTableHandle {
 class ConnectorInsertTableHandle {
  public:
   virtual ~ConnectorInsertTableHandle() {}
+
+  // Whether multi-threaded write is supported by this connector. Planner uses
+  // this flag to determine number of drivers.
+  virtual bool supportsMultiThreading() const {
+    return false;
+  }
 };
 
 class DataSink {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -177,8 +177,11 @@ uint32_t maxDrivers(
 
     if (auto tableWrite =
             std::dynamic_pointer_cast<const core::TableWriteNode>(node)) {
-      // Multi-threaded table write is not supported yet.
-      return 1;
+      if (!tableWrite->insertTableHandle()
+               ->connectorInsertTableHandle()
+               ->supportsMultiThreading()) {
+        return 1;
+      }
     }
   }
   return std::numeric_limits<uint32_t>::max();


### PR DESCRIPTION
Summary: Added methods to ConnectorInsertTableHandle so planner can use that to decide thread count for TableWrite.

Reviewed By: helfman, mbasmanova

Differential Revision: D31290705

