### PR TITLE
Add gmock to test dependency

### DIFF
--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable(velox_function_registry_test FunctionRegistryTest.cpp)
 add_test(NAME velox_function_registry_test COMMAND velox_function_registry_test)
 
 target_link_libraries(velox_function_registry_test velox_function_registry
-                      ${GTEST_BOTH_LIBRARIES})
+                      ${GMock} ${GTEST_BOTH_LIBRARIES})


### PR DESCRIPTION
To fix breaking builds: https://app.circleci.com/pipelines/github/facebookincubator/velox/1966/workflows/f7f224dc-e365-467d-883f-a0fd802b8f51/jobs/8067 . 