### PR TITLE
Buffer::as(Mutable)Range needs template parameter

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -88,7 +88,7 @@ class Buffer {
 
   template <typename T>
   Range<T> asRange() {
-    return Range(as<T>(), 0, size() / sizeof(T));
+    return Range<T>(as<T>(), 0, size() / sizeof(T));
   }
 
   template <typename T>
@@ -102,7 +102,7 @@ class Buffer {
 
   template <typename T>
   MutableRange<T> asMutableRange() {
-    return MutableRange(asMutable<T>(), 0, size() / sizeof(T));
+    return MutableRange<T>(asMutable<T>(), 0, size() / sizeof(T));
   }
 
   size_t size() const {

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -97,6 +97,23 @@ TEST_F(BufferTest, testAlignedBuffer) {
   EXPECT_EQ(pool_->getCurrentBytes(), 0);
 }
 
+TEST_F(BufferTest, testAsRange) {
+  // Simple 2 element vector.
+  std::vector<uint8_t> testData({5, 255});
+  BufferPtr buffer =
+      AlignedBuffer::allocate<uint8_t>(2 /*numElements*/, pool_.get());
+
+  memcpy(buffer->asMutable<uint8_t>(), testData.data(), testData.size());
+
+  Range<uint8_t> range = buffer->asRange<uint8_t>();
+  MutableRange<uint8_t> mutRange = buffer->asMutableRange<uint8_t>();
+  EXPECT_EQ(5, range[0]);
+  EXPECT_EQ(255, range[1]);
+
+  EXPECT_EQ(5, mutRange[0]);
+  EXPECT_EQ(255, mutRange[1]);
+}
+
 TEST_F(BufferTest, testAlignedBufferPrint) {
   // We'll only put non-default values for the first 2 bytes. Note how below
   // in the string it has 05 ff which corresponds to these.


### PR DESCRIPTION
Summary:
`Buffer::asRange<T>` and `Buffer::asMutableRange<T>`  never compiled.

Adding a simple test to verify

1. compilation
2. random-access (within bounds of buffer)

Reviewed By: mbasmanova

Differential Revision: D31768083

