### PR TITLE
Implementation for startsWith, endsWith and contains

### DIFF
--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -106,6 +106,13 @@ void registerFunctions(const std::string& prefix) {
   // broken out into a separate compilation unit to improve build latency.
   registerArithmeticFunctions(prefix);
   registerCompareFunctions(prefix);
+
+  // String sreach function
+  registerFunction<udf_starts_with, bool, Varchar, Varchar>(
+      {prefix + "startswith"});
+  registerFunction<udf_ends_with, bool, Varchar, Varchar>(
+      {prefix + "endswith"});
+  registerFunction<udf_contains, bool, Varchar, Varchar>({prefix + "contains"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -62,4 +62,63 @@ std::shared_ptr<exec::VectorFunction> makeLength(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs);
 
+/// contains function
+/// contains(string, string) -> bool
+/// Searches the second argument in the first one.
+/// Returns true if it is found
+VELOX_UDF_BEGIN(contains)
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<bool>& result,
+    const arg_type<Varchar>& str,
+    const arg_type<Varchar>& pattern) {
+  result = std::string_view(str).find(std::string_view(pattern)) !=
+      std::string_view::npos;
+  return true;
+}
+VELOX_UDF_END();
+
+/// startsWith function
+/// startsWith(string, string) -> bool
+/// Returns true if the first string starts with the second string
+VELOX_UDF_BEGIN(starts_with)
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<bool>& result,
+    const arg_type<Varchar>& str,
+    const arg_type<Varchar>& pattern) {
+  auto str1 = std::string_view(str);
+  auto str2 = std::string_view(pattern);
+  // TODO: Once C++20 supported we may want to replace this with
+  // string_view::starts_with
+
+  if (str2.length() > str1.length()) {
+    result = false;
+  } else {
+    result = str1.substr(0, str2.length()) == str2;
+    ;
+  }
+  return true;
+}
+VELOX_UDF_END();
+
+/// endsWith function
+/// endsWith(string, string) -> bool
+/// Returns true if the first string ends with the second string
+VELOX_UDF_BEGIN(ends_with)
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<bool>& result,
+    const arg_type<Varchar>& str,
+    const arg_type<Varchar>& pattern) {
+  auto str1 = std::string_view(str);
+  auto str2 = std::string_view(pattern);
+  // TODO Once C++20 supported we may want to replace this with
+  // string_view::ends_with
+  if (str2.length() > str1.length()) {
+    result = false;
+  } else {
+    result = str1.substr(str1.length() - str2.length(), str2.length()) == str2;
+  }
+  return true;
+}
+VELOX_UDF_END();
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -54,6 +54,29 @@ class StringTest : public SparkFunctionBaseTest {
     return evaluateOnce<std::string, std::string>(
         "md5(c0)", {arg}, {VARBINARY()});
   }
+
+  bool compareFunction(
+      const std::string& function,
+      const std::optional<std::string>& str,
+      const std::optional<std::string>& pattern) {
+    return evaluateOnce<bool>(function + "(c0, c1)", str, pattern).value();
+  }
+
+  std::optional<bool> startsWith(
+      const std::optional<std::string>& str,
+      const std::optional<std::string>& pattern) {
+    return evaluateOnce<bool>("startsWith(c0, c1)", str, pattern);
+  }
+  std::optional<bool> endsWith(
+      const std::optional<std::string>& str,
+      const std::optional<std::string>& pattern) {
+    return evaluateOnce<bool>("endsWith(c0, c1)", str, pattern);
+  }
+  std::optional<bool> contains(
+      const std::optional<std::string>& str,
+      const std::optional<std::string>& pattern) {
+    return evaluateOnce<bool>("contains(c0, c1)", str, pattern);
+  }
 };
 
 TEST_F(StringTest, Ascii) {
@@ -116,6 +139,42 @@ TEST_F(StringTest, MD5) {
   EXPECT_EQ(md5(std::nullopt), std::nullopt);
   EXPECT_EQ(md5(""), "d41d8cd98f00b204e9800998ecf8427e");
   EXPECT_EQ(md5("Infinity"), "eb2ac5b04180d8d6011a016aeb8f75b3");
+}
+
+TEST_F(StringTest, startsWith) {
+  EXPECT_FALSE(startsWith("hello", "ello").value());
+  EXPECT_TRUE(startsWith("hello", "hell").value());
+  EXPECT_FALSE(startsWith("hello", "hello there!").value());
+  EXPECT_TRUE(startsWith("hello there!", "hello").value());
+  EXPECT_TRUE(startsWith("-- hello there!", "-").value());
+  EXPECT_TRUE(startsWith("-- hello there!", "").value());
+  EXPECT_FALSE(startsWith("-- hello there!", std::nullopt).has_value());
+  EXPECT_FALSE(startsWith(std::nullopt, "abc").has_value());
+}
+
+TEST_F(StringTest, contains) {
+  EXPECT_TRUE(contains("hello", "ello").value());
+  EXPECT_TRUE(contains("hello", "hell").value());
+  EXPECT_FALSE(contains("hello", "hello there!").value());
+  EXPECT_TRUE(contains("hello there!", "hello").value());
+  EXPECT_TRUE(contains("hello there!", "").value());
+  EXPECT_FALSE(contains("-- hello there!", std::nullopt).has_value());
+  EXPECT_FALSE(contains(std::nullopt, "abc").has_value());
+}
+
+TEST_F(StringTest, endsWith) {
+  EXPECT_TRUE(endsWith("hello", "ello").value());
+  EXPECT_FALSE(endsWith("hello", "hell").value());
+  EXPECT_FALSE(endsWith("hello", "hello there!").value());
+  EXPECT_FALSE(endsWith("hello there!", "hello").value());
+  EXPECT_TRUE(endsWith("hello there!", "!").value());
+  EXPECT_TRUE(endsWith("hello there!", "there!").value());
+  EXPECT_TRUE(endsWith("hello there!", "hello there!").value());
+  EXPECT_TRUE(endsWith("hello there!", "").value());
+  EXPECT_FALSE(endsWith("hello there!", "hello there").value());
+  EXPECT_FALSE(endsWith("-- hello there!", "hello there").value());
+  EXPECT_FALSE(endsWith("-- hello there!", std::nullopt).has_value());
+  EXPECT_FALSE(endsWith(std::nullopt, "abc").has_value());
 }
 
 } // namespace


### PR DESCRIPTION
Summary: This diff implements startsWith, endsWith and contains that are used in implementation of LIKE for Spark SQL

Reviewed By: funrollloops

Differential Revision: D31868537

