### PR TITLE
Add regexp_extract_all Presto function

### DIFF
--- a/velox/docs/functions/regexp.rst
+++ b/velox/docs/functions/regexp.rst
@@ -21,6 +21,13 @@ See https://github.com/google/re2/wiki/Syntax for more information.
 
         SELECT regexp_extract('1a 2b 14m', '(\d+)([a-z]+)', 2); -- 'a'
 
+.. function:: regexp_extract_all(string, pattern, group) -> array(varchar)
+
+    Finds all occurrences of the regular expression ``pattern`` in
+    ``string`` and returns the capturing group number ``group``::
+
+        SELECT regexp_extract_all('1a 2b 14m', '(\d+)([a-z]+)', 2); -- ['a', 'b', 'm']
+
 .. function:: regexp_like(string, pattern) -> boolean
 
     Evaluates the regular expression ``pattern`` and determines if it is

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -79,4 +79,25 @@ std::shared_ptr<exec::VectorFunction> makeLike(
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> likeSignatures();
 
+/// re2ExtractAll(string, pattern, group_id) → array<string>
+/// re2ExtractAll(string, pattern) → array<string>
+///
+/// If string has a substring that matches the given pattern, returns ALL of the
+/// substrings matching the given group in the pattern. pattern will be parsed
+/// using the RE2 pattern syntax, a subset of PCRE. Groups are 1-indexed.
+/// Providing zero as the group_id extracts and returns the entire match; this
+/// is more efficient than extracting a subgroup. Extracting the first subgroup
+/// is more efficient than extracting larger indexes; use non-capturing
+/// subgroups (?:...) if the pattern includes groups that don't need to be
+/// captured.
+///
+/// If the pattern is invalid or the group id is out of range, throws an
+/// exception. If the pattern does not match, returns null.
+///
+/// If group_id parameter is not specified, extracts and returns the entire
+/// match.
+std::shared_ptr<exec::VectorFunction> makeRe2ExtractAll(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -69,6 +69,8 @@ void registerVectorFunctions() {
   exec::registerStatefulVectorFunction(
       "regexp_extract", re2ExtractSignatures(), makeRe2Extract);
   exec::registerStatefulVectorFunction(
+      "regexp_extract_all", re2ExtractSignatures(), makeRe2ExtractAll);
+  exec::registerStatefulVectorFunction(
       "regexp_like", re2SearchSignatures(), makeRe2Search);
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, "to_utf8");


### PR DESCRIPTION
Summary:
Adding the regexp_extract_all to Velox

- **regexp_extract_all(string, pattern)**

  - Returns the substring(s) matched by the regular expression pattern in string. For example:

```
SELECT regexp_extract_all('1a 2b 14m', '\d+'); -- [1, 2, 14]
```

- **regexp_extract_all(string, pattern, group)**

  - Finds all occurrences of the regular expression pattern in string and returns the capturing group number group. For example:

```
SELECT regexp_extract_all('1a 2b 14m', '(\d+)([a-z]+)', 2); -- ['a', 'b', 'm']
```

Differential Revision: D31283176

