### PR TITLE
Support encoded vector in flat map writer

### DIFF
--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -201,6 +201,10 @@ class ColumnWriter {
         !context_.isLowMemoryMode();
   }
 
+  WriterContext::LocalDecodedVector decode(
+      const VectorPtr& slice,
+      const Ranges& ranges);
+
   WriterContext& context_;
   const dwio::common::TypeWithId& type_;
   const uint32_t id_;

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -187,43 +187,31 @@ struct TypeInfo {};
 template <>
 struct TypeInfo<TypeKind::TINYINT> {
   using StatisticsBuilder = IntegerStatisticsBuilder;
-  using Key = TypeTraits<TypeKind::TINYINT>::NativeType;
-  using Vector = FlatVector<TypeTraits<TypeKind::TINYINT>::NativeType>;
 };
 
 template <>
 struct TypeInfo<TypeKind::SMALLINT> {
   using StatisticsBuilder = IntegerStatisticsBuilder;
-  using Key = TypeTraits<TypeKind::SMALLINT>::NativeType;
-  using Vector = FlatVector<TypeTraits<TypeKind::SMALLINT>::NativeType>;
 };
 
 template <>
 struct TypeInfo<TypeKind::INTEGER> {
   using StatisticsBuilder = IntegerStatisticsBuilder;
-  using Key = TypeTraits<TypeKind::INTEGER>::NativeType;
-  using Vector = FlatVector<TypeTraits<TypeKind::INTEGER>::NativeType>;
 };
 
 template <>
 struct TypeInfo<TypeKind::BIGINT> {
   using StatisticsBuilder = IntegerStatisticsBuilder;
-  using Key = TypeTraits<TypeKind::BIGINT>::NativeType;
-  using Vector = FlatVector<TypeTraits<TypeKind::BIGINT>::NativeType>;
 };
 
 template <>
 struct TypeInfo<TypeKind::VARCHAR> {
   using StatisticsBuilder = StringStatisticsBuilder;
-  using Key = folly::StringPiece;
-  using Vector = FlatVector<TypeTraits<TypeKind::VARCHAR>::NativeType>;
 };
 
 template <>
 struct TypeInfo<TypeKind::VARBINARY> {
   using StatisticsBuilder = BinaryStatisticsBuilder;
-  using Key = folly::StringPiece;
-  using Vector = FlatVector<TypeTraits<TypeKind::VARBINARY>::NativeType>;
 };
 
 } // namespace
@@ -250,19 +238,18 @@ class FlatMapColumnWriter : public ColumnWriter {
                               statsFactory) const override;
 
  private:
+  using KeyType = typename TypeTraits<K>::NativeType;
+
   void setEncoding(proto::ColumnEncoding& encoding) const override;
 
-  ValueWriter& getValueWriter(
-      const typename TypeInfo<K>::Key& key,
-      uint32_t inMapSize);
+  ValueWriter& getValueWriter(KeyType key, uint32_t inMapSize);
 
   void clearNodes();
 
   // Map of value writers for each key in the dictionary. Needs referential
   // stability because a member variable is captured by reference by lambda
   // function passed to another class.
-  folly::F14NodeMap<typename TypeInfo<K>::Key, ValueWriter, folly::Hash>
-      valueWriters_;
+  folly::F14NodeMap<KeyType, ValueWriter, folly::Hash> valueWriters_;
 
   // Captures row count for each completed stride in current stripe
   std::vector<size_t> rowsInStrides_;

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -390,8 +390,15 @@ class WriterContext : public CompressionBufferPool {
     explicit LocalDecodedVector(WriterContext& context)
         : context_(context), vector_(context_.getDecodedVector()) {}
 
+    LocalDecodedVector(LocalDecodedVector&& other) noexcept
+        : context_{other.context_}, vector_{std::move(other.vector_)} {}
+
+    LocalDecodedVector& operator=(LocalDecodedVector&& other) = delete;
+
     ~LocalDecodedVector() {
-      context_.releaseDecodedVector(std::move(vector_));
+      if (vector_) {
+        context_.releaseDecodedVector(std::move(vector_));
+      }
     }
 
     DecodedVector& get() {
@@ -407,46 +414,17 @@ class WriterContext : public CompressionBufferPool {
     return LocalDecodedVector{*this};
   }
 
-  class LocalSelectivityVector {
-   public:
-    LocalSelectivityVector(WriterContext& context, velox::vector_size_t size)
-        : context_(context), vector_(context_.getSelectivityVector(size)) {}
-
-    ~LocalSelectivityVector() {
-      context_.releaseSelectivityVector(std::move(vector_));
+  SelectivityVector& getSharedSelectivityVector(velox::vector_size_t size) {
+    if (UNLIKELY(!selectivityVector_)) {
+      selectivityVector_ = std::make_unique<velox::SelectivityVector>(size);
+    } else {
+      selectivityVector_->resize(size);
     }
-
-    SelectivityVector& get() {
-      return *vector_;
-    }
-
-   private:
-    WriterContext& context_;
-    std::unique_ptr<velox::SelectivityVector> vector_;
-  };
-
-  LocalSelectivityVector getLocalSelectivityVector(velox::vector_size_t size) {
-    return LocalSelectivityVector{*this, size};
+    return *selectivityVector_;
   }
 
  private:
   void validateConfigs() const;
-
-  std::unique_ptr<velox::SelectivityVector> getSelectivityVector(
-      velox::vector_size_t size) {
-    if (selectivityVectorPool_.empty()) {
-      return std::make_unique<velox::SelectivityVector>(size);
-    }
-    auto vector = std::move(selectivityVectorPool_.back());
-    selectivityVectorPool_.pop_back();
-    vector->resize(size);
-    return vector;
-  }
-
-  void releaseSelectivityVector(
-      std::unique_ptr<velox::SelectivityVector>&& vector) {
-    selectivityVectorPool_.push_back(std::move(vector));
-  }
 
   std::unique_ptr<velox::DecodedVector> getDecodedVector() {
     if (decodedVectorPool_.empty()) {
@@ -482,8 +460,8 @@ class WriterContext : public CompressionBufferPool {
   std::unique_ptr<dwio::common::DataBuffer<char>> compressionBuffer_;
   // A pool of reusable DecodedVectors.
   std::vector<std::unique_ptr<velox::DecodedVector>> decodedVectorPool_;
-  // A pool of reusable SelectivityVectors.
-  std::vector<std::unique_ptr<velox::SelectivityVector>> selectivityVectorPool_;
+  // Reusable SelectivityVector
+  std::unique_ptr<velox::SelectivityVector> selectivityVector_;
 
   std::unique_ptr<encryption::EncryptionHandler> handler_;
   folly::F14FastMap<uint32_t, uint64_t> nodeSize;


### PR DESCRIPTION
Summary:
Flatmap writer previously supports only flat vectors.

Approach:
1. Similar to other column writers, added a decode path if input vector is encoded
2. To make code easier to read, unlike other column writers, added adapter so flat and decoded path can be handled by same iterator. This is because we have to decode both the map and map keys in some cases. Code would be easier to handle this way (but probably a little harder to understand initially).
3. Changed local decoded vector and selectivity vector logic. Selectivity vector is only used inside one method, so make it a single instance shared. Decode vector remains as is (we may have to use one for map and another for keys)

Differential Revision: D32241671

