### PR TITLE
Free Task child MemoryPools after all other Task members

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -35,13 +35,13 @@ Task::Task(
     std::shared_ptr<core::QueryCtx> queryCtx,
     ConsumerSupplier consumerSupplier,
     std::function<void(std::exception_ptr)> onError)
-    : taskId_(taskId),
+    : pool_(queryCtx->pool()->addScopedChild("task_root")),
+      taskId_(taskId),
       planNode_(planNode),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
-      pool_(queryCtx_->pool()->addScopedChild("task_root")),
       bufferManager_(
           PartitionedOutputBufferManager::getInstance(queryCtx_->host())) {}
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -425,6 +425,15 @@ class Task {
 
   void addSplitLocked(SplitsState& splitsState, exec::Split&& split);
 
+  std::unique_ptr<velox::memory::MemoryPool> pool_;
+
+  // Keep driver and operator memory pools alive for the duration of
+  // the task to allow for sharing vectors across drivers without
+  // copy. Declare before other members so as to have this last in
+  // destruction order, e.g. after JoinBridges and other things that
+  // can hold vectors allocated in these pools.
+  std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
+
   const std::string taskId_;
   std::shared_ptr<const core::PlanNode> planNode_;
   const int destination_;
@@ -467,11 +476,6 @@ class Task {
   std::vector<VeloxPromise<bool>> stateChangePromises_;
 
   TaskStats taskStats_;
-  std::unique_ptr<velox::memory::MemoryPool> pool_;
-
-  // Keep driver and operator memory pools alive for the duration of the task to
-  // allow for sharing vectors across drivers without copy.
-  std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
 
   std::vector<std::shared_ptr<MergeSource>> localMergeSources_;
 


### PR DESCRIPTION
It could happen that a Task cancellation would free memory pools
before freeing the vectors allocated in these pools inside a
JoinBridge. Putting the pools vector above other members fixes this
since destruction order is from last to first.