### PR TITLE
Migrate simple arithmentic function to new framework

### DIFF
--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -20,21 +20,21 @@
 namespace facebook::velox::functions {
 namespace {
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryIntegral(const std::vector<std::string>& aliases) {
-  registerFunction<T<int8_t>, int8_t, int8_t, int8_t>(aliases);
-  registerFunction<T<int16_t>, int16_t, int16_t, int16_t>(aliases);
-  registerFunction<T<int32_t>, int32_t, int32_t, int32_t>(aliases);
-  registerFunction<T<int64_t>, int64_t, int64_t, int64_t>(aliases);
+  registerFunction<T, int8_t, int8_t, int8_t>(aliases);
+  registerFunction<T, int16_t, int16_t, int16_t>(aliases);
+  registerFunction<T, int32_t, int32_t, int32_t>(aliases);
+  registerFunction<T, int64_t, int64_t, int64_t>(aliases);
 }
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryFloatingPoint(const std::vector<std::string>& aliases) {
-  registerFunction<T<double>, double, double, double>(aliases);
-  registerFunction<T<float>, float, float, float>(aliases);
+  registerFunction<T, double, double, double>(aliases);
+  registerFunction<T, float, float, float>(aliases);
 }
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryNumeric(const std::vector<std::string>& aliases) {
   registerBinaryIntegral<T>(aliases);
   registerBinaryFloatingPoint<T>(aliases);

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -26,51 +26,61 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(plus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = plus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct PlusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = plus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(minus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = minus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = minus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(multiply)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = multiply(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = multiply(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(divide)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b)
+struct DivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b)
 // depend on compiler have correct behaviour for divide by zero
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)
-    __attribute__((__no_sanitize__("float-divide-by-zero")))
+      __attribute__((__no_sanitize__("float-divide-by-zero")))
 #endif
 #endif
-{
-  result = a / b;
-  return true;
-}
-VELOX_UDF_END();
+  {
+    result = a / b;
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(modulus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = modulus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct ModulusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = modulus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(ceil)
@@ -128,12 +138,14 @@ FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
 VELOX_UDF_END();
 
 template <typename T>
-VELOX_UDF_BEGIN(min)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = std::min(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MinFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = std::min(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(clamp)

--- a/velox/functions/prestosql/CheckedArithmetic.h
+++ b/velox/functions/prestosql/CheckedArithmetic.h
@@ -21,57 +21,57 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
 
-namespace facebook {
-namespace velox {
-namespace functions {
+namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_plus)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedPlus(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
-
-template <typename T>
-VELOX_UDF_BEGIN(checked_minus)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedMinus(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
+struct CheckedPlusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedPlus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_multiply)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedMultiply(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
-
-template <typename T>
-VELOX_UDF_BEGIN(checked_divide)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedDivide(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct CheckedMinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedMinus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_modulus)
+struct CheckedMultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedMultiply(a, b);
+    return true;
+  }
+};
 
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedModulus(a, b);
-  return true;
-}
+template <typename T>
+struct CheckedDivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedDivide(a, b);
+    return true;
+  }
+};
 
-VELOX_UDF_END();
+template <typename T>
+struct CheckedModulusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedModulus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(checked_negate)
@@ -81,6 +81,4 @@ FOLLY_ALWAYS_INLINE bool call(T& result, const T& a) {
 }
 VELOX_UDF_END();
 
-} // namespace functions
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/RegisterArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterArithmetic.cpp
@@ -40,11 +40,11 @@ void registerBitwiseUnaryIntegral(const std::vector<std::string>& aliases) {
 } // namespace
 
 void registerArithmeticFunctions() {
-  registerBinaryFloatingPoint<udf_plus>({});
-  registerBinaryFloatingPoint<udf_minus>({});
-  registerBinaryFloatingPoint<udf_multiply>({});
-  registerBinaryFloatingPoint<udf_divide>({});
-  registerBinaryFloatingPoint<udf_modulus>({});
+  registerBinaryFloatingPoint<PlusFunction>({"plus"});
+  registerBinaryFloatingPoint<MinusFunction>({"minus"});
+  registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
+  registerBinaryFloatingPoint<DivideFunction>({"divide"});
+  registerBinaryFloatingPoint<ModulusFunction>({"modulus"});
   registerUnaryNumeric<udf_ceil>({"ceil", "ceiling"});
   registerUnaryNumeric<udf_floor>({});
   registerUnaryNumeric<udf_abs>({});

--- a/velox/functions/prestosql/RegisterCheckedArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterCheckedArithmetic.cpp
@@ -21,11 +21,11 @@
 namespace facebook::velox::functions {
 
 void registerCheckedArithmeticFunctions() {
-  registerBinaryIntegral<udf_checked_plus>({"plus"});
-  registerBinaryIntegral<udf_checked_minus>({"minus"});
-  registerBinaryIntegral<udf_checked_multiply>({"multiply"});
-  registerBinaryIntegral<udf_checked_modulus>({"modulus"});
-  registerBinaryIntegral<udf_checked_divide>({"divide"});
+  registerBinaryIntegral<CheckedPlusFunction>({"plus"});
+  registerBinaryIntegral<CheckedMinusFunction>({"minus"});
+  registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
+  registerBinaryIntegral<CheckedModulusFunction>({"modulus"});
+  registerBinaryIntegral<CheckedDivideFunction>({"divide"});
   registerUnaryIntegral<udf_checked_negate>({"negate"});
 }
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -25,27 +25,31 @@
 namespace facebook::velox::functions::sparksql {
 
 template <typename T>
-VELOX_UDF_BEGIN(pmod)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T a, const T n) {
-  if (UNLIKELY(n == 0)) {
-    return false;
+struct PModFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    TInput r = a % n;
+    result = (r > 0) ? r : (r + n) % n;
+    return true;
   }
-  T r = a % n;
-  result = (r > 0) ? r : (r + n) % n;
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(remainder)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T a, const T n) {
-  if (UNLIKELY(n == 0)) {
-    return false;
+struct RemainderFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    result = a % n;
+    return true;
   }
-  result = a % n;
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(unaryminus)

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -24,16 +24,16 @@ namespace facebook::velox::functions::sparksql {
 
 void registerArithmeticFunctions(const std::string& prefix) {
   // Operators.
-  registerBinaryNumeric<udf_plus>({prefix + "add"});
-  registerBinaryNumeric<udf_minus>({prefix + "subtract"});
-  registerBinaryNumeric<udf_multiply>({prefix + "multiply"});
+  registerBinaryNumeric<PlusFunction>({prefix + "add"});
+  registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
+  registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
   registerFunction<udf_divide, double, double, double>({prefix + "divide"});
-  registerBinaryIntegral<udf_remainder>({prefix + "remainder"});
+  registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<udf_unaryminus>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<udf_abs>({prefix + "abs"});
   registerFunction<udf_exp, double, double>({prefix + "exp"});
-  registerBinaryIntegral<udf_pmod>({prefix + "pmod"});
+  registerBinaryIntegral<PModFunction>({prefix + "pmod"});
   registerFunction<udf_power<double>, double, double, double>(
       {prefix + "power"});
   registerUnaryNumeric<udf_round>({prefix + "round"});


### PR DESCRIPTION
Summary:
Migrating simple arithmetic functions (checked and unchecked) to the
new framework, in addition to some helper registration functions.

Differential Revision: D32321191

