### PR TITLE
Fix bug on variant::inferType() of null arrays

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -512,8 +512,13 @@ class variant {
         return ROW(std::move(children));
       }
       case TypeKind::ARRAY: {
-        auto& a = array();
-        auto elementType = a.empty() ? UNKNOWN() : a.at(0).inferType();
+        TypePtr elementType = UNKNOWN();
+        if (!isNull()) {
+          auto& a = array();
+          if (!a.empty()) {
+            elementType = a.at(0).inferType();
+          }
+        }
         return ARRAY(elementType);
       }
       case TypeKind::OPAQUE: {

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -18,11 +18,26 @@
 
 using namespace facebook::velox;
 
+TEST(Variant, arrayInferType) {
+  EXPECT_EQ(*ARRAY(UNKNOWN()), *variant(TypeKind::ARRAY).inferType());
+  EXPECT_EQ(*ARRAY(UNKNOWN()), *variant::array({}).inferType());
+  EXPECT_EQ(
+      *ARRAY(BIGINT()),
+      *variant::array({variant(TypeKind::BIGINT)}).inferType());
+  EXPECT_EQ(
+      *ARRAY(VARCHAR()),
+      *variant::array({variant(TypeKind::VARCHAR)}).inferType());
+  EXPECT_EQ(
+      *ARRAY(ARRAY(DOUBLE())),
+      *variant::array({variant::array({variant(TypeKind::DOUBLE)})})
+           .inferType());
+}
+
 struct Foo {};
 
 struct Bar {};
 
-TEST(Variant, Opaque) {
+TEST(Variant, opaque) {
   auto foo = std::make_shared<Foo>();
   auto foo2 = std::make_shared<Foo>();
   auto bar = std::make_shared<Bar>();


### PR DESCRIPTION
Summary:
inferType() was unable to inferType of null arrays since array() call
would throw.

Differential Revision: D32565300

