### PR TITLE
Reset nulls in Velox Reader if all vector entries are not null

### DIFF
--- a/velox/dwio/dwrf/test/utils/BatchMaker.cpp
+++ b/velox/dwio/dwrf/test/utils/BatchMaker.cpp
@@ -178,7 +178,7 @@ VectorPtr createBinary(
     vector->setNull(i, !notNull);
     if (notNull) {
       // Make sure not all strings will be inlined
-      auto len = Random::rand32(0, 10, gen) + 1;
+      auto len = Random::rand32(0, 20, gen) + 1;
       lengths[i] = len;
       childSize += len;
     } else {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -241,8 +241,8 @@ TEST_F(HashJoinTest, memory) {
   auto tracker = memory::MemoryUsageTracker::create();
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});
-  EXPECT_GT(2500, tracker->getNumAllocs());
-  EXPECT_GT(7'500'000, tracker->getCumulativeBytes());
+  EXPECT_GT(2800, tracker->getNumAllocs());
+  EXPECT_GT(11'810'000, tracker->getCumulativeBytes());
 }
 
 TEST_F(HashJoinTest, lazyVectors) {

--- a/velox/vector/tests/VectorMaker.cpp
+++ b/velox/vector/tests/VectorMaker.cpp
@@ -28,12 +28,23 @@ std::shared_ptr<const RowType> VectorMaker::rowType(
 }
 
 RowVectorPtr VectorMaker::rowVector(const std::vector<VectorPtr>& children) {
+  std::vector<std::string> names;
+  for (int32_t i = 0; i < children.size(); ++i) {
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  return rowVector(std::move(names), children);
+}
+
+RowVectorPtr VectorMaker::rowVector(
+    std::vector<std::string> childNames,
+    const std::vector<VectorPtr>& children) {
   std::vector<std::shared_ptr<const Type>> childTypes;
   childTypes.resize(children.size());
   for (int i = 0; i < children.size(); i++) {
     childTypes[i] = children[i]->type();
   }
-  auto rowType = this->rowType(std::move(childTypes));
+  auto rowType = ROW(std::move(childNames), std::move(childTypes));
 
   return std::make_shared<RowVector>(
       pool_, rowType, BufferPtr(nullptr), children[0]->size(), children);

--- a/velox/vector/tests/VectorMaker.h
+++ b/velox/vector/tests/VectorMaker.h
@@ -57,6 +57,10 @@ class VectorMaker {
   RowVectorPtr rowVector(const std::vector<VectorPtr>& children);
 
   RowVectorPtr rowVector(
+      std::vector<std::string> childNames,
+      const std::vector<VectorPtr>& children);
+
+  RowVectorPtr rowVector(
       const std::shared_ptr<const RowType>& rowType,
       vector_size_t size);
 


### PR DESCRIPTION
Summary: If all entries in a vector are not null, we need to make sure vector->mayHaveNulls() indicate that correctly (and return false).

Reviewed By: zzhao0

Differential Revision: D31811933

