### PR TITLE
Introduce ArrayView type for simple functions 

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -171,6 +171,7 @@ class ArrayValWriter {
   const_iterator end() const {
     return values_.end();
   }
+
   const_reference at(size_t index) const {
     return values_.at(index);
   }
@@ -191,6 +192,18 @@ class ArrayValReader : public ArrayValWriter<VAL> {
     for (auto& val : vals) {
       append(std::move(val));
     }
+  }
+
+  bool mayHaveNulls() const {
+    return false;
+  }
+
+  std::optional<VAL> operator[](size_t index) const {
+    return {ArrayValWriter<VAL>::at(index)};
+  }
+
+  std::optional<VAL> at(size_t index) const {
+    return {ArrayValWriter<VAL>::at(index)};
   }
 };
 

--- a/velox/core/FunctionRegistry.h
+++ b/velox/core/FunctionRegistry.h
@@ -17,7 +17,6 @@
 
 #include "folly/hash/Hash.h"
 #include "velox/common/serialization/Registry.h"
-#include "velox/core/CoreTypeSystem.h"
 #include "velox/core/ScalarFunction.h"
 #include "velox/type/Type.h"
 

--- a/velox/expression/VectorFunctionAdapter.h
+++ b/velox/expression/VectorFunctionAdapter.h
@@ -101,7 +101,9 @@ class VectorAdapter : public VectorFunction {
       const std::vector<VectorPtr>& constantInputs,
       std::shared_ptr<const Type> returnType)
       : fn_{std::make_unique<FUNC>(move(returnType))} {
-    unpack<0>(config, constantInputs);
+    if constexpr (FUNC::udf_has_initialize) {
+      unpack<0>(config, constantInputs);
+    }
   }
 
   void apply(

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -15,18 +15,25 @@
  */
 
 #pragma once
-#include <algorithm>
 
+#include <algorithm>
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/functions/UDFOutputString.h"
 #include "velox/type/Type.h"
 #include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox::exec {
 
 template <typename VectorType = FlatVector<StringView>, bool reuseInput = false>
 class StringProxy;
+
+template <typename V>
+class ArrayView;
+
+template <typename T, typename U>
+struct VectorReader;
 
 namespace detail {
 template <typename T>
@@ -52,7 +59,7 @@ struct resolver<Row<T...>> {
 
 template <typename V>
 struct resolver<Array<V>> {
-  using in_type = core::ArrayValReader<typename resolver<V>::in_type>;
+  using in_type = ArrayView<V>;
   using out_type = core::ArrayValWriter<typename resolver<V>::out_type>;
 };
 
@@ -122,6 +129,7 @@ struct VectorWriter {
       vector_->setNull(offset_, true);
     }
   }
+
   void setOffset(int32_t offset) {
     offset_ = offset;
   }
@@ -147,6 +155,10 @@ struct VectorReader {
 
   bool isSet(size_t offset) const {
     return !decoded_.isNullAt(offset);
+  }
+
+  bool mayHaveNulls() const {
+    return decoded_.mayHaveNulls();
   }
 
   bool doLoad(size_t offset, exec_in_t& v) const {
@@ -244,6 +256,139 @@ struct VectorWriter<Map<K, V>> {
   size_t offset_ = 0;
 };
 
+// Represents an array of elements with an interface similar to std::vector.
+template <typename V>
+class ArrayView {
+  using reader_t = VectorReader<V>;
+  using element_t = typename reader_t::exec_in_t;
+
+ public:
+  ArrayView(const reader_t* reader, vector_size_t offset, vector_size_t size)
+      : reader_(reader), offset_(offset), size_(size) {}
+
+  // The previous doLoad protocal creates a value and then assigns to it.
+  // TODO: this should deprecated once we deprectae the doLoad protocoal.
+  ArrayView() : reader_(nullptr), offset_(0), size_(0) {}
+
+  // Represents an element in the array with an interface similar to
+  // std::optional.
+  struct Element {
+    operator bool() const {
+      return this->has_value();
+    }
+
+    bool operator==(const element_t& rhs) const {
+      return has_value() && (rhs == value());
+    }
+
+    bool operator==(const std::optional<element_t>& rhs) const {
+      if (!rhs.has_value()) {
+        return !has_value();
+      } else {
+        return rhs == value();
+      }
+    }
+
+    bool has_value() const {
+      return reader_->isSet(index_);
+    }
+
+    element_t value() const {
+      DCHECK(has_value());
+      return (*reader_)[index_];
+    }
+
+    element_t operator*() const {
+      DCHECK(has_value());
+      return (*reader_)[index_];
+    }
+
+   private:
+    Element(const ArrayView& arrayView, size_t index)
+        : reader_(arrayView.reader_), index_(index + arrayView.offset_) {}
+
+    const reader_t* reader_;
+    size_t index_;
+
+    friend class ArrayView;
+  };
+
+  // Iterator class.
+  struct Iterator
+      : public std::iterator<std::input_iterator_tag, Element, size_t> {
+    FOLLY_ALWAYS_INLINE bool operator!=(const Iterator& rhs) const {
+      return element_.index_ != rhs.element_.index_;
+    }
+
+    FOLLY_ALWAYS_INLINE bool operator==(const Iterator& rhs) const {
+      return element_.index_ == rhs.element_.index_;
+    }
+
+    FOLLY_ALWAYS_INLINE const Element& operator*() const {
+      return element_;
+    }
+
+    FOLLY_ALWAYS_INLINE const Element* operator->() const {
+      return &element_;
+    }
+
+    FOLLY_ALWAYS_INLINE bool operator<(const Iterator& rhs) const {
+      return this->element_.index_ < rhs.element_.index_;
+    }
+
+    // Implelement post increment.
+    FOLLY_ALWAYS_INLINE Iterator operator++(int) {
+      Iterator old = *this;
+      ++*this;
+      return old;
+    }
+
+    // Implelement pre increment.
+    FOLLY_ALWAYS_INLINE Iterator& operator++() {
+      ++element_.index_;
+      return *this;
+    }
+
+   private:
+    explicit Iterator(const Element& element) : element_(element) {}
+
+    Element element_;
+
+    friend class ArrayView;
+  };
+
+  Iterator begin() const {
+    return Iterator{Element{*this, 0}};
+  }
+
+  Iterator end() const {
+    return Iterator{Element{*this, size_}};
+  }
+
+  // Returns true if any of the arrayViews in the vector might have null
+  // element.
+  bool mayHaveNulls() const {
+    return reader_->mayHaveNulls();
+  }
+
+  const Element operator[](size_t index) const {
+    return Element{*this, index};
+  }
+
+  const Element at(size_t index) const {
+    return (*this)[index];
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  const reader_t* reader_;
+  vector_size_t offset_;
+  size_t size_;
+};
+
 namespace detail {
 
 template <typename TOut, typename TIn>
@@ -259,7 +404,7 @@ DecodeResult<T> decode(DecodedVector& decoder, const BaseVector& vector) {
   return decoder.as<T>();
 }
 
-}; // namespace detail
+} // namespace detail
 
 template <typename K, typename V>
 struct VectorReader<Map<K, V>> {
@@ -348,25 +493,13 @@ struct VectorReader<Array<V>> {
         childReader_{
             detail::decode<exec_in_child_t>(decoder_, *vector_.elements())} {}
 
+  // TODO: Once other types are converted to view types, the doLoad protocol
+  // will be removed.
   bool doLoad(size_t outerOffset, exec_in_t& results) const {
     if (!isSet(outerOffset)) {
       return false;
     }
-    vector_size_t offset = decoded_.decodedIndex(outerOffset);
-    const size_t offsetStart = offsets_[offset];
-    const size_t offsetEnd = offsetStart + lengths_[offset];
-
-    results.reserve(results.size() + offsetEnd - offsetStart);
-
-    for (size_t i = offsetStart; i < offsetEnd; ++i) {
-      exec_in_child_t childval{};
-      if (childReader_.doLoad(i, childval)) {
-        results.append(std::move(childval));
-      } else {
-        results.appendNullable();
-      }
-    }
-
+    results = (*this)[outerOffset];
     return true;
   }
 
@@ -374,10 +507,9 @@ struct VectorReader<Array<V>> {
     return !decoded_.isNullAt(offset);
   }
 
-  exec_in_t& operator[](size_t offset) const {
-    returnval_.clear();
-    doLoad(offset, returnval_);
-    return returnval_;
+  exec_in_t operator[](size_t offset) const {
+    auto index = decoder_.index(offset);
+    return ArrayView{&childReader_, offsets_[index], lengths_[index]};
   }
 
   DecodedVector decoder_;
@@ -386,7 +518,6 @@ struct VectorReader<Array<V>> {
   const vector_size_t* offsets_;
   const vector_size_t* lengths_;
   VectorReader<V> childReader_;
-  mutable exec_in_t returnval_;
 };
 
 template <typename V>
@@ -456,6 +587,7 @@ struct VectorWriter<Array<V>> {
     m_.clear();
     childWriter_.reset();
   }
+
   vector_t* vector_ = nullptr;
   exec_out_t m_{};
 

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace {
+
+using namespace facebook::velox;
+
+class ArrayViewTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::vector<std::vector<std::optional<int64_t>>> arrayDataBigInt = {
+      {0, 1, 2, 4},
+      {99, 98},
+      {101, std::nullopt},
+      {10001, 12345676, std::nullopt},
+  };
+};
+
+TEST_F(ArrayViewTest, intArray) {
+  auto arrayVector = makeNullableArrayVector(arrayDataBigInt);
+  DecodedVector decoded;
+  exec::VectorReader<Array<int64_t>> reader(
+      exec::detail::decode<exec::ArrayView<int64_t>>(
+          decoded, *arrayVector.get()));
+
+  auto testItem = [&](int i, int j, auto item) {
+    // Test has_value.
+    ASSERT_EQ(arrayDataBigInt[i][j].has_value(), item.has_value());
+
+    // Test bool implicit cast.
+    ASSERT_EQ(arrayDataBigInt[i][j].has_value(), item);
+
+    if (arrayDataBigInt[i][j].has_value()) {
+      // Test * operator.
+      ASSERT_EQ(arrayDataBigInt[i][j].value(), *item) << i << j;
+
+      // Test value().
+      ASSERT_EQ(arrayDataBigInt[i][j].value(), item.value());
+      ASSERT_TRUE(item == arrayDataBigInt[i][j].value());
+    }
+    ASSERT_TRUE(item == arrayDataBigInt[i][j]);
+  };
+
+  for (auto i = 0; i < arrayVector->size(); i++) {
+    auto arrayView = reader[i];
+    auto j = 0;
+
+    // Test iterate loop.
+    for (auto item : arrayView) {
+      testItem(i, j, item);
+      j++;
+    }
+    ASSERT_EQ(j, arrayDataBigInt[i].size());
+
+    // Test iterate loop 2.
+    auto it = arrayView.begin();
+    j = 0;
+    while (it != arrayView.end()) {
+      testItem(i, j, *it);
+      j++;
+      ++it;
+    }
+    ASSERT_EQ(j, arrayDataBigInt[i].size());
+
+    // Test index based loop.
+    for (j = 0; j < arrayView.size(); j++) {
+      testItem(i, j, arrayView[j]);
+    }
+    ASSERT_EQ(j, arrayDataBigInt[i].size());
+
+    // Test loop iterator with <.
+    j = 0;
+    for (auto it = arrayView.begin(); it < arrayView.end(); it++) {
+      testItem(i, j, *it);
+      j++;
+    }
+    ASSERT_EQ(j, arrayDataBigInt[i].size());
+  }
+}
+} // namespace

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 add_executable(
-  velox_expression_test ExprTest.cpp CastExprTest.cpp EvalSimplifiedTest.cpp
-                        SignatureBinderTest.cpp SimpleFunctionTest.cpp)
+  velox_expression_test
+  ExprTest.cpp CastExprTest.cpp EvalSimplifiedTest.cpp SignatureBinderTest.cpp
+  SimpleFunctionTest.cpp ArrayViewTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -372,7 +372,8 @@ struct ArrayRowReaderFunction {
       const arg_type<Array<Row<int64_t, double>>>& input) {
     out = 0;
     for (size_t i = 0; i < input.size(); i++) {
-      out += *input.at(i)->template at<0>();
+      auto&& row = *input.at(i);
+      out += *row.template at<0>();
     }
     return true;
   }


### PR DESCRIPTION
This is continuous and extension work of 
https://github.com/facebookincubator/velox/pull/493

## ArrayView 
Introduce and use ArrayView<T> as an input type for simple functions for ArrayType. 
ArrayView is a lightweight lazy access abstraction for the underlying array 
with the following interface.
- size()
- operator [ ], at returns an ArrayView<T>::Element

Element is an abstract over the value and nullability
 of the array at a specific index, it have an interface similar to std::optional:
 
- value()  // for now unchecked access, (shall we make it checked?) i.e add a dynamic check that value is not null
- operator *  // unchecked access
- has_value()
-  implicit bool cast => if(v)  == if(v.has_value())

ArrayView provides an iterator interface to  iterate over the elements

i.e:
```
foo( ArrayView<T> inputs){
  for(const auto & element: inputs){
      if(element.has_value()){
         bar(*element); 
       }
  }
}
```
or 
```
foo( ArrayView<T> inputs){
  for(int i=0; i<inputs.size(); i++){
      if(inputs[i].has_value()){
         bar(*inputs[i]); 
       }
  }
}
```

or 
```
foo( ArrayView<T> inputs){
 auto it = inputs.begin(); 
 while(it!=inputs.end()){
    if(*it.has_value()){
             bar(**it); 
    }
    ++it;
 }
}
```

## Performance:
this diff speedup simple functions by 2X, simple functions are not yet as fast as optimized vector functions, but they are almost  as fast as vector functions that do not have special fast paths based on dynamic info not available to simple functions.

### 1) min function
VectorMinIntegerBasic is added and it computes min with out any vector-function privileged optimizations
It is added as a comparison point to observe the overhead (if any) of the argument dispatch in the vector reader.
the performance of vectorMinIntegerBasic and simpleMinIntegerIterator are similar 
```
============================================================================
fastMinInteger                                             488.62us    2.05K
vectorMinInteger                                  84.74%   576.58us    1.73K
vectorMinIntegerNoFastPath                        58.81%   830.82us    1.20K
simpleMinIntegerIterator                          58.75%   831.76us    1.20K
simpleMinInteger                                  56.18%   869.66us    1.15K
============================================================================
```
#### before and after this diff
the simple function min implementation did not support null reading:
so here we compare non-nulls min
before: 1.58ms
after: 803.24us 
### 2) compare  function
- with current vector function 
```
with this diff
============================================================================
vectorSimpleFunction                                         1.04ms   961.28
vectorFunctionInteger                            202.30%   514.24us    1.94K
============================================================================

before this diff
============================================================================
SimpleFunction                                         2.11ms   473.00
vectorFunction                            364.69%   579.71us    1.72K
============================================================================
```
- with the fast path under those conditions disabled in the vector function:
(elementsDecoded.isIdentityMapping() &&
      !elementsDecoded.mayHaveNulls() && searchDecoded.isConstantMapping())
```
with this diff
============================================================================
vectorSimpleFunction                                         1.03ms   974.86
vectorFunctionInteger                            128.00%   801.37us    1.25K
============================================================================

before this diff
============================================================================
SimpleFunction                                         1.91ms   523.35
vectorFunction                            233.55%   818.14us    1.22K
```

 
## Test 
- add ArrayViewTest
- simpleFunctionTest already covers cases of nested complex types.

## Next
- introduce View types for row, map .
- introduce 0-copy write proxies for complex types.
