### PR TITLE
Use DecodedVector& instead of DecodedResults in vector readers,

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -457,7 +457,7 @@ class MapView {
  private:
   const key_reader_t* keyReader_;
   const value_reader_t* valueReader_;
-  const vector_size_t offset_;
-  const vector_size_t size_;
+  vector_size_t offset_;
+  vector_size_t size_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunctionAdapter.h
+++ b/velox/expression/VectorFunctionAdapter.h
@@ -185,13 +185,13 @@ class VectorAdapter : public VectorFunction {
               bool allNotNull,
               const DecodedArgs& packed,
               TReader&... readers) const {
-    auto oneUnpacked = packed.at(POSITION)->as<exec_arg_at<POSITION>>();
+    auto* oneUnpacked = packed.at(POSITION);
     auto oneReader = VectorReader<arg_at<POSITION>>(oneUnpacked);
 
     // context->nullPruned() is true after rows with nulls have been
     // pruned out of 'rows', so we won't be seeing any more nulls here.
     bool nextNonNull = applyContext.context->nullsPruned() ||
-        (allNotNull && !oneUnpacked.mayHaveNulls());
+        (allNotNull && !oneUnpacked->mayHaveNulls());
     unpack<POSITION + 1>(
         applyContext, nextNonNull, packed, readers..., oneReader);
   }

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -37,8 +37,7 @@ TEST_F(ArrayViewTest, intArray) {
   auto arrayVector = makeNullableArrayVector(arrayDataBigInt);
   DecodedVector decoded;
   exec::VectorReader<Array<int64_t>> reader(
-      exec::detail::decode<exec::ArrayView<int64_t>>(
-          decoded, *arrayVector.get()));
+      exec::detail::decode(decoded, *arrayVector.get()));
 
   auto testItem = [&](int i, int j, auto item) {
     // Test has_value.

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -22,8 +22,13 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 namespace {
-
 using namespace facebook::velox;
+
+DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
+  SelectivityVector rows(vector.size());
+  decoder.decode(vector, rows);
+  return &decoder;
+}
 
 class MapViewTest : public functions::test::FunctionBaseTest {
  protected:
@@ -49,8 +54,7 @@ TEST_F(MapViewTest, testReadingRangeLoop) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   for (auto i = 0; i < mapsData.size(); i++) {
     auto mapView = reader[i];
@@ -75,8 +79,7 @@ TEST_F(MapViewTest, testReadingIteratorLoop) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   for (auto i = 0; i < mapsData.size(); ++i) {
     auto mapView = reader[i];
@@ -102,8 +105,7 @@ TEST_F(MapViewTest, testIndexedLoop) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   for (auto i = 0; i < mapsData.size(); ++i) {
     auto mapView = reader[i];
@@ -128,8 +130,7 @@ TEST_F(MapViewTest, testCompareLazyValueAccess) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   // Compare LazyValueAccess with constant.
   ASSERT_EQ(reader[1][0].first, 1);
@@ -155,8 +156,7 @@ TEST_F(MapViewTest, testCompareVectorOptionalValueAccessor) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   // Compare VectorOptionalValueAccessor with std::optional.
   ASSERT_EQ(reader[2][2].second, std::optional(4));
@@ -217,8 +217,7 @@ TEST_F(MapViewTest, testCompareMapViewElement) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   // Compare VectorOptionalValueAccessor with constant.
   ASSERT_NE(reader[2][2], reader[2][1]);
@@ -229,8 +228,7 @@ TEST_F(MapViewTest, testAssignToOptional) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   std::optional<int64_t> element = reader[2][2].second;
   std::optional<int64_t> element2 = reader[2][1].second;
@@ -243,8 +241,7 @@ TEST_F(MapViewTest, testFind) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   ASSERT_EQ(reader[1].find(5), reader[1].end());
   ASSERT_NE(reader[1].find(4), reader[1].end());
@@ -256,8 +253,7 @@ TEST_F(MapViewTest, testAt) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   ASSERT_THROW(reader[1].at(5), VeloxException);
   ASSERT_EQ(reader[1].at(4), std::nullopt);
@@ -268,8 +264,7 @@ TEST_F(MapViewTest, testValueOr) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
-      exec::detail::decode<exec::MapView<int64_t, int64_t>>(
-          decoded, *mapVector.get()));
+      decode(decoded, *mapVector.get()));
 
   ASSERT_EQ(reader[1].at(4).value_or(10), 10);
   ASSERT_EQ(reader[1].at(3).value_or(10), 3);

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -166,8 +166,7 @@ class NestedMapWithMapView : public exec::VectorFunction {
     LocalDecodedVector decoded_(context, *args[0], rows);
     using exec_in_t = typename VectorExec::template resolver<
         Map<int64_t, Map<int64_t, int64_t>>>::in_type;
-    VectorReader<Map<int64_t, Map<int64_t, int64_t>>> reader{
-        decoded_->as<exec_in_t>()};
+    VectorReader<Map<int64_t, Map<int64_t, int64_t>>> reader{decoded_.get()};
 
     // Prepare results
     BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -24,6 +24,8 @@
 
 namespace facebook::velox {
 
+// TODO: Deprecate this after all uses are deprecated.
+// This is not used in VELOX and should be avoided.
 // Represents the result of decoding a vector into base data, nulls
 // and indices for base data/nulls. This is meant to be lightweight
 // copyable and does not own memory.

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -47,7 +47,6 @@ class DecodedVectorTest : public testing::Test {
       SimpleVector<T>* outVector,
       bool dbgPrintVec) {
     DecodedVector decoded(*outVector, selection);
-    auto decodedResult = decoded.as<T>();
     auto end = selection.end();
     ASSERT_EQ(expected.size(), end);
 
@@ -57,9 +56,10 @@ class DecodedVectorTest : public testing::Test {
       }
       bool actualIsNull = outVector->isNullAt(index);
       auto actualValue = outVector->valueAt(index);
-      ASSERT_EQ(actualIsNull, decodedResult.isNullAt(index));
+      ASSERT_EQ(actualIsNull, decoded.isNullAt(index));
       if (!actualIsNull) {
-        ASSERT_EQ(actualValue, decodedResult[index]);
+        auto decodedValue = decoded.template valueAt<T>(index);
+        ASSERT_EQ(actualValue, decodedValue);
       }
       const bool isNull = (expected[index] == std::nullopt);
       if (dbgPrintVec) {


### PR DESCRIPTION
**Only last commit belongs to this PR**

DecodedResults is used in Vector Readers to access the values and the nullability of 
the underlying vector. It has some efficiencies, such as forcing indicies to materialize and 
not checking identity and constant mapping. Solving those made DecodedResults just a repetition 
of DecodedVector. 
in this diff i remove DecodedResults and use the underlying DecodedVector instead.

## Performance:
Its interesting that now, nestedMapSumSimpleFunction and nestedMapSumVectorFunctionMapView 
do not have similar performance, i expect the expanded vectorFunctionAdapter for the simple function 
to look like nestedMapSumVectorFunctionMapView.
after the diff:
```
============================================================================
mapSumVectorFunction                                         2.91ms   343.24
mapSumSimpleFunction                              89.23%     3.27ms   306.28
nestedMapSumVectorFunction                                   6.36ms   157.33
nestedMapSumSimpleFunction                        61.92%    10.27ms    97.42
nestedMapSumVectorFunctionMapView                 99.47%     6.39ms   156.50
============================================================================
```
before the diff:
```
============================================================================
mapSumVectorFunction                                         2.97ms   337.17
mapSumSimpleFunction                              40.09%     7.40ms   135.17
nestedMapSumVectorFunction                                   6.19ms   161.47
nestedMapSumSimpleFunction                        26.78%    23.12ms    43.25
nestedMapSumVectorFunctionMapView                 29.53%    20.97ms    47.68
============================================================================
```

one more point is the min.max: 
now simpleMinIntegerIterator is 17% slower than vectorMinInteger it used to be
30%slower.
```
vectorMinInteger                                  86.31%   557.59us    1.79K
vectorMinIntegerNoFastPath                        60.64%   793.60us    1.26K
simpleMinIntegerIterator                          69.31%   694.34us    1.44K
```