### PR TITLE
Fix IN predicate for Spark

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -733,6 +733,11 @@ void Expr::evalWithMemo(
       }
 
       cachedDictionaryIndices_->select(*uncached);
+
+      // Resize the dictionaryCache_ to accommodate all the necessary rows.
+      if (dictionaryCache_->size() < uncached->end()) {
+        dictionaryCache_->resize(uncached->end());
+      }
       dictionaryCache_->copy(result->get(), *uncached, nullptr);
     }
     return;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2173,25 +2173,25 @@ TEST_F(ExprTest, memo) {
   auto oddIndices = makeIndices(100, [](auto row) { return 9 + row * 2; });
 
   auto rowType = ROW({"c0"}, {base->type()});
-  auto exprSet = compileExpression("c0[1]", rowType);
+  auto exprSet = compileExpression("c0[1] = 1", rowType);
 
   auto result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(evenIndices, 100, base)}));
-  auto expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (8 + row * 2) % 3; });
+  auto expectedResult = makeFlatVector<bool>(
+      100, [](auto row) { return (8 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 
   result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(oddIndices, 100, base)}));
-  expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (9 + row * 2) % 3; });
+  expectedResult = makeFlatVector<bool>(
+      100, [](auto row) { return (9 + row * 2) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 
   auto everyFifth = makeIndices(100, [](auto row) { return row * 5; });
   result = evaluate(
       exprSet.get(), makeRowVector({wrapInDictionary(everyFifth, 100, base)}));
   expectedResult =
-      makeFlatVector<int64_t>(100, [](auto row) { return (row * 5) % 3; });
+      makeFlatVector<bool>(100, [](auto row) { return (row * 5) % 3 == 1; });
   assertEqualVectors(expectedResult, result);
 }
 

--- a/velox/functions/sparksql/In.cpp
+++ b/velox/functions/sparksql/In.cpp
@@ -94,12 +94,12 @@ class In final : public exec::VectorFunction {
       localSelected->deselectNulls(lhsNulls, rows.begin(), rows.end());
       selected = localSelected.get();
     }
-    if (args[0]->encoding() == VectorEncoding::Simple::CONSTANT) {
-      auto* lhs = args[0]->as<ConstantVector<T>>();
-      if (lhs->isNullAt(0)) {
+    if (args[0]->isConstant(rows)) {
+      auto* lhs = args[0]->as<SimpleVector<T>>();
+      if (lhs->isNullAt(rows.begin())) {
         return;
       }
-      const bool present = elements_.contains(lhs->valueAt(0));
+      const bool present = elements_.contains(lhs->valueAt(rows.begin()));
       selected->applyToSelected([&](vector_size_t i) {
         bits::setBit(resultValues, i, present);
         if (rhsHasNull && !present) {


### PR DESCRIPTION
Summary:
Vector function that has a single argument is guaranteed to receive its input as
flat. Vector function that has multiple arguments all but one of which are
constant is guaranteed to receive its not-necessarily-constant argument as flat
or constant. However, in this context "constant" doesn't mean vector of
constant encoding. Instead, it means that the vector has same value for all
rows in scope, e.g. BaseVector::isConstant(rows) is true.

Differential Revision: D32197009

