### PR TITLE
Add rpad and lpad Presto functions

### DIFF
--- a/velox/docs/functions/string.rst
+++ b/velox/docs/functions/string.rst
@@ -41,6 +41,13 @@ String Functions
 
     Converts ``string`` to lowercase.
 
+.. function:: lpad(string, size, padstring) -> varchar
+
+     Left pads ``string`` to ``size`` characters with ``padstring``. If
+     ``size`` is less than the length of ``string``, the result is truncated
+     to ``size`` characters. ``size`` must not be negative and ``padstring``
+     must be non-empty.
+
 .. function:: ltrim(string) -> varchar
 
     Removes leading whitespace from string.
@@ -55,6 +62,17 @@ String Functions
 
     If ``search`` is an empty string, inserts ``replace`` in front of every
     character and at the end of the ``string``.
+
+.. function:: reverse(string) -> varchar
+
+    Reverses ``string``.
+
+.. function:: rpad(string, size, padstring) -> varchar
+
+     Right pads ``string`` to ``size`` characters with ``padstring``. If
+     ``size`` is less than the length of ``string``, the result is truncated
+     to ``size`` characters. ``size`` must not be negative and ``padstring``
+     must be non-empty.
 
 .. function:: rtrim(string) -> varchar
 
@@ -101,10 +119,6 @@ String Functions
 .. function:: upper(string) -> varchar
 
     Converts ``string`` to uppercase.
-
-.. function:: reverse(string) -> varchar
-
-    Reverses ``string``.
 
 Unicode Functions
 -----------------

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -57,7 +57,11 @@ static std::unordered_set<std::string> kSkipFunctions = {
     "replace",
     // Fails because like requires 2nd arg to be a constant of type VARCHAR.
     "like",
-};
+    // The pad functions cause the test to OOM. The 2nd arg is only bound by
+    // the max value of int32_t, which leads to strings billions of characters
+    // long.
+    "lpad",
+    "rpad"};
 
 // Called if at least one of the ptrs has an exception.
 void compareExceptions(

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -61,6 +61,10 @@ void registerFunctions() {
 
   registerFunction<RandFunction, double>({"rand"});
 
+  registerFunction<udf_pad<true>, Varchar, Varchar, int64_t, Varchar>({"lpad"});
+  registerFunction<udf_pad<false>, Varchar, Varchar, int64_t, Varchar>(
+      {"rpad"});
+
   // Date time functions.
   registerFunction<ToUnixtimeFunction, double, Timestamp>(
       {"to_unixtime", "to_unix_timestamp"});

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -286,4 +286,36 @@ struct LengthFunction {
   }
 };
 
+/// Pad functions
+/// lpad(string, size, padString) → varchar
+///     Left pads string to size characters with padString.  If size is
+///     less than the length of string, the result is truncated to size
+///     characters.  size must not be negative and padString must be non-empty.
+/// rpad(string, size, padString) → varchar
+///     Right pads string to size characters with padString.  If size is
+///     less than the length of string, the result is truncated to size
+///     characters.  size must not be negative and padString must be non-empty.
+template <bool lpad>
+VELOX_UDF_BEGIN(pad)
+// ASCII input always produces ASCII result.
+static constexpr bool is_default_ascii_behavior = true;
+
+FOLLY_ALWAYS_INLINE bool call(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& string,
+    const arg_type<int64_t>& size,
+    const arg_type<Varchar>& padString) {
+  stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, padString);
+  return true;
+}
+
+FOLLY_ALWAYS_INLINE bool callAscii(
+    out_type<Varchar>& result,
+    const arg_type<Varchar>& string,
+    const arg_type<int64_t>& size,
+    const arg_type<Varchar>& padString) {
+  stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, padString);
+  return true;
+}
+VELOX_UDF_END();
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Add functions to reproduce the behavior of Presto's

lpad(string, size, padstring) → varchar#
Left pads string to size characters with padstring. If size is less than the length of string, the result is truncated to size characters. size must not be negative and padstring must be non-empty.

rpad(string, size, padstring) → varchar#
Right pads string to size characters with padstring. If size is less than the length of string, the result is truncated to size characters. size must not be negative and padstring must be non-empty.