### PR TITLE
Make sure to initialize dictionary indices for all rows

### DIFF
--- a/velox/aggregates/MapAggAggregate.cpp
+++ b/velox/aggregates/MapAggAggregate.cpp
@@ -215,7 +215,7 @@ class MapAggAggregate : public exec::Aggregate {
                 mapVector->mapKeys()->size(), mapVector->pool());
             rawNewSizes = newSizes->asMutable<vector_size_t>();
 
-            elementIndices = AlignedBuffer::allocate<vector_size_t>(
+            elementIndices = allocateIndices(
                 mapVector->mapKeys()->size(), mapVector->pool());
             rawElementIndices = elementIndices->asMutable<vector_size_t>();
 

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -246,8 +246,7 @@ std::vector<BufferPtr> allocateIndexBuffers(
   std::vector<BufferPtr> indexBuffers;
   indexBuffers.reserve(numBuffers);
   for (auto i = 0; i < numBuffers; i++) {
-    indexBuffers.emplace_back(
-        AlignedBuffer::allocate<vector_size_t>(size, pool));
+    indexBuffers.emplace_back(allocateIndices(size, pool));
   }
   return indexBuffers;
 }

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -93,8 +93,7 @@ RowVectorPtr Unnest::getOutput() {
 
   // Create "indices" buffer to repeat rows as many times as there are elements
   // in the array.
-  BufferPtr repeatedIndices =
-      AlignedBuffer::allocate<vector_size_t>(numElements, pool());
+  BufferPtr repeatedIndices = allocateIndices(numElements, pool());
   auto* rawIndices = repeatedIndices->asMutable<vector_size_t>();
   vector_size_t index = 0;
   for (auto row = 0; row < size; ++row) {
@@ -115,8 +114,7 @@ RowVectorPtr Unnest::getOutput() {
 
   // Make "elements" column. Elements may be out of order. Use a
   // dictionary to ensure the right order.
-  BufferPtr elementIndices =
-      AlignedBuffer::allocate<vector_size_t>(numElements, pool());
+  BufferPtr elementIndices = allocateIndices(numElements, pool());
   auto* rawElementIndices = elementIndices->asMutable<vector_size_t>();
   index = 0;
   bool identityMapping = true;

--- a/velox/functions/lib/LambdaFunctionUtil.cpp
+++ b/velox/functions/lib/LambdaFunctionUtil.cpp
@@ -47,7 +47,7 @@ void flattenBuffers(
   newNulls = flattenNulls(rows, decodedVector);
   uint64_t* rawNewNulls = newNulls ? newNulls->asMutable<uint64_t>() : nullptr;
 
-  elementIndices = AlignedBuffer::allocate<vector_size_t>(newNumElements, pool);
+  elementIndices = allocateIndices(newNumElements, pool);
   auto rawElementIndices = elementIndices->asMutable<vector_size_t>();
   newSizes = AlignedBuffer::allocate<vector_size_t>(rows.end(), pool);
   auto rawNewSizes = newSizes->asMutable<vector_size_t>();

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -155,8 +155,7 @@ class SubscriptImpl : public exec::VectorFunction {
       exec::EvalCtx* context) const {
     auto pool = context->pool();
 
-    BufferPtr indices =
-        AlignedBuffer::allocate<vector_size_t>(rows.size(), pool);
+    BufferPtr indices = allocateIndices(rows.size(), pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
 
     // Create nulls for lazy initialization.
@@ -294,8 +293,7 @@ class SubscriptImpl : public exec::VectorFunction {
       exec::EvalCtx* context) const {
     auto pool = context->pool();
 
-    BufferPtr indices =
-        AlignedBuffer::allocate<vector_size_t>(rows.size(), pool);
+    BufferPtr indices = allocateIndices(rows.size(), pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
 
     // Create nulls for lazy initialization.

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -64,8 +64,7 @@ class ArrayDistinctFunction : public exec::VectorFunction {
 
     // Allocate new vectors for indices, length and offsets.
     memory::MemoryPool* pool = context->pool();
-    BufferPtr newIndices =
-        AlignedBuffer::allocate<vector_size_t>(elementsCount, pool);
+    BufferPtr newIndices = allocateIndices(elementsCount, pool);
     BufferPtr newLengths =
         AlignedBuffer::allocate<vector_size_t>(rowCount, pool);
     BufferPtr newOffsets =

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -145,8 +145,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
     vector_size_t rowCount = left->size();
 
     // Allocate new vectors for indices, nulls, length and offsets.
-    BufferPtr newIndices =
-        AlignedBuffer::allocate<vector_size_t>(leftElementsCount, pool);
+    BufferPtr newIndices = allocateIndices(leftElementsCount, pool);
     BufferPtr newElementNulls =
         AlignedBuffer::allocate<bool>(leftElementsCount, pool, bits::kNotNull);
     BufferPtr newLengths =

--- a/velox/functions/prestosql/ArrayMinMax.cpp
+++ b/velox/functions/prestosql/ArrayMinMax.cpp
@@ -56,7 +56,7 @@ VectorPtr applyTyped(
   auto rawSizes = baseArray->rawSizes();
   auto rawOffsets = baseArray->rawOffsets();
 
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(rows.size(), pool);
+  BufferPtr indices = allocateIndices(rows.size(), pool);
   auto rawIndices = indices->asMutable<vector_size_t>();
 
   // Create nulls for lazy initialization.

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -89,8 +89,8 @@ class MapFunction : public exec::VectorFunction {
           rows.size(), context->pool(), 0);
       auto rawSizes = sizes->asMutable<vector_size_t>();
 
-      BufferPtr valuesIndices = AlignedBuffer::allocate<vector_size_t>(
-          keysArray->elements()->size(), context->pool(), 0);
+      BufferPtr valuesIndices =
+          allocateIndices(keysArray->elements()->size(), context->pool());
       auto rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
 
       rows.applyToSelected([&](vector_size_t row) {

--- a/velox/functions/prestosql/MapConcat.cpp
+++ b/velox/functions/prestosql/MapConcat.cpp
@@ -122,8 +122,7 @@ class MapConcatFunction : public exec::VectorFunction {
       uniqueKeys.updateBounds();
       auto uniqueCount = uniqueKeys.countSelected();
 
-      BufferPtr uniqueIndices =
-          AlignedBuffer::allocate<vector_size_t>(uniqueCount, context->pool());
+      BufferPtr uniqueIndices = allocateIndices(uniqueCount, context->pool());
       auto rawUniqueIndices = uniqueIndices->asMutable<vector_size_t>();
       vector_size_t index = 0;
       uniqueKeys.applyToSelected(

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -87,8 +87,8 @@ class ReduceFunction : public exec::VectorFunction {
     SelectivityVector* callableRows;
 
     SelectivityVector arrayRows(flatArray->size(), false);
-    BufferPtr elementIndices = AlignedBuffer::allocate<vector_size_t>(
-        flatArray->size(), context->pool());
+    BufferPtr elementIndices =
+        allocateIndices(flatArray->size(), context->pool());
 
     const auto& initialState = args[1];
     auto partialResult =

--- a/velox/functions/prestosql/Reverse.cpp
+++ b/velox/functions/prestosql/Reverse.cpp
@@ -103,8 +103,7 @@ class ReverseFunction : public exec::VectorFunction {
 
     // Allocate new vectors for indices.
     auto pool = context->pool();
-    BufferPtr indices =
-        AlignedBuffer::allocate<vector_size_t>(elementCount, pool);
+    BufferPtr indices = allocateIndices(elementCount, pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
 
     auto elementsVector = arrayVector->elements();

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -635,6 +635,12 @@ using VectorPtr = std::shared_ptr<BaseVector>;
 // been loaded yet.
 bool isLazyNotLoaded(const BaseVector& vector);
 
+// Allocates a buffer to fit at least 'size' indices and initializes them to
+// zero.
+inline BufferPtr allocateIndices(vector_size_t size, memory::MemoryPool* pool) {
+  return AlignedBuffer::allocate<vector_size_t>(size, pool, 0);
+}
+
 } // namespace velox
 } // namespace facebook
 


### PR DESCRIPTION
DictionaryVector with only some rows initialized still needs to have "valid"
indices for all rows in [0, length) range. This change introduces a helper
function to allocate an indices buffer to hold at least N values and initialize
these to zero. This change also updates functions and operators to replace
AlignedBuffer::allocate<vector_size_t>(size, pool) calls for allocating indices
with the new allocatedIndices(size, pool) function.

A follow-up will introduce similar functions for allocating offsets and sizes
buffers.