### PR TITLE
Rename CODEGEN_SUPPORT option to VELOX_CODEGEN_SUPPORT and fix dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,16 +89,16 @@ endif()
 
 # If CODEGEN support isn't explicitly set, we guestimate the value based on the
 # compiler
-if((NOT DEFINED CODEGEN_SUPPORT) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+if((NOT DEFINED VELOX_CODEGEN_SUPPORT) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
   message(STATUS "Enabling Codegen")
-  set(CODEGEN_SUPPORT True)
+  set(VELOX_CODEGEN_SUPPORT True)
 else()
   message(STATUS "Disabling Codegen")
-  set(CODEGEN_SUPPORT False)
+  set(VELOX_CODEGEN_SUPPORT False)
 endif()
 
 # define processor variable for conditional compilation
-if(${CODEGEN_SUPPORT})
+if(${VELOX_CODEGEN_SUPPORT})
   add_compile_definitions(CODEGEN_ENABLED=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,8 @@ endif()
 
 # If CODEGEN support isn't explicitly set, we guestimate the value based on the
 # compiler
-if((NOT DEFINED VELOX_CODEGEN_SUPPORT) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+if((NOT DEFINED VELOX_CODEGEN_SUPPORT) AND (CMAKE_CXX_COMPILER_ID MATCHES
+                                            "Clang"))
   message(STATUS "Enabling Codegen")
   set(VELOX_CODEGEN_SUPPORT True)
 else()

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -61,6 +61,6 @@ if(${VELOX_ENABLE_DUCKDB})
   add_subdirectory(external/duckdb)
 endif()
 
-if(${CODEGEN_SUPPORT} AND ${VELOX_BUILD_TESTING})
+if(${VELOX_CODEGEN_SUPPORT} AND ${VELOX_BUILD_TESTING})
   add_subdirectory(experimental/codegen)
 endif()

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -61,6 +61,6 @@ if(${VELOX_ENABLE_DUCKDB})
   add_subdirectory(external/duckdb)
 endif()
 
-if(${VELOX_CODEGEN_SUPPORT} AND ${VELOX_BUILD_TESTING})
+if(${VELOX_CODEGEN_SUPPORT})
   add_subdirectory(experimental/codegen)
 endif()

--- a/velox/codegen/CMakeLists.txt
+++ b/velox/codegen/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_codegen Codegen.cpp)
-if(${CODEGEN_SUPPORT})
+if(${VELOX_CODEGEN_SUPPORT})
   target_link_libraries(velox_codegen velox_experimental_codegen)
 else()
   target_link_libraries(velox_codegen velox_core velox_exec velox_expression

--- a/velox/experimental/codegen/CMakeLists.txt
+++ b/velox/experimental/codegen/CMakeLists.txt
@@ -28,7 +28,6 @@ add_subdirectory(code_generator)
 add_subdirectory(ast)
 add_subdirectory(udf_manager)
 add_subdirectory(utils)
-add_subdirectory(benchmark)
 add_subdirectory(functions)
 add_subdirectory(vector_function)
 
@@ -49,5 +48,6 @@ target_link_libraries(
   velox_expression)
 
 if(${VELOX_BUILD_TESTING})
+  add_subdirectory(benchmark)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
CODEGEN_SUPPORT must be renamed to VELOX_CODEGEN_SUPPORT to align with the rest of the option names.

This PR also fixes the following dependency issue.
If `{VELOX_BUILD_TESTING=OFF` then `experimental/codegen` is disabled. However, this is required when `VELOX_CODEGEN_SUPPORT=ON`