### PR TITLE
Compression configuration log lines

### DIFF
--- a/velox/dwio/dwrf/common/Compression.cpp
+++ b/velox/dwio/dwrf/common/Compression.cpp
@@ -444,14 +444,22 @@ std::unique_ptr<BufferedOutputStream> createCompressor(
       }
       // compressor remain as nullptr
       break;
-    case CompressionKind_ZLIB:
-      compressor = std::make_unique<ZlibCompressor>(
-          config.get(Config::ZLIB_COMPRESSION_LEVEL));
+    case CompressionKind_ZLIB: {
+      int32_t zlibCompressionLevel = config.get(Config::ZLIB_COMPRESSION_LEVEL);
+      compressor = std::make_unique<ZlibCompressor>(zlibCompressionLevel);
+      LOG_FIRST_N(INFO, 1) << fmt::format(
+          "Initialized zlib compressor with compression level {}",
+          zlibCompressionLevel);
       break;
-    case CompressionKind_ZSTD:
-      compressor = std::make_unique<ZstdCompressor>(
-          config.get(Config::ZSTD_COMPRESSION_LEVEL));
+    }
+    case CompressionKind_ZSTD: {
+      int32_t zstdCompressionLevel = config.get(Config::ZSTD_COMPRESSION_LEVEL);
+      compressor = std::make_unique<ZstdCompressor>(zstdCompressionLevel);
+      LOG_FIRST_N(INFO, 1) << fmt::format(
+          "Initialized zstd compressor with compression level {}",
+          zstdCompressionLevel);
       break;
+    }
     case CompressionKind_SNAPPY:
     case CompressionKind_LZO:
     case CompressionKind_LZ4:

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -69,6 +69,7 @@ class WriterContext : public CompressionBufferPool {
       handler_ = std::make_unique<encryption::EncryptionHandler>();
     }
     validateConfigs();
+    LOG(INFO) << fmt::format("Compression config: {}", compression);
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }


### PR DESCRIPTION
Summary:
Print compression config per WriterContext and compression level once
per process.

Differential Revision: D32402922

