### PR TITLE
Fix wrapChild for constant inputs

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -150,7 +150,10 @@ wrapChild(vector_size_t size, BufferPtr mapping, const VectorPtr& child) {
   }
 
   if (child->encoding() == VectorEncoding::Simple::CONSTANT) {
-    return child;
+    if (size == child->size()) {
+      return child;
+    }
+    return BaseVector::wrapInConstant(size, 0, child);
   }
 
   return BaseVector::wrapInDictionary(BufferPtr(nullptr), mapping, size, child);

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
   TopNTest.cpp
   LimitTest.cpp
   OrderByTest.cpp
+  OperatorUtilsTest.cpp
   MergeTest.cpp
   HashJoinTest.cpp
   PlanNodeToStringTest.cpp

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/OperatorUtils.h"
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+class OperatorUtilsTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+};
+
+TEST_F(OperatorUtilsTest, wrapChildConstant) {
+  auto constant = BaseVector::createConstant(11, 1'000, pool_.get());
+
+  BufferPtr mapping = allocateIndices(1'234, pool_.get());
+  auto rawMapping = mapping->asMutable<vector_size_t>();
+  for (auto i = 0; i < 1'234; i++) {
+    rawMapping[i] = i / 2;
+  }
+
+  auto wrapped = exec::wrapChild(1'234, mapping, constant);
+  ASSERT_EQ(wrapped->size(), 1'234);
+  ASSERT_TRUE(wrapped->isConstantEncoding());
+  ASSERT_TRUE(wrapped->equalValueAt(constant.get(), 100, 100));
+}


### PR DESCRIPTION
Wrapping constant vector doesn't change the value represented by that vecotor,
but vector size needs to be updated.