### PR TITLE
Separate config for flatmap string dictionary encoding

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -114,6 +114,10 @@ Config::Entry<bool> Config::MAP_FLAT_DISABLE_DICT_ENCODING(
     "orc.map.flat.disable.dict.encoding",
     true);
 
+Config::Entry<bool> Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING(
+    "orc.map.flat.disable.dict.encoding.string",
+    true);
+
 Config::Entry<bool> Config::MAP_FLAT_DICT_SHARE(
     "orc.map.flat.dict.share",
     true);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -102,6 +102,7 @@ class Config {
   static Entry<uint32_t> STRING_STATS_LIMIT;
   static Entry<bool> FLATTEN_MAP;
   static Entry<bool> MAP_FLAT_DISABLE_DICT_ENCODING;
+  static Entry<bool> MAP_FLAT_DISABLE_DICT_ENCODING_STRING;
   static Entry<bool> MAP_FLAT_DICT_SHARE;
   static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -960,6 +960,14 @@ class StringColumnWriter : public ColumnWriter {
     strideOffsets_.clear();
   }
 
+ protected:
+  bool useDictionaryEncoding() const override {
+    return (sequence_ == 0 ||
+            !context_.getConfig(
+                Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING)) &&
+        !context_.isLowMemoryMode();
+  }
+
  private:
   uint64_t writeDict(DecodedVector& decodedVector, const Ranges& ranges);
 

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -195,7 +195,7 @@ class ColumnWriter {
     return context_.isIndexEnabled;
   }
 
-  bool useDictionaryEncoding() const {
+  virtual bool useDictionaryEncoding() const {
     return (sequence_ == 0 ||
             !context_.getConfig(Config::MAP_FLAT_DISABLE_DICT_ENCODING)) &&
         !context_.isLowMemoryMode();


### PR DESCRIPTION
Summary: We need isolation between string and integer dictionary encoding configs in flatmap because string subcolumns can potentially cause additional storage or other tradeoffs that we haven't tackled.

Reviewed By: zzhao0

Differential Revision: D31489909

