### PR TITLE
Use raw_vector as vector type for VectorHasher and HashLookup

### DIFF
--- a/velox/common/base/RawVector.h
+++ b/velox/common/base/RawVector.h
@@ -125,6 +125,21 @@ class raw_vector {
     }
   }
 
+  auto begin() const {
+    return &data_[0];
+  }
+
+  auto end() const {
+    return &data_[size_];
+  }
+
+  T& back() {
+    return data_[size_ - 1];
+  }
+  const T& back() const {
+    return data_[size_ - 1];
+  }
+
  private:
   // Adds 'bytes' to the address 'pointer'.
   inline T* addBytes(T* pointer, int32_t bytes) {

--- a/velox/common/tests/RawVectorTest.cpp
+++ b/velox/common/tests/RawVectorTest.cpp
@@ -87,3 +87,15 @@ TEST(RawVectorTest, iota) {
   // Larger sizes are allocated in 'storage'.
   EXPECT_FALSE(storage.empty());
 }
+
+TEST(RawVectorTest, iterator) {
+  raw_vector<int> data;
+  data.push_back(11);
+  data.push_back(22);
+  data.push_back(33);
+  int32_t sum = 0;
+  for (auto d : data) {
+    sum += d;
+  }
+  EXPECT_EQ(66, sum);
+}

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -111,7 +111,7 @@ class HashBuild final : public Operator {
   bool analyzeKeys_;
 
   // Temporary space for hash numbers.
-  std::vector<uint64_t> hashes_;
+  raw_vector<uint64_t> hashes_;
 
   // Set of active rows during addInput().
   SelectivityVector activeRows_;

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -39,6 +39,6 @@ class HashPartitionFunction : public core::PartitionFunction {
 
   // Reusable memory.
   SelectivityVector rows_;
-  std::vector<uint64_t> hashes_;
+  raw_vector<uint64_t> hashes_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -144,7 +144,7 @@ class HashProbe : public Operator {
   DecodedVector valueIdDecoder_;
 
   // Temporary for de-duplicating value ids for dictionary inputs.
-  std::vector<uint64_t> deduppedHashes_;
+  raw_vector<uint64_t> deduppedHashes_;
 
   // Rows to apply 'filter_' to.
   SelectivityVector filterRows_;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -37,14 +37,14 @@ struct HashLookup {
 
   // One entry per aggregation or join key
   const std::vector<std::unique_ptr<VectorHasher>>& hashers;
-  std::vector<vector_size_t> rows;
+  raw_vector<vector_size_t> rows;
   // Hash number for all input rows.
-  std::vector<uint64_t> hashes;
+  raw_vector<uint64_t> hashes;
   // If using valueIds, list of concatenated valueIds. 1:1 with 'hashes'.
-  std::vector<uint64_t> normalizedKeys;
+  raw_vector<uint64_t> normalizedKeys;
   // Hit for each row of input. nullptr if no hit. Points to the
   // corresponding group row.
-  std::vector<char*> hits;
+  raw_vector<char*> hits;
   std::vector<vector_size_t> newGroups;
 };
 
@@ -75,8 +75,8 @@ class BaseHashTable {
       return lastRow == rows->size();
     }
 
-    const std::vector<vector_size_t>* rows;
-    const std::vector<char*>* hits;
+    const raw_vector<vector_size_t>* rows;
+    const raw_vector<char*>* hits;
     char* nextHit{nullptr};
     vector_size_t lastRow{0};
   };

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -18,6 +18,7 @@
 #include <folly/container/F14Set.h>
 
 #include <velox/type/Filter.h>
+#include "velox/common/base/RawVector.h"
 #include "velox/exec/Operator.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
@@ -172,7 +173,7 @@ class VectorHasher {
       const BaseVector& values,
       const SelectivityVector& rows,
       bool mix,
-      std::vector<uint64_t>* result);
+      raw_vector<uint64_t>* result);
 
   // Computes a normalized key for 'rows' in 'values' and stores this
   // in 'result'. If this is not the first hasher with normalized
@@ -185,7 +186,7 @@ class VectorHasher {
   bool computeValueIds(
       const BaseVector& values,
       SelectivityVector& rows,
-      std::vector<uint64_t>* result);
+      raw_vector<uint64_t>* result);
 
   // Updates the value id in 'result' for values in 'decoded' at
   // positions in 'rows'. If some value does not have an id, result is
@@ -197,8 +198,8 @@ class VectorHasher {
   void lookupValueIds(
       const DecodedVector& decoded,
       SelectivityVector& rows,
-      std::vector<uint64_t>& cachedHashes,
-      std::vector<uint64_t>* result) const;
+      raw_vector<uint64_t>& cachedHashes,
+      raw_vector<uint64_t>* result) const;
 
   // Returns true if either range or distinct values have not overflowed.
   bool mayUseValueIds() const {
@@ -325,7 +326,7 @@ class VectorHasher {
   void lookupValueIdsTyped(
       const DecodedVector& decoded,
       SelectivityVector& rows,
-      std::vector<uint64_t>& cachedHashes,
+      raw_vector<uint64_t>& cachedHashes,
       uint64_t* result) const;
 
   template <typename T>
@@ -451,7 +452,7 @@ class VectorHasher {
   TypePtr type_;
   const TypeKind typeKind_;
   DecodedVector decoded_;
-  std::vector<uint64_t> cachedHashes_;
+  raw_vector<uint64_t> cachedHashes_;
 
   // Members for fast map to int domain for array/normalized key.
   // Maximum integer mapping. If distinct count exceeds this,
@@ -459,13 +460,16 @@ class VectorHasher {
   uint32_t rangeSize_ = 0;
 
   // Multiply int mapping by this before adding it to array index/normalized ey.
-  uint64_t multiplier_;
+  uint64_t multiplier_ = 1;
 
   // true if the mapping is simply value - min_.
   bool isRange_ = false;
 
   // True if 'min_' and 'max_' are initialized.
   bool hasRange_ = false;
+
+  // Maximum character size of a string that can fit the range.
+  uint32_t rangeMaxChars_ = 0;
 
   // True when range or distinct mapping is not possible or practical.
   bool rangeOverflow_ = false;
@@ -494,7 +498,6 @@ bool VectorHasher::computeValueIdForRows<StringView>(
 
 template <>
 void VectorHasher::analyzeValue(StringView value);
-
 template <>
 inline bool VectorHasher::tryMapToRange(
     const StringView* /*values*/,
@@ -575,6 +578,12 @@ inline bool VectorHasher::tryMapToRange(
   });
   return true;
 }
+
+template <>
+bool VectorHasher::tryMapToRange(
+    const StringView* /*values*/,
+    const SelectivityVector& /*rows*/,
+    uint64_t* /*result*/);
 
 template <>
 bool VectorHasher::makeValueIdsFlatNoNulls<bool>(

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -69,7 +69,7 @@ void benchmarkComputeValueIds(bool withNulls) {
       [](vector_size_t row) { return row % 17; },
       withNulls ? test::VectorMaker::nullEvery(7) : nullptr);
 
-  std::vector<uint64_t> hashes(size);
+  raw_vector<uint64_t> hashes(size);
   SelectivityVector rows(size);
   hasher.computeValueIds(*values, rows, &hashes);
   hasher.enableValueRange(1, 0);
@@ -148,7 +148,7 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
   uint64_t multiplier = 1;
   for (int i = 0; i < 4; i++) {
     auto hasher = hashers[i].get();
-    std::vector<uint64_t> result(size);
+    raw_vector<uint64_t> result(size);
     auto ok = hasher->computeValueIds(*vectors[i], allRows, &result);
     folly::doNotOptimizeAway(ok);
 
@@ -156,7 +156,7 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
   }
   suspender.dismiss();
 
-  std::vector<uint64_t> result(size);
+  raw_vector<uint64_t> result(size);
   for (int i = 0; i < 10'000; i++) {
     for (int j = 0; j < 4; j++) {
       auto hasher = hashers[j].get();

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -199,7 +199,7 @@ class HashTableTest : public testing::Test {
       int32_t tableOffset,
       HashTable<true>* table) {
     int32_t batchSize = batches[0]->size();
-    std::vector<uint64_t> dummy(batchSize);
+    raw_vector<uint64_t> dummy(batchSize);
     int32_t batchOffset = 0;
     rowOfKey_.resize(tableOffset + batchSize * batches.size());
     auto rowContainer = table->rows();
@@ -337,7 +337,7 @@ class HashTableTest : public testing::Test {
     int32_t numProbed = 0;
     int32_t numHit = 0;
     DecodedVector decoded;
-    std::vector<uint64_t> scratch;
+    raw_vector<uint64_t> scratch;
     auto& hashers = topTable_->hashers();
     for (auto batchIndex = 0; batchIndex < batches_.size(); ++batchIndex) {
       auto batch = batches_[batchIndex];

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -279,7 +279,7 @@ TEST_F(RowContainerTest, types) {
     auto extracted = copy->childAt(column);
     extracted->resize(kNumRows);
     data->extractColumn(rows.data(), rows.size(), column, extracted);
-    std::vector<uint64_t> hashes(kNumRows);
+    raw_vector<uint64_t> hashes(kNumRows);
     auto source = batch->childAt(column);
     auto columnType = batch->type()->as<TypeKind::ROW>().childAt(column);
     VectorHasher hasher(columnType, column);


### PR DESCRIPTION
Uses raw_vector which is SIMD padded and aligned for bulk hashing and lookup.

Fixes undefined behavior asan errors with count leading zeros.