### PR TITLE
Add GroupTracker for file group access tracking

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 add_library(velox_caching DataCache.cpp FileIds.cpp StringIdMap.cpp
-                          AsyncDataCache.cpp ScanTracker.cpp)
+                          AsyncDataCache.cpp ScanTracker.cpp GroupTracker.cpp)
+
 target_link_libraries(velox_caching velox_memory velox_exception ${GLOG}
                       ${FOLLY_WITH_DEPENDENCIES})
 

--- a/velox/common/caching/GroupTracker.cpp
+++ b/velox/common/caching/GroupTracker.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/GroupTracker.h"
+
+#include "velox/common/base/BitUtil.h"
+
+#include <gflags/gflags.h>
+
+DEFINE_int32(
+    max_tracked_columns,
+    200000,
+    "Max number of columns*partitions tracked for possible staging "
+    "on SSD");
+
+namespace facebook::velox::cache {
+
+void GroupTracker::recordFile(uint64_t fileId, int32_t numStripes) {
+  if (numFiles_.add(fileId)) {
+    numStripes_ += numStripes;
+  }
+}
+
+void GroupTracker::recordReference(
+    uint64_t fileId,
+    int32_t columnId,
+    int32_t bytes) {
+  auto& data = columns_[columnId];
+  data.referencedBytes += bytes;
+  ++data.numReferences;
+}
+
+void GroupTracker::recordRead(
+    uint64_t fileId,
+    int32_t columnId,
+    int32_t bytes) {
+  auto& data = columns_[columnId];
+  data.readBytes += bytes;
+  ++data.numReads;
+}
+
+namespace {
+uint64_t ssdFilterHash(uint64_t groupId, int32_t columnId) {
+  return bits::hashMix(
+      folly::hasher<uint64_t>()(groupId), folly::hasher<uint64_t>()(columnId));
+}
+
+// Returns an arbitrary multiplier for score based on
+// size.
+
+float sizeFactor(float size) {
+  // Number of bytes transferred as part of a large request in in
+  // the time of a round trip with no data transfer.
+  constexpr float kBytesPerLatency = 10000;
+  return kBytesPerLatency / (kBytesPerLatency + size);
+}
+
+// Decayse count by decayPct%. 'count' always decreases by at least
+// 1. bytes is scaled down pro rata so as to maintain bytes/count.
+void decay(int32_t decayPct, int64_t& bytes, int32_t& count) {
+  if (!count) {
+    bytes = 0;
+    return;
+  }
+  auto newCount = count * (100 - decayPct) / 100;
+  bytes = bytes * newCount / count;
+  count = newCount;
+}
+
+void decay(int32_t decayPct, TrackingData& data) {
+  decay(decayPct, data.referencedBytes, data.numReferences);
+  decay(decayPct, data.readBytes, data.numReads);
+}
+} // namespace
+
+void GroupTracker::addColumnScores(
+    int32_t decayPct,
+    std::vector<SsdScore>& scores) {
+  int32_t numFiles = numFiles_.count();
+  if (!numFiles) {
+    return;
+  }
+  std::vector<int32_t> toErase;
+  auto stripesInFile = numStripes_ / numFiles;
+  auto numStripes = numFiles * stripesInFile;
+  for (auto& pair : columns_) {
+    auto& data = pair.second;
+    if (decayPct) {
+      decay(decayPct, data);
+    }
+    if (!data.numReads || !data.numReferences) {
+      toErase.push_back(pair.first);
+      continue;
+    }
+    float size = (data.referencedBytes / data.numReferences) * numStripes;
+    float readSize = data.readBytes / data.numReads;
+    float readFraction = readSize / size;
+    float score = data.numReads * sizeFactor(size) * readFraction;
+    scores.push_back(SsdScore{
+        score,
+        static_cast<float>(size),
+        static_cast<float>(data.readBytes),
+        name_.id(),
+        pair.first});
+  }
+  for (auto id : toErase) {
+    columns_.erase(id);
+  }
+}
+
+FileGroupStats::FileGroupStats() : maxColumns_(FLAGS_max_tracked_columns) {}
+
+void FileGroupStats::recordFile(
+    uint64_t fileId,
+    uint64_t groupId,
+    int32_t numStripes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  groupLocked(groupId).recordFile(fileId, numStripes);
+}
+
+void FileGroupStats::recordReference(
+    uint64_t fileId,
+    uint64_t groupId,
+    TrackingId trackingId,
+    int32_t bytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  groupLocked(groupId).recordReference(fileId, trackingId.columnId(), bytes);
+}
+
+void FileGroupStats::recordRead(
+    uint64_t fileId,
+    uint64_t groupId,
+    TrackingId trackingId,
+    int32_t bytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  groupLocked(groupId).recordRead(fileId, trackingId.columnId(), bytes);
+}
+
+bool FileGroupStats::shouldSaveToSsd(uint64_t groupId, TrackingId trackingId)
+    const {
+  if (!ssdFilterInited_) {
+    return false;
+  }
+  if (allFitOnSsd_) {
+    return true;
+  }
+  uint64_t hash = ssdFilterHash(groupId, trackingId.columnId());
+  return saveToSsd_.withRLock(
+      [&](auto& set) { return set.find(hash) != set.end(); });
+}
+
+std::vector<SsdScore> FileGroupStats::ssdScoresLocked(
+    uint64_t cacheBytes,
+    int32_t decayPct) {
+  std::vector<SsdScore> scores;
+  std::vector<SsdScore> deleted;
+  for (auto& pair : groups_) {
+    pair.second->addColumnScores(decayPct, scores);
+  }
+  // Sort the scores, high score first.
+  std::sort(
+      scores.begin(),
+      scores.end(),
+      [](const SsdScore& left, const SsdScore& right) {
+        return left.score > right.score;
+      });
+  if (scores.size() > maxColumns_) {
+    for (auto i = maxColumns_; i < scores.size(); ++i) {
+      eraseStatLocked(scores[i].groupId, scores[i].columnId);
+    }
+    scores.resize(maxColumns_);
+  }
+  float totalSize = 0;
+  totalRead_ = 0;
+  int32_t numCachable = -1;
+  float cachableReads = 0;
+  for (auto i = 0; i < scores.size(); ++i) {
+    totalSize += scores[i].totalBytes;
+    totalRead_ += scores[i].readBytes;
+    if (totalSize < cacheBytes) {
+      cachableReads += scores[i].readBytes;
+    } else if (numCachable == -1) {
+      numCachable = i;
+    }
+  }
+  dataSize_ = totalSize;
+  cachableDataPct_ = 100 * cacheBytes / totalSize;
+  cachableReadPct_ = 100 * cachableReads / totalRead_;
+
+  return scores;
+}
+
+void FileGroupStats::eraseStatLocked(uint64_t groupId, int32_t columnId) {
+  auto it = groups_.find(groupId);
+  if (it != groups_.end()) {
+    if (it->second->eraseColumn(columnId)) {
+      groups_.erase(it);
+    }
+  }
+}
+
+void FileGroupStats::updateSsdFilter(uint64_t ssdSize, int32_t decayPct) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto scores = ssdScoresLocked(ssdSize, decayPct);
+  float size = 0;
+
+  int32_t i = 0;
+  for (; i < scores.size(); ++i) {
+    size += scores[i].totalBytes;
+    if (size > ssdSize) {
+      break;
+    }
+  }
+  if (i == scores.size()) {
+    allFitOnSsd_ = true;
+    ssdFilterInited_ = true;
+  } else {
+    folly::F14FastSet<uint64_t> newFilter;
+    for (auto included = 0; included < i; ++included) {
+      auto hash = ssdFilterHash(scores[i].groupId, scores[i].columnId);
+      newFilter.insert(hash);
+    }
+    saveToSsd_.withWLock([&](auto& set) { set = std::move(newFilter); });
+    ssdFilterInited_ = true;
+    allFitOnSsd_ = false;
+  }
+}
+
+void FileGroupStats::clear() {
+  groups_.clear();
+  dataSize_ = 0;
+  cachableDataPct_ = 0;
+  cachableReadPct_ = 0;
+}
+
+std::string FileGroupStats::toString(uint64_t cacheBytes) {
+  std::stringstream out;
+  std::vector<SsdScore> scores;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    scores = ssdScoresLocked(cacheBytes);
+  }
+  out << fmt::format(
+      "Group tracking: {} groups, {} bytes, {} bytes read\n",
+      scores.size(),
+      dataSize_,
+      totalRead_);
+  out << fmt::format(
+      "Cache covers {}% of data and {}% of reads\n",
+      cachableDataPct_,
+      cachableReadPct_);
+
+  return out.str();
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/GroupTracker.h
+++ b/velox/common/caching/GroupTracker.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/BloomFilter.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/ScanTracker.h"
+#include "velox/common/caching/StringIdMap.h"
+
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+
+namespace facebook::velox::cache {
+
+// Counts distinct integers. 'range' is an estimate of expected distinct
+class DistinctCounter {
+ public:
+  DistinctCounter(int32_t /*range*/) {}
+
+  //  Adds a value. Returns true if the value is new.
+  bool add(uint64_t value) {
+    return values_.insert(value).second;
+  }
+
+  int32_t count() const {
+    return values_.size();
+  }
+
+ private:
+  folly::F14FastSet<uint64_t> values_;
+};
+
+// Represents a groupId, column and its size and score. These are
+// sorted and as many are selected from the top as will fit on SSD.
+struct SsdScore {
+  // Number used for ranking. Correlates to access frequency and
+  // inversely to size.
+  float score;
+
+  // Expected size in bytes for caching to SSD
+  float totalBytes;
+  // Recorded read activity, with older reads decayed.
+  float readBytes;
+  // The column and file group. Not const because this struct must be
+  // move assignable as an operand to std::sort.
+  uint64_t groupId;
+  int32_t columnId;
+};
+
+// Tracks usage of different columns inside a file group. Tracks the number
+// of distinct files in the group and their average number of splits. Produces
+// estimates of the column size for each accessed column in the group.
+class GroupTracker {
+ public:
+  static constexpr int32_t kExpectedNumFiles = 100;
+
+  // Constructs a tracker for file group 'ame'. 'name' is for example
+  // the directory path of a Hive partition.
+  GroupTracker(const StringIdLease& name)
+      : name_(name), numFiles_(kExpectedNumFiles) {}
+
+  // Records that 'fileId' belongs to this group and has 'numStripes'
+  // stripes. Used to scale up the column sizes reported by
+  // recordReference().
+  void recordFile(uint64_t fileId, int32_t numStripes);
+
+  // Records a sample stripe size for 'columnId'.
+  void recordReference(uint64_t fileId, int32_t columnId, int32_t bytes);
+
+  // Records read of 'bytes' from 'columnId' This is compared to the
+  // reference size to get read density.
+  void recordRead(uint64_t fileId, int32_t columnId, int32_t bytes);
+
+  // Adds the column scores to 'scores'. If 'decayPct' is non-0,
+  // decays the recorded accesses by 'decayPct'% but at least by one
+  // whole access.
+  void addColumnScores(int32_t decayPct, std::vector<SsdScore>& scores);
+
+  bool eraseColumn(int32_t columnId) {
+    columns_.erase(columnId);
+    return columns_.empty();
+  }
+
+ private:
+  StringIdLease name_;
+
+  // Map of column to access data.
+  folly::F14FastMap<int32_t, TrackingData> columns_;
+
+  // Count of distinct files seen in recordFile().
+  DistinctCounter numFiles_;
+
+  uint64_t numStripes_{0};
+};
+
+// Set of file group stats. There is one instance per SSD cache.
+class FileGroupStats {
+ public:
+  FileGroupStats();
+  // Records the existence of a distinct file inside 'groupId'
+  void recordFile(uint64_t fileId, uint64_t groupId, int32_t numStripes);
+
+  // Records ScanTracker::recordReference at group level
+  void recordReference(
+      uint64_t fileId,
+      uint64_t groupId,
+      TrackingId id,
+      int32_t bytes);
+
+  // Records ScanTracker::recordRead at group level
+  void recordRead(
+      uint64_t fileId,
+      uint64_t groupId,
+      TrackingId trackingId,
+      int32_t bytes);
+
+  // Returns true if groupId, trackingId qualify the data to be cached to SSD.
+  bool shouldSaveToSsd(uint64_t groupId, TrackingId trackingId) const;
+
+  // Updates the SSD selection criteria. The group. trackingId pairs
+  // that account for the top 'ssdSize' bytes of reported IO are
+  // selected. If 'decayPct' is non-0, old stats are decayed and
+  // removed if counts go to zero.
+  void updateSsdFilter(uint64_t ssdSize, int32_t decayPct = 0);
+
+  // Returns an estimate of the total size of the dataset based of the
+  // groups, files and columns referenced to data.
+  float dataSize() const {
+    return dataSize_;
+  }
+
+  // Returns the percentage of historical reads that hit the currently SSD
+  // cachable fraction of the data.
+  float cachableReadPct() const {
+    return cachableReadPct_;
+  }
+
+  // Returns percent of all seen data that fits in the SSD cachable fraction.
+  float cachableDataPct() const {
+    return cachableDataPct_;
+  }
+
+  // Clears the state to be as after default construction.
+  void clear();
+
+  // Recalculates the best groups and makes a human readable
+  // summary. 'cacheBytes' is used to compute what fraction of the tracked
+  // working set can be cached in 'cacheBytes'.
+  std::string toString(uint64_t cacheBytes);
+
+ private:
+  GroupTracker& groupLocked(uint64_t id) {
+    auto it = groups_.find(id);
+    if (it == groups_.end()) {
+      groups_[id] =
+          std::make_unique<GroupTracker>(StringIdLease(fileIds(), id));
+      return *groups_[id];
+    }
+    return *it->second;
+  }
+
+  // Returns the tracked group/column pairs best score first. Sets the
+  // 'dataSize_', 'cachableReadPct_' and 'cachableDataPct_' according
+  // to 'cacheBytes'. access counts by decayPct if decayPct% is
+  // non-0. Trims away scores that fall to zero accesses by decay or
+  // fall outside of the top FLAGS_max_group_stats top scores.
+  std::vector<SsdScore> ssdScoresLocked(
+      uint64_t cacheBytes,
+      int32_t decayPct = 0);
+
+  //  Removes the information on groupId/id.
+  void eraseStatLocked(uint64_t groupId, int32_t columnId);
+  // Serializes access to  all data members and private methods.
+  std::mutex mutex_;
+
+  folly::F14FastMap<uint64_t, std::unique_ptr<GroupTracker>> groups_;
+
+  // Max number of columns tracked.
+  const int32_t maxColumns_;
+
+  // Set of groupId, columnId combinations for streams that should be saved
+  // to SSD.
+  folly::Synchronized<folly::F14FastSet<uint64_t>> saveToSsd_;
+  bool ssdFilterInited_{false};
+  bool allFitOnSsd_{false};
+  double dataSize_{0};
+  double totalRead_{0};
+  float cachableDataPct_{0};
+  float cachableReadPct_{0};
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/caching/GroupTracker.h"
 
 #include <sstream>
 
@@ -23,7 +24,11 @@ namespace facebook::velox::cache {
 void ScanTracker::recordReference(
     const TrackingId id,
     uint64_t bytes,
-    uint64_t /*groupId*/) {
+    uint64_t fileId,
+    uint64_t groupId) {
+  if (fileGroupStats_) {
+    fileGroupStats_->recordReference(fileId, groupId, id, bytes);
+  }
   std::lock_guard<std::mutex> l(mutex_);
   data_[id].incrementReference(bytes);
   sum_.incrementReference(bytes);
@@ -32,7 +37,11 @@ void ScanTracker::recordReference(
 void ScanTracker::recordRead(
     const TrackingId id,
     uint64_t bytes,
-    uint64_t /*groupId*/) {
+    uint64_t fileId,
+    uint64_t groupId) {
+  if (fileGroupStats_) {
+    fileGroupStats_->recordRead(fileId, groupId, id, bytes);
+  }
   std::lock_guard<std::mutex> l(mutex_);
   data_[id].incrementRead(bytes);
   sum_.incrementRead(bytes);

--- a/velox/common/caching/StringIdMap.h
+++ b/velox/common/caching/StringIdMap.h
@@ -55,6 +55,14 @@ class StringIdMap {
   // Increments the use count of 'id'.
   void addReference(uint64_t id);
 
+  // Returns a copy of the string associated with id or empty string if id has
+  // no string.
+  std::string string(uint64_t id) {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto it = idToString_.find(id);
+    return it == idToString_.end() ? "" : it->second.string;
+  }
+
  private:
   struct Entry {
     std::string string;

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ add_test(simple_lru_cache_test simple_lru_cache_test)
 target_link_libraries(simple_lru_cache_test ${GTEST_BOTH_LIBRARIES} ${GLOG}
                       ${gflags_LIBRARIES} ${FOLLY_WITH_DEPENDENCIES})
 
-add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp)
+add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
+                                GroupTrackerTest.cpp)
 add_test(velox_cache_test velox_cache_test)
 target_link_libraries(
   velox_cache_test

--- a/velox/common/caching/tests/GroupTrackerTest.cpp
+++ b/velox/common/caching/tests/GroupTrackerTest.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/GroupTracker.h"
+#include "velox/common/caching/FileIds.h"
+
+#include <folly/Random.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::cache;
+
+struct TestFile {
+  StringIdLease id;
+  int32_t numStripes;
+};
+
+struct TestGroup {
+  StringIdLease id;
+  std::vector<TestFile> files;
+  std::vector<int32_t> columnSizes;
+};
+
+struct TestTable {
+  std::vector<TestGroup> groups;
+};
+
+class GroupTrackerTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    rng_.seed(1);
+    stats_ = std::make_unique<FileGroupStats>();
+  }
+
+  // Makes a test population of tables. A table has many file groups
+  // (partitions) with the same number of columns and same column sizes.
+  void makeTables(int32_t numTables) {
+    for (auto i = 0; i < numTables; ++i) {
+      int32_t sizeClass = random(100);
+      int32_t numColumns = 0;
+      if (sizeClass < 30) {
+        numColumns = 15 + random(10);
+      } else if (sizeClass < 95) {
+        numColumns = 30 + random(20);
+      } else {
+        numColumns = (1000) + random(1000);
+      }
+
+      std::vector<int32_t> sizes;
+      for (auto i = 0; i < numColumns; ++i) {
+        sizes.push_back(columnSizes_[random(columnSizes_.size())]);
+      }
+      int32_t numGroups = 10 + random(30);
+      std::vector<TestGroup> groups;
+      for (auto i = 0; i < numGroups; ++i) {
+        TestGroup group;
+        group.id = StringIdLease(fileIds(), fmt::format("group{}", i));
+        int32_t numFiles = 10 + random(6);
+        for (auto fileNum = 0; fileNum < numFiles; ++fileNum) {
+          group.files.push_back(TestFile{
+              StringIdLease(
+                  fileIds(),
+                  fmt::format(
+                      "{}/file{}", fileIds().string(group.id.id()), fileNum)),
+              10});
+        }
+        group.columnSizes = sizes;
+        groups.push_back(std::move(group));
+      }
+      TestTable table;
+      table.groups = std::move(groups);
+      tables_.push_back(std::move(table));
+    }
+  }
+
+  // Reads a random set of groups from a random table, selecting a biased
+  // random set of columns with some being sparsely read.
+  void query(int32_t tableIndex) {
+    std::vector<int32_t> columns;
+    auto& table = tables_[tableIndex];
+    auto numColumns = table.groups[0].columnSizes.size();
+    std::unordered_set<int32_t> readColumns;
+    int32_t toRead =
+        readAllColumns_ ? numColumns : 5 + random(numColumns > 20 ? 10 : 5);
+    for (auto i = 0; i < toRead; ++i) {
+      if (readAllColumns_) {
+        readColumns.insert(i);
+      } else {
+        readColumns.insert(random(numColumns, numColumns));
+      }
+    }
+    auto numGroups = table.groups.size();
+    auto readGroups = std::min<int32_t>(numGroups, 5 + random(numGroups));
+    for (auto groupIndex = numGroups - readGroups; groupIndex < numGroups;
+         ++groupIndex) {
+      auto& group = table.groups[groupIndex];
+      for (auto& file : group.files) {
+        stats_->recordFile(file.id.id(), group.id.id(), file.numStripes);
+        for (auto column : readColumns) {
+          stats_->recordReference(
+              file.id.id(),
+              group.id.id(),
+              TrackingId(column, 0),
+              group.columnSizes[column]);
+          auto readBytes = shouldRead(column, group.columnSizes[column]);
+          if (readBytes) {
+            if (stats_->shouldSaveToSsd(group.id.id(), TrackingId(column, 0))) {
+              numFromSsd_ += readBytes;
+            } else {
+              numFromDisk_ += readBytes;
+            }
+            stats_->recordRead(
+                file.id.id(), group.id.id(), TrackingId(column, 0), readBytes);
+          }
+        }
+      }
+    }
+  }
+
+  // For a stable 1/3, read 1/3 of the data.
+  int32_t shouldRead(int32_t column, int32_t size) {
+    if (readAll_) {
+      return size;
+    }
+    int32_t rnd = random(100);
+    if (column % 21 == 0) {
+      // 5% are read for 1/10.
+      return rnd > 95 ? size / 10 : 0;
+    }
+    if (column % 7 == 0) {
+      // 1/7 is read for 1/1 1/2 of the time.
+      if (rnd > 50) {
+        return size / 3;
+      }
+      return 0;
+    }
+
+    return size;
+  }
+
+  // A bitwise or of random numbers will make 3/4 of the bits in
+  // common true, giving a biased distribution.
+  int32_t random(int32_t range, int32_t maskRange) {
+    return ((folly::Random::rand32(rng_) % range) |
+            (folly::Random::rand32(rng_) % maskRange)) %
+        range;
+  }
+
+  int32_t random(int32_t pctLow, int32_t lowRange, int32_t highRange) {
+    return folly::Random::rand32(rng_) %
+        (folly::Random::rand32() % 100 > pctLow ? highRange : lowRange);
+  }
+
+  int32_t random(int32_t range) {
+    return folly::Random::rand32(rng_) % range;
+  }
+
+  std::unique_ptr<FileGroupStats> stats_;
+  std::vector<TestTable> tables_;
+  std::vector<int32_t>
+      columnSizes_{1000, 2000, 3000, 3000, 3000, 4000, 10000, 15000, 100000};
+  uint64_t numFromSsd_{0};
+  uint64_t numFromDisk_{0};
+  folly::Random::DefaultGenerator rng_;
+  bool readAll_{false};
+  bool readAllColumns_{false};
+};
+
+TEST_F(GroupTrackerTest, randomScan) {
+  // Runs 1K random queries on 100 files. The file and column read
+  // probabilities are biased. Checks that cache covers a small
+  // percentage of the data but selects the more frequently hit
+  // columns and groups.
+  constexpr int32_t kQueries = 1000;
+  constexpr uint64_t kSsdSize = 1UL << 30;
+  makeTables(101);
+  auto numTables = tables_.size();
+  for (auto i = 0; i < kQueries; ++i) {
+    int32_t tableIndex = random(numTables, numTables);
+    query(tableIndex);
+    if (i % (kQueries / 10) == 0) {
+      stats_->updateSsdFilter(kSsdSize);
+    }
+  }
+  LOG(INFO) << stats_->toString(kSsdSize);
+
+  auto dataPct = stats_->cachableDataPct();
+  auto readPct = stats_->cachableReadPct();
+  EXPECT_LE(3, dataPct);
+  EXPECT_GE(4, dataPct);
+  EXPECT_LE(45, readPct);
+  EXPECT_GE(55, readPct);
+}
+
+TEST_F(GroupTrackerTest, limitAndDecay) {
+  constexpr uint64_t kSsdSize = 1UL << 30;
+  makeTables(1000);
+  auto numTables = tables_.size();
+  // We read all the  tables once and every 5th twice.
+  readAllColumns_ = true;
+  for (auto i = 0; i < numTables; ++i) {
+    query(i);
+    if (i % 5 == 0) {
+      query(i);
+    }
+
+    if (i % 20 == 0) {
+      stats_->updateSsdFilter(kSsdSize, 2);
+    }
+  }
+  LOG(INFO) << stats_->toString(kSsdSize);
+  auto dataPct = stats_->cachableDataPct();
+  auto readPct = stats_->cachableReadPct();
+  EXPECT_LE(0.4, dataPct);
+  EXPECT_GE(1, dataPct);
+  EXPECT_LE(10, readPct);
+  EXPECT_GE(16, readPct);
+}

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -88,6 +88,8 @@ class BufferedInput {
     return false;
   }
 
+  virtual void setNumStripes(int32_t /*numStripes*/) {}
+
  protected:
   dwio::common::InputStream& input_;
 

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -56,7 +56,7 @@ bool CacheInputStream::Next(const void** buffer, int32_t* size) {
   offsetInRun_ += *size;
   position_ += *size;
   if (tracker_) {
-    tracker_->recordRead(trackingId_, *size, groupId_);
+    tracker_->recordRead(trackingId_, *size, fileNum_, groupId_);
   }
   return true;
 }

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
   }
   requests_.emplace_back(CacheRequest{
       RawFileCacheKey{fileNum_, region.offset}, region.length, id, CachePin()});
-  tracker_->recordReference(id, region.length, groupId_);
+  tracker_->recordReference(id, region.length, fileNum_, groupId_);
   return std::make_unique<CacheInputStream>(
       cache_, ioStats_.get(), region, input_, fileNum_, tracker_, id, groupId_);
 }

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/GroupTracker.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/dwrf/common/BufferedInput.h"
@@ -90,6 +91,12 @@ class CachedBufferedInput : public BufferedInput {
 
   bool shouldPrefetchStripes() const override {
     return true;
+  }
+
+  void setNumStripes(int32_t numStripes) override {
+    if (tracker_->fileGroupStats()) {
+      tracker_->fileGroupStats()->recordFile(fileNum_, groupId_, numStripes);
+    }
   }
 
  private:

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -213,8 +213,10 @@ ReaderBase::ReaderBase(
     const std::string tailKey = TailKey(dataCacheConfig->filenum);
     dataCacheConfig->cache->put(tailKey, {tail.get(), tailSize});
   }
+
   if (input_->shouldPrefetchStripes()) {
     auto numStripes = getFooter().stripes_size();
+    input_->setNumStripes(numStripes);
     for (auto i = 0; i < numStripes; i++) {
       const auto& stripe = getFooter().stripes(i);
       input_->enqueue(


### PR DESCRIPTION
GroupStats holds process-wide access stats for column access in each
file group. A file group is typically a Hive partition of a
table. Different partitions will have different access frequencies for
different columns. For each file group we estimate the number of
distinct files and the number of splits per file. For columns, we
track the references and actual reads.

This information gives us the sizes of the hot columns and allows
deciding which ones should be staged on SSD. We order group/column
pairs on a score and qualify the top k GB worth of columns to be
written to SSD at the next opportunity.


Only columns that are actually referenced by queries are
recorded. Unlike ScanTracker, this does not differentiate between
different streams of one column.  If one stream will be cached on SSD,
then all the related streams should also be cached.

The number of columns can be very large. Therefore the tracker has a
size limit and removes tracking data for columns if there are no
accesses. Column access stats can be periodically decayed so as to
deemphasize old activity. The frequency and amount of decay is up to
the caller.