### PR TITLE
Don't delete the global fileId cache on shutdown

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -420,8 +420,7 @@ void CacheShard::updateStats(CacheStats& stats) {
 AsyncDataCache::AsyncDataCache(
     std::unique_ptr<MappedMemory> mappedMemory,
     uint64_t maxBytes)
-    : fileIds_(fileIdsShared()),
-      mappedMemory_(std::move(mappedMemory)),
+    : mappedMemory_(std::move(mappedMemory)),
       cachedPages_(0),
       maxBytes_(maxBytes) {
   for (auto i = 0; i < kNumShards; ++i) {

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -635,8 +635,6 @@ class AsyncDataCache : public memory::MappedMemory,
  private:
   static constexpr int32_t kNumShards = 4; // Must be power of 2.
   static constexpr int32_t kShardMask = kNumShards - 1;
-  // Keeps the id to file map alive as long as 'this' is live.
-  std::shared_ptr<StringIdMap> fileIds_;
   std::unique_ptr<memory::MappedMemory> mappedMemory_;
   std::vector<std::unique_ptr<CacheShard>> shards_;
   int32_t shardCounter_{};

--- a/velox/common/caching/FileIds.cpp
+++ b/velox/common/caching/FileIds.cpp
@@ -20,12 +20,7 @@
 
 namespace facebook::velox {
 StringIdMap& fileIds() {
-  return *fileIdsShared();
+  static StringIdMap* ids = new StringIdMap();
+  return *ids;
 }
-
-const std::shared_ptr<StringIdMap>& fileIdsShared() {
-  static std::shared_ptr<StringIdMap> ids = std::make_shared<StringIdMap>();
-  return ids;
-}
-
 } // namespace facebook::velox

--- a/velox/common/caching/FileIds.h
+++ b/velox/common/caching/FileIds.h
@@ -21,9 +21,4 @@ namespace facebook::velox {
 // Returns a process-wide map of file path to id and id to file path.
 StringIdMap& fileIds();
 
-// Returns a shared_ptr to fileIds(). Needed to control destruction
-// order at end of process, so that caches that pin ids to names keep
-// the map alive.
-const std::shared_ptr<StringIdMap>& fileIdsShared();
-
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
This was resulting in crashes on process exit.  File handles etc should be
flushed on process shutdown to avoid data loss, but there's no need to free
memory on process shutdown: the OS will take care of it.

Reviewed By: syscl

Differential Revision: D31524441

