### PR TITLE
Add benchmark to measure Map type argument dispatch cost in simple functions

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -241,7 +241,7 @@ struct IMapVal {
   static std::shared_ptr<const Type> veloxType() {
     return MAP(UdfToType<KEY>::veloxType(), UdfToType<VAL>::veloxType());
   }
-  using container_t = typename std::unordered_map<KEY, std::optional<VAL>>;
+  using container_t = typename folly::F14FastMap<KEY, std::optional<VAL>>;
   using iterator = typename container_t::iterator;
   using reference = typename container_t::reference;
   using const_iterator = typename container_t::const_iterator;

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -61,3 +61,8 @@ target_link_libraries(velox_functions_prestosql_benchmarks_bitwise
 add_executable(velox_functions_prestosql_benchmarks_in InBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_in
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_map_input
+               MapInputBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_map_input
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/VectorFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class MapSumValuesAndKeysVector : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    auto arg = args.at(0);
+
+    exec::LocalDecodedVector mapHolder(context, *arg, rows);
+    auto mapVector = mapHolder->base()->as<MapVector>();
+    auto mapIndices = mapHolder->indices();
+
+    auto mapKeys = mapVector->mapKeys();
+    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, rows);
+    auto decodedMapKeys = mapKeysHolder.get();
+
+    auto mapValues = mapVector->mapValues();
+    exec::LocalDecodedVector mapValuesHolder(context, *mapValues, rows);
+    auto decodedMapValues = mapValuesHolder.get();
+
+    auto rawOffsets = mapVector->rawOffsets();
+    auto rawSizes = mapVector->rawSizes();
+
+    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
+    auto flatResult = (*result)->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      size_t mapIndex = mapIndices[row];
+      size_t offsetStart = rawOffsets[mapIndex];
+      size_t offsetEnd = offsetStart + rawSizes[mapIndex];
+
+      auto sum = 0;
+      for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
+        sum += decodedMapKeys->valueAt<int64_t>(offset);
+        sum += decodedMapValues->valueAt<int64_t>(offset);
+      }
+      flatResult->set(row, sum);
+    });
+  }
+};
+
+class NestedMapSumValuesAndKeysVector : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    auto arg = args.at(0);
+
+    auto mapVector = arg->as<MapVector>();
+    exec::LocalDecodedVector mapHolder(context, *arg, rows);
+    auto mapIndices = mapHolder->indices();
+
+    auto mapKeys = mapVector->mapKeys();
+    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, rows);
+    auto decodedMapKeys = mapKeysHolder.get();
+
+    auto mapValues = mapVector->mapValues();
+    exec::LocalDecodedVector mapValuesHolder(context, *mapValues, rows);
+    auto decodedMapValues = mapValuesHolder.get();
+
+    auto rawOffsets = mapVector->rawOffsets();
+    auto rawSizes = mapVector->rawSizes();
+
+    // Read inner map
+    auto innerMapVector = decodedMapValues->base()->as<MapVector>();
+    exec::LocalDecodedVector innerMapHolder(context, *innerMapVector, rows);
+    auto innerMapIndices = innerMapHolder->indices();
+
+    auto innerMapKeys = innerMapVector->mapKeys();
+    exec::LocalDecodedVector innerMapKeysHolder(context, *innerMapKeys, rows);
+    auto decodedInnerMapKeys = innerMapKeysHolder.get();
+
+    auto innerMapValues = innerMapVector->mapValues();
+    exec::LocalDecodedVector innerMapValuesHolder(
+        context, *innerMapValues, rows);
+    auto decodedInnerMapValues = innerMapValuesHolder.get();
+
+    auto innerRawOffsets = innerMapVector->rawOffsets();
+    auto innerRawSizes = innerMapVector->rawSizes();
+
+    // Prepare results
+    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
+    auto flatResult = (*result)->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      size_t mapIndex = mapIndices[row];
+      size_t offsetStart = rawOffsets[mapIndex];
+      size_t offsetEnd = offsetStart + rawSizes[mapIndex];
+
+      auto sum = 0;
+      for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
+        sum += decodedMapKeys->valueAt<int64_t>(offset);
+
+        size_t innerMapIndex = innerMapIndices[offset];
+        size_t innerOffsetStart = innerRawOffsets[innerMapIndex];
+        size_t innerOffsetEnd = innerOffsetStart + innerRawSizes[innerMapIndex];
+        for (size_t innerOffset = innerOffsetStart;
+             innerOffset < innerOffsetEnd;
+             ++innerOffset) {
+          sum += decodedInnerMapKeys->valueAt<int64_t>(innerOffset);
+          sum += decodedInnerMapValues->valueAt<int64_t>(innerOffset);
+        }
+      }
+
+      flatResult->set(row, sum);
+    });
+  }
+};
+
+// Simple function implementation
+template <typename T>
+struct MapSumValuesAndKeysSimple {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& out,
+      const arg_type<Map<int64_t, int64_t>>& map) {
+    out = 0;
+    for (const auto& entry : map) {
+      out += entry.first;
+      out += *entry.second;
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct NestedMapSumValuesAndKeysSimple {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& out,
+      const arg_type<Map<int64_t, Map<int64_t, int64_t>>>& map) {
+    out = 0;
+    for (const auto& innerMap : map) {
+      out += innerMap.first;
+      for (const auto& entry : *innerMap.second) {
+        out += entry.first;
+        out += *entry.second;
+      }
+    }
+    return true;
+  }
+};
+
+class MapInputBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  MapInputBenchmark() : FunctionBenchmarkBase() {
+    functions::registerVectorFunctions();
+
+    registerFunction<MapSumValuesAndKeysSimple, int64_t, Map<int64_t, int64_t>>(
+        {"map_sum_simple"});
+    facebook::velox::exec::registerVectorFunction(
+        "map_sum_vector",
+        {exec::FunctionSignatureBuilder()
+             .returnType("bigint")
+             .argumentType("map(bigint,bigint)")
+             .build()},
+        std::make_unique<MapSumValuesAndKeysVector>());
+
+    registerFunction<
+        NestedMapSumValuesAndKeysSimple,
+        int64_t,
+        Map<int64_t, Map<int64_t, int64_t>>>({"nested_map_sum_simple"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "nested_map_sum_vector",
+        {exec::FunctionSignatureBuilder()
+             .typeVariable("K")
+             .typeVariable("V")
+             .returnType("bigint")
+             .argumentType("map(K,V)")
+             .build()},
+        std::make_unique<NestedMapSumValuesAndKeysVector>());
+  }
+
+  RowVectorPtr makeMapDataMap() {
+    const vector_size_t size = 1'000;
+    auto mapVector = vectorMaker_.mapVector<int64_t, int64_t>(
+        size,
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; });
+
+    return vectorMaker_.rowVector({mapVector});
+  }
+
+  RowVectorPtr makeDataNestedMap() {
+    const vector_size_t size = 1000;
+    auto keysOuter = vectorMaker_.arrayVector<int64_t>(
+        size, [](auto) { return 3; }, [](auto row) { return row % 100; });
+
+    auto keysInner = vectorMaker_.arrayVector<int64_t>(
+        size,
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; });
+
+    auto valuesInner = vectorMaker_.arrayVector<int64_t>(
+        size,
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; });
+
+    auto rowVector =
+        vectorMaker_.rowVector({keysOuter, keysInner, valuesInner});
+
+    auto expression = compileExpression(
+        "map(c0, array_constructor ( map(c1, c2), map(c1, c2), map(c1, c2)))",
+        rowVector->type());
+
+    return vectorMaker_.rowVector({evaluate(expression, rowVector)});
+  }
+
+  void run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto rowVector = makeMapDataMap();
+    auto exprSet = compileExpression(
+        fmt::format("{}(c0)", functionName), rowVector->type());
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  void runNested(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto rowVector = makeDataNestedMap();
+    auto exprSet = compileExpression(
+        fmt::format("{}(c0)", functionName), rowVector->type());
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool hasSameResults(
+      ExprSet& expr1,
+      ExprSet& expr2,
+      const RowVectorPtr& rowVector) {
+    auto result1 = evaluate(expr1, rowVector);
+    auto result2 = evaluate(expr2, rowVector);
+    auto flatResults1 = result1->asFlatVector<int64_t>();
+    auto flatResults2 = result2->asFlatVector<int64_t>();
+
+    if (flatResults1->size() != flatResults2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < flatResults1->size(); i++) {
+      if (flatResults1->valueAt(i) != flatResults2->valueAt(i)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool testMapSum() {
+    auto rowVector = makeMapDataMap();
+    auto exprSet1 = compileExpression("map_sum_vector(c0)", rowVector->type());
+    auto exprSet2 = compileExpression("map_sum_simple(c0)", rowVector->type());
+    return hasSameResults(exprSet1, exprSet2, rowVector);
+  }
+
+  bool testNestedMapSum() {
+    auto rowVector = makeDataNestedMap();
+    auto exprSet1 =
+        compileExpression("nested_map_sum_vector(c0)", rowVector->type());
+    auto exprSet2 =
+        compileExpression("nested_map_sum_simple(c0)", rowVector->type());
+    return hasSameResults(exprSet1, exprSet2, rowVector);
+  }
+};
+
+BENCHMARK(mapSumVectorFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.run("map_sum_vector");
+}
+
+BENCHMARK_RELATIVE(mapSumSimpleFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.run("map_sum_simple");
+}
+
+BENCHMARK(nestedMapSumVectorFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.runNested("nested_map_sum_vector");
+}
+
+BENCHMARK_RELATIVE(nestedMapSumSimpleFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.runNested("nested_map_sum_simple");
+}
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  MapInputBenchmark benchmark;
+  if (benchmark.testNestedMapSum() && benchmark.testMapSum()) {
+    folly::runBenchmarks();
+  } else {
+    VELOX_UNREACHABLE("tests failed");
+  }
+  return 0;
+}


### PR DESCRIPTION
Add a benchmark to measure the cost of dispatching map to simple 
function interface. The benchmark simply sums all the keys and values
No special optimizations are added on the vector function side, the current
numbers are stunning! simple function is ~ 200X slower.
I changed the simple function interface to folly::F14FastMap based on @funrollloops 
suggestion in this diff as well which makes it 22X slower instead.

```
============================================================================
vectorFunction                                               2.72ms   368.27
simpleFunction                                     4.44%    61.16ms    16.35
============================================================================
```