### PR TITLE
Test Row Group Skipping in SelectiveColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -87,6 +87,9 @@ class ColumnReader {
     return kEmpty;
   }
 
+  // Sets the streams of this and child readers to the first row of
+  // the row group at 'index'. This advances readers and touches the
+  // actual data, unlike setRowGroup().
   virtual void seekToRowGroup(uint32_t /*index*/) {
     VELOX_NYI();
   }

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -38,8 +38,7 @@ class SelectiveColumnReader : public ColumnReader {
       const EncodingKey& ek,
       StripeStreams& stripe,
       common::ScanSpec* scanSpec,
-      const TypePtr& type,
-      bool loadIndex = false);
+      const TypePtr& type);
 
   /**
    * Read the next group of values into a RowVector.
@@ -188,6 +187,20 @@ class SelectiveColumnReader : public ColumnReader {
     readOffset_ = readOffset;
   }
 
+  virtual void setReadOffsetRecursive(int32_t readOffset) {
+    setReadOffset(readOffset);
+  }
+
+  // Recursively sets 'isTopLevel_'. Recurses down non-nullable structs,
+  // otherwise only sets 'isTopLevel_' of 'this'
+  virtual void setIsTopLevel() {
+    isTopLevel_ = true;
+  }
+
+  bool isTopLevel() const {
+    return isTopLevel_;
+  }
+
   uint64_t initTimeClocks() const {
     return initTimeClocks_;
   }
@@ -229,6 +242,7 @@ class SelectiveColumnReader : public ColumnReader {
 
  protected:
   static constexpr int8_t kNoValueSize = -1;
+  static constexpr uint32_t kRowGroupNotSet = ~0;
 
   template <typename T>
   void ensureValuesCapacity(vector_size_t numRows);
@@ -278,6 +292,7 @@ class SelectiveColumnReader : public ColumnReader {
   char* copyStringValue(folly::StringPiece value);
 
   void ensureRowGroupIndex() const {
+    VELOX_CHECK(index_ || indexStream_, "Reader needs to have an index stream");
     if (indexStream_) {
       index_ = ProtoUtils::readProto<proto::RowIndex>(std::move(indexStream_));
     }
@@ -292,6 +307,7 @@ class SelectiveColumnReader : public ColumnReader {
   mutable std::unique_ptr<proto::RowIndex> index_;
   // Number of rows in a row group. Last row group may have fewer rows.
   uint32_t rowsPerRowGroup_;
+
   // Row number after last read row, relative to stripe start.
   vector_size_t readOffset_ = 0;
   // The rows to process in read(). References memory supplied by
@@ -326,6 +342,13 @@ class SelectiveColumnReader : public ColumnReader {
 
   // true if 'this' is in a state where gatValues can be called.
   bool mayGetValues_ = false;
+
+  // True if row numbers of 'this' correspond 1:1 to row numbers in
+  // the file. This is false inside lists, maps and nullable
+  // structs. If true, a skip of n rows can use row group indices to
+  // skip long distances. Lazy vectors will only be made for results
+  // of top level readers.
+  bool isTopLevel_{false};
 
   // Maps from position in non-null rows to a position in value
   // sequence with nulls included. Empty if no nulls.
@@ -384,8 +407,10 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
       uint32_t sequence) override {
-    return SelectiveColumnReader::build(
+    auto reader = SelectiveColumnReader::build(
         requestedType, dataType, stripe, scanSpec_, sequence);
+    reader->setIsTopLevel();
+    return reader;
   }
 
  private:

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -296,6 +296,9 @@ TEST_P(TestColumnReader, testBooleanWithNulls) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
@@ -341,6 +344,8 @@ TEST_P(TestColumnReader, testBooleanWithNullsFractional) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -399,6 +404,8 @@ TEST_P(TestColumnReader, testBooleanSkipsWithNulls) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
@@ -448,6 +455,8 @@ TEST_P(TestColumnReader, testByteWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -503,6 +512,8 @@ TEST_P(TestColumnReader, testBatchReusedSizeEnsured) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
@@ -539,6 +550,8 @@ TEST_P(TestColumnReader, testByteSkipsWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -598,6 +611,8 @@ TEST_P(TestColumnReader, testIntegerWithNulls) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {0x16, 0xf0};
@@ -645,6 +660,8 @@ TEST_P(TestColumnReader, testIntDictSkipNoNullsAllInDict) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
@@ -707,6 +724,8 @@ TEST_P(TestColumnReader, testIntDictSkipWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -793,6 +812,8 @@ TEST_P(TestColumnReader, testIntDictBoundary) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
@@ -856,6 +877,8 @@ TEST_P(StringReaderTests, testDictionaryWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, _, _)).WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {0x19, 0xf0};
@@ -929,6 +952,8 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   char data[1024];
@@ -1073,6 +1098,8 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char present[] = {0x16, 0xaa};
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
@@ -1307,6 +1334,8 @@ TEST_P(TestColumnReader, testSkipWithNulls) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {
@@ -1402,6 +1431,8 @@ TEST_P(StringReaderTests, testBinaryDirect) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -1458,6 +1489,8 @@ TEST_P(StringReaderTests, testBinaryDirectWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
@@ -1525,6 +1558,8 @@ TEST_P(TestColumnReader, testShortBlobError) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -1568,6 +1603,8 @@ TEST_P(StringReaderTests, testStringDirectShortBuffer) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
@@ -1625,6 +1662,8 @@ TEST_P(StringReaderTests, testStringDirectShortBufferWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
@@ -1697,6 +1736,8 @@ TEST_P(StringReaderTests, testStringDirectNullAcrossWindow) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
@@ -1771,6 +1812,8 @@ TEST_P(StringReaderTests, testStringDirectSkip) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
@@ -1836,6 +1879,8 @@ TEST_P(StringReaderTests, testStringDirectSkipWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
@@ -2797,7 +2842,7 @@ TEST_P(TestColumnReader, testFloatBatchNotAligned) {
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const float testValues[] = {1.0f, 2.5f, -100.125f};
@@ -2838,7 +2883,7 @@ TEST_P(TestColumnReader, testFloatWithNulls) {
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 13 non-nulls followed by 19 nulls
@@ -2907,7 +2952,7 @@ TEST_P(TestColumnReader, testFloatSkipWithNulls) {
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 2 non-nulls, 2 nulls, 2 non-nulls, 2 nulls
@@ -2994,7 +3039,7 @@ TEST_P(TestColumnReader, testDoubleWithNulls) {
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 13 non-nulls followed by 19 nulls
@@ -3068,7 +3113,7 @@ TEST_P(TestColumnReader, testDoubleSkipWithNulls) {
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 1 non-null, 5 nulls, 2 non-nulls
@@ -3498,6 +3543,8 @@ TEST_P(StringReaderTests, testStringDictUseBatchAfterClose) {
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
@@ -3606,6 +3653,8 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   std::array<char, 1024> data;
@@ -3759,6 +3808,8 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   std::array<char, 1024> data;


### PR DESCRIPTION
Adds a test with column values that allow row group (stride)
skipping. Fixes seekToRowGroup for struct reader for a column with
nulls.