### PR TITLE
Disable DriveTest.pause and DriverTest.yield tests

### DIFF
--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -400,7 +400,7 @@ TEST_F(DriverTest, slow) {
   EXPECT_TRUE(stateFutures_.at(0).hasException());
 }
 
-TEST_F(DriverTest, pause) {
+TEST_F(DriverTest, DISABLED_pause) {
   CursorParameters params;
   int32_t hits;
   params.planNode = makeValuesFilterProject(
@@ -428,7 +428,7 @@ TEST_F(DriverTest, pause) {
   EXPECT_EQ(operators[1].outputPositions, 10 * hits);
 }
 
-TEST_F(DriverTest, yield) {
+TEST_F(DriverTest, DISABLED_yield) {
   constexpr int32_t kNumTasks = 20;
   constexpr int32_t kThreadsPerTask = 5;
   std::vector<int32_t> counters;


### PR DESCRIPTION
The `DriverTest.pause` and `DriverTest.yield` tests have been failing frequently in "Release" mode. Disabling them for now.
