### PR TITLE
Empty for null flag in map concat

### DIFF
--- a/velox/functions/prestosql/tests/MapConcatTest.cpp
+++ b/velox/functions/prestosql/tests/MapConcatTest.cpp
@@ -13,10 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/VectorFunctions.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions {
+void registerMapConcastEmptyNullKeys() {
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_concat_empty_null, "map_concat_empty_nulls");
+}
+}; // namespace facebook::velox::functions
 
 class MapConcatTest : public FunctionBaseTest {
  protected:
@@ -93,6 +101,81 @@ TEST_F(MapConcatTest, basic) {
 
   result =
       evaluate<MapVector>("map_concat(c1, c0)", makeRowVector({aMap, bMap}));
+  ASSERT_EQ(result->size(), size);
+  for (vector_size_t i = 0; i < size; i++) {
+    ASSERT_TRUE(expectedMap->equalValueAt(result.get(), i, i))
+        << "at " << i << ": expected " << expectedMap->toString(i) << ", got "
+        << result->toString(i);
+  }
+}
+
+TEST_F(MapConcatTest, nullKeys) {
+  facebook::velox::functions::registerMapConcastEmptyNullKeys();
+  vector_size_t size = 1'000;
+
+  std::map<std::string, int32_t> a = {{"a1", 1}, {"a2", 2}, {"a3", 3}};
+  std::map<std::string, int32_t> b = {
+      {"b1", 1}, {"b2", 2}, {"b3", 3}, {"b4", 4}};
+  auto isNullA = nullEvery(2);
+  auto isNullB = nullEvery(3);
+  auto aMap = makeMapVector(size, a, isNullA);
+  auto bMap = makeMapVector(size, b, isNullB);
+  std::map<std::string, int32_t> ab = concat(a, b);
+
+  auto keysAB = mapKeys(ab);
+  auto valuesAB = mapValues(ab);
+  auto keysA = mapKeys(a);
+  auto valuesA = mapValues(a);
+  auto keysB = mapKeys(b);
+  auto valuesB = mapValues(b);
+  auto expectedSizes = [&](vector_size_t mapRow) {
+    if (!isNullA(mapRow) && !isNullB(mapRow)) {
+      return keysAB.size();
+    }
+    if (isNullA(mapRow)) {
+      return keysB.size();
+    }
+    if (isNullB(mapRow)) {
+      return keysA.size();
+    }
+    return size_t(0);
+  };
+  auto expectedValues = [&](vector_size_t mapRow, vector_size_t row) {
+    if (!isNullA(mapRow) && !isNullB(mapRow)) {
+      return mapRow % 11 + valuesAB[row];
+    }
+    if (isNullA(mapRow)) {
+      return mapRow % 11 + valuesB[row];
+    }
+    if (isNullB(mapRow)) {
+      return mapRow % 11 + valuesA[row];
+    }
+    return 0;
+  };
+  auto expectedKeys = [&](vector_size_t mapRow, vector_size_t row) {
+    if (!isNullA(mapRow) && !isNullB(mapRow)) {
+      return StringView(keysAB[row]);
+    }
+    if (isNullA(mapRow)) {
+      return StringView(keysB[row]);
+    }
+    if (isNullB(mapRow)) {
+      return StringView(keysA[row]);
+    }
+    return StringView();
+  };
+  auto expectedMap = vectorMaker_.mapVector<StringView, int32_t>(
+      size, expectedSizes, expectedKeys, expectedValues);
+
+  // Setting the parts of the output with null key to empty
+  for (auto i = 0; i < size; i++) {
+    if (isNullA(i) && isNullB(i)) {
+      expectedMap->setOffsetAndSize(i, i, 0);
+    }
+  }
+
+  auto result = evaluate<MapVector>(
+      "map_concat_empty_nulls(c0, c1)", makeRowVector({aMap, bMap}));
   ASSERT_EQ(result->size(), size);
   for (vector_size_t i = 0; i < size; i++) {
     ASSERT_TRUE(expectedMap->equalValueAt(result.get(), i, i))


### PR DESCRIPTION
Summary: This diff add a template flag to make map concat produce empty map when facing a null key.

Differential Revision: D32175431

