### PR TITLE
Reject list for map key filtering

### DIFF
--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -390,6 +390,55 @@ TEST(TestReader, testReadFlatMapWithKeyFilters) {
   } while (true);
 }
 
+TEST(TestReader, testReadFlatMapWithKeyRejectList) {
+  const std::string fmSmall(getExampleFilePath("fm_small.orc"));
+
+  // batch size is set as 1000 in reading
+  // file has schema: a int, b struct<a:int, b:float, c:string>, c float
+  ReaderOptions readerOpts;
+  RowReaderOptions rowReaderOpts;
+  std::shared_ptr<const RowType> requestedType =
+      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
+          id:int,\
+      map1:map<int, array<float>>,\
+      map2:map<string, map<smallint,bigint>>,\
+      map3:map<int,int>,\
+      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
+      memo:string>"));
+  auto cs = std::make_shared<ColumnSelector>(
+      requestedType, std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
+  rowReaderOpts.select(cs);
+  auto reader = DwrfReader::create(
+      std::make_unique<FileInputStream>(fmSmall), readerOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  VectorPtr batch;
+
+  const std::unordered_set<int32_t> map1RejectList{2, 3};
+
+  do {
+    bool result = rowReader->next(1000, batch);
+    if (!result) {
+      break;
+    }
+
+    // verify current batch
+    auto root = batch->as<RowVector>();
+
+    // verify map1
+    {
+      auto map1 = root->childAt(1)->as<MapVector>();
+      auto map1KeyInt = map1->mapKeys()->as<SimpleVector<int32_t>>();
+
+      // every key value should be 1
+      EXPECT_GT(map1KeyInt->size(), 0);
+      for (int32_t i = 0; i < map1KeyInt->size(); ++i) {
+        // These keys should not exist
+        EXPECT_TRUE(map1RejectList.count(map1KeyInt->valueAt(i)) == 0);
+      }
+    }
+  } while (true);
+}
+
 namespace {
 std::unordered_set<uint32_t> getNodeIdsFromColumnNames(
     const std::vector<std::string>& columns,

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -80,6 +80,8 @@ struct StringView {
       : StringView(value.data(), value.size()) {}
   explicit StringView(const std::string& value)
       : StringView(value.data(), value.size()) {}
+  explicit StringView(const std::string_view& value)
+      : StringView(value.data(), value.size()) {}
 
   bool isInline() const {
     return isInline(size_);


### PR DESCRIPTION
Summary:
# Problem
Currently we can read a flatmap with a key filter. This filter only works as an allow list. You have to specify what you want to read from a map column.

I need a feature to expand this to support a reject list. This is reasonable but I need some input about how to pass the information.

# Solution
Currently we use `ColumnSelector` to pass an expression, as a json array.

```
columnName#[1,2,3,4]
```
In this diff, I'm proposing this:
```
columnName#["!1","!2"]
```
To read `columnName` all keys but `1`, and `2`.
I'm not sure if this is a right choice, and not sure if we can do this for string key type. I only used `!` for integer keys when they came as string type for now.

Differential Revision: D31912159

