### PR TITLE
Fix duckdb dictionary vector conversion.

### DIFF
--- a/velox/duckdb/conversion/DuckWrapper.cpp
+++ b/velox/duckdb/conversion/DuckWrapper.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/duckdb/conversion/DuckWrapper.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/duckdb/conversion/DuckConversion.h"
 #include "velox/external/duckdb/duckdb.hpp"
 #include "velox/external/duckdb/tpch/include/tpch-extension.hpp"
@@ -106,7 +107,8 @@ VectorPtr convert(
     ::duckdb::Vector& duckVector,
     const TypePtr& veloxType,
     size_t size,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    uint8_t* validity = nullptr) {
   auto vectorType = duckVector.GetVectorType();
   switch (vectorType) {
     case ::duckdb::VectorType::FLAT_VECTOR: {
@@ -125,7 +127,8 @@ VectorPtr convert(
           duckVector.GetType() == LogicalTypeId::DATE ||
           duckVector.GetType() == LogicalTypeId::VARCHAR) {
         for (auto i = 0; i < size; i++) {
-          if (duckValidity.RowIsValid(i)) {
+          if (duckValidity.RowIsValid(i) &&
+              (!validity || bits::isBitSet(validity, i))) {
             flatResult->set(i, OP::toVelox(duckData[i]));
           }
         }
@@ -151,7 +154,23 @@ VectorPtr convert(
       for (auto i = 0; i < size; i++) {
         maxIndex = std::max(maxIndex, (vector_size_t)selection.get_index(i));
       }
-      auto base = convert<OP>(child, veloxType, maxIndex + 1, pool);
+      VectorPtr base;
+      // Unused dictionary elements can be uninitialized. That can cause
+      // errors if we try to decode them. Here we create a bitmap of
+      // used values to avoid that.
+      if (child.GetType() == LogicalTypeId::HUGEINT ||
+          child.GetType() == LogicalTypeId::TIMESTAMP ||
+          child.GetType() == LogicalTypeId::DATE ||
+          child.GetType() == LogicalTypeId::VARCHAR) {
+        std::vector<uint8_t> validity((maxIndex + 7) / 8, 0);
+        auto validity_ptr = validity.data();
+        for (auto i = 0; i < size; i++) {
+          bits::setBit(validity_ptr, selection.get_index(i));
+        }
+        base = convert<OP>(child, veloxType, maxIndex + 1, pool, validity_ptr);
+      } else {
+        base = convert<OP>(child, veloxType, maxIndex + 1, pool);
+      }
 
       auto indices = AlignedBuffer::allocate<vector_size_t>(size, pool);
       memcpy(

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "velox/duckdb/conversion/DuckWrapper.h"
+#include "velox/external/duckdb/duckdb.hpp"
+#include "velox/vector/tests/VectorMaker.h"
+
 #include <gtest/gtest.h>
 
 using namespace facebook::velox;
@@ -192,4 +195,33 @@ TEST_F(BaseDuckWrapperTest, tpchSF1) {
   verifyUnaryResult<StringView>(
       "SELECT l_comment FROM lineitem LIMIT 1",
       {StringView("egular courts above the")});
+}
+
+TEST_F(BaseDuckWrapperTest, dictConversion) {
+  ::duckdb::Vector data(::duckdb::LogicalTypeId::VARCHAR, 5);
+  auto dataPtr =
+      reinterpret_cast<::duckdb::string_t*>(data.GetBuffer()->GetData());
+  // Make dirty data which shouldn't be accessed.
+  memset(dataPtr, 0xAB, sizeof(::duckdb::string_t) * 5);
+  dataPtr[2] = ::duckdb::string_t("value1");
+  dataPtr[4] = ::duckdb::string_t("value2");
+
+  // Turn vector into dictionary.
+  ::duckdb::SelectionVector sel(5);
+  sel.set_index(0, 2);
+  sel.set_index(1, 4);
+  sel.set_index(2, 2);
+  sel.set_index(3, 4);
+  sel.set_index(4, 2);
+  data.Slice(sel, 5);
+
+  auto actual = toVeloxVector(5, data, VarcharType::create(), pool_.get());
+
+  test::VectorMaker maker(pool_.get());
+  std::vector<std::string> expectedData(
+      {"value1", "value2", "value1", "value2", "value1"});
+  auto expected = maker.flatVector(expectedData);
+  for (auto i = 0; i < actual->size(); i++) {
+    ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i));
+  }
 }


### PR DESCRIPTION
In the child of a DuckDB dictionary vector, only the values that are actually pointed to by the dictionary need to be initialized. This means this vector can have uninitialized values that shouldn't be decoded by DuckDB to Velox vector converter. Currently, the converter may dereference invalid pointers during dictionary encoded varchar vector conversion.

This patch introduces an additional validity bitmap to convert only valid dictionary values when non-trivial conversion is used.