### PR TITLE
DecodedVector should flatten null constants

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -347,7 +347,7 @@ void DecodedVector::setBaseData(
       return;
 
     case VectorEncoding::Simple::CONSTANT: {
-      if (!vector.isScalar() && !vector.isNullAt(0)) {
+      if (!vector.isScalar()) {
         baseVector_ = vector.wrappedVector();
         constantIndex_ = vector.wrappedIndex(0);
       }

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -109,13 +109,13 @@ class DecodedVectorTest : public testing::Test {
     DecodedVector decoded(*constantVector, selection);
     EXPECT_TRUE(decoded.isConstantMapping());
     EXPECT_FALSE(decoded.isIdentityMapping());
+    EXPECT_EQ(base->encoding(), decoded.base()->encoding());
     bool isNull = base->isNullAt(index);
     if (isNull) {
       for (int32_t i = 0; i < 100; i++) {
         EXPECT_TRUE(decoded.isNullAt(i)) << "at " << i;
       }
     } else {
-      EXPECT_EQ(base->encoding(), decoded.base()->encoding());
       for (int32_t i = 0; i < 100; i++) {
         EXPECT_FALSE(decoded.isNullAt(i));
         EXPECT_TRUE(base->equalValueAt(decoded.base(), index, decoded.index(i)))


### PR DESCRIPTION
Summary:
Previously, DecodedVector::base() could be a ConstantVector for null constants. This confused users of this type, which expected a flat vector (FlatVector, RowVector, ArrayVector, MapVector).

I've only modified the behavior for complex constants in this diff.

A separate diff shows the same problem exists for scalars.

Differential Revision: D31557380

