### PR TITLE
Re-evaluate row group pruning after setting dynamic filter

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -36,8 +36,9 @@ void DwrfRowReader::checkSkipStrides(
     return;
   }
 
-  if (currentRowInStripe == 0) {
+  if (currentRowInStripe == 0 || recomputeStridesToSkip_) {
     stridesToSkip_ = columnReader_->filterRowGroups(strideSize, context);
+    recomputeStridesToSkip_ = false;
   }
 
   if (stridesToSkip_.empty()) {
@@ -124,6 +125,7 @@ uint64_t DwrfRowReader::next(uint64_t size, VectorPtr& result) {
 
 void DwrfRowReader::resetFilterCaches() {
   dynamic_cast<SelectiveColumnReader*>(columnReader())->resetFilterCaches();
+  recomputeStridesToSkip_ = true;
 }
 
 std::unique_ptr<DwrfReader> DwrfReader::create(

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -76,6 +76,11 @@ class DwrfRowReader : public DwrfRowReaderShared {
 
   // Number of skipped strides.
   int64_t skippedStrides_{0};
+
+  // Set to true after clearing filter caches, i.e.  adding a dynamic
+  // filter. Causes filters to be re-evaluated against stride stats on
+  // next stride instead of next stripe.
+  bool recomputeStridesToSkip_{false};
 };
 
 class DwrfReader : public DwrfReaderShared {


### PR DESCRIPTION
Checks new filters against row group stats after the filters have been
added. Otherwise dynamic filter pushdown would only take effect on the
next stripe. This is significant with narrow tables with long stripes.