### PR TITLE
Fix integer overflow in resizing

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -68,7 +68,7 @@ void BaseVector::allocateNulls() {
 }
 
 template <>
-vector_size_t BaseVector::byteSize<bool>(vector_size_t count) {
+uint64_t BaseVector::byteSize<bool>(vector_size_t count) {
   return bits::nbytes(count);
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -452,7 +452,7 @@ class BaseVector {
   }
 
   template <typename T>
-  static inline vector_size_t byteSize(vector_size_t count) {
+  static inline uint64_t byteSize(vector_size_t count) {
     return sizeof(T) * count;
   }
 
@@ -627,7 +627,7 @@ class BaseVector {
 };
 
 template <>
-vector_size_t BaseVector::byteSize<bool>(vector_size_t count);
+uint64_t BaseVector::byteSize<bool>(vector_size_t count);
 
 using VectorPtr = std::shared_ptr<BaseVector>;
 

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -287,7 +287,7 @@ void FlatVector<T>::resize(vector_size_t size) {
   if (!values_) {
     return;
   }
-  vector_size_t minBytes = BaseVector::byteSize<T>(size);
+  const uint64_t minBytes = BaseVector::byteSize<T>(size);
   if (values_->capacity() < minBytes) {
     AlignedBuffer::reallocate<T>(&values_, size);
     rawValues_ = values_->asMutable<T>();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1210,3 +1210,9 @@ TEST_F(VectorTest, valueHook) {
   lazy->load(rows, &hook);
   EXPECT_EQ(hook.errors(), 0);
 }
+
+TEST_F(VectorTest, byteSize) {
+  constexpr vector_size_t count = std::numeric_limits<vector_size_t>::max();
+  constexpr uint64_t expected = count * sizeof(int64_t);
+  EXPECT_EQ(BaseVector::byteSize<int64_t>(count), expected);
+}


### PR DESCRIPTION
Summary:
# Problem
When we resize a `FlatVector`, we resize the internal buffer with the byte size required to store the given # of elements. To be exact:
First, Get the byte size required.
```
vector_size_t minBytes = BaseVector::byteSize<T>(size);
```
Second, Resize the buffer
```
values_->setSize(minBytes);
```

The problem was:
- `setSize()` accepts an **`uint64_t`**.
- `byteSize()` returns `vector_size_t`, which is **`int32_t`**.
- With a big enough `size`, `byteSize()` hit integer overflow.
- __And the overflowed `int32_t` gets implicit-casted to `uint64_t`__.

Resulting we get an exception like this:
```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (18446744071562069392 vs. 3221225376)
Retriable: False
Expression: size <= capacity_
Function: setSize
```

So the limit that a `FlatVector` could hold was way-lower than the `int32_t` limit, and the exception was confusing.

# Solution
`byteSize()` must return `uint64_t` which is what we use for buffer size. `vector_size_t` is not the right type for the case. I changed it and now it looks working.

I did not add safe-multiplication, in `byteSize()` function. We would hit memory problems way before that to be a problem.

Differential Revision: D31528591

