### PR TITLE
[Draft] Move some part of arithmetic functions in presto to new framework

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -26,32 +26,45 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(plus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = plus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct PlusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& result,
+      const TInput& a,
+      const TInput& b) {
+    result = plus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(minus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = minus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& result,
+      const TInput& a,
+      const TInput& b) {
+    result = minus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(multiply)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = multiply(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& result,
+      const TInput& a,
+      const TInput& b) {
+    result = multiply(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(divide)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b)
+struct DivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput& a, const TInput& b)
 // depend on compiler have correct behaviour for divide by zero
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)
@@ -59,18 +72,22 @@ FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b)
 #endif
 #endif
 {
-  result = a / b;
-  return true;
+    result = a / b;
+    return true;
 }
-VELOX_UDF_END();
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(modulus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = modulus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct ModulusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& result,
+      const TInput& a,
+      const TInput& b) {
+    result = modulus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(ceil)

--- a/velox/functions/prestosql/RegisterArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterArithmetic.cpp
@@ -40,11 +40,11 @@ void registerBitwiseUnaryIntegral(const std::vector<std::string>& aliases) {
 } // namespace
 
 void registerArithmeticFunctions() {
-  registerBinaryFloatingPoint<udf_plus>({});
-  registerBinaryFloatingPoint<udf_minus>({});
-  registerBinaryFloatingPoint<udf_multiply>({});
-  registerBinaryFloatingPoint<udf_divide>({});
-  registerBinaryFloatingPoint<udf_modulus>({});
+  registerBinaryNumeric<PlusFunction>({"plus"});
+  registerBinaryNumeric<MinusFunction>({"minus"});
+  registerBinaryNumeric<MultiplyFunction>({"multiply"});
+  registerBinaryNumeric<DivideFunction>({"divide"});
+  registerBinaryNumeric<ModulusFunction>({"modulus"});
   registerUnaryNumeric<udf_ceil>({"ceil", "ceiling"});
   registerUnaryNumeric<udf_floor>({});
   registerUnaryNumeric<udf_abs>({});

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -24,9 +24,9 @@ namespace facebook::velox::functions::sparksql {
 
 void registerArithmeticFunctions(const std::string& prefix) {
   // Operators.
-  registerBinaryNumeric<udf_plus>({prefix + "add"});
-  registerBinaryNumeric<udf_minus>({prefix + "subtract"});
-  registerBinaryNumeric<udf_multiply>({prefix + "multiply"});
+  registerBinaryNumeric<PlusFunction>({prefix + "add"});
+  registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
+  registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
   registerFunction<udf_divide, double, double, double>({prefix + "divide"});
   registerBinaryIntegral<udf_remainder>({prefix + "remainder"});
   registerUnaryNumeric<udf_unaryminus>({prefix + "unaryminus"});


### PR DESCRIPTION
Move some part of arithmetic functions in presto to new framework, function list:
1.  plus
2.  minus
3.  mutiply
4.  divide
5.  modulus