### PR TITLE
Add timing of IO (data read/load).

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -3975,7 +3975,8 @@ class ColumnLoader : public velox::VectorLoader {
         fieldReader_(fieldReader),
         version_(version) {}
 
-  void load(RowSet rows, ValueHook* hook, VectorPtr* result) override;
+ protected:
+  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override;
 
  private:
   SelectiveStructColumnReader* structReader_;
@@ -4003,7 +4004,10 @@ static void scatter(RowSet rows, VectorPtr* result) {
       BaseVector::wrapInDictionary(BufferPtr(nullptr), indices, end, *result);
 }
 
-void ColumnLoader::load(RowSet rows, ValueHook* hook, VectorPtr* result) {
+void ColumnLoader::loadInternal(
+    RowSet rows,
+    ValueHook* hook,
+    VectorPtr* result) {
   VELOX_CHECK_EQ(
       version_,
       structReader_->numReads(),

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/TableScan.h"
+#include "velox/common/time/Timer.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
 
@@ -89,7 +90,11 @@ RowVectorPtr TableScan::getOutput() {
       ++stats_.numSplits;
     }
 
+    const auto ioTimeStartMicros = getCurrentTimeMicro();
     auto data = dataSource_->next(kDefaultBatchSize);
+    stats().addRuntimeStat(
+        "dataSourceWallNanos",
+        (getCurrentTimeMicro() - ioTimeStartMicros) * 1'000);
     stats_.rawInputPositions = dataSource_->getCompletedRows();
     stats_.rawInputBytes = dataSource_->getCompletedBytes();
     if (data) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/vector/tests/VectorMaker.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 struct OpaqueState;
 
@@ -96,19 +97,6 @@ struct TestData {
   VectorAndReference<std::shared_ptr<void>> opaquestate1;
 };
 
-class TestingVectorLoader : public VectorLoader {
- public:
-  explicit TestingVectorLoader(std::function<VectorPtr(RowSet)> loader)
-      : loader_(std::move(loader)) {}
-
-  void load(RowSet rows, ValueHook* hook, VectorPtr* result) override {
-    VELOX_CHECK(!hook, "SimpleVectorLoader doesn't support ValueHook");
-    *result = loader_(rows);
-  }
-
- private:
-  const std::function<VectorPtr(RowSet)> loader_;
-};
 } // namespace
 
 class ExprTest : public testing::Test {
@@ -657,7 +645,7 @@ class ExprTest : public testing::Test {
         execCtx_->pool(),
         CppToType<T>::create(),
         size,
-        std::make_unique<TestingVectorLoader>([=](RowSet rows) {
+        std::make_unique<SimpleVectorLoader>([=](RowSet rows) {
           VELOX_CHECK_EQ(rows.size(), expectedSize);
           for (auto i = 0; i < rows.size(); i++) {
             VELOX_CHECK_EQ(rows[i], expectedRowAt(i));

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -19,13 +19,14 @@ add_library(
   DecodedVector.cpp
   FlatVector.cpp
   LazyVector.cpp
-  SequenceVector.cpp
   SelectivityVector.cpp
+  SequenceVector.cpp
   SimpleVector.cpp
-  VectorStream.cpp
-  VectorEncoding.cpp)
+  VectorEncoding.cpp
+  VectorStream.cpp)
 
-target_link_libraries(velox_vector velox_memory velox_type velox_encode)
+target_link_libraries(velox_vector velox_encode velox_memory velox_time
+                      velox_type)
 
 add_subdirectory(arrow)
 

--- a/velox/vector/tests/VectorMaker.h
+++ b/velox/vector/tests/VectorMaker.h
@@ -30,7 +30,7 @@ class SimpleVectorLoader : public VectorLoader {
   explicit SimpleVectorLoader(std::function<VectorPtr(RowSet)> loader)
       : loader_(loader) {}
 
-  void load(RowSet rows, ValueHook* hook, VectorPtr* result) override {
+  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
     VELOX_CHECK(!hook, "SimpleVectorLoader doesn't support ValueHook");
     *result = loader_(rows);
   }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdio.h>
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <stdio.h>
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/BiasVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -34,7 +34,7 @@ class TestingLoader : public VectorLoader {
  public:
   explicit TestingLoader(VectorPtr data) : data_(data) {}
 
-  void load(RowSet rows, ValueHook* hook, VectorPtr* result) override {
+  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
     if (hook) {
       VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
           applyHook, data_->typeKind(), rows, hook);


### PR DESCRIPTION
Summary:
We use runtime stats to publish two new counters for operators: "ioWallNanos" and "ioLazyWallNanos".
The first one is for the direct load in the TableScan operator.
The second one is for the loads happening elsewhere through Lazy Vectors.
We use thread local and a tiny interface to implement the stats collection.
In case of significant overhead (I doubt it) we can easily disable the methods from using thread local and doing anything, using a define or altogether.
The counters should allow us to see how much time we spend on waiting on sync IO during queries.

Differential Revision: D31615769

