### PR TITLE
Add an explicit cast to std::string_view from velox::StringView

### DIFF
--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -185,6 +185,10 @@ struct StringView {
     return folly::dynamic(folly::StringPiece(data(), size()));
   }
 
+  explicit operator std::string_view() const {
+    return std::string_view(data(), size());
+  }
+
   std::string str() const {
     return std::string(data(), size());
   }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -33,7 +33,7 @@ struct DummyReleaser {
 } // namespace
 
 template <typename T>
-class ConstantVector : public SimpleVector<T> {
+class ConstantVector final : public SimpleVector<T> {
  public:
   static constexpr bool can_simd =
       (std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||


### PR DESCRIPTION
Summary:
I mark this conversion operator explicit because the referenced StringView must
remain live (in the case of an inlined string), so an implicit conversion is
dangerous.

Differential Revision: D31465351

