### PR TITLE
setup-macos.sh: fix bug in `install_folly`, make `NPROC` detection portable

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -29,7 +29,7 @@ set -e # Exit on error.
 set -x # Print commands that are executed.
 
 FB_OS_VERSION=v2021.05.10.00
-NPROC=$(sysctl -n hw.physicalcpu)
+NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS="-mavx2 -mfma -mavx -mf16c -masm=intel -mlzcnt"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 MACOS_DEPS="ninja cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
@@ -125,7 +125,8 @@ function install_double_conversion {
 
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF
 }
 
 function install_ranges_v3 {


### PR DESCRIPTION
I usually use this script for installing source dependencies on Linux because it has support for controlling install paths, prefixes, etc. The "ubuntu" script does not. Also this script just generally gets a lot more love -- the build options have been optimized etc. Some tweaks are required to make this script work, however:

* `getconf _NPROCESSORS_ONLN` is the more portable alternative to `nproc` and `sysctl`.
* `install_folly` - we override the `CMAKE_PREFIX_PATH` here, which causes lots of issues if you have conflicting library versions installed in your target prefix and at the system level. Use the `OPENSSL_ROOT_DIR` variable instead.

On Linux, the call to `brew --prefix openssl@1.1` fails (of course) but this failure is silently ignored. As long as `install_build_prerequisites` is skipped the script will succeed.