### PR TITLE
Add AVX2 implementation of BigintValuesUsingHashTable

### DIFF
--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -236,9 +236,14 @@ struct Vectors<int64_t> {
         scale);
   }
 
-  // Widens 4x32 signed values to 4x64.
+  // Widens 4x32 unsigned values to 4x64.
   static auto from32u(__m128si x) {
     return _mm256_cvtepu32_epi64((__m128i)x);
+  }
+
+  // Widens 4x32 signed values to 4x64.
+  static auto from32(__m128si x) {
+    return _mm256_cvtepi32_epi64((__m128i)x);
   }
 
   // Returns the value of the 'ith' lane.
@@ -364,6 +369,11 @@ struct Vectors<int32_t> {
   template <uint8_t i>
   static auto as4x64u(TV x) {
     return _mm256_cvtepu32_epi64(_mm256_extracti128_si256(to256i(x), i));
+  }
+
+  template <uint8_t i>
+  static auto as4x64(TV x) {
+    return _mm256_cvtepi32_epi64(_mm256_extracti128_si256(to256i(x), i));
   }
 
   static const ByteSetBitsType& byteSetBits() {

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
 
 target_link_libraries(
   velox_type
+  velox_common_base
   velox_encode
   velox_exception
   velox_serialization

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -653,7 +653,9 @@ class BigintValuesUsingHashTable final : public Filter {
         min_(other.min_),
         max_(other.max_),
         hashTable_(other.hashTable_),
-        containsEmptyMarker_(other.containsEmptyMarker_) {}
+        containsEmptyMarker_(other.containsEmptyMarker_),
+        values_(other.values_),
+        sizeMask_(other.sizeMask_) {}
 
   std::unique_ptr<Filter> clone(
       std::optional<bool> nullAllowed = std::nullopt) const final {
@@ -666,7 +668,9 @@ class BigintValuesUsingHashTable final : public Filter {
   }
 
   bool testInt64(int64_t value) const final;
+  __m256i test4x64(__m256i x) final;
 
+  __m256si test8x32(__m256i x) final;
   bool testInt64Range(int64_t min, int64_t max, bool hashNull) const final;
 
   std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
@@ -700,6 +704,7 @@ class BigintValuesUsingHashTable final : public Filter {
   std::vector<int64_t> hashTable_;
   bool containsEmptyMarker_ = false;
   std::vector<int64_t> values_;
+  int32_t sizeMask_;
 };
 
 /// IN-list filter for integral data types. Implemented as a bitmask. Offers

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -27,3 +27,16 @@ target_link_libraries(
   ${GTEST_BOTH_LIBRARIES}
   ${gflags_LIBRARIES}
   glog::glog)
+
+add_executable(velox_filter_benchmark FilterBenchmark.cpp)
+
+target_link_libraries(
+  velox_filter_benchmark
+  velox_type
+  velox_serialization
+  ${FOLLY}
+  ${FOLLY_BENCHMARK}
+  ${DOUBLE_CONVERSION}
+  ${GTEST_BOTH_LIBRARIES}
+  ${gflags_LIBRARIES}
+  glog::glog)

--- a/velox/type/tests/FilterBenchmark.cpp
+++ b/velox/type/tests/FilterBenchmark.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include "folly/Benchmark.h"
+#include "folly/Portability.h"
+#include "folly/Random.h"
+#include "folly/Varint.h"
+#include "folly/init/Init.h"
+#include "folly/lang/Bits.h"
+#include "velox/dwio/common/exception/Exception.h"
+
+#include "velox/type/Filter.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+
+using V64 = simd::Vectors<int64_t>;
+std::vector<int64_t> sparseValues;
+std::vector<int64_t> denseValues;
+std::unique_ptr<BigintValuesUsingHashTable> filter;
+
+int32_t run1x64(const std::vector<int64_t>& data) {
+  int32_t count = 0;
+  for (auto i = 0; i < data.size(); ++i) {
+    count += filter->testInt64(data[i]);
+  }
+  return count;
+}
+
+int32_t run4x64(const std::vector<int64_t>& data) {
+  using TV = simd::Vectors<int64_t>;
+  int32_t count = 0;
+  assert(data.size() % 4 == 0);
+  for (auto i = 0; i < data.size(); i += 4) {
+    auto result = filter->test4x64(V64::load(data.data() + i));
+    count += TV::compareBitMask(TV::compareResult(result));
+  }
+  return count;
+}
+
+BENCHMARK(scalarDense) {
+  folly::doNotOptimizeAway(run1x64(sparseValues));
+}
+
+BENCHMARK_RELATIVE(simdDense) {
+  folly::doNotOptimizeAway(run4x64(sparseValues));
+}
+
+BENCHMARK(scalarSparse) {
+  folly::doNotOptimizeAway(run1x64(sparseValues));
+}
+
+BENCHMARK_RELATIVE(simdSparse) {
+  folly::doNotOptimizeAway(run4x64(sparseValues));
+}
+
+int32_t main(int32_t argc, char* argv[]) {
+  constexpr int32_t kNumValues = 1000000;
+  constexpr int32_t kFilterValues = 1000;
+  folly::init(&argc, &argv);
+
+  std::vector<int64_t> filterValues;
+  filterValues.reserve(1000);
+  for (auto i = 0; i < 1000; ++i) {
+    filterValues.push_back(i * 1000);
+  }
+  filter = std::make_unique<BigintValuesUsingHashTable>(
+      filterValues.front(), filterValues.back(), filterValues, false);
+  denseValues.resize(kNumValues);
+  sparseValues.resize(kNumValues);
+  for (auto i = 0; i < kNumValues; ++i) {
+    denseValues[i] = (folly::Random::rand32() % 3000) * 1000;
+    sparseValues[i] = (folly::Random::rand32() % 100000) * 1000;
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Does range checks and index calculation and load of first hit
candidate 4 values at a time. If the initial load gets a hit or an
empty marker in every lane, the IN is resolved. If there are lanes
that were neither a match of the value nor an empty marker, we load
the next 4 values and check if either a hit or empty marker is found
in them. We do so until either a hit or empty marker is found. We pad
the 4 values above the hash table's last value to be equal to the last
value so that we do not have to wrap around on the first load after a
collision but only after that.

Evaluating the scalar IN filter is up to 10% of e.g. Baymax CPU and is
generally a common operation.

Adds a benchmark to compare with the scalar path:

../../velox/type/tests/FilterBenchmark.cpp      relative  time/iter  iters/s
============================================================================
scalarDense                                                  2.72ms   367.80
simdDense                                        301.84%   900.75us    1.11K
scalarSparse                                                 1.83ms   546.22
simdSparse                                       208.73%   877.10us    1.14K