### PR TITLE
Optimize ConstantExpr::evalSpecialForm

### DIFF
--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -36,10 +36,15 @@ void ConstantExpr::evalSpecialForm(
     vector->computeAndSetIsAscii(rows);
   }
 
-  context->moveOrCopyResult(
-      BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_),
-      rows,
-      result);
+  if (sharedSubexprValues_.unique()) {
+    sharedSubexprValues_->resize(rows.end());
+    context->moveOrCopyResult(sharedSubexprValues_, rows, result);
+  } else {
+    context->moveOrCopyResult(
+        BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_),
+        rows,
+        result);
+  }
 }
 
 void ConstantExpr::evalSpecialFormSimplified(


### PR DESCRIPTION
Summary:
Reuse ConstantVector when possible. This change improves performance of IN predicate with large number of values.

Before:

```
============================================================================
velox/functions/prestosql/benchmarks/InBenchmark.cpprelative  time/iter  iters/s
============================================================================
fastIn                                                       4.38ms   228.06
in                                                34.65%    12.65ms    79.02
fastIn1K                                                     4.02ms   248.83
in1K                                               1.84%   218.08ms     4.59
============================================================================
```

After:

```
============================================================================
velox/functions/prestosql/benchmarks/InBenchmark.cpprelative  time/iter  iters/s
============================================================================
fastIn                                                       3.90ms   256.21
in                                                38.97%    10.02ms    99.84
fastIn1K                                                     3.81ms   262.79
in1K                                              10.20%    37.29ms    26.82
============================================================================
```

Reviewed By: funrollloops

Differential Revision: D32007225

