### PR TITLE
Add support for array(double) bins argument in width_bucket

### DIFF
--- a/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
+++ b/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
@@ -24,45 +24,12 @@ namespace {
 
 class WidthBucketArrayTest : public FunctionBaseTest {
  protected:
-  void testFailure(
-      const double operand,
-      const std::vector<std::vector<double>>& bins,
-      const std::string& expected_message) {
-    auto binsVector = makeArrayVector<double>(bins);
-    assertUserInvalidArgument(
-        [&]() {
-          evaluate<SimpleVector<int64_t>>(
-              "width_bucket(c0, c1)",
-              makeRowVector(
-                  {makeConstant(operand, binsVector->size()), binsVector}));
-        },
-        expected_message);
-  }
-
-  void testFailureForConstant(
-      const double operand,
-      const std::string& bins,
-      const std::string& expected_message) {
-    assertUserInvalidArgument(
-        [&]() {
-          evaluate<SimpleVector<int64_t>>(
-              fmt::format("width_bucket(c0, {})", bins),
-              makeRowVector({makeConstant(operand, 1)}));
-        },
-        expected_message);
-  }
+  static constexpr double kInf = std::numeric_limits<double>::infinity();
+  static constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
 };
 
 TEST_F(WidthBucketArrayTest, success) {
-  auto binsVector = makeArrayVector<double>({{0.0, 2.0, 4.0}, {0.0}});
-
-  // Also encode the Array in a dictionary, and test using it as input.
-  // The dictionary repeats each row of the original array twice.
-  auto binsVectorNewSize = binsVector->size() * 2;
-  auto binsIndices =
-      makeIndices(binsVectorNewSize, [](auto row) { return row / 2; });
-  auto binsDict = wrapInDictionary(binsIndices, binsVectorNewSize, binsVector);
-
+  VectorPtr binsVector;
   auto testWidthBucketArray = [&](const double operand,
                                   const std::vector<int64_t>& expected) {
     auto result = evaluate<SimpleVector<int64_t>>(
@@ -74,36 +41,58 @@ TEST_F(WidthBucketArrayTest, success) {
 
     assertEqualVectors(makeFlatVector<int64_t>(expected), result);
 
+    // Encode the bins array in a dictionary repeating each row of the original
+    // array twice.
+    auto newSize = binsVector->size() * 2;
+    auto binsIndices = makeIndices(newSize, [](auto row) { return row / 2; });
+
     // Flatten the constant operand to avoid peeling of encodings.
-    auto operandFlat = flatten(makeConstant(operand, binsVectorNewSize));
+    auto operandFlat = flatten(makeConstant(operand, newSize));
     auto dictResult = evaluate<SimpleVector<int64_t>>(
         "width_bucket(c0, c1)",
         makeRowVector({
             operandFlat,
-            binsDict,
+            wrapInDictionary(binsIndices, newSize, binsVector),
         }));
     auto dictExpected = wrapInDictionary(
-        binsIndices, binsVectorNewSize, makeFlatVector<int64_t>(expected));
+        binsIndices, newSize, makeFlatVector<int64_t>(expected));
     assertEqualVectors(dictExpected, dictResult);
   };
 
-  testWidthBucketArray(3.14, {2, 1});
-  testWidthBucketArray(std::numeric_limits<double>::infinity(), {3, 1});
-  testWidthBucketArray(-1, {0, 0});
+  {
+    binsVector = makeArrayVector<double>({{0.0, 2.0, 4.0}, {0.0}});
+    testWidthBucketArray(3.14, {2, 1});
+    testWidthBucketArray(kInf, {3, 1});
+    testWidthBucketArray(-1, {0, 0});
+  }
+
+  {
+    binsVector = makeArrayVector<int64_t>({{0, 2, 4}, {0}});
+    testWidthBucketArray(3.14, {2, 1});
+    testWidthBucketArray(kInf, {3, 1});
+    testWidthBucketArray(-1, {0, 0});
+  }
 }
 
 TEST_F(WidthBucketArrayTest, failure) {
+  auto testFailure = [&](const double operand,
+                         const std::vector<std::vector<double>>& bins,
+                         const std::string& expected_message) {
+    auto binsVector = makeArrayVector<double>(bins);
+    assertUserInvalidArgument(
+        [&]() {
+          evaluate<SimpleVector<int64_t>>(
+              "width_bucket(c0, c1)",
+              makeRowVector(
+                  {makeConstant(operand, binsVector->size()), binsVector}));
+        },
+        expected_message);
+  };
+
   testFailure(0, {{}}, "Bins cannot be an empty array");
-  testFailure(
-      std::numeric_limits<double>::quiet_NaN(), {{0}}, "Operand cannot be NaN");
-  testFailure(
-      1,
-      {{0, std::numeric_limits<double>::infinity()}},
-      "Bin value must be finite");
-  testFailure(
-      1,
-      {{0, std::numeric_limits<double>::quiet_NaN()}},
-      "Bin values are not sorted in ascending order");
+  testFailure(kNan, {{0}}, "Operand cannot be NaN");
+  testFailure(1, {{0, kInf}}, "Bin value must be finite");
+  testFailure(1, {{0, kNan}}, "Bin values are not sorted in ascending order");
   testFailure(2, {{1, 0}}, "Bin values are not sorted in ascending order");
 }
 
@@ -126,24 +115,31 @@ TEST_F(WidthBucketArrayTest, successForConstantArray) {
   };
 
   testWidthBucketArray(3.14, "ARRAY[0.0, 2.0, 4.0]", 2);
-  testWidthBucketArray(
-      std::numeric_limits<double>::infinity(), "ARRAY[0.0, 2.0, 4.0]", 3);
+  testWidthBucketArray(kInf, "ARRAY[0.0, 2.0, 4.0]", 3);
   testWidthBucketArray(-1, "ARRAY[0.0, 2.0, 4.0]", 0);
   testWidthBucketArray(3.14, "ARRAY[0.0]", 1);
-  testWidthBucketArray(
-      std::numeric_limits<double>::infinity(), "ARRAY[0.0]", 1);
+  testWidthBucketArray(kInf, "ARRAY[0.0]", 1);
   testWidthBucketArray(-1, "ARRAY[0.0]", 0);
 }
 
 TEST_F(WidthBucketArrayTest, failureForConstant) {
+  auto testFailure = [&](const double operand,
+                         const std::string& bins,
+                         const std::string& expected_message) {
+    assertUserInvalidArgument(
+        [&]() {
+          evaluate<SimpleVector<int64_t>>(
+              fmt::format("width_bucket(c0, {})", bins),
+              makeRowVector({makeConstant(operand, 1)}));
+        },
+        expected_message);
+  };
+
   // TODO: Add tests for empty bin and bins that contains infinity(), nan()
   //       once corresponding casting and non-constant array literal element is
   //       supported.
-  testFailureForConstant(
-      std::numeric_limits<double>::quiet_NaN(),
-      "ARRAY[0.0]",
-      "Operand cannot be NaN");
-  testFailureForConstant(
+  testFailure(kNan, "ARRAY[0.0]", "Operand cannot be NaN");
+  testFailure(
       2, "ARRAY[1.0, 0.0]", "Bin values are not sorted in ascending order");
 }
 


### PR DESCRIPTION
Summary: Fix VeloxRuntimeError: binsVector.type->asArray().elementType()->isDouble()  error when invoking width_bucket on array(bigint).

Differential Revision: D31771471

