### PR TITLE
Match from_unixtime semantics with Presto

### DIFF
--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -31,13 +31,32 @@ FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {
 }
 
 FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
-  if (UNLIKELY(std::isinf(unixtime) || std::isnan(unixtime))) {
-    return std::nullopt;
+  if (UNLIKELY(std::isnan(unixtime))) {
+    return Timestamp(0, 0);
+  }
+
+  static const int64_t kMax = std::numeric_limits<int64_t>::max();
+  static const int64_t kMin = std::numeric_limits<int64_t>::min();
+
+  static const Timestamp kMaxTimestamp(
+      kMax / 1000, kMax % 1000 * kNanosecondsInMilliseconds);
+  static const Timestamp kMinTimestamp(
+      kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMilliseconds);
+
+  if (UNLIKELY(unixtime >= kMax)) {
+    return kMaxTimestamp;
+  }
+
+  if (UNLIKELY(unixtime <= kMin)) {
+    return kMinTimestamp;
+  }
+
+  if (UNLIKELY(std::isinf(unixtime))) {
+    return unixtime < 0 ? kMinTimestamp : kMaxTimestamp;
   }
 
   auto seconds = std::floor(unixtime);
   auto nanos = unixtime - seconds;
   return Timestamp(seconds, nanos * kNanosecondsInSecond);
 }
-
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -117,15 +117,20 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
     return evaluateOnce<Timestamp>("from_unixtime(c0)", t);
   };
 
+  static const double kInf = std::numeric_limits<double>::infinity();
+  static const double kNan = std::numeric_limits<double>::quiet_NaN();
+
   EXPECT_EQ(Timestamp(0, 0), fromUnixtime(0));
   EXPECT_EQ(Timestamp(-1, 9000), fromUnixtime(-0.999991));
   EXPECT_EQ(Timestamp(4000000000, 0), fromUnixtime(4000000000));
+  EXPECT_EQ(
+      Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(3.87111e+37));
   // double(123000000) to uint64_t conversion returns 123000144.
   EXPECT_EQ(Timestamp(4000000000, 123000144), fromUnixtime(4000000000.123));
+  EXPECT_EQ(Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(kInf));
   EXPECT_EQ(
-      std::nullopt, fromUnixtime(std::numeric_limits<double>::infinity()));
-  EXPECT_EQ(
-      std::nullopt, fromUnixtime(std::numeric_limits<double>::quiet_NaN()));
+      Timestamp(-9'223'372'036'854'776, 192'000'000), fromUnixtime(-kInf));
+  EXPECT_EQ(Timestamp(0, 0), fromUnixtime(kNan));
 }
 
 TEST_F(DateTimeFunctionsTest, year) {


### PR DESCRIPTION
Summary: Fix from_unixtime function for positive and negative infinity, nan and very large, but not infinite inputs.

Differential Revision: D31660694

