### PR TITLE
Optimize ConstantExpr::evalSpecialForm for strings

### DIFF
--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -60,10 +60,12 @@ class ConstantExpr : public SpecialForm {
  public:
   ConstantExpr(std::shared_ptr<const Type> type, variant value)
       : SpecialForm(std::move(type), std::vector<ExprPtr>(), "literal"),
-        value_(std::move(value)) {}
+        value_(std::move(value)),
+        needToSetIsAscii_{type->isVarchar()} {}
 
   explicit ConstantExpr(VectorPtr value)
-      : SpecialForm(value->type(), std::vector<ExprPtr>(), "literal") {
+      : SpecialForm(value->type(), std::vector<ExprPtr>(), "literal"),
+        needToSetIsAscii_{value->type()->isVarchar()} {
     VELOX_CHECK_EQ(value->encoding(), VectorEncoding::Simple::CONSTANT);
     sharedSubexprValues_ = std::move(value);
   }
@@ -87,6 +89,7 @@ class ConstantExpr : public SpecialForm {
 
  private:
   const variant value_;
+  bool needToSetIsAscii_;
 };
 
 class FieldReference : public SpecialForm {

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -286,12 +286,12 @@ class SimpleVector : public BaseVector {
   }
 
   /// Computes and saves is-ascii flag for a given set of rows if not already
-  /// present.
+  /// present. Returns computed value.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, void>::type
+  typename std::enable_if<std::is_same<U, StringView>::value, bool>::type
   computeAndSetIsAscii(const SelectivityVector& rows) {
     if (rows.isSubset(asciiSetRows_)) {
-      return;
+      return isAllAscii_;
     }
     ensureIsAsciiCapacity(rows.end());
     bool isAllAscii = true;
@@ -311,6 +311,7 @@ class SimpleVector : public BaseVector {
     }
 
     asciiSetRows_.select(rows);
+    return isAllAscii_;
   }
 
   /// Clears asciiness state.


### PR DESCRIPTION
ConstantExpr::evalSpecialForm used to scan string constant to detect if it
is all-ASCII repeatedly as many times as there are rows. This change is
to scan the string once.

Before:

```
============================================================================
functions/sparksql/benchmarks/In.cpprelative  time/iter  iters/s
============================================================================
in_int(presto_rhs1)                                          1.47ns  679.59M
in_int(spark_rhs1)                               587.98%   250.26ps    4.00G
in_int(presto_rhs3)                                          4.18ns  239.38M
in_int(spark_rhs3)                               127.30%     3.28ns  304.73M
in_int(presto_rhs10)                                         8.18ns  122.19M
in_int(spark_rhs10)                              226.24%     3.62ns  276.44M
in_int(presto_rhs100)                                       13.23ns   75.60M
in_int(spark_rhs100)                             202.79%     6.52ns  153.32M
in_str(presto_rhs1)                                          5.72ns  174.76M
in_str(spark_rhs1)                                76.94%     7.44ns  134.45M
in_str(presto_rhs3)                                        159.63ns    6.26M
in_str(spark_rhs3)                               198.34%    80.48ns   12.42M
in_str(presto_rhs10)                                       294.60ns    3.39M
in_str(spark_rhs10)                              104.56%   281.75ns    3.55M
in_str(presto_rhs100)                                        1.92us  520.44K
in_str(spark_rhs100)                             102.73%     1.87us  534.64K
============================================================================
```

After:

```
============================================================================
functions/sparksql/benchmarks/In.cpprelative  time/iter  iters/s
============================================================================
in_int(presto_rhs1)                                        824.63ps    1.21G
in_int(spark_rhs1)                                  inf%     0.00fs  Infinity
in_int(presto_rhs3)                                          2.88ns  347.26M
in_int(spark_rhs3)                               108.89%     2.64ns  378.11M
in_int(presto_rhs10)                                         5.92ns  168.96M
in_int(spark_rhs10)                              185.93%     3.18ns  314.16M
in_int(presto_rhs100)                                       11.61ns   86.17M
in_int(spark_rhs100)                             204.31%     5.68ns  176.05M
in_str(presto_rhs1)                                          4.15ns  240.82M
in_str(spark_rhs1)                                85.00%     4.89ns  204.70M
in_str(presto_rhs3)                                        102.24ns    9.78M
in_str(spark_rhs3)                               213.48%    47.89ns   20.88M
in_str(presto_rhs10)                                       108.81ns    9.19M
in_str(spark_rhs10)                              215.88%    50.41ns   19.84M
in_str(presto_rhs100)                                      149.43ns    6.69M
in_str(spark_rhs100)                             207.02%    72.18ns   13.85M
============================================================================
```