### PR TITLE
Add --only flag to ExpressionFuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -364,6 +364,8 @@ class ExpressionFuzzer {
 
  public:
   void go(size_t steps) {
+    VELOX_CHECK(!signatures_.empty(), "No function signatures available.");
+
     for (size_t i = 0; i < steps; ++i) {
       LOG(INFO) << "==============================> Started iteration " << i
                 << " (seed: " << currentSeed_ << ")";

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -53,14 +53,13 @@ bool prepareFlatResultsVector(
     VELOX_CHECK(
         argToReuse.get()->encoding() == VectorEncoding::Simple::FLAT &&
         argToReuse.get()->typeKind() == TypeKind::VARCHAR);
-
     *result = std::move(argToReuse);
     return true;
   }
   // This will allocate results if not allocated
   BaseVector::ensureWritable(rows, VARCHAR(), context->pool(), result);
 
-  VELOX_CHECK((*result).get()->encoding() == VectorEncoding::Simple::FLAT);
+  VELOX_CHECK_EQ((*result).get()->encoding(), VectorEncoding::Simple::FLAT);
   return false;
 }
 


### PR DESCRIPTION
Summary:
Adding --only flag to make it more convenient to restrict the set of
function signatures available to the Fuzzer. Also adding more documentation to
the code

Differential Revision: D31528429

