### PR TITLE
Remove registerAllFileSystems

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -117,9 +117,4 @@ void registerLocalFileSystem() {
       LocalFileSystem::schemeMatcher(), LocalFileSystem::fileSystemGenerator());
 }
 
-// Register FileSystems.
-void registerAllFileSystems() {
-  registerLocalFileSystem();
-}
-
 } // namespace facebook::velox::filesystems

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -62,12 +62,4 @@ void registerFileSystem(
 // Register the local filesystem.
 void registerLocalFileSystem();
 
-// Register all filesystems.
-// Ideally, the prefix for each filesystem would be different,
-// eg. s3://, hdfs://, file://. The filename string should contain this prefix.
-// However, prefix uniqueness is not checked and each registered file system is
-// tried in the order it was registered.
-// So keep this in mind if multiple file systems could match the same prefix.
-void registerAllFileSystems();
-
 } // namespace facebook::velox::filesystems


### PR DESCRIPTION
Since most of the storage adapters are optional, let us remove the registerAllFileSystems method for now and avoid the optional dependency handling. We can add this later if there is a demand for it.