### PR TITLE
Fix DecodedVector.wrap with constant encoding

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -16,6 +16,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/vector/BaseVector.h"
 #include "velox/vector/BiasVector.h"
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SequenceVector.h"
@@ -409,6 +410,10 @@ VectorPtr DecodedVector::wrap(
   auto encoding = data->encoding();
   if (encoding == VectorEncoding::Simple::CONSTANT) {
     return data;
+  }
+  if (wrapper.isConstantEncoding()) {
+    return BaseVector::wrapInConstant(
+        rows.end(), wrapper.wrappedIndex(0), data);
   }
   VELOX_CHECK(size_ >= rows.end());
   // If 'wrapper' is one level of dictionary we use the indices and nulls array

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -525,4 +525,19 @@ TEST_F(DecodedVectorTest, wrapOnDictionaryEncoding) {
   }
 }
 
+TEST_F(DecodedVectorTest, wrapOnConstantEncoding) {
+  const int kSize = 12;
+  auto intVector =
+      vectorMaker_->flatVector<int32_t>(kSize, [](auto row) { return row; });
+  auto rowVector = vectorMaker_->rowVector({intVector});
+  auto constantVector = BaseVector::wrapInConstant(kSize, 1, rowVector);
+  SelectivityVector allRows(kSize);
+  DecodedVector decoded(*constantVector, allRows);
+  auto wrappedVector = decoded.wrap(intVector, *constantVector, allRows);
+  for (auto i = 0; i < kSize; i++) {
+    ASSERT_TRUE(
+        wrappedVector->equalValueAt(intVector.get(), i, decoded.index(i)));
+  }
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary: Fix DecodedVector.wrap bug which surfaced in `FieldReference::evalSpecialForm`.

Differential Revision: D31749636

