### PR TITLE
Remove duplicate getter method in FlatVector

### DIFF
--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -30,7 +30,7 @@ namespace {
 
 /// Check if the input vector's  buffers are single referenced
 bool hasSingleReferencedBuffers(const FlatVector<StringView>* vec) {
-  for (auto& buffer : vec->getStringBuffers()) {
+  for (auto& buffer : vec->stringBuffers()) {
     if (buffer->refCount() > 1) {
       return false;
     }

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -46,9 +46,7 @@ class GreatestLeastTest : public functions::test::FunctionBaseTest {
     if (stringBuffersExpectedCount.has_value()) {
       ASSERT_EQ(
           *stringBuffersExpectedCount,
-          result->template asFlatVector<StringView>()
-              ->getStringBuffers()
-              .size());
+          result->template asFlatVector<StringView>()->stringBuffers().size());
     }
   }
 };

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -287,10 +287,6 @@ class FlatVector final : public SimpleVector<T> {
     return nullptr;
   }
 
-  const std::vector<BufferPtr>& getStringBuffers() const {
-    return stringBuffers_;
-  }
-
   void ensureWritable(const SelectivityVector& rows) override;
 
  private:


### PR DESCRIPTION
Summary: Removing for code cleaness

Reviewed By: mbasmanova

Differential Revision: D31095810

