### PR TITLE
Add handling for STRUCT_EXTRACT DuckDB function

### DIFF
--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -235,3 +235,12 @@ TEST(DuckParserTest, isNull) {
 TEST(DuckParserTest, isNotNull) {
   EXPECT_EQ("not(is_null(\"a\"))", parseExpr("a IS NOT NULL")->toString());
 }
+
+TEST(DuckParserTest, structExtract) {
+  // struct_extract is not the desired parsed function, but it being handled
+  // enables nested dot (e.g. (a).b.c or (a.b).c)
+  EXPECT_EQ("dot(\"a\",\"b\")", parseExpr("(a).b")->toString());
+  EXPECT_EQ("dot(\"a\",\"b\")", parseExpr("(a.b)")->toString());
+  EXPECT_EQ("dot(dot(\"a\",\"b\"),\"c\")", parseExpr("(a).b.c")->toString());
+  EXPECT_EQ("dot(dot(\"a\",\"b\"),\"c\")", parseExpr("(a.b).c")->toString());
+}


### PR DESCRIPTION
Summary:
To support nested field access (dot) syntax, this diff adds handling for the `STRUCT_EXTRACT` DuckDB function.
- See https://duckdb.org/docs/sql/functions/nested

Syntax such as `(a).b.c` and `(a.b).c` are translated to `STRUCT_EXTRACT` calls internally.

Reviewed By: mbasmanova

Differential Revision: D32378055

