### PR TITLE
Add DenseHll::cardinality(serialized) method

### DIFF
--- a/velox/aggregates/hyperloglog/DenseHll.h
+++ b/velox/aggregates/hyperloglog/DenseHll.h
@@ -55,6 +55,8 @@ class DenseHll {
 
   int64_t cardinality() const;
 
+  static int64_t cardinality(const char* serialized);
+
   /// Serializes internal state using Presto DenseV2 format.
   void serialize(char* output);
 
@@ -77,23 +79,13 @@ class DenseHll {
   static int32_t estimateInMemorySize(int8_t indexBitLength);
 
  private:
-  static const int kBitsPerBucket = 4;
-  static const int8_t kMaxDelta = (1 << kBitsPerBucket) - 1;
-  static const int8_t kBucketMask = (1 << kBitsPerBucket) - 1;
-
-  static constexpr double kLinearCountingMinEmptyBuckets = 0.4;
-
   int8_t getDelta(int32_t index) const;
-
-  int8_t getValue(int bucket) const;
 
   void setDelta(int32_t index, int8_t value);
 
   int8_t getOverflow(int32_t index) const;
 
   int findOverflowEntry(int32_t index) const;
-
-  double correctBias(double rawEstimate) const;
 
   void adjustBaselineIfNeeded();
 

--- a/velox/aggregates/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/aggregates/hyperloglog/tests/DenseHllTest.cpp
@@ -85,6 +85,11 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
 
     ASSERT_EQ(hllLeft.cardinality(), expected.cardinality());
     ASSERT_EQ(serialize(hllLeft), serialize(expected));
+
+    auto hllLeftSerialized = serialize(hllLeft);
+    ASSERT_EQ(
+        DenseHll::cardinality(hllLeftSerialized.data()),
+        expected.cardinality());
   }
 
   exec::HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
@@ -114,6 +119,9 @@ TEST_P(DenseHllTest, basic) {
 
   DenseHll deserialized = roundTrip(denseHll);
   ASSERT_EQ(expectedCardinality, deserialized.cardinality());
+
+  auto serialized = serialize(denseHll);
+  ASSERT_EQ(expectedCardinality, DenseHll::cardinality(serialized.data()));
 }
 
 TEST_P(DenseHllTest, highCardinality) {
@@ -131,6 +139,9 @@ TEST_P(DenseHllTest, highCardinality) {
 
   DenseHll deserialized = roundTrip(denseHll);
   ASSERT_EQ(denseHll.cardinality(), deserialized.cardinality());
+
+  auto serialized = serialize(denseHll);
+  ASSERT_EQ(denseHll.cardinality(), DenseHll::cardinality(serialized.data()));
 }
 
 namespace {


### PR DESCRIPTION
Allow for calculating cardinality from serialized dense HLL. This method will be
used to implement Presto's cardinality(hll) function efficientlly.