### PR TITLE
Add URL extract_* Presto functions.

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   ElementAt.cpp
   FilterFunctions.cpp
   FromUnixTime.cpp
+  GreatestLeast.cpp
   InPredicate.cpp
   Map.cpp
   MapConcat.cpp
@@ -45,10 +46,10 @@ add_library(
   Subscript.cpp
   ToUtf8.cpp
   Transform.cpp
+  URLFunctions.cpp
   VectorArithmetic.cpp
   VectorFunctions.cpp
-  WidthBucketArray.cpp
-  GreatestLeast.cpp)
+  WidthBucketArray.cpp)
 
 target_link_libraries(
   velox_functions_prestosql

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -27,6 +27,7 @@
 #include "velox/functions/prestosql/SplitPart.h"
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/prestosql/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/URLFunctions.h"
 
 namespace facebook::velox::functions {
 
@@ -95,6 +96,22 @@ void registerFunctions() {
       Varchar>({"parse_datetime"});
 
   registerFunction<CardinalityFunction, int64_t, HyperLogLog>({"cardinality"});
+
+  // Url Functions.
+  registerFunction<UrlExtractHostFunction, Varchar, Varchar>(
+      {"url_extract_host"});
+  registerFunction<UrlExtractFragmentFunction, Varchar, Varchar>(
+      {"url_extract_fragment"});
+  registerFunction<UrlExtractPathFunction, Varchar, Varchar>(
+      {"url_extract_path"});
+  registerFunction<UrlExtractParameterFunction, Varchar, Varchar, Varchar>(
+      {"url_extract_parameter"});
+  registerFunction<UrlExtractProtocolFunction, Varchar, Varchar>(
+      {"url_extract_protocol"});
+  registerFunction<UrlExtractPortFunction, int64_t, Varchar>(
+      {"url_extract_port"});
+  registerFunction<UrlExtractQueryFunction, Varchar, Varchar>(
+      {"url_extract_query"});
 
   registerArithmeticFunctions();
   registerCheckedArithmeticFunctions();

--- a/velox/functions/prestosql/URLFunctions.cpp
+++ b/velox/functions/prestosql/URLFunctions.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "URLFunctions.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::functions {
+
+bool matchAuthorityAndPath(
+    const boost::cmatch& urlMatch,
+    boost::cmatch& authAndPathMatch,
+    boost::cmatch& authorityMatch,
+    bool& hasAuthority) {
+  static const boost::regex kAuthorityAndPathRegex("//([^/]*)(/.*)?");
+  auto authorityAndPath = submatch(urlMatch, 2);
+  if (!boost::regex_match(
+          authorityAndPath.begin(),
+          authorityAndPath.end(),
+          authAndPathMatch,
+          kAuthorityAndPathRegex)) {
+    // Does not start with //, doesn't have authority.
+    hasAuthority = false;
+    return true;
+  }
+
+  static const boost::regex kAuthorityRegex(
+      "(?:([^@:]*)(?::([^@]*))?@)?" // username, password.
+      "(\\[[^\\]]*\\]|[^\\[:]*)" // host (IP-literal (e.g. '['+IPv6+']',
+      // dotted-IPv4, or named host).
+      "(?::(\\d*))?"); // port.
+
+  const auto authority = authAndPathMatch[1];
+  if (!boost::regex_match(
+          authority.first, authority.second, authorityMatch, kAuthorityRegex)) {
+    return false; // Invalid URI Authority.
+  }
+
+  hasAuthority = true;
+
+  return true;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/URLFunctions.h
+++ b/velox/functions/prestosql/URLFunctions.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/regex.hpp>
+#include <cctype>
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+FOLLY_ALWAYS_INLINE StringView submatch(const boost::cmatch& match, int idx) {
+  const auto& sub = match[idx];
+  return StringView(sub.first, sub.length());
+}
+
+template <typename TInString>
+bool parse(const TInString& rawUrl, boost::cmatch& match) {
+  static const boost::regex kUriRegex(
+      "([a-zA-Z][a-zA-Z0-9+.-]*):" // scheme:
+      "([^?#]*)" // authority and path
+      "(?:\\?([^#]*))?" // ?query
+      "(?:#(.*))?"); // #fragment
+
+  return boost::regex_match(rawUrl.data(), match, kUriRegex);
+}
+
+} // namespace
+
+bool matchAuthorityAndPath(
+    const boost::cmatch& urlMatch,
+    boost::cmatch& authAndPathMatch,
+    boost::cmatch& authorityMatch,
+    bool& hasAuthority);
+
+template <typename T>
+struct UrlExtractProtocolFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+    } else {
+      result.setNoCopy(submatch(match, 1));
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct UrlExtractFragmentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+    } else {
+      result.setNoCopy(submatch(match, 4));
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct UrlExtractHostFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+      return true;
+    }
+    boost::cmatch authAndPathMatch;
+    boost::cmatch authorityMatch;
+    bool hasAuthority;
+
+    if (matchAuthorityAndPath(
+            match, authAndPathMatch, authorityMatch, hasAuthority) &&
+        hasAuthority) {
+      result.setNoCopy(submatch(authorityMatch, 3));
+    } else {
+      result.setEmpty();
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct UrlExtractPortFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      return false;
+    }
+
+    boost::cmatch authAndPathMatch;
+    boost::cmatch authorityMatch;
+    bool hasAuthority;
+    if (matchAuthorityAndPath(
+            match, authAndPathMatch, authorityMatch, hasAuthority) &&
+        hasAuthority) {
+      auto port = submatch(authorityMatch, 4);
+      if (!port.empty()) {
+        try {
+          result = to<int64_t>(port);
+          return true;
+        } catch (folly::ConversionError const&) {
+        }
+      }
+    }
+    return false;
+  }
+};
+
+template <typename T>
+struct UrlExtractPathFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+      return true;
+    }
+
+    boost::cmatch authAndPathMatch;
+    boost::cmatch authorityMatch;
+    bool hasAuthority;
+
+    if (matchAuthorityAndPath(
+            match, authAndPathMatch, authorityMatch, hasAuthority)) {
+      if (hasAuthority) {
+        result.setNoCopy(submatch(authAndPathMatch, 2));
+      } else {
+        result.setNoCopy(submatch(match, 2));
+      }
+    }
+
+    return true;
+  }
+};
+
+template <typename T>
+struct UrlExtractQueryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+      return true;
+    }
+
+    auto query = submatch(match, 3);
+    result.setNoCopy(query);
+    return true;
+  }
+};
+
+template <typename T>
+struct UrlExtractParameterFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& param) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      result.setEmpty();
+      return false;
+    }
+
+    auto query = submatch(match, 3);
+    if (!query.empty()) {
+      // Parse query string.
+      static const boost::regex kQueryParamRegex(
+          "(^|&)" // start of query or start of parameter "&"
+          "([^=&]*)=?" // parameter name and "=" if value is expected
+          "([^=&]*)" // parameter value
+          "(?=(&|$))" // forward reference, next should be end of query or
+                      // start of next parameter
+      );
+
+      const boost::cregex_iterator begin(
+          query.data(), query.data() + query.size(), kQueryParamRegex);
+      boost::cregex_iterator end;
+
+      for (auto it = begin; it != end; ++it) {
+        if (it->length(2) != 0) { // key shouldnt be empty.
+          auto key = submatch((*it), 2);
+          if (param.compare(key) == 0) {
+            auto value = submatch((*it), 3);
+            result.setNoCopy(value);
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -66,3 +66,6 @@ add_executable(velox_functions_prestosql_benchmarks_map_input
                MapInputBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_input
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_benchmarks_url URLBenchmark.cpp)
+target_link_libraries(velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "folly/Uri.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/SimpleFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+namespace {
+
+template <typename Fn, typename TOutString, typename TInputString>
+FOLLY_ALWAYS_INLINE bool
+runURIFn(Fn func, TOutString& result, TInputString& url) {
+  try {
+    auto parsedUrl = folly::Uri(url);
+    auto datum = (parsedUrl.*func)();
+    result.resize(datum.size());
+    if (datum.size() != 0) {
+      std::strncpy(result.data(), datum.c_str(), datum.size());
+    }
+  } catch (const std::invalid_argument&) { // thrown if URI is invalid.
+    result.resize(0);
+  }
+
+  return true;
+}
+
+template <typename T>
+struct FollyUrlExtractFragmentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& urlString) {
+    return runURIFn(&folly::Uri::fragment, result, urlString);
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractHostFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& urlString) {
+    return runURIFn(&folly::Uri::host, result, urlString);
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractPathFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& urlString) {
+    return runURIFn(&folly::Uri::path, result, urlString);
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractQueryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& urlString) {
+    return runURIFn(&folly::Uri::query, result, urlString);
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractProtocolFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& urlString) {
+    return runURIFn(&folly::Uri::scheme, result, urlString);
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractPortFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Varchar>& url) {
+    try {
+      auto parsedUrl = folly::Uri(url);
+      result = parsedUrl.port();
+    } catch (const folly::ConversionError&) {
+      return false;
+    } catch (const std::invalid_argument& e) {
+      return false;
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct FollyUrlExtractParameterFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& param) {
+    try {
+      auto parsedUrl = folly::Uri(url);
+      auto params = parsedUrl.getQueryParams();
+
+      for (const auto& pair : params) {
+        if (std::string(param) == pair.first) {
+          result.resize(pair.second.length());
+          strncpy(result.data(), pair.second.c_str(), pair.second.length());
+        }
+      }
+    } catch (const std::invalid_argument& e) {
+      return false;
+    }
+    return false;
+  }
+};
+
+class UrlBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  UrlBenchmark() : FunctionBenchmarkBase() {
+    functions::registerFunctions();
+
+    registerFunction<FollyUrlExtractFragmentFunction, Varchar, Varchar>(
+        {"folly_url_extract_fragment"});
+    registerFunction<FollyUrlExtractHostFunction, Varchar, Varchar>(
+        {"folly_url_extract_host"});
+    registerFunction<FollyUrlExtractPathFunction, Varchar, Varchar>(
+        {"folly_url_extract_path"});
+    registerFunction<FollyUrlExtractQueryFunction, Varchar, Varchar>(
+        {"folly_url_extract_query"});
+    registerFunction<FollyUrlExtractProtocolFunction, Varchar, Varchar>(
+        {"folly_url_extract_protocol"});
+    registerFunction<FollyUrlExtractPortFunction, int64_t, Varchar>(
+        {"folly_url_extract_port"});
+    registerFunction<
+        FollyUrlExtractParameterFunction,
+        Varchar,
+        Varchar,
+        Varchar>({"folly_url_extract_parameter"});
+  }
+
+  void runUrlExtract(const std::string& fnName, bool isParameter = false) {
+    folly::BenchmarkSuspender suspender;
+
+    size_t size = 1000;
+    auto vectorUrls = vectorMaker_.flatVector<StringView>(
+        size,
+        [](auto row) {
+          // construct some pseudo random url
+          return StringView(fmt::format(
+              "http://somehost{}.com:8080/somepath{}/p.php?k1={}#Refi",
+              row,
+              row % 2,
+              row % 3));
+        },
+        nullptr);
+    auto constVector = BaseVector::createConstant("k1", size, pool());
+    auto rowVector = isParameter
+        ? vectorMaker_.rowVector({vectorUrls, constVector})
+        : vectorMaker_.rowVector({vectorUrls});
+
+    auto queryString = isParameter ? "{}(c0, c1)" : "{}(c0)";
+    auto exprSet =
+        compileExpression(fmt::format(queryString, fnName), rowVector->type());
+
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    uint32_t cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(folly_fragment) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_fragment");
+}
+
+BENCHMARK_RELATIVE(velox_fragment) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_fragment");
+}
+
+BENCHMARK(folly_host) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_host");
+}
+
+BENCHMARK_RELATIVE(velox_host) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_host");
+}
+
+BENCHMARK(folly_path) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_path");
+}
+
+BENCHMARK_RELATIVE(velox_path) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_path");
+}
+
+BENCHMARK(folly_query) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_query");
+}
+
+BENCHMARK_RELATIVE(velox_query) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_query");
+}
+
+BENCHMARK(folly_port) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_port");
+}
+
+BENCHMARK_RELATIVE(velox_port) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_port");
+}
+
+BENCHMARK(folly_protocol) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_protocol");
+}
+
+BENCHMARK_RELATIVE(velox_protocol) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_protocol");
+}
+
+BENCHMARK(folly_param) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("folly_url_extract_parameter", true);
+}
+
+BENCHMARK_RELATIVE(velox_param) {
+  UrlBenchmark benchmark;
+  benchmark.runUrlExtract("url_extract_parameter", true);
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ArrayIntersectTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
+  BitwiseTest.cpp
   CardinalityTest.cpp
   CeilFloorTest.cpp
   CoalesceTest.cpp
@@ -51,9 +52,9 @@ add_executable(
   SplitTest.cpp
   StringFunctionsTest.cpp
   TransformTest.cpp
+  URLFunctionsTest.cpp
   WidthBucketArrayTest.cpp
-  GreatestLeastTest.cpp
-  BitwiseTest.cpp)
+  GreatestLeastTest.cpp)
 
 add_test(velox_functions_test velox_functions_test)
 

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gmock/gmock.h>
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+using string_t = std::string;
+
+namespace facebook::velox {
+
+namespace {
+class URLFunctionsTest : public functions::test::FunctionBaseTest {
+ protected:
+  void validate(
+      const string_t& url,
+      const string_t expectedProtocol,
+      const string_t expectedHost,
+      const string_t expectedPath,
+      const string_t expectedFragment,
+      const string_t expectedQuery,
+      const std::optional<int32_t> expectedPort) {
+    const auto extractFn = [&](const string_t& fn,
+                               const std::optional<string_t>& a) {
+      return evaluateOnce<string_t>(fmt::format("url_extract_{}(c0)", fn), a);
+    };
+
+    const auto extractPort = [&](const std::optional<string_t>& a) {
+      return evaluateOnce<int64_t>("url_extract_port(c0)", a);
+    };
+
+    EXPECT_EQ(extractFn("protocol", url), expectedProtocol);
+    EXPECT_EQ(extractFn("host", url).value(), expectedHost);
+    EXPECT_EQ(extractFn("path", url), expectedPath);
+    EXPECT_EQ(extractFn("fragment", url), expectedFragment);
+    EXPECT_EQ(extractFn("query", url), expectedQuery);
+    EXPECT_EQ(extractPort(url), expectedPort);
+  }
+};
+
+TEST_F(URLFunctionsTest, validateURL) {
+  validate(
+      "http://example.com/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      "example.com",
+      "/path1/p.php",
+      "Ref1",
+      "k1=v1&k2=v2",
+      std::nullopt);
+  validate(
+      "http://example.com/path1/p.php?",
+      "http",
+      "example.com",
+      "/path1/p.php",
+      "",
+      "",
+      std::nullopt);
+  validate(
+      "HTTP://example.com/path1/p.php?",
+      "HTTP",
+      "example.com",
+      "/path1/p.php",
+      "",
+      "",
+      std::nullopt);
+  validate(
+      "http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      "example.com",
+      "/path1/p.php",
+      "Ref1",
+      "k1=v1&k2=v2",
+      8080);
+  validate(
+      "https://username@example.com",
+      "https",
+      "example.com",
+      "",
+      "",
+      "",
+      std::nullopt);
+  validate(
+      "https:/auth/login.html",
+      "https",
+      "",
+      "/auth/login.html",
+      "",
+      "",
+      std::nullopt);
+  validate("foo", "", "", "", "", "", std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, extractParameter) {
+  const auto extractParam = [&](const std::optional<std::string>& a,
+                                const std::optional<std::string>& b) {
+    return evaluateOnce<std::string>("url_extract_parameter(c0, c1)", a, b);
+  };
+
+  EXPECT_EQ(
+      extractParam("http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "k2"),
+      "v2");
+  EXPECT_EQ(
+      extractParam(
+          "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k1"),
+      "v1");
+  EXPECT_EQ(
+      extractParam(
+          "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k3"),
+      "");
+  EXPECT_EQ(
+      extractParam(
+          "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k6"),
+      std::nullopt);
+  EXPECT_EQ(extractParam("foo", ""), std::nullopt);
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
URL extract functions are otpimized to use zero string copy and reduce number of regexp's as much as possible. Benchmark results against folly:uri are as below:

```
============================================================================
/Users/kpai/src/Velox/velox/functions/prestosql/benchmarks/URLBenchmark.cpprelative  time/iter  iters/s
============================================================================
folly_fragment                                             749.92ms     1.33
velox_fragment                                   417.53%   179.61ms     5.57
folly_host                                                 747.69ms     1.34
velox_host                                       149.12%   501.39ms     1.99
folly_path                                                 752.88ms     1.33
velox_path                                       147.99%   508.73ms     1.97
folly_query                                                743.80ms     1.34
velox_query                                      406.35%   183.04ms     5.46
folly_port                                                 744.74ms     1.34
velox_port                                       136.14%   547.04ms     1.83
folly_protocol                                             747.89ms     1.34
velox_protocol                                   416.03%   179.77ms     5.56
folly_param                                                   1.17s  855.53m
velox_param                                      315.45%   370.53ms     2.70
============================================================================
```