### PR TITLE
Simplify array_min/max functions and add a benchmark

### DIFF
--- a/velox/functions/prestosql/ArrayMinMax.cpp
+++ b/velox/functions/prestosql/ArrayMinMax.cpp
@@ -26,9 +26,6 @@ class Min {
   bool operator()(const T& arg1, const T& arg2) const {
     return arg1 < arg2;
   }
-  bool operator()() const {
-    return false;
-  }
 };
 
 template <typename T>
@@ -37,24 +34,19 @@ class Max {
   bool operator()(const T& arg1, const T& arg2) const {
     return arg1 > arg2;
   }
-  bool operator()() const {
-    return true;
-  }
 };
 
 template <template <typename> class F, TypeKind kind>
 VectorPtr applyTyped(
     const SelectivityVector& rows,
-    DecodedVector& arrayDecoded,
+    const ArrayVector& arrayVector,
     DecodedVector& elementsDecoded,
     exec::EvalCtx* context) {
   auto pool = context->pool();
   using T = typename TypeTraits<kind>::NativeType;
 
-  auto baseArray = arrayDecoded.base()->as<ArrayVector>();
-  auto inIndices = arrayDecoded.indices();
-  auto rawSizes = baseArray->rawSizes();
-  auto rawOffsets = baseArray->rawOffsets();
+  auto rawSizes = arrayVector.rawSizes();
+  auto rawOffsets = arrayVector.rawOffsets();
 
   BufferPtr indices = allocateIndices(rows.size(), pool);
   auto rawIndices = indices->asMutable<vector_size_t>();
@@ -72,40 +64,60 @@ VectorPtr applyTyped(
   };
 
   if (elementsDecoded.isIdentityMapping() && !elementsDecoded.mayHaveNulls()) {
-    auto rawElements = elementsDecoded.values<T>();
-
-    rows.applyToSelected([&](auto row) {
-      auto size = rawSizes[inIndices[row]];
-      auto offset = rawOffsets[inIndices[row]];
-      if (size == 0) {
-        processNull(row);
-      } else {
-        auto elementIndex = offset;
-        for (auto i = 1; i < size; i++) {
-          if (F<T>()(rawElements[offset + i], rawElements[elementIndex])) {
-            elementIndex = offset + i;
+    if constexpr (std::is_same_v<bool, T>) {
+      auto rawElements = elementsDecoded.values<uint64_t>();
+      rows.applyToSelected([&](auto row) {
+        auto size = rawSizes[row];
+        if (size == 0) {
+          processNull(row);
+        } else {
+          auto offset = rawOffsets[row];
+          auto elementIndex = offset;
+          for (auto i = offset + 1; i < offset + size; i++) {
+            if (F<T>()(
+                    bits::isBitSet(rawElements, i),
+                    bits::isBitSet(rawElements, elementIndex))) {
+              elementIndex = i;
+            }
           }
+          rawIndices[row] = elementIndex;
         }
-        rawIndices[row] = elementIndex;
-      }
-    });
+      });
+    } else {
+      auto rawElements = elementsDecoded.values<T>();
+      rows.applyToSelected([&](auto row) {
+        auto size = rawSizes[row];
+        if (size == 0) {
+          processNull(row);
+        } else {
+          auto offset = rawOffsets[row];
+          auto elementIndex = offset;
+          for (auto i = offset + 1; i < offset + size; i++) {
+            if (F<T>()(rawElements[i], rawElements[elementIndex])) {
+              elementIndex = i;
+            }
+          }
+          rawIndices[row] = elementIndex;
+        }
+      });
+    }
   } else {
     rows.applyToSelected([&](auto row) {
-      auto size = rawSizes[inIndices[row]];
+      auto size = rawSizes[row];
       if (size == 0) {
         processNull(row);
       } else {
-        auto offset = rawOffsets[inIndices[row]];
+        auto offset = rawOffsets[row];
         auto elementIndex = offset;
-        for (auto i = 0; i < size; i++) {
-          if (elementsDecoded.isNullAt(offset + i)) {
+        for (auto i = offset; i < offset + size; i++) {
+          if (elementsDecoded.isNullAt(i)) {
             // If a NULL value is encountered, min/max are always NULL
             processNull(row);
             break;
           } else if (F<T>()(
-                         elementsDecoded.valueAt<T>(offset + i),
+                         elementsDecoded.valueAt<T>(i),
                          elementsDecoded.valueAt<T>(elementIndex))) {
-            elementIndex = offset + i;
+            elementIndex = i;
           }
         }
         rawIndices[row] = elementIndex;
@@ -114,69 +126,7 @@ VectorPtr applyTyped(
   }
 
   return BaseVector::wrapInDictionary(
-      nulls, indices, rows.size(), baseArray->elements());
-}
-
-template <template <typename> class F>
-VectorPtr applyBoolean(
-    const SelectivityVector& rows,
-    DecodedVector& arrayDecoded,
-    DecodedVector& elementsDecoded,
-    exec::EvalCtx* context) {
-  auto pool = context->pool();
-  using T = typename TypeTraits<TypeKind::BOOLEAN>::NativeType;
-
-  auto baseArray = arrayDecoded.base()->as<ArrayVector>();
-  auto inIndices = arrayDecoded.indices();
-  auto rawSizes = baseArray->rawSizes();
-  auto rawOffsets = baseArray->rawOffsets();
-
-  BufferPtr indices = allocateIndices(rows.size(), pool);
-  auto rawIndices = indices->asMutable<vector_size_t>();
-
-  // Create nulls for lazy initialization.
-  BufferPtr nulls(nullptr);
-  uint64_t* rawNulls = nullptr;
-
-  auto processNull = [&](vector_size_t row) {
-    if (nulls == nullptr) {
-      nulls = AlignedBuffer::allocate<bool>(rows.size(), pool, bits::kNotNull);
-      rawNulls = nulls->asMutable<uint64_t>();
-    }
-    bits::setNull(rawNulls, row, true);
-  };
-  bool mayHaveNulls = elementsDecoded.mayHaveNulls();
-  rows.applyToSelected([&](auto row) {
-    auto size = rawSizes[inIndices[row]];
-    if (size == 0) {
-      processNull(row);
-    } else {
-      auto offset = rawOffsets[inIndices[row]];
-      auto elementIndex = offset;
-      bool foundElement = false;
-      for (auto i = 0; i < size; i++) {
-        if (elementsDecoded.isNullAt(offset + i)) {
-          // If a NULL value is encountered, min/max is always NULL
-          processNull(row);
-          break;
-        } else if (
-            !foundElement &&
-            elementsDecoded.valueAt<T>(offset + i) == F<T>()()) {
-          // check for a new element only if we did not find one yet.
-          elementIndex = offset + i;
-          foundElement = true;
-          // if there are no Nulls, break
-          if (!mayHaveNulls) {
-            break;
-          }
-        }
-      }
-      rawIndices[row] = elementIndex;
-    }
-  });
-
-  return BaseVector::wrapInDictionary(
-      nulls, indices, rows.size(), baseArray->elements());
+      nulls, indices, rows.size(), arrayVector.elements());
 }
 
 template <template <typename> class F>
@@ -189,58 +139,58 @@ class ArrayMinMaxFunction : public exec::VectorFunction {
       exec::EvalCtx* context,
       VectorPtr* result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
-    const auto& arrayVector = args[0];
-    VELOX_CHECK(arrayVector->type()->isArray());
+    auto arrayVector = args[0]->asUnchecked<ArrayVector>();
 
-    exec::LocalDecodedVector arrayHolder(context, *arrayVector, rows);
-    auto decodedArray = arrayHolder.get();
-    auto baseArray = decodedArray->base()->as<ArrayVector>();
-    auto elementsVector = baseArray->elements();
-    auto elementsRows = toElementRows(elementsVector->size(), rows, baseArray);
+    auto elementsVector = arrayVector->elements();
+    auto elementsRows =
+        toElementRows(elementsVector->size(), rows, arrayVector);
     exec::LocalDecodedVector elementsHolder(
         context, *elementsVector, elementsRows);
-    auto decodedElements = elementsHolder.get();
-    VectorPtr localResult;
-    auto typeKind = elementsVector->typeKind();
-    switch (typeKind) {
-      case TypeKind::BOOLEAN: {
-        localResult =
-            applyBoolean<F>(rows, *decodedArray, *decodedElements, context);
-        break;
-      }
-      default:
-        localResult = VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
-            applyTyped,
-            F,
-            typeKind,
-            rows,
-            *decodedArray,
-            *decodedElements,
-            context);
-    }
+    auto localResult = VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+        applyTyped,
+        F,
+        elementsVector->typeKind(),
+        rows,
+        *arrayVector,
+        *elementsHolder.get(),
+        context);
     context->moveOrCopyResult(localResult, rows, result);
-  }
-
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    // array(T) -> T
-    return {exec::FunctionSignatureBuilder()
-                .typeVariable("T")
-                .returnType("T")
-                .argumentType("array(T)")
-                .build()};
   }
 };
 
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  static const std::vector<std::string> kSupportedTypeNames = {
+      "boolean",
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "real",
+      "double",
+      "varchar",
+      "timestamp"};
+
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  signatures.reserve(kSupportedTypeNames.size());
+  for (const auto& typeName : kSupportedTypeNames) {
+    signatures.emplace_back(
+        exec::FunctionSignatureBuilder()
+            .returnType(typeName)
+            .argumentType(fmt::format("array({})", typeName))
+            .build());
+  }
+  return signatures;
+}
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_array_min,
-    ArrayMinMaxFunction<Min>::signatures(),
+    signatures(),
     std::make_unique<ArrayMinMaxFunction<Min>>());
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_array_max,
-    ArrayMinMaxFunction<Max>::signatures(),
+    signatures(),
     std::make_unique<ArrayMinMaxFunction<Max>>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/VectorFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+template <typename T>
+VELOX_UDF_BEGIN(array_min_simple)
+FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
+  if (x.begin() == x.end()) {
+    return false;
+  }
+  out = std::min_element(x.begin(), x.end())->value();
+  return true;
+}
+VELOX_UDF_END();
+
+template <typename T>
+VELOX_UDF_BEGIN(array_max_simple)
+FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
+  if (x.begin() == x.end()) {
+    return false;
+  }
+  out = std::max_element(x.begin(), x.end())->value();
+  return true;
+}
+VELOX_UDF_END();
+
+class ArrayMinMaxBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  ArrayMinMaxBenchmark() : FunctionBenchmarkBase() {
+    functions::registerVectorFunctions();
+    registerFunction<udf_array_min_simple<int32_t>, int32_t, Array<int32_t>>();
+    registerFunction<udf_array_max_simple<int32_t>, int32_t, Array<int32_t>>();
+  }
+
+  void runInteger(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    vector_size_t size = 1'000;
+    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
+        size,
+        [](auto row) { return row % 5; },
+        [](auto row) { return row % 23; });
+
+    auto rowVector = vectorMaker_.rowVector({arrayVector});
+    auto exprSet = compileExpression(
+        fmt::format("{}(c0)", functionName), rowVector->type());
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(simpleMinInteger) {
+  ArrayMinMaxBenchmark benchmark;
+  benchmark.runInteger("array_min_simple");
+}
+
+BENCHMARK_RELATIVE(vectorMinInteger) {
+  ArrayMinMaxBenchmark benchmark;
+  benchmark.runInteger("array_min");
+}
+
+BENCHMARK(simpleMaxInteger) {
+  ArrayMinMaxBenchmark benchmark;
+  benchmark.runInteger("array_max_simple");
+}
+
+BENCHMARK_RELATIVE(vectorMaxInteger) {
+  ArrayMinMaxBenchmark benchmark;
+  benchmark.runInteger("array_max");
+}
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -28,6 +28,11 @@ add_executable(velox_functions_benchmarks_array_contains
 target_link_libraries(velox_functions_benchmarks_array_contains
                       ${BENCHMARK_DEPENDENCIES})
 
+add_executable(velox_functions_benchmarks_array_min_max
+               ArrayMinMaxBenchmark.cpp)
+target_link_libraries(velox_functions_benchmarks_array_min_max
+                      ${BENCHMARK_DEPENDENCIES})
+
 add_executable(velox_functions_benchmarks_width_bucket WidthBucketBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_width_bucket
                       ${BENCHMARK_DEPENDENCIES})


### PR DESCRIPTION
Array_min and array_max functions take a single argument, hence, it is
guaranteed to be flat and doesn't need decoding. 

Also, 
- combined code paths for boolean and other primitive types to reduce copy-paste;
- fixed list of signatures to restrict to arrays of primitive types.

Added benchmark to compare performance of the vector and simple versions
of these functions. Simple functions are ~2x slower.

```
============================================================================
ArrayMinMaxBenchmark.cpprelative  time/iter  iters/s
============================================================================
simpleMinInteger                                             1.39ms   717.75
vectorMinInteger                                 188.52%   739.04us    1.35K
simpleMaxInteger                                             1.52ms   659.47
vectorMaxInteger                                 188.69%   803.62us    1.24K
============================================================================
```