### PR TITLE
Fix ASAN failure in compacting nulls in SelectiveColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -285,6 +285,10 @@ class SelectiveColumnReader : public ColumnReader {
   template <typename T, typename TVector>
   void upcastScalarValues(RowSet rows);
 
+  // Returns true if compactScalarValues and upcastScalarValues should
+  // move null flags. Checks consistency of nulls-related state.
+  bool shouldMoveNulls(RowSet rows);
+
   void addStringValue(folly::StringPiece value);
 
   // Copies 'value' to buffers owned by 'this' and returns the start of the


### PR DESCRIPTION
If a filtered column is followed by another filtered column, the
non-last filtered columns will be compacted to align with the last
filtered column's passing rows. In doing this, nulls must be compacted
only if there actualxly are nulls. There can be nulls because some
filters will pass nulls. The error occurs when there were nulls in a
previous batch and there are no nulls in a subsequent batch and the
nulls uffer is too small, leading to a rare access past the end of the
resultNulls_ buffer.