### PR TITLE
Replace std::unordered_map with F14FastMap (#328)

### DIFF
--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -16,12 +16,12 @@
 
 #include "velox/type/tz/TimeZoneMap.h"
 #include <fmt/core.h>
-#include <unordered_map>
+#include <folly/container/F14Map.h>
 
 namespace facebook::velox::util {
 
 // Defined on TimeZoneDatabase.cpp
-extern const std::unordered_map<int64_t, std::string>& getTimeZoneDB();
+extern const folly::F14FastMap<int64_t, std::string>& getTimeZoneDB();
 
 std::string getTimeZoneName(int64_t timeZoneID) {
   const auto& tzDB = getTimeZoneDB();
@@ -34,9 +34,9 @@ std::string getTimeZoneName(int64_t timeZoneID) {
 }
 
 namespace {
-std::unordered_map<std::string_view, int64_t> makeReverseMap(
-    const std::unordered_map<int64_t, std::string>& map) {
-  std::unordered_map<std::string_view, int64_t> reversed;
+folly::F14FastMap<std::string_view, int64_t> makeReverseMap(
+    const folly::F14FastMap<int64_t, std::string>& map) {
+  folly::F14FastMap<std::string_view, int64_t> reversed;
   reversed.reserve(map.size());
   for (const auto& entry : map) {
     reversed.emplace(entry.second, entry.first);
@@ -46,7 +46,7 @@ std::unordered_map<std::string_view, int64_t> makeReverseMap(
 } // namespace
 
 int64_t getTimeZoneID(std::string_view timeZone) {
-  static std::unordered_map<std::string_view, int64_t> nameToIdMap =
+  static folly::F14FastMap<std::string_view, int64_t> nameToIdMap =
       makeReverseMap(getTimeZoneDB());
 
   auto it = nameToIdMap.find(timeZone);


### PR DESCRIPTION
In this PR, replaced std::unordered_map with F14FastMap in velox/type/tz/TimeZoneMap.cpp