### PR TITLE
Added fuzzer for dwrf writer

### DIFF
--- a/velox/expression/tests/VectorFuzzer.h
+++ b/velox/expression/tests/VectorFuzzer.h
@@ -76,6 +76,9 @@ class VectorFuzzer {
   // DictionaryVector.
   VectorPtr fuzzDictionary(const VectorPtr& vector);
 
+  // Returns a "fuzzed" row vector with randomized data and nulls.
+  VectorPtr fuzzRow(const RowTypePtr& rowType);
+
   variant randVariant(const TypePtr& arg);
 
   void reSeed(size_t seed) {


### PR DESCRIPTION
Summary: To help validate dwrf writer against possible combinations of encodings, use the VectorFuzzer introduced as part of expression fuzz test to produce vectors.

Differential Revision: D31600246

