### PR TITLE
Implement FixedSizeArray type.

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -196,6 +196,17 @@ folly::dynamic ArrayType::serialize() const {
   return obj;
 }
 
+FixedSizeArrayType::FixedSizeArrayType(
+    FixedSizeArrayType::size_type len,
+    std::shared_ptr<const Type> child)
+    : ArrayType(child), len_(len) {}
+
+std::string FixedSizeArrayType::toString() const {
+  std::stringstream ss;
+  ss << "FIXED_SIZE_ARRAY(" << len_ << ")<" << child_->toString() << ">";
+  return ss.str();
+}
+
 const std::shared_ptr<const Type>& MapType::childAt(uint32_t idx) const {
   if (idx == 0) {
     return keyType();
@@ -473,6 +484,13 @@ void OpaqueType::registerSerializationTypeErased(
 std::shared_ptr<const ArrayType> ARRAY(
     std::shared_ptr<const Type> elementType) {
   return std::make_shared<const ArrayType>(std::move(elementType));
+}
+
+std::shared_ptr<const FixedSizeArrayType> FIXED_SIZE_ARRAY(
+    FixedSizeArrayType::size_type len,
+    std::shared_ptr<const Type> elementType) {
+  return std::make_shared<const FixedSizeArrayType>(
+      len, std::move(elementType));
 }
 
 std::shared_ptr<const RowType> ROW(

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -27,16 +27,19 @@ TEST(Type, Array) {
   EXPECT_STREQ(arr0->kindName(), "ARRAY");
   EXPECT_EQ(arr0->isPrimitiveType(), false);
   EXPECT_STREQ(arr0->elementType()->kindName(), "ARRAY");
-  int32_t n = 0;
-  for (auto& i : *arr0) {
-    if (n == 0) {
-      EXPECT_EQ(i->toString(), "ARRAY<ARRAY<INTEGER>>");
-    } else {
-      FAIL();
-    }
-    ++n;
-  }
-  EXPECT_EQ(n, 1);
+  EXPECT_EQ(arr0->childAt(0)->toString(), "ARRAY<ARRAY<INTEGER>>");
+  EXPECT_THROW(arr0->childAt(1), VeloxUserError);
+}
+
+TEST(Type, FixedLenArray) {
+  auto arr0 = FIXED_SIZE_ARRAY(3, INTEGER());
+  EXPECT_EQ("FIXED_SIZE_ARRAY(3)<INTEGER>", arr0->toString());
+  EXPECT_EQ(arr0->size(), 1);
+  EXPECT_STREQ(arr0->kindName(), "FIXED_SIZE_ARRAY");
+  EXPECT_EQ(arr0->isPrimitiveType(), false);
+  EXPECT_STREQ(arr0->elementType()->kindName(), "INTEGER");
+  EXPECT_EQ(arr0->childAt(0)->toString(), "INTEGER");
+  EXPECT_THROW(arr0->childAt(1), VeloxUserError);
 }
 
 TEST(Type, Integer) {


### PR DESCRIPTION
Summary:
This is the first step to adding tensor support to Velox.  Here we add support for fixed size arrays.

Purpose: support implementation of Tensor types in TorchArrow (https://docs.google.com/document/d/1QIrcJinkO8yCAVDQGwElPh2VUNXrHrfuhOkkq2m5Ohg/edit)

In this diff we add the type itself.  A FixedSizeArray is an array that is
constrained to always have member elements of a given fixed size.  Its
equivalent in Arrow type system is Fixed-Size List:

https://arrow.apache.org/docs/format/Columnar.html#fixed-size-list-layout

We implement FixedSizeArrayType as a subtype of ArrayType so that anywhere an
ArrayType can be used, a FixedSizeArrayType can be provided.  Currently neither
Presto / Spark have a notion of fixed size array, so when passing this type
over the wire it maybe become a general variable width array.

Differential Revision: D31164681

