### PR TITLE
Allow user defined types in simple functions

### DIFF
--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -37,6 +37,18 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
     Returns ``timestamp`` truncated to ``unit``.
 
+Java Date Functions
+-------------------
+
+The functions in this section leverage a native cpp implementation that follows
+a format string compatible with JodaTime’s `DateTimeFormat
+<http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html>`_
+pattern format.
+
+.. function:: parse_datetime(string, format) -> timestamp with time zone
+
+    Parses string into a timestamp with time zone using ``format``.
+
 Convenience Extraction Functions
 --------------------------------
 

--- a/velox/functions/lib/JodaDateTime.cpp
+++ b/velox/functions/lib/JodaDateTime.cpp
@@ -64,7 +64,7 @@ inline JodaFormatSpecifier getSpecifier(char c) {
 
 } // namespace
 
-JodaFormatter::JodaFormatter(std::string format) : format_(std::move(format)) {
+void JodaFormatter::initialize() {
   literalTokens_.reserve(kJodaReserveSize);
   patternTokens_.reserve(kJodaReserveSize);
   patternTokensCount_.reserve(kJodaReserveSize);

--- a/velox/functions/lib/JodaDateTime.h
+++ b/velox/functions/lib/JodaDateTime.h
@@ -92,7 +92,14 @@ enum class JodaFormatSpecifier : uint8_t {
 /// Compiles a Joda-compatible datetime format string.
 class JodaFormatter {
  public:
-  explicit JodaFormatter(std::string format);
+  explicit JodaFormatter(std::string format) : format_(std::move(format)) {
+    initialize();
+  }
+
+  explicit JodaFormatter(StringView format)
+      : format_(format.data(), format.size()) {
+    initialize();
+  }
 
   const std::vector<std::string_view>& literalTokens() const {
     return literalTokens_;
@@ -111,6 +118,8 @@ class JodaFormatter {
   Timestamp parse(const std::string& input);
 
  private:
+  void initialize();
+
   const std::string format_;
 
   // Stores the literal tokens (substrings) found while parsing `format_`.

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/RegisterCheckedArithmetic.h"
 #include "velox/functions/prestosql/RegisterComparisons.h"
 #include "velox/functions/prestosql/StringFunctions.h"
+#include "velox/functions/prestosql/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::functions {
 
@@ -83,6 +84,11 @@ void registerFunctions() {
   registerFunction<MillisecondFunction, int64_t, Timestamp>({"millisecond"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {"date_trunc"});
+  registerFunction<
+      ParseDateTimeFunction,
+      TimestampWithTimezone,
+      Varchar,
+      Varchar>({"parse_datetime"});
 
   registerFunction<CardinalityFunction, int64_t, HyperLogLog>({"cardinality"});
 

--- a/velox/functions/prestosql/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/TimestampWithTimeZoneType.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include "velox/expression/VectorUdfTypeSystem.h"
 #include "velox/type/Type.h"
+#include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox {
 
@@ -48,5 +50,8 @@ inline std::shared_ptr<const TimestampWithTimeZoneType>
 TIMESTAMP_WITH_TIME_ZONE() {
   return TimestampWithTimeZoneType::get();
 }
+
+// Type used for function registration.
+using TimestampWithTimezone = Row<int64_t, int16_t>;
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -344,10 +344,8 @@ class FunctionBaseTest : public testing::Test {
         0);
   }
 
-  template <typename T>
-  std::shared_ptr<T> evaluate(
-      const std::string& expression,
-      const RowVectorPtr& data) {
+  // Use this directly if you don't want it to cast the returned vector.
+  VectorPtr evaluate(const std::string& expression, const RowVectorPtr& data) {
     auto rowType = std::dynamic_pointer_cast<const RowType>(data->type());
     exec::ExprSet exprSet({makeTypedExpr(expression, rowType)}, &execCtx_);
 
@@ -355,8 +353,14 @@ class FunctionBaseTest : public testing::Test {
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
     std::vector<VectorPtr> results(1);
     exprSet.eval(*rows, &evalCtx, &results);
+    return results[0];
+  }
 
-    auto result = results[0];
+  template <typename T>
+  std::shared_ptr<T> evaluate(
+      const std::string& expression,
+      const RowVectorPtr& data) {
+    auto result = evaluate(expression, data);
     VELOX_CHECK(result, "Expression evaluation result is null: {}", expression);
 
     auto castedResult = std::dynamic_pointer_cast<T>(result);


### PR DESCRIPTION
Summary:
Adding template specialization to allow user defined types in simple
functions. In this diff, we add simple function support for
TimestampWithTimezone and add a simple implementation of parse_datetime() to
exercise the new feature.

Reviewed By: mbasmanova

Differential Revision: D32272864

