### PR TITLE
Fix the 'Split' function documnetation.

### DIFF
--- a/velox/docs/functions/string.rst
+++ b/velox/docs/functions/string.rst
@@ -65,6 +65,7 @@ String Functions
     Splits ``string`` on ``delimiter`` and returns an array.
 
 .. function:: split(string, delimiter, limit) -> array(string)
+
     Splits ``string`` on ``delimiter`` and returns an array of size at most ``limit``.
 
     The last element in the array always contains everything left in the string.


### PR DESCRIPTION
Summary:
Fix the 'Split' function documentation.

It needs an empty line, otherwise the BOLD setting is taken from the line above.
https://facebookincubator.github.io/velox/functions/string.html

Differential Revision: D32009750

