### PR TITLE
Add an SSD layer  for AsyncDataCache

### DIFF
--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -18,11 +18,18 @@ add_library(
   FileIds.cpp
   StringIdMap.cpp
   AsyncDataCache.cpp
+  ScanTracker.cpp
+  SsdCache.cpp
   SsdFile.cpp
-  SsdFileTracker.cpp
-  ScanTracker.cpp)
-target_link_libraries(velox_caching velox_memory velox_exception velox_file
-                      glog::glog ${FOLLY_WITH_DEPENDENCIES})
+  SsdFileTracker.cpp)
+target_link_libraries(
+  velox_caching
+  velox_memory
+  velox_exception
+  velox_file
+  velox_time
+  glog::glog
+  ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/caching/FileGroupStats.h
+++ b/velox/common/caching/FileGroupStats.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/caching/ScanTracker.h"
+
+namespace facebook::velox::cache {
+
+// Dummy implementation of SsdCache admission stats.
+class FileGroupStats {
+ public:
+  // Returns true if groupId, trackingId qualify the data to be cached to SSD.
+  bool shouldSaveToSsd(uint64_t /*groupId*/, TrackingId /*trackingId*/) const {
+    return true;
+  }
+
+  // Updates the SSD selection criteria. 'ssdsize' is the capacity,
+  // 'decayPct' gives by how much old accesses are discounted.
+  void updateSsdFilter(uint64_t /*ssdSize*/, int32_t /*decayPct*/ = 0) {}
+
+  // Recalculates the best groups and makes a human readable
+  // summary. 'cacheBytes' is used to compute what fraction of the tracked
+  // working set can be cached in 'cacheBytes'.
+  std::string toString(uint64_t /*cacheBytes*/) {
+    return "<dummy FileGroupStats>";
+  }
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Executor.h>
+#include <folly/portability/SysUio.h>
+#include <numeric>
+#include "velox/common/caching/FileIds.h"
+
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/time/Timer.h"
+
+namespace facebook::velox::cache {
+
+SsdCache::SsdCache(
+    std::string_view filePrefix,
+    uint64_t maxBytes,
+    int32_t numShards,
+    folly::Executor* executor)
+    : filePrefix_(filePrefix),
+      numShards_(numShards),
+      groupStats_(std::make_unique<FileGroupStats>()),
+      executor_(executor) {
+  files_.reserve(numShards_);
+  // Cache size must be a multiple of this so that each shard has the same max
+  // size.
+  uint64_t sizeQuantum = numShards_ * SsdFile::kRegionSize;
+  int32_t fileMaxRegions = bits::roundUp(maxBytes, sizeQuantum) / sizeQuantum;
+  for (auto i = 0; i < numShards_; ++i) {
+    files_.push_back(std::make_unique<SsdFile>(
+        fmt::format("{}{}", filePrefix_, i), i, fileMaxRegions));
+  }
+}
+
+SsdFile& SsdCache::file(uint64_t fileId) {
+  auto index = fileId % numShards_;
+  return *files_[index];
+}
+
+bool SsdCache::startWrite() {
+  if (0 == writesInProgress_.fetch_add(numShards_)) {
+    // No write was pending, so now all shards are counted as writing.
+    return true;
+  }
+  // There were writes in progress, so compensate for the increment.
+  writesInProgress_.fetch_sub(numShards_);
+  return false;
+}
+
+void SsdCache::write(std::vector<CachePin> pins) {
+  VELOX_CHECK_LE(numShards_, writesInProgress_);
+  uint64_t bytes = 0;
+  auto start = getCurrentTimeMicro();
+  std::vector<std::vector<CachePin>> shards(numShards_);
+  for (auto& pin : pins) {
+    bytes += pin.checkedEntry()->size();
+    auto& target = file(pin.checkedEntry()->key().fileNum.id());
+    shards[target.shardId()].push_back(std::move(pin));
+  }
+  int32_t numNoStore = 0;
+  for (auto i = 0; i < numShards_; ++i) {
+    if (shards[i].empty()) {
+      ++numNoStore;
+      continue;
+    }
+    struct PinHolder {
+      std::vector<CachePin> pins;
+
+      explicit PinHolder(std::vector<CachePin>&& _pins)
+          : pins(std::move(_pins)) {}
+    };
+
+    // We move the mutable vector of pins to the executor. These must
+    // be wrapped in a shared struct to be passed via lambda capture.
+    auto pinHolder = std::make_shared<PinHolder>(std::move(shards[i]));
+    executor_->add([this, i, pinHolder, bytes, start]() {
+      try {
+        files_[i]->write(pinHolder->pins);
+      } catch (const std::exception& e) {
+        // Catch so as not to miss updating 'writesInProgress_'. Could
+        // theoretically happen for std::bad_alloc or such.
+        LOG(INFO) << "Ignoring error in SsdFile::write: " << e.what();
+      }
+      if (--writesInProgress_ == 0) {
+        // Typically occurs every few GB. Allows detecting unusually slow rates
+        // from failing devices.
+        LOG(INFO) << fmt::format(
+            "SSDCA: Wrote {}MB, {} MB/s",
+            bytes >> 20,
+            static_cast<float>(bytes) / (getCurrentTimeMicro() - start));
+      }
+    });
+  }
+  writesInProgress_.fetch_sub(numNoStore);
+}
+
+SsdCacheStats SsdCache::stats() const {
+  SsdCacheStats stats;
+  for (auto& file : files_) {
+    file->updateStats(stats);
+  }
+  return stats;
+}
+
+void SsdCache::clear() {
+  for (auto& file : files_) {
+    file->clear();
+  }
+}
+
+std::string SsdCache::toString() const {
+  auto data = stats();
+  uint64_t capacity = maxBytes();
+  std::stringstream out;
+  out << "Ssd cache IO: Write " << (data.bytesWritten >> 20) << "MB read "
+      << (data.bytesRead >> 20) << "MB Size " << (capacity >> 30)
+      << "GB Occupied " << (data.bytesCached >> 30) << "GB";
+  out << (data.entriesCached >> 10) << "K entries.";
+  out << "\nGroupStats: " << groupStats_->toString(capacity);
+  return out.str();
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/caching/SsdFile.h"
+
+namespace facebook::velox::cache {
+
+class SsdCache {
+ public:
+  //  Constructs a cache with backing files at path
+  //  'filePrefix'.<ordinal>. <ordinal> ranges from 0 to 'numShards' -
+  //  1. '. 'maxBytes' is the total capacity of the cache. This is
+  //  rounded up to the next multiple of kRegionSize *
+  //  'numShards'. This means that all the shards have an equal number
+  //  of regions. For 2 shards and 200MB size, the size rounds up to
+  //  256M with 2 shards each of 128M (2 regions).
+  SsdCache(
+      std::string_view filePrefix,
+      uint64_t maxBytes,
+      int32_t numShards,
+      folly::Executor* executor);
+
+  // Returns the shard corresponding to 'fileId'. 'fileId' is a
+  //  file id from e.g. FileCacheKey.
+  SsdFile& file(uint64_t fileId);
+
+  // Returnss the maximum capacity, rounded up from the capacity passed to the
+  // constructor.
+  uint64_t maxBytes() const {
+    return files_[0]->maxRegions() * files_.size() * SsdFile::kRegionSize;
+  }
+
+  // Returns true if no write is in progress. Atomically sets a write
+  // to be in progress. write() must be called after this. The writing
+  // state is reset asynchronously after writing to SSD finishes.
+  bool startWrite();
+
+  bool writeInProgress() const {
+    return writesInProgress_ != 0;
+  }
+
+  // Stores the entries of 'pins' into the corresponding files. Sets
+  // the file for the successfully stored entries. May evict existing
+  // entries from unpinned regions. startWrite() must have been called first and
+  // it must have returned true.
+  void write(std::vector<CachePin> pins);
+
+  // Returns  stats aggregated from all shards.
+  SsdCacheStats stats() const;
+
+  FileGroupStats& groupStats() const {
+    return *groupStats_;
+  }
+
+  // Drops all entries. Outstanding pins become invalid but reading
+  // them will mostly succeed since the files will not be rewritten
+  // until new content is stored.
+  void clear();
+
+  std::string toString() const;
+
+ private:
+  const std::string filePrefix_;
+  const int32_t numShards_;
+  std::vector<std::unique_ptr<SsdFile>> files_;
+
+  // Count of shards with unfinished writes.
+  std::atomic<int32_t> writesInProgress_{0};
+
+  // Stats for selecting entries to save from AsyncDataCache.
+  std::unique_ptr<FileGroupStats> groupStats_;
+  folly::Executor* executor_;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -34,9 +34,14 @@ SsdPin::SsdPin(SsdFile& file, SsdRun run) : file_(&file), run_(run) {
 }
 
 SsdPin::~SsdPin() {
+  clear();
+}
+
+void SsdPin::clear() {
   if (file_) {
     file_->unpinRegion(run_.offset());
   }
+  file_ = nullptr;
 }
 
 void SsdPin::operator=(SsdPin&& other) {
@@ -46,6 +51,17 @@ void SsdPin::operator=(SsdPin&& other) {
   file_ = other.file_;
   other.file_ = nullptr;
   run_ = other.run_;
+}
+
+std::string SsdPin::toString() const {
+  if (empty()) {
+    return "<empty SsdPin>";
+  }
+  return fmt::format(
+      "SsdPin(shard {} offset {} size {})",
+      file_->shardId(),
+      run_.offset(),
+      run_.size());
 }
 
 SsdFile::SsdFile(
@@ -131,18 +147,40 @@ SsdPin SsdFile::find(RawFileCacheKey key) {
   return SsdPin(*this, run);
 }
 
+bool SsdFile::erase(RawFileCacheKey key) {
+  FileCacheKey ssdKey{StringIdLease(fileIds(), key.fileNum), key.offset};
+  std::lock_guard<std::mutex> l(mutex_);
+  auto it = entries_.find(ssdKey);
+  if (it == entries_.end()) {
+    return false;
+  }
+  entries_.erase(it);
+  return true;
+}
+
 CoalesceIoStats SsdFile::load(
     const std::vector<SsdPin>& ssdPins,
     const std::vector<CachePin>& pins) {
   VELOX_CHECK_EQ(ssdPins.size(), pins.size());
+  if (pins.empty()) {
+    return CoalesceIoStats();
+  }
   int payloadTotal = 0;
   for (auto i = 0; i < pins.size(); ++i) {
     auto runSize = ssdPins[i].run().size();
-    VELOX_CHECK_EQ(runSize, pins[i].entry()->size());
-    payloadTotal += runSize;
+    auto entry = pins[i].checkedEntry();
+    if (runSize > entry->size()) {
+      LOG(INFO) << "IOERR: Requested prefix of SSD cache entry: " << runSize
+                << " entry: " << entry->size();
+    }
+    VELOX_CHECK_GE(
+        runSize,
+        entry->size(),
+        "IOERR SSd cache entry shorter than requested range");
+    payloadTotal += entry->size();
     regionRead(regionIndex(ssdPins[i].run().offset()), runSize);
     ++stats_.entriesRead;
-    stats_.bytesRead += runSize;
+    stats_.bytesRead += entry->size();
   }
   // Do coalesced IO for the pins. For short payloads, the break-even
   // between discrete pread calls and a single preadv that discards
@@ -369,6 +407,9 @@ void SsdFile::updateStats(SsdCacheStats& stats) const {
   stats.entriesCached += entries_.size();
   for (auto& regionSize : regionSize_) {
     stats.bytesCached += regionSize;
+  }
+  for (auto pins : regionPins_) {
+    stats.numPins += pins;
   }
 }
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -88,6 +88,9 @@ class SsdPin {
 
   ~SsdPin();
 
+  // Resets 'this' to default-constructed state.
+  void clear();
+
   void operator=(SsdPin&&);
 
   bool empty() const {
@@ -100,6 +103,8 @@ class SsdPin {
   SsdRun run() const {
     return run_;
   }
+
+  std::string toString() const;
 
  private:
   SsdFile* file_;
@@ -114,6 +119,7 @@ struct SsdCacheStats {
   uint64_t bytesRead{0};
   uint64_t entriesCached{0};
   uint64_t bytesCached{0};
+  int32_t numPins{0};
 };
 
 // A shard of SsdCache. Corresponds to one file on SSD.  The data
@@ -139,6 +145,9 @@ class SsdFile {
 
   // Finds an entry for 'key'. If no entry is found, the returned pin is empty.
   SsdPin find(RawFileCacheKey key);
+
+  // Erases 'key'
+  bool erase(RawFileCacheKey key);
 
   // Copies the data in 'ssdPins' into 'pins'. Coalesces IO for nearby
   // entries if they are in ascending order and near enough.

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/common/caching/SsdFile.h"
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <glog/logging.h>

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/dwrf/common/InputStream.h"
 

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/dwrf/common/BufferedInput.h"
 #include "velox/dwio/dwrf/common/CacheInputStream.h"

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -16,8 +16,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
-
-#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"


### PR DESCRIPTION
If AsyncDataCache is given an optional SsdCache, moves qualifying
entries into the SsdCache as a by-product of scanning entries for
eviction.

SsdCache has the same key and quantization as the RAM cache. Writing
to SSD is done on a best effort basis so as not to block reading from
storage while waiting to save on SSD.