### PR TITLE
Memory tracking bug fix for Non POD type

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -603,7 +603,7 @@ class NonPODAlignedBuffer : public Buffer {
   }
 
   void freeToPool() override {
-    pool_->free(this, sizeof(this) + capacity_);
+    pool_->free(this, AlignedBuffer::kPaddedSize + capacity_);
   }
 
   // Needs to use this class from static methods of AlignedBuffer

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -326,5 +326,12 @@ TEST_F(BufferTest, testNonPOD) {
   EXPECT_EQ(NonPOD::constructed, NonPOD::destructed);
 }
 
+TEST_F(BufferTest, testNonPODMemoryUsage) {
+  using T = std::shared_ptr<void>;
+  const int64_t currentBytes = pool_->getCurrentBytes();
+  { auto buffer = AlignedBuffer::allocate<T>(0, pool_.get()); }
+  EXPECT_EQ(pool_->getCurrentBytes(), currentBytes);
+}
+
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary:
# Problem
When we use a non POD type data for `Buffer`, the memory tracking is broken, and Velox is claiming that it is leaking memory.

It uses padded memory to allocate memory.
```
size_t preferredSize = pool->getPreferredSize(size + kPaddedSize);
void* memory = pool->allocate(preferredSize);
```
and updated the stats when we free the memory in a different way
```
pool_->free(this, sizeof(this) + capacity_);
```

I'm not sure the intention of this code, but it is resulting memory stats being wrong, so Velox is complaining if there is memory leak.

```
I1020 10:57:55.787961 3405402 Memory.h:806] Leaked total memory of 88 bytes.
```

Simple setup to test:
```
using T = std::shared_ptr<void>;
auto pool = &velox::memory::getProcessDefaultMemoryManager().getRoot();
auto buffer = velox::AlignedBuffer::allocate<T>(0, pool);
```

# Solution
I copied the `freeToPool()` from `AlignedBuffer`. It looks correct at least considering the memory allocation to prepare.

Also existing test cases already reporting this leak in the unittest. This diff fixes it as well.

Differential Revision: D31805500

