### PR TITLE
[Draft] initial mapView and DecodedResults optimization

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -241,7 +241,7 @@ struct IMapVal {
   static std::shared_ptr<const Type> veloxType() {
     return MAP(UdfToType<KEY>::veloxType(), UdfToType<VAL>::veloxType());
   }
-  using container_t = typename std::unordered_map<KEY, std::optional<VAL>>;
+  using container_t = typename folly::F14FastMap<KEY, std::optional<VAL>>;
   using iterator = typename container_t::iterator;
   using reference = typename container_t::reference;
   using const_iterator = typename container_t::const_iterator;

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -76,4 +76,4 @@ target_link_libraries(velox_functions_prestosql_benchmarks_in
 add_executable(velox_functions_prestosql_benchmarks_map_input
                MapInputBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_input
-                      ${BENCHMARK_DEPENDENCIES_NO_FUNCTIONS})
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -23,6 +23,17 @@ set(BENCHMARK_DEPENDENCIES
     ${FOLLY_WITH_DEPENDENCIES}
     ${FOLLY_BENCHMARK})
 
+set(BENCHMARK_DEPENDENCIES_NO_FUNCTIONS
+    velox_functions_test_lib
+    velox_exec
+    velox_functions_prestosql
+    velox_exec_test_util
+    velox_vector_fuzzer
+    ${GTEST_BOTH_LIBRARIES}
+    ${gflags_LIBRARIES}
+    ${FOLLY_WITH_DEPENDENCIES}
+    ${FOLLY_BENCHMARK})
+
 add_executable(velox_functions_prestosql_benchmarks_array_contains
                ArrayContainsBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains
@@ -61,3 +72,8 @@ target_link_libraries(velox_functions_prestosql_benchmarks_bitwise
 add_executable(velox_functions_prestosql_benchmarks_in InBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_in
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_map_input
+               MapInputBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_map_input
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNCTIONS})

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/VectorFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+// Vector function implementation
+class MapSumValuesAndKeysVector : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    auto arg = args.at(0);
+
+    auto mapVector = arg->as<MapVector>();
+    exec::LocalDecodedVector mapHolder(context, *arg, rows);
+    auto mapIndices = mapHolder->indices();
+
+    auto mapKeys = mapVector->mapKeys();
+    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, rows);
+    auto decodedMapKeys = mapKeysHolder.get();
+
+    auto mapValues = mapVector->mapValues();
+    exec::LocalDecodedVector mapValuesHolder(context, *mapValues, rows);
+    auto decodedMapValues = mapKeysHolder.get();
+
+    auto rawOffsets = mapVector->rawOffsets();
+    auto rawSizes = mapVector->rawSizes();
+
+    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
+    auto flatResult = (*result)->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      size_t mapIndex = mapIndices[row];
+      size_t offsetStart = rawOffsets[mapIndex];
+      size_t offsetEnd = offsetStart + rawSizes[mapIndex];
+
+      auto sum = 0;
+      for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
+        sum += decodedMapKeys->valueAt<int64_t>(offset);
+        sum += decodedMapValues->valueAt<int64_t>(offset);
+      }
+      flatResult->set(row, sum);
+    });
+  }
+};
+
+// Simple function implementation
+template <typename T>
+struct MapSumValuesAndKeysSimple {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& out,
+      const arg_type<Map<int64_t, int64_t>>& map) {
+    out = 0;
+    for (const auto& entry : map) {
+      out += entry.first;
+      out += *entry.second;
+    }
+    return true;
+  }
+};
+
+class MapInputBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  MapInputBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<MapSumValuesAndKeysSimple, int64_t, Map<int64_t, int64_t>>(
+        {"map_sum_simple"});
+    facebook::velox::exec::registerVectorFunction(
+        "map_sum_vector",
+        {exec::FunctionSignatureBuilder()
+             .returnType("bigint")
+             .argumentType("map(bigint,bigint)")
+             .variableArity()
+             .build()},
+        std::make_unique<MapSumValuesAndKeysVector>());
+  }
+
+  RowVectorPtr makeData() {
+    const vector_size_t size = 1'000;
+    auto arrayVector = vectorMaker_.mapVector<int64_t, int64_t>(
+        size,
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; },
+        [](auto row) { return row % 100; });
+
+    return vectorMaker_.rowVector({arrayVector});
+  }
+
+  void run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto rowVector = makeData();
+    auto exprSet = compileExpression(
+        fmt::format("{}(c0)", functionName), rowVector->type());
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool test() {
+    auto rowVector = makeData();
+    auto exprSet1 =
+        compileExpression(fmt::format("map_sum_vector(c0)"), rowVector->type());
+    auto exprSet2 =
+        compileExpression(fmt::format("map_sum_simple(c0)"), rowVector->type());
+    auto result1 = evaluate(exprSet1, rowVector);
+    auto result2 = evaluate(exprSet2, rowVector);
+
+    auto flatResults1 = result1->asFlatVector<int64_t>();
+    auto flatResults2 = result2->asFlatVector<int64_t>();
+
+    if (flatResults1->size() != flatResults2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < flatResults1->size(); i++) {
+      if (flatResults1->valueAt(i) != flatResults2->valueAt(i)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+BENCHMARK(vectorFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.run("map_sum_vector");
+}
+
+BENCHMARK_RELATIVE(simpleFunction) {
+  MapInputBenchmark benchmark;
+  benchmark.run("map_sum_simple");
+}
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  MapInputBenchmark benchmark;
+  if (benchmark.test()) {
+    folly::runBenchmarks();
+  }
+  return 0;
+}


### PR DESCRIPTION
initial mapView implementation.
numbers for the benchmarks are better but there is still a significant gap!
3X-4X 
will try to optimize it a bit more.
```
============================================================================
mapSumVectorFunction                                               2.81ms   356.33
mapSumSimpleFunction                                    38.48%     7.29ms   137.11
nestedMapSumVectorFunction                                      5.98ms   167.15
nestedMapSumSimpleFunction                           25.83%    23.16ms    43.17
============================================================================
```
- this need to be rebased on top of arrayView and the benchmark diffs and reorg shared components.
- iterators for values only and keys only can be created.

In order to understand the 3x difference i added a benchmark where a vector reader is defined inside a vector function 
and the whole function is written using the simple function mapView reader. (see the new nested_map_sum_vector_mapview in the diff) . results are the same

```
============================================================================
nestedSumVectorFunction                                      7.47ms   133.87
nestedSumSimpleFunction                           29.49%    25.33ms    39.48
nestedSumVectorFunctionMapView                    34.26%    21.80ms    45.87
============================================================================
```
next i will compare this mapView with @mbasmanova  initial solution to see if its faster.

I tried the prev approach of masha and its same numbers:
```
============================================================================
vectorFunction                                               3.69ms   271.15
simpleFunction                                    38.49%     9.58ms   104.37
============================================================================
```

my suspicion is that the usage of decodedResults Vs decoder. and the way the index() function 
is computed in decoder is more efficient, in addition to the copying done for the decodedResults
allocation/deallocation. could all be the reason of the slowdown
I will investigate that next.'

update: by updating the decodedResults to avoid un-needed materialization of indicies() we get 2x more speedup and the current results are as the following:
```
============================================================================
vectorFunction                                               2.87ms   347.98
simpleFunction                                    84.87%     3.39ms   295.32
nestedSumVectorFunction                                      5.95ms   168.09
nestedSumSimpleFunction                           54.20%    10.98ms    91.11
nestedSumVectorFunctionMapView                    86.87%     6.85ms   146.02
============================================================================
```
