### PR TITLE
Convenience method to set memory usage tracker for writer

### DIFF
--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -38,6 +38,19 @@ class Writer : public WriterShared {
   // Write columnar batch
   void write(const VectorPtr& slice);
 
+  void setMemoryUsageTracker(
+      const std::shared_ptr<velox::memory::MemoryUsageTracker>& tracker) {
+    getContext()
+        .getMemoryPool(velox::dwrf::MemoryUsageCategory::DICTIONARY)
+        .setMemoryUsageTracker(tracker);
+    getContext()
+        .getMemoryPool(velox::dwrf::MemoryUsageCategory::GENERAL)
+        .setMemoryUsageTracker(tracker);
+    getContext()
+        .getMemoryPool(velox::dwrf::MemoryUsageCategory::OUTPUT_STREAM)
+        .setMemoryUsageTracker(tracker);
+  }
+
  protected:
   void flushImpl(std::function<proto::ColumnEncoding&(uint32_t)>
                      encodingFactory) override {


### PR DESCRIPTION
Summary:
Writer creates its own memory pools upon construction, so it's hard to
set up memory usage tracker from the outside. This change allows memory usage
tracker to be properly set on the internally created writer memory pools after
construction.

Differential Revision: D31966607

