### PR TITLE
Extract values and calculate timestamp for parse_datetime()

### DIFF
--- a/velox/functions/lib/JodaDateTime.h
+++ b/velox/functions/lib/JodaDateTime.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include "velox/type/Timestamp.h"
 
 namespace facebook::velox::functions {
 
@@ -104,6 +105,10 @@ class JodaFormatter {
   const std::vector<size_t>& patternTokensCount() const {
     return patternTokensCount_;
   }
+
+  // Parses `input` according to the format specified in the constructor. Throws
+  // in case the input couldn't be parsed.
+  Timestamp parse(const std::string& input);
 
  private:
   const std::string format_;

--- a/velox/functions/lib/tests/JodaDateTimeTest.cpp
+++ b/velox/functions/lib/tests/JodaDateTimeTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/lib/JodaDateTime.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/TimestampConversion.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -25,7 +26,12 @@ namespace facebook::velox::functions {
 
 namespace {
 
-class JodaDateTimeTest : public testing::Test {};
+class JodaDateTimeTest : public testing::Test {
+ protected:
+  Timestamp parse(const std::string& input, const std::string& format) {
+    return JodaFormatter(format).parse(input);
+  }
+};
 
 TEST_F(JodaDateTimeTest, parseLiterals) {
   std::vector<std::string_view> expected;
@@ -81,10 +87,122 @@ TEST_F(JodaDateTimeTest, parsePatternCount) {
 }
 
 TEST_F(JodaDateTimeTest, invalid) {
+  // Format:
   EXPECT_THROW(JodaFormatter(""), VeloxUserError);
   EXPECT_THROW(JodaFormatter("p"), VeloxUserError);
   EXPECT_THROW(JodaFormatter("P"), VeloxUserError);
   EXPECT_THROW(JodaFormatter("YDM u"), VeloxUserError);
+
+  // Parse:
+  EXPECT_THROW(parse("", ""), VeloxUserError);
+  EXPECT_THROW(parse(" ", ""), VeloxUserError);
+  EXPECT_THROW(parse("", " "), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseYear) {
+  // By the default, assume epoch.
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse(" ", " "));
+
+  // Number of times the token is repeated doesn't change the parsing behavior.
+  EXPECT_EQ(util::fromTimestampString("2134-01-01"), parse("2134", "Y"));
+  EXPECT_EQ(util::fromTimestampString("2134-01-01"), parse("2134", "YYYYYYYY"));
+
+  // Probe the year range. Joda only supports positive years.
+  EXPECT_EQ(util::fromTimestampString("294247-01-01"), parse("294247", "Y"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "Y"));
+  EXPECT_THROW(parse("294248", "Y"), VeloxUserError);
+  EXPECT_THROW(parse("0", "Y"), VeloxUserError);
+  EXPECT_THROW(parse("-1", "Y"), VeloxUserError);
+  EXPECT_THROW(parse("  ", " Y "), VeloxUserError);
+  EXPECT_THROW(parse(" 1 2", "Y Y"), VeloxUserError);
+
+  // Last token read overwrites:
+  EXPECT_EQ(
+      util::fromTimestampString("0005-01-01"), parse("1 2 3 4 5", "Y Y Y Y Y"));
+}
+
+TEST_F(JodaDateTimeTest, parseMonth) {
+  // Joda has this weird behavior where if minute or hour is specified, year
+  // falls back to 2000, instead of epoch (1970)  ¯\_(ツ)_/¯
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "M"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parse(" 7", " MM"));
+  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parse("11-", "M-"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-01"), parse("-12-", "-M-"));
+
+  EXPECT_THROW(parse("0", "M"), VeloxUserError);
+  EXPECT_THROW(parse("13", "M"), VeloxUserError);
+  EXPECT_THROW(parse("12345", "M"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseDay) {
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "d"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parse("7 ", "dd "));
+  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parse("/11", "/dd"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-31"), parse("/31/", "/d/"));
+
+  EXPECT_THROW(parse("0", "d"), VeloxUserError);
+  EXPECT_THROW(parse("32", "d"), VeloxUserError);
+  EXPECT_THROW(parse("12345", "d"), VeloxUserError);
+
+  EXPECT_THROW(parse("02-31", "M-d"), VeloxUserError);
+  EXPECT_THROW(parse("04-31", "M-d"), VeloxUserError);
+
+  // Probe around leap year.
+  EXPECT_EQ(
+      util::fromTimestampString("2000-02-29"), parse("2000-02-29", "Y-M-d"));
+  EXPECT_THROW(parse("2001-02-29", "Y-M-d"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseHour) {
+  EXPECT_EQ(util::fromTimestampString("1970-01-01 07:00:00"), parse("7", "H"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 23:00:00"), parse("23", "HH"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parse("0", "HHH"));
+
+  EXPECT_THROW(parse("24", "H"), VeloxUserError);
+  EXPECT_THROW(parse("-1", "H"), VeloxUserError);
+  EXPECT_THROW(parse("123456789", "H"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseMinute) {
+  EXPECT_EQ(util::fromTimestampString("1970-01-01 00:08:00"), parse("8", "m"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:59:00"), parse("59", "mm"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parse("0/", "mmm/"));
+
+  EXPECT_THROW(parse("60", "m"), VeloxUserError);
+  EXPECT_THROW(parse("-1", "m"), VeloxUserError);
+  EXPECT_THROW(parse("123456789", "m"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseSecond) {
+  EXPECT_EQ(util::fromTimestampString("1970-01-01 00:00:09"), parse("9", "s"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:58"), parse("58", "ss"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parse("0/", "s/"));
+
+  EXPECT_THROW(parse("60", "s"), VeloxUserError);
+  EXPECT_THROW(parse("-1", "s"), VeloxUserError);
+  EXPECT_THROW(parse("123456789", "s"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeTest, parseMixed) {
+  // Common patterns found.
+  EXPECT_EQ(
+      util::fromTimestampString("2021-11-04 23:00:00"),
+      parse("2021-11-04+23:00", "YYYY-MM-dd+HH:mm"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2019-07-03 11:04:10"),
+      parse("2019-07-03 11:04:10", "YYYY-MM-dd HH:mm:ss"));
+
+  // Backwards, just for fun:
+  EXPECT_EQ(
+      util::fromTimestampString("2019-07-03 11:04:10"),
+      parse("10:04:11 03-07-2019", "ss:mm:HH dd-MM-YYYY"));
 }
 
 } // namespace

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -497,15 +497,16 @@ int64_t fromTimeString(const char* str, size_t len) {
   return microsSinceMidnight;
 }
 
-namespace {
-
 Timestamp fromDatetime(int32_t daysSinceEpoch, int64_t microsSinceMidnight) {
-  int64_t secondsSinceEpoch = daysSinceEpoch * kSecsPerDay;
+  int64_t secondsSinceEpoch =
+      static_cast<int64_t>(daysSinceEpoch) * kSecsPerDay;
   secondsSinceEpoch += microsSinceMidnight / kMicrosPerSec;
   return Timestamp(
       secondsSinceEpoch,
       (microsSinceMidnight % kMicrosPerSec) * kNanosPerMicro);
 }
+
+namespace {
 
 void parserError(const char* str, size_t len) {
   VELOX_USER_FAIL(

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -76,4 +76,6 @@ inline Timestamp fromTimestampString(const StringView& str) {
   return fromTimestampString(str.data(), str.size());
 }
 
+Timestamp fromDatetime(int32_t daysSinceEpoch, int64_t microsSinceMidnight);
+
 } // namespace facebook::velox::util


### PR DESCRIPTION
Summary:
Adding support for the most common parse_datetime tokens: year, month,
day, hour, minute, and second. Adding unit tests validated against Presto's
current implementation.

Following specification available on:

> http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html

Differential Revision: D32194995

