### PR TITLE
Fix infinite loop in regexp_extract_all

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -451,6 +451,9 @@ void re2ExtractAll(
 
     array.emplace_back(subMatch.data(), subMatch.size());
     pos = fullMatch.data() + fullMatch.size() - input.data();
+    if (UNLIKELY(fullMatch.size() == 0)) {
+      ++pos;
+    }
   }
 }
 

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -634,6 +634,10 @@ TEST_F(Re2FunctionsTest, regexExtractAllNoMatch) {
       {"81jnp58n31BtMdlUsP1hiF4QWSYv411"},
       groupIds0,
       {{{}}});
+
+  // Test empty pattern.
+  testRe2ExtractAll<int32_t>(
+      {"abcdef"}, {""}, {}, {{{"", "", "", "", "", "", ""}}});
 }
 
 TEST_F(Re2FunctionsTest, regexExtractAllBadArgs) {

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -512,8 +512,13 @@ class variant {
         return ROW(std::move(children));
       }
       case TypeKind::ARRAY: {
-        auto& a = array();
-        auto elementType = a.empty() ? UNKNOWN() : a.at(0).inferType();
+        TypePtr elementType = UNKNOWN();
+        if (!isNull()) {
+          auto& a = array();
+          if (!a.empty()) {
+            elementType = a.at(0).inferType();
+          }
+        }
         return ARRAY(elementType);
       }
       case TypeKind::OPAQUE: {

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -18,6 +18,21 @@
 
 using namespace facebook::velox;
 
+TEST(Variant, ArrayInferType) {
+  EXPECT_EQ(*ARRAY(UNKNOWN()), *variant(TypeKind::ARRAY).inferType());
+  EXPECT_EQ(*ARRAY(UNKNOWN()), *variant::array({}).inferType());
+  EXPECT_EQ(
+      *ARRAY(BIGINT()),
+      *variant::array({variant(TypeKind::BIGINT)}).inferType());
+  EXPECT_EQ(
+      *ARRAY(VARCHAR()),
+      *variant::array({variant(TypeKind::VARCHAR)}).inferType());
+  EXPECT_EQ(
+      *ARRAY(ARRAY(DOUBLE())),
+      *variant::array({variant::array({variant(TypeKind::DOUBLE)})})
+           .inferType());
+}
+
 struct Foo {};
 
 struct Bar {};


### PR DESCRIPTION
Summary: regexp_extract_all would get stuck if the pattern string was empty.

Reviewed By: mbasmanova

Differential Revision: D32566080

