### PR TITLE
Add support for RIGHT joins

### DIFF
--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -2,9 +2,9 @@
 Joins
 =====
 
-Velox supports inner, left, semi and anti hash joins using either partitioned or
-broadcast distribution strategies. Cross joins are coming soon. Right and full
-outer joins will follow.
+Velox supports inner, left, right, semi and anti hash joins using either
+partitioned or broadcast distribution strategies. Velox also supports cross
+joins. Full outer joins are not supported yet.
 
 Join Implementation
 -------------------
@@ -18,7 +18,7 @@ values need to match, and an optional filter to apply to join results.
     :align: center
 
 The join type can be one of kInner, kLeft, kRight, kFull, kSemi, or kAnti.
-kRight and kFull join types are not supported yet.
+kFull join type is not supported yet.
 
 Filter is optional. If specified it can be any expression over the results of
 the join. This expression will be evaluated using the same expression

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -87,7 +87,7 @@ class HashBuild final : public Operator {
   const core::JoinType joinType_;
 
   // Container for the rows being accumulated.
-  std::unique_ptr<HashTable<true>> table_;
+  std::unique_ptr<BaseHashTable> table_;
 
   // Key channels in 'input_'
   std::vector<ChannelIndex> keyChannels_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -40,6 +40,8 @@ class HashProbe : public Operator {
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
+  void finish() override;
+
   void clearDynamicFilters() override;
 
   void close() override {}
@@ -59,6 +61,10 @@ class HashProbe : public Operator {
 
   // Populate output columns.
   void fillOutput(vector_size_t size);
+
+  // Populate output columns with build-side rows that didn't match join
+  // condition.
+  RowVectorPtr getNonMatchingOutputForRightJoin();
 
   // Populate filter input columns.
   void fillFilterInput(vector_size_t size);
@@ -212,6 +218,12 @@ class HashProbe : public Operator {
 
   /// For left join, true if we received new 'input_'.
   bool newInputForLeftJoin_{false};
+
+  /// True if this is the last HashProbe operator in the pipeline. It is
+  /// responsible for producing non-matching build-side rows for the right join.
+  bool lastRightJoinProbe_{false};
+
+  BaseHashTable::NotProbedRowsIterator rightJoinIterator_;
 
   /// For left join, tracks the probe side rows which had matches on the build
   /// side but didn't pass the filter.

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -208,10 +208,25 @@ class RowContainer {
       RowContainerIterator* iter,
       int32_t maxRows,
       uint64_t maxBytes,
-      char** rows);
+      char** rows) {
+    return listRows<false>(iter, maxRows, maxBytes, rows);
+  }
 
   int32_t listRows(RowContainerIterator* iter, int32_t maxRows, char** rows) {
-    return listRows(iter, maxRows, kUnlimited, rows);
+    return listRows<false>(iter, maxRows, kUnlimited, rows);
+  }
+
+  /// Sets 'probed' flag for the specified rows. Used by the right join to mark
+  /// build-side rows that matches join condition.
+  void setProbedFlag(char** rows, int32_t numRows);
+
+  /// Returns rows with 'probed' flag unset. Used by the right join.
+  int32_t listNotProbedRows(
+      RowContainerIterator* iter,
+      int32_t maxRows,
+      uint64_t maxBytes,
+      char** rows) {
+    return listRows<true>(iter, maxRows, maxBytes, rows);
   }
 
   // Returns true if 'row' at 'column' equals the value at 'index' in
@@ -595,6 +610,70 @@ class RowContainer {
       int32_t offset,
       int32_t nullByte = 0,
       uint8_t nullMask = 0);
+
+  template <bool nonProbedRowsOnly>
+  int32_t listRows(
+      RowContainerIterator* iter,
+      int32_t maxRows,
+      uint64_t maxBytes,
+      char** rows) {
+    int32_t count = 0;
+    uint64_t totalBytes = 0;
+    auto numAllocations = rows_.numAllocations();
+    if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
+        iter->rowOffset == 0) {
+      iter->normalizedKeysLeft = numRowsWithNormalizedKey_;
+    }
+    int32_t rowSize = fixedRowSize_ +
+        (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
+    for (auto i = iter->allocationIndex; i < numAllocations; ++i) {
+      auto allocation = rows_.allocationAt(i);
+      auto numRuns = allocation->numRuns();
+      for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
+        memory::MappedMemory::PageRun run = allocation->runAt(runIndex);
+        auto data = run.data<char>();
+        int64_t limit;
+        if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
+          limit = rows_.currentOffset();
+        } else {
+          limit = run.numPages() * memory::MappedMemory::kPageSize;
+        }
+        auto row = iter->rowOffset;
+        while (row + rowSize <= limit) {
+          rows[count++] = data + row +
+              (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
+          row += rowSize;
+          if (--iter->normalizedKeysLeft == 0) {
+            rowSize -= sizeof(normalized_key_t);
+          }
+          if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+            --count;
+            continue;
+          }
+          if constexpr (nonProbedRowsOnly) {
+            if (bits::isBitSet(rows[count - 1], probedFlagOffset_)) {
+              --count;
+              continue;
+            }
+          }
+          totalBytes += rowSize;
+          if (rowSizeOffset_) {
+            totalBytes += variableRowSize(rows[count - 1]);
+          }
+          if (count == maxRows || totalBytes > maxBytes) {
+            iter->rowOffset = row;
+            iter->runIndex = runIndex;
+            iter->allocationIndex = i;
+            return count;
+          }
+        }
+        iter->rowOffset = 0;
+      }
+      iter->runIndex = 0;
+    }
+    iter->allocationIndex = std::numeric_limits<int32_t>::max();
+    return count;
+  }
 
   static void extractComplexType(
       const char* const* rows,

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -124,7 +124,7 @@ TEST_F(CrossJoinTest, basic) {
                {0, 1})
            .planNode();
 
-  assertQuery(op, "SELECT null, null LIMIT 0");
+  assertQueryReturnsEmptyResult(op);
 
   // Multi-threaded build side.
   CursorParameters params;

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -41,7 +41,6 @@ class HashTableTest : public testing::Test {
       int32_t numWays,
       TypePtr buildType,
       int32_t numKeys) {
-    std::vector<std::unique_ptr<HashTable<true>>> otherTables;
     std::vector<TypePtr> dependentTypes;
     int32_t sequence = 0;
     isInTable_.resize(
@@ -60,6 +59,7 @@ class HashTableTest : public testing::Test {
       }
     }
     int32_t startOffset = 0;
+    std::vector<std::unique_ptr<BaseHashTable>> otherTables;
     for (auto way = 0; way < numWays; ++way) {
       std::vector<RowVectorPtr> batches;
       std::vector<std::unique_ptr<VectorHasher>> keyHashers;
@@ -68,7 +68,7 @@ class HashTableTest : public testing::Test {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, mappedMemory_);
+          std::move(keyHashers), dependentTypes, true, false, mappedMemory_);
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());

--- a/velox/exec/tests/QueryAssertions.cpp
+++ b/velox/exec/tests/QueryAssertions.cpp
@@ -426,6 +426,22 @@ std::shared_ptr<Task> assertQuery(
       plan, [](Task*) {}, duckDbSql, duckDbQueryRunner, sortingKeys);
 }
 
+std::shared_ptr<Task> assertQueryReturnsEmptyResult(
+    const std::shared_ptr<const core::PlanNode>& plan) {
+  CursorParameters params;
+  params.planNode = plan;
+  auto result = readCursor(params, [](Task*) {});
+
+  auto totalCount = 0;
+  for (const auto& vector : result.second) {
+    totalCount += vector->size();
+  }
+
+  EXPECT_EQ(0, totalCount) << "Expected empty result but received "
+                           << totalCount << " rows";
+  return result.first->task();
+}
+
 void assertResults(
     const std::vector<RowVectorPtr>& results,
     const std::shared_ptr<const RowType>& resultType,

--- a/velox/exec/tests/QueryAssertions.h
+++ b/velox/exec/tests/QueryAssertions.h
@@ -92,6 +92,9 @@ std::shared_ptr<Task> assertQuery(
     DuckDbQueryRunner& duckDbQueryRunner,
     std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
 
+std::shared_ptr<Task> assertQueryReturnsEmptyResult(
+    const std::shared_ptr<const core::PlanNode>& plan);
+
 void assertResults(
     const std::vector<RowVectorPtr>& results,
     const std::shared_ptr<const RowType>& resultType,

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -50,5 +50,5 @@ TEST_F(UnnestTest, allEmptyOrNullArrays) {
   });
 
   auto op = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}).planNode();
-  assertQuery(op, "SELECT 1 LIMIT 0");
+  assertQueryReturnsEmptyResult(op);
 }


### PR DESCRIPTION
- Do not ignore null keys when building hash table.
- Mark rows of the hash table that had a match for the join condition.
- After seeing all probe-side rows, produce an extra set of rows which didn't have any match from the hash table.
- Fix an existing bug in HashProbe::evalFilter where null result of the filter expression wasn't handled correctly.