### PR TITLE
Add array_duplicates Presto function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -28,6 +28,13 @@ Array Functions
         SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
         SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
 
+.. function:: array_duplicates(array(E)) -> array(E)
+
+    Returns a set of elements that occur more than once in array.
+    E must be bigint or varchar.
+
+        select array_duplicates(ARRAY [5, 2, 5, 1, 1, 5, null, null])); -- [null, 1, 5]
+
 .. function:: array_max(array(E)) -> E
 
     Returns the maximum value of input array. ::

--- a/velox/functions/lib/ComparatorUtil.h
+++ b/velox/functions/lib/ComparatorUtil.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions::lib {
+
+// Sort on an indices array by corresponding values array
+template <typename T>
+struct Index2ValueNullableLess {
+  explicit Index2ValueNullableLess(
+      const exec::LocalDecodedVector& decodedVector)
+      : decodedVector_(decodedVector) {}
+
+  constexpr bool operator()(const vector_size_t& a, const vector_size_t& b)
+      const {
+    // null should be moved to the head of the array
+    if (decodedVector_->isNullAt(a)) {
+      return !decodedVector_->isNullAt(b);
+    }
+    if (decodedVector_->isNullAt(b)) {
+      return false;
+    }
+    return decodedVector_->valueAt<T>(a) < decodedVector_->valueAt<T>(b);
+  }
+
+ private:
+  const exec::LocalDecodedVector& decodedVector_;
+};
+
+template <typename T>
+struct Index2ValueNullableGreater : private Index2ValueNullableLess<T> {
+  constexpr bool operator()(const vector_size_t& a, const vector_size_t& b)
+      const {
+    return Index2ValueNullableGreater<T>::operator()(b, a);
+  }
+};
+} // namespace facebook::velox::functions::lib

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/F14Map.h>
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/ComparatorUtil.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at https://prestodb.io/docs/current/functions/array.html
+///
+/// Implements the array_duplicates function.
+///
+/// Along with the hash map, we maintain a `hasNull` flag that indicates
+/// whether null is present in the array.
+///
+/// Zero element copy:
+///
+/// In order to prevent copies of array elements, the function reuses the
+/// internal elements() vector from the original ArrayVector.
+///
+/// First a new vector is created containing the indices of the elements
+/// which will be present in the output, and wrapped into a DictionaryVector.
+/// Next the `sizes` and `offsets` vectors that control where output arrays
+/// start and end are wrapped into the output ArrayVector.
+template <typename T>
+class ArrayDuplicatesFunction : public exec::VectorFunction {
+ public:
+  // Execute function.
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    // Acquire the array elements vector.
+    auto arrayVector = args[0]->as<ArrayVector>();
+    VELOX_CHECK(arrayVector);
+    auto elementsVector = arrayVector->elements();
+
+    auto elementsRows =
+        toElementRows(elementsVector->size(), rows, arrayVector);
+    exec::LocalDecodedVector elements(context, *elementsVector, elementsRows);
+
+    vector_size_t numElements = elementsRows.size();
+    vector_size_t numRows = arrayVector->size();
+
+    // Allocate new vectors for indices, length and offsets.
+    memory::MemoryPool* pool = context->pool();
+    BufferPtr newIndices = allocateIndices(numElements, pool);
+    BufferPtr newSizes = allocateSizes(numRows, pool);
+    BufferPtr newOffsets = allocateOffsets(numRows, pool);
+
+    // Pointers and cursor to the raw data.
+    vector_size_t indexCursor = 0;
+    auto* rawIndices = newIndices->asMutable<vector_size_t>();
+    auto* rawSizes = newSizes->asMutable<vector_size_t>();
+    auto* rawOffsets = newOffsets->asMutable<vector_size_t>();
+
+    // Process the rows: use a hashmap to store unique values and
+    // whether it occurred once or more than once.
+    folly::F14FastMap<T, bool> uniqueMap;
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto size = arrayVector->sizeAt(row);
+      auto offset = arrayVector->offsetAt(row);
+
+      rawOffsets[row] = indexCursor;
+      vector_size_t numNulls = 0;
+
+      for (vector_size_t i = offset; i < offset + size; ++i) {
+        if (elements->isNullAt(i)) {
+          numNulls++;
+          if (numNulls == 2) {
+            rawIndices[indexCursor] = i;
+            indexCursor++;
+          }
+        } else {
+          T value = elements->valueAt<T>(i);
+          auto it = uniqueMap.find(value);
+          if (it == uniqueMap.end()) {
+            uniqueMap[value] = true;
+          } else if (it->second) {
+            it->second = false;
+            rawIndices[indexCursor] = i;
+            indexCursor++;
+          }
+        }
+      }
+
+      uniqueMap.clear();
+      rawSizes[row] = indexCursor - rawOffsets[row];
+
+      std::sort(
+          rawIndices + rawOffsets[row],
+          rawIndices + indexCursor,
+          lib::Index2ValueNullableLess<T>(elements));
+    });
+
+    newIndices->setSize(indexCursor * sizeof(vector_size_t));
+    auto newElements =
+        BaseVector::transpose(newIndices, std::move(elementsVector));
+
+    // Prepare and return result set.
+    auto resultArray = std::make_shared<ArrayVector>(
+        pool,
+        outputType,
+        nullptr,
+        numRows,
+        std::move(newOffsets),
+        std::move(newSizes),
+        std::move(newElements));
+
+    context->moveOrCopyResult(resultArray, rows, result);
+  }
+};
+
+// Validate number of parameters and types.
+void validateType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_USER_CHECK_EQ(
+      inputArgs.size(), 1, "array_duplicates requires exactly one parameter");
+
+  auto arrayType = inputArgs.front().type;
+  VELOX_USER_CHECK_EQ(
+      arrayType->kind(),
+      TypeKind::ARRAY,
+      "array_duplicates requires arguments of type ARRAY");
+}
+
+// Create function template based on type.
+template <TypeKind kind>
+std::shared_ptr<exec::VectorFunction> createTyped(
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_CHECK_EQ(inputArgs.size(), 1);
+
+  using T = typename TypeTraits<kind>::NativeType;
+  return std::make_shared<ArrayDuplicatesFunction<T>>();
+}
+
+// Create function.
+std::shared_ptr<exec::VectorFunction> create(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  validateType(inputArgs);
+  auto elementType = inputArgs.front().type->childAt(0);
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      createTyped, elementType->kind(), inputArgs);
+}
+
+// Define function signature.
+// array(T) -> array(T) where T must be bigint or varchar.
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .argumentType("array(bigint)")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("array(varchar)")
+          .argumentType("array(varchar)")
+          .build()};
+}
+
+} // namespace
+
+// Register function.
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_array_duplicates,
+    signatures(),
+    create);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   ArrayConstructor.cpp
   ArrayContains.cpp
   ArrayDistinct.cpp
+  ArrayDuplicates.cpp
   ArrayIntersectExcept.cpp
   ArrayMinMax.cpp
   Cardinality.cpp

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -42,6 +42,7 @@ void registerVectorFunctions() {
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_duplicates, "array_duplicates");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_intersect, "array_intersect");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, "array_except");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_max, "array_max");

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+// Class to test the array_duplicates operator.
+class ArrayDuplicatesTest : public FunctionBaseTest {
+ protected:
+  // Evaluate an expression.
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result = evaluate<ArrayVector>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  // Execute test for bigint type.
+  void testBigint() {
+    auto array = makeNullableArrayVector<int64_t>({
+        {},
+        {1,
+         std::numeric_limits<int64_t>::min(),
+         std::numeric_limits<int64_t>::max()},
+        {std::nullopt},
+        {1, 2, 3},
+        {2, 1, 1, -2},
+        {1, 1, 1},
+        {-1, std::nullopt, -1, -1},
+        {std::nullopt, std::nullopt, std::nullopt},
+        {1, -2, -2, 8, -2, 4, 8, 1},
+        {std::numeric_limits<int64_t>::max(),
+         std::numeric_limits<int64_t>::max(),
+         1,
+         std::nullopt,
+         0,
+         1,
+         std::nullopt,
+         0},
+    });
+
+    auto expected = makeNullableArrayVector<int64_t>({
+        {},
+        {},
+        {},
+        {},
+        {1},
+        {1},
+        {-1},
+        {std::nullopt},
+        {-2, 1, 8},
+        {std::nullopt, 0, 1, std::numeric_limits<int64_t>::max()},
+    });
+
+    testExpr(expected, "array_duplicates(C0)", {array});
+  }
+};
+
+} // namespace
+
+// Test integer arrays.
+TEST_F(ArrayDuplicatesTest, integerArrays) {
+  testBigint();
+}
+
+// Test inline (short) strings.
+TEST_F(ArrayDuplicatesTest, inlineStringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {},
+      {S("")},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), std::nullopt, S("b")},
+      {S("a"), S("a")},
+      {S("b"), S("a"), S("b"), S("a"), S("a")},
+      {std::nullopt, std::nullopt},
+      {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {},
+      {},
+      {},
+      {},
+      {},
+      {S("a")},
+      {S("a"), S("b")},
+      {std::nullopt},
+      {std::nullopt, S("a"), S("b")},
+  });
+
+  testExpr(expected, "array_duplicates(C0)", {array});
+}
+
+// Test non-inline (> 12 character length) strings.
+TEST_F(ArrayDuplicatesTest, stringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {S("blue clear sky above"),
+       S("yellow rose flowers"),
+       std::nullopt,
+       S("blue clear sky above"),
+       S("orange beautiful sunset")},
+      {
+          S("red shiny car ahead"),
+          std::nullopt,
+          S("purple is an elegant color"),
+          S("red shiny car ahead"),
+          S("green plants make us happy"),
+          S("purple is an elegant color"),
+          std::nullopt,
+          S("purple is an elegant color"),
+      },
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {},
+      {S("blue clear sky above")},
+      {std::nullopt, S("purple is an elegant color"), S("red shiny car ahead")},
+  });
+
+  testExpr(expected, "array_duplicates(C0)", {array});
+}
+
+TEST_F(ArrayDuplicatesTest, nonContiguousRows) {
+  auto c0 = makeFlatVector<int64_t>(4, [](auto row) { return row; });
+  auto c1 = makeArrayVector<int64_t>({
+      {1, 1, 2, 3, 3},
+      {1, 1, 2, 3, 4, 4},
+      {1, 1, 2, 3, 4, 5, 5},
+      {1, 1, 2, 3, 3, 4, 5, 6, 6},
+  });
+
+  auto c2 = makeArrayVector<int64_t>({
+      {0, 0, 1, 1, 2, 3, 3},
+      {0, 0, 1, 1, 2, 3, 4, 4},
+      {0, 0, 1, 1, 2, 3, 4, 5, 5},
+      {0, 0, 1, 1, 2, 3, 4, 5, 6, 6},
+  });
+
+  auto expected = makeArrayVector<int64_t>({
+      {1, 3},
+      {0, 1, 4},
+      {1, 5},
+      {0, 1, 6},
+  });
+
+  auto result = evaluate<ArrayVector>(
+      "if(c0 % 2 = 0, array_duplicates(c1), array_duplicates(c2))",
+      makeRowVector({c0, c1, c2}));
+  assertEqualVectors(expected, result);
+}
+
+// Test for invalid signature and types.
+TEST_F(ArrayDuplicatesTest, invalidTypes) {
+  auto array = makeNullableArrayVector<int64_t>({{1, 1}});
+  auto expected = makeNullableArrayVector<int64_t>({{1}});
+
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(1)", {array}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(C0, CO)", {array, array}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(ARRAY[1], 1)", {array}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(ARRAY[ARRAY[1]])", {array}),
+      facebook::velox::VeloxUserError);
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates()", {array}), std::invalid_argument);
+
+  EXPECT_NO_THROW(testExpr(expected, "array_duplicates(C0)", {array}));
+}
+
+TEST_F(ArrayDuplicatesTest, invalidBooleanElementType) {
+  auto array = makeNullableArrayVector<bool>({{true, true}});
+  auto expected = makeNullableArrayVector<bool>({{true}});
+
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(C0)", {array}),
+      std::invalid_argument);
+}
+
+TEST_F(ArrayDuplicatesTest, invalidFloatElementType) {
+  auto array = makeNullableArrayVector<float>({{1.1, 1.1}});
+  auto expected = makeNullableArrayVector<float>({{1.1}});
+
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(C0)", {array}),
+      std::invalid_argument);
+}
+
+TEST_F(ArrayDuplicatesTest, invalidDoubleElementType) {
+  auto array = makeNullableArrayVector<double>({{1.1, 1.1}});
+  auto expected = makeNullableArrayVector<double>({{1.1}});
+
+  EXPECT_THROW(
+      testExpr(expected, "array_duplicates(C0)", {array}),
+      std::invalid_argument);
+}

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ArrayConstructorTest.cpp
   ArrayContainsTest.cpp
   ArrayDistinctTest.cpp
+  ArrayDuplicatesTest.cpp
   ArrayExceptTest.cpp
   ArrayFilterTest.cpp
   ArrayIntersectTest.cpp


### PR DESCRIPTION
## Summary
* Adding the array_duplicates Presto function to Velox

`array_duplicates(array(T))`

> Returns a set of elements that occur more than once in array. 
> T must be coercible to bigint or varchar.

For example:
```
select ARRAY_DUPLICATES(ARRAY [5, 2, 5, 1, 1, 5, null, null])); -- [null, 1, 5]
select ARRAY_DUPLICATES(ARRAY [true, true])); -- (SYNTAX_ERROR) line 1:8: Unexpected parameters (array(boolean)) for function array_dupes. Expected: array_duplicates(array(varchar)) , array_duplicates(array(bigint))
```

Diff: D31718890