### PR TITLE
Tokenization logic to support Joda datetime

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -13,9 +13,10 @@
 # limitations under the License.
 find_library(RE2 re2 REQUIRED)
 
-add_library(velox_functions_lib IsNull.cpp LambdaFunctionUtil.cpp
-                                Re2Functions.cpp
-                                StringEncodingUtils.cpp)
+add_library(
+  velox_functions_lib IsNull.cpp LambdaFunctionUtil.cpp Re2Functions.cpp
+                      StringEncodingUtils.cpp JodaDateTime.cpp)
+
 target_link_libraries(velox_functions_lib velox_vector ${RE2})
 
 add_subdirectory(string)

--- a/velox/functions/lib/JodaDateTime.cpp
+++ b/velox/functions/lib/JodaDateTime.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/JodaDateTime.h"
+#include <cctype>
+#include <unordered_map>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+static constexpr size_t kJodaReserveSize{8};
+
+inline JodaFormatSpecifier getSpecifier(char c) {
+  static std::unordered_map<char, JodaFormatSpecifier> specifierMap{
+      {'G', JodaFormatSpecifier::ERA},
+      {'C', JodaFormatSpecifier::CENTURY_OF_ERA},
+      {'Y', JodaFormatSpecifier::YEAR_OF_ERA},
+      {'x', JodaFormatSpecifier::WEEK_YEAR},
+      {'w', JodaFormatSpecifier::WEEK_OF_WEEK_YEAR},
+      {'e', JodaFormatSpecifier::DAY_OF_WEEK},
+      {'E', JodaFormatSpecifier::DAY_OF_WEEK_TEXT},
+      {'y', JodaFormatSpecifier::YEAR},
+      {'D', JodaFormatSpecifier::DAY_OF_YEAR},
+      {'M', JodaFormatSpecifier::MONTH_OF_YEAR},
+      {'d', JodaFormatSpecifier::DAY_OF_MONTH},
+      {'a', JodaFormatSpecifier::HALFDAY_OF_DAY},
+      {'K', JodaFormatSpecifier::HOUR_OF_HALFDAY},
+      {'h', JodaFormatSpecifier::CLOCK_HOUR_OF_HALFDAY},
+      {'H', JodaFormatSpecifier::HOUR_OF_DAY},
+      {'k', JodaFormatSpecifier::CLOCK_HOUR_OF_DAY},
+      {'m', JodaFormatSpecifier::MINUTE_OF_HOUR},
+      {'s', JodaFormatSpecifier::SECOND_OF_MINUTE},
+      {'S', JodaFormatSpecifier::FRACTION_OF_SECOND},
+      {'z', JodaFormatSpecifier::TIMEZONE},
+      {'Z', JodaFormatSpecifier::TIMEZONE_OFFSET_ID},
+  };
+
+  auto it = specifierMap.find(c);
+  if (it == specifierMap.end()) {
+    VELOX_USER_FAIL("Illegal pattern component: '{}'", c);
+  }
+  return it->second;
+}
+
+} // namespace
+
+JodaFormatter::JodaFormatter(std::string format) : format_(std::move(format)) {
+  literalTokens_.reserve(kJodaReserveSize);
+  patternTokens_.reserve(kJodaReserveSize);
+  patternTokensCount_.reserve(kJodaReserveSize);
+
+  if (format_.empty()) {
+    VELOX_USER_FAIL("Invalid pattern specification.");
+  }
+
+  const char* cur = format_.data();
+  const char* end = cur + format_.size();
+
+  // While we don't exhaust the buffer, we always interleave reading one
+  // literal token, and one pattern, even if the literal token is empty.
+  //
+  // - pattern tokens are consecutive runs of the same letter (a-zA-Z).
+  // - literal tokens are anything else in between.
+  while (cur < end) {
+    // 1. Always try to read and add a literal token first, if it's empty.
+    const char* literalEnd = cur;
+
+    while ((literalEnd < end) && !std::isalpha(*literalEnd)) {
+      ++literalEnd;
+    }
+
+    literalTokens_.emplace_back(cur, literalEnd - cur);
+    cur = literalEnd;
+
+    // 2. If we still have at least one char left, try to read a pattern.
+    if (cur < end) {
+      const char* patternEnd = cur;
+
+      while ((patternEnd < end) && (*cur == *patternEnd)) {
+        ++patternEnd;
+      }
+
+      patternTokens_.emplace_back(getSpecifier(*cur));
+      patternTokensCount_.emplace_back(patternEnd - cur);
+      cur = patternEnd;
+    }
+  }
+
+  // The first and last tokens are always literals, even if they are empty.
+  if (literalTokens_.size() == patternTokens_.size()) {
+    literalTokens_.emplace_back("");
+  }
+  VELOX_CHECK_EQ(literalTokens_.size(), patternTokens_.size() + 1);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/JodaDateTime.h
+++ b/velox/functions/lib/JodaDateTime.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook::velox::functions {
+
+// Follow the Joda time library, as described in:
+//  http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
+enum class JodaFormatSpecifier : uint8_t {
+  // Era, e.g: "AD"
+  ERA = 0,
+
+  // Century of era (>=0), e.g: 20
+  CENTURY_OF_ERA = 1,
+
+  // Year of era (>=0), e.g: 1996
+  YEAR_OF_ERA = 2,
+
+  // Year of era (>=0), e.g: 1996
+  WEEK_YEAR = 3,
+
+  // Week of weekyear, e.g: 27
+  WEEK_OF_WEEK_YEAR = 4,
+
+  // Day of week, e.g: 2
+  DAY_OF_WEEK = 5,
+
+  // Day of week, e.g: "Tuesday" or "Tue"
+  DAY_OF_WEEK_TEXT = 6,
+
+  // Year, e.g: 1996
+  YEAR = 7,
+
+  // Day of year, e.g: 189
+  DAY_OF_YEAR = 8,
+
+  // Month of year, e.g: "July", "Jul" or 07
+  MONTH_OF_YEAR = 9,
+
+  // Day of month, e.g: 10
+  DAY_OF_MONTH = 10,
+
+  // Halfday of day, e.g: "PM"
+  HALFDAY_OF_DAY = 11,
+
+  // Hour of halfday (0~11)
+  HOUR_OF_HALFDAY = 12,
+
+  // Clockhour of halfday (1~12)
+  CLOCK_HOUR_OF_HALFDAY = 13,
+
+  // Hour of day (0~23)
+  HOUR_OF_DAY = 14,
+
+  // Clockhour of day (1~24)
+  CLOCK_HOUR_OF_DAY = 15,
+
+  // Minute of hour, e.g: 30
+  MINUTE_OF_HOUR = 16,
+
+  // Second of minute, e.g: 55
+  SECOND_OF_MINUTE = 17,
+
+  // Fraction of second, e.g: 978
+  FRACTION_OF_SECOND = 18,
+
+  // Timezone, e.g: "Pacific Standard Time" or "PST"
+  TIMEZONE = 19,
+
+  // Timezone offset/id, e.g: "-0800", "-08:00" or "America/Los_Angeles"
+  TIMEZONE_OFFSET_ID = 20
+};
+
+/// Compiles a Joda-compatible datetime format string.
+class JodaFormatter {
+ public:
+  explicit JodaFormatter(std::string format);
+
+  const std::vector<std::string_view>& literalTokens() const {
+    return literalTokens_;
+  }
+
+  const std::vector<JodaFormatSpecifier>& patternTokens() const {
+    return patternTokens_;
+  }
+
+  const std::vector<size_t>& patternTokensCount() const {
+    return patternTokensCount_;
+  }
+
+ private:
+  const std::string format_;
+
+  // Stores the literal tokens (substrings) found while parsing `format_`.
+  // There are always `patternTokens_ + 1` literal tokens, to follow the
+  // format below:
+  //
+  //   l[0] - p[0] - l[1] - p[1] - ... - p[n] - l[n+1]
+  //
+  // for instance, the format string "YYYY-MM-dd" would be stored as:
+  //
+  //  literals: {"", "-", "-", ""}
+  //  patterns: {YEAR_OF_ERA, MONTH_OF_YEAR, DAY_OF_MONTH}
+  //  patternCount: {4, 2, 2}
+  //
+  std::vector<std::string_view> literalTokens_;
+  std::vector<JodaFormatSpecifier> patternTokens_;
+
+  // Stores the number of times each pattern token was read, e.g: "Y" (1) vs
+  // "YYYY" (4).
+  std::vector<size_t> patternTokensCount_;
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_executable(
-  velox_functions_lib_test IsNullTest.cpp IsNotNullTest.cpp
-                           Re2FunctionsTest.cpp ArrayBuilderTest.cpp)
+  velox_functions_lib_test
+  IsNullTest.cpp IsNotNullTest.cpp JodaDateTimeTest.cpp Re2FunctionsTest.cpp
+  ArrayBuilderTest.cpp)
 
 add_test(velox_functions_lib_test velox_functions_lib_test)
 

--- a/velox/functions/lib/tests/JodaDateTimeTest.cpp
+++ b/velox/functions/lib/tests/JodaDateTimeTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/JodaDateTime.h"
+#include "velox/common/base/Exceptions.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+namespace facebook::velox::functions {
+
+namespace {
+
+class JodaDateTimeTest : public testing::Test {};
+
+TEST_F(JodaDateTimeTest, parseLiterals) {
+  std::vector<std::string_view> expected;
+
+  expected = {" "};
+  EXPECT_EQ(expected, JodaFormatter(" ").literalTokens());
+
+  expected = {" ", ""};
+  EXPECT_EQ(expected, JodaFormatter(" Y").literalTokens());
+
+  expected = {"", " "};
+  EXPECT_EQ(expected, JodaFormatter("YY ").literalTokens());
+
+  expected = {" 132&2618*673 *--+= }{[]\\:"};
+  EXPECT_EQ(
+      expected, JodaFormatter(" 132&2618*673 *--+= }{[]\\:").literalTokens());
+
+  expected = {"   ", " &^  "};
+  EXPECT_EQ(expected, JodaFormatter("   YYYY &^  ").literalTokens());
+
+  expected = {"", "  % & ", " ", ""};
+  EXPECT_EQ(expected, JodaFormatter("Y  % & YYY YYYYY").literalTokens());
+}
+
+TEST_F(JodaDateTimeTest, parsePatterns) {
+  std::vector<JodaFormatSpecifier> expected;
+
+  expected = {JodaFormatSpecifier::YEAR_OF_ERA};
+  EXPECT_EQ(expected, JodaFormatter("Y").patternTokens());
+
+  expected = {
+      JodaFormatSpecifier::YEAR_OF_ERA,
+      JodaFormatSpecifier::MONTH_OF_YEAR,
+      JodaFormatSpecifier::DAY_OF_MONTH};
+  EXPECT_EQ(expected, JodaFormatter("YYYY-MM-dd").patternTokens());
+}
+
+TEST_F(JodaDateTimeTest, parsePatternCount) {
+  std::vector<size_t> expected;
+
+  expected = {};
+  EXPECT_EQ(expected, JodaFormatter("  ").patternTokensCount());
+
+  expected = {1};
+  EXPECT_EQ(expected, JodaFormatter("Y").patternTokensCount());
+
+  expected = {4, 2, 2, 1};
+  EXPECT_EQ(expected, JodaFormatter("YYYY YY YY Y").patternTokensCount());
+
+  expected = {4, 2, 2, 1, 10};
+  EXPECT_EQ(
+      expected, JodaFormatter("YYYY-MM-dd m YYYYYYYYYY").patternTokensCount());
+}
+
+TEST_F(JodaDateTimeTest, invalid) {
+  EXPECT_THROW(JodaFormatter(""), VeloxUserError);
+  EXPECT_THROW(JodaFormatter("p"), VeloxUserError);
+  EXPECT_THROW(JodaFormatter("P"), VeloxUserError);
+  EXPECT_THROW(JodaFormatter("YDM u"), VeloxUserError);
+}
+
+} // namespace
+
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Tokenization logic to support Joda datetime, in order to eventually
support Presto's parse_datetime() with the same semantic as in Java.

This diff only contains the tokenization logic; the next one in the stack
will add the parsing logic based on the tokens identified in this diff, then
the logic to convert the parsed input back to a timestamp.

The tokenization logic follows the definition in:
> http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html

Reviewed By: mbasmanova

Differential Revision: D32013564

