### PR TITLE
Fix strpos crash

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -54,7 +54,6 @@ using exec::SignatureBinder;
 // TODO: List of the functions that at some point crash or fail and need to
 // be fixed before we can enable.
 static std::unordered_set<std::string> kSkipFunctions = {
-    "strpos",
     "replace",
     // Fails because like requires 2nd arg to be a constant of type VARCHAR.
     "like",

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -257,6 +257,35 @@ class ExpressionFuzzer {
       }
     }
 
+    // We sort the available signatures to ensure we can deterministically
+    // generate expressions across platforms. We just do this once and the
+    // vector is small, so it doesn't need to be terribly efficient.
+    std::sort(
+        signatures_.begin(),
+        signatures_.end(),
+        // Returns true if lhs is less (comes before).
+        [](const CallableSignature& lhs, const CallableSignature& rhs) {
+          // The comparison logic is the following:
+          //
+          // 1. Compare based on function name.
+          // 2. If names are the same, compare the number of args.
+          // 3. If number of args are the same, look for any different arg
+          // types.
+          // 4. If all arg types are the same, compare return type.
+          if (lhs.name == rhs.name) {
+            if (lhs.args.size() == rhs.args.size()) {
+              for (size_t i = 0; i < lhs.args.size(); ++i) {
+                if (!lhs.args[i]->kindEquals(rhs.args[i])) {
+                  return lhs.args[i]->toString() < rhs.args[i]->toString();
+                }
+              }
+              return lhs.returnType->toString() < rhs.returnType->toString();
+            }
+            return lhs.args.size() < rhs.args.size();
+          }
+          return lhs.name < rhs.name;
+        });
+
     // Generates signaturesMap, which maps a given type to the function
     // signature that returns it.
     for (const auto& it : signatures_) {

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -291,6 +291,7 @@ class StringFunctionsTest : public FunctionBaseTest {
   using strpos_input_test_t = std::vector<
       std::pair<std::tuple<std::string, std::string, int64_t>, int64_t>>;
 
+  template <typename TInstance>
   void testStringPositionAllFlatVector(
       const strpos_input_test_t& tests,
       const std::vector<std::optional<bool>>& stringEncodings,
@@ -858,6 +859,7 @@ TEST_F(StringFunctionsTest, length) {
 }
 
 // Test strpos function
+template <typename TInstance>
 void StringFunctionsTest::testStringPositionAllFlatVector(
     const strpos_input_test_t& tests,
     const std::vector<std::optional<bool>>& asciiEncodings,
@@ -865,7 +867,7 @@ void StringFunctionsTest::testStringPositionAllFlatVector(
   auto stringVector = makeFlatVector<StringView>(tests.size());
   auto subStringVector = makeFlatVector<StringView>(tests.size());
   auto instanceVector =
-      withInstanceArgument ? makeFlatVector<int64_t>(tests.size()) : nullptr;
+      withInstanceArgument ? makeFlatVector<TInstance>(tests.size()) : nullptr;
 
   for (int i = 0; i < tests.size(); i++) {
     stringVector->set(i, StringView(std::get<0>(tests[i].first)));
@@ -916,9 +918,13 @@ TEST_F(StringFunctionsTest, stringPosition) {
   // We dont have to try all encoding combinations here since there is a test
   // that test the encoding resolution but we want to to have a test for each
   // possible resolution
-  testStringPositionAllFlatVector(testsAscii, {true, true}, false);
+  testStringPositionAllFlatVector<int64_t>(testsAscii, {true, true}, false);
 
-  testStringPositionAllFlatVector(testsAsciiWithPosition, {false, false}, true);
+  // Try instance parameter using BIGINT and INTEGER.
+  testStringPositionAllFlatVector<int32_t>(
+      testsAsciiWithPosition, {false, false}, true);
+  testStringPositionAllFlatVector<int64_t>(
+      testsAsciiWithPosition, {false, false}, true);
 
   // Test constant vectors
   auto rows = makeRowVector(makeRowType({BIGINT()}), 10);


### PR DESCRIPTION
Summary:
Strpos wasn't checking the type of the 3rd optional parameter, which
could be either bigint or integer. In case it was an integer, it would either
return wrong results or crash.

Reviewed By: mbasmanova

Differential Revision: D31628540

