### PR TITLE
Fix Linux GCC release build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,11 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-comment \
          -Wno-int-in-bool-context \
          -Wno-redundant-move \
+         -Wno-array-bounds \
+         -Wno-maybe-uninitialized \
+         -Wno-unused-result \
+         -Wno-format-overflow \
+         -Wno-strict-aliasing \
          -Wno-type-limits")
   endif()
 

--- a/velox/common/tests/BitUtilTest.cpp
+++ b/velox/common/tests/BitUtilTest.cpp
@@ -456,7 +456,7 @@ TEST_F(BitUtilTest, isPowerOfTwo) {
 }
 
 TEST_F(BitUtilTest, getAndClearLastSetBit) {
-  uint16_t bits;
+  uint16_t bits = 0;
   for (int32_t i = 0; i < 16; i++) {
     bits::setBit(&bits, i, i % 3 == 0);
   }

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1268,8 +1268,8 @@ void StringDictionaryColumnReader::readFlatVector(
 
   auto dataPtr = data->asMutable<StringView>();
 
-  const char* strideDictPtr;
-  int64_t* strideDictOffsetPtr;
+  const char* strideDictPtr = nullptr;
+  int64_t* strideDictOffsetPtr = nullptr;
   if (strideDict) {
     strideDictPtr = strideDict->as<char>();
     strideDictOffsetPtr = strideDictOffset->asMutable<int64_t>();


### PR DESCRIPTION
Disable warnings that make GCC release build fail in Ubuntu 20.04 (gcc 9.3).