### PR TITLE
Extract QueryConfig from QueryCtx

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/Context.h"
+
+namespace facebook::velox::core {
+
+class QueryConfig {
+ public:
+  explicit QueryConfig(BaseConfigManager* config) : config_{config} {}
+
+  static constexpr const char* kCodegenEnabled = "driver.codegen.enabled";
+
+  static constexpr const char* kCodegenConfigurationFilePath =
+      "driver.codegen.configuration_file_path";
+
+  static constexpr const char* kCodegenLazyLoading =
+      "driver.codegen.lazy_loading";
+
+  // User provided session timezone. Stores a string with the actual timezone
+  // name, e.g: "America/Los_Angeles".
+  static constexpr const char* kSessionTimezone = "driver.session.timezone";
+
+  // If true, timezone-less timestamp conversions (e.g. string to timestamp,
+  // when the string does not specify a timezone) will be adjusted to the user
+  // provided session timezone (if any).
+  //
+  // For instance:
+  //
+  //  if this option is true and user supplied "America/Los_Angeles",
+  //  "1970-01-01" will be converted to -28800 instead of 0.
+  //
+  // False by default.
+  static constexpr const char* kAdjustTimestampToTimezone =
+      "driver.session.adjust_timestamp_to_timezone";
+
+  // Whether to use the simplified expression evaluation path. False by default.
+  static constexpr const char* kExprEvalSimplified =
+      "driver.expr_eval.simplified";
+
+  // Flags used to configure the CAST operator:
+
+  // This flag makes the Row conversion to by applied
+  // in a way that the casting row field are matched by
+  // name instead of position
+  static constexpr const char* kCastMatchStructByName =
+      "driver.cast.match_struct_by_name";
+
+  // This flags forces the cast from float/double to integer to be performed by
+  // truncating the decimal part instead of rounding.
+  static constexpr const char* kCastIntByTruncate =
+      "driver.cast.int_by_truncate";
+
+  static constexpr const char* kMaxLocalExchangeBufferSize =
+      "max_local_exchange_buffer_size";
+
+  static constexpr const char* kMaxPartialAggregationMemory =
+      "max_partial_aggregation_memory";
+
+  static constexpr const char* kMaxPartitionedOutputBufferSize =
+      "driver.max-page-partitioning-buffer-size";
+
+  static constexpr const char* kHashAdaptivityEnabled =
+      "driver.hash_adaptivity_enabled";
+
+  static constexpr const char* kAdaptiveFilterReorderingEnabled =
+      "driver.adaptive_filter_reordering_enabled";
+
+  uint64_t maxPartialAggregationMemoryUsage() const {
+    static constexpr uint64_t kDefault = 1L << 24;
+    return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
+  }
+
+  uint64_t maxPartitionedOutputBufferSize() const {
+    static constexpr uint64_t kDefault = 32UL << 20;
+    return get<uint64_t>(kMaxPartitionedOutputBufferSize, kDefault);
+  }
+
+  uint64_t maxLocalExchangeBufferSize() const {
+    static constexpr uint64_t kDefault = 32UL << 20;
+    return get<uint64_t>(kMaxLocalExchangeBufferSize, kDefault);
+  }
+
+  bool hashAdaptivityEnabled() const {
+    return get<bool>(kHashAdaptivityEnabled, true);
+  }
+
+  uint32_t writeStrideSize() const {
+    static constexpr uint32_t kDefault = 100'000;
+    return kDefault;
+  }
+
+  bool flushPerBatch() const {
+    static constexpr bool kDefault = true;
+    return kDefault;
+  }
+
+  bool adaptiveFilterReorderingEnabled() const {
+    return get<bool>(kAdaptiveFilterReorderingEnabled, true);
+  }
+
+  bool isMatchStructByName() const {
+    return get<bool>(kCastMatchStructByName, false);
+  }
+
+  bool isCastIntByTruncate() const {
+    return get<bool>(kCastIntByTruncate, false);
+  }
+
+  bool codegenEnabled() const {
+    return get<bool>(kCodegenEnabled, false);
+  }
+
+  std::string codegenConfigurationFilePath() const {
+    return get<std::string>(kCodegenConfigurationFilePath, "");
+  }
+
+  bool codegenLazyLoading() const {
+    return get<bool>(kCodegenLazyLoading, true);
+  }
+
+  bool adjustTimestampToTimezone() const {
+    return get<bool>(kAdjustTimestampToTimezone, false);
+  }
+
+  std::string sessionTimezone() const {
+    return get<std::string>(kSessionTimezone, "");
+  }
+
+  bool exprEvalSimplified() const {
+    return get<bool>(kExprEvalSimplified, false);
+  }
+
+ private:
+  template <typename T>
+  T get(const std::string& key, const T& defaultValue) const {
+    return config_->get<T>(key, defaultValue);
+  }
+
+  BaseConfigManager* config_;
+};
+} // namespace facebook::velox::core

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -20,6 +20,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/core/CancelPool.h"
 #include "velox/core/Context.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::core {
@@ -77,7 +78,8 @@ class QueryCtx : public Context {
         pool_(std::move(pool)),
         mappedMemory_(mappedMemory),
         connectorConfigs_(connectorConfigs),
-        executor_{std::move(executor)} {
+        executor_{std::move(executor)},
+        config_{std::make_unique<QueryConfig>(this)} {
     setConfigOverrides(config);
   }
 
@@ -91,6 +93,10 @@ class QueryCtx : public Context {
 
   folly::Executor* executor() const {
     return executor_.get();
+  }
+
+  QueryConfig* config() const {
+    return config_.get();
   }
 
   Config* getConnectorConfig(const std::string& connectorId) const {
@@ -111,116 +117,6 @@ class QueryCtx : public Context {
     return get<std::string>("host", local);
   }
 
-  uint64_t maxPartialAggregationMemoryUsage() const {
-    return get<uint64_t>(
-        kMaxPartialAggregationMemory, kMaxPartialAggregationMemoryDefault);
-  }
-
-  uint64_t maxPartitionedOutputBufferSize() const {
-    return get<uint64_t>(
-        kMaxPartitionedOutputBufferSize,
-        kMaxPartitionedOutputBufferSizeDefault);
-  }
-
-  uint64_t maxLocalExchangeBufferSize() const {
-    return get<uint64_t>(
-        kMaxLocalExchangeBufferSize, kMaxLocalExchangeBufferSizeDefault);
-  }
-
-  bool hashAdaptivityEnabled() const {
-    return get<bool>(kHashAdaptivityEnabled, true);
-  }
-
-  uint32_t writeStrideSize() const {
-    return kWriteStrideSize;
-  }
-
-  bool flushPerBatch() const {
-    return kFlushPerBatch;
-  }
-
-  bool adaptiveFilterReorderingEnabled() const {
-    return get<bool>(kAdaptiveFilterReorderingEnabled, true);
-  }
-
-  bool isMatchStructByName() const {
-    return get<bool>(kCastMatchStructByName, false);
-  }
-
-  bool isCastIntByTruncate() const {
-    return get<bool>(kCastIntByTruncate, false);
-  }
-
-  bool codegenEnabled() const {
-    return get<bool>(kCodegenEnabled, false);
-  }
-
-  std::string codegenConfigurationFilePath() const {
-    return get<std::string>(kCodegenConfigurationFilePath, "");
-  }
-
-  bool codegenLazyLoading() const {
-    return get<bool>(kCodegenLazyLoading, true);
-  }
-
-  bool adjustTimestampToTimezone() const {
-    return get<bool>(kAdjustTimestampToTimezone, false);
-  }
-
-  std::string sessionTimezone() const {
-    return get<std::string>(kSessionTimezone, "");
-  }
-
-  bool exprEvalSimplified() const {
-    return get<bool>(kExprEvalSimplified, false);
-  }
-
-  static constexpr const char* kCodegenEnabled = "driver.codegen.enabled";
-  static constexpr const char* kCodegenConfigurationFilePath =
-      "driver.codegen.configuration_file_path";
-  static constexpr const char* kCodegenLazyLoading =
-      "driver.codegen.lazy_loading";
-
-  // User provided session timezone. Stores a string with the actual timezone
-  // name, e.g: "America/Los_Angeles".
-  static constexpr const char* kSessionTimezone = "driver.session.timezone";
-
-  // If true, timezone-less timestamp conversions (e.g. string to timestamp,
-  // when the string does not specify a timezone) will be adjusted to the user
-  // provided session timezone (if any).
-  //
-  // For instance:
-  //
-  //  if this option is true and user supplied "America/Los_Angeles",
-  //  "1970-01-01" will be converted to -28800 instead of 0.
-  //
-  // False by default.
-  static constexpr const char* kAdjustTimestampToTimezone =
-      "driver.session.adjust_timestamp_to_timezone";
-
-  // Whether to use the simplified expression evaluation path. False by default.
-  static constexpr const char* kExprEvalSimplified =
-      "driver.expr_eval.simplified";
-
-  // Flags used to configure the CAST operator:
-
-  // This flag makes the Row conversion to by applied
-  // in a way that the casting row field are matched by
-  // name instead of position
-  static constexpr const char* kCastMatchStructByName =
-      "driver.cast.match_struct_by_name";
-
-  // This flags forces the cast from float/double to integer to be performed by
-  // truncating the decimal part instead of rounding.
-  static constexpr const char* kCastIntByTruncate =
-      "driver.cast.int_by_truncate";
-
-  static constexpr const char* kMaxLocalExchangeBufferSize =
-      "max_local_exchange_buffer_size";
-
-  static constexpr const char* kMaxPartialAggregationMemory =
-      "max_partial_aggregation_memory";
-
   // Overrides the previous configuration. Note that this function is NOT
   // thread-safe and should probably only be used in tests.
   void setConfigOverridesUnsafe(
@@ -237,26 +133,13 @@ class QueryCtx : public Context {
   }
 
   static constexpr const char* kQueryRootMemoryPool = "query_root";
-  static constexpr const char* kMaxPartitionedOutputBufferSize =
-      "driver.max-page-partitioning-buffer-size";
-  static constexpr uint64_t kMaxPartitionedOutputBufferSizeDefault = 32UL << 20;
-  static constexpr const char* kHashAdaptivityEnabled =
-      "driver.hash_adaptivity_enabled";
-  static constexpr uint32_t kWriteStrideSize = 100'000;
-  static constexpr bool kFlushPerBatch = true;
-  static constexpr const char* kAdaptiveFilterReorderingEnabled =
-      "driver.adaptive_filter_reordering_enabled";
-
-  static constexpr uint64_t kMaxLocalExchangeBufferSizeDefault = 32UL << 20;
-
-  // 16MB
-  static constexpr uint64_t kMaxPartialAggregationMemoryDefault = 1L << 24;
 
   CancelPoolPtr cancelPool_;
   std::unique_ptr<memory::MemoryPool> pool_;
   memory::MappedMemory* mappedMemory_;
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
   std::shared_ptr<folly::Executor> executor_;
+  std::unique_ptr<QueryConfig> config_;
 };
 
 // Represents the state of one thread of query execution.

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -64,7 +64,8 @@ GroupingSet::GroupingSet(
       mappedMemory_(operatorCtx->mappedMemory()),
       stringAllocator_(mappedMemory_),
       rows_(mappedMemory_),
-      isAdaptive_(operatorCtx->task()->queryCtx()->hashAdaptivityEnabled()) {
+      isAdaptive_(
+          operatorCtx->task()->queryCtx()->config()->hashAdaptivityEnabled()) {
   for (auto& hasher : hashers_) {
     keyChannels_.push_back(hasher->channel());
   }

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -37,6 +37,7 @@ HashAggregation::HashAggregation(
       maxPartialAggregationMemoryUsage_(
           operatorCtx_->task()
               ->queryCtx()
+              ->config()
               ->maxPartialAggregationMemoryUsage()) {
   auto inputType = aggregationNode->sources()[0]->outputType();
 

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -98,7 +98,7 @@ class PartitionedOutputBuffer {
       : task_(std::move(task)),
         broadcast_(broadcast),
         numDrivers_(numDrivers),
-        maxSize_(task_->queryCtx()->maxPartitionedOutputBufferSize()),
+        maxSize_(task_->queryCtx()->config()->maxPartitionedOutputBufferSize()),
         continueSize_(maxSize_ / 2) {
     buffers_.reserve(numDestinations);
     for (int i = 0; i < numDestinations; i++) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -65,14 +65,15 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
   }
 
 #if CODEGEN_ENABLED == 1
-  if (self->queryCtx()->codegenEnabled() &&
-      self->queryCtx()->codegenConfigurationFilePath().length() != 0) {
+  auto config = self->queryCtx()->config();
+  if (config->codegenEnabled() &&
+      config->codegenConfigurationFilePath().length() != 0) {
     auto codegenLogger =
         std::make_shared<codegen::DefaultLogger>(self->taskId_);
     auto codegen = codegen::Codegen(codegenLogger);
-    auto lazyLoading = self->queryCtx()->codegenLazyLoading();
+    auto lazyLoading = config->codegenLazyLoading();
     codegen.initializeFromFile(
-        self->queryCtx()->codegenConfigurationFilePath(), lazyLoading);
+        config->codegenConfigurationFilePath(), lazyLoading);
     auto newPlanNode = codegen.compile(*(self->planNode_));
     self->planNode_ = newPlanNode != nullptr ? newPlanNode : self->planNode_;
   }
@@ -678,7 +679,7 @@ void Task::createLocalExchangeSources(
 
   LocalExchange exchange;
   exchange.memoryManager = std::make_unique<LocalExchangeMemoryManager>(
-      queryCtx_->maxLocalExchangeBufferSize());
+      queryCtx_->config()->maxLocalExchangeBufferSize());
 
   exchange.sources.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -416,7 +416,7 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
   params.queryCtx = core::QueryCtx::create();
 
   params.queryCtx->setConfigOverridesUnsafe({
-      {core::QueryCtx::kMaxPartialAggregationMemory, "100"},
+      {core::QueryConfig::kMaxPartialAggregationMemory, "100"},
   });
 
   // Distinct aggregation.

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -205,7 +205,7 @@ TEST_F(LocalPartitionTest, maxBufferSizeGather) {
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({
-      {core::QueryCtx::kMaxLocalExchangeBufferSize, "100"},
+      {core::QueryConfig::kMaxLocalExchangeBufferSize, "100"},
   });
 
   auto task = ::assertQuery(
@@ -251,7 +251,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({
-      {core::QueryCtx::kMaxLocalExchangeBufferSize, "100"},
+      {core::QueryConfig::kMaxLocalExchangeBufferSize, "100"},
   });
 
   uint32_t fileIndex = 0;
@@ -273,7 +273,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
 
   // Re-run with higher memory limit (enough to hold ~10 vectors at a time).
   params.queryCtx->setConfigOverridesUnsafe({
-      {core::QueryCtx::kMaxLocalExchangeBufferSize, "10240"},
+      {core::QueryConfig::kMaxLocalExchangeBufferSize, "10240"},
   });
 
   fileIndex = 0;

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -79,8 +79,8 @@ void CastExpr::applyCastWithTry(
     exec::EvalCtx* context,
     const DecodedVector& input,
     FlatVector<To>* resultFlatVector) {
-  const auto& queryCtx = context->execCtx()->queryCtx();
-  auto isCastIntByTruncate = queryCtx->isCastIntByTruncate();
+  const auto& queryConfig = context->execCtx()->queryCtx()->config();
+  auto isCastIntByTruncate = queryConfig->isCastIntByTruncate();
 
   if (!nullOnFailure_) {
     if (!isCastIntByTruncate) {
@@ -128,8 +128,8 @@ void CastExpr::applyCastWithTry(
   // GMT timezone to the user provided session timezone.
   if constexpr (CppToType<To>::typeKind == TypeKind::TIMESTAMP) {
     // If user explicitly asked us to adjust the timezone.
-    if (queryCtx->adjustTimestampToTimezone()) {
-      auto sessionTzName = queryCtx->sessionTimezone();
+    if (queryConfig->adjustTimestampToTimezone()) {
+      auto sessionTzName = queryConfig->sessionTimezone();
       if (!sessionTzName.empty()) {
         // locate_zone throws runtime_error if the timezone couldn't be found
         // (so we're safe to dereference the pointer).
@@ -315,7 +315,8 @@ void CastExpr::applyRow(
 
   // Extract the flag indicating matching of children must be done by name or
   // position
-  auto matchByName = context->execCtx()->queryCtx()->isMatchStructByName();
+  auto matchByName =
+      context->execCtx()->queryCtx()->config()->isMatchStructByName();
 
   // Cast each row child to its corresponding output child
   std::vector<VectorPtr> newChildren;

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -394,8 +394,10 @@ void ConjunctExpr::evalSpecialForm(
   // Clear errors for 'rows' that are not in 'activeRows'.
   finalizeErrors(rows, *activeRows, throwOnError, context);
   if (!reorderEnabledChecked_) {
-    reorderEnabled_ =
-        context->execCtx()->queryCtx()->adaptiveFilterReorderingEnabled();
+    reorderEnabled_ = context->execCtx()
+                          ->queryCtx()
+                          ->config()
+                          ->adaptiveFilterReorderingEnabled();
     reorderEnabledChecked_ = true;
   }
   if (reorderEnabled_) {

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1164,7 +1164,7 @@ void ExprSetSimplified::eval(
 std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
     core::ExecCtx* execCtx) {
-  if (execCtx->queryCtx()->exprEvalSimplified() ||
+  if (execCtx->queryCtx()->config()->exprEvalSimplified() ||
       FLAGS_force_eval_simplified) {
     return std::make_unique<ExprSetSimplified>(std::move(source), execCtx);
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -177,8 +177,8 @@ TEST_F(CastExprTest, timestampInvalid) {
 
 TEST_F(CastExprTest, timestampAdjustToTimezone) {
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kSessionTimezone, "America/Los_Angeles"},
-      {core::QueryCtx::kAdjustTimestampToTimezone, "true"},
+      {core::QueryConfig::kSessionTimezone, "America/Los_Angeles"},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
   });
 
   // Expect unix epochs to be converted to LA timezone (8h offset).
@@ -205,8 +205,8 @@ TEST_F(CastExprTest, timestampAdjustToTimezone) {
 
   // Empty timezone is assumed to be GMT.
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kSessionTimezone, ""},
-      {core::QueryCtx::kAdjustTimestampToTimezone, "true"},
+      {core::QueryConfig::kSessionTimezone, ""},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
   });
   testCast<std::string, Timestamp>(
       "timestamp", {"1970-01-01"}, {Timestamp(0, 0)});
@@ -219,8 +219,8 @@ TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
   };
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kSessionTimezone, "bla"},
-      {core::QueryCtx::kAdjustTimestampToTimezone, "true"},
+      {core::QueryConfig::kSessionTimezone, "bla"},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
   });
   EXPECT_THROW(testFunc(), std::runtime_error);
 }
@@ -228,13 +228,13 @@ TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
 TEST_F(CastExprTest, truncateVsRound) {
   // Testing truncate vs round cast from double to int.
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "true"},
+      {core::QueryConfig::kCastIntByTruncate, "true"},
   });
   testCast<double, int>(
       "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {1, 2, 3, 100, -100});
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "false"},
+      {core::QueryConfig::kCastIntByTruncate, "false"},
   });
   testCast<double, int>(
       "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
@@ -242,12 +242,12 @@ TEST_F(CastExprTest, truncateVsRound) {
   testCast<int8_t, int32_t>("int", {111, 2, 3, 10, -10}, {111, 2, 3, 10, -10});
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "true"},
+      {core::QueryConfig::kCastIntByTruncate, "true"},
   });
   testCast<int32_t, int8_t>(
       "tinyint", {1111111, 2, 3, 1000, -100101}, {71, 2, 3, -24, -5});
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "false"},
+      {core::QueryConfig::kCastIntByTruncate, "false"},
   });
   EXPECT_THROW(
       (testCast<int32_t, int8_t>(
@@ -281,7 +281,7 @@ TEST_F(CastExprTest, errorHandling) {
       true);
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "true"},
+      {core::QueryConfig::kCastIntByTruncate, "true"},
   });
   testCast<double, int>(
       "int",
@@ -291,7 +291,7 @@ TEST_F(CastExprTest, errorHandling) {
       true);
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastIntByTruncate, "false"},
+      {core::QueryConfig::kCastIntByTruncate, "false"},
   });
   testCast<double, int>(
       "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
@@ -410,7 +410,7 @@ TEST_F(CastExprTest, rowCast) {
       {intVectorNullEvery11, doubleVectorNullEvery3}, nullEvery(5));
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastMatchStructByName, "false"},
+      {core::QueryConfig::kCastMatchStructByName, "false"},
   });
   // Position-based cast: ROW(c0: bigint, c1: double) -> ROW(c0: double, c1:
   // bigint)
@@ -444,7 +444,7 @@ TEST_F(CastExprTest, rowCast) {
   }
   // Name-based cast: ROW(c0: bigint, c1: double) -> ROW(c0: double) dropping b
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kCastMatchStructByName, "true"},
+      {core::QueryConfig::kCastMatchStructByName, "true"},
   });
   {
     auto intVectorNullAll = makeFlatVector<int64_t>(

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -163,7 +163,7 @@ TEST_F(EvalSimplifiedTest, doubles) {
 // is specified.
 TEST_F(EvalSimplifiedTest, queryParameter) {
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kExprEvalSimplified, "true"},
+      {core::QueryConfig::kExprEvalSimplified, "true"},
   });
 
   auto expr = makeTypedExpr("1 + 1", nullptr);

--- a/velox/functions/prestosql/Hour.cpp
+++ b/velox/functions/prestosql/Hour.cpp
@@ -27,10 +27,10 @@ namespace {
 class HourFunction : public exec::VectorFunction {
  public:
   const date::time_zone* FOLLY_NULLABLE
-  getTimeZoneIfNeeded(const core::QueryCtx& queryCtx) const {
+  getTimeZoneIfNeeded(core::QueryConfig* config) const {
     const date::time_zone* timeZone = nullptr;
-    if (queryCtx.adjustTimestampToTimezone()) {
-      auto sessionTzName = queryCtx.sessionTimezone();
+    if (config->adjustTimestampToTimezone()) {
+      auto sessionTzName = config->sessionTimezone();
       if (!sessionTzName.empty()) {
         timeZone = date::locate_zone(sessionTzName);
       }
@@ -54,7 +54,8 @@ class HourFunction : public exec::VectorFunction {
 
     // Check if we need to adjust the current UTC timestamps to
     // the user provided session timezone.
-    const auto* timeZone = getTimeZoneIfNeeded(*context->execCtx()->queryCtx());
+    const auto* timeZone =
+        getTimeZoneIfNeeded(context->execCtx()->queryCtx()->config());
     if (timeZone != nullptr) {
       rows.applyToSelected([&](int row) {
         auto timestamp = timestamps[row];

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -144,8 +144,8 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(19, hour(Timestamp(998423705, 321000000)));
 
   queryCtx_->setConfigOverridesUnsafe({
-      {core::QueryCtx::kSessionTimezone, "Pacific/Apia"},
-      {core::QueryCtx::kAdjustTimestampToTimezone, "true"},
+      {core::QueryConfig::kSessionTimezone, "Pacific/Apia"},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
   });
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(13, hour(Timestamp(0, 0)));


### PR DESCRIPTION
In a future PR, simple functions will receive a pointer to QueryConfig in the constructor. This will allow to implement functions that depend on session's timezone (hour, minute, second, etc.) as simple functions.