### PR TITLE
Install brew package with a different version

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -102,11 +102,11 @@ function update_brew {
 function install_build_prerequisites {
   for pkg in ${MACOS_DEPS}
   do
-    if [[ "${pkg}" =~ ([0-9a-z-]*):([0-9](\.[0-9\])*) ]];
+    if [[ "${pkg}" =~ ^([0-9a-z-]*):([0-9](\.[0-9\])*)$ ]];
     then
       pkg=${BASH_REMATCH[1]}
       ver=${BASH_REMATCH[2]}
-      echo "Installing ${pkg} at ${ver}"
+      echo "Installing '${pkg}' at '${ver}'"
       tap="velox/local-${pkg}"
       brew tap-new "${tap}"
       brew extract "--version=${ver}" "${pkg}" "${tap}"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -112,7 +112,7 @@ function install_build_prerequisites {
       brew extract "--version=${ver}" "${pkg}" "${tap}"
       brew install "${tap}/${pkg}@${ver}"
     else
-      brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula $pkg
+      brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula "$pkg"
     fi
   done
 

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -102,7 +102,19 @@ function update_brew {
 function install_build_prerequisites {
   for pkg in ${MACOS_DEPS}
   do
-    brew install --formula $pkg && echo "Installation of $pkg is successful" || brew upgrade --formula $pkg
+    echo $pkg
+    if [[ "${pkg}" =~ ([0-9a-z-]*):([0-9](\.[0-9\])*) ]];
+    then
+      pkg=${BASH_REMATCH[1]}
+      ver=${BASH_REMATCH[2]}
+      echo "Installing ${pkg} at ${ver}"
+      tap="velox/local-${pkg}"
+      brew tap-new "${tap}"
+      brew extract "--version=${ver}" "${pkg}" "${tap}"
+      brew install "${tap}/${pkg}@${ver}"
+    else
+      brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula $pkg
+    fi
   done
 
   pip3 install --user cmake-format regex

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -102,7 +102,6 @@ function update_brew {
 function install_build_prerequisites {
   for pkg in ${MACOS_DEPS}
   do
-    echo $pkg
     if [[ "${pkg}" =~ ([0-9a-z-]*):([0-9](\.[0-9\])*) ]];
     then
       pkg=${BASH_REMATCH[1]}


### PR DESCRIPTION
Add support to install a brew package with a different version in setup-macos.sh
This useful when there is some problem with the latest version from brew so you wan to pin the build to a certain old version.
After this PR, you just add something like "package:version" to the "end" of MACOS_DEPS list, e.g.:
MACOS_DEPS="... antlr4-cpp-runtime:4.9.2"
Note that the ':' is used to separate package name and version. This is different from '@' where '@' is actually part of the formula name in brew.

This the article I read as a reference on how to install a brew package with a specific older version:
https://cmichel.io/how-to-install-an-old-package-version-with-brew/