### PR TITLE
Support splitting incoming batches for writer

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -165,4 +165,7 @@ Config::Entry<bool> Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED(
     "orc.stream.size.above.threshold.check.enabled",
     true);
 
+Config::Entry<uint64_t> Config::RAW_DATA_SIZE_PER_BATCH(
+    "hive.exec.orc.raw.data.size.per.batch",
+    50 * 1000 * 1000);
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -116,6 +116,9 @@ class Config {
   // Fail the writer, when Stream size is above threshold
   // Streams greater than 2GB will be failed to be read by Jolly/Presto reader.
   static Entry<bool> STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED;
+  // Limit the raw data size per batch to avoid being forced
+  // to write oversized stripes.
+  static Entry<uint64_t> RAW_DATA_SIZE_PER_BATCH;
 
  private:
   std::unordered_map<std::string, std::string> configs_;

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -39,6 +39,8 @@ using namespace facebook::velox;
 using facebook::velox::memory::MemoryPool;
 using folly::Random;
 
+constexpr uint64_t kSizeMB = 1024UL * 1024UL;
+
 // This test can be run to generate test files. Run it with following command
 // buck test velox/dwio/dwrf/test:velox_dwrf_e2e_writer_tests --
 // DISABLED_TestFileCreation
@@ -573,6 +575,94 @@ TEST(E2EWriterTests, PartialStride) {
   ASSERT_EQ(size - nullCount, reader->columnStatistics(1)->getNumberOfValues())
       << reader->columnStatistics(1)->toString();
   ASSERT_EQ(true, reader->columnStatistics(1)->hasNull().value());
+}
+
+TEST(E2EWriterTests, OversizeRows) {
+  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto& pool = scopedPool->getPool();
+
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "map_val:map<string, map<string, map<string, map<string, string>>>>,"
+      "list_val:array<array<array<array<string>>>>,"
+      "struct_val:struct<"
+      "map_val_field_1:map<string, map<string, map<string, map<string, string>>>>,"
+      "list_val_field_1:array<array<array<array<string>>>>,"
+      "list_val_field_2:array<array<array<array<string>>>>,"
+      "map_val_field_2:map<string, map<string, map<string, map<string, string>>>>"
+      ">,"
+      ">");
+  auto config = std::make_shared<Config>();
+  config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+  config->set(Config::STRIPE_SIZE, 10 * kSizeMB);
+  config->set(
+      Config::RAW_DATA_SIZE_PER_BATCH, folly::to<uint64_t>(20 * 1024UL));
+
+  // Retained bytes in vector: 44704
+  auto singleBatch = E2EWriterTestUtil::generateBatches(
+      type, 1, 1, /* seed */ 1411367325, pool);
+
+  E2EWriterTestUtil::testWriter(
+      pool,
+      type,
+      singleBatch,
+      1,
+      1,
+      config,
+      /* useDefaultFlushPolicy */ true,
+      /* flushPerBatch */ false,
+      /* memoryBudget */ std::numeric_limits<int64_t>::max(),
+      false);
+}
+
+TEST(E2EWriterTests, OversizeBatches) {
+  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto& pool = scopedPool->getPool();
+
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "bool_val:boolean,"
+      "byte_val:tinyint,"
+      "float_val:float,"
+      "double_val:double,"
+      ">");
+  auto config = std::make_shared<Config>();
+  config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
+  config->set(Config::STRIPE_SIZE, 10 * kSizeMB);
+
+  // Test splitting a gigantic batch.
+  auto singleBatch = E2EWriterTestUtil::generateBatches(
+      type, 1, 10000000, /* seed */ 1411367325, pool);
+  // A gigantic batch is split into 10 stripes.
+  E2EWriterTestUtil::testWriter(
+      pool,
+      type,
+      singleBatch,
+      10,
+      10,
+      config,
+      /* useDefaultFlushPolicy */ true,
+      /* flushPerBatch */ false,
+      /* memoryBudget */ std::numeric_limits<int64_t>::max(),
+      false);
+
+  // Test splitting multiple huge batches.
+  auto batches = E2EWriterTestUtil::generateBatches(
+      type, 3, 5000000, /* seed */ 1411367325, pool);
+  // 3 gigantic batches are split into 15~16 stripes.
+  E2EWriterTestUtil::testWriter(
+      pool,
+      type,
+      batches,
+      15,
+      16,
+      config,
+      /* useDefaultFlushPolicy */ true,
+      /* flushPerBatch */ false,
+      /* memoryBudget */ std::numeric_limits<int64_t>::max(),
+      false);
 }
 
 namespace facebook::velox::dwrf {

--- a/velox/dwio/dwrf/writer/FlushPolicy.cpp
+++ b/velox/dwio/dwrf/writer/FlushPolicy.cpp
@@ -59,8 +59,8 @@ bool DefaultFlushPolicy::operator()(
 }
 
 RowsPerStripeFlushPolicy::RowsPerStripeFlushPolicy(
-    const std::vector<uint64_t>& rowsPerStripe)
-    : rowsPerStripe_{rowsPerStripe} {
+    std::vector<uint64_t> rowsPerStripe)
+    : rowsPerStripe_{std::move(rowsPerStripe)} {
   // Note: Vector will be empty for empty files.
   for (auto i = 0; i < rowsPerStripe_.size(); i++) {
     DWIO_ENSURE_GT(

--- a/velox/dwio/dwrf/writer/FlushPolicy.h
+++ b/velox/dwio/dwrf/writer/FlushPolicy.h
@@ -39,7 +39,7 @@ class DefaultFlushPolicy {
 
 class RowsPerStripeFlushPolicy {
  public:
-  explicit RowsPerStripeFlushPolicy(const std::vector<uint64_t>& rowsPerStripe);
+  explicit RowsPerStripeFlushPolicy(std::vector<uint64_t> rowsPerStripe);
   bool operator()(bool overMemoryBudget, const WriterContext& context) const;
 
  private:

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -20,22 +20,30 @@ namespace facebook::velox::dwrf {
 
 void Writer::write(const VectorPtr& slice) {
   auto& context = getContext();
-  size_t offset = 0;
+  vector_size_t offset = 0;
+  // Calculate length increment based on linear projection of micro batch size.
+  // Total length is capped later.
+  const vector_size_t lengthIncrement = std::max(
+      1,
+      slice->retainedSize() > 0 ? folly::to<vector_size_t>(std::floor(
+                                      1.0 * context.rawDataSizePerBatch /
+                                      slice->retainedSize() * slice->size()))
+                                : slice->size());
   while (offset < slice->size()) {
-    size_t length = slice->size() - offset;
-    // Length can be further chunked down if we estimate the slice to be too
-    // large. Challenging for first write, though, so we still assume reasonable
-    // slice size for now, and let the application deal with memory capping
-    // exception and retries.
+    vector_size_t length = lengthIncrement;
     if (context.isIndexEnabled) {
       length = std::min(
           length,
-          static_cast<size_t>(context.indexStride - context.indexRowCount));
+          folly::to<vector_size_t>(
+              context.indexStride - context.indexRowCount));
     }
 
+    length = std::min(length, slice->size() - offset);
+    VELOX_CHECK_GT(length, 0);
     if (shouldFlush(context, length)) {
       flush();
     }
+
     auto rawSize = writer_->write(slice, Ranges::of(offset, offset + length));
     offset += length;
     getContext().incRawSize(rawSize);

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -53,6 +53,7 @@ class WriterContext : public CompressionBufferPool {
         dictionarySizeFlushThreshold{getConfig(Config::MAX_DICTIONARY_SIZE)},
         isStreamSizeAboveThresholdCheckEnabled{
             getConfig(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED)},
+        rawDataSizePerBatch{getConfig(Config::RAW_DATA_SIZE_PER_BATCH)},
         // Currently logging with no metadata. Might consider populating
         // metadata with dwio::common::request::AccessDescriptor upstream and
         // pass down the metric log.
@@ -514,6 +515,7 @@ class WriterContext : public CompressionBufferPool {
   const uint64_t stripeSizeFlushThreshold;
   const uint64_t dictionarySizeFlushThreshold;
   const bool isStreamSizeAboveThresholdCheckEnabled;
+  const uint64_t rawDataSizePerBatch;
   const dwio::common::MetricsLogPtr metricLogger;
 
   template <typename TestType>


### PR DESCRIPTION
Summary:
Writer should split incoming slices from their memory estimates to
1) protect itself from super big batches causing memory issue or forcing a super big stripe (extremely wide schema or deeply nested data)
2) increase the granularity of memory footprint control

Microbatching also helps with better stripe size control and estimates.

Reviewed By: zzhao0

Differential Revision: D30555339

