### PR TITLE
Simplify CastExpr::apply

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -484,10 +484,7 @@ void CastExpr::apply(
       }
     }
 
-    if (decoded->isConstantMapping()) {
-      localResult = BaseVector::wrapInConstant(
-          rows.end(), translatedRows->begin(), localResult);
-    } else if (!decoded->isIdentityMapping()) {
+    if (!decoded->isIdentityMapping()) {
       localResult = decoded->wrap(localResult, *input, rows);
     }
 


### PR DESCRIPTION
Now that DecodedVector::wrap is fixed (#458), CastExpr::apply can
be simplified.