### PR TITLE
Make flush a public api

### DIFF
--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -313,7 +313,7 @@ void WriterShared::flushStripe(bool close) {
   resetImpl();
 }
 
-void WriterShared::flush(bool close) {
+void WriterShared::flushInternal(bool close) {
   flushStripe(close);
 
   auto& context = getContext();
@@ -412,8 +412,12 @@ void WriterShared::flush(bool close) {
   }
 }
 
+void WriterShared::flush() {
+  flushInternal(false);
+}
+
 void WriterShared::close() {
-  flush(true);
+  flushInternal(true);
   WriterBase::close();
 }
 

--- a/velox/dwio/dwrf/writer/WriterShared.h
+++ b/velox/dwio/dwrf/writer/WriterShared.h
@@ -65,6 +65,9 @@ class WriterShared : public WriterBase {
 
   ~WriterShared() override = default;
 
+  // Forces the writer to flush, does not close the writer.
+  void flush();
+
   void close() override;
 
   void setLowMemoryMode();
@@ -82,7 +85,7 @@ class WriterShared : public WriterBase {
   void enterLowMemoryMode();
 
   // Create a new stripe. No-op if there is no data written.
-  void flush(bool close = false);
+  void flushInternal(bool close = false);
 
   void flushStripe(bool close);
 


### PR DESCRIPTION
Summary:
It is generally desirable to force flush writer in resource
management. Expose flush as a public api.

Differential Revision: D32211231

