### PR TITLE
Use velox memory pool based allocator in Parquet reader.

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -168,7 +168,8 @@ size_t ParquetRowReader::estimatedRowSize() const {
 ParquetReader::ParquetReader(
     std::unique_ptr<dwio::common::InputStream> stream,
     const dwio::common::ReaderOptions& options)
-    : reader_(std::make_shared<::duckdb::ParquetReader>(
+    : allocator_(options.getMemoryPool()),
+      reader_(std::make_shared<::duckdb::ParquetReader>(
           allocator_,
           getFileSystem()->OpenStream(std::move(stream)))),
       pool_(options.getMemoryPool()) {

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/parquet/reader/duckdb/Allocator.h"
 #include "velox/dwio/parquet/reader/duckdb/InputStreamFileSystem.h"
 #include "velox/external/duckdb/parquet-amalgamation.hpp"
 
@@ -75,7 +76,7 @@ class ParquetReader : public dwio::common::Reader {
     return &fileSystem;
   }
 
-  ::duckdb::Allocator allocator_;
+  duckdb::VeloxPoolAllocator allocator_;
   std::shared_ptr<::duckdb::ParquetReader> reader_;
   memory::MemoryPool& pool_;
 

--- a/velox/dwio/parquet/reader/duckdb/Allocator.cpp
+++ b/velox/dwio/parquet/reader/duckdb/Allocator.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/duckdb/Allocator.h"
+
+namespace facebook::velox::duckdb {
+
+::duckdb::data_ptr_t veloxPoolAllocate(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::idx_t size) {
+  auto veloxPrivateData = dynamic_cast<PrivateVeloxAllocatorData*>(privateData);
+  VELOX_CHECK(veloxPrivateData);
+  return static_cast<::duckdb::data_ptr_t>(
+      veloxPrivateData->pool.allocate(size));
+}
+
+void veloxPoolFree(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::data_ptr_t pointer,
+    ::duckdb::idx_t size) {
+  auto veloxPrivateData = dynamic_cast<PrivateVeloxAllocatorData*>(privateData);
+  VELOX_CHECK(veloxPrivateData);
+  veloxPrivateData->pool.free(pointer, size);
+}
+
+::duckdb::data_ptr_t veloxPoolReallocate(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::data_ptr_t pointer,
+    ::duckdb::idx_t size) {
+  auto veloxPrivateData = dynamic_cast<PrivateVeloxAllocatorData*>(privateData);
+  VELOX_CHECK(veloxPrivateData);
+  // We don't have an old size to pass to reallocate. Here we pass
+  // 0 because it's not used by allocator. Alternatively, we would
+  // have to track sizes of all allocated segments in the private
+  // data.
+  return static_cast<::duckdb::data_ptr_t>(
+      veloxPrivateData->pool.reallocate(pointer, 0, size));
+}
+
+} // namespace facebook::velox::duckdb

--- a/velox/dwio/parquet/reader/duckdb/Allocator.h
+++ b/velox/dwio/parquet/reader/duckdb/Allocator.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+#include "velox/external/duckdb/duckdb.hpp"
+
+namespace facebook::velox::duckdb {
+
+struct PrivateVeloxAllocatorData : public ::duckdb::PrivateAllocatorData {
+  PrivateVeloxAllocatorData(memory::MemoryPool& pool_) : pool(pool_) {}
+
+  ~PrivateVeloxAllocatorData() override {}
+
+  memory::MemoryPool& pool;
+};
+
+::duckdb::data_ptr_t veloxPoolAllocate(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::idx_t size);
+
+void veloxPoolFree(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::data_ptr_t pointer,
+    ::duckdb::idx_t size);
+
+::duckdb::data_ptr_t veloxPoolReallocate(
+    ::duckdb::PrivateAllocatorData* privateData,
+    ::duckdb::data_ptr_t pointer,
+    ::duckdb::idx_t size);
+
+class VeloxPoolAllocator : public ::duckdb::Allocator {
+ public:
+  VeloxPoolAllocator(memory::MemoryPool& pool)
+      : ::duckdb::Allocator(
+            veloxPoolAllocate,
+            veloxPoolFree,
+            veloxPoolReallocate,
+            std::make_unique<PrivateVeloxAllocatorData>(pool)) {}
+};
+
+} // namespace facebook::velox::duckdb

--- a/velox/dwio/parquet/reader/duckdb/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/duckdb/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_dwio_parquet_reader_duckdb InputStreamFileHandle.cpp)
+add_library(velox_dwio_parquet_reader_duckdb Allocator.cpp
+                                             InputStreamFileHandle.cpp)
 
 target_link_libraries(velox_dwio_parquet_reader_duckdb velox_dwio_common duckdb
                       ${FMT})


### PR DESCRIPTION
Currently, Parquet reader uses the default DuckDB allocator. This patch introduces an allocator which uses Velox memory pools.