### PR TITLE
 Add greatest and least Presto functions

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -7,6 +7,7 @@ Presto Functions
 
     functions/math
     functions/bitwise
+    functions/comparison
     functions/string
     functions/datetime
     functions/array

--- a/velox/docs/functions/comparison.rst
+++ b/velox/docs/functions/comparison.rst
@@ -1,0 +1,19 @@
+=====================================
+Comparison Functions
+=====================================
+
+GREATEST and LEAST
+-----------------
+These functions are not in the SQL standard, but are a common extension.
+Like most other functions in Presto, they return null if any argument is null.
+Note that in some other databases, such as PostgreSQL, they only return null
+if all arguments are null.
+The following types are supported: DOUBLE, BIGINT, VARCHAR, TIMESTAMP
+
+.. function:: least(value1, value2, ..., valueN) -> [same as input]
+
+    Returns the smallest of the provided values.
+
+.. function:: greatest(value1, value2, ..., valueN) -> [same as input]
+
+    Returns the largest of the provided values.

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -111,7 +111,7 @@ class VectorFunction {
 
   // If set, the string encoding of the results will be set by propagating
   // the specified inputs string encodings if presented.
-  // If one of the specififed inputs have its encoding not determined, the
+  // If one of the specified inputs have its encoding not determined, the
   // encoding of the result is not determined.
   virtual std::optional<std::vector<size_t>> propagateStringEncodingFrom()
       const {
@@ -129,7 +129,7 @@ class VectorAdapterFactory {
   virtual const TypePtr returnType() const = 0;
 };
 
-/// Returns a list of signatured supposed by VectorFunction with the specified
+/// Returns a list of signatures supposed by VectorFunction with the specified
 /// name. Returns std::nullopt if there is no function with the specified name.
 std::optional<std::vector<std::shared_ptr<FunctionSignature>>>
 getVectorFunctionSignatures(const std::string& name);

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -47,7 +47,8 @@ add_library(
   Transform.cpp
   VectorArithmetic.cpp
   VectorFunctions.cpp
-  WidthBucketArray.cpp)
+  WidthBucketArray.cpp
+  GreatestLeast.cpp)
 
 target_link_libraries(
   velox_functions_prestosql

--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+#include <type_traits>
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+template <bool>
+class ExtremeValueFunction;
+
+using LeastFunction = ExtremeValueFunction<true>;
+using GreatestFunction = ExtremeValueFunction<false>;
+
+/**
+ * This class implements two functions:
+ *
+ * greatest(value1, value2, ..., valueN) → [same as input]
+ * Returns the largest of the provided values.
+ *
+ * least(value1, value2, ..., valueN) → [same as input]
+ * Returns the smallest of the provided values.
+ **/
+template <bool isLeast>
+class ExtremeValueFunction : public exec::VectorFunction {
+ private:
+  template <typename T>
+  bool shouldOverride(const T& currentValue, const T& candidateValue) const {
+    return isLeast ? candidateValue < currentValue
+                   : candidateValue > currentValue;
+  }
+
+  // For double, presto should throw error if input is Nan
+  template <typename T>
+  void checkNan(const T& value) const {
+    if constexpr (std::is_same<T, TypeTraits<TypeKind::DOUBLE>::NativeType>::
+                      value) {
+      if (std::isnan(value)) {
+        VELOX_USER_FAIL(
+            "Invalid argument to {}: NaN", isLeast ? "least()" : "greatest()");
+      }
+    }
+  }
+
+  template <typename T>
+  void applyTyped(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const {
+    BaseVector::ensureWritable(rows, outputType, context->pool(), result);
+    BufferPtr resultValues =
+        (*result)->as<FlatVector<T>>()->mutableValues(rows.end());
+    T* __restrict rawResult = resultValues->asMutable<T>();
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+
+    std::set<size_t> usedInputs;
+    rows.applyToSelected([&](int row) {
+      size_t valueIndex = 0;
+
+      T currentValue = decodedArgs.at(0)->valueAt<T>(row);
+      checkNan(currentValue);
+
+      for (auto i = 1; i < args.size(); ++i) {
+        auto candidateValue = decodedArgs.at(i)->template valueAt<T>(row);
+        checkNan(candidateValue);
+
+        if (shouldOverride(currentValue, candidateValue)) {
+          currentValue = candidateValue;
+          valueIndex = i;
+        }
+      }
+      usedInputs.insert(valueIndex);
+      rawResult[row] = currentValue;
+    });
+
+    if constexpr (std::is_same<T, TypeTraits<TypeKind::VARCHAR>::NativeType>::
+                      value) {
+      auto* flatResult = (*result)->as<FlatVector<T>>();
+      for (auto index : usedInputs) {
+        flatResult->acquireSharedStringBuffers(args[index].get());
+      }
+    }
+  }
+
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    switch (outputType.get()->kind()) {
+      case TypeKind::BIGINT:
+        applyTyped<TypeTraits<TypeKind::BIGINT>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      case TypeKind::DOUBLE:
+        applyTyped<TypeTraits<TypeKind::DOUBLE>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      case TypeKind::VARCHAR:
+        applyTyped<TypeTraits<TypeKind::VARCHAR>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      case TypeKind::TIMESTAMP:
+        applyTyped<TypeTraits<TypeKind::TIMESTAMP>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      default:
+        VELOX_FAIL(
+            "Unsupported input type for {}: {}",
+            isLeast ? "least()" : "greatest()",
+            outputType->toString());
+    }
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    std::vector<std::string> types = {
+        "bigint", "double", "varchar", "timestamp"};
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+    for (const auto& type : types) {
+      signatures.emplace_back(exec::FunctionSignatureBuilder()
+                                  .returnType(type)
+                                  .argumentType(type)
+                                  .variableArity()
+                                  .build());
+    }
+    return signatures;
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_least,
+    LeastFunction::signatures(),
+    std::make_unique<LeastFunction>());
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_greatest,
+    GreatestFunction ::signatures(),
+    std::make_unique<GreatestFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -87,6 +87,9 @@ void registerVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "ROW");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "concatRow");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "concatrow");
+
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_least, "least");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_greatest, "greatest");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ add_executable(
   SplitTest.cpp
   StringFunctionsTest.cpp
   TransformTest.cpp
-  WidthBucketArrayTest.cpp)
+  WidthBucketArrayTest.cpp
+  GreatestLeastTest.cpp)
 
 add_test(velox_functions_test velox_functions_test)
 

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+
+class GreatestLeastTest : public functions::test::FunctionBaseTest {
+ protected:
+  template <typename T>
+  void runTest(
+      const std::string& query,
+      const std::vector<std::vector<T>>& inputs,
+      const std::vector<T>& output,
+      std::optional<size_t> stringBuffersExpectedCount = std::nullopt) {
+    // Create input vectors
+    auto vectorSize = inputs[0].size();
+    std::vector<VectorPtr> inputColumns(inputs.size());
+    for (auto i = 0; i < inputColumns.size(); ++i) {
+      inputColumns[i] = makeFlatVector<T>(inputs[i]);
+      for (auto j = 0; j < vectorSize; ++j) {
+        inputColumns[i]->asFlatVector<T>()->set(j, inputs[i][j]);
+      }
+    }
+
+    // Call evaluate to run the query on the created input
+    auto result = evaluate<SimpleVector<T>>(query, makeRowVector(inputColumns));
+    for (int32_t i = 0; i < vectorSize; ++i) {
+      ASSERT_EQ(result->valueAt(i), output[i]);
+    }
+
+    if (stringBuffersExpectedCount.has_value()) {
+      ASSERT_EQ(
+          *stringBuffersExpectedCount,
+          result->template asFlatVector<StringView>()
+              ->getStringBuffers()
+              .size());
+    }
+  }
+};
+
+TEST_F(GreatestLeastTest, leastDouble) {
+  runTest<double>("least(c0)", {{0, 1.1, -1.1}}, {0, 1.1, -1.1});
+  runTest<double>("least(c0, 1.0)", {{0, 1.1, -1.1}}, {0, 1, -1.1});
+  runTest<double>(
+      "least(c0, 1.0 , c1)", {{0, 1.1, -1.1}, {100, -100, 0}}, {0, -100, -1.1});
+}
+
+TEST_F(GreatestLeastTest, nanInput) {
+  assertUserInvalidArgument(
+      [&]() { runTest<double>("least(c0)", {{0.0 / 0.0}}, {0}); },
+      "Invalid argument to least(): NaN");
+
+  assertUserInvalidArgument(
+      [&]() {
+        runTest<double>("greatest(c0)", {1, {0.0 / 0.0}}, {1, 0});
+      },
+      "Invalid argument to greatest(): NaN");
+}
+
+TEST_F(GreatestLeastTest, greatestDouble) {
+  runTest<double>("greatest(c0)", {{0, 1.1, -1.1}}, {0, 1.1, -1.1});
+  runTest<double>("greatest(c0, 1.0)", {{0, 1.1, -1.1}}, {1, 1.1, 1});
+  runTest<double>(
+      "greatest(c0, 1.0 , c1)",
+      {{0, 1.1, -1.1}, {100, -100, 0}},
+      {100, 1.1, 1});
+}
+
+TEST_F(GreatestLeastTest, leastBigInt) {
+  runTest<int64_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>("least(c0, 1)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>(
+      "least(c0, 1 , c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
+}
+
+TEST_F(GreatestLeastTest, greatestBigInt) {
+  runTest<int64_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>("greatest(c0, 1)", {{0, 1, -1}}, {1, 1, 1});
+  runTest<int64_t>(
+      "greatest(c0, 1 , c1)", {{0, 1, -1}, {100, -100, 0}}, {100, 1, 1});
+}
+
+TEST_F(GreatestLeastTest, greatestVarchar) {
+  runTest<StringView>(
+      "greatest(c0)",
+      {{StringView("a"), StringView("b"), StringView("c")}},
+      {StringView("a"), StringView("b"), StringView("c")});
+
+  runTest<StringView>(
+      "greatest(c0, 'aaa')",
+      {{StringView(""), StringView("abb")}},
+      {StringView("aaa"), StringView("abb")});
+}
+
+TEST_F(GreatestLeastTest, leasstVarchar) {
+  runTest<StringView>(
+      "least(c0)",
+      {{StringView("a"), StringView("b"), StringView("c")}},
+      {StringView("a"), StringView("b"), StringView("c")});
+
+  runTest<StringView>(
+      "least(c0, 'aaa')",
+      {{StringView(""), StringView("abb")}},
+      {StringView(""), StringView("aaa")});
+}
+
+TEST_F(GreatestLeastTest, greatestTimeStamp) {
+  runTest<Timestamp>(
+      "greatest(c0, c1, c2)",
+      {{Timestamp(0, 0), Timestamp(10, 100), Timestamp(100, 10)},
+       {Timestamp(1, 0), Timestamp(10, 1), Timestamp(100, 10)},
+       {Timestamp(0, 1), Timestamp(312, 100), Timestamp(100, 11)}},
+      {Timestamp(1, 0), Timestamp(312, 100), Timestamp(100, 11)});
+}
+
+TEST_F(GreatestLeastTest, leastTimeStamp) {
+  runTest<Timestamp>(
+      "least(c0, c1, c2)",
+      {{Timestamp(0, 0), Timestamp(10, 100), Timestamp(100, 10)},
+       {Timestamp(1, 0), Timestamp(10, 1), Timestamp(100, 10)},
+       {Timestamp(0, 1), Timestamp(312, 100), Timestamp(1, 10)}},
+      {Timestamp(0, 0), Timestamp(10, 1), Timestamp(1, 10)});
+}
+
+TEST_F(GreatestLeastTest, stringBuffersMoved) {
+  runTest<StringView>(
+      "least(c0, c1)",
+      {{StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
+       {StringView("cccccccccccccc"), StringView("dddddddddddddd")}},
+      {StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
+      1);
+
+  runTest<StringView>(
+      "least(c0, c1, '')",
+      {{StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
+       {StringView("cccccccccccccc"), StringView("dddddddddddddd")}},
+      {StringView(""), StringView("")},
+      0);
+}


### PR DESCRIPTION
add greatest and least functions 
implemented as vector functions because they consume variadic inputs.
https://prestodb.io/docs/current/functions/comparison.html#greatest-and-least