### PR TITLE
Fix infinite loop in AssignUniqueId operator

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -191,6 +191,7 @@ AssignUniqueIdNode::AssignUniqueIdNode(
   names.emplace_back(idName);
   types.emplace_back(BIGINT());
   outputType_ = ROW(std::move(names), std::move(types));
+  uniqueIdCounter_ = std::make_shared<std::atomic_int64_t>();
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1293,10 +1293,15 @@ class AssignUniqueIdNode : public PlanNode {
     return taskUniqueId_;
   }
 
+  std::shared_ptr<std::atomic_int64_t> uniqueIdCounter() const {
+    return uniqueIdCounter_;
+  };
+
  private:
   const int32_t taskUniqueId_;
   const std::vector<std::shared_ptr<const PlanNode>> sources_;
   RowTypePtr outputType_;
+  std::shared_ptr<std::atomic_int64_t> uniqueIdCounter_;
 };
 
 } // namespace facebook::velox::core

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1293,7 +1293,7 @@ class AssignUniqueIdNode : public PlanNode {
     return taskUniqueId_;
   }
 
-  const std::shared_ptr<std::atomic_int64_t> uniqueIdCounter() const {
+  const std::shared_ptr<std::atomic_int64_t>& uniqueIdCounter() const {
     return uniqueIdCounter_;
   };
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1293,7 +1293,7 @@ class AssignUniqueIdNode : public PlanNode {
     return taskUniqueId_;
   }
 
-  std::shared_ptr<std::atomic_int64_t> uniqueIdCounter() const {
+  const std::shared_ptr<std::atomic_int64_t> uniqueIdCounter() const {
     return uniqueIdCounter_;
   };
 

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -60,38 +60,43 @@ RowVectorPtr AssignUniqueId::getOutput() {
   if (input_ == nullptr) {
     return nullptr;
   }
-  generateIdColumn();
+  generateIdColumn(input_->size());
   auto output = fillOutput(input_->size(), nullptr);
   input_ = nullptr;
   return output;
 }
 
-void AssignUniqueId::generateIdColumn() {
-  auto numInput = input_->size();
+void AssignUniqueId::generateIdColumn(vector_size_t size) {
   auto result = results_[0];
   if (!result || !BaseVector::isReusableFlatVector(result)) {
-    result = BaseVector::create(BIGINT(), numInput, operatorCtx_->pool());
+    result = BaseVector::create(BIGINT(), size, operatorCtx_->pool());
     results_[0] = result;
   } else {
-    result->resize(numInput);
+    result->resize(size);
   }
   auto rawResults =
       result->asUnchecked<FlatVector<int64_t>>()->mutableRawValues();
 
   vector_size_t start = 0;
-  while (start < numInput) {
+  while (start < size) {
     if (rowIdCounter_ >= maxRowIdCounterValue_) {
-      rowIdCounter_ = rowIdPool_->fetch_add(kRowIdsPerRequest);
-      maxRowIdCounterValue_ =
-          std::min({rowIdCounter_ + kRowIdsPerRequest, kMaxRowId});
+      requestRowIds();
     }
 
-    auto end = std::min(numInput, (int32_t)(start + kRowIdsPerRequest));
-
+    auto end = std::min(size, (int32_t)(start + kRowIdsPerRequest));
+    VELOX_CHECK_EQ((rowIdCounter_ + end - 1) & uniqueValueMask_, 0);
     std::iota(
         rawResults + start, rawResults + end, uniqueValueMask_ | rowIdCounter_);
     rowIdCounter_ += end;
     start = end;
   }
+}
+
+void AssignUniqueId::requestRowIds() {
+  rowIdCounter_ = rowIdPool_->fetch_add(kRowIdsPerRequest);
+  maxRowIdCounterValue_ =
+      std::min({rowIdCounter_ + kRowIdsPerRequest, kMaxRowId});
+  VELOX_CHECK_LT(
+      maxRowIdCounterValue_, kMaxRowId, "Unique row id exceeds the limit");
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -83,12 +83,13 @@ void AssignUniqueId::generateIdColumn(vector_size_t size) {
       requestRowIds();
     }
 
-    auto batchSize = std::min(
-        {maxRowIdCounterValue_ - rowIdCounter_ + 1, kRowIdsPerRequest});
-    auto end = (int32_t)std::min({(int64_t)size, start + batchSize});
+    auto batchSize =
+        std::min(maxRowIdCounterValue_ - rowIdCounter_ + 1, kRowIdsPerRequest);
+    auto end = (int32_t)std::min((int64_t)size, start + batchSize);
     VELOX_CHECK_EQ((rowIdCounter_ + end - 1) & uniqueValueMask_, 0);
     std::iota(
         rawResults + start, rawResults + end, uniqueValueMask_ | rowIdCounter_);
+    rowIdCounter_ += end;
     start = end;
   }
 }
@@ -96,6 +97,6 @@ void AssignUniqueId::generateIdColumn(vector_size_t size) {
 void AssignUniqueId::requestRowIds() {
   rowIdCounter_ = rowIdPool_->fetch_add(kRowIdsPerRequest);
   maxRowIdCounterValue_ =
-      std::min({rowIdCounter_ + kRowIdsPerRequest, kMaxRowId});
+      std::min(rowIdCounter_ + kRowIdsPerRequest, kMaxRowId);
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/AssignUniqueId.h
+++ b/velox/exec/AssignUniqueId.h
@@ -50,6 +50,7 @@ class AssignUniqueId : public Operator {
 
  private:
   void generateIdColumn(vector_size_t size);
+
   void requestRowIds();
 
   const int64_t kRowIdsPerRequest = 1L << 20;

--- a/velox/exec/AssignUniqueId.h
+++ b/velox/exec/AssignUniqueId.h
@@ -49,10 +49,11 @@ class AssignUniqueId : public Operator {
   }
 
  private:
-  void generateIdColumn();
+  void generateIdColumn(vector_size_t size);
+  void requestRowIds();
 
   const int64_t kRowIdsPerRequest = 1L << 20;
-  const int64_t kMaxRowId = 1L << 32;
+  const int64_t kMaxRowId = 1L << 40;
   const int64_t kTaskUniqueIdLimit = 1L << 24;
 
   int64_t uniqueValueMask_;

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -215,12 +215,6 @@ struct DriverFactory {
   // True if 'planNodes' contains a sync node for the task, e.g.
   // PartitionedOutput.
   bool outputDriver{false};
-  // Ensure one counter per AssignUniqueId plan node.
-  folly::F14FastMap<const std::string, std::shared_ptr<std::atomic_int64_t>>
-      assignUniqueIdCounters;
-
-  std::shared_ptr<std::atomic_int64_t> getAssignUniqueIdCounter(
-      const std::string& planNodeId);
 
   std::shared_ptr<Driver> createDriver(
       std::unique_ptr<DriverCtx> ctx,

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -222,18 +222,6 @@ void LocalPlanner::plan(
   }
 }
 
-std::shared_ptr<std::atomic_int64_t> DriverFactory::getAssignUniqueIdCounter(
-    const std::string& planNodeId) {
-  auto it = assignUniqueIdCounters.find(planNodeId);
-  if (it != assignUniqueIdCounters.end()) {
-    return it->second;
-  } else {
-    auto counter = std::make_shared<std::atomic_int64_t>();
-    assignUniqueIdCounters.insert({planNodeId, counter});
-    return counter;
-  }
-}
-
 std::shared_ptr<Driver> DriverFactory::createDriver(
     std::unique_ptr<DriverCtx> ctx,
     std::shared_ptr<ExchangeClient> exchangeClient,
@@ -367,7 +355,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
           ctx.get(),
           assignUniqueIdNode,
           assignUniqueIdNode->taskUniqueId(),
-          getAssignUniqueIdCounter(assignUniqueIdNode->id())));
+          assignUniqueIdNode->uniqueIdCounter()));
     } else {
       auto extended = Operator::fromPlanNode(ctx.get(), id, planNode);
       VELOX_CHECK(extended, "Unsupported plan node: {}", planNode->toString());

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -94,11 +94,10 @@ TEST_F(AssignUniqueIdTest, multiThread) {
 }
 
 TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
-  auto input = {
-      makeRowVector({makeFlatVector<bool>(1, [](auto row) { return row; })})};
+  auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
-  // Increase the counter to kMaxRowId
+  // Increase the counter to kMaxRowId.
   std::dynamic_pointer_cast<core::AssignUniqueIdNode>(plan)
       ->uniqueIdCounter()
       ->fetch_add(1L << 40);
@@ -107,8 +106,7 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {
-  auto input = {
-      makeRowVector({makeFlatVector<bool>(1, [](auto row) { return row; })})};
+  auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
 
   auto plan =
       PlanBuilder().values(input).assignUniqueId("unique", 1L << 24).planNode();

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -67,9 +67,9 @@ TEST_F(AssignUniqueIdTest, multiBatch) {
     input.push_back(makeRowVector({column}));
   }
 
-  auto plan = PlanBuilder().values(input, true).assignUniqueId().planNode();
+  auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  verifyUniqueId(plan, input, 1000);
+  verifyUniqueId(plan, input);
 }
 
 TEST_F(AssignUniqueIdTest, exceedRequestLimit) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -328,9 +328,11 @@ PlanBuilder& PlanBuilder::enforceSingleRow() {
   return *this;
 }
 
-PlanBuilder& PlanBuilder::assignUniqueId() {
+PlanBuilder& PlanBuilder::assignUniqueId(
+    const std::string& idName,
+    const int32_t taskUniqueId) {
   planNode_ = std::make_shared<core::AssignUniqueIdNode>(
-      nextPlanNodeId(), "unique", 1, planNode_);
+      nextPlanNodeId(), idName, taskUniqueId, planNode_);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -149,7 +149,9 @@ class PlanBuilder {
 
   PlanBuilder& enforceSingleRow();
 
-  PlanBuilder& assignUniqueId();
+  PlanBuilder& assignUniqueId(
+      const std::string& idName = "unique",
+      const int32_t taskUniqueId = 1);
 
   std::shared_ptr<const core::FieldAccessTypedExpr> field(int index);
 


### PR DESCRIPTION
1.  Increase the `kMaxRowId` from 32 bit to 40 bit, given the `taskUniqueid` is limited to 24 bit only
2. Add range check on rowId to prevent bit range overlap between `taskUniqueId` & rowId
3. Move the rowId counter from `DriverFactory` to `AssignUniqueIdNode` to enable unit test on counter value
4. Make `assignUniqueId` takes args in `velox/exec/tests/PlanBuilder.h` to enable unit test on taskUniqueId range


Signed-off-by: frankobe <frank.hu@bytedance.com>