### PR TITLE
Add ArrowArray conversion to Velox Vector

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -330,6 +330,8 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
   _VELOX_USER_CHECK_OP(e1, e2, ==, ##__VA_ARGS__)
 #define VELOX_USER_CHECK_NE(e1, e2, ...) \
   _VELOX_USER_CHECK_OP(e1, e2, !=, ##__VA_ARGS__)
+#define VELOX_USER_CHECK_NULL(e, ...) \
+  VELOX_USER_CHECK(e == nullptr, ##__VA_ARGS__)
 #define VELOX_USER_CHECK_NOT_NULL(e, ...) \
   VELOX_USER_CHECK(e != nullptr, ##__VA_ARGS__)
 
@@ -349,6 +351,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
   VELOX_USER_CHECK_NE(e1, e2, ##__VA_ARGS__)
 #define VELOX_USER_DCHECK_NOT_NULL(e, ...) \
   VELOX_USER_CHECK_NOT_NULL(e, ##__VA_ARGS__)
+#define VELOX_USER_DCHECK_NULL(e, ...) VELOX_USER_CHECK_NULL(e, ##__VA_ARGS__)
 #else
 #define VELOX_USER_DCHECK(expr, ...) VELOX_USER_CHECK(true)
 #define VELOX_USER_DCHECK_GT(e1, e2, ...) VELOX_USER_CHECK(true)
@@ -357,6 +360,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxUserError);
 #define VELOX_USER_DCHECK_LE(e1, e2, ...) VELOX_USER_CHECK(true)
 #define VELOX_USER_DCHECK_EQ(e1, e2, ...) VELOX_USER_CHECK(true)
 #define VELOX_USER_DCHECK_NE(e1, e2, ...) VELOX_USER_CHECK(true)
+#define VELOX_USER_DCHECK_NULL(e, ...) VELOX_USER_CHECK(true)
 #define VELOX_USER_DCHECK_NOT_NULL(e, ...) VELOX_USER_CHECK(true)
 #endif
 

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "velox/vector/arrow/Bridge.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::arrow {
 
@@ -379,6 +383,103 @@ TypePtr importFromArrow(const ArrowSchema& arrowSchema) {
   }
   VELOX_USER_FAIL(
       "Unable to convert '{}' ArrowSchema format type to Velox.", format);
+}
+
+namespace {
+struct DummyReleaser {
+  void addRef() const {}
+  void release() const {}
+};
+
+// Wraps a naked pointer using a Velox buffer view, without copying it. Adding a
+// dummy releaser as the buffer lifetime is fully controled by the client of the
+// API.
+BufferPtr wrapInBufferView(const void* buffer, size_t length) {
+  static const DummyReleaser kDummy;
+  return BufferView<DummyReleaser>::create(
+      static_cast<const uint8_t*>(buffer), length, kDummy);
+}
+
+// Dispatch based on the type.
+template <TypeKind kind>
+VectorPtr importFromArrowImpl(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    size_t length,
+    BufferPtr values,
+    int64_t nullCount) {
+  using T = typename TypeTraits<kind>::NativeType;
+  return std::make_shared<FlatVector<T>>(
+      pool,
+      type,
+      nulls,
+      length,
+      values,
+      std::vector<BufferPtr>(),
+      cdvi::EMPTY_METADATA,
+      std::nullopt,
+      nullCount == -1 ? std::nullopt : std::optional<int64_t>(nullCount));
+}
+} // namespace
+
+VectorPtr importFromArrow(
+    const ArrowSchema& arrowSchema,
+    const ArrowArray& arrowArray,
+    memory::MemoryPool* pool) {
+  VELOX_USER_CHECK_NULL(
+      arrowArray.dictionary,
+      "Dictionary encoded arrowArrays not supported yet.");
+  VELOX_USER_CHECK(
+      (arrowArray.n_children == 0) && (arrowArray.children == nullptr),
+      "Only flat buffers are supported for now.");
+  VELOX_USER_CHECK_EQ(
+      arrowArray.offset,
+      0,
+      "Offsets are not supported during arrow conversion yet.");
+  VELOX_CHECK_GE(arrowArray.length, 0, "Array length needs to be positive.");
+
+  // First parse and generate a Velox type.
+  auto type = importFromArrow(arrowSchema);
+  VELOX_CHECK(
+      type->isPrimitiveType(),
+      "Only conversion of primitive types is supported for now.");
+
+  // Wrap the nulls buffer into a Velox BufferView (zero-copy). Null buffer size
+  // needs to be at least one bit per element.
+  BufferPtr nulls = nullptr;
+
+  // If either greater than zero or -1 (unknown).
+  if (arrowArray.null_count != 0) {
+    VELOX_USER_CHECK_NOT_NULL(
+        arrowArray.buffers[0],
+        "Nulls buffer can't be null unless null_count is zero.");
+    nulls = wrapInBufferView(
+        arrowArray.buffers[0], bits::nbytes(arrowArray.length));
+  } else {
+    VELOX_USER_CHECK_NULL(
+        arrowArray.buffers[0],
+        "Nulls buffer must be nullptr when null_count is zero.");
+  }
+
+  // Wrap the values buffer into a Velox BufferView (also zero-copy).
+  VELOX_USER_CHECK_EQ(
+      arrowArray.n_buffers,
+      2,
+      "Expecting two buffers as input "
+      "(only simple types supported for now).");
+  auto values = wrapInBufferView(
+      arrowArray.buffers[1], arrowArray.length * type->cppSizeInBytes());
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      importFromArrowImpl,
+      type->kind(),
+      pool,
+      type,
+      nulls,
+      arrowArray.length,
+      values,
+      arrowArray.null_count);
 }
 
 } // namespace facebook::velox::arrow

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -19,6 +19,10 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/arrow/Abi.h"
 
+namespace facebook::velox::memory {
+class MemoryPool;
+}
+
 namespace facebook::velox::arrow {
 
 /// Export a generic Velox Vector to an ArrowArray, as defined by Arrow's C data
@@ -85,5 +89,34 @@ void exportToArrow(const TypePtr& type, ArrowSchema& arrowSchema);
 ///   arrowSchema.release(&arrowSchema);
 ///
 TypePtr importFromArrow(const ArrowSchema& arrowSchema);
+
+/// Import an ArrowArray and ArrowSchema into a Velox vector.
+///
+/// This function takes both an ArrowArray (which contains the buffers) and an
+/// ArrowSchema (which describes the data type), since a Velox vector needs
+/// both (buffer and type). A memory pool is also required, since all vectors
+/// carry a pointer to it, but not really used in most cases - unless the
+/// conversion itself requires a new allocation. In most cases no new
+/// allocations are required, unless for arrays of varchars (or varbinaries) and
+/// complex types written out of order.
+///
+/// The new Velox vector returned contains only references to the underlying
+/// buffers, so it's the client's responsibility to ensure the buffer's
+/// lifetime.
+///
+/// The function throws in case the conversion fails.
+///
+/// Example usage:
+///
+///   ArrowSchema arrowSchema;
+///   ArrowArray arrowArray;
+///   ... // fills structures
+///   auto vector = arrow::importToArrow(arrowSchema, arrowArray, pool);
+///   ... // ensure buffers in arrowArray remain alive while vector is used.
+///
+VectorPtr importFromArrow(
+    const ArrowSchema& arrowSchema,
+    const ArrowArray& arrowArray,
+    memory::MemoryPool* pool);
 
 } // namespace facebook::velox::arrow

--- a/velox/vector/arrow/tests/ArrowBridgeTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeTest.cpp
@@ -24,8 +24,9 @@
 namespace {
 
 using namespace facebook::velox;
+static void mockRelease(ArrowSchema*) {}
 
-class ArrowBridgeTest : public testing::Test {
+class ArrowBridgeExportTest : public testing::Test {
  protected:
   template <typename T>
   void testFlatVector(const std::vector<std::optional<T>>& inputData) {
@@ -79,7 +80,7 @@ class ArrowBridgeTest : public testing::Test {
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
 
-TEST_F(ArrowBridgeTest, flatNotNull) {
+TEST_F(ArrowBridgeExportTest, flatNotNull) {
   std::vector<int64_t> inputData = {1, 2, 3, 4, 5};
   ArrowArray arrowArray;
   {
@@ -114,7 +115,7 @@ TEST_F(ArrowBridgeTest, flatNotNull) {
   EXPECT_EQ(nullptr, arrowArray.private_data);
 }
 
-TEST_F(ArrowBridgeTest, flatBool) {
+TEST_F(ArrowBridgeExportTest, flatBool) {
   testFlatVector<bool>({
       true,
       false,
@@ -126,7 +127,7 @@ TEST_F(ArrowBridgeTest, flatBool) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatTinyint) {
+TEST_F(ArrowBridgeExportTest, flatTinyint) {
   testFlatVector<int8_t>({
       1,
       std::numeric_limits<int8_t>::min(),
@@ -137,7 +138,7 @@ TEST_F(ArrowBridgeTest, flatTinyint) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatSmallint) {
+TEST_F(ArrowBridgeExportTest, flatSmallint) {
   testFlatVector<int16_t>({
       std::numeric_limits<int16_t>::min(),
       1000,
@@ -146,7 +147,7 @@ TEST_F(ArrowBridgeTest, flatSmallint) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatInteger) {
+TEST_F(ArrowBridgeExportTest, flatInteger) {
   testFlatVector<int32_t>({
       std::numeric_limits<int32_t>::min(),
       std::nullopt,
@@ -157,7 +158,7 @@ TEST_F(ArrowBridgeTest, flatInteger) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatBigint) {
+TEST_F(ArrowBridgeExportTest, flatBigint) {
   testFlatVector<int64_t>({
       std::nullopt,
       99876,
@@ -169,7 +170,7 @@ TEST_F(ArrowBridgeTest, flatBigint) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatReal) {
+TEST_F(ArrowBridgeExportTest, flatReal) {
   testFlatVector<float>({
       std::nullopt,
       std::numeric_limits<float>::infinity(),
@@ -181,7 +182,7 @@ TEST_F(ArrowBridgeTest, flatReal) {
   });
 }
 
-TEST_F(ArrowBridgeTest, flatDouble) {
+TEST_F(ArrowBridgeExportTest, flatDouble) {
   testFlatVector<double>({
       1.1,
       std::numeric_limits<double>::infinity(),
@@ -193,7 +194,7 @@ TEST_F(ArrowBridgeTest, flatDouble) {
   });
 }
 
-TEST_F(ArrowBridgeTest, unsupported) {
+TEST_F(ArrowBridgeExportTest, unsupported) {
   ArrowArray arrowArray;
   VectorPtr vector;
 
@@ -230,7 +231,171 @@ TEST_F(ArrowBridgeTest, unsupported) {
   EXPECT_THROW(arrow::exportToArrow(vector, arrowArray), VeloxException);
 }
 
-class ArrowBridgeSchemaExportTest : public ArrowBridgeTest {
+class ArrowBridgeImportTest : public ArrowBridgeExportTest {
+ protected:
+  // Takes a vector with input data, generates an input ArrowArray and Velox
+  // Vector (using vector maker). Then converts ArrowArray into Velox vector and
+  // assert that both Velox vectors are semantically the same.
+  template <typename T>
+  void testArrowImport(
+      const char* format,
+      const std::vector<std::optional<T>>& inputValues) {
+    int64_t length = inputValues.size();
+    int64_t nullCount = 0;
+
+    BufferPtr values = AlignedBuffer::allocate<T>(length, pool_.get());
+    BufferPtr nulls = AlignedBuffer::allocate<uint64_t>(length, pool_.get());
+
+    auto rawValues = values->asMutable<T>();
+    auto rawNulls = nulls->asMutable<uint64_t>();
+
+    for (size_t i = 0; i < length; ++i) {
+      if (inputValues[i] == std::nullopt) {
+        bits::setNull(rawNulls, i);
+        nullCount++;
+      } else {
+        bits::clearNull(rawNulls, i);
+        if constexpr (std::is_same<T, bool>::value) {
+          bits::setBit(rawValues, i, *inputValues[i]);
+        } else {
+          rawValues[i] = *inputValues[i];
+        }
+      }
+    }
+
+    const void* buffers[2];
+    buffers[0] = (nullCount == 0) ? nullptr : (const void*)rawNulls;
+    buffers[1] = (length == 0) ? nullptr : (const void*)rawValues;
+
+    ArrowArray arrowArray{
+        .dictionary = nullptr,
+        .n_children = 0,
+        .children = nullptr,
+        .offset = 0,
+        .n_buffers = 2,
+        .buffers = buffers,
+        .null_count = nullCount,
+        .length = length};
+    ArrowSchema arrowSchema{.release = mockRelease, .format = format};
+    auto output = arrow::importFromArrow(arrowSchema, arrowArray, pool_.get());
+
+    EXPECT_EQ((nullCount > 0), output->mayHaveNulls());
+    EXPECT_EQ(nullCount, *output->getNullCount());
+    EXPECT_EQ(inputValues.size(), output->size());
+
+    auto expected = vectorMaker_.flatVectorNullable<T>(inputValues);
+
+    // Assert new vector contents.
+    for (vector_size_t i = 0; i < length; ++i) {
+      ASSERT_TRUE(expected->equalValueAt(output.get(), i, i))
+          << "at " << i << ": " << expected->toString(i) << " vs. "
+          << output->toString(i);
+    }
+  }
+
+  std::unique_ptr<memory::ScopedMemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+};
+
+TEST_F(ArrowBridgeImportTest, scalar) {
+  testArrowImport<bool>("b", {});
+  testArrowImport<bool>("b", {true});
+  testArrowImport<bool>("b", {false});
+  testArrowImport<bool>("b", {true, false, true});
+  testArrowImport<bool>("b", {true, std::nullopt, true});
+
+  testArrowImport<int8_t>("c", {});
+  testArrowImport<int8_t>("c", {101});
+  testArrowImport<int8_t>("c", {5, 4, 3, 1, 2});
+  testArrowImport<int8_t>("c", {8, std::nullopt, std::nullopt});
+  testArrowImport<int8_t>("c", {std::nullopt, std::nullopt});
+
+  testArrowImport<int16_t>("s", {5, 4, 3, 1, 2});
+  testArrowImport<int32_t>("i", {5, 4, 3, 1, 2});
+
+  testArrowImport<int64_t>("l", {});
+  testArrowImport<int64_t>("l", {std::nullopt});
+  testArrowImport<int64_t>("l", {-99, 4, 318321631, 1211, -12});
+  testArrowImport<int64_t>("l", {std::nullopt, 12345678, std::nullopt});
+  testArrowImport<int64_t>("l", {std::nullopt, std::nullopt});
+
+  testArrowImport<double>("g", {});
+  testArrowImport<double>("g", {std::nullopt});
+  testArrowImport<double>("g", {-99.9, 4.3, 31.1, 129.11, -12});
+  testArrowImport<float>("f", {-99.9, 4.3, 31.1, 129.11, -12});
+
+  // VARCHAR and VARBINARY not supported for now.
+  EXPECT_THROW(
+      testArrowImport<std::string>("u", {"hello world"}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testArrowImport<std::string>("z", {"hello world"}),
+      std::invalid_argument);
+}
+
+TEST_F(ArrowBridgeImportTest, failures) {
+  ArrowSchema arrowSchema{.release = mockRelease, .format = "i"};
+
+  const void* buffers[2];
+  const int32_t values[] = {1, 2, 3, 4};
+  buffers[0] = nullptr;
+  buffers[1] = values;
+
+  ArrowArray arrowArray{
+      .dictionary = nullptr,
+      .null_count = 0,
+      .n_children = 0,
+      .children = nullptr,
+      .offset = 0,
+      .n_buffers = 2,
+      .buffers = buffers,
+      .length = 4};
+
+  // Unsupported:
+
+  // Children not yet supported.
+  arrowArray.n_children = 1;
+  EXPECT_THROW(
+      arrow::importFromArrow(arrowSchema, arrowArray, pool_.get()),
+      VeloxUserError);
+  arrowArray.n_children = 0;
+
+  // Offset not yet supported.
+  arrowArray.offset = 1;
+  EXPECT_THROW(
+      arrow::importFromArrow(arrowSchema, arrowArray, pool_.get()),
+      VeloxUserError);
+  arrowArray.offset = 0;
+
+  // Broken input.
+
+  // Expect two buffers.
+  arrowArray.n_buffers = 1;
+  EXPECT_THROW(
+      arrow::importFromArrow(arrowSchema, arrowArray, pool_.get()),
+      VeloxUserError);
+  arrowArray.n_buffers = 2;
+
+  // Can't have nulls without null buffer.
+  arrowArray.null_count = 1;
+  EXPECT_THROW(
+      arrow::importFromArrow(arrowSchema, arrowArray, pool_.get()),
+      VeloxUserError);
+  arrowArray.null_count = 0;
+
+  // Non-existing type.
+  EXPECT_THROW(
+      arrow::importFromArrow(
+          ArrowSchema{.release = mockRelease, .format = "a"},
+          arrowArray,
+          pool_.get()),
+      VeloxUserError);
+
+  // Ensure the baseline works.
+  EXPECT_NO_THROW(arrow::importFromArrow(arrowSchema, arrowArray, pool_.get()));
+}
+
+class ArrowBridgeSchemaExportTest : public ArrowBridgeExportTest {
  protected:
   void testScalarType(const TypePtr& type, const char* arrowFormat) {
     ArrowSchema arrowSchema;
@@ -356,9 +521,7 @@ TEST_F(ArrowBridgeSchemaExportTest, unsupported) {
       testScalarType(ROW({BIGINT(), REAL(), UNKNOWN()}), ""), VeloxException);
 }
 
-static void mockRelease(ArrowSchema*) {}
-
-class ArrowBridgeSchemaImportTest : public ArrowBridgeTest {
+class ArrowBridgeSchemaImportTest : public ArrowBridgeExportTest {
  protected:
   TypePtr testSchemaImport(const char* format) {
     ArrowSchema arrowSchema{.release = mockRelease, .format = format};
@@ -467,7 +630,7 @@ TEST_F(ArrowBridgeSchemaImportTest, unsupported) {
   EXPECT_THROW(testSchemaImport("+w"), VeloxUserError);
 }
 
-class ArrowBridgeSchemaTest : public ArrowBridgeTest {
+class ArrowBridgeSchemaTest : public ArrowBridgeExportTest {
  protected:
   void roundtripTest(const TypePtr& inputType) {
     ArrowSchema arrowSchema;


### PR DESCRIPTION
Summary:
Adding function to convert ArrowArray into velox vector by leveraging
BufferView in order to prevent copying the buffer.

Differential Revision: D31454522

