### PR TITLE
Fix Expr::evalWithMemo

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -733,6 +733,11 @@ void Expr::evalWithMemo(
       }
 
       cachedDictionaryIndices_->select(*uncached);
+
+      // Resize the dictionaryCache_ to accommodate all the necessary rows.
+      if (dictionaryCache_->size() < uncached->end()) {
+        dictionaryCache_->resize(uncached->end());
+      }
       dictionaryCache_->copy(result->get(), *uncached, nullptr);
     }
     return;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2173,25 +2173,25 @@ TEST_F(ExprTest, memo) {
   auto oddIndices = makeIndices(100, [](auto row) { return 9 + row * 2; });
 
   auto rowType = ROW({"c0"}, {base->type()});
-  auto exprSet = compileExpression("c0[1]", rowType);
+  auto exprSet = compileExpression("c0[1] = 1", rowType);
 
   auto result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(evenIndices, 100, base)}));
-  auto expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (8 + row * 2) % 3; });
+  auto expectedResult = makeFlatVector<bool>(
+      100, [](auto row) { return (8 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 
   result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(oddIndices, 100, base)}));
-  expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (9 + row * 2) % 3; });
+  expectedResult = makeFlatVector<bool>(
+      100, [](auto row) { return (9 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 
   auto everyFifth = makeIndices(100, [](auto row) { return row * 5; });
   result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(everyFifth, 100, base)}));
   expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (row * 5) % 3; });
+      makeFlatVector<bool>(100, [](auto row) { return (row * 5) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 }
 


### PR DESCRIPTION
Expr::evalWithMemo is an optimization that allows to compute an expression on
dictionary values once and re-use the results for multiple dictionary vectors
that use the same base vector. On first run, evalWithMemo computes the
expression on specified rows and stores the results in dictionaryCache_. On
next run, it checks if dictionaryCache_ already has results for all requested
rows and if so returns these without re-evaluating the expression. If some rows
are missing from dictionaryCache_, evalWithMemo evaluates the expression on
these rows and updates dictionaryCache_.  See https://facebookincubator.github.io/velox/develop/expression-evaluation.html#memoizing-the-dictionaries for more details.

Before this change evalWithMemo didn't check that dictionaryCache_ has room for
all the new rows, which caused a failure:

```
Expression: BaseVector::length_ >= rows.end()
Function: copyValuesAndNulls
File: velox/vector/FlatVector.cpp
Line: 56
```

The fix is to resize dictionaryCache_ to ensure there is enough room.