### PR TITLE
Enable DriveTest.pause and DriverTest.yield tests

### DIFF
--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -415,7 +415,7 @@ TEST_F(DriverTest, slow) {
   EXPECT_TRUE(stateFutures_.at(0).hasException());
 }
 
-TEST_F(DriverTest, DISABLED_pause) {
+TEST_F(DriverTest, pause) {
   CursorParameters params;
   int32_t hits;
   params.planNode = makeValuesFilterProject(
@@ -443,7 +443,7 @@ TEST_F(DriverTest, DISABLED_pause) {
   EXPECT_EQ(operators[1].outputPositions, 10 * hits);
 }
 
-TEST_F(DriverTest, DISABLED_yield) {
+TEST_F(DriverTest, yield) {
   constexpr int32_t kNumTasks = 20;
   constexpr int32_t kThreadsPerTask = 5;
   std::vector<int32_t> counters;


### PR DESCRIPTION
This reverts commit 0bbcd7d9b89e6640998887e1e8f126dbcd364e16.

The non-deterministic failures should be resolved with #586 