### PR TITLE
Ensure initialization of rowIdCounter in AssignUniqueIdOperator

### DIFF
--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -44,6 +44,9 @@ AssignUniqueId::AssignUniqueId(
 
   resultProjections_.emplace_back(0, numColumns - 1);
   results_.resize(1);
+
+  rowIdCounter_ = 0;
+  maxRowIdCounterValue_ = 0;
 }
 
 void AssignUniqueId::addInput(RowVectorPtr input) {

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -83,11 +83,12 @@ TEST_F(AssignUniqueIdTest, exceedRequestLimit) {
 }
 
 TEST_F(AssignUniqueIdTest, multiThread) {
-  vector_size_t batchSize = 1000;
-  auto input = {makeRowVector(
-      {makeFlatVector<int32_t>(batchSize, [](auto row) { return row; })})};
+  for (int i = 0; i < 3; i++) {
+    vector_size_t batchSize = 1000;
+    auto input = {makeRowVector(
+        {makeFlatVector<int32_t>(batchSize, [](auto row) { return row; })})};
+    auto plan = PlanBuilder().values(input, true).assignUniqueId().planNode();
 
-  auto plan = PlanBuilder().values(input, true).assignUniqueId().planNode();
-
-  verifyUniqueId(plan, input, 3);
+    verifyUniqueId(plan, input, 8);
+  }
 }


### PR DESCRIPTION
Fix the flakiness of the multithread unit test. 

The root cause is that the values of `rowIdCounter_ `  & `maxRowIdCounterValue_ ` is not initialized in https://github.com/facebookincubator/velox/blob/main/velox/exec/AssignUniqueId.cpp#L80 so the behavior is unpredictable

Signed-off-by: frankobe <frank.hu@bytedance.com>