### PR TITLE
Fix bug on rtrim() with single character

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -484,7 +484,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
   auto start = curPos;
   curPos = input.end() - 1;
   if constexpr (rightTrim) {
-    while (curPos > start && isAsciiWhiteSpace(*curPos)) {
+    while (curPos >= start && isAsciiWhiteSpace(*curPos)) {
       curPos--;
     }
   }


### PR DESCRIPTION
Summary:
Fix bug on rtrim() function with single whitespace-like character, in
the ascii path. It wasn't being exercised by unit tests yet because the whole
vector was being tagged as UTF-8 and only exericing the unicode-aware path of
trim.

Reviewed By: kgpai

Differential Revision: D32264259

