### PR TITLE
Update velox public doc url in docs readme

### DIFF
--- a/velox/docs/README.md
+++ b/velox/docs/README.md
@@ -21,7 +21,7 @@ Navigate to
 
 GitHub pages is configured to display the contents of the top-level docs directory
 found in the gh-pages branch. The documentation is available at
-https://fantastic-broccoli-4f7558bb.pages.github.io.
+https://facebookincubator.github.io/velox.
 
 To publish updated documentation copy the contents of the _build/html
 directory to the top-level docs folder and push to gh-pages branch.


### PR DESCRIPTION
As the project is public so docs are now served from a non-obfuscated URI: https://facebookincubator.github.io/velox/
Update README in docs folder accordingly