### PR TITLE
Add convenience StringView user-defined literal

### DIFF
--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -20,21 +20,21 @@
 namespace facebook::velox::functions {
 namespace {
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryIntegral(const std::vector<std::string>& aliases) {
-  registerFunction<T<int8_t>, int8_t, int8_t, int8_t>(aliases);
-  registerFunction<T<int16_t>, int16_t, int16_t, int16_t>(aliases);
-  registerFunction<T<int32_t>, int32_t, int32_t, int32_t>(aliases);
-  registerFunction<T<int64_t>, int64_t, int64_t, int64_t>(aliases);
+  registerFunction<T, int8_t, int8_t, int8_t>(aliases);
+  registerFunction<T, int16_t, int16_t, int16_t>(aliases);
+  registerFunction<T, int32_t, int32_t, int32_t>(aliases);
+  registerFunction<T, int64_t, int64_t, int64_t>(aliases);
 }
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryFloatingPoint(const std::vector<std::string>& aliases) {
-  registerFunction<T<double>, double, double, double>(aliases);
-  registerFunction<T<float>, float, float, float>(aliases);
+  registerFunction<T, double, double, double>(aliases);
+  registerFunction<T, float, float, float>(aliases);
 }
 
-template <template <class> class T>
+template <template <class> typename T>
 void registerBinaryNumeric(const std::vector<std::string>& aliases) {
   registerBinaryIntegral<T>(aliases);
   registerBinaryFloatingPoint<T>(aliases);

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -26,51 +26,61 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(plus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = plus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct PlusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = plus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(minus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = minus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = minus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(multiply)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = multiply(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = multiply(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(divide)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b)
+struct DivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b)
 // depend on compiler have correct behaviour for divide by zero
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)
-    __attribute__((__no_sanitize__("float-divide-by-zero")))
+      __attribute__((__no_sanitize__("float-divide-by-zero")))
 #endif
 #endif
-{
-  result = a / b;
-  return true;
-}
-VELOX_UDF_END();
+  {
+    result = a / b;
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(modulus)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = modulus(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct ModulusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = modulus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(ceil)
@@ -128,12 +138,14 @@ FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
 VELOX_UDF_END();
 
 template <typename T>
-VELOX_UDF_BEGIN(min)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = std::min(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct MinFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = std::min(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(clamp)

--- a/velox/functions/prestosql/CheckedArithmetic.h
+++ b/velox/functions/prestosql/CheckedArithmetic.h
@@ -21,57 +21,57 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
 
-namespace facebook {
-namespace velox {
-namespace functions {
+namespace facebook::velox::functions {
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_plus)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedPlus(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
-
-template <typename T>
-VELOX_UDF_BEGIN(checked_minus)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedMinus(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
+struct CheckedPlusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedPlus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_multiply)
-
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedMultiply(a, b);
-  return true;
-}
-
-VELOX_UDF_END();
-
-template <typename T>
-VELOX_UDF_BEGIN(checked_divide)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedDivide(a, b);
-  return true;
-}
-VELOX_UDF_END();
+struct CheckedMinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedMinus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(checked_modulus)
+struct CheckedMultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedMultiply(a, b);
+    return true;
+  }
+};
 
-FOLLY_ALWAYS_INLINE bool call(T& result, const T& a, const T& b) {
-  result = checkedModulus(a, b);
-  return true;
-}
+template <typename T>
+struct CheckedDivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedDivide(a, b);
+    return true;
+  }
+};
 
-VELOX_UDF_END();
+template <typename T>
+struct CheckedModulusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedModulus(a, b);
+    return true;
+  }
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(checked_negate)
@@ -81,6 +81,4 @@ FOLLY_ALWAYS_INLINE bool call(T& result, const T& a) {
 }
 VELOX_UDF_END();
 
-} // namespace functions
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/RegisterArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterArithmetic.cpp
@@ -40,11 +40,11 @@ void registerBitwiseUnaryIntegral(const std::vector<std::string>& aliases) {
 } // namespace
 
 void registerArithmeticFunctions() {
-  registerBinaryFloatingPoint<udf_plus>({});
-  registerBinaryFloatingPoint<udf_minus>({});
-  registerBinaryFloatingPoint<udf_multiply>({});
-  registerBinaryFloatingPoint<udf_divide>({});
-  registerBinaryFloatingPoint<udf_modulus>({});
+  registerBinaryFloatingPoint<PlusFunction>({"plus"});
+  registerBinaryFloatingPoint<MinusFunction>({"minus"});
+  registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
+  registerBinaryFloatingPoint<DivideFunction>({"divide"});
+  registerBinaryFloatingPoint<ModulusFunction>({"modulus"});
   registerUnaryNumeric<udf_ceil>({"ceil", "ceiling"});
   registerUnaryNumeric<udf_floor>({});
   registerUnaryNumeric<udf_abs>({});

--- a/velox/functions/prestosql/RegisterCheckedArithmetic.cpp
+++ b/velox/functions/prestosql/RegisterCheckedArithmetic.cpp
@@ -21,11 +21,11 @@
 namespace facebook::velox::functions {
 
 void registerCheckedArithmeticFunctions() {
-  registerBinaryIntegral<udf_checked_plus>({"plus"});
-  registerBinaryIntegral<udf_checked_minus>({"minus"});
-  registerBinaryIntegral<udf_checked_multiply>({"multiply"});
-  registerBinaryIntegral<udf_checked_modulus>({"modulus"});
-  registerBinaryIntegral<udf_checked_divide>({"divide"});
+  registerBinaryIntegral<CheckedPlusFunction>({"plus"});
+  registerBinaryIntegral<CheckedMinusFunction>({"minus"});
+  registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
+  registerBinaryIntegral<CheckedModulusFunction>({"modulus"});
+  registerBinaryIntegral<CheckedDivideFunction>({"divide"});
   registerUnaryIntegral<udf_checked_negate>({"negate"});
 }
 

--- a/velox/functions/prestosql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMaxTest.cpp
@@ -70,78 +70,74 @@ TEST_F(ArrayMaxTest, booleanNoNulls) {
 }
 
 TEST_F(ArrayMaxTest, varcharWithNulls) {
-  using S = StringView;
-  auto input = makeNullableArrayVector<S>({
-      {S("red"), S("blue")},
-      {std::nullopt, S("blue"), S("yellow"), S("orange")},
+  auto input = makeNullableArrayVector<StringView>({
+      {"red"_sv, "blue"_sv},
+      {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv},
       {},
-      {S("red"), S("purple"), S("green")},
+      {"red"_sv, "purple"_sv, "green"_sv},
   });
 
   auto expected = makeNullableFlatVector<StringView>(
-      {S("red"), std::nullopt, std::nullopt, S("red")});
+      {"red"_sv, std::nullopt, std::nullopt, "red"_sv});
 
   testArrayMax(input, expected);
 }
 
 TEST_F(ArrayMaxTest, varcharNoNulls) {
-  using S = StringView;
-  auto input = makeArrayVector<S>({
-      {S("red"), S("blue")},
-      {S("blue"), S("yellow"), S("orange")},
+  auto input = makeArrayVector<StringView>({
+      {"red"_sv, "blue"_sv},
+      {"blue"_sv, "yellow"_sv, "orange"_sv},
       {},
-      {S("red"), S("purple"), S("green")},
+      {"red"_sv, "purple"_sv, "green"_sv},
   });
 
   auto expected = makeNullableFlatVector<StringView>(
-      {S("red"), S("yellow"), std::nullopt, S("red")});
+      {"red"_sv, "yellow"_sv, std::nullopt, "red"_sv});
 
   testArrayMax(input, expected);
 }
 
 // Test non-inlined (> 12 length) nullable strings.
 TEST_F(ArrayMaxTest, longVarcharWithNulls) {
-  using S = StringView;
-  auto input = makeNullableArrayVector<S>({
-      {S("red shiny car ahead"), S("blue clear sky above")},
+  auto input = makeNullableArrayVector<StringView>({
+      {"red shiny car ahead"_sv, "blue clear sky above"_sv},
       {std::nullopt,
-       S("blue clear sky above"),
-       S("yellow rose flowers"),
-       S("orange beautiful sunset")},
+       "blue clear sky above"_sv,
+       "yellow rose flowers"_sv,
+       "orange beautiful sunset"_sv},
       {},
-      {S("red shiny car ahead"),
-       S("purple is an elegant color"),
-       S("green plants make us happy")},
+      {"red shiny car ahead"_sv,
+       "purple is an elegant color"_sv,
+       "green plants make us happy"_sv},
   });
 
-  auto expected = makeNullableFlatVector<S>(
-      {S("red shiny car ahead"),
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red shiny car ahead"_sv,
        std::nullopt,
        std::nullopt,
-       S("red shiny car ahead")});
+       "red shiny car ahead"_sv});
 
   testArrayMax(input, expected);
 }
 
 // Test non-inlined (> 12 length) strings.
 TEST_F(ArrayMaxTest, longVarcharNoNulls) {
-  using S = StringView;
-  auto input = makeNullableArrayVector<S>({
-      {S("red shiny car ahead"), S("blue clear sky above")},
-      {S("blue clear sky above"),
-       S("yellow rose flowers"),
-       S("orange beautiful sunset")},
+  auto input = makeNullableArrayVector<StringView>({
+      {"red shiny car ahead"_sv, "blue clear sky above"_sv},
+      {"blue clear sky above"_sv,
+       "yellow rose flowers"_sv,
+       "orange beautiful sunset"_sv},
       {},
-      {S("red shiny car ahead"),
-       S("purple is an elegant color"),
-       S("green plants make us happy")},
+      {"red shiny car ahead"_sv,
+       "purple is an elegant color"_sv,
+       "green plants make us happy"_sv},
   });
 
-  auto expected = makeNullableFlatVector<S>(
-      {S("red shiny car ahead"),
-       S("yellow rose flowers"),
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red shiny car ahead"_sv,
+       "yellow rose flowers"_sv,
        std::nullopt,
-       S("red shiny car ahead")});
+       "red shiny car ahead"_sv});
 
   testArrayMax(input, expected);
 }

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -95,26 +95,18 @@ TEST_F(GreatestLeastTest, greatestBigInt) {
 
 TEST_F(GreatestLeastTest, greatestVarchar) {
   runTest<StringView>(
-      "greatest(c0)",
-      {{StringView("a"), StringView("b"), StringView("c")}},
-      {StringView("a"), StringView("b"), StringView("c")});
+      "greatest(c0)", {{"a"_sv, "b"_sv, "c"_sv}}, {"a"_sv, "b"_sv, "c"_sv});
 
   runTest<StringView>(
-      "greatest(c0, 'aaa')",
-      {{StringView(""), StringView("abb")}},
-      {StringView("aaa"), StringView("abb")});
+      "greatest(c0, 'aaa')", {{""_sv, "abb"_sv}}, {"aaa"_sv, "abb"_sv});
 }
 
 TEST_F(GreatestLeastTest, leasstVarchar) {
   runTest<StringView>(
-      "least(c0)",
-      {{StringView("a"), StringView("b"), StringView("c")}},
-      {StringView("a"), StringView("b"), StringView("c")});
+      "least(c0)", {{"a"_sv, "b"_sv, "c"_sv}}, {"a"_sv, "b"_sv, "c"_sv});
 
   runTest<StringView>(
-      "least(c0, 'aaa')",
-      {{StringView(""), StringView("abb")}},
-      {StringView(""), StringView("aaa")});
+      "least(c0, 'aaa')", {{""_sv, "abb"_sv}}, {""_sv, "aaa"_sv});
 }
 
 TEST_F(GreatestLeastTest, greatestTimeStamp) {
@@ -138,15 +130,15 @@ TEST_F(GreatestLeastTest, leastTimeStamp) {
 TEST_F(GreatestLeastTest, stringBuffersMoved) {
   runTest<StringView>(
       "least(c0, c1)",
-      {{StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
-       {StringView("cccccccccccccc"), StringView("dddddddddddddd")}},
-      {StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
+      {{"aaaaaaaaaaaaaa"_sv, "bbbbbbbbbbbbbb"_sv},
+       {"cccccccccccccc"_sv, "dddddddddddddd"_sv}},
+      {"aaaaaaaaaaaaaa"_sv, "bbbbbbbbbbbbbb"_sv},
       1);
 
   runTest<StringView>(
       "least(c0, c1, '')",
-      {{StringView("aaaaaaaaaaaaaa"), StringView("bbbbbbbbbbbbbb")},
-       {StringView("cccccccccccccc"), StringView("dddddddddddddd")}},
-      {StringView(""), StringView("")},
+      {{"aaaaaaaaaaaaaa"_sv, "bbbbbbbbbbbbbb"_sv},
+       {"cccccccccccccc"_sv, "dddddddddddddd"_sv}},
+      {""_sv, ""_sv},
       0);
 }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -25,27 +25,31 @@
 namespace facebook::velox::functions::sparksql {
 
 template <typename T>
-VELOX_UDF_BEGIN(pmod)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T a, const T n) {
-  if (UNLIKELY(n == 0)) {
-    return false;
+struct PModFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    TInput r = a % n;
+    result = (r > 0) ? r : (r + n) % n;
+    return true;
   }
-  T r = a % n;
-  result = (r > 0) ? r : (r + n) % n;
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(remainder)
-FOLLY_ALWAYS_INLINE bool call(T& result, const T a, const T n) {
-  if (UNLIKELY(n == 0)) {
-    return false;
+struct RemainderFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    result = a % n;
+    return true;
   }
-  result = a % n;
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
 VELOX_UDF_BEGIN(unaryminus)

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -24,16 +24,16 @@ namespace facebook::velox::functions::sparksql {
 
 void registerArithmeticFunctions(const std::string& prefix) {
   // Operators.
-  registerBinaryNumeric<udf_plus>({prefix + "add"});
-  registerBinaryNumeric<udf_minus>({prefix + "subtract"});
-  registerBinaryNumeric<udf_multiply>({prefix + "multiply"});
+  registerBinaryNumeric<PlusFunction>({prefix + "add"});
+  registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
+  registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
   registerFunction<udf_divide, double, double, double>({prefix + "divide"});
-  registerBinaryIntegral<udf_remainder>({prefix + "remainder"});
+  registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<udf_unaryminus>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<udf_abs>({prefix + "abs"});
   registerFunction<udf_exp, double, double>({prefix + "exp"});
-  registerBinaryIntegral<udf_pmod>({prefix + "pmod"});
+  registerBinaryIntegral<PModFunction>({prefix + "pmod"});
   registerFunction<udf_power<double>, double, double, double>(
       {prefix + "power"});
   registerUnaryNumeric<udf_round>({prefix + "round"});

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -25,8 +25,7 @@
 
 #include "velox/common/base/BitUtil.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 // Variable length string or binary type for use in vectors. This has
 // semantics similar to std::string_view or folly::StringPiece and
@@ -230,8 +229,15 @@ struct StringView {
   } value_;
 };
 
-} // namespace velox
-} // namespace facebook
+// This creates a user-defined literal for StringView. You can use it as:
+//
+//   auto myStringView = "my string"_sv;
+//   auto vec = {"str1"_sv, "str2"_sv};
+inline StringView operator"" _sv(const char* str, size_t len) {
+  return StringView(str, len);
+}
+
+} // namespace facebook::velox
 
 namespace std {
 template <>

--- a/velox/type/tests/StringViewTest.cpp
+++ b/velox/type/tests/StringViewTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sstream>
 #include "velox/type/Type.h"
@@ -111,4 +112,11 @@ TEST(Type, StringViewSelfComparison) {
     EXPECT_EQ(lhs == rhs, true);
     EXPECT_EQ(lhs != rhs, false);
   }
+}
+
+TEST(Type, StringViewLiteral) {
+  EXPECT_EQ("ab"_sv, StringView("ab"));
+
+  std::vector<StringView> vec = {"a"_sv, "b"_sv};
+  EXPECT_THAT(vec, ::testing::ElementsAre("a"_sv, "b"_sv));
 }

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -65,9 +65,8 @@ void assertIsAscii(
 
 class SimpleVectorNonParameterizedTest : public SimpleVectorTest {
  protected:
-  using S = StringView;
   ExpectedData<StringView> stringData_ =
-      {S("àá"), S("abc"), S("xyz"), S("mno"), S("wv"), S("abc"), S("xyz")};
+      {"àá"_sv, "abc"_sv, "xyz"_sv, "mno"_sv, "wv"_sv, "abc"_sv, "xyz"_sv};
 };
 
 TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTest) {

--- a/velox/vector/tests/SimpleVectorTestHelper.h
+++ b/velox/vector/tests/SimpleVectorTestHelper.h
@@ -51,33 +51,33 @@ class SimpleVectorTest : public ::testing::Test {
 
   ExpectedData<StringView> genStringRoundTripDataVariableWidth() {
     return {
-        StringView("foo"),
+        "foo"_sv,
         std::nullopt,
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("banana"),
-        StringView("banana"),
-        StringView("banana"),
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "banana"_sv,
+        "banana"_sv,
+        "banana"_sv,
     };
   }
 
   ExpectedData<StringView> genStringRoundTripFixedWidthData() {
     return {
-        StringView("foo"),
+        "foo"_sv,
         std::nullopt,
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("baz"),
-        StringView("grr"),
-        StringView("grr"),
-        StringView("grr"),
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "baz"_sv,
+        "grr"_sv,
+        "grr"_sv,
+        "grr"_sv,
     };
   }
 

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -88,7 +88,7 @@ TEST_F(VectorMakerTest, flatVectorString) {
   EXPECT_EQ(0, flatVector->getNullCount().value());
   EXPECT_FALSE(flatVector->isSorted().value());
   EXPECT_EQ(5, flatVector->getDistinctValueCount().value());
-  EXPECT_EQ(StringView(""), flatVector->getMin().value());
+  EXPECT_EQ(""_sv, flatVector->getMin().value());
   EXPECT_EQ(StringView("world"), flatVector->getMax().value());
 
   for (vector_size_t i = 0; i < data.size(); i++) {
@@ -564,15 +564,15 @@ TEST_F(VectorMakerTest, sequenceVector) {
 
 TEST_F(VectorMakerTest, sequenceVectorString) {
   std::vector<std::optional<StringView>> data = {
-      StringView{"a"},
-      StringView{"a"},
-      StringView{"a"},
+      "a"_sv,
+      "a"_sv,
+      "a"_sv,
       std::nullopt,
       std::nullopt,
-      StringView{"b"},
+      "b"_sv,
       std::nullopt,
-      StringView{"c"},
-      StringView{"c"},
+      "c"_sv,
+      "c"_sv,
   };
   auto sequenceVector = maker_.sequenceVector(data);
 
@@ -582,8 +582,8 @@ TEST_F(VectorMakerTest, sequenceVectorString) {
   EXPECT_EQ(3, sequenceVector->getNullCount().value());
   EXPECT_FALSE(sequenceVector->isSorted().value());
   EXPECT_EQ(3, sequenceVector->getDistinctValueCount().value());
-  EXPECT_EQ(StringView("a"), sequenceVector->getMin().value());
-  EXPECT_EQ(StringView("c"), sequenceVector->getMax().value());
+  EXPECT_EQ("a"_sv, sequenceVector->getMin().value());
+  EXPECT_EQ("c"_sv, sequenceVector->getMax().value());
 
   for (vector_size_t i = 0; i < data.size(); i++) {
     if (data[i] == std::nullopt) {


### PR DESCRIPTION
Summary:
Makes it more convenient to write tests, particularly when using
std::vector<StringView>. Now:

> StringView("abc") == "abc"_sv

Differential Revision: D32340623

