### PR TITLE
fix applyFunctionWithPeeling with nulls

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1009,7 +1009,7 @@ bool Expr::applyFunctionWithPeeling(
   } else {
     auto decoded = localDecoded.get();
     decoded->makeIndices(*firstWrapper, applyRows, numLevels);
-    newRows = translateToInnerRows(rows, *decoded, newRowsHolder);
+    newRows = translateToInnerRows(applyRows, *decoded, newRowsHolder);
     context->saveAndReset(&saver, rows);
     setDictionaryWrapping(*decoded, rows, *firstWrapper, context);
   }


### PR DESCRIPTION
applyFunctionWithPeeling uses rows instead of applyRows to generate newRows.

This can break with a SIGSEGV when the function is applied with newRows as it may incorrectly indicate certain values are non-null, when they are actually null leading to accessing data in surprising memory locations.  Particularly when the function uses the default null behavior and so doesn't check for nulls.