### PR TITLE
Add slice() Presto function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -99,6 +99,11 @@ Array Functions
 
     Returns an array which has the reversed order of the input array.
 
+.. function:: slice(array(E), start, length) -> array(E)
+
+    Returns a subarray starting from index ``start``(or starting from the end
+    if ``start`` is negative) with a length of ``length``.
+
 .. function:: subscript(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``. The index starts from one.

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -201,6 +201,12 @@ void EvalCtx::setError(
   addError(index, exceptionPtr, &errors_);
 }
 
+void EvalCtx::setErrors(
+    const SelectivityVector& rows,
+    const std::exception_ptr& exceptionPtr) {
+  rows.applyToSelected([&](auto row) { setError(row, exceptionPtr); });
+}
+
 VectorPtr EvalCtx::getField(int32_t index) const {
   VectorPtr field;
   if (!peeledFields_.empty()) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -74,6 +74,10 @@ class EvalCtx {
 
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);
 
+  void setErrors(
+      const SelectivityVector& rows,
+      const std::exception_ptr& exceptionPtr);
+
   /// Invokes a function on each selected row. Records per-row exceptions by
   /// calling 'setError'. The function must take a single "row" argument of type
   /// vector_size_t and return void.

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(
   RegisterComparisons.cpp
   Reverse.cpp
   RowFunction.cpp
+  Slice.cpp
   Split.cpp
   StringFunctions.cpp
   Subscript.cpp

--- a/velox/functions/prestosql/Slice.cpp
+++ b/velox/functions/prestosql/Slice.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at
+//   - https://prestodb.io/docs/current/functions/array.html
+/// This class is used for slice function with presto semantics).
+///
+/// For a query slice(input, 2, 2):
+/// Input ArrayVector is
+/// [
+///  [1, 2, 3]
+///  [4, 5, 6, 7]
+///  [8, 9, 10, 11, 12]
+/// ]
+/// Output ArrayVector is (with default presto behavior) is
+/// [
+///  [2, 3]
+///  [5, 6]
+///  [9, 10]
+/// ]
+///
+/// The function achieves zero copy through re-using base vector and adjusting
+/// the rawOffsets and rawSizes vectors.
+/// For the input ArrayVector:
+/// rawOffsets vector [0, 3, 7]
+/// rawSizes vector   [3, 4, 5]
+///
+/// After adjustment, for the output ArrayVector:
+/// rawOffsets vector [1, 4, 8]
+/// rawSizes vector   [2, 2, 2]
+class SliceFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    VELOX_USER_CHECK_EQ(
+        args[0]->typeKind(),
+        TypeKind::ARRAY,
+        "Function slice() requires first argument of type ARRAY");
+    VELOX_USER_CHECK_EQ(
+        args[1]->typeKind(),
+        TypeKind::BIGINT,
+        "Function slice() requires second argument of type BIGINT");
+    VELOX_USER_CHECK_EQ(
+        args[1]->typeKind(),
+        args[2]->typeKind(),
+        "Function slice() requires start and length to be the same type");
+
+    VectorPtr localResult =
+        applyArray<int64_t>(rows, args, context, outputType);
+    context->moveOrCopyResult(localResult, rows, result);
+  }
+
+ private:
+  // Use template parameter rather than hard-coded TypeKind to specify array
+  // data type.
+  template <typename T>
+  VectorPtr applyArray(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      exec::EvalCtx* context,
+      const TypePtr& outputType) const {
+    auto pool = context->pool();
+    BufferPtr offsets = allocateOffsets(rows.end(), pool);
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+    BufferPtr sizes = allocateSizes(rows.end(), pool);
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto decodedArray = decodedArgs.at(0);
+    auto baseArray = decodedArray->base()->as<ArrayVector>();
+    auto arrayIndices = decodedArray->indices();
+    auto baseRawSizes = baseArray->rawSizes();
+    auto baseRawOffsets = baseArray->rawOffsets();
+
+    auto decodedStart = decodedArgs.at(1);
+    auto decodedLength = decodedArgs.at(2);
+
+    const auto fillResultVectorFunc = [&](vector_size_t row,
+                                          vector_size_t adjustedStart) {
+      auto arraySize = baseRawSizes[arrayIndices[row]];
+      auto index = getIndex(adjustedStart, arraySize);
+      if (index != -1) {
+        auto start = baseRawOffsets[arrayIndices[row]] + index;
+        rawOffsets[row] = start;
+        rawSizes[row] = adjustLength(
+            start,
+            // Indices are always 32-bit integers, template arguments are used
+            // to accommodate more data types.
+            static_cast<vector_size_t>(decodedLength->valueAt<T>(row)),
+            row,
+            baseRawSizes,
+            baseRawOffsets,
+            arrayIndices);
+      }
+    };
+
+    if (decodedStart->isConstantMapping()) {
+      // The save here is that if the constant is invalid, no need to perform
+      // computation over and over again.
+      try {
+        vector_size_t adjustedStart = adjustIndex(
+            static_cast<vector_size_t>(decodedStart->valueAt<T>(0)));
+        context->applyToSelectedNoThrow(
+            rows, [&](auto row) { fillResultVectorFunc(row, adjustedStart); });
+      } catch (const std::exception& /*e*/) {
+        context->setErrors(rows, std::current_exception());
+      }
+    } else {
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        auto adjustedStart = adjustIndex(
+            static_cast<vector_size_t>(decodedStart->valueAt<T>(row)));
+        fillResultVectorFunc(row, adjustedStart);
+      });
+    }
+    return std::make_shared<ArrayVector>(
+        pool,
+        outputType,
+        nullptr,
+        rows.end(),
+        offsets,
+        sizes,
+        baseArray->elements());
+  }
+
+  // Presto has the semantics of starting index from one, need to add a minus
+  // one offset here.
+  vector_size_t adjustIndex(vector_size_t index) const {
+    // If it's zero, throw.
+    if (UNLIKELY(index == 0)) {
+      VELOX_USER_FAIL("SQL array indices start at 1");
+    }
+
+    // If larger than zero, adjust it.
+    if (index > 0) {
+      index--;
+    }
+    return index;
+  }
+
+  vector_size_t getIndex(vector_size_t start, vector_size_t size) const {
+    if (start < 0) {
+      // If we see negative start, we wrap it around by size amount.
+      start += size;
+    }
+
+    // Check if start is within bound.
+    if ((start >= size) || (start < 0)) {
+      // Return -1 when start is out of bound, caller will make it an empty
+      // array.
+      return -1;
+    }
+
+    return start;
+  }
+
+  vector_size_t adjustLength(
+      vector_size_t start,
+      vector_size_t length,
+      vector_size_t row,
+      const vector_size_t* rawSizes,
+      const vector_size_t* rawOffsets,
+      const vector_size_t* indices) const {
+    if (length < 0) {
+      VELOX_USER_FAIL(
+          "The value of length argument of slice() function should not be negative");
+    }
+    auto endIndex = rawOffsets[indices[row]] + rawSizes[indices[row]];
+    return std::min(endIndex - start, length);
+  }
+};
+
+static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  return {// array(T, bigint, bigint) -> array(T)
+          exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .returnType("array(T)")
+              .argumentType("array(T)")
+              .argumentType("bigint")
+              .argumentType("bigint")
+              .build()};
+}
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_slice,
+    signatures(),
+    std::make_unique<SliceFunction>());
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/VectorFunctions.cpp
+++ b/velox/functions/prestosql/VectorFunctions.cpp
@@ -52,6 +52,7 @@ void registerVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_max, "array_max");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_min, "array_min");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_cardinality, "cardinality");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_slice, "slice");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_filter, "filter");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_filter, "map_filter");

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(
   ReduceTest.cpp
   ReverseTest.cpp
   RoundTest.cpp
+  SliceTest.cpp
   SplitTest.cpp
   StringFunctionsTest.cpp
   TransformTest.cpp

--- a/velox/functions/prestosql/tests/SliceTest.cpp
+++ b/velox/functions/prestosql/tests/SliceTest.cpp
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class SliceTest : public FunctionBaseTest {
+ protected:
+  static const vector_size_t kVectorSize{1000};
+
+  void testSlice(
+      const std::string& expression,
+      const std::vector<VectorPtr>& parameters,
+      const ArrayVectorPtr& expectedArrayVector) {
+    auto result = evaluate<ArrayVector>(expression, makeRowVector(parameters));
+    assertEqualVectors(expectedArrayVector, result);
+  }
+};
+} // namespace
+
+TEST_F(SliceTest, prestoTestCases) {
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2}});
+    testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
+    testSlice("slice(C0, 3, 2)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
+    testSlice("slice(C0, 3, 3)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
+    testSlice("slice(C0, -3, 3)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
+    testSlice("slice(C0, -3, 5)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, 1, 0)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, -5, 5)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    // The implementation is zero-copy, so floating point number comparison
+    // won't have issue here since numerical representation remains the same.
+    auto arrayVector = makeArrayVector<double>({{2.3, 2.3, 2.2}});
+    auto expectedArrayVector = makeArrayVector<double>({{2.3, 2.2}});
+    testSlice("slice(C0, 2, 3)", {arrayVector}, expectedArrayVector);
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    assertUserInvalidArgument(
+        [&]() {
+          testSlice(
+              "slice(C0, 1, -1)",
+              {arrayVector, arrayVector, expectedArrayVector},
+              expectedArrayVector);
+        },
+        "The value of length argument of slice() function should not be negative");
+  }
+  {
+    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+    assertUserInvalidArgument(
+        [&]() {
+          testSlice(
+              "slice(C0, 0, 1)",
+              {arrayVector, arrayVector, expectedArrayVector},
+              expectedArrayVector);
+        },
+        "SQL array indices start at 1");
+  }
+}
+
+TEST_F(SliceTest, constantInputArray) {
+  auto arrayVector = makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 5, 6, 7},
+      {1, 2, 7},
+      {1, 2, 3, 5, 6, 7},
+  });
+
+  // Happy test 1.
+  {
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>({{2, 3}, {2, 7}, {2, 3}});
+    testSlice("slice(C0, 2, 2)", {arrayVector}, expectedArrayVector);
+  }
+
+  // Happy test 2.
+  {
+    auto expectedArrayVector = makeArrayVector<int64_t>({{3}, {7}, {3}});
+
+    testSlice("slice(C0, 3, 1)", {arrayVector}, expectedArrayVector);
+  }
+
+  // Allow negative start index.
+  {
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>({{6, 7}, {2, 7}, {6, 7}});
+
+    testSlice("slice(C0, -2, 2)", {arrayVector}, expectedArrayVector);
+  }
+
+  // Allow length extends beyond boundary.
+  {
+    auto expectedArrayVector = makeArrayVector<int64_t>(
+        {{1, 2, 3, 4, 5, 6, 7}, {1, 2, 7}, {1, 2, 3, 5, 6, 7}});
+    testSlice("slice(C0, 1, 7)", {arrayVector}, expectedArrayVector);
+  }
+
+  // Throw invalid argument when start index = 0.
+  {
+    auto expectedArrayVector = makeArrayVector<int64_t>(
+        {{1, 2, 3, 4, 5, 6, 7}, {1, 2, 7}, {1, 2, 3, 5, 6, 7}});
+    assertUserInvalidArgument(
+        [&]() {
+          testSlice("slice(C0, 0, 1)", {arrayVector}, expectedArrayVector);
+        },
+        "SQL array indices start at 1");
+  }
+}
+
+TEST_F(SliceTest, variableInputArray) {
+  {
+    auto startsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+    auto lengthsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t /*row*/) { return 1; });
+    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+      return 1 + idx;
+    };
+    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
+
+    auto expectedSizeAt = [](vector_size_t /*row*/) { return 1; };
+    auto expectedValueAt = [](vector_size_t row, vector_size_t /*idx*/) {
+      return 1 + row % 7;
+    };
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+    testSlice(
+        "slice(C0, C1, C2)",
+        {arrayVector, startsVector, lengthsVector},
+        expectedArrayVector);
+  }
+
+  {
+    auto startsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+    auto lengthsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t /*row*/) { return 2; });
+    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+      return 1 + idx;
+    };
+    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
+
+    auto expectedSizeAt = [](vector_size_t row) {
+      return (row + 1) % 7 == 0 ? 1 : 2;
+    };
+    auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+      return 1 + row % 7 + idx;
+    };
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+    testSlice(
+        "slice(C0, C1, C2)",
+        {arrayVector, startsVector, lengthsVector},
+        expectedArrayVector);
+  }
+
+  {
+    auto startsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+    auto lengthsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t /*row*/) { return 7; });
+    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+      return 1 + idx;
+    };
+    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
+
+    auto expectedSizeAt = [](vector_size_t row) { return 7 - row % 7; };
+    auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+      return 1 + row % 7 + idx;
+    };
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+    testSlice(
+        "slice(C0, C1, C2)",
+        {arrayVector, startsVector, lengthsVector},
+        expectedArrayVector);
+  }
+}
+
+TEST_F(SliceTest, varcharVariableInput) {
+  auto startsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+  auto lengthsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return 7; });
+
+  auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+  auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+    return StringView(folly::to<std::string>(idx + 1));
+  };
+  auto arrayVector = makeArrayVector<StringView>(kVectorSize, sizeAt, valueAt);
+
+  auto expectedSizeAt = [](vector_size_t row) { return 7 - row % 7; };
+  auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+    return StringView(folly::to<std::string>(1 + row % 7 + idx));
+  };
+  auto expectedArrayVector =
+      makeArrayVector<StringView>(kVectorSize, expectedSizeAt, expectedValueAt);
+
+  testSlice(
+      "slice(C0, C1, C2)",
+      {arrayVector, startsVector, lengthsVector},
+      expectedArrayVector);
+}
+
+TEST_F(SliceTest, allIndicesGreaterThanArraySize) {
+  auto startsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return 8; });
+  auto lengthsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return 7; });
+  auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+  auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+    return 1 + idx;
+  };
+  auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
+
+  auto expectedSizeAt = [](vector_size_t /*row*/) { return 0; };
+  // Not going to be used, created to satisfy function signature.
+  auto expectedValueAt = [](vector_size_t row) { return 1 + row % 7; };
+  auto expectedArrayVector =
+      makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+  testSlice(
+      "slice(C0, C1, C2)",
+      {arrayVector, startsVector, lengthsVector},
+      expectedArrayVector);
+}
+
+TEST_F(SliceTest, errorStatesArray) {
+  auto startsVector =
+      makeFlatVector<int64_t>(kVectorSize, [](vector_size_t row) {
+        // Zero out index -> should throw an error.
+        if (row == 40) {
+          return 0;
+        }
+        return 1 + row % 7;
+      });
+  auto lengthsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return 7; });
+
+  auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+  auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+    return StringView(folly::to<std::string>(idx + 1));
+  };
+  auto arrayVector = makeArrayVector<StringView>(kVectorSize, sizeAt, valueAt);
+
+  auto expectedSizeAt = [](vector_size_t row) { return 7 - row % 7; };
+  auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+    return StringView(folly::to<std::string>(1 + row % 7 + idx));
+  };
+  auto expectedArrayVector =
+      makeArrayVector<StringView>(kVectorSize, expectedSizeAt, expectedValueAt);
+
+  assertUserInvalidArgument(
+      [&]() {
+        testSlice(
+            "slice(C0, C1, C2)",
+            {arrayVector, startsVector, lengthsVector},
+            expectedArrayVector);
+      },
+      "SQL array indices start at 1");
+
+  EXPECT_THROW(
+      testSlice(
+          "slice(C0, 1.1, 1)",
+          {arrayVector, startsVector, lengthsVector},
+          expectedArrayVector),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      testSlice(
+          "slice(C0, 'bla', 1)",
+          {arrayVector, startsVector, lengthsVector},
+          expectedArrayVector),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      testSlice(
+          "slice(C0, 1, 1.1)",
+          {arrayVector, startsVector, lengthsVector},
+          expectedArrayVector),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      testSlice(
+          "slice(C0, 1, 'bla')",
+          {arrayVector, startsVector, lengthsVector},
+          expectedArrayVector),
+      std::invalid_argument);
+}
+
+TEST_F(SliceTest, zeroSliceLength) {
+  auto startsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+  auto lengthsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return 0; });
+
+  auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+  auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+    return StringView(folly::to<std::string>(idx + 1));
+  };
+  auto arrayVector = makeArrayVector<StringView>(kVectorSize, sizeAt, valueAt);
+
+  auto expectedSizeAt = [](vector_size_t /*row*/) { return 0; };
+  auto expectedValueAt = [](vector_size_t /*row*/, vector_size_t /*idx*/) {
+    return StringView(folly::to<std::string>());
+  };
+  auto expectedArrayVector =
+      makeArrayVector<StringView>(kVectorSize, expectedSizeAt, expectedValueAt);
+
+  testSlice(
+      "slice(C0, C1, C2)",
+      {arrayVector, startsVector, lengthsVector},
+      expectedArrayVector);
+}
+
+TEST_F(SliceTest, negativeSliceLength) {
+  auto startsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
+  auto lengthsVector = makeFlatVector<int64_t>(
+      kVectorSize, [](vector_size_t /*row*/) { return -1; });
+  auto sizeAt = [](vector_size_t /*row*/) { return 7; };
+  auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
+    return 1 + idx;
+  };
+  auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
+
+  // Not actually used.
+  auto expectedSizeAt = [](vector_size_t row) { return 7 - row % 7; };
+  auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+    return 1 + row % 7 + idx;
+  };
+  auto expectedArrayVector =
+      makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+  assertUserInvalidArgument(
+      [&]() {
+        testSlice(
+            "slice(C0, C1, C2)",
+            {arrayVector, startsVector, lengthsVector},
+            expectedArrayVector);
+      },
+      "The value of length argument of slice() function should not be negative");
+}


### PR DESCRIPTION
Summary:
This change implements slice for arrays with the same semantics as presto.

Presto unit test cases are included, in addition more test cases are added to test different edge cases.

Reviewed By: mbasmanova

Differential Revision: D31948737

