### PR TITLE
Fix copy from constant UNKNOWN vector

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -179,11 +179,11 @@ void FlatVector<T>::copyValuesAndNulls(
       }
     }
   } else if (source->isConstantEncoding()) {
-    auto constant = source->as<ConstantVector<T>>();
-    if (constant->isNullAt(0)) {
+    if (source->isNullAt(0)) {
       BaseVector::addNulls(nullptr, rows);
       return;
     }
+    auto constant = source->as<ConstantVector<T>>();
     T value = constant->valueAt(0);
     while (iter.next(row)) {
       rawValues_[row] = value;
@@ -252,11 +252,11 @@ void FlatVector<T>::copyValuesAndNulls(
       }
     }
   } else if (source->isConstantEncoding()) {
-    auto constant = source->as<ConstantVector<T>>();
-    if (constant->isNullAt(0)) {
+    if (source->isNullAt(0)) {
       bits::fillBits(rawNulls, targetIndex, targetIndex + count, bits::kNull);
       return;
     }
+    auto constant = source->as<ConstantVector<T>>();
     T value = constant->valueAt(0);
     for (auto row = targetIndex; row < targetIndex + count; ++row) {
       rawValues_[row] = value;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -915,6 +915,12 @@ TEST_F(VectorTest, unknown) {
   for (auto i = 0; i < vector->size(); i++) {
     ASSERT_TRUE(vector->isNullAt(i));
   }
+
+  auto copy = BaseVector::create(BIGINT(), 10, pool_.get());
+  copy->copy(vector.get(), 0, 0, 1);
+
+  SelectivityVector rows(1);
+  copy->copy(vector.get(), rows, nullptr);
 }
 
 TEST_F(VectorTest, copyBoolAllNullFlatVector) {


### PR DESCRIPTION
UNKNOWN type is used to represent nulls whose type is unknown. Copying from a
constant vector of UNKNOWN type was crashing.