### PR TITLE
Fix CMake failure when tests are disabled

### DIFF
--- a/velox/experimental/codegen/CMakeLists.txt
+++ b/velox/experimental/codegen/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   velox_core
   velox_exec
   velox_expression)
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/velox/experimental/codegen/code_generator/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/CMakeLists.txt
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(velox_all_link STATIC)
+target_link_libraries(
+  velox_all_link
+  velox_codegen_code_generator
+  velox_codegen_utils_resource_path
+  velox_core
+  velox_parse_parser
+  velox_exec_test_util
+  velox_functions_lib
+  velox_functions_prestosql
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${GTEST_BOTH_LIBRARIES}
+  ${GFLAGS_LIBRARIES}
+  ${GLOG}
+  ${FMT})
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/velox/experimental/codegen/code_generator/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/tests/CMakeLists.txt
@@ -14,22 +14,6 @@
 
 # write all cmake var in a file for post-processing
 
-add_library(velox_all_link STATIC)
-target_link_libraries(
-  velox_all_link
-  velox_codegen_code_generator
-  velox_codegen_utils_resource_path
-  velox_core
-  velox_parse_parser
-  velox_exec_test_util
-  velox_functions_lib
-  velox_functions_prestosql
-  ${FOLLY_WITH_DEPENDENCIES}
-  ${GTEST_BOTH_LIBRARIES}
-  ${GFLAGS_LIBRARIES}
-  ${GLOG}
-  ${FMT})
-
 set(CODEGEN_LINK_PATH "$<TARGET_FILE:velox_all_link>")
 get_directory_property(DEFINED_VARIABLE VARIABLES)
 foreach(VR IN LISTS DEFINED_VARIABLE)


### PR DESCRIPTION
The target `velox_all_link` is used inside https://github.com/facebookincubator/velox/blob/main/velox/experimental/codegen/utils/resources/CMakeLists.txt
However, this target never gets built when the tests are disabled (`VELOX_BUILD_TESTING=OFF`).
This PR fixes this.