### PR TITLE
Add benchmark for Presto IN expression

### DIFF
--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -23,32 +23,41 @@ set(BENCHMARK_DEPENDENCIES
     ${FOLLY_WITH_DEPENDENCIES}
     ${FOLLY_BENCHMARK})
 
-add_executable(velox_functions_benchmarks_array_contains
+add_executable(velox_functions_prestosql_benchmarks_array_contains
                ArrayContainsBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_array_contains
+target_link_libraries(velox_functions_prestosql_benchmarks_array_contains
                       ${BENCHMARK_DEPENDENCIES})
 
-add_executable(velox_functions_benchmarks_array_min_max
+add_executable(velox_functions_prestosql_benchmarks_array_min_max
                ArrayMinMaxBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_array_min_max
+target_link_libraries(velox_functions_prestosql_benchmarks_array_min_max
                       ${BENCHMARK_DEPENDENCIES})
 
-add_executable(velox_functions_benchmarks_width_bucket WidthBucketBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_width_bucket
+add_executable(velox_functions_prestosql_benchmarks_width_bucket
+               WidthBucketBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_width_bucket
                       ${BENCHMARK_DEPENDENCIES})
 
-add_executable(velox_functions_benchmarks_string_ascii_utf_functions
+add_executable(velox_functions_prestosql_benchmarks_string_ascii_utf_functions
                StringAsciiUTFFunctionBenchmarks.cpp)
-target_link_libraries(velox_functions_benchmarks_string_ascii_utf_functions
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_string_ascii_utf_functions
+  ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_not NotBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_not
                       ${BENCHMARK_DEPENDENCIES})
 
-add_executable(velox_functions_benchmarks_not NotBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_not ${BENCHMARK_DEPENDENCIES})
-
-add_executable(velox_functions_benchmarks_date_time DateTimeBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_date_time
+add_executable(velox_functions_prestosql_benchmarks_date_time
+               DateTimeBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_date_time
                       ${BENCHMARK_DEPENDENCIES})
 
-add_executable(velox_functions_benchmarks_bitwise BitwiseBenchmark.cpp)
-target_link_libraries(velox_functions_benchmarks_bitwise
+add_executable(velox_functions_prestosql_benchmarks_bitwise
+               BitwiseBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_bitwise
+                      ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_in InBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_in
                       ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/InBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/InBenchmark.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/container/F14Set.h>
+#include <folly/init/Init.h>
+#include "velox/expression/tests/VectorFuzzer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/VectorFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+
+/// Fast implementation of IN (a, b, c,..) using F14FastSet.
+VectorPtr fastIn(
+    const folly::F14FastSet<int32_t>& inSet,
+    const VectorPtr& data) {
+  const auto numRows = data->size();
+  auto result = std::static_pointer_cast<FlatVector<bool>>(
+      BaseVector::create(BOOLEAN(), numRows, data->pool()));
+  auto rawResults = result->mutableRawValues<int32_t>();
+
+  auto rawData = data->asUnchecked<FlatVector<int32_t>>()->rawValues();
+  for (auto row = 0; row < numRows; ++row) {
+    bits::setBit(rawResults, row, inSet.contains(rawData[row]));
+  }
+
+  return result;
+}
+
+class InBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  InBenchmark() : FunctionBenchmarkBase() {
+    functions::registerVectorFunctions();
+  }
+
+  RowVectorPtr makeData() {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = 1'000;
+    return vectorMaker_.rowVector(
+        {VectorFuzzer(opts, pool()).fuzzFlat(INTEGER())});
+  }
+
+  void run(size_t numValues) {
+    folly::BenchmarkSuspender suspender;
+    auto data = makeData();
+
+    std::ostringstream inList;
+    inList << "0";
+    for (auto i = 1; i < numValues; ++i) {
+      inList << ", " << i * 2;
+    }
+
+    auto sql = fmt::format("c0 IN ({})", inList.str());
+    auto exprSet = compileExpression(sql, data->type());
+    suspender.dismiss();
+
+    doRun(exprSet, data);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 1000; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  void runFast(size_t numValues) {
+    folly::BenchmarkSuspender suspender;
+    auto data = makeData();
+
+    folly::F14FastSet<int32_t> inSet;
+    inSet.reserve(numValues);
+    for (auto i = 0; i < numValues; ++i) {
+      inSet.insert(i);
+    }
+    suspender.dismiss();
+
+    doRunFast(inSet, data->childAt(0));
+  }
+
+  void doRunFast(
+      const folly::F14FastSet<int32_t>& inSet,
+      const VectorPtr& data) {
+    int cnt = 0;
+    for (auto i = 0; i < 1000; i++) {
+      cnt += fastIn(inSet, data)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(fastIn) {
+  InBenchmark benchmark;
+  benchmark.runFast(10);
+}
+
+BENCHMARK_RELATIVE(in) {
+  InBenchmark benchmark;
+  benchmark.run(10);
+}
+
+BENCHMARK(fastIn1K) {
+  InBenchmark benchmark;
+  benchmark.runFast(1'000);
+}
+
+BENCHMARK_RELATIVE(in1K) {
+  InBenchmark benchmark;
+  benchmark.run(1'000);
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
The benchmark shows that IN expression with large number of values is incredibly
slow. This is because IN is implemented as a function with variable number of
arguments. IN with 10K values is represented as an expression tree with one
node for the IN, one for the column and 10K nodes for values. Each value is
wrapped in a ConstantExpr which gets evaluated for each batch of rows making ne
shared pointers to constant vectors.

A follow-up PR will optimize IN expression to take values as a single array.

```
prestosql/benchmarks/InBenchmark.cpprelative  time/iter  iters/s
============================================================================
fastIn                                                       3.49ms   286.17
in                                                55.08%     6.34ms   157.62
fastIn10K                                                    3.12ms   320.43
in10K                                              0.07%      4.72s  211.75m
============================================================================
```