### PR TITLE
MapView for simple functions 

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <optional>
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/vector/TypeAliases.h"
+
+namespace facebook::velox::exec {
+template <typename T, typename U>
+struct VectorReader;
+
+// Implements an iterator for T that moves by calling incrementIndex(). T must
+// implement index() and incrementIndex(). Two iterators from the same
+// "container" points to the same element if they have the same index.
+template <typename T>
+class IndexBasedIterator
+    : public std::iterator<std::input_iterator_tag, T, size_t> {
+ public:
+  using Iterator = IndexBasedIterator<T>;
+
+  explicit IndexBasedIterator<T>(const T& element) : element_(element) {}
+
+  bool operator!=(const Iterator& rhs) const {
+    return element_.index() != rhs.element_.index();
+  }
+
+  bool operator==(const Iterator& rhs) const {
+    return element_.index() == rhs.element_.index();
+  }
+
+  const T& operator*() const {
+    return element_;
+  }
+
+  const T* operator->() const {
+    return &element_;
+  }
+
+  bool operator<(const Iterator& rhs) const {
+    return element_.index() < rhs.element_.index();
+  }
+
+  // Implement post increment.
+  Iterator operator++(int) {
+    Iterator old = *this;
+    ++*this;
+    return old;
+  }
+
+  // Implement pre increment.
+  Iterator& operator++() {
+    element_.incrementIndex();
+    return *this;
+  }
+
+ protected:
+  T element_;
+};
+
+// This class represents a lazy access wrapper around the T members at a
+// specific index.
+template <typename T>
+struct VectorValueAccessor {
+  using element_t = typename T::exec_in_t;
+  operator element_t() const {
+    return (*reader_)[index_];
+  }
+
+  bool operator==(const VectorValueAccessor<T>& other) const {
+    return element_t(other) == element_t(*this);
+  }
+
+  vector_size_t index() const {
+    return index_;
+  }
+
+  void setIndex(vector_size_t index) const {
+    index_ = index;
+  }
+
+ private:
+  VectorValueAccessor(const T* reader, vector_size_t index)
+      : reader_(reader), index_(index) {}
+
+  const T* reader_;
+  mutable vector_size_t index_;
+  template <typename K, typename V>
+  friend class MapView;
+};
+
+// Given a vectorReader T, this class represents a lazy access optional wrapper
+// around an element in the vectorReader with interface similar to
+// std::optional<T::exec_in_t>. This is used to represent elements of ArrayView
+// and values of MapView. VectorOptionalValueAccessor can be compared with and
+// assigned to std::optional.
+template <typename T>
+class VectorOptionalValueAccessor final {
+ public:
+  using element_t = typename T::exec_in_t;
+
+  operator bool() const {
+    return has_value();
+  }
+
+  // Enable to be assigned to std::optional<element_t>.
+  operator std::optional<element_t>() const {
+    if (!has_value()) {
+      return std::nullopt;
+    }
+    return {value()};
+  }
+
+  // Disable all other implicit casts to avoid odd behaviors.
+  template <typename B>
+  operator B() const = delete;
+
+  bool operator==(const VectorOptionalValueAccessor& other) const {
+    if (other.has_value() != has_value()) {
+      return false;
+    }
+
+    if (has_value()) {
+      return value() == other.value();
+    }
+    // Both are nulls.
+    return true;
+  }
+
+  bool operator!=(const VectorOptionalValueAccessor& other) const {
+    return !(*this == other);
+  }
+
+  bool has_value() const {
+    return reader_->isSet(index_);
+  }
+
+  element_t value() const {
+    return (*reader_)[index_];
+  }
+
+  element_t value_or(const element_t& defaultValue) const {
+    return has_value() ? value() : defaultValue;
+  }
+
+  element_t operator*() const {
+    return value();
+  }
+
+  void incrementIndex() const {
+    index_++;
+  }
+
+  vector_size_t index() const {
+    return index_;
+  }
+
+  void setIndex(vector_size_t index) const {
+    index_ = index;
+  }
+
+ private:
+  VectorOptionalValueAccessor<T>(const T* reader, vector_size_t index)
+      : reader_(reader), index_(index) {}
+
+  const T* reader_;
+  // Index of element within the reader.
+  mutable vector_size_t index_;
+
+  template <typename V>
+  friend class ArrayView;
+
+  template <typename K, typename V>
+  friend class MapView;
+};
+
+// Allow comparing VectorOptionalValueAccessor with std::optional.
+template <typename T, typename U>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator==(
+    const std::optional<T>& lhs,
+    const VectorOptionalValueAccessor<U>& rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+
+  if (lhs.has_value()) {
+    return lhs.value() == rhs.value();
+  }
+  // Both are nulls.
+  return true;
+}
+
+template <typename U, typename T>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator==(
+    const VectorOptionalValueAccessor<U>& lhs,
+    const std::optional<T>& rhs) {
+  return rhs == lhs;
+}
+
+template <typename T, typename U>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator!=(
+    const std::optional<T>& lhs,
+    const VectorOptionalValueAccessor<U>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename U, typename T>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator!=(
+    const VectorOptionalValueAccessor<U>& lhs,
+    const std::optional<T>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename T>
+bool operator==(std::nullopt_t, const VectorOptionalValueAccessor<T>& rhs) {
+  return !rhs.has_value();
+}
+
+template <typename T>
+bool operator!=(std::nullopt_t, const VectorOptionalValueAccessor<T>& rhs) {
+  return rhs.has_value();
+}
+
+template <typename T>
+bool operator==(const VectorOptionalValueAccessor<T>& lhs, std::nullopt_t) {
+  return !lhs.has_value();
+}
+
+template <typename T>
+bool operator!=(const VectorOptionalValueAccessor<T>& lhs, std::nullopt_t) {
+  return lhs.has_value();
+}
+
+// Allow comparing VectorOptionalValueAccessor<T> with T::exec_t.
+template <typename T, typename U>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator==(const T& lhs, const VectorOptionalValueAccessor<U>& rhs) {
+  return rhs.has_value() && (*rhs == lhs);
+}
+
+template <typename U, typename T>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator==(const VectorOptionalValueAccessor<U>& lhs, const T& rhs) {
+  return rhs == lhs;
+}
+
+template <typename T, typename U>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator!=(const T& lhs, const VectorOptionalValueAccessor<U>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename U, typename T>
+typename std::enable_if<
+    std::is_trivially_constructible<typename U::exec_in_t, T>::value,
+    bool>::type
+operator!=(const VectorOptionalValueAccessor<U>& lhs, const T& rhs) {
+  return !(lhs == rhs);
+}
+
+// Represents an array of elements with an interface similar to std::vector.
+template <typename V>
+class ArrayView {
+  using reader_t = VectorReader<V, void>;
+  using element_t = typename reader_t::exec_in_t;
+
+ public:
+  ArrayView(const reader_t* reader, vector_size_t offset, vector_size_t size)
+      : reader_(reader), offset_(offset), size_(size) {}
+
+  // The previous doLoad protocol creates a value and then assigns to it.
+  // TODO: this should deprecated once we deprecate the doLoad protocol.
+  ArrayView() : reader_(nullptr), offset_(0), size_(0) {}
+
+  using Element = VectorOptionalValueAccessor<reader_t>;
+
+  using Iterator = IndexBasedIterator<Element>;
+
+  Iterator begin() const {
+    return Iterator{Element{reader_, offset_}};
+  }
+
+  Iterator end() const {
+    return Iterator{Element{reader_, offset_ + size_}};
+  }
+
+  // Returns true if any of the arrayViews in the vector might have null
+  // element.
+  bool mayHaveNulls() const {
+    return reader_->mayHaveNulls();
+  }
+
+  Element operator[](vector_size_t index) const {
+    return Element{reader_, index + offset_};
+  }
+
+  Element at(vector_size_t index) const {
+    return (*this)[index];
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  const reader_t* reader_;
+  vector_size_t offset_;
+  vector_size_t size_;
+};
+
+// This class is used to represent map inputs in simple functions with an
+// interface similar to std::map.
+template <typename K, typename V>
+class MapView {
+ public:
+  using key_reader_t = VectorReader<K, void>;
+  using value_reader_t = VectorReader<V, void>;
+  using key_element_t = typename key_reader_t::exec_in_t;
+
+  MapView(
+      const key_reader_t* keyReader,
+      const value_reader_t* valueReader,
+      vector_size_t offset,
+      vector_size_t size)
+      : keyReader_(keyReader),
+        valueReader_(valueReader),
+        offset_(offset),
+        size_(size) {}
+
+  MapView()
+      : keyReader_(nullptr), valueReader_(nullptr), offset_(0), size_(0) {}
+
+  class Element;
+  using ValueAccessor = VectorOptionalValueAccessor<value_reader_t>;
+
+  // Lazy access wrapper around the key.
+  using KeyAccessor = VectorValueAccessor<key_reader_t>;
+
+  class Element {
+   public:
+    Element(
+        const key_reader_t* keyReader,
+        const value_reader_t* valueReader,
+        vector_size_t index)
+        : first(keyReader, index), second(valueReader, index), index_(index) {}
+    const KeyAccessor first;
+    const ValueAccessor second;
+
+    bool operator==(const Element& other) const {
+      return first == other.first && second == other.second;
+    }
+
+    // T is pair like object.
+    template <typename T>
+    bool operator==(const T& other) const {
+      return first == other.first && second == other.second;
+    }
+
+    template <typename T>
+    bool operator!=(const T& other) const {
+      return !(*this == other);
+    }
+
+    void incrementIndex() {
+      index_++;
+      first.setIndex(index_);
+      second.setIndex(index_);
+    }
+
+    vector_size_t index() const {
+      return index_;
+    }
+
+   private:
+    vector_size_t index_;
+  };
+
+  using Iterator = IndexBasedIterator<Element>;
+
+  Iterator begin() const {
+    return Iterator{Element{keyReader_, valueReader_, 0 + offset_}};
+  }
+
+  Iterator end() const {
+    return Iterator{Element{keyReader_, valueReader_, size_ + offset_}};
+  }
+
+  const Element operator[](vector_size_t index) const {
+    return Element{keyReader_, valueReader_, index + offset_};
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+  Iterator find(const key_element_t& key) const {
+    auto it = begin();
+    while (it != end()) {
+      if (it->first == key) {
+        break;
+      }
+      it++;
+    }
+    return it;
+  }
+
+  ValueAccessor at(const key_element_t& key) const {
+    auto it = find(key);
+    VELOX_USER_CHECK(it != end(), "accessed key is not found in the map");
+    return it->second;
+  }
+
+  // Cast to SlowMapVal<K,V> used to allow this to be written to current writer.
+  // This should change once we implement writer proxies.
+  operator core::SlowMapVal<K, V>() const {
+    core::SlowMapVal<K, V> map;
+    for (const auto& entry : map) {
+      // Note: This does not handle nested maps, but since it's just workaround
+      // its ok for now.
+      map.appendNullable(entry.first) = entry.second;
+    }
+    return map;
+  }
+
+ private:
+  const key_reader_t* keyReader_;
+  const value_reader_t* valueReader_;
+  const vector_size_t offset_;
+  const vector_size_t size_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -17,7 +17,6 @@
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 #include "velox/expression/VectorUdfTypeSystem.h"
-#include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 namespace {
@@ -46,7 +45,7 @@ TEST_F(ArrayViewTest, intArray) {
     ASSERT_EQ(arrayDataBigInt[i][j].has_value(), item.has_value());
 
     // Test bool implicit cast.
-    ASSERT_EQ(arrayDataBigInt[i][j].has_value(), item);
+    ASSERT_EQ(arrayDataBigInt[i][j].has_value(), static_cast<bool>(item));
 
     if (arrayDataBigInt[i][j].has_value()) {
       // Test * operator.
@@ -54,7 +53,6 @@ TEST_F(ArrayViewTest, intArray) {
 
       // Test value().
       ASSERT_EQ(arrayDataBigInt[i][j].value(), item.value());
-      ASSERT_TRUE(item == arrayDataBigInt[i][j].value());
     }
     ASSERT_TRUE(item == arrayDataBigInt[i][j]);
   };

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -14,8 +14,13 @@
 
 add_executable(
   velox_expression_test
-  ExprTest.cpp CastExprTest.cpp EvalSimplifiedTest.cpp SignatureBinderTest.cpp
-  SimpleFunctionTest.cpp ArrayViewTest.cpp)
+  ExprTest.cpp
+  CastExprTest.cpp
+  EvalSimplifiedTest.cpp
+  SignatureBinderTest.cpp
+  SimpleFunctionTest.cpp
+  ArrayViewTest.cpp
+  MapViewTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace {
+
+using namespace facebook::velox;
+
+class MapViewTest : public functions::test::FunctionBaseTest {
+ protected:
+  using map_type = std::vector<std::pair<int64_t, std::optional<int64_t>>>;
+  map_type map1 = {};
+  map_type map2 = {{1, 4}, {3, 3}, {4, std::nullopt}};
+  map_type map3 = {
+      {10, 10},
+      {4, std::nullopt},
+      {1, 4},
+      {10, 4},
+      {10, std::nullopt},
+  };
+
+  std::vector<map_type> mapsData = {map1, map2, map3};
+
+  MapVectorPtr createTestMapVector() {
+    return makeMapVector<int64_t, int64_t>(mapsData);
+  }
+};
+
+TEST_F(MapViewTest, testReadingRangeLoop) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  for (auto i = 0; i < mapsData.size(); i++) {
+    auto mapView = reader[i];
+    auto it = mapsData[i].begin();
+    int count = 0;
+    ASSERT_EQ(mapsData[i].size(), mapView.size());
+    for (const auto& entry : mapView) {
+      ASSERT_EQ(entry.first, it->first);
+      ASSERT_EQ(entry.second.has_value(), it->second.has_value());
+      if (it->second.has_value()) {
+        ASSERT_EQ(entry.second.value(), it->second.value());
+      }
+      ASSERT_EQ(entry.second, it->second);
+      it++;
+      count++;
+    }
+    ASSERT_EQ(count, mapsData[i].size());
+  }
+}
+
+TEST_F(MapViewTest, testReadingIteratorLoop) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  for (auto i = 0; i < mapsData.size(); ++i) {
+    auto mapView = reader[i];
+    auto it = mapsData[i].begin();
+    int count = 0;
+    ASSERT_EQ(mapsData[i].size(), mapView.size());
+    for (auto itView = mapView.begin(); itView != mapView.end(); ++itView) {
+      ASSERT_EQ(itView->first, it->first);
+      ASSERT_EQ(itView->second.has_value(), it->second.has_value());
+      if (it->second.has_value()) {
+        ASSERT_EQ(itView->second.value(), it->second.value());
+      }
+      ASSERT_EQ(itView->second, it->second);
+      it++;
+      count++;
+    }
+    ASSERT_EQ(count, mapsData[i].size());
+  }
+}
+
+// MapView can be seen as std::vector<pair<key, value>>.
+TEST_F(MapViewTest, testIndexedLoop) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  for (auto i = 0; i < mapsData.size(); ++i) {
+    auto mapView = reader[i];
+    auto it = mapsData[i].begin();
+    int count = 0;
+    ASSERT_EQ(mapsData[i].size(), mapView.size());
+    for (int j = 0; j < mapView.size(); j++) {
+      ASSERT_EQ(mapView[j].first, it->first);
+      ASSERT_EQ(mapView[j].second.has_value(), it->second.has_value());
+      if (it->second.has_value()) {
+        ASSERT_EQ(mapView[j].second.value(), it->second.value());
+      }
+      ASSERT_EQ(mapView[j].second, it->second);
+      it++;
+      count++;
+    }
+    ASSERT_EQ(count, mapsData[i].size());
+  }
+}
+
+TEST_F(MapViewTest, testCompareLazyValueAccess) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  // Compare LazyValueAccess with constant.
+  ASSERT_EQ(reader[1][0].first, 1);
+  ASSERT_NE(reader[1][0].first, 10);
+  ASSERT_EQ(1, reader[1][0].first);
+  ASSERT_NE(10, reader[1][0].first);
+
+  // Compare LazyValueAccess with LazyValueAccess.
+  ASSERT_EQ(reader[2][2].first, reader[1][0].first);
+  ASSERT_NE(reader[2][2].first, reader[1][1].first);
+
+  // Compare LazyValueAccess with VectorOptionalValueAccessor value.
+  ASSERT_EQ(reader[2][1].first, reader[1][0].second.value());
+  ASSERT_NE(reader[2][2].first, reader[1][1].second.value());
+  ASSERT_EQ(reader[1][0].second.value(), reader[2][1].first);
+  ASSERT_NE(reader[1][1].second.value(), reader[2][2].first);
+
+  // Compare null VectorOptionalValueAccessor with LazyValueAccess.
+  ASSERT_NE(reader[1][1].second.value(), reader[1][2].first);
+}
+
+TEST_F(MapViewTest, testCompareVectorOptionalValueAccessor) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  // Compare VectorOptionalValueAccessor with std::optional.
+  ASSERT_EQ(reader[2][2].second, std::optional(4));
+  ASSERT_EQ(reader[2][2].second, std::optional(4l));
+  ASSERT_EQ(reader[2][2].second, std::optional(4ll));
+  ASSERT_EQ(reader[2][2].second, std::optional(4.0F));
+
+  ASSERT_NE(reader[2][2].second, std::optional(4.01F));
+  ASSERT_NE(reader[2][2].second, std::optional(8));
+
+  ASSERT_EQ(std::optional(4), reader[2][2].second);
+  ASSERT_EQ(std::optional(4l), reader[2][2].second);
+  ASSERT_EQ(std::optional(4ll), reader[2][2].second);
+
+  ASSERT_NE(std::optional(4.01F), reader[2][2].second);
+
+  ASSERT_EQ(std::nullopt, reader[1][2].second);
+  ASSERT_NE(std::nullopt, reader[1][1].second);
+
+  std::optional<int64_t> nullOpt;
+  ASSERT_EQ(reader[1][2].second, std::nullopt);
+  ASSERT_NE(reader[1][1].second, std::nullopt);
+
+  ASSERT_EQ(reader[1][2].second, nullOpt);
+  ASSERT_NE(reader[1][1].second, nullOpt);
+
+  // Compare VectorOptionalValueAccessor<T> with T::exec_t.
+  ASSERT_EQ(reader[2][2].second, 4);
+  ASSERT_EQ(reader[2][2].second, 4l);
+  ASSERT_EQ(reader[2][2].second, 4ll);
+  ASSERT_EQ(reader[2][2].second, 4.0F);
+
+  ASSERT_NE(reader[2][2].second, 4.01F);
+  ASSERT_NE(reader[2][2].second, 8);
+
+  ASSERT_EQ(4, reader[2][2].second);
+  ASSERT_EQ(4l, reader[2][2].second);
+  ASSERT_EQ(4ll, reader[2][2].second);
+  ASSERT_NE(4.01F, reader[2][2].second);
+
+  // VectorOptionalValueAccessor is null here.
+  ASSERT_NE(4.01F, reader[1][2].second);
+  ASSERT_NE(reader[1][2].second, 4);
+
+  // Compare VectorOptionalValueAccessor with VectorOptionalValueAccessor.
+  ASSERT_EQ(reader[2][2].second, reader[2][3].second);
+  ASSERT_NE(reader[2][2].second, reader[2][0].second);
+
+  // Compare with empty VectorOptionalValueAccessor.
+  // One null and one not null.
+  ASSERT_NE(reader[1][1].second, reader[1][2].second);
+  ASSERT_NE(reader[1][2].second, reader[1][1].second);
+  // Both are null.
+  ASSERT_EQ(reader[2][1].second, reader[1][2].second);
+}
+
+TEST_F(MapViewTest, testCompareMapViewElement) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  // Compare VectorOptionalValueAccessor with constant.
+  ASSERT_NE(reader[2][2], reader[2][1]);
+  ASSERT_EQ(reader[1][0], reader[2][2]);
+}
+
+TEST_F(MapViewTest, testAssignToOptional) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  std::optional<int64_t> element = reader[2][2].second;
+  std::optional<int64_t> element2 = reader[2][1].second;
+  ASSERT_EQ(element, reader[2][2].second);
+  ASSERT_EQ(element2, reader[2][1].second);
+  ASSERT_NE(element2, element);
+}
+
+TEST_F(MapViewTest, testFind) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  ASSERT_EQ(reader[1].find(5), reader[1].end());
+  ASSERT_NE(reader[1].find(4), reader[1].end());
+  ASSERT_EQ(reader[1].find(4)->first, 4);
+  ASSERT_EQ(reader[1].find(4)->second, std::nullopt);
+}
+
+TEST_F(MapViewTest, testAt) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  ASSERT_THROW(reader[1].at(5), VeloxException);
+  ASSERT_EQ(reader[1].at(4), std::nullopt);
+  ASSERT_EQ(reader[1].at(3), 3);
+}
+
+TEST_F(MapViewTest, testValueOr) {
+  auto mapVector = createTestMapVector();
+  DecodedVector decoded;
+  exec::VectorReader<Map<int64_t, int64_t>> reader(
+      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
+          decoded, *mapVector.get()));
+
+  ASSERT_EQ(reader[1].at(4).value_or(10), 10);
+  ASSERT_EQ(reader[1].at(3).value_or(10), 3);
+}
+
+} // namespace

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -273,6 +273,35 @@ class FunctionBaseTest : public testing::Test {
         size, sizeAt, keyAt, valueAt, isNullAt, valueIsNullAt);
   }
 
+  // Create map vector from nested std::vector representation.
+  template <typename TKey, typename TValue>
+  MapVectorPtr makeMapVector(
+      const std::vector<std::vector<std::pair<TKey, std::optional<TValue>>>>&
+          maps) {
+    std::vector<vector_size_t> lengths;
+    std::vector<TKey> keys;
+    std::vector<TValue> values;
+    std::vector<bool> nullValues;
+    auto undefined = TValue();
+
+    for (const auto& map : maps) {
+      lengths.push_back(map.size());
+      for (const auto& [key, value] : map) {
+        keys.push_back(key);
+        values.push_back(value.value_or(undefined));
+        nullValues.push_back(!value.has_value());
+      }
+    }
+
+    return makeMapVector<TKey, TValue>(
+        maps.size(),
+        [&](vector_size_t row) { return lengths[row]; },
+        [&](vector_size_t idx) { return keys[idx]; },
+        [&](vector_size_t idx) { return values[idx]; },
+        nullptr,
+        [&](vector_size_t idx) { return nullValues[idx]; });
+  }
+
   template <typename T>
   VectorPtr makeConstant(T value, vector_size_t size) {
     return BaseVector::createConstant(value, size, execCtx_.pool());


### PR DESCRIPTION
This diff introduce mapView as type representing map objects in simple functions interface.
mapView has similar limited interface as std::map<key, std::optional<val>> .

- begin()
- end()
- size()
- and element *it can be accessed using first and second.
- elements can be compared with std::pair<key, std::optional<value>>.

This diff includes some refactoring:
- move view types to a different header file.
- OptionalVectorValueAccessor: represents values in mapVies and elements in array.
 (a lazy optional like access to vector elements), comparable and assignable to std:optional and has
 similar interface as std::optional.
 - IndexBasedIterator: unify iterator implementation for both mapView and arrayView.

## Performance:
Went down from 20X slower to 2X-3X, PR #584 address major part of that and shows that the slowdown is not 
from the mapView implementation but other parts in the vectorAdapter. 

a new benchmark nestedMapSumVectorFunctionMapView is added:
which uses a vectorReader inside a vector function (used to isolate potential overhead of vector adapter).
PR shows interesting difference between nestedMapSumSimpleFunction and nestedMapSumVectorFunctionMapView

Before:
```
============================================================================
mapSumVectorFunction                                               2.72ms   368.27
mapSumSimpleFunction                                     4.44%    61.16ms    16.35
============================================================================
```
After:
```
============================================================================
mapSumVectorFunction                                         2.97ms   337.17
mapSumSimpleFunction                              40.09%     7.40ms   135.17
nestedMapSumVectorFunction                                   6.19ms   161.47
nestedMapSumSimpleFunction                        26.78%    23.12ms    43.25
nestedMapSumVectorFunctionMapView                 29.53%    20.97ms    47.68
============================================================================
```