### PR TITLE
Add support for DATE inputs to date extraction functions

### DIFF
--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -37,6 +37,10 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
     Returns ``timestamp`` truncated to ``unit``.
 
+.. function:: date_trunc(unit, date) -> date
+
+    Returns ``date`` truncated to ``unit``.
+
 Java Date Functions
 -------------------
 

--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -33,13 +33,10 @@ Unit        Example Truncated Value
 
 The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
-.. function:: date_trunc(unit, timestamp) -> timestamp
+.. function:: date_trunc(unit, x) -> x
 
-    Returns ``timestamp`` truncated to ``unit``.
+    Returns ``x`` truncated to ``unit``. The supported types for ``x`` are TIMESTAMP and DATE.
 
-.. function:: date_trunc(unit, date) -> date
-
-    Returns ``date`` truncated to ``unit``.
 
 Java Date Functions
 -------------------

--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -52,52 +52,54 @@ pattern format.
 Convenience Extraction Functions
 --------------------------------
 
-.. function:: day(timestamp) -> bigint
+These functions are supported for TIMESTAMP and DATE values.
 
-    Returns the day of the month from ``timestamp``.
+.. function:: day(x) -> bigint
 
-.. function:: day_of_month(timestamp) -> bigint
+    Returns the day of the month from ``x``.
+
+.. function:: day_of_month(x) -> bigint
 
     This is an alias for :func:`day`.
 
-.. function:: day_of_week(timestamp) -> bigint
+.. function:: day_of_week(x) -> bigint
 
-    Returns the ISO day of the week from ``timestamp``.
+    Returns the ISO day of the week from ``x``.
     The value ranges from ``1`` (Monday) to ``7`` (Sunday).
 
-.. function:: day_of_year(timestamp) -> bigint
+.. function:: day_of_year(x) -> bigint
 
-    Returns the day of the year from ``timestamp``.
+    Returns the day of the year from ``x``.
     The value ranges from ``1`` to ``366``.
 
-.. function:: dow(timestamp) -> bigint
+.. function:: dow(x) -> bigint
 
     This is an alias for :func:`day_of_week`.
 
-.. function:: doy(timestamp) -> bigint
+.. function:: doy(x) -> bigint
 
     This is an alias for :func:`day_of_year`.
 
-.. function:: hour(timestamp) -> bigint
+.. function:: hour(x) -> bigint
 
-    Returns the hour of the day from ``timestamp``. The value ranges from 0 to 23.
+    Returns the hour of the day from ``x``. The value ranges from 0 to 23.
 
-.. function:: millisecond(timestamp) -> int64
+.. function:: millisecond(x) -> int64
 
-    Returns the millisecond of the second from ``timestamp``.
+    Returns the millisecond of the second from ``x``.
 
-.. function:: minute(timestamp) -> bigint
+.. function:: minute(x) -> bigint
 
-    Returns the minute of the hour from ``timestamp``.
+    Returns the minute of the hour from ``x``.
 
-.. function:: month(timestamp) -> bigint
+.. function:: month(x) -> bigint
 
-    Returns the month of the year from ``timestamp``.
+    Returns the month of the year from ``x``.
 
-.. function:: second(timestamp) -> bigint
+.. function:: second(x) -> bigint
 
-    Returns the second of the minute from ``timestamp``.
+    Returns the second of the minute from ``x``.
 
-.. function:: year(timestamp) -> bigint
+.. function:: year(x) -> bigint
 
-    Returns the year from ``timestamp``.
+    Returns the year from ``x``.

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -75,9 +75,9 @@ getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
 FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
-  std::tm dateTime;
-  gmtime_r((const time_t*)&seconds, &dateTime);
-  return dateTime;
+  std::tm dateTm;
+  gmtime_r((const time_t*)&seconds, &dateTm);
+  return dateTm;
 }
 
 FOLLY_ALWAYS_INLINE

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -252,7 +252,9 @@ struct MillisecondFunction {
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& /*date*/) {
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Date>& /*date*/) {
     // Dates do not have millisecond granularity.
     result = 0;
     return true;

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -50,7 +50,7 @@ struct FromUnixtimeFunction {
 };
 
 namespace {
-constexpr int64_t kSecondsInDay = 86'400;
+inline constexpr int64_t kSecondsInDay = 86'400;
 
 FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
     const core::QueryConfig& config) {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -81,7 +81,7 @@ std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
 }
 
 FOLLY_ALWAYS_INLINE
-std::tm getDateTime(Date date) {
+std::tm getDateTm(Date date) {
   int64_t seconds = date.days() * kSecondsInDay;
   std::tm dateTime;
   gmtime_r((const time_t*)&seconds, &dateTime);
@@ -114,7 +114,7 @@ struct YearFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = 1900 + getDateTime(date).tm_year;
+    result = 1900 + getDateTm(date).tm_year;
     return true;
   }
 };
@@ -131,7 +131,7 @@ struct MonthFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = 1 + getDateTime(date).tm_mon;
+    result = 1 + getDateTm(date).tm_mon;
     return true;
   }
 };
@@ -148,7 +148,7 @@ struct DayFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = getDateTime(date).tm_mday;
+    result = getDateTm(date).tm_mday;
     return true;
   }
 };
@@ -166,8 +166,8 @@ struct DayOfWeekFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    std::tm dateTime = getDateTime(date);
-    result = dateTime.tm_wday == 0 ? 7 : dateTime.tm_wday;
+    std::tm dateTm = getDateTm(date);
+    result = dateTm.tm_wday == 0 ? 7 : dateTm.tm_wday;
     return true;
   }
 };
@@ -184,7 +184,7 @@ struct DayOfYearFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = 1 + getDateTime(date).tm_yday;
+    result = 1 + getDateTm(date).tm_yday;
     return true;
   }
 };
@@ -201,7 +201,7 @@ struct HourFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = getDateTime(date).tm_hour;
+    result = getDateTm(date).tm_hour;
     return true;
   }
 };
@@ -218,7 +218,7 @@ struct MinuteFunction : public InitSessionTimezone<T> {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = getDateTime(date).tm_min;
+    result = getDateTm(date).tm_min;
     return true;
   }
 };
@@ -235,7 +235,7 @@ struct SecondFunction {
   }
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
-    result = getDateTime(date).tm_sec;
+    result = getDateTm(date).tm_sec;
     return true;
   }
 };
@@ -382,7 +382,7 @@ struct DateTruncFunction {
       VELOX_USER_FAIL("{} is not a valid DATE field", unitString);
     }
 
-    auto dateTm = getDateTime(date);
+    auto dateTm = getDateTm(date);
     fixTmForTruncation(dateTm, unit);
 
     result = Date(timegm(&dateTm) / kSecondsInDay);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -82,7 +82,7 @@ std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
 
 FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Date date) {
-  int64_t seconds = date.days() * KSecondsInDay;
+  int64_t seconds = date.days() * kSecondsInDay;
   std::tm dateTime;
   gmtime_r((const time_t*)&seconds, &dateTime);
   return dateTime;

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -50,6 +50,7 @@ struct FromUnixtimeFunction {
 };
 
 namespace {
+constexpr int64_t kSecondsInDay = 86'400;
 
 FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
     const core::QueryConfig& config) {
@@ -251,7 +252,7 @@ struct MillisecondFunction {
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& date) {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Date>& /*date*/) {
     // Dates do not have millisecond granularity.
     result = 0;
     return true;
@@ -315,7 +316,7 @@ struct DateTruncFunction {
   }
 
   FOLLY_ALWAYS_INLINE void initialize(
-      const core::QueryConfig& config,
+      const core::QueryConfig& /*config*/,
       const arg_type<Varchar>* unitString,
       const arg_type<Date>* /*date*/) {
     if (unitString != nullptr) {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -324,7 +324,8 @@ struct DateTruncFunction {
   }
 
   FOLLY_ALWAYS_INLINE void fixTmForTruncation(
-      std::tm& tmValue, const DateTimeUnit& unit) {
+      std::tm& tmValue,
+      const DateTimeUnit& unit) {
     switch (unit) {
       case DateTimeUnit::kYear:
         tmValue.tm_mon = 0;
@@ -384,7 +385,7 @@ struct DateTruncFunction {
     auto dateTm = getDateTime(date);
     fixTmForTruncation(dateTm, unit);
 
-    result = Date(timegm(&dateTm)/kSecondsInDay);
+    result = Date(timegm(&dateTm) / kSecondsInDay);
     return true;
   }
 };

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -83,9 +83,9 @@ std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
 FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Date date) {
   int64_t seconds = date.days() * kSecondsInDay;
-  std::tm dateTm;
-  gmtime_r((const time_t*)&seconds, &dateTm);
-  return dateTm;
+  std::tm dateTime;
+  gmtime_r((const time_t*)&seconds, &dateTime);
+  return dateTime;
 }
 
 template <typename T>

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -75,17 +75,17 @@ getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
 FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
-  std::tm dateTm;
-  gmtime_r((const time_t*)&seconds, &dateTm);
-  return dateTm;
+  std::tm dateTime;
+  gmtime_r((const time_t*)&seconds, &dateTime);
+  return dateTime;
 }
 
 FOLLY_ALWAYS_INLINE
 std::tm getDateTm(Date date) {
   int64_t seconds = date.days() * kSecondsInDay;
-  std::tm dateTime;
-  gmtime_r((const time_t*)&seconds, &dateTime);
-  return dateTime;
+  std::tm dateTm;
+  gmtime_r((const time_t*)&seconds, &dateTm);
+  return dateTm;
 }
 
 template <typename T>

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -22,7 +22,6 @@ namespace facebook::velox::functions {
 namespace {
 constexpr double kNanosecondsInSecond = 1'000'000'000;
 constexpr int64_t kNanosecondsInMilliseconds = 1'000'000;
-constexpr int64_t kSecondsInDay = 86'400;
 } // namespace
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -22,7 +22,7 @@ namespace facebook::velox::functions {
 namespace {
 constexpr double kNanosecondsInSecond = 1'000'000'000;
 constexpr int64_t kNanosecondsInMilliseconds = 1'000'000;
-constexpr int64_t KSecondsInDay = 86'400;
+constexpr int64_t kSecondsInDay = 86'400;
 } // namespace
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -22,6 +22,7 @@ namespace facebook::velox::functions {
 namespace {
 constexpr double kNanosecondsInSecond = 1'000'000'000;
 constexpr int64_t kNanosecondsInMilliseconds = 1'000'000;
+constexpr int64_t KSecondsInDay = 86'400;
 } // namespace
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -99,6 +99,8 @@ void registerFunctions() {
   registerFunction<MillisecondFunction, int64_t, Date>({"millisecond"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {"date_trunc"});
+  registerFunction<DateTruncFunction, Date, Varchar, Date>(
+      {"date_trunc"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -99,8 +99,7 @@ void registerFunctions() {
   registerFunction<MillisecondFunction, int64_t, Date>({"millisecond"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {"date_trunc"});
-  registerFunction<DateTruncFunction, Date, Varchar, Date>(
-      {"date_trunc"});
+  registerFunction<DateTruncFunction, Date, Varchar, Date>({"date_trunc"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/SimpleFunctions.cpp
+++ b/velox/functions/prestosql/SimpleFunctions.cpp
@@ -76,17 +76,27 @@ void registerFunctions() {
   registerFunction<ToUnixtimeFunction, double, Timestamp>(
       {"to_unixtime", "to_unix_timestamp"});
   registerFunction<FromUnixtimeFunction, Timestamp, double>({"from_unixtime"});
+
   registerFunction<YearFunction, int64_t, Timestamp>({"year"});
+  registerFunction<YearFunction, int64_t, Date>({"year"});
   registerFunction<MonthFunction, int64_t, Timestamp>({"month"});
+  registerFunction<MonthFunction, int64_t, Date>({"month"});
   registerFunction<DayFunction, int64_t, Timestamp>({"day", "day_of_month"});
+  registerFunction<DayFunction, int64_t, Date>({"day", "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(
       {"dow", "day_of_week"});
+  registerFunction<DayOfWeekFunction, int64_t, Date>({"dow", "day_of_week"});
   registerFunction<DayOfYearFunction, int64_t, Timestamp>(
       {"doy", "day_of_year"});
+  registerFunction<DayOfYearFunction, int64_t, Date>({"doy", "day_of_year"});
   registerFunction<HourFunction, int64_t, Timestamp>({"hour"});
+  registerFunction<HourFunction, int64_t, Date>({"hour"});
   registerFunction<MinuteFunction, int64_t, Timestamp>({"minute"});
+  registerFunction<MinuteFunction, int64_t, Date>({"minute"});
   registerFunction<SecondFunction, int64_t, Timestamp>({"second"});
+  registerFunction<SecondFunction, int64_t, Date>({"second"});
   registerFunction<MillisecondFunction, int64_t, Timestamp>({"millisecond"});
+  registerFunction<MillisecondFunction, int64_t, Date>({"millisecond"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {"date_trunc"});
   registerFunction<

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -536,11 +536,13 @@ TEST_F(DateTimeFunctionsTest, dateTruncDate) {
   };
 
   EXPECT_EQ(std::nullopt, dateTrunc("year", std::nullopt));
+
+  EXPECT_EQ(Date(0), dateTrunc("day", Date(0)));
+  EXPECT_EQ(Date(0), dateTrunc("year", Date(0)));
+  EXPECT_EQ(Date(0), dateTrunc("month", Date(0)));
   EXPECT_THROW(dateTrunc("second", Date(0)), VeloxUserError);
   EXPECT_THROW(dateTrunc("minute", Date(0)), VeloxUserError);
   EXPECT_THROW(dateTrunc("hour", Date(0)), VeloxUserError);
-
-  EXPECT_EQ(Date(0), dateTrunc("day", Date(0)));
 
   // Date(18297) is 2020-02-04
   EXPECT_EQ(Date(18297), dateTrunc("day", Date(18297)));

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -529,6 +529,37 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
       dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
 }
 
+TEST_F(DateTimeFunctionsTest, dateTruncDate) {
+  const auto dateTrunc = [&](const std::string& unit,
+                             std::optional<Date> date) {
+    return evaluateOnce<Date>(
+        fmt::format("date_trunc('{}', c0)", unit), date);
+  };
+
+ EXPECT_EQ(std::nullopt, dateTrunc("year", std::nullopt));
+ EXPECT_THROW(dateTrunc("second", Date(0)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("minute", Date(0)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("hour", Date(0)), VeloxUserError);
+
+ EXPECT_EQ(Date(0), dateTrunc("day", Date(0)));
+
+ // Date(18297) is 2020-02-04
+ EXPECT_EQ(Date(18297), dateTrunc("day", Date(18297)));
+ EXPECT_EQ(Date(18293), dateTrunc("month", Date(18297)));
+ EXPECT_EQ(Date(18262), dateTrunc("year", Date(18297)));
+ EXPECT_THROW(dateTrunc("second", Date(18297)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("minute", Date(18297)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("hour", Date(18297)), VeloxUserError);
+
+ // Date(-18297) is 1919-11-27
+ EXPECT_EQ(Date(-18297), dateTrunc("day", Date(-18297)));
+ EXPECT_EQ(Date(-18324), dateTrunc("month", Date(-18297)));
+ EXPECT_EQ(Date(-18628), dateTrunc("year", Date(-18297)));
+ EXPECT_THROW(dateTrunc("second", Date(-18297)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("minute", Date(-18297)), VeloxUserError);
+ EXPECT_THROW(dateTrunc("hour", Date(-18297)), VeloxUserError);
+}
+
 TEST_F(DateTimeFunctionsTest, parseDatetime) {
   // Check null behavior.
   EXPECT_EQ(std::nullopt, parseDatetime("1970-01-01", std::nullopt));

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -532,32 +532,31 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
 TEST_F(DateTimeFunctionsTest, dateTruncDate) {
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<Date> date) {
-    return evaluateOnce<Date>(
-        fmt::format("date_trunc('{}', c0)", unit), date);
+    return evaluateOnce<Date>(fmt::format("date_trunc('{}', c0)", unit), date);
   };
 
- EXPECT_EQ(std::nullopt, dateTrunc("year", std::nullopt));
- EXPECT_THROW(dateTrunc("second", Date(0)), VeloxUserError);
- EXPECT_THROW(dateTrunc("minute", Date(0)), VeloxUserError);
- EXPECT_THROW(dateTrunc("hour", Date(0)), VeloxUserError);
+  EXPECT_EQ(std::nullopt, dateTrunc("year", std::nullopt));
+  EXPECT_THROW(dateTrunc("second", Date(0)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("minute", Date(0)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("hour", Date(0)), VeloxUserError);
 
- EXPECT_EQ(Date(0), dateTrunc("day", Date(0)));
+  EXPECT_EQ(Date(0), dateTrunc("day", Date(0)));
 
- // Date(18297) is 2020-02-04
- EXPECT_EQ(Date(18297), dateTrunc("day", Date(18297)));
- EXPECT_EQ(Date(18293), dateTrunc("month", Date(18297)));
- EXPECT_EQ(Date(18262), dateTrunc("year", Date(18297)));
- EXPECT_THROW(dateTrunc("second", Date(18297)), VeloxUserError);
- EXPECT_THROW(dateTrunc("minute", Date(18297)), VeloxUserError);
- EXPECT_THROW(dateTrunc("hour", Date(18297)), VeloxUserError);
+  // Date(18297) is 2020-02-04
+  EXPECT_EQ(Date(18297), dateTrunc("day", Date(18297)));
+  EXPECT_EQ(Date(18293), dateTrunc("month", Date(18297)));
+  EXPECT_EQ(Date(18262), dateTrunc("year", Date(18297)));
+  EXPECT_THROW(dateTrunc("second", Date(18297)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("minute", Date(18297)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("hour", Date(18297)), VeloxUserError);
 
- // Date(-18297) is 1919-11-27
- EXPECT_EQ(Date(-18297), dateTrunc("day", Date(-18297)));
- EXPECT_EQ(Date(-18324), dateTrunc("month", Date(-18297)));
- EXPECT_EQ(Date(-18628), dateTrunc("year", Date(-18297)));
- EXPECT_THROW(dateTrunc("second", Date(-18297)), VeloxUserError);
- EXPECT_THROW(dateTrunc("minute", Date(-18297)), VeloxUserError);
- EXPECT_THROW(dateTrunc("hour", Date(-18297)), VeloxUserError);
+  // Date(-18297) is 1919-11-27
+  EXPECT_EQ(Date(-18297), dateTrunc("day", Date(-18297)));
+  EXPECT_EQ(Date(-18324), dateTrunc("month", Date(-18297)));
+  EXPECT_EQ(Date(-18628), dateTrunc("year", Date(-18297)));
+  EXPECT_THROW(dateTrunc("second", Date(-18297)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("minute", Date(-18297)), VeloxUserError);
+  EXPECT_THROW(dateTrunc("hour", Date(-18297)), VeloxUserError);
 }
 
 TEST_F(DateTimeFunctionsTest, parseDatetime) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Date.h"
 #include "velox/type/Timestamp.h"
 
 using namespace facebook::velox;
@@ -191,6 +192,17 @@ TEST_F(DateTimeFunctionsTest, year) {
   EXPECT_EQ(2001, year(Timestamp(998423705, 321000000)));
 }
 
+TEST_F(DateTimeFunctionsTest, yearDate) {
+  const auto year = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("year(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, year(std::nullopt));
+  EXPECT_EQ(1970, year(Date(0)));
+  EXPECT_EQ(1969, year(Date(-1)));
+  EXPECT_EQ(2020, year(Date(18262)));
+  EXPECT_EQ(1920, year(Date(-18262)));
+}
+
 TEST_F(DateTimeFunctionsTest, month) {
   const auto month = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("month(c0)", date);
@@ -212,6 +224,19 @@ TEST_F(DateTimeFunctionsTest, month) {
   EXPECT_EQ(10, month(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(8, month(Timestamp(998474645, 321000000)));
   EXPECT_EQ(8, month(Timestamp(998423705, 321000000)));
+}
+
+TEST_F(DateTimeFunctionsTest, monthDate) {
+  const auto month = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("month(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, month(std::nullopt));
+  EXPECT_EQ(1, month(Date(0)));
+  EXPECT_EQ(12, month(Date(-1)));
+  EXPECT_EQ(11, month(Date(-40)));
+  EXPECT_EQ(2, month(Date(40)));
+  EXPECT_EQ(1, month(Date(18262)));
+  EXPECT_EQ(1, month(Date(-18262)));
 }
 
 TEST_F(DateTimeFunctionsTest, hour) {
@@ -237,6 +262,19 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(8, hour(Timestamp(998423705, 321000000)));
 }
 
+TEST_F(DateTimeFunctionsTest, hourDate) {
+  const auto hour = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("hour(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, hour(std::nullopt));
+  EXPECT_EQ(0, hour(Date(0)));
+  EXPECT_EQ(0, hour(Date(-1)));
+  EXPECT_EQ(0, hour(Date(-40)));
+  EXPECT_EQ(0, hour(Date(40)));
+  EXPECT_EQ(0, hour(Date(18262)));
+  EXPECT_EQ(0, hour(Date(-18262)));
+}
+
 TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   const auto day = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("day_of_month(c0)", date);
@@ -258,6 +296,19 @@ TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   EXPECT_EQ(1, day(Timestamp(1633076100, 0)));
   EXPECT_EQ(6, day(Timestamp(1633508100, 0)));
   EXPECT_EQ(31, day(Timestamp(1635668100, 0)));
+}
+
+TEST_F(DateTimeFunctionsTest, dayOfMonthDate) {
+  const auto day = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("day_of_month(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, day(std::nullopt));
+  EXPECT_EQ(1, day(Date(0)));
+  EXPECT_EQ(31, day(Date(-1)));
+  EXPECT_EQ(22, day(Date(-40)));
+  EXPECT_EQ(10, day(Date(40)));
+  EXPECT_EQ(1, day(Date(18262)));
+  EXPECT_EQ(2, day(Date(-18262)));
 }
 
 TEST_F(DateTimeFunctionsTest, dayOfWeek) {
@@ -289,6 +340,19 @@ TEST_F(DateTimeFunctionsTest, dayOfWeek) {
   EXPECT_EQ(7, day(Timestamp(1633853700, 0)));
 }
 
+TEST_F(DateTimeFunctionsTest, dayOfWeekDate) {
+  const auto day = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("day_of_week(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, day(std::nullopt));
+  EXPECT_EQ(4, day(Date(0)));
+  EXPECT_EQ(3, day(Date(-1)));
+  EXPECT_EQ(6, day(Date(-40)));
+  EXPECT_EQ(2, day(Date(40)));
+  EXPECT_EQ(3, day(Date(18262)));
+  EXPECT_EQ(5, day(Date(-18262)));
+}
+
 TEST_F(DateTimeFunctionsTest, dayOfYear) {
   const auto day = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("day_of_year(c0)", date);
@@ -310,6 +374,19 @@ TEST_F(DateTimeFunctionsTest, dayOfYear) {
   EXPECT_EQ(274, day(Timestamp(1633076100, 0)));
   EXPECT_EQ(279, day(Timestamp(1633508100, 0)));
   EXPECT_EQ(304, day(Timestamp(1635668100, 0)));
+}
+
+TEST_F(DateTimeFunctionsTest, dayOfYearDate) {
+  const auto day = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("day_of_year(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, day(std::nullopt));
+  EXPECT_EQ(1, day(Date(0)));
+  EXPECT_EQ(365, day(Date(-1)));
+  EXPECT_EQ(326, day(Date(-40)));
+  EXPECT_EQ(41, day(Date(40)));
+  EXPECT_EQ(1, day(Date(18262)));
+  EXPECT_EQ(2, day(Date(-18262)));
 }
 
 TEST_F(DateTimeFunctionsTest, minute) {
@@ -335,6 +412,19 @@ TEST_F(DateTimeFunctionsTest, minute) {
   EXPECT_EQ(25, minute(Timestamp(998423705, 321000000)));
 }
 
+TEST_F(DateTimeFunctionsTest, minuteDate) {
+  const auto minute = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("minute(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, minute(std::nullopt));
+  EXPECT_EQ(0, minute(Date(0)));
+  EXPECT_EQ(0, minute(Date(-1)));
+  EXPECT_EQ(0, minute(Date(-40)));
+  EXPECT_EQ(0, minute(Date(40)));
+  EXPECT_EQ(0, minute(Date(18262)));
+  EXPECT_EQ(0, minute(Date(-18262)));
+}
+
 TEST_F(DateTimeFunctionsTest, second) {
   const auto second = [&](std::optional<Timestamp> timestamp) {
     return evaluateOnce<int64_t>("second(c0)", timestamp);
@@ -346,6 +436,19 @@ TEST_F(DateTimeFunctionsTest, second) {
   EXPECT_EQ(59, second(Timestamp(-1, 12300000000)));
 }
 
+TEST_F(DateTimeFunctionsTest, secondDate) {
+  const auto second = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("second(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, second(std::nullopt));
+  EXPECT_EQ(0, second(Date(0)));
+  EXPECT_EQ(0, second(Date(-1)));
+  EXPECT_EQ(0, second(Date(-40)));
+  EXPECT_EQ(0, second(Date(40)));
+  EXPECT_EQ(0, second(Date(18262)));
+  EXPECT_EQ(0, second(Date(-18262)));
+}
+
 TEST_F(DateTimeFunctionsTest, millisecond) {
   const auto millisecond = [&](std::optional<Timestamp> timestamp) {
     return evaluateOnce<int64_t>("millisecond(c0)", timestamp);
@@ -355,6 +458,19 @@ TEST_F(DateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(0, millisecond(Timestamp(4000000000, 0)));
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
   EXPECT_EQ(12300, millisecond(Timestamp(-1, 12300000000)));
+}
+
+TEST_F(DateTimeFunctionsTest, millisecondDate) {
+  const auto millisecond = [&](std::optional<Date> date) {
+    return evaluateOnce<int64_t>("millisecond(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, millisecond(std::nullopt));
+  EXPECT_EQ(0, millisecond(Date(0)));
+  EXPECT_EQ(0, millisecond(Date(-1)));
+  EXPECT_EQ(0, millisecond(Date(-40)));
+  EXPECT_EQ(0, millisecond(Date(40)));
+  EXPECT_EQ(0, millisecond(Date(18262)));
+  EXPECT_EQ(0, millisecond(Date(-18262)));
 }
 
 TEST_F(DateTimeFunctionsTest, dateTrunc) {


### PR DESCRIPTION
- Add support for DATE type to date extraction functions:
   year, month, day, dow, doy, hour, minute, second, millisecond.
- Add support for DATE type to date_trunc function.