### PR TITLE
Add timezone offset support to parse_datetime()

### DIFF
--- a/velox/functions/lib/JodaDateTime.h
+++ b/velox/functions/lib/JodaDateTime.h
@@ -89,6 +89,11 @@ enum class JodaFormatSpecifier : uint8_t {
   TIMEZONE_OFFSET_ID = 20
 };
 
+struct JodaResult {
+  Timestamp timestamp;
+  int64_t timezoneId{-1};
+};
+
 /// Compiles a Joda-compatible datetime format string.
 class JodaFormatter {
  public:
@@ -115,7 +120,7 @@ class JodaFormatter {
 
   // Parses `input` according to the format specified in the constructor. Throws
   // in case the input couldn't be parsed.
-  Timestamp parse(const std::string& input);
+  JodaResult parse(const std::string& input);
 
  private:
   void initialize();

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -18,6 +18,7 @@
 #include "velox/functions/lib/JodaDateTime.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
 
@@ -306,6 +307,7 @@ struct ParseDateTimeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   std::optional<JodaFormatter> format_;
+  std::optional<int64_t> sessionTzID_;
 
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
@@ -314,17 +316,25 @@ struct ParseDateTimeFunction {
     if (format != nullptr) {
       format_.emplace(*format);
     }
+
+    auto sessionTzName = config.sessionTimezone();
+    if (!sessionTzName.empty()) {
+      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    }
   }
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& format) {
-    auto ts = format_.has_value() ? format_->parse(input)
-                                  : JodaFormatter(format).parse(input);
-    // TODO: Need to extend JodaFormatter to parse and add the timezone
-    // information as the second argument.
-    result = std::make_tuple(ts.toMillis(), (int16_t)0);
+    auto jodaResult = format_.has_value() ? format_->parse(input)
+                                          : JodaFormatter(format).parse(input);
+
+    // If timezone was not parsed, fallback to the session timezone. If there's
+    // no session timezone, fallback to 0 (GMT).
+    int16_t timezoneId = jodaResult.timezoneId != -1 ? jodaResult.timezoneId
+                                                     : sessionTzID_.value_or(0);
+    result = std::make_tuple(jodaResult.timestamp.toMillis(), timezoneId);
     return true;
   }
 };

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Timestamp.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
 
@@ -430,4 +431,14 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
   EXPECT_EQ(
       TimestampWithTimezone(86400000, 0),
       parseDatetime("1970-01-02", "YYYY-MM-dd"));
+
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, util::getTimeZoneID("-09:00")),
+      parseDatetime("1970-01-02+00:00-09:00", "YYYY-MM-dd+HH:mmZZ"));
+
+  setQueryTimeZone("Asia/Kolkata");
+
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, util::getTimeZoneID("Asia/Kolkata")),
+      parseDatetime("1970-01-02+00:00", "YYYY-MM-dd+HH:mm"));
 }


### PR DESCRIPTION
Summary: Adding support for parsing timezone offsets in parse_datetime().

Differential Revision: D32330661

