### PR TITLE
Adjust TableScan batch size by DataSource row size estimate

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -89,6 +89,7 @@ class DataSink {
 
 class DataSource {
  public:
+  static constexpr int64_t kUnknownRowSize = -1;
   virtual ~DataSource() = default;
 
   // Add split to process, then call next multiple times to process the split.
@@ -116,6 +117,16 @@ class DataSource {
   virtual uint64_t getCompletedRows() = 0;
 
   virtual std::unordered_map<std::string, int64_t> runtimeStats() = 0;
+
+  // Returns a connector dependent row size if available. This can be
+  // called after addSplit().  This estimates uncompressed data
+  // sizes. This is better than getCompletedBytes()/getCompletedRows()
+  // since these track sizes before decompression and may include
+  // read-ahead and extra IO from coalescing reads and  will not
+  // fully account for size of sparsely accessed columns.
+  virtual int64_t estimatedRowSize() {
+    return kUnknownRowSize;
+  }
 
   // TODO Allow DataSource to indicate that it is blocked (say waiting for IO)
   // to avoid holding up the thread.

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -158,6 +158,13 @@ class HiveDataSource : public DataSource {
 
   std::unordered_map<std::string, int64_t> runtimeStats() override;
 
+  int64_t estimatedRowSize() override {
+    if (!rowReader_) {
+      return kUnknownRowSize;
+    }
+    return rowReader_->estimatedRowSize();
+  }
+
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
   // passed. Populates filterEvalCtx_.selectedIndices and selectedBits if only

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -88,10 +88,11 @@ RowVectorPtr TableScan::getOutput() {
 
       dataSource_->addSplit(connectorSplit);
       ++stats_.numSplits;
+      setBatchSize();
     }
 
     const auto ioTimeStartMicros = getCurrentTimeMicro();
-    auto data = dataSource_->next(kDefaultBatchSize);
+    auto data = dataSource_->next(readBatchSize_);
     stats().addRuntimeStat(
         "dataSourceWallNanos",
         (getCurrentTimeMicro() - ioTimeStartMicros) * 1'000);
@@ -110,6 +111,19 @@ RowVectorPtr TableScan::getOutput() {
     currentSplitGroupId_ = -1;
     needNewSplit_ = true;
   }
+}
+
+void TableScan::setBatchSize() {
+  constexpr int64_t kMB = 1 << 20;
+  auto estimate = dataSource_->estimatedRowSize();
+  if (estimate == connector::DataSource::kUnknownRowSize) {
+    readBatchSize_ = kDefaultBatchSize;
+    return;
+  }
+  if (estimate < 1024) {
+    readBatchSize_ = 10000; // No more than 10MB of data per batch.
+  }
+  readBatchSize_ = std::min<int64_t>(100, 10 * kMB / estimate);
 }
 
 void TableScan::addDynamicFilter(

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -58,6 +58,8 @@ class TableScan : public SourceOperator {
  private:
   static constexpr int32_t kDefaultBatchSize = 1024;
 
+  // Adjust batch size according to split information.
+  void setBatchSize();
   const core::PlanNodeId planNodeId_;
   const std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
   const std::
@@ -76,5 +78,6 @@ class TableScan : public SourceOperator {
   // Dynamic filters to add to the data source when it gets created.
   std::unordered_map<ChannelIndex, std::shared_ptr<common::Filter>>
       pendingDynamicFilters_;
+  int32_t readBatchSize_{kDefaultBatchSize};
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
A constant batch size of 1K rows has been seen to lead to timers and
other per-batch overhead going to up to 10% of profile for narrow and
sparse workloads. Furthermore some of this expense involves mutexes,
for example inside retrieving CPU thread time, surprising as this may
seem. This also increases safety for very wide tables, e.g. maps of
10K keys.

We aim at a target batch size of up to 10MB, which for 100 threads
would be 1GB * ~5 operators per pipeline = ~5GB, which is a reasonable
figure for intermediate result size.

A more portable implementation could be to compare raw input size to
processed input rows but this would undercount sparsely accessed
columns, be relative to compressed size and would count in extra reads
from coalescing, which would make this quite unusable.

The code is covered by TableScanTest.* as is.