### PR TITLE
Implementing isnotnull function for SparkSQL

### DIFF
--- a/velox/functions/prestosql/IsNull.cpp
+++ b/velox/functions/prestosql/IsNull.cpp
@@ -19,6 +19,7 @@
 namespace facebook::velox::functions {
 namespace {
 
+template <bool IsNotNULL>
 class IsNullFunction : public exec::VectorFunction {
  public:
   bool isDefaultNullBehavior() const override {
@@ -31,12 +32,12 @@ class IsNullFunction : public exec::VectorFunction {
       const TypePtr& /* outputType */,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    auto arg = args[0];
+    BaseVector* arg = args[0].get();
     if (rows.isAllSelected()) {
       if (!arg->mayHaveNulls()) {
         // no nulls
         *result =
-            BaseVector::createConstant(false, rows.end(), context->pool());
+            BaseVector::createConstant(IsNotNULL, rows.end(), context->pool());
         return;
       }
 
@@ -49,19 +50,28 @@ class IsNullFunction : public exec::VectorFunction {
           flatResult->mutableRawValues<int64_t>(),
           rawNulls,
           bits::nbytes(rows.end()));
-      bits::negate(flatResult->mutableRawValues<char>(), rows.end());
+      if constexpr (!IsNotNULL) {
+        bits::negate(flatResult->mutableRawValues<char>(), rows.end());
+      }
       return;
     }
 
     BaseVector::ensureWritable(rows, BOOLEAN(), arg->pool(), result);
     FlatVector<bool>* flatResult = (*result)->asFlatVector<bool>();
     if (!arg->mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) { flatResult->set(i, false); });
+      rows.applyToSelected(
+          [&](vector_size_t i) { flatResult->set(i, IsNotNULL); });
     } else {
       auto rawNulls = arg->flatRawNulls(rows);
-      rows.applyToSelected([&](vector_size_t i) {
-        flatResult->set(i, bits::isBitNull(rawNulls, i));
-      });
+      if constexpr (!IsNotNULL) {
+        rows.applyToSelected([&](vector_size_t i) {
+          flatResult->set(i, bits::isBitNull(rawNulls, i));
+        });
+      } else {
+        rows.applyToSelected([&](vector_size_t i) {
+          flatResult->set(i, !bits::isBitNull(rawNulls, i));
+        });
+      }
     }
   }
 
@@ -73,11 +83,18 @@ class IsNullFunction : public exec::VectorFunction {
                 .argumentType("T")
                 .build()};
   }
+
+  bool isNotNul_;
 };
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_is_null,
-    IsNullFunction::signatures(),
-    std::make_unique<IsNullFunction>());
+    IsNullFunction<false>::signatures(),
+    std::make_unique<IsNullFunction<false>>());
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_is_not_null,
+    IsNullFunction<true>::signatures(),
+    std::make_unique<IsNullFunction<true>>());
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -52,6 +52,7 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   // Logical.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_coalesce, prefix + "coalesce");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_is_null, prefix + "isnull");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_is_not_null, prefix + "isnotnull");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
 }
 

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   ArithmeticTest.cpp
   HashTest.cpp
   InTest.cpp
+  IsNotNullTest.cpp
   LeastGreatestTest.cpp
   RegexFunctionsTest.cpp
   SplitFunctionsTest.cpp

--- a/velox/functions/sparksql/tests/IsNotNullTest.cpp
+++ b/velox/functions/sparksql/tests/IsNotNullTest.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class IsNotNullTest : public SparkFunctionBaseTest {
+ public:
+  template <typename T>
+  std::optional<bool> isnotnull(std::optional<T> arg) {
+    return evaluateOnce<bool>("isnotnull(c0)", arg);
+  }
+};
+
+TEST_F(IsNotNullTest, singleValues) {
+  EXPECT_FALSE(isnotnull<int32_t>(std::nullopt).value());
+  EXPECT_FALSE(isnotnull<double>(std::nullopt).value());
+  EXPECT_TRUE(isnotnull<int64_t>(1).value());
+  EXPECT_TRUE(isnotnull<float>(1.5).value());
+  EXPECT_TRUE(isnotnull<std::string>("1").value());
+  EXPECT_TRUE(isnotnull<double>(std::numeric_limits<double>::max()).value());
+}
+
+// The rest of the file is copied and modified from IsNullTest.cpp
+
+TEST_F(IsNotNullTest, basicVectors) {
+  vector_size_t size = 20;
+
+  // all nulls
+  auto allNulls = makeFlatVector<int32_t>(
+      size, [](vector_size_t /*row*/) { return 0; }, vectorMaker_.nullEvery(1));
+  auto result =
+      evaluate<SimpleVector<bool>>("isnotnull(c0)", makeRowVector({allNulls}));
+  for (int i = 0; i < size; ++i) {
+    EXPECT_FALSE(result->valueAt(i)) << "at " << i;
+  }
+
+  // nulls in odd positions: 0, null, 2, null,...
+  auto oddNulls = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      vectorMaker_.nullEvery(2, 1));
+  result =
+      evaluate<SimpleVector<bool>>("isnotnull(c0)", makeRowVector({oddNulls}));
+  for (int i = 0; i < size; ++i) {
+    EXPECT_EQ(result->valueAt(i), i % 2 == 0) << "at " << i;
+  }
+
+  // no nulls
+  auto noNulls =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row; });
+  result =
+      evaluate<SimpleVector<bool>>("isnotnull(c0)", makeRowVector({noNulls}));
+  for (int i = 0; i < size; ++i) {
+    EXPECT_TRUE(result->valueAt(i)) << "at " << i;
+  }
+}
+
+TEST_F(IsNotNullTest, somePositions) {
+  vector_size_t size = 20;
+
+  // nulls in odd positions: 0, null, 2, null,...
+  auto oddNulls = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      vectorMaker_.nullEvery(2, 1));
+  auto result = BaseVector::create(BOOLEAN(), size, execCtx_.pool());
+  auto flatResult = std::dynamic_pointer_cast<FlatVector<bool>>(result);
+  for (int i = 0; i < size; i++) {
+    flatResult->set(i, true);
+  }
+
+  // select odd rows 1, 3, 5,...
+  SelectivityVector oddRows(size);
+  for (int i = 0; i < size; i++) {
+    oddRows.setValid(i, i % 2 == 1);
+  }
+
+  flatResult = evaluate<FlatVector<bool>>(
+      "isnotnull(c0)", makeRowVector({oddNulls}), oddRows, result);
+  for (int i = 0; i < size; i += 2) {
+    EXPECT_EQ(flatResult->valueAt(i), i % 2 == 0) << "at " << i;
+  }
+
+  // select even rows 0, 2, 4...
+  SelectivityVector evenRows(size);
+  for (int i = 0; i < size; i++) {
+    evenRows.setValid(i, i % 2 == 0);
+  }
+  flatResult = evaluate<FlatVector<bool>>(
+      "isnotnull(c0)", makeRowVector({oddNulls}), evenRows, result);
+  for (int i = 0; i < size; ++i) {
+    EXPECT_TRUE(flatResult->valueAt(i)) << "at " << i;
+  }
+}
+
+}; // namespace
+}; // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Summary: This diff adds isnotnull Vector function to spark register function by customizing the already existing isnull function using isNotNull_ flag.

Differential Revision: D31929457

