### PR TITLE
Add more runtime stats for Task

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -388,6 +388,7 @@ void Task::setAllOutputConsumed() {
   partitionedOutputConsumed_ = true;
   if (!numDrivers_ && state_ == kRunning) {
     state_ = kFinished;
+    taskStats_.endTimeMs = getCurrentTimeMs();
     stateChangedLocked();
   }
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -60,6 +60,10 @@ struct TaskStats {
 
   // Epoch time (ms) when last split is fetched from the task by an operator.
   uint64_t lastSplitStartTimeMs{0};
+
+  // Epoch time (ms) when the task completed, e.g. all splits were processed and
+  // results have been consumed.
+  uint64_t endTimeMs{0};
 };
 
 class JoinBridge;


### PR DESCRIPTION
Summary: Report task start and end time as well as the delay between all splits processed and results being fetched by the downstream tasks. These stats should help debug high latencies.

Differential Revision: D31472402

