### PR TITLE
Dwio-alpha integration

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -46,6 +46,7 @@ enum class FileFormat {
   TEXT = 5,
   JSON = 6,
   PARQUET = 7,
+  ALPHA = 8,
 };
 
 FileFormat toFileFormat(std::string s);


### PR DESCRIPTION
Summary: This fix targets for the integration between dwio and alpha file format. It checks the input format in metadata and based on that creates a reader in metadata.

Differential Revision: D32220678

