### PR TITLE
Optimize array_min and array_max Presto functions

### DIFF
--- a/velox/functions/prestosql/ArrayMinMax.cpp
+++ b/velox/functions/prestosql/ArrayMinMax.cpp
@@ -134,10 +134,9 @@ class ArrayMinMaxFunction : public exec::VectorFunction {
     auto arrayVector = args[0]->asUnchecked<ArrayVector>();
 
     auto elementsVector = arrayVector->elements();
-    auto elementsRows =
-        toElementRows(elementsVector->size(), rows, arrayVector);
+    exec::LocalSelectivityVector elementsRows(context, elementsVector->size());
     exec::LocalDecodedVector elementsHolder(
-        context, *elementsVector, elementsRows);
+        context, *elementsVector, *elementsRows.get());
     auto localResult = VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
         applyTyped,
         F,


### PR DESCRIPTION
Profile for array_min shows lots of time being spent in toElementRows function.
Replacing this function with SelectivityVector that covers all row in the
elements vector makes array_min/max only 20% slower than hand-written loop
(compare with 2x slow before the change).

This change means that in some cases the function will be decoding more rows
than strictly necessary. If this turns out important we can optimize further.

```
============================================================================
prestosql/benchmarks/ArrayMinMaxBenchmark.cpprelative  time/iter  iters/s
============================================================================
fastMinInteger                                             445.55us    2.24K
vectorMinInteger                                  78.99%   564.09us    1.77K
simpleMinInteger                                  28.68%     1.55ms   643.68
fastMaxInteger                                             397.62us    2.51K
vectorMaxInteger                                  67.33%   590.55us    1.69K
simpleMaxInteger                                  27.25%     1.46ms   685.28
============================================================================
```