### PR TITLE
Add support for non-string hive partition keys (#546)

### DIFF
--- a/velox/aggregates/benchmarks/PushdownBenchmark.cpp
+++ b/velox/aggregates/benchmarks/PushdownBenchmark.cpp
@@ -65,8 +65,9 @@ class PushdownBenchmark : public HiveConnectorTestBase {
 
     std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
         assignments;
-    for (auto& name : rowType_->names()) {
-      assignments[name] = regularColumn(name);
+    for (uint32_t i = 0; i < rowType_->size(); ++i) {
+      const auto& name = rowType_->nameOf(i);
+      assignments[name] = regularColumn(name, rowType_->childAt(i));
     }
 
     return PlanBuilder()

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,8 +16,12 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include <velox/dwio/dwrf/reader/SelectiveColumnReader.h>
 #include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/expression/ControlExpr.h"
+#include "velox/type/Conversions.h"
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
 
 using namespace facebook::velox::dwrf;
 using WriterConfig = facebook::velox::dwrf::Config;
@@ -129,26 +133,28 @@ HiveDataSource::HiveDataSource(
       mappedMemory_(mappedMemory),
       scanId_(scanId),
       executor_(executor) {
+  for (const auto& entry : columnHandles) {
+    auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(entry.second);
+    VELOX_CHECK(
+        handle != nullptr,
+        "ColumnHandle must be an instance of HiveColumnHandle for {}",
+        entry.first);
+    columnHandles_.emplace(entry.first, handle);
+  }
   regularColumns_.reserve(outputType->size());
 
   std::vector<std::string> columnNames;
   columnNames.reserve(outputType->size());
   for (auto& name : outputType->names()) {
-    auto it = columnHandles.find(name);
+    auto it = columnHandles_.find(name);
     VELOX_CHECK(
-        it != columnHandles.end(),
+        it != columnHandles_.end(),
         "ColumnHandle is missing for output column {}",
         name);
 
-    auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(it->second);
-    VELOX_CHECK(
-        handle != nullptr,
-        "ColumnHandle must be an instance of HiveColumnHandle for {}",
-        name);
-
-    columnNames.emplace_back(handle->name());
-    if (handle->columnType() == HiveColumnHandle::ColumnType::kRegular) {
-      regularColumns_.emplace_back(handle->name());
+    columnNames.emplace_back(it->second->name());
+    if (it->second->columnType() == HiveColumnHandle::ColumnType::kRegular) {
+      regularColumns_.emplace_back(it->second->name());
     }
   }
 
@@ -266,6 +272,22 @@ std::unique_ptr<InputStreamHolder> makeStreamHolder(
   return std::make_unique<InputStreamHolder>(factory->generate(path), stats);
 }
 
+template <TypeKind ToKind>
+velox::variant convertFromString(const std::optional<std::string>& value) {
+  if (value.has_value()) {
+    if constexpr (ToKind == TypeKind::VARCHAR) {
+      return velox::variant(value.value());
+    }
+    bool nullOutput = false;
+    auto result =
+        velox::util::Converter<ToKind>::cast(value.value(), nullOutput);
+    VELOX_CHECK(
+        not nullOutput, "Failed to cast {} to {}", value.value(), ToKind)
+    return velox::variant(result);
+  }
+  return velox::variant(ToKind);
+}
+
 } // namespace
 
 void HiveDataSource::addDynamicFilter(
@@ -362,10 +384,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
     auto keyIt = split_->partitionKeys.find(fieldName);
     if (keyIt != split_->partitionKeys.end()) {
-      setConstantValue(
-          scanChildSpec,
-          keyIt->second.has_value() ? velox::variant(*(keyIt->second))
-                                    : velox::variant(TypeKind::VARCHAR));
+      setPartitionValue(scanChildSpec, fieldName, keyIt->second);
     } else if (fieldName == kPath) {
       setConstantValue(scanChildSpec, velox::variant(split_->filePath));
     } else if (fieldName == kBucket) {
@@ -386,10 +405,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   for (const auto& entry : split_->partitionKeys) {
     auto childSpec = scanSpec_->childByName(entry.first);
     if (childSpec) {
-      setConstantValue(
-          childSpec,
-          entry.second.has_value() ? velox::variant(*(entry.second))
-                                   : velox::variant(TypeKind::VARCHAR));
+      setPartitionValue(childSpec, entry.first, entry.second);
     }
   }
 
@@ -510,6 +526,20 @@ void HiveDataSource::setNullConstantValue(
     common::ScanSpec* spec,
     const TypePtr& type) const {
   spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
+}
+
+void HiveDataSource::setPartitionValue(
+    common::ScanSpec* spec,
+    const std::string& partitionKey,
+    const std::optional<std::string>& value) const {
+  auto it = columnHandles_.find(partitionKey);
+  VELOX_CHECK(
+      it != columnHandles_.end(),
+      "ColumnHandle is missing for partition key {}",
+      partitionKey);
+  auto constValue = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      convertFromString, it->second->dataType()->kind(), value);
+  setConstantValue(spec, constValue);
 }
 
 std::unordered_map<std::string, int64_t> HiveDataSource::runtimeStats() {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -33,8 +33,11 @@ class HiveColumnHandle : public ColumnHandle {
  public:
   enum class ColumnType { kPartitionKey, kRegular, kSynthesized };
 
-  HiveColumnHandle(const std::string& name, ColumnType columnType)
-      : name_(name), columnType_(columnType) {}
+  HiveColumnHandle(
+      const std::string& name,
+      ColumnType columnType,
+      TypePtr dataType)
+      : name_(name), columnType_(columnType), dataType_(std::move(dataType)) {}
 
   const std::string& name() const {
     return name_;
@@ -44,9 +47,14 @@ class HiveColumnHandle : public ColumnHandle {
     return columnType_;
   }
 
+  const TypePtr& dataType() const {
+    return dataType_;
+  }
+
  private:
   const std::string name_;
   const ColumnType columnType_;
+  const TypePtr dataType_;
 };
 
 using SubfieldFilters =
@@ -165,7 +173,14 @@ class HiveDataSource : public DataSource {
       common::ScanSpec* FOLLY_NONNULL spec,
       const TypePtr& type) const;
 
+  void setPartitionValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const std::string& partitionKey,
+      const std::optional<std::string>& value) const;
+
   const std::shared_ptr<const RowType> outputType_;
+  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
+      columnHandles_;
   FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
   velox::memory::MemoryPool* FOLLY_NONNULL pool_;
   std::vector<std::string> regularColumns_;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -546,8 +546,8 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     auto scanOutputType = ROW({"a", "b"}, {INTEGER(), BIGINT()});
     ColumnHandleMap assignments;
-    assignments["a"] = regularColumn("c0");
-    assignments["b"] = regularColumn("c1");
+    assignments["a"] = regularColumn("c0", INTEGER());
+    assignments["b"] = regularColumn("c1", BIGINT());
 
     auto op =
         PlanBuilder(10)

--- a/velox/exec/tests/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/HiveConnectorTestBase.cpp
@@ -174,21 +174,27 @@ exec::Split HiveConnectorTestBase::makeHiveSplit(
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>
-HiveConnectorTestBase::regularColumn(const std::string& name) {
+HiveConnectorTestBase::regularColumn(
+    const std::string& name,
+    const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kRegular);
+      name, connector::hive::HiveColumnHandle::ColumnType::kRegular, type);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>
-HiveConnectorTestBase::synthesizedColumn(const std::string& name) {
+HiveConnectorTestBase::synthesizedColumn(
+    const std::string& name,
+    const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kSynthesized);
+      name, connector::hive::HiveColumnHandle::ColumnType::kSynthesized, type);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>
-HiveConnectorTestBase::partitionKey(const std::string& name) {
+HiveConnectorTestBase::partitionKey(
+    const std::string& name,
+    const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kPartitionKey);
+      name, connector::hive::HiveColumnHandle::ColumnType::kPartitionKey, type);
 }
 
 void HiveConnectorTestBase::addConnectorSplit(

--- a/velox/exec/tests/HiveConnectorTestBase.h
+++ b/velox/exec/tests/HiveConnectorTestBase.h
@@ -97,20 +97,24 @@ class HiveConnectorTestBase : public OperatorTestBase {
   }
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
-      const std::string& name);
+      const std::string& name,
+      const TypePtr& type);
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> partitionKey(
-      const std::string& name);
+      const std::string& name,
+      const TypePtr& type);
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> synthesizedColumn(
-      const std::string& name);
+      const std::string& name,
+      const TypePtr& type);
 
   static ColumnHandleMap allRegularColumns(
       const std::shared_ptr<const RowType>& rowType) {
     ColumnHandleMap assignments;
     assignments.reserve(rowType->size());
-    for (auto& name : rowType->names()) {
-      assignments[name] = regularColumn(name);
+    for (uint32_t i = 0; i < rowType->size(); ++i) {
+      const auto& name = rowType->nameOf(i);
+      assignments[name] = regularColumn(name, rowType->childAt(i));
     }
     return assignments;
   }

--- a/velox/exec/tests/PlanBuilder.cpp
+++ b/velox/exec/tests/PlanBuilder.cpp
@@ -47,11 +47,13 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::shared_ptr<const RowType>& outputType) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
-  for (auto& name : outputType->names()) {
+  for (uint32_t i = 0; i < outputType->size(); ++i) {
+    const auto& name = outputType->nameOf(i);
+    const auto& type = outputType->childAt(i);
     assignments.insert(
         {name,
          std::make_shared<HiveColumnHandle>(
-             name, HiveColumnHandle::ColumnType::kRegular)});
+             name, HiveColumnHandle::ColumnType::kRegular, type)});
   }
 
   auto tableHandle =

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/tests/Cursor.h"
 #include "velox/exec/tests/HiveConnectorTestBase.h"
 #include "velox/exec/tests/PlanBuilder.h"
+#include "velox/type/Type.h"
 #include "velox/type/tests/FilterBuilder.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 
@@ -114,9 +115,10 @@ class TableScanTest : public virtual HiveConnectorTestBase,
 
   void testPartitionedTableImpl(
       const std::string& filePath,
+      const TypePtr& partitionType,
       const std::optional<std::string>& partitionValue) {
     std::unordered_map<std::string, std::optional<std::string>> partitionKeys =
-        {{"ds", partitionValue}};
+        {{"pkey", partitionValue}};
     auto split = std::make_shared<HiveConnectorSplit>(
         kHiveConnectorId,
         filePath,
@@ -124,12 +126,13 @@ class TableScanTest : public virtual HiveConnectorTestBase,
         0,
         fs::file_size(filePath),
         partitionKeys);
-    auto outputType = ROW({"ds", "c0", "c1"}, {VARCHAR(), BIGINT(), DOUBLE()});
+    auto outputType =
+        ROW({"pkey", "c0", "c1"}, {partitionType, BIGINT(), DOUBLE()});
     auto tableHandle = makeTableHandle(SubfieldFilters{});
     ColumnHandleMap assignments = {
-        {"ds", partitionKey("ds")},
-        {"c0", regularColumn("c0")},
-        {"c1", regularColumn("c1")}};
+        {"pkey", partitionKey("pkey", partitionType)},
+        {"c0", regularColumn("c0", BIGINT())},
+        {"c1", regularColumn("c1", DOUBLE())}};
 
     auto op = PlanBuilder()
                   .tableScan(outputType, tableHandle, assignments)
@@ -140,7 +143,7 @@ class TableScanTest : public virtual HiveConnectorTestBase,
     assertQuery(
         op, split, fmt::format("SELECT {}, * FROM tmp", partitionValueStr));
 
-    outputType = ROW({"c0", "ds", "c1"}, {BIGINT(), VARCHAR(), DOUBLE()});
+    outputType = ROW({"c0", "pkey", "c1"}, {BIGINT(), partitionType, DOUBLE()});
     op = PlanBuilder()
              .tableScan(outputType, tableHandle, assignments)
              .planNode();
@@ -148,7 +151,7 @@ class TableScanTest : public virtual HiveConnectorTestBase,
         op,
         split,
         fmt::format("SELECT c0, {}, c1 FROM tmp", partitionValueStr));
-    outputType = ROW({"c0", "c1", "ds"}, {BIGINT(), DOUBLE(), VARCHAR()});
+    outputType = ROW({"c0", "c1", "pkey"}, {BIGINT(), DOUBLE(), partitionType});
     op = PlanBuilder()
              .tableScan(outputType, tableHandle, assignments)
              .planNode();
@@ -158,8 +161,8 @@ class TableScanTest : public virtual HiveConnectorTestBase,
         fmt::format("SELECT c0, c1, {} FROM tmp", partitionValueStr));
 
     // select only partition key
-    assignments = {{"ds", partitionKey("ds")}};
-    outputType = ROW({"ds"}, {VARCHAR()});
+    assignments = {{"pkey", partitionKey("pkey", partitionType)}};
+    outputType = ROW({"pkey"}, {partitionType});
     op = PlanBuilder()
              .tableScan(outputType, tableHandle, assignments)
              .planNode();
@@ -167,9 +170,12 @@ class TableScanTest : public virtual HiveConnectorTestBase,
         op, split, fmt::format("SELECT {} FROM tmp", partitionValueStr));
   }
 
-  void testPartitionedTable(const std::string& filePath) {
-    testPartitionedTableImpl(filePath, "2020-11-01");
-    testPartitionedTableImpl(filePath, std::nullopt);
+  void testPartitionedTable(
+      const std::string& filePath,
+      const TypePtr& partitionType,
+      const std::optional<std::string>& partitionValue) {
+    testPartitionedTableImpl(filePath, partitionType, partitionValue);
+    testPartitionedTableImpl(filePath, partitionType, std::nullopt);
   }
 
   std::shared_ptr<const RowType> rowType_{
@@ -192,7 +198,7 @@ TEST_P(TableScanTest, columnAliases) {
   writeToFile(filePath->path, kTableScanTest, vectors);
   createDuckDbTable(vectors);
 
-  ColumnHandleMap assignments = {{"a", regularColumn("c0")}};
+  ColumnHandleMap assignments = {{"a", regularColumn("c0", BIGINT())}};
   auto outputType = ROW({"a"}, {BIGINT()});
   auto op = PlanBuilder()
                 .tableScan(
@@ -290,8 +296,8 @@ TEST_P(TableScanTest, missingColumns) {
   outputType = ROW({"a", "b"}, {BIGINT(), DOUBLE()});
 
   assignments.clear();
-  assignments["a"] = regularColumn("c0");
-  assignments["b"] = regularColumn("c1");
+  assignments["a"] = regularColumn("c0", BIGINT());
+  assignments["b"] = regularColumn("c1", DOUBLE());
 
   op = PlanBuilder().tableScan(outputType, tableHandle, assignments).planNode();
   assertQuery(op, filePaths, "SELECT * FROM tmp");
@@ -552,14 +558,77 @@ TEST_P(TableScanTest, emptyFile) {
   }
 }
 
-TEST_P(TableScanTest, partitionedTable) {
+TEST_P(TableScanTest, partitionedTableVarcharKey) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, kTableScanTest, vectors);
   createDuckDbTable(vectors);
 
-  testPartitionedTable(filePath->path);
+  testPartitionedTable(filePath->path, VARCHAR(), "2020-11-01");
+}
+
+TEST_P(TableScanTest, partitionedTableBigIntKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, BIGINT(), "123456789123456789");
+}
+
+TEST_P(TableScanTest, partitionedTableIntegerKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, INTEGER(), "123456789");
+}
+
+TEST_P(TableScanTest, partitionedTableSmallIntKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, SMALLINT(), "1");
+}
+
+TEST_P(TableScanTest, partitionedTableTinyIntKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, TINYINT(), "1");
+}
+
+TEST_P(TableScanTest, partitionedTableBooleanKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, BOOLEAN(), "0");
+}
+
+TEST_P(TableScanTest, partitionedTableRealKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, REAL(), "3.5");
+}
+
+TEST_P(TableScanTest, partitionedTableDoubleKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, DOUBLE(), "3.5");
 }
 
 std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
@@ -585,7 +654,7 @@ TEST_P(TableScanTest, statsBasedSkippingBool) {
 
   auto subfieldFilters = singleSubfieldFilter("c1", boolEqual(true));
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments = {{"c0", regularColumn("c0")}};
+      assignments = {{"c0", regularColumn("c0", INTEGER())}};
   auto assertQuery = [&](const std::string& query) {
     auto tableHandle = makeTableHandle(std::move(subfieldFilters));
     return TableScanTest::assertQuery(
@@ -618,7 +687,7 @@ TEST_P(TableScanTest, statsBasedSkippingDouble) {
   auto subfieldFilters =
       singleSubfieldFilter("c0", lessThanOrEqualDouble(-1.05));
 
-  ColumnHandleMap assignments = {{"c0", regularColumn("c0")}};
+  ColumnHandleMap assignments = {{"c0", regularColumn("c0", DOUBLE())}};
 
   auto assertQuery = [&](const std::string& query) {
     auto tableHandle = makeTableHandle(std::move(subfieldFilters));
@@ -671,7 +740,7 @@ TEST_P(TableScanTest, statsBasedSkippingFloat) {
   auto subfieldFilters =
       singleSubfieldFilter("c0", lessThanOrEqualFloat(-1.05));
 
-  ColumnHandleMap assignments = {{"c0", regularColumn("c0")}};
+  ColumnHandleMap assignments = {{"c0", regularColumn("c0", REAL())}};
 
   auto assertQuery = [&](const std::string& query) {
     auto tableHandle = makeTableHandle(std::move(subfieldFilters));
@@ -744,7 +813,7 @@ TEST_P(TableScanTest, statsBasedSkipping) {
   // c0 <= -1 -> whole file should be skipped based on stats
   auto subfieldFilters = singleSubfieldFilter("c0", lessThanOrEqual(-1));
 
-  ColumnHandleMap assignments = {{"c1", regularColumn("c1")}};
+  ColumnHandleMap assignments = {{"c1", regularColumn("c1", INTEGER())}};
 
   auto assertQuery = [&](const std::string& query) {
     auto tableHandle = makeTableHandle(std::move(subfieldFilters));
@@ -1300,7 +1369,7 @@ TEST_P(TableScanTest, filterPushdown) {
 
   // Repeat the same but do not project out the filtered columns.
   assignments.clear();
-  assignments["c0"] = regularColumn("c0");
+  assignments["c0"] = regularColumn("c0", TINYINT());
   assertQuery(
       PlanBuilder()
           .tableScan(ROW({"c0"}, {TINYINT()}), tableHandle, assignments)
@@ -1340,7 +1409,7 @@ TEST_P(TableScanTest, path) {
   static const char* kPath = "$path";
 
   auto assignments = allRegularColumns(rowType);
-  assignments[kPath] = synthesizedColumn(kPath);
+  assignments[kPath] = synthesizedColumn(kPath, VARCHAR());
 
   auto tableHandle = makeTableHandle(SubfieldFilters{}, nullptr);
 
@@ -1408,7 +1477,7 @@ TEST_P(TableScanTest, bucket) {
       std::dynamic_pointer_cast<const RowType>(rowVectors.front()->type());
 
   auto assignments = allRegularColumns(rowType);
-  assignments[kBucket] = synthesizedColumn(kBucket);
+  assignments[kBucket] = synthesizedColumn(kBucket, INTEGER());
 
   // Query that spans on all buckets
   auto typeWithBucket =
@@ -1487,7 +1556,7 @@ TEST_P(TableScanTest, remainingFilter) {
       "SELECT * FROM tmp WHERE c1 > c0 AND c0 >= 0");
 
   // Remaining filter uses columns that are not used otherwise.
-  assignments = {{"c2", regularColumn("c2")}};
+  assignments = {{"c2", regularColumn("c2", DOUBLE())}};
   tableHandle =
       makeTableHandle(SubfieldFilters{}, parseExpr("c1 > c0", rowType));
   assertQuery(
@@ -1499,7 +1568,9 @@ TEST_P(TableScanTest, remainingFilter) {
 
   // Remaining filter uses one column that is used elsewhere (is projected out)
   // and another column that is not used anywhere else.
-  assignments = {{"c1", regularColumn("c1")}, {"c2", regularColumn("c2")}};
+  assignments = {
+      {"c1", regularColumn("c1", INTEGER())},
+      {"c2", regularColumn("c2", DOUBLE())}};
   tableHandle =
       makeTableHandle(SubfieldFilters{}, parseExpr("c1 > c0", rowType));
   assertQuery(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/presto_cpp/pull/546

Added column data type info in HiveColumnHandle. Further used
this info in Hive connector to convert partition values to correct
type.

Differential Revision: D31861917

