### PR TITLE
Proper implementation for floor/ceil for Spruce

### DIFF
--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
+#include <system_error>
 
 #include "velox/functions/Macros.h"
 
@@ -64,6 +66,50 @@ call(double& result, const double num, const double denom) {
     return false;
   }
   result = num / denom;
+  return true;
+}
+VELOX_UDF_END();
+
+/*
+  In Spark both ceil and floor must return Long type
+  sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+*/
+template <typename T>
+int64_t safeDoubleToInt64(const T& /*value*/) {
+  throw std::runtime_error("Invalid input for floor/ceil");
+}
+
+template <>
+inline int64_t safeDoubleToInt64(const double& arg) {
+  if (std::isnan(arg)) {
+    return 0;
+  }
+  if (arg > std::numeric_limits<int64_t>::max()) {
+    return std::numeric_limits<int64_t>::max();
+  }
+  if (arg < std::numeric_limits<int64_t>::min()) {
+    return std::numeric_limits<int64_t>::min();
+  }
+  return arg;
+}
+
+template <>
+inline int64_t safeDoubleToInt64(const int64_t& arg) {
+  return arg;
+}
+
+template <typename T>
+VELOX_UDF_BEGIN(ceil)
+FOLLY_ALWAYS_INLINE bool call(int64_t& result, const T value) {
+  result = safeDoubleToInt64(std::ceil(value));
+  return true;
+}
+VELOX_UDF_END();
+
+template <typename T>
+VELOX_UDF_BEGIN(floor)
+FOLLY_ALWAYS_INLINE bool call(int64_t& result, const T value) {
+  result = safeDoubleToInt64(std::floor(value));
   return true;
 }
 VELOX_UDF_END();

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -32,9 +32,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerUnaryNumeric<udf_unaryminus>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<udf_abs>({prefix + "abs"});
-  registerUnaryNumeric<udf_ceil>({prefix + "ceil"});
   registerFunction<udf_exp, double, double>({prefix + "exp"});
-  registerUnaryNumeric<udf_floor>({prefix + "floor"});
   registerBinaryIntegral<udf_pmod>({prefix + "pmod"});
   registerFunction<udf_power<double>, double, double, double>(
       {prefix + "power"});
@@ -50,6 +48,11 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<udf_round<double>, double, double, int32_t>(
       {prefix + "round"});
   registerFunction<udf_round<float>, float, float, int32_t>({prefix + "round"});
+  // In Spark only long, double, and decimal have ceil/floor
+  registerFunction<udf_ceil<int64_t>, int64_t, int64_t>({prefix + "ceil"});
+  registerFunction<udf_ceil<int64_t>, int64_t, double>({prefix + "ceil"});
+  registerFunction<udf_floor<int64_t>, int64_t, int64_t>({prefix + "floor"});
+  registerFunction<udf_floor<int64_t>, int64_t, double>({prefix + "floor"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterCompare.cpp
+++ b/velox/functions/sparksql/RegisterCompare.cpp
@@ -24,8 +24,8 @@ void registerCompareFunctions(const std::string& prefix) {
   registerBinaryScalar<udf_eq, bool>({prefix + "equalto"});
   registerBinaryScalar<udf_neq, bool>({prefix + "notequalto"});
   registerBinaryScalar<udf_lt, bool>({prefix + "lessthan"});
-  registerBinaryScalar<udf_gt, bool>({prefix + "lessthanorequal"});
-  registerBinaryScalar<udf_lte, bool>({prefix + "greaterthan"});
+  registerBinaryScalar<udf_gt, bool>({prefix + "greaterthan"});
+  registerBinaryScalar<udf_lte, bool>({prefix + "lessthanorequal"});
   registerBinaryScalar<udf_gte, bool>({prefix + "greaterthanorequal"});
 
   registerFunction<udf_between<int8_t>, bool, int8_t, int8_t, int8_t>(


### PR DESCRIPTION
Summary:
In Spark both ceil and floor must return Long type
  sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala

Differential Revision: D31487138

