### PR TITLE
Disable experimental codegen benchmark when tests build is disabled

### DIFF
--- a/velox/experimental/codegen/CMakeLists.txt
+++ b/velox/experimental/codegen/CMakeLists.txt
@@ -28,7 +28,6 @@ add_subdirectory(code_generator)
 add_subdirectory(ast)
 add_subdirectory(udf_manager)
 add_subdirectory(utils)
-add_subdirectory(benchmark)
 add_subdirectory(functions)
 add_subdirectory(vector_function)
 
@@ -50,4 +49,5 @@ target_link_libraries(
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
+  add_subdirectory(benchmark)
 endif()


### PR DESCRIPTION
When `VELOX_BUILD_TESTING=OFF`, codegen benchmark library `velox_codegen_benchmark_single_output` that depends on `velox_exec_test_lib` fails to build. This PR fixes that by disabling the experimental codegen benchmark as well.