### PR TITLE
Add date_trunc Presto function

### DIFF
--- a/velox/core/ScalarFunction.h
+++ b/velox/core/ScalarFunction.h
@@ -286,9 +286,11 @@ class UDFHolder final
   explicit UDFHolder(std::shared_ptr<const Type> returnType)
       : Metadata(std::move(returnType)), instance_{} {}
 
-  FOLLY_ALWAYS_INLINE void initialize(const core::QueryConfig& config) {
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const typename Exec::template resolver<TArgs>::in_type*... constantArgs) {
     if constexpr (udf_has_initialize<Fun>::value) {
-      return instance_.initialize(config);
+      return instance_.initialize(config, constantArgs...);
     }
   }
 

--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -15,6 +15,28 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+Truncation Function
+-------------------
+
+The ``date_trunc`` function supports the following units:
+
+=========== ===========================
+Unit        Example Truncated Value
+=========== ===========================
+``second``  ``2001-08-22 03:04:05.000``
+``minute``  ``2001-08-22 03:04:00.000``
+``hour``    ``2001-08-22 03:00:00.000``
+``day``     ``2001-08-22 00:00:00.000``
+``month``   ``2001-08-01 00:00:00.000``
+``year``    ``2001-01-01 00:00:00.000``
+=========== ===========================
+
+The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
+
+.. function:: date_trunc(unit, timestamp) -> timestamp
+
+    Returns ``timestamp`` truncated to ``unit``.
+
 Convenience Extraction Functions
 --------------------------------
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -350,11 +350,10 @@ ExprPtr compileExpression(
           adapterFunc->returnType(),
           resultType,
           folly::join(", ", inputTypes));
+      auto func = adapterFunc->getVectorInterpreter(
+          config, getConstantInputs(compiledInputs));
       result = std::make_shared<Expr>(
-          resultType,
-          std::move(compiledInputs),
-          adapterFunc->getVectorInterpreter(config),
-          call->name());
+          resultType, std::move(compiledInputs), std::move(func), call->name());
     } else if (
         auto func = getVectorFunction(
             call->name(), inputTypes, getConstantInputs(compiledInputs))) {

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -123,7 +123,8 @@ class VectorFunction {
 class VectorAdapterFactory {
  public:
   virtual std::unique_ptr<VectorFunction> getVectorInterpreter(
-      const core::QueryConfig& config) const = 0;
+      const core::QueryConfig& config,
+      const std::vector<VectorPtr>& constantInputs) const = 0;
   virtual ~VectorAdapterFactory() = default;
   virtual const TypePtr returnType() const = 0;
 };

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -72,6 +72,7 @@ void registerFunctions() {
   registerFunction<udf_minute, int64_t, Timestamp>();
   registerFunction<udf_second, int64_t, Timestamp>();
   registerFunction<udf_millisecond, int64_t, Timestamp>();
+  registerFunction<udf_date_trunc, Timestamp, Varchar, Timestamp>();
 
   registerArithmeticFunctions();
   registerCheckedArithmeticFunctions();

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -321,3 +321,59 @@ TEST_F(DateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
   EXPECT_EQ(12300, millisecond(Timestamp(-1, 12300000000)));
 }
+
+TEST_F(DateTimeFunctionsTest, dateTrunc) {
+  const auto dateTrunc = [&](const std::string& unit,
+                             std::optional<Timestamp> timestamp) {
+    return evaluateOnce<Timestamp>(
+        fmt::format("date_trunc('{}', c0)", unit), timestamp);
+  };
+
+  setQueryTimeZone("America/Los_Angeles");
+
+  EXPECT_EQ(std::nullopt, dateTrunc("second", std::nullopt));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 0)));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 123)));
+  EXPECT_EQ(
+      Timestamp(998474645, 0),
+      dateTrunc("second", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474640, 0),
+      dateTrunc("minute", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474400, 0),
+      dateTrunc("hour", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998463600, 0),
+      dateTrunc("day", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(996649200, 0),
+      dateTrunc("month", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(978336000, 0),
+      dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
+
+  setQueryTimeZone("Asia/Kolkata");
+
+  EXPECT_EQ(std::nullopt, dateTrunc("second", std::nullopt));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 0)));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 123)));
+  EXPECT_EQ(
+      Timestamp(998474645, 0),
+      dateTrunc("second", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474640, 0),
+      dateTrunc("minute", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998472600, 0),
+      dateTrunc("hour", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998418600, 0),
+      dateTrunc("day", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(996604200, 0),
+      dateTrunc("month", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(978287400, 0),
+      dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
+}


### PR DESCRIPTION
Enhance simple function interface to allow the function to process constant
arguments once, e.g. parse regular expression pattern or time unit. To get
access to constant arguments, the function must define `initialize` method that
takes constant reference to QueryConfig and a list of const pointers to input
arguments. Arguments which are constant will have corresponding values.
Arguments which are not constant will be passed as nulls. The signature of the
`initialize` method is similar to that of `callNullable` method with an
additional first parameter `const core::QueryConfig&`.

Here is how date_trunc function receives constant `unit` argument:

```
VELOX_UDF_BEGIN(date_trunc)
const date::time_zone* timeZone_ = nullptr;
std::optional<DateTimeUnit> unit_;

FOLLY_ALWAYS_INLINE void initialize(
    const core::QueryConfig& config,
    const arg_type<Varchar>* unitString,
    const arg_type<Timestamp>* /*timestamp*/) {
  timeZone_ = getTimeZoneFromConfig(config);
  if (unitString != nullptr) {
    unit_ = fromDateTimeUnitString(*unitString);
  }
}
```