### PR TITLE
Add fast all-ASCII path to simple functions

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -36,6 +36,14 @@ struct StringWriter : public UDFOutputString {
     setData(storage_.data());
   }
 
+  void setEmpty() {
+    VELOX_FAIL("setEmpty is not implemented");
+  }
+
+  void setNoCopy(StringView /*value*/) {
+    VELOX_FAIL("setNoCopy is not implemented");
+  }
+
   StringWriter(const StringWriter& rh) : storage_{rh.storage_} {
     setData(storage_.data());
     setSize(rh.size());

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -31,6 +31,7 @@
 #include "velox/common/encode/Base64.h"
 #include "velox/external/md5/md5.h"
 #include "velox/functions/lib/string/StringCore.h"
+#include "velox/type/StringView.h"
 
 namespace facebook::velox::functions::stringImpl {
 using namespace stringCore;
@@ -466,7 +467,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
     TOutString& output,
     const TInString& input) {
   if (input.empty()) {
-    output = TOutString("");
+    output.setEmpty();
     return;
   }
 
@@ -477,7 +478,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
     }
   }
   if (curPos >= input.end()) {
-    output = TOutString("");
+    output.setEmpty();
     return;
   }
   auto start = curPos;
@@ -487,7 +488,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
       curPos--;
     }
   }
-  output = TOutString(start, curPos - start + 1);
+  output.setNoCopy(StringView(start, curPos - start + 1));
 }
 
 template <
@@ -499,7 +500,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
     TOutString& output,
     const TInString& input) {
   if (input.empty()) {
-    output = TOutString("");
+    output.setEmpty();
     return;
   }
 
@@ -510,7 +511,8 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
       auto codePoint = utf8proc_codepoint(input.data() + curPos, codePointSize);
       // Invalid encoding, return the remaining of the input
       if (UNLIKELY(-1 == codePoint)) {
-        output = TOutString(input.data() + curPos, input.size() - curPos);
+        output.setNoCopy(
+            StringView(input.data() + curPos, input.size() - curPos));
         break;
       }
 
@@ -522,7 +524,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
     }
   }
   if (curPos >= input.size()) {
-    output = TOutString("");
+    output.setEmpty();
     return;
   }
   size_t start = curPos;
@@ -535,7 +537,8 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
       auto codePoint = utf8proc_codepoint(input.data() + curPos, codePointSize);
       // Invalid encoding, return the remaining of the input
       if (UNLIKELY(-1 == codePoint)) {
-        output = TOutString(input.data() + start, input.size() - start);
+        output.setNoCopy(
+            StringView(input.data() + start, input.size() - start));
         return;
       }
 
@@ -552,7 +555,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
       curPos += codePointSize;
     }
   }
-  output = TOutString(input.data() + start, lastNonWhiteSpace - start);
+  output.setNoCopy(StringView(input.data() + start, lastNonWhiteSpace - start));
 }
 
 template <bool ascii, typename TOutString, typename TInString>

--- a/velox/functions/prestosql/CoreFunctions.cpp
+++ b/velox/functions/prestosql/CoreFunctions.cpp
@@ -39,6 +39,15 @@ void registerFunctions() {
   registerFunction<udf_chr, Varchar, int64_t>();
   registerFunction<udf_codepoint, int32_t, Varchar>();
 
+  registerFunction<udf_substr<int64_t>, Varchar, Varchar, int64_t>();
+  registerFunction<udf_substr<int64_t>, Varchar, Varchar, int64_t, int64_t>();
+  registerFunction<udf_substr<int32_t>, Varchar, Varchar, int32_t>();
+  registerFunction<udf_substr<int32_t>, Varchar, Varchar, int32_t, int32_t>();
+
+  registerFunction<udf_trim<true, true>, Varchar, Varchar>({"trim"});
+  registerFunction<udf_trim<true, false>, Varchar, Varchar>({"ltrim"});
+  registerFunction<udf_trim<false, true>, Varchar, Varchar>({"rtrim"});
+
   // Register hash functions
   registerFunction<udf_xxhash64, Varbinary, Varbinary>({"xxhash64"});
   registerFunction<udf_md5<Varbinary, Varbinary>, Varbinary, Varbinary>(

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -37,273 +37,34 @@ bool hasSingleReferencedBuffers(const FlatVector<StringView>* vec) {
   }
   return true;
 };
+} // namespace
 
-/**
- * substr(string, start) -> varchar
- *           Returns the rest of string from the starting position start.
- * Positions start with 1. A negative starting position is interpreted as
- being
- * relative to the end of the string.
+/// Helper function that prepares a string result vector and initializes it.
+/// It will use the input argToReuse vector instead of creating new one when
+/// possible. Returns true if argToReuse vector was moved to results
+VectorPtr emptyVectorPtr;
+bool prepareFlatResultsVector(
+    VectorPtr* result,
+    const SelectivityVector& rows,
+    exec::EvalCtx* context,
+    VectorPtr& argToReuse = emptyVectorPtr) {
+  if (!*result && argToReuse && argToReuse.unique()) {
+    // Move input vector to result
+    VELOX_CHECK(
+        argToReuse.get()->encoding() == VectorEncoding::Simple::FLAT &&
+        argToReuse.get()->typeKind() == TypeKind::VARCHAR);
 
- * substr(string, start, length) -> varchar
- *           Returns a substring from string of length length from the
- starting
- * position start. Positions start with 1. A negative starting position is
- * interpreted as being relative to the end of the string.
- */
-
-class SubstrFunction : public exec::VectorFunction {
- public:
-  bool isDefaultNullBehavior() const override {
+    *result = std::move(argToReuse);
     return true;
   }
+  // This will allocate results if not allocated
+  BaseVector::ensureWritable(rows, VARCHAR(), context->pool(), result);
 
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  VELOX_CHECK((*result).get()->encoding() == VectorEncoding::Simple::FLAT);
+  return false;
+}
 
-    // varchar, integer|bigint -> varchar
-    for (const auto& startType : {"integer", "bigint"}) {
-      signatures.emplace_back(exec::FunctionSignatureBuilder()
-                                  .returnType("varchar")
-                                  .argumentType("varchar")
-                                  .argumentType(startType)
-                                  .build());
-    }
-
-    // varchar, integer|bigint, integer|bigint -> varchar
-    for (const auto& startType : {"integer", "bigint"}) {
-      for (const auto& lengthType : {"integer", "bigint"}) {
-        signatures.emplace_back(exec::FunctionSignatureBuilder()
-                                    .returnType("varchar")
-                                    .argumentType("varchar")
-                                    .argumentType(startType)
-                                    .argumentType(lengthType)
-                                    .build());
-      }
-    }
-    return signatures;
-  }
-
- private:
-  /**
-   * The inner most kernel of the vector operations for substr
-   */
-  template <typename I>
-  inline void applyInner(
-      I start,
-      I length,
-      const StringView& input,
-      StringView& output,
-      bool isAscii) const {
-    // Following Presto semantics
-    if (start == 0) {
-      output = StringView("");
-      return;
-    }
-
-    I numCharacters;
-    if (isAscii) {
-      numCharacters = stringImpl::length</*isAscii*/ true>(input);
-    } else {
-      numCharacters = stringImpl::length</*isAscii*/ false>(input);
-    }
-
-    // Adjusting start
-    if (start < 0) {
-      start = numCharacters + start + 1;
-    }
-
-    // Following Presto semantics
-    if (start <= 0 || start > numCharacters || length <= 0) {
-      output = StringView("");
-      return;
-    }
-
-    // Adjusting length
-    if (length == std::numeric_limits<I>::max() ||
-        length + start - 1 > numCharacters) {
-      // set length to the max valid length
-      length = numCharacters - start + 1;
-    }
-
-    std::pair<size_t, size_t> byteRange;
-    if (isAscii) {
-      byteRange = getByteRange</*isAscii*/ true>(input.data(), start, length);
-    } else {
-      byteRange = getByteRange</*isAscii*/ false>(input.data(), start, length);
-    }
-
-    // Generating output string
-    output = StringView(
-        input.data() + byteRange.first, byteRange.second - byteRange.first);
-  }
-
-  /**
-   * The function calls the right typed function based on the vector types
-   */
-  void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      exec::Expr* caller,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    VELOX_CHECK(args.size() == 3 || args.size() == 2);
-    if (args.size() == 3) {
-      VELOX_CHECK(args[1]->typeKind() == args[2]->typeKind());
-    }
-    switch (args[1]->typeKind()) {
-      case TypeKind::INTEGER:
-        applyTyped<int32_t>(rows, args, caller, context, result);
-        return;
-      case TypeKind::BIGINT:
-        applyTyped<int64_t>(rows, args, caller, context, result);
-        return;
-      default:
-        VELOX_CHECK(false, "Bad type for substr");
-    }
-  }
-
-  template <typename I>
-  void applyTyped(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      exec::Expr* caller,
-      exec::EvalCtx* context,
-      VectorPtr* result) const {
-    // We use this flag to enable the version of the function in which length
-    // is not provided.
-    bool noLengthVector = (args.size() == 2);
-    BaseVector* stringsVector = args[0].get();
-    BaseVector* startsVector = args[1].get();
-    BaseVector* lengthsVector = noLengthVector ? nullptr : args[2].get();
-    auto ascii = isAscii(stringsVector, rows);
-
-    auto stringArgVectorEncoding = stringsVector->encoding();
-    auto startArgVectorEncoding = startsVector->encoding();
-    auto lengthArgVectorEncoding =
-        noLengthVector ? startArgVectorEncoding : lengthsVector->encoding();
-
-    VectorPtr emptyVectorPtr;
-    prepareFlatResultsVector(
-        result,
-        rows,
-        context,
-        args[0]->encoding() == VectorEncoding::Simple::FLAT ? args[0]
-                                                            : emptyVectorPtr);
-
-    BufferPtr resultValues =
-        (*result)->as<FlatVector<StringView>>()->mutableValues(rows.end());
-    StringView* rawResult = resultValues->asMutable<StringView>();
-
-    // If all of the vectors are flat or constant directly access the data in
-    // the inner loop (1) We are not optimizing a case in which all of the
-    // inputs are constant! (2) We are not optimizing a case in which start is
-    // constant and length is vector (3) We are not optimizing a case in which
-    // start is vector and length is constant
-    // TODO: If turns out case 1..3 are popular we need to optimize them as
-    // well
-    if (stringArgVectorEncoding == VectorEncoding::Simple::FLAT) {
-      const StringView* rawStrings =
-          stringsVector->as<FlatVector<StringView>>()->rawValues();
-      if (startArgVectorEncoding == VectorEncoding::Simple::FLAT) {
-        if (lengthArgVectorEncoding == VectorEncoding::Simple::FLAT) {
-          const I* rawStarts = startsVector->as<FlatVector<I>>()->rawValues();
-          // Incrementing ref count of the string buffer of the input vector
-          // so that if the argument owner goes out of scope the string buffer
-          // still remains in memory.
-          (*result)->as<FlatVector<StringView>>()->acquireSharedStringBuffers(
-              stringsVector->as<FlatVector<StringView>>());
-          const I* rawLengths = noLengthVector
-              ? nullptr
-              : lengthsVector->as<FlatVector<I>>()->rawValues();
-          // Fast path 1 (all Flat): apply the inner kernel in a loop
-          if (noLengthVector) {
-            rows.applyToSelected([&](int row) {
-              applyInner<I>(
-                  rawStarts[row],
-                  std::numeric_limits<I>::max(),
-                  rawStrings[row],
-                  rawResult[row],
-                  ascii);
-            });
-          } else {
-            rows.applyToSelected([&](int row) {
-              applyInner<I>(
-                  rawStarts[row],
-                  rawLengths[row],
-                  rawStrings[row],
-                  rawResult[row],
-                  ascii);
-            });
-          }
-          return;
-        }
-      }
-      if (startArgVectorEncoding == VectorEncoding::Simple::CONSTANT &&
-          lengthArgVectorEncoding == VectorEncoding::Simple::CONSTANT) {
-        // Incrementing ref count of the string buffer of the input vector so
-        // that if the argument owner goes out of scope the string buffer
-        // still remains in memory.
-        (*result)->as<FlatVector<StringView>>()->acquireSharedStringBuffers(
-            stringsVector->as<FlatVector<StringView>>());
-        int startIndex = startsVector->as<ConstantVector<I>>()->valueAt(0);
-        I length = noLengthVector
-            ? std::numeric_limits<I>::max()
-            : lengthsVector->as<ConstantVector<I>>()->valueAt(0);
-        // Fast path 2 (Constant start and length):
-        rows.applyToSelected([&](int row) {
-          applyInner<I>(
-              startIndex, length, rawStrings[row], rawResult[row], ascii);
-        });
-        return;
-      }
-    }
-
-    // The rest of the cases are handled through this slow path
-    // which involves decoding all inputs and no direct access
-    exec::LocalDecodedVector stringHolder(context, *stringsVector, rows);
-    exec::LocalDecodedVector startHolder(context, *startsVector, rows);
-    exec::LocalDecodedVector lengthHolder(context);
-    auto strings = stringHolder.get();
-    auto starts = startHolder.get();
-    DecodedVector* lengths = noLengthVector ? nullptr : lengthHolder.get();
-    if (!noLengthVector) {
-      lengths->decode(*lengthsVector, rows);
-    }
-    auto baseVector = strings->base();
-    (*result)->as<FlatVector<StringView>>()->acquireSharedStringBuffers(
-        baseVector);
-
-    if (noLengthVector) {
-      rows.applyToSelected([&](int row) {
-        applyInner<I>(
-            starts->valueAt<I>(row),
-            std::numeric_limits<I>::max(),
-            strings->valueAt<StringView>(row),
-            rawResult[row],
-            ascii);
-      });
-    } else {
-      rows.applyToSelected([&](int row) {
-        applyInner<I>(
-            starts->valueAt<I>(row),
-            lengths->valueAt<I>(row),
-            strings->valueAt<StringView>(row),
-            rawResult[row],
-            ascii);
-      });
-    }
-  }
-
-  bool ensureStringEncodingSetAtAllInputs() const override {
-    return true;
-  }
-
-  bool propagateStringEncodingFromAllInputs() const override {
-    return true;
-  }
-};
-
+namespace {
 /**
  * Upper and Lower functions have a fast path for ascii where the functions
  * can be applied in place.
@@ -751,95 +512,7 @@ class Replace : public exec::VectorFunction {
     return {{0, 2}};
   }
 };
-
-// Trim functions
-// ltrim(string) -> varchar
-//    Removes leading whitespace from string.
-// rtrim(string) -> varchar
-//    Removes trailing whitespace from string.
-// trim(string) -> varchar
-//    Removes leading and trailing whitespace from string.
-template <bool leftTrim, bool rightTrim>
-class TrimTemplateFunction : public exec::VectorFunction {
- public:
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    // varchar -> varchar
-    return {exec::FunctionSignatureBuilder()
-                .returnType("varchar")
-                .argumentType("varchar")
-                .build()};
-  }
-
-  void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      [[maybe_unused]] exec::Expr* caller,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    VELOX_CHECK_EQ(args.size(), 1);
-    // For a deterministic function that takes a single argument Velox
-    // guaranteed to receive its only input as a flat vector
-    BaseVector* stringsVector = args[0].get();
-    const StringView* rawStrings =
-        stringsVector->as<FlatVector<StringView>>()->rawValues();
-
-    auto ascii = isAscii(stringsVector, rows);
-    prepareFlatResultsVector(result, rows, context, args[0]);
-    BufferPtr resultValues =
-        (*result)->as<FlatVector<StringView>>()->mutableValues(rows.end());
-    StringView* rawResult = resultValues->asMutable<StringView>();
-
-    (*result)->as<FlatVector<StringView>>()->acquireSharedStringBuffers(
-        stringsVector->as<FlatVector<StringView>>());
-
-    // Fast path
-    if (ascii) {
-      rows.applyToSelected([&](int row) {
-        stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim>(
-            rawResult[row], rawStrings[row]);
-      });
-    } else {
-      rows.applyToSelected([&](int row) {
-        stringImpl::trimUnicodeWhiteSpace<leftTrim, rightTrim>(
-            rawResult[row], rawStrings[row]);
-      });
-    }
-  }
-
-  bool ensureStringEncodingSetAtAllInputs() const override {
-    return true;
-  }
-
-  bool propagateStringEncodingFromAllInputs() const override {
-    return true;
-  }
-};
-
-using TrimFunction = TrimTemplateFunction<true, true>;
-using LtrimFunction = TrimTemplateFunction<true, false>;
-using RtrimFunction = TrimTemplateFunction<false, true>;
-
 } // namespace
-
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_substr,
-    SubstrFunction::signatures(),
-    std::make_unique<SubstrFunction>());
-
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_trim,
-    TrimFunction::signatures(),
-    std::make_unique<TrimFunction>());
-
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_ltrim,
-    LtrimFunction::signatures(),
-    std::make_unique<LtrimFunction>());
-
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_rtrim,
-    RtrimFunction::signatures(),
-    std::make_unique<RtrimFunction>());
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_upper,

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -19,6 +19,7 @@
 
 #include "velox/external/xxhash.h"
 #include "velox/functions/Udf.h"
+#include "velox/functions/lib/string/StringCore.h"
 #include "velox/functions/lib/string/StringImpl.h"
 
 namespace facebook::velox::functions {
@@ -115,6 +116,115 @@ FOLLY_ALWAYS_INLINE bool call(
     out_type<Varchar>& result,
     const arg_type<Varbinary>& input) {
   return stringImpl::urlUnescape(result, input);
+}
+VELOX_UDF_END();
+
+/// substr(string, start) -> varchar
+///
+///     Returns the rest of string from the starting position start.
+///     Positions start with 1. A negative starting position is interpreted as
+///     being relative to the end of the string.
+///
+/// substr(string, start, length) -> varchar
+///
+///     Returns a substring from string of length length from the
+///     starting position start. Positions start with 1. A negative starting
+///     position is interpreted as being relative to the end of the string.
+template <typename I>
+VELOX_UDF_BEGIN(substr)
+
+// Results refer to strings in the first argument.
+static constexpr int32_t reuse_strings_from_arg = 0;
+
+// ASCII input always produces ASCII result.
+static constexpr bool is_default_ascii_behavior = true;
+
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& input,
+    I start,
+    I length = std::numeric_limits<I>::max()) {
+  return doCall<false>(result, input, start, length);
+}
+
+FOLLY_ALWAYS_INLINE bool callAscii(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& input,
+    I start,
+    I length = std::numeric_limits<I>::max()) {
+  return doCall<true>(result, input, start, length);
+}
+
+template <bool isAscii>
+FOLLY_ALWAYS_INLINE bool doCall(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& input,
+    I start,
+    I length = std::numeric_limits<I>::max()) {
+  // Following Presto semantics
+  if (start == 0) {
+    result.setEmpty();
+    return true;
+  }
+
+  I numCharacters = stringImpl::length<isAscii>(input);
+
+  // Adjusting start
+  if (start < 0) {
+    start = numCharacters + start + 1;
+  }
+
+  // Following Presto semantics
+  if (start <= 0 || start > numCharacters || length <= 0) {
+    result.setEmpty();
+    return true;
+  }
+
+  // Adjusting length
+  if (length == std::numeric_limits<I>::max() ||
+      length + start - 1 > numCharacters) {
+    // set length to the max valid length
+    length = numCharacters - start + 1;
+  }
+
+  auto byteRange =
+      stringCore::getByteRange<isAscii>(input.data(), start, length);
+
+  // Generating output string
+  result.setNoCopy(StringView(
+      input.data() + byteRange.first, byteRange.second - byteRange.first));
+  return true;
+}
+VELOX_UDF_END();
+
+/// Trim functions
+/// ltrim(string) -> varchar
+///    Removes leading whitespaces from the string.
+/// rtrim(string) -> varchar
+///    Removes trailing whitespaces from the string.
+/// trim(string) -> varchar
+///    Removes leading and trailing whitespaces from the string.
+template <bool leftTrim, bool rightTrim>
+VELOX_UDF_BEGIN(trim)
+
+// Results refer to strings in the first argument.
+static constexpr int32_t reuse_strings_from_arg = 0;
+
+// ASCII input always produces ASCII result.
+static constexpr bool is_default_ascii_behavior = true;
+
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& input) {
+  stringImpl::trimUnicodeWhiteSpace<leftTrim, rightTrim>(result, input);
+  return true;
+}
+
+FOLLY_ALWAYS_INLINE bool callAscii(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& input) {
+  stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim>(result, input);
+  return true;
 }
 VELOX_UDF_END();
 

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -53,11 +53,7 @@ void registerVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, "map_keys");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, "map_values");
 
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_substr, "substr");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, "lower");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_ltrim, "ltrim");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_rtrim, "rtrim");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_trim, "trim");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_split, "split");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, "upper");

--- a/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include "velox/expression/tests/VectorFuzzer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/CoreFunctions.h"
 #include "velox/functions/prestosql/VectorFunctions.h"
 
 using namespace facebook::velox;
@@ -29,6 +30,7 @@ class StringAsciiUTFFunctionBenchmark
     : public functions::test::FunctionBenchmarkBase {
  public:
   StringAsciiUTFFunctionBenchmark() : FunctionBenchmarkBase() {
+    functions::registerFunctions();
     functions::registerVectorFunctions();
   }
 
@@ -121,7 +123,6 @@ BENCHMARK_RELATIVE(asciiSubStr) {
   StringAsciiUTFFunctionBenchmark benchmark;
   benchmark.runSubStr(false);
 }
-
 } // namespace
 
 // Preliminary release run, before ascii optimization.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonExtractScalar.h"
 #include "velox/functions/prestosql/Rand.h"
+#include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/sparksql/Hash.h"
 #include "velox/functions/sparksql/In.h"
 #include "velox/functions/sparksql/LeastGreatest.h"
@@ -47,7 +48,6 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_substr, prefix + "substring");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, prefix + "upper");
   // Logical.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_coalesce, prefix + "coalesce");
@@ -66,6 +66,11 @@ void registerFunctions(const std::string& prefix) {
   // Register string functions.
   registerFunction<udf_chr, Varchar, int64_t>();
   registerFunction<udf_ascii, int32_t, Varchar>();
+
+  registerFunction<udf_substr<int32_t>, Varchar, Varchar, int32_t>(
+      {prefix + "substring"});
+  registerFunction<udf_substr<int32_t>, Varchar, Varchar, int32_t, int32_t>(
+      {prefix + "substring"});
 
   exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(


### PR DESCRIPTION
This change enhances simple functions that operate on strings to allow these to
provide fast path for all-ASCII inputs. To keep things simple fast all-ASCII
path is used only if function has default null behavior and all its string
inputs are all-ASCII. By default, the function is not assumed to propagate
ASCII-ness, but most functions do. Set is_default_ascii_behavior to true if
ASCII inputs always produce ASCII result.

To add all-ASCII fast path to a simple function, define both call and callAscii
methods. callAscii is called only if all string inputs are all-ASCII. call is
called otherwise.

```
template <bool leftTrim, bool rightTrim>
VELOX_UDF_BEGIN(trim)

static constexpr bool is_default_ascii_behavior = true;

FOLLY_ALWAYS_INLINE bool call(
    out_type<Varchar>& result,
    const arg_type<Varchar>& input) {
  stringImpl::trimUnicodeWhiteSpace<leftTrim, rightTrim>(result, input);
  return true;
}

FOLLY_ALWAYS_INLINE bool callAscii(
    out_type<Varchar>& result,
    const arg_type<Varchar>& input) {
  stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim>(result, input);
  return true;
}
VELOX_UDF_END();
```

Also, `static constexpr int32_t reuse_strings_from_arg` field can be used to
specify that the result string is referencing input string. The value
of 'reuseStringsFromArg' is the zero-based index of the input argument whose
strings are being referenced. The engine will automatically add references to
the input string buffers to the result vector. The function can use
result.setNoCopy(StringView(...)) to create zero-copy result referencing the 
input string..

Migrated substr, trim, ltrim and rtrim Presto functions from vector to simple.
Ran benchmark for substr to confirm the performance reduction is minimal.

```
============================================================================
utfLower                                                     10.23s   97.76m
asciiLower                                      5649.08%   181.08ms     5.52
utfUpper                                                      9.77s  102.37m
asciiUpper                                      5645.27%   173.05ms     5.78
utfSubStr                                                  830.25ms     1.20
asciiSubStr                                     7752.21%    10.71ms    93.37
utfSubStrOrig                                              843.81ms     1.19
asciiSubStrOrig                                 9346.52%     9.03ms   110.77
============================================================================
```