### PR TITLE
Fix like function when no escape char specified

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -405,7 +405,6 @@ class LikeConstantPattern final : public VectorFunction {
 
     // apply() will not be invoked if the selection is empty.
     checkForBadPattern(re_);
-
     FlatVector<bool>& result =
         ensureWritableBool(rows, context->pool(), resultRef);
 
@@ -745,9 +744,9 @@ std::shared_ptr<exec::VectorFunction> makeLike(
       name,
       inputArgs[1].type->toString());
 
-  bool hasEscape = false;
+  bool hasEscape = numArgs == 3;
   char escapeChar;
-  if (numArgs == 3) {
+  if (hasEscape) {
     VELOX_USER_CHECK(
         inputArgs[2].type->isVarchar(),
         "{} requires third argument of type VARCHAR, but got {}",
@@ -766,7 +765,6 @@ std::shared_ptr<exec::VectorFunction> makeLike(
     // Escape char should be a single char value
     VELOX_USER_CHECK_EQ(constantEscape->valueAt(0).size(), 1);
     escapeChar = constantEscape->valueAt(0).data()[0];
-    hasEscape = true;
   }
 
   BaseVector* constantPattern = inputArgs[1].constantValue.get();

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -125,18 +125,21 @@ bool re2Extract(
   }
 }
 
-std::string
-likePatternToRe2(StringView pattern, bool hasEscape, char escapeChar, bool& validPattern) {
+std::string likePatternToRe2(
+    StringView pattern,
+    bool hasEscape,
+    char escapeChar,
+    bool& validPattern) {
   std::string regex;
   validPattern = true;
   regex.reserve(pattern.size() * 2);
   regex.append("^");
   bool escaped = false;
   for (const char c : pattern) {
-      if (hasEscape && escaped && !(c == '%' || c == '_' || c == escapeChar)) {
+    if (hasEscape && escaped && !(c == '%' || c == '_' || c == escapeChar)) {
       validPattern = false;
     }
-      if (hasEscape && !escaped && (c == escapeChar)) {
+    if (hasEscape && !escaped && (c == escapeChar)) {
       escaped = true;
     } else {
       switch (c) {
@@ -378,7 +381,11 @@ class Re2SearchAndExtract final : public VectorFunction {
 class LikeConstantPattern final : public VectorFunction {
  public:
   LikeConstantPattern(StringView pattern, bool hasEscape, char escapeChar)
-      : re_(toStringPiece(likePatternToRe2(pattern, hasEscape, escapeChar, validPattern_)),
+      : re_(toStringPiece(likePatternToRe2(
+                pattern,
+                hasEscape,
+                escapeChar,
+                validPattern_)),
             RE2::Quiet) {}
 
   void apply(

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -355,6 +355,7 @@ TEST_F(Re2FunctionsTest, likePattern) {
   EXPECT_EQ(like("abc", "%b%"), true);
   EXPECT_EQ(like("bcd", "%b%"), true);
   EXPECT_EQ(like("cde", "%b%"), false);
+  EXPECT_EQ(like("cde", "def"), false);
 
   EXPECT_EQ(like("abc", "_b%"), true);
   EXPECT_EQ(like("bcd", "_b%"), false);
@@ -387,6 +388,8 @@ TEST_F(Re2FunctionsTest, likePattern) {
           u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ",
           u8"\u7231\u4FE1%\u7231%"),
       false);
+
+  EXPECT_EQ(like("abc", "MEDIUM POLISHED%"), false);
 }
 
 TEST_F(Re2FunctionsTest, likePatternAndEscape) {


### PR DESCRIPTION
The 'like' function logic had a bug when escape char
was not specified in its invocation. In this situation,
the escape char was left uninitialized and could pick up
any value. If that random value matched a char in the
'pattern' parameter then it resulted in failures with error
'Escape character must be followed by ...'

This change fixes the bug by tracking using a boolean if indeed the
escape char was specified in the invocation, and modifying the logic
accordingly.