### PR TITLE
Add support for intermediate input to CountAggregate (#561)

### DIFF
--- a/velox/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/aggregates/tests/CountAggregationTest.cpp
@@ -53,6 +53,7 @@ TEST_F(CountAggregation, count) {
     auto agg = PlanBuilder()
                    .values(vectors)
                    .partialAggregation({}, {"count(c1)"})
+                   .finalAggregation({}, {"count(a0)"})
                    .planNode();
     assertQuery(agg, "SELECT count(c1) FROM tmp");
   }
@@ -63,6 +64,7 @@ TEST_F(CountAggregation, count) {
                    .values(vectors)
                    .filter("c0 % 3 > 5")
                    .partialAggregation({}, {"count(c1)"})
+                   .finalAggregation({}, {"count(a0)"})
                    .planNode();
     assertQuery(agg, "SELECT count(c1) FROM tmp WHERE c0 % 3 > 5");
   }
@@ -82,6 +84,7 @@ TEST_F(CountAggregation, count) {
                    .values(vectors)
                    .project({"c0 % 10", "c1"})
                    .partialAggregation({0}, {"count(1)"})
+                   .finalAggregation({0}, {"count(a0)"})
                    .planNode();
     assertQuery(agg, "SELECT c0 % 10, count(1) FROM tmp GROUP BY 1");
   }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -434,7 +434,7 @@ TEST_F(MultiFragmentTest, broadcast) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan = PlanBuilder()
                        .exchange(leafPlan->outputType())
-                       .finalAggregation({}, {"count(1)"})
+                       .singleAggregation({}, {"count(1)"})
                        .partitionedOutput({}, 1)
                        .planNode();
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/561

This diff has 2 changes on CountAggregate,
1) Implement addIntermediateResults and addSingleGroupIntermediateResults to support direct call on the methods.
2) remove the SumAggregate from the registration, which was used as an alternative for CountAggregate for intermediate input.

Reviewed By: mbasmanova

Differential Revision: D32066592

