### PR TITLE
Optimize simple functions taking array as input

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -171,6 +171,7 @@ class ArrayValWriter {
   const_iterator end() const {
     return values_.end();
   }
+
   const_reference at(size_t index) const {
     return values_.at(index);
   }
@@ -191,6 +192,18 @@ class ArrayValReader : public ArrayValWriter<VAL> {
     for (auto& val : vals) {
       append(std::move(val));
     }
+  }
+
+  bool mayHaveNulls() const {
+    VELOX_NYI();
+  }
+
+  bool isSet(size_t index) const {
+    VELOX_NYI();
+  }
+
+  VAL operator[](size_t index) const {
+    VELOX_NYI();
   }
 };
 
@@ -223,6 +236,11 @@ struct RowWriter {
   template <size_t N>
   const auto& at() const {
     return std::get<N>(values_);
+  }
+
+  template <size_t N>
+  const auto& atNew() const {
+    return std::get<N>(values_).value();
   }
 
   void clear() {
@@ -297,6 +315,18 @@ struct IMapVal {
   }
   size_t size() const {
     return data_.size();
+  }
+
+  const key_type& keyAt(size_t index) const {
+    VELOX_NYI();
+  }
+
+  bool isSet(size_t index) const {
+    VELOX_NYI();
+  }
+
+  const val_type& valueAt(size_t index) const {
+    VELOX_NYI();
   }
 
  private:

--- a/velox/core/Metaprogramming.h
+++ b/velox/core/Metaprogramming.h
@@ -167,7 +167,7 @@ struct has_method {
 #define DECLARE_METHOD_RESOLVER(Name, MethodName)              \
   struct Name {                                                \
     template <class __T, typename... __TArgs>                  \
-    constexpr auto resolve(__TArgs... args) const              \
+    constexpr auto resolve(__TArgs&&... args) const            \
         -> decltype(std::declval<__T>().MethodName(args...)) { \
       return {};                                               \
     }                                                          \

--- a/velox/expression/VectorFunctionAdapter.h
+++ b/velox/expression/VectorFunctionAdapter.h
@@ -101,7 +101,9 @@ class VectorAdapter : public VectorFunction {
       const std::vector<VectorPtr>& constantInputs,
       std::shared_ptr<const Type> returnType)
       : fn_{std::make_unique<FUNC>(move(returnType))} {
-    unpack<0>(config, constantInputs);
+    if constexpr (FUNC::udf_has_initialize) {
+      unpack<0>(config, constantInputs);
+    }
   }
 
   void apply(

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -26,12 +26,19 @@ namespace {
 
 template <typename T>
 VELOX_UDF_BEGIN(contains)
-// UDF to tell whether a element is part of an array
+// UDF to tell whether an element is part of an array
 FOLLY_ALWAYS_INLINE bool call(
     bool& out,
     const arg_type<Array<T>>& x,
     const arg_type<T>& element) {
-  out = std::find(x.begin(), x.end(), element) != x.end();
+  const auto size = x.size();
+  out = false;
+  for (auto i = 0; i < size; ++i) {
+    if (x[i] == element) {
+      out = true;
+      break;
+    }
+  }
   return true;
 }
 VELOX_UDF_END();

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -63,10 +63,24 @@ VectorPtr fastMax(const VectorPtr& in) {
 template <typename T>
 VELOX_UDF_BEGIN(array_min_simple)
 FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
-  if (x.begin() == x.end()) {
-    return false;
+  const auto size = x.size();
+  if (size == 0) {
+    return false; // NULL
   }
-  out = std::min_element(x.begin(), x.end())->value();
+  if (x.mayHaveNulls()) {
+    for (auto i = 0; i < size; ++i) {
+      if (!x.isSet(i)) {
+        return false; // NULL
+      }
+    }
+  }
+  out = x[0];
+  for (auto i = 1; i < size; ++i) {
+    auto v = x[i];
+    if (v < out) {
+      out = v;
+    }
+  }
   return true;
 }
 VELOX_UDF_END();
@@ -74,10 +88,24 @@ VELOX_UDF_END();
 template <typename T>
 VELOX_UDF_BEGIN(array_max_simple)
 FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
-  if (x.begin() == x.end()) {
-    return false;
+  const auto size = x.size();
+  if (size == 0) {
+    return false; // NULL
   }
-  out = std::max_element(x.begin(), x.end())->value();
+  if (x.mayHaveNulls()) {
+    for (auto i = 0; i < size; ++i) {
+      if (!x.isSet(i)) {
+        return false; // NULL
+      }
+    }
+  }
+  out = x[0];
+  for (auto i = 1; i < size; ++i) {
+    auto v = x[i];
+    if (v > out) {
+      out = v;
+    }
+  }
   return true;
 }
 VELOX_UDF_END();


### PR DESCRIPTION
ArrayMinMaxBenchmark compares vector and simple implementations of the array_min and array_max functions. These functions return a minimum and a maximum value in the input array. Vector function is 2x faster than simple one. The bottleneck is in creating ArrayValReader for each row. ArrayValReader contains an std::vector<std::optional<T>> and it takes a long time to create that from a range of int64_t values stored in FlatVector<int64_t>::rawValues buffer.

Replacing ArrayValReader with ArrayProxy which is just a view into the Array's elements vector makes simple function even faster than vector function.

```
============================================================================
prestosql/benchmarks/ArrayMinMaxBenchmark.cpprelative  time/iter  iters/s
============================================================================
fastMinInteger                                             467.76us    2.14K
vectorMinInteger                                  49.25%   949.79us    1.05K
simpleMinInteger                                  57.86%   808.39us    1.24K
fastMaxInteger                                             431.98us    2.31K
vectorMaxInteger                                  46.22%   934.66us    1.07K
simpleMaxInteger                                  52.69%   819.88us    1.22K
============================================================================
```

ArrayValReader and ArrayProxy have different implementations, but also expose different interface to the function's author. ArrayValReader provides an iterator over std::optional<T> while ArrayProxy exposes an [] operator + bool isSet(index) methods.

Exposing std::optional<T> is expensive as it requires wrapping each value. Can we get away with [] + isSet instead? Do we like isSet name (currently used) or rather rename it to isNull?