### PR TITLE
Install libdwarf in linux docker image and update circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
 executors:
   build:
     docker:
-      - image : prestocpp/velox-circleci:mikesh-20210610
+      - image : prestocpp/velox-circleci:mikesh-20211012
     resource_class: 2xlarge
     environment:
         CC:  /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -28,7 +28,7 @@ dnf_install epel-release dnf-plugins-core # For ccache, ninja
 dnf config-manager --set-enabled powertools
 dnf_install ninja-build ccache gcc-toolset-9 git wget which libevent-devel \
   openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
-  protobuf-devel fmt-devel
+  protobuf-devel fmt-devel libdwarf-devel
 
 dnf remove -y gflags
 


### PR DESCRIPTION
Install libdwarf in linux docker image and rebuild folly to pickup dwarf
Create a new image prestocpp/velox-circleci:mikesh-20210610 and pushed it
And update circleci to use the new image