### PR TITLE
Fix variantArrayToVector for large strings

### DIFF
--- a/velox/parse/VariantToVector.cpp
+++ b/velox/parse/VariantToVector.cpp
@@ -46,18 +46,15 @@ ArrayVectorPtr variantArrayToVectorImpl(
       variantArraySize,
       std::move(arrayElementsBuffer),
       std::vector<BufferPtr>());
-  auto stringBuffers = StringViewBufferHolder(pool);
 
   // Populate internal array elements (flat vector).
   for (vector_size_t i = 0; i < variantArraySize; i++) {
     if (!variantArray[i].isNull()) {
       // `getOwnedValue` copies the content to its internal buffers (in case of
       // string/StringView); no-op for other primitive types.
-      arrayElements->set(
-          i, stringBuffers.getOwnedValue(variantArray[i].value<KIND>()));
+      arrayElements->set(i, T(variantArray[i].value<KIND>()));
     }
   }
-  arrayElements->setStringBuffers(stringBuffers.moveBuffers());
 
   // Create ArrayVector around the FlatVector containing array elements.
   BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(1, pool, 0);

--- a/velox/parse/tests/VariantToVectorTest.cpp
+++ b/velox/parse/tests/VariantToVectorTest.cpp
@@ -118,6 +118,8 @@ TEST_F(VariantToVectorTest, varchar) {
   testCreateVector<TypeKind::VARCHAR>({
       variant::create<TypeKind::VARCHAR>("hello"),
       variant::create<TypeKind::VARCHAR>("world"),
+      variant::create<TypeKind::VARCHAR>(
+          "Some longer string that doesn't get inlined..."),
   });
 }
 


### PR DESCRIPTION
FlatVector<StringView::set() copies the string into internal string buffers,
hence, this method is safe and the caller doesn't need to worry about the
lifetime of the buffer referenced by the StringView. variantArrayToVector was
using this method as if it worked like setNoCopy which doesn't copy the string.
variantArrayToVector was overwriting the internal string buffers making
StringView entries in the vector point to memory that's no longer owned by
anyone.