### PR TITLE
Add and iterate encoding through EncodingManager

### DIFF
--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -177,6 +177,37 @@ target_link_libraries(
   ${ZLIB_LIBRARIES}
   ${TEST_LINK_LIBS})
 
+add_executable(velox_dwio_dwrf_writer_context_test TestWriterContext.cpp)
+add_test(velox_dwio_dwrf_writer_context_test
+         velox_dwio_dwrf_writer_context_test)
+
+target_link_libraries(
+  velox_dwio_dwrf_writer_context_test
+  ${VELOX_LINK_LIBS}
+  ${DOUBLE_CONVERSION}
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${LZ4}
+  ${LZO}
+  ${ZSTD}
+  ${ZLIB_LIBRARIES}
+  ${TEST_LINK_LIBS})
+
+add_executable(velox_dwio_dwrf_writer_encoding_manager_test
+               EncodingManagerTests.cpp)
+add_test(velox_dwio_dwrf_writer_encoding_manager_test
+         velox_dwio_dwrf_writer_encoding_manager_test)
+
+target_link_libraries(
+  velox_dwio_dwrf_writer_encoding_manager_test
+  ${VELOX_LINK_LIBS}
+  ${DOUBLE_CONVERSION}
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${LZ4}
+  ${LZO}
+  ${ZSTD}
+  ${ZLIB_LIBRARIES}
+  ${TEST_LINK_LIBS})
+
 add_executable(velox_dwio_dwrf_writer_sink_test WriterSinkTests.cpp)
 add_test(velox_dwio_dwrf_writer_sink_test velox_dwio_dwrf_writer_sink_test)
 

--- a/velox/dwio/dwrf/test/EncodingManagerTests.cpp
+++ b/velox/dwio/dwrf/test/EncodingManagerTests.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/dwio/dwrf/writer/WriterShared.h"
+
+using namespace ::testing;
+
+namespace facebook::velox::dwrf {
+void testEncodingIter(
+    const std::vector<std::pair<uint32_t, uint32_t>>& footerEncodingNodes,
+    const std::vector<std::vector<std::pair<uint32_t, uint32_t>>>&
+        encryptionGroupNodes) {
+  proto::StripeFooter footer;
+  std::vector<proto::StripeEncryptionGroup> encryptionGroups;
+  std::vector<std::pair<uint32_t, uint32_t>> allEncoding;
+  for (const auto& pair : footerEncodingNodes) {
+    auto encoding = footer.add_encoding();
+    encoding->set_node(pair.first);
+    encoding->set_sequence(pair.second);
+    allEncoding.push_back(pair);
+  }
+
+  for (const auto& groupNodes : encryptionGroupNodes) {
+    proto::StripeEncryptionGroup group;
+    for (const auto& pair : groupNodes) {
+      auto encoding = group.add_encoding();
+      encoding->set_node(pair.first);
+      encoding->set_sequence(pair.second);
+      allEncoding.push_back(pair);
+    }
+    encryptionGroups.push_back(group);
+  }
+
+  EncodingIter iter{footer, encryptionGroups};
+  ASSERT_FALSE(iter.empty());
+  std::vector<std::pair<uint32_t, uint32_t>> iteratedEncodings;
+  do {
+    iteratedEncodings.push_back(
+        {iter.current().node(), iter.current().sequence()});
+  } while (iter.next());
+
+  EXPECT_THAT(
+      iteratedEncodings,
+      ElementsAreArray(allEncoding.data(), allEncoding.size()));
+}
+
+TEST(TestWriterContext, EmptyEncodingIter) {
+  proto::StripeFooter footer;
+  std::vector<proto::StripeEncryptionGroup> encryptionGroups;
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_TRUE(iter.empty());
+  }
+
+  footer.add_encoding();
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_FALSE(iter.empty());
+  }
+
+  footer.Clear();
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_TRUE(iter.empty());
+  }
+
+  proto::StripeEncryptionGroup group1;
+  proto::StripeEncryptionGroup group2;
+  encryptionGroups.push_back(group1);
+  encryptionGroups.push_back(group2);
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_TRUE(iter.empty());
+  }
+
+  encryptionGroups[1].add_encoding();
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_FALSE(iter.empty());
+  }
+
+  encryptionGroups.clear();
+  {
+    EncodingIter iter{footer, encryptionGroups};
+    ASSERT_TRUE(iter.empty());
+  }
+}
+
+TEST(TestEncodingManager, EncodingIter) {
+  testEncodingIter({{1, 0}}, {});
+  testEncodingIter({}, {{{1, 0}}});
+  testEncodingIter({{1, 0}}, {{{2, 1}, {2, 3}}});
+  testEncodingIter({{2, 1}, {2, 3}}, {{{1, 0}}});
+  testEncodingIter(
+      {{1, 0}}, {{{2, 1}, {2, 3}}, {{3, 0}, {4, 0}, {5, 1}, {5, 2}, {5, 4}}});
+  testEncodingIter(
+      {{2, 1}, {2, 3}, {3, 0}, {4, 0}, {5, 1}, {5, 2}, {5, 4}}, {{{1, 0}}});
+}
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -19,7 +19,6 @@
 #include <gtest/gtest_prod.h>
 
 #include "velox/dwio/dwrf/common/Compression.h"
-#include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
 #include "velox/dwio/dwrf/writer/RatioTracker.h"

--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -21,6 +21,112 @@
 
 namespace facebook::velox::dwrf {
 
+EncodingIter::EncodingIter(
+    const proto::StripeFooter& footer,
+    const std::vector<proto::StripeEncryptionGroup>& encryptionGroups)
+    : footer_{footer},
+      encryptionGroups_{encryptionGroups},
+      current_{footer_.encoding().begin()},
+      currentEnd_{footer_.encoding().end()} {
+  // Move to the end or a valid position.
+  if (footer_.encoding().empty()) {
+    next();
+  }
+}
+
+bool EncodingIter::empty() const {
+  return footer_.encoding().empty() && emptyEncryptionGroups();
+}
+
+bool EncodingIter::next() {
+  // The check is needed for the initial position
+  // if footer is empty but encryption groups are not.
+  if (current_ != currentEnd_) {
+    ++current_;
+  }
+  // Get to the absolute end or a valid position.
+  while (current_ == currentEnd_) {
+    if (encryptionGroupIndex_ == encryptionGroups_.size() - 1) {
+      return false;
+    }
+    const auto& encryptionGroup = encryptionGroups_.at(++encryptionGroupIndex_);
+    current_ = encryptionGroup.encoding().begin();
+    currentEnd_ = encryptionGroup.encoding().end();
+  }
+  return true;
+}
+
+const proto::ColumnEncoding& EncodingIter::current() const {
+  return *current_;
+}
+
+bool EncodingIter::emptyEncryptionGroups() const {
+  if (encryptionGroups_.empty()) {
+    return true;
+  }
+  for (const auto& group : encryptionGroups_) {
+    if (!group.encoding().empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+EncodingManager::EncodingManager(
+    const encryption::EncryptionHandler& encryptionHandler)
+    : encryptionHandler_{encryptionHandler} {
+  initEncryptionGroups();
+}
+
+proto::ColumnEncoding& EncodingManager::addEncodingToFooter(uint32_t nodeId) {
+  if (encryptionHandler_.isEncrypted(nodeId)) {
+    auto index = encryptionHandler_.getEncryptionGroupIndex(nodeId);
+    return *encryptionGroups_.at(index).add_encoding();
+  } else {
+    return *footer_.add_encoding();
+  }
+}
+
+proto::Stream* EncodingManager::addStreamToFooter(
+    uint32_t nodeId,
+    uint32_t& currentIndex) {
+  if (encryptionHandler_.isEncrypted(nodeId)) {
+    currentIndex = encryptionHandler_.getEncryptionGroupIndex(nodeId);
+    return encryptionGroups_.at(currentIndex).add_streams();
+  } else {
+    currentIndex = std::numeric_limits<uint32_t>::max();
+    return footer_.add_streams();
+  }
+}
+
+std::string* EncodingManager::addEncryptionGroupToFooter() {
+  return footer_.add_encryptiongroups();
+}
+
+proto::StripeEncryptionGroup EncodingManager::getEncryptionGroup(uint32_t i) {
+  return encryptionGroups_.at(i);
+}
+
+const proto::StripeFooter& EncodingManager::getFooter() const {
+  return footer_;
+}
+
+EncodingIter EncodingManager::getEncodingIter() const {
+  return EncodingIter{footer_, encryptionGroups_};
+}
+
+void EncodingManager::initEncryptionGroups() {
+  // initialize encryption groups
+  if (encryptionHandler_.isEncrypted()) {
+    auto count = encryptionHandler_.getEncryptionGroupCount();
+    // We use uint32_t::max to represent non-encrypted when adding streams, so
+    // make sure number of encryption groups is smaller than that
+    DWIO_ENSURE_LT(count, std::numeric_limits<uint32_t>::max());
+    encryptionGroups_.resize(count);
+  }
+}
+
+namespace {
 // We currently use previous stripe raw size as the proxy for the expected
 // stripe raw size. For the first stripe, we are more conservative about
 // flush overhead memory unless we know otherwise, e.g. perhaps from
@@ -45,6 +151,7 @@ int64_t getTotalMemoryUsage(const WriterContext& context) {
   return outputStreamPool.getCurrentBytes() + dictionaryPool.getCurrentBytes() +
       generalPool.getCurrentBytes();
 }
+} // namespace
 
 uint64_t WriterShared::flushTimeMemoryUsageEstimate(
     const WriterContext& context,
@@ -145,25 +252,10 @@ void WriterShared::flushStripe(bool close) {
   }
 
   auto& handler = context.getEncryptionHandler();
-  proto::StripeFooter footer;
-  std::vector<proto::StripeEncryptionGroup> groups;
-
-  // initialize encryption groups
-  if (handler.isEncrypted()) {
-    auto count = handler.getEncryptionGroupCount();
-    // We use uint32_t::max to represent non-encrypted when adding streams, so
-    // make sure number of encryption groups is smaller than that
-    DWIO_ENSURE_LT(count, std::numeric_limits<uint32_t>::max());
-    groups.resize(count);
-  }
+  EncodingManager encodingManager{handler};
 
   flushImpl([&](uint32_t nodeId) -> proto::ColumnEncoding& {
-    if (handler.isEncrypted(nodeId)) {
-      auto index = handler.getEncryptionGroupIndex(nodeId);
-      return *groups.at(index).add_encoding();
-    } else {
-      return *footer.add_encoding();
-    }
+    return encodingManager.addEncodingToFooter(nodeId);
   });
 
   // Collects the memory increment from flushing data to output streams.
@@ -183,13 +275,7 @@ void WriterShared::flushStripe(bool close) {
     proto::Stream* s;
     uint32_t currentIndex;
     auto nodeId = stream.node;
-    if (handler.isEncrypted(nodeId)) {
-      currentIndex = handler.getEncryptionGroupIndex(nodeId);
-      s = groups.at(currentIndex).add_streams();
-    } else {
-      s = footer.add_streams();
-      currentIndex = std::numeric_limits<uint32_t>::max();
-    }
+    s = encodingManager.addStreamToFooter(nodeId, currentIndex);
 
     // set offset only when needed, ie. when offset of current stream cannot be
     // calculated based on offset and length of previous stream. In that case,
@@ -219,7 +305,7 @@ void WriterShared::flushStripe(bool close) {
   // deals with streams
   uint64_t indexLength = 0;
   sink.setMode(WriterSink::Mode::Index);
-  LayoutPlanner planner(context);
+  LayoutPlanner planner{context};
   planner.iterateIndexStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE_EQ(
         streamId.kind,
@@ -249,10 +335,10 @@ void WriterShared::flushStripe(bool close) {
   if (handler.isEncrypted()) {
     // fill encryption metadata
     for (uint32_t i = 0; i < handler.getEncryptionGroupCount(); ++i) {
-      auto group = footer.add_encryptiongroups();
+      auto group = encodingManager.addEncryptionGroupToFooter();
       writeProtoAsString(
           *group,
-          groups.at(i),
+          encodingManager.getEncryptionGroup(i),
           std::addressof(handler.getEncryptionProviderByIndex(i)));
     }
   }
@@ -262,7 +348,7 @@ void WriterShared::flushStripe(bool close) {
   DWIO_ENSURE_EQ(footerOffset, stripeOffset + dataLength + indexLength);
 
   sink.setMode(WriterSink::Mode::Footer);
-  writeProto(footer);
+  writeProto(encodingManager.getFooter());
   sink.setMode(WriterSink::Mode::None);
 
   auto& stripe = addStripeInfo();


### PR DESCRIPTION
Summary:
Centralize encoding handling logic at flush time and providing an encoding
iterator so that layout planner can utilize this information later.

Introduce encoding iterator class to lazily iterate over all encoding in
current footer or encryption groups when needed.

Differential Revision: D32163312

