### PR TITLE
Migrate more functions to new simple framework

### DIFF
--- a/velox/core/Metaprogramming.h
+++ b/velox/core/Metaprogramming.h
@@ -167,7 +167,7 @@ struct has_method {
 #define DECLARE_METHOD_RESOLVER(Name, MethodName)              \
   struct Name {                                                \
     template <class __T, typename... __TArgs>                  \
-    constexpr auto resolve(__TArgs... args) const              \
+    constexpr auto resolve(__TArgs&&... args) const            \
         -> decltype(std::declval<__T>().MethodName(args...)) { \
       return {};                                               \
     }                                                          \

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -32,26 +32,23 @@ using namespace facebook::velox;
 //
 // Check `velox/docs/develop/scalar-functions.rst` for more documentation on how
 // to build scalar functions.
-VELOX_UDF_BEGIN(times_two)
-FOLLY_ALWAYS_INLINE bool call(int64_t& out, const int64_t& a) {
-  out = a * 2;
-  return true; // True if result is not null.
-}
-VELOX_UDF_END();
+template <typename T>
+struct TimesTwoFunction {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& out, const int64_t& a) {
+    out = a * 2;
+    return true; // True if result is not null.
+  }
+};
 
 int main(int argc, char** argv) {
-  // Register the function defined above. Note that the first parameter requires
-  // the "udf_" prefix in the tag, and that the first template parameter is the
-  // function return type.
+  // Register the function defined above. The first template parameter is the
+  // class that implements the `call()` function (or one of its variations), the
+  // second template parameter is the function return type, followed by the list
+  // of function input parameters.
   //
-  // Optionally, this function takes as an argument a list of aliases for the
-  // function being registered. If a list is specified, you need to specify
-  // both the original name and aliases (original name is not added by
-  // default).
-  //
-  // By default it will be registered as the "times_two" defined name (since
-  // alias list is empty).
-  registerFunction<udf_times_two, int64_t, int64_t>();
+  // This function takes as an argument a list of aliases for the function being
+  // registered.
+  registerFunction<TimesTwoFunction, int64_t, int64_t>({"times_two"});
 
   // First of all, executing an expression in Velox will require us to create a
   // query context, a memory pool, and an execution context.

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1683,36 +1683,42 @@ struct OpaqueState {
 int OpaqueState::constructed = 0;
 int OpaqueState::destructed = 0;
 
-VELOX_UDF_BEGIN(test_opaque_create)
-FOLLY_ALWAYS_INLINE bool call(
-    out_type<std::shared_ptr<OpaqueState>>& out,
-    const arg_type<int64_t>& x) {
-  out = std::make_shared<OpaqueState>(x);
-  return true;
-}
-VELOX_UDF_END()
+template <typename T>
+struct TestOpaqueCreateFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
-VELOX_UDF_BEGIN(test_opaque_add)
-FOLLY_ALWAYS_INLINE bool call(
-    int64_t& out,
-    const arg_type<std::shared_ptr<OpaqueState>>& state,
-    const arg_type<int64_t>& y) {
-  out = state->x + y;
-  return true;
-}
-VELOX_UDF_END()
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<std::shared_ptr<OpaqueState>>& out,
+      const arg_type<int64_t>& x) {
+    out = std::make_shared<OpaqueState>(x);
+    return true;
+  }
+};
+
+template <typename T>
+struct TestOpaqueAddFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& out,
+      const arg_type<std::shared_ptr<OpaqueState>>& state,
+      const arg_type<int64_t>& y) {
+    out = state->x + y;
+    return true;
+  }
+};
 
 bool registerTestUDFs() {
   static bool once = [] {
     registerFunction<
-        udf_test_opaque_create,
+        TestOpaqueCreateFunction,
         std::shared_ptr<OpaqueState>,
-        int64_t>({});
+        int64_t>({"test_opaque_create"});
     registerFunction<
-        udf_test_opaque_add,
+        TestOpaqueAddFunction,
         int64_t,
         std::shared_ptr<OpaqueState>,
-        int64_t>({});
+        int64_t>({"test_opaque_add"});
     return true;
   }();
   return once;

--- a/velox/functions/prestosql/Hash.h
+++ b/velox/functions/prestosql/Hash.h
@@ -23,18 +23,17 @@
 #include "folly/hash/Hash.h"
 #include "velox/functions/Macros.h"
 
-namespace facebook {
-namespace velox {
-namespace functions {
+namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(hash)
-public : FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<T>& a) {
-  result = computeHash(a);
-  return true;
-}
-VELOX_UDF_END();
+struct HashFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
-} // namespace functions
-} // namespace velox
-} // namespace facebook
+  template <typename TFrom>
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const TFrom& a) {
+    result = computeHash(a);
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/JsonExtractScalar.h
+++ b/velox/functions/prestosql/JsonExtractScalar.h
@@ -23,23 +23,26 @@ namespace facebook::velox::functions {
 // Like jsonExtract(), but returns the result value as a string (as opposed
 // to being encoded as JSON). The value referenced by json_path must be a scalar
 // (boolean, number or string)
-VELOX_UDF_BEGIN(json_extract_scalar)
-FOLLY_ALWAYS_INLINE bool call(
-    out_type<Varchar>& result,
-    const arg_type<Varchar>& json,
-    const arg_type<Varchar>& jsonPath) {
-  const folly::StringPiece& jsonStringPiece = json;
-  const folly::StringPiece& jsonPathStringPiece = jsonPath;
-  auto extractResult = jsonExtractScalar(jsonStringPiece, jsonPathStringPiece);
-  if (extractResult.hasValue()) {
-    UDFOutputString::assign(result, *extractResult);
-    return true;
+template <typename T>
+struct JsonExtractScalarFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  } else {
-    return false;
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& json,
+      const arg_type<Varchar>& jsonPath) {
+    const folly::StringPiece& jsonStringPiece = json;
+    const folly::StringPiece& jsonPathStringPiece = jsonPath;
+    auto extractResult =
+        jsonExtractScalar(jsonStringPiece, jsonPathStringPiece);
+    if (extractResult.hasValue()) {
+      UDFOutputString::assign(result, *extractResult);
+      return true;
+
+    } else {
+      return false;
+    }
   }
-}
-
-VELOX_UDF_END();
+};
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Rand.h
+++ b/velox/functions/prestosql/Rand.h
@@ -18,19 +18,16 @@
 #include "folly/Random.h"
 #include "velox/functions/Macros.h"
 
-namespace facebook {
-namespace velox {
-namespace functions {
+namespace facebook::velox::functions {
 
-VELOX_UDF_BEGIN(rand)
-static constexpr bool is_deterministic = false;
+template <typename T>
+struct RandFunction {
+  static constexpr bool is_deterministic = false;
 
-FOLLY_ALWAYS_INLINE bool call(double& result) {
-  result = folly::Random::randDouble01();
-  return true;
-}
-VELOX_UDF_END();
+  FOLLY_ALWAYS_INLINE bool call(double& result) {
+    result = folly::Random::randDouble01();
+    return true;
+  }
+};
 
-} // namespace functions
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -29,11 +29,8 @@ namespace facebook::velox::functions {
 
 void registerFunctions() {
   // Register functions here.
-  static const std::vector<std::string> EMPTY{};
-
-  registerFunction<udf_rand, double>(EMPTY);
-
-  registerFunction<udf_json_extract_scalar, Varchar, Varchar, Varchar>();
+  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
+      {"json_extract_scalar"});
 
   // Register string functions.
   registerFunction<ChrFunction, Varchar, int64_t>({"chr"});
@@ -60,6 +57,8 @@ void registerFunctions() {
   registerFunction<FromBase64Function, Varbinary, Varchar>({"from_base64"});
   registerFunction<UrlEncodeFunction, Varchar, Varchar>({"url_encode"});
   registerFunction<UrlDecodeFunction, Varchar, Varchar>({"url_decode"});
+
+  registerFunction<RandFunction, double>({"rand"});
 
   // Date time functions.
   registerFunction<ToUnixtimeFunction, double, Timestamp>(

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -61,33 +61,41 @@ VectorPtr fastMax(const VectorPtr& in) {
 }
 
 template <typename T>
-VELOX_UDF_BEGIN(array_min_simple)
-FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
-  if (x.begin() == x.end()) {
-    return false;
+struct ArrayMinSimpleFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(TInput& out, const arg_type<Array<TInput>>& x) {
+    if (x.begin() == x.end()) {
+      return false;
+    }
+    out = std::min_element(x.begin(), x.end())->value();
+    return true;
   }
-  out = std::min_element(x.begin(), x.end())->value();
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(array_max_simple)
-FOLLY_ALWAYS_INLINE bool call(T& out, const arg_type<Array<T>>& x) {
-  if (x.begin() == x.end()) {
-    return false;
+struct ArrayMaxSimpleFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(TInput& out, const arg_type<Array<TInput>>& x) {
+    if (x.begin() == x.end()) {
+      return false;
+    }
+    out = std::max_element(x.begin(), x.end())->value();
+    return true;
   }
-  out = std::max_element(x.begin(), x.end())->value();
-  return true;
-}
-VELOX_UDF_END();
+};
 
 class ArrayMinMaxBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   ArrayMinMaxBenchmark() : FunctionBenchmarkBase() {
     functions::registerVectorFunctions();
-    registerFunction<udf_array_min_simple<int32_t>, int32_t, Array<int32_t>>();
-    registerFunction<udf_array_max_simple<int32_t>, int32_t, Array<int32_t>>();
+    registerFunction<ArrayMinSimpleFunction, int32_t, Array<int32_t>>(
+        {"array_min_simple"});
+    registerFunction<ArrayMaxSimpleFunction, int32_t, Array<int32_t>>(
+        {"array_max_simple"});
   }
 
   void runInteger(const std::string& functionName) {

--- a/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
@@ -25,18 +25,19 @@ using namespace facebook::velox::test;
 
 namespace {
 
-VELOX_UDF_BEGIN(not_scalar)
-bool call(bool& result, const bool& arg) {
-  result = !arg;
-  return true;
-}
-VELOX_UDF_END()
+template <typename T>
+struct NotScalarFunction {
+  bool call(bool& result, const bool& arg) {
+    result = !arg;
+    return true;
+  }
+};
 
 class NotBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   NotBenchmark() : FunctionBenchmarkBase() {
     functions::registerVectorFunctions();
-    registerFunction<udf_not_scalar, bool, bool>({"not_scalar"});
+    registerFunction<NotScalarFunction, bool, bool>({"not_scalar"});
   }
 
   void run(const std::string& functionName) {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -58,9 +58,9 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
 namespace sparksql {
 
 void registerFunctions(const std::string& prefix) {
-  registerFunction<udf_rand, double>({"rand"});
+  registerFunction<RandFunction, double>({"rand"});
 
-  registerFunction<udf_json_extract_scalar, Varchar, Varchar, Varchar>(
+  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {prefix + "get_json_object"});
 
   // Register string functions.


### PR DESCRIPTION
Summary:
Migrating more functions to the new simple framework. Once all
functions are moved, we'll be able to remove the code old, and allow for simple
functions that don't rely on any complex or string types not to provide the
default template type.

Differential Revision: D31965526

