### PR TITLE
Allow duplicate keys for spark maps created by map function

### DIFF
--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/VectorFunctions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions {
+void registerMapAllowingDuplicates() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_allow_duplicates, "map2");
+}
+}; // namespace facebook::velox::functions
 
 class MapTest : public FunctionBaseTest {};
 
@@ -102,6 +109,13 @@ TEST_F(MapTest, duplicateKeys) {
     ASSERT_TRUE(false) << "Expected an error";
   } catch (const VeloxUserError& e) {
     ASSERT_EQ(e.message(), "Duplicate map keys are not allowed");
+  }
+  // Trying the map version with allowing duplicates
+  facebook::velox::functions::registerMapAllowingDuplicates();
+  try {
+    evaluate<MapVector>("map2(c0, c1)", makeRowVector({keys, values}));
+  } catch (const VeloxUserError& e) {
+    ASSERT_TRUE(false) << "No error expected";
   }
 }
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -44,7 +44,8 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "array_contains");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, prefix + "element_at");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, prefix + "named_struct");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map_from_arrays");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_allow_duplicates, prefix + "map_from_arrays");
   // String functions.
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");


### PR DESCRIPTION
Summary: Spark allows duplicated keys in map.

Differential Revision: D32128411

