### PR TITLE
Minor build fix for Ubuntu 20.04

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -30,6 +30,7 @@ cd "${BUILD_DIR}"
 sudo apt install -y \
   g++ \
   cmake \
+  ccache \
   ninja-build \
   checkinstall \
   git \

--- a/velox/type/tz/tests/CMakeLists.txt
+++ b/velox/type/tz/tests/CMakeLists.txt
@@ -16,4 +16,5 @@ add_executable(velox_type_tz_test TimeZoneMapTest.cpp)
 
 add_test(velox_type_tz_test velox_type_tz_test)
 
-target_link_libraries(velox_type_tz_test velox_type_tz ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(velox_type_tz_test velox_type_tz ${GTEST_BOTH_LIBRARIES}
+                      pthread)


### PR DESCRIPTION
1. Add ccache to scripts/setup-ubuntu.sh as it's useful to debug build
failure.
2. Add pthread to link target in `velox_type_tz_test` to avoid linker
error in Ubuntu.