### PR TITLE
Fix clang shift errors.

### DIFF
--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -53,22 +53,25 @@ VELOX_UDF_END();
 
 template <typename T>
 VELOX_UDF_BEGIN(bitwise_arithmetic_shift_right)
-FOLLY_ALWAYS_INLINE bool call(int64_t& result, T number, T shift) {
+FOLLY_ALWAYS_INLINE
+#if defined(__clang__)
+    __attribute__((no_sanitize("integer")))
+#endif
+    bool call(int64_t& result, T number, T shift) {
   VELOX_USER_CHECK_GE(shift, 0, "Shift must be positive")
-  if (shift >= sizeof(T)) {
-    result = 0;
-  } else {
-    result = number >> shift;
-  }
-
+  result = number >> shift;
   return true;
 }
 VELOX_UDF_END();
 
 namespace {
 template <typename T, int MAX_SHIFT>
-FOLLY_ALWAYS_INLINE bool bitwiseLeftShift(int64_t& result, T number, T shift) {
-  if ((uint32_t)shift >= MAX_SHIFT || shift < 0 || number < 0) {
+#if defined(__clang__)
+__attribute__((no_sanitize("integer")))
+#endif
+FOLLY_ALWAYS_INLINE bool
+bitwiseLeftShift(int64_t& result, T number, T shift) {
+  if ((uint32_t)shift >= MAX_SHIFT) {
     result = 0;
   } else {
     result = (number << shift);
@@ -163,7 +166,10 @@ VELOX_UDF_END();
 
 VELOX_UDF_BEGIN(bitwise_logical_shift_right)
 FOLLY_ALWAYS_INLINE bool
-call(int64_t& result, int64_t number, int64_t shift, int64_t bits) {
+#if defined(__clang__)
+    __attribute__((no_sanitize("integer")))
+#endif
+    call(int64_t& result, int64_t number, int64_t shift, int64_t bits) {
   // Presto defines this only for bigint, thus we will define this only for
   // int64_t.
   if (bits == 64) {
@@ -181,7 +187,10 @@ VELOX_UDF_END();
 
 VELOX_UDF_BEGIN(bitwise_shift_left)
 FOLLY_ALWAYS_INLINE bool
-call(int64_t& result, int64_t number, int64_t shift, int64_t bits) {
+#if defined(__clang__)
+    __attribute__((no_sanitize("integer")))
+#endif
+    call(int64_t& result, int64_t number, int64_t shift, int64_t bits) {
   // Presto defines this only for bigint, thus we will define this only for
   // int64_t.
   if (bits == 64) {

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -209,6 +209,10 @@ TEST_F(BitwiseTest, arithmeticShiftRight) {
   EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(3, 0), 3);
   EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(3, 3), 0);
   EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-1, 2), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-1, 2), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-100, 65), -50);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-100, 66), -25);
+
   assertUserError(
       [&]() { bitwiseArithmeticShiftRight<int32_t>(3, -1); },
       "Shift must be positive");
@@ -268,7 +272,7 @@ TEST_F(BitwiseTest, leftShift) {
   EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, kMax16), 0);
   EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, kMax16), 0);
   EXPECT_EQ(bitwiseLeftShift<int16_t>(kMax16, 1), kMax16 << 1);
-  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, 1).value(), -65536);
+  EXPECT_EQ(bitwiseLeftShift<int16_t>(kMin16, 1), -65536);
 
   EXPECT_EQ(bitwiseLeftShift<int32_t>(kMin32, kMax32), 0);
   EXPECT_EQ(bitwiseLeftShift<int32_t>(kMax32, kMax32), 0);
@@ -295,12 +299,12 @@ TEST_F(BitwiseTest, rightShift) {
   EXPECT_EQ(bitwiseRightShift<int32_t>(kMin32, kMax32), 0);
   EXPECT_EQ(bitwiseRightShift<int32_t>(kMax32, kMax32), 0);
   EXPECT_EQ(bitwiseRightShift<int32_t>(kMax32, 1), kMax32 >> 1);
-  EXPECT_EQ(bitwiseRightShift<int32_t>(kMin32, 1).value(), (kMax32 >> 1) + 1);
+  EXPECT_EQ(bitwiseRightShift<int32_t>(kMin32, 1), (kMax32 >> 1) + 1);
 
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, kMax64), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, kMax64), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, 1), kMax64 >> 1);
-  EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, 1).value(), (kMax64 >> 1) + 1);
+  EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, 1), (kMax64 >> 1) + 1);
 }
 
 TEST_F(BitwiseTest, logicalShiftRight) {


### PR DESCRIPTION
Clang complains about shift sanitization if the base is negative since the C standard leaves that implementation to be platform specific: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html . However the current behavior shown is the same behavior shown by presto.