### PR TITLE
Make stronger range test for BigintValuesUsingHashTable

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -699,6 +699,7 @@ class BigintValuesUsingHashTable final : public Filter {
   const int64_t max_;
   std::vector<int64_t> hashTable_;
   bool containsEmptyMarker_ = false;
+  std::vector<int64_t> values_;
 };
 
 /// IN-list filter for integral data types. Implemented as a bitmask. Offers

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -244,6 +244,16 @@ TEST(FilterTest, bigintValuesUsingHashTable) {
   EXPECT_FALSE(filter->testInt64Range(11, 11, false));
   EXPECT_FALSE(filter->testInt64Range(-10, -5, false));
   EXPECT_FALSE(filter->testInt64Range(10'234, 20'000, false));
+  EXPECT_FALSE(filter->testInt64(102));
+  EXPECT_FALSE(filter->testInt64(INT64_MAX));
+
+  EXPECT_TRUE(filter->testInt64Range(5, 50, false));
+  EXPECT_FALSE(filter->testInt64Range(11, 11, false));
+  EXPECT_FALSE(filter->testInt64Range(-10, -5, false));
+  EXPECT_TRUE(filter->testInt64Range(10'000, 20'000, false));
+  EXPECT_FALSE(filter->testInt64Range(9'000, 9'999, false));
+  EXPECT_TRUE(filter->testInt64Range(9'000, 10'000, false));
+  EXPECT_TRUE(filter->testInt64Range(0, 1, false));
 }
 
 TEST(FilterTest, bigintValuesUsingBitmask) {


### PR DESCRIPTION
Returns false for any range that does not contain a value in the IN
filter. Keeps a sorted copy of the values and uses lower_bound to find
the first element >= min. If this is != min and max < this, then we
have a miss.