### PR TITLE
Add spilling to RowContainer

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -149,8 +149,9 @@ LocalWriteFile::LocalWriteFile(std::string_view path) {
     VELOX_CHECK(
         !exists, "Failure in LocalWriteFile: path '{}' already exists.", path);
   }
-  file_ = fopen(buf.get(), "ab");
-  VELOX_CHECK(file_, "fread failure in LocalWriteFile constructor, {}.", path);
+  auto file = fopen(buf.get(), "ab");
+  VELOX_CHECK(file, "fopen failure in LocalWriteFile constructor, {}.", path);
+  file_ = file;
 }
 
 LocalWriteFile::~LocalWriteFile() {

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   HashPartitionFunction.cpp
   HashProbe.cpp
   Spill.cpp
+  Spiller.cpp
   HashTable.cpp
   JoinBridge.cpp
   Limit.cpp

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -53,7 +53,8 @@ WriteFile& SpillFile::output() {
 }
 
 void SpillFile::startRead() {
-  constexpr uint64_t kMaxReadBufferSize = 1 << 20; // 1MB
+  constexpr uint64_t kMaxReadBufferSize =
+      (1 << 20) - AlignedBuffer::kPaddedSize; // 1MB - padding.
   VELOX_CHECK(!output_);
   VELOX_CHECK(!input_);
   auto fs = filesystems::getFileSystem(path_, nullptr);

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -361,7 +361,7 @@ class SpillState {
       int32_t partition,
       std::unique_ptr<SpillStream>&& extra);
 
-  bool hasFiles(int32_t partition) {
+  bool hasFiles(int32_t partition) const {
     return partition < files_.size() && files_[partition];
   }
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Spiller.h"
+
+#include "velox/common/base/AsyncSource.h"
+
+#include <folly/ScopeGuard.h>
+
+namespace facebook::velox::exec {
+
+void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
+  if (!resultPtr) {
+    resultPtr =
+        BaseVector::create<RowVector>(rowType_, rows.size(), &spillPool());
+  } else {
+    resultPtr->prepareForReuse();
+    resultPtr->resize(rows.size());
+  }
+  auto result = resultPtr.get();
+  auto& types = container_.columnTypes();
+  for (auto i = 0; i < types.size(); ++i) {
+    container_.extractColumn(rows.data(), rows.size(), i, result->childAt(i));
+  }
+  auto& aggregates = container_.aggregates();
+  auto numKeys = types.size();
+  for (auto i = 0; i < aggregates.size(); ++i) {
+    aggregates[i]->finalize(rows.data(), rows.size());
+    aggregates[i]->extractAccumulators(
+        rows.data(), rows.size(), &result->childAt(i + numKeys));
+  }
+}
+
+int64_t Spiller::extractSpillVector(
+    SpillRows& rows,
+    int32_t maxRows,
+    int64_t maxBytes,
+    RowVectorPtr& spillVector,
+    size_t& nextBatchIndex) {
+  auto limit = std::min<size_t>(rows.size() - nextBatchIndex, maxRows);
+  assert(!rows.empty());
+  int32_t numRows = 0;
+  int64_t bytes = 0;
+  for (; numRows < limit; ++numRows) {
+    bytes += container_.rowSize(rows[nextBatchIndex + numRows]);
+    if (bytes > maxBytes) {
+      // Increment because the row that went over the limit is part
+      // of the result. We must spill at least one row.
+      ++numRows;
+      break;
+    }
+  }
+  extractSpill(folly::Range(&rows[nextBatchIndex], numRows), spillVector);
+  nextBatchIndex += numRows;
+  return bytes;
+}
+
+namespace {
+// A stream of ordered rows being read from the in memory
+// container. This is the part of a spillable range that is not yet
+// spilled when starting to produce output. This is only used for
+// sorted spills since for hash join spilling we just use the data in
+// the RowContainer as is.
+class RowContainerSpillStream : public SpillStream {
+ public:
+  RowContainerSpillStream(
+      RowTypePtr type,
+      int32_t numSortingKeys,
+      memory::MemoryPool& pool,
+      Spiller::SpillRows&& rows,
+      Spiller& spiller)
+      : SpillStream(std::move(type), numSortingKeys, pool),
+        rows_(std::move(rows)),
+        spiller_(spiller) {
+    if (!rows_.empty()) {
+      nextBatch();
+    }
+  }
+
+  uint64_t size() const override {
+    // 0 means that 'this' does not own spilled data in files.
+    return 0;
+  }
+
+ private:
+  void nextBatch() override {
+    // Extracts up to 64 rows at a time. Small batch size because may
+    // have wide data and no advantage in large size for narrow data
+    // since this is all processed row by row.
+    static constexpr vector_size_t kMaxRows = 64;
+    constexpr uint64_t kMaxBytes = 4 << 20;
+    size_t bytes = 0;
+    vector_size_t numRows = 0;
+    spiller_.extractSpillVector(
+        rows_, kMaxRows, kMaxBytes, rowVector_, nextBatchIndex_);
+    size_ = rowVector_->size();
+    index_ = 0;
+  }
+
+  Spiller::SpillRows rows_;
+  Spiller& spiller_;
+  size_t nextBatchIndex_ = 0;
+};
+} // namespace
+
+std::unique_ptr<SpillStream> Spiller::spillStreamOverRows(int32_t partition) {
+  VELOX_CHECK(spillFinalized_);
+  VELOX_CHECK_LT(partition, spillRuns_.size());
+  ensureSorted(spillRuns_[partition]);
+  return std::make_unique<RowContainerSpillStream>(
+      rowType_,
+      container_.keyTypes().size(),
+      pool_,
+      std::move(spillRuns_[partition].rows),
+      *this);
+}
+
+void Spiller::ensureSorted(SpillRun& run) {
+  if (!run.sorted) {
+    std::sort(
+        run.rows.begin(),
+        run.rows.end(),
+        [&](const char* left, const char* right) {
+          return container_.compareRows(left, right) < 0;
+        });
+    run.sorted = true;
+  }
+}
+
+std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(
+    int32_t partition,
+    uint64_t maxBytes) {
+  // Target size of a single vector of spilled content. One of
+  // these will be materialized at a time for each stream of the
+  // merge.
+  constexpr int32_t kTargetBatchBytes = 1 << 18; // 256K
+
+  RowVectorPtr spillVector;
+  auto& run = spillRuns_[partition];
+  try {
+    ensureSorted(run);
+    int64_t totalBytes = 0;
+    size_t written = 0;
+    while (written < run.rows.size()) {
+      totalBytes += extractSpillVector(
+          run.rows, 64, kTargetBatchBytes, spillVector, written);
+      state_.appendToPartition(partition, spillVector);
+      if (totalBytes > maxBytes) {
+        break;
+      }
+    }
+    return std::make_unique<SpillStatus>(partition, written, nullptr);
+  } catch (const std::exception& e) {
+    // The exception is passed to the caller thread which checks this in
+    // advanceSpill().
+    return std::make_unique<SpillStatus>(
+        partition, 0, std::current_exception());
+  }
+}
+
+void Spiller::advanceSpill(uint64_t maxBytes) {
+  std::vector<std::shared_ptr<AsyncSource<SpillStatus>>> writes;
+  for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
+    if (pendingSpillPartitions_.find(partition) ==
+        pendingSpillPartitions_.end()) {
+      continue;
+    }
+    writes.push_back(std::make_shared<AsyncSource<SpillStatus>>(
+        [partition, this, maxBytes]() {
+          return writeSpill(
+              partition, maxBytes / pendingSpillPartitions_.size());
+        }));
+    if (executor_) {
+      executor_->add([source = writes.back()]() { source->prepare(); });
+    }
+  }
+  auto sync = folly::makeGuard([&]() {
+    for (auto& write : writes) {
+      // We consume the result for the pending writes. This is a
+      // cleanup in the guard and must not throw. The first error is
+      // already captured before this runs.
+      try {
+        write->move();
+      } catch (const std::exception& e) {
+      }
+    }
+  });
+
+  for (auto& write : writes) {
+    auto result = write->move();
+
+    if (result->error) {
+      std::rethrow_exception(result->error);
+    }
+    auto numWritten = result->rowsWritten;
+    auto partition = result->partition;
+    auto& run = spillRuns_[partition];
+    auto spilled = folly::Range<char**>(run.rows.data(), numWritten);
+    eraser_(spilled);
+    if (!container_.numRows()) {
+      // If the container became empty, free its memory.
+      container_.clear();
+    }
+    run.rows.erase(run.rows.begin(), run.rows.begin() + numWritten);
+    if (run.rows.empty()) {
+      // Run ends, start with a new file next time.
+      run.clear();
+      state_.finishWrite(partition);
+      pendingSpillPartitions_.erase(partition);
+    }
+  }
+}
+
+void Spiller::spill(
+    uint64_t targetRows,
+    uint64_t targetBytes,
+    RowContainerIterator& iterator) {
+  bool doneFullSweep = false;
+  bool startedFullSweep = false;
+  VELOX_CHECK(!spillFinalized_);
+  if (!state_.numPartitions()) {
+    state_.setNumPartitions(1);
+  }
+  for (;;) {
+    auto rowsLeft = container_.numRows();
+    auto spaceLeft = container_.stringAllocator().retainedSize() -
+        container_.stringAllocator().freeSpace();
+    if (!rowsLeft || (rowsLeft <= targetRows && spaceLeft < targetBytes)) {
+      return;
+    }
+    if (!pendingSpillPartitions_.empty()) {
+      advanceSpill(std::numeric_limits<uint64_t>::max());
+      if (!pendingSpillPartitions_.empty()) {
+        continue;
+      }
+    }
+    if (doneFullSweep) {
+      return;
+    }
+    for (auto newPartition = spillRuns_.size();
+         newPartition < state_.maxPartitions();
+         ++newPartition) {
+      spillRuns_.emplace_back(spillMappedMemory());
+    }
+    clearSpillRuns();
+    iterator.reset();
+    if (fillSpillRuns(
+            iterator,
+            targetBytes < state_.targetFileSize() ? RowContainer::kUnlimited
+                                                  : state_.targetFileSize())) {
+      // Arrived at end of the container. Add more spilled ranges if any left.
+      if (state_.numPartitions() < state_.maxPartitions()) {
+        state_.setNumPartitions(state_.numPartitions() + 1);
+      } else {
+        doneFullSweep = startedFullSweep;
+        startedFullSweep = true;
+      }
+      iterator.reset();
+    }
+  }
+}
+
+Spiller::SpillRows Spiller::finishSpill() {
+  VELOX_CHECK(!spillFinalized_);
+  spillFinalized_ = true;
+  clearSpillRuns();
+  RowContainerIterator iterator;
+  iterator.reset();
+  SpillRows rowsFromNonSpillingPartitions(
+      0, memory::StlMappedMemoryAllocator<char*>(&spillMappedMemory()));
+  fillSpillRuns(
+      iterator, RowContainer::kUnlimited, &rowsFromNonSpillingPartitions);
+  return rowsFromNonSpillingPartitions;
+}
+
+void Spiller::clearSpillRuns() {
+  for (auto& run : spillRuns_) {
+    run.clear();
+  }
+}
+
+bool Spiller::fillSpillRuns(
+    RowContainerIterator& iterator,
+    uint64_t targetSize,
+    SpillRows* rowsFromNonSpillingPartitions) {
+  // Number of rows to hash and divide into spill partitions at a time.
+  constexpr int32_t kHashBatchSize = 1024;
+  bool final = false;
+  if (rowsFromNonSpillingPartitions) {
+    final = true;
+    VELOX_CHECK_EQ(
+        targetSize,
+        RowContainer::kUnlimited,
+        "Retrieving rows of non-spilling partitions is only "
+        "allowed if retrieving the whole container");
+    final = true;
+  } else if (targetSize == RowContainer::kUnlimited) {
+    final = true;
+  }
+  std::vector<uint64_t> hashes(kHashBatchSize);
+  std::vector<char*> rows(kHashBatchSize);
+  int64_t numConsidered = 0;
+  for (;;) {
+    auto numRows = container_.listRows(
+        &iterator, rows.size(), RowContainer::kUnlimited, rows.data());
+    numConsidered += numRows;
+
+    // Calculate hashes for this batch of spill candidates.
+    auto rowSet = folly::Range<char**>(rows.data(), numRows);
+    for (auto i = 0; i < container_.keyTypes().size(); ++i) {
+      container_.hash(i, rowSet, i > 0, hashes.data());
+    }
+
+    // Put each in its run.
+    for (auto i = 0; i < numRows; ++i) {
+      auto partition = bits_.partition(hashes[i], spillRuns_.size());
+      if (partition == -1) {
+        if (rowsFromNonSpillingPartitions) {
+          rowsFromNonSpillingPartitions->push_back(rows[i]);
+        }
+        continue;
+      }
+      spillRuns_[partition].rows.push_back(rows[i]);
+      spillRuns_[partition].numBytes += container_.rowSize(rows[i]);
+    }
+    // The final phase goes through the whole container and makes runs for all
+    // non-empty spilling partitions.
+    if (final && numRows) {
+      continue;
+    }
+    bool anyStarted = false;
+    for (auto i = 0; i < spillRuns_.size(); ++i) {
+      auto& run = spillRuns_[i];
+      if (!run.rows.empty() && (run.numBytes > targetSize || final)) {
+        pendingSpillPartitions_.insert(i);
+        anyStarted = true;
+      }
+    }
+    if (final) {
+      return true;
+    }
+    if (!numRows) {
+      if (numConsidered == container_.numRows()) {
+        // If done full sweep but no spill started yet, start enough partitions
+        // to cover the ask.
+        std::vector<int32_t> indices(spillRuns_.size());
+        std::iota(indices.begin(), indices.end(), 0);
+        std::sort(
+            indices.begin(), indices.end(), [&](int32_t left, int32_t right) {
+              return spillRuns_[left].numBytes > spillRuns_[right].numBytes;
+            });
+        int64_t started = 0;
+        for (auto i : indices) {
+          pendingSpillPartitions_.insert(i);
+          started += spillRuns_[i].numBytes;
+          if (started > targetSize) {
+            break;
+          }
+        }
+        clearNonSpillingRuns();
+        return false;
+      }
+      clearNonSpillingRuns();
+      return true;
+    }
+    if (anyStarted) {
+      clearNonSpillingRuns();
+      return false;
+    }
+  }
+}
+
+void Spiller::clearNonSpillingRuns() {
+  for (auto i = 0; i < spillRuns_.size(); ++i) {
+    if (pendingSpillPartitions_.find(i) == pendingSpillPartitions_.end()) {
+      spillRuns_[i].clear();
+    }
+  }
+}
+
+// static
+memory::MappedMemory& Spiller::spillMappedMemory() {
+  // Return the top level instance. Since this too may be full,
+  // another possibility is to return an emergency instance that
+  // delegates to the process wide one and makes a file-backed mmap
+  // if the allocation fails.
+  return *memory::MappedMemory::getInstance();
+}
+
+// static
+memory::MemoryPool& Spiller::spillPool() {
+  static auto pool = memory::getDefaultScopedMemoryPool();
+  return *pool;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/RowContainer.h"
+
+namespace facebook::velox::exec {
+
+// Describes a bit range inside a 64 bit hash number for use in
+// partitioning data over multiple sets of spill files.
+class HashBitRange {
+ public:
+  HashBitRange(uint8_t begin, uint8_t end)
+      : begin_(begin), end_(end), fieldMask_(bits::lowMask(end - begin)) {}
+
+  int32_t partition(uint64_t hash, int32_t numPartitions) const {
+    int32_t number = (hash >> begin_) & fieldMask_;
+    return number < numPartitions ? number : -1;
+  }
+
+  int32_t numPartitions() const {
+    return 1 << (end_ - begin_);
+  }
+
+ private:
+  // Low bit number of hash number bit range.
+  const uint8_t begin_;
+  // Bit number of first bit above the hash number bit range.
+  const uint8_t end_;
+
+  const uint64_t fieldMask_;
+};
+
+// Manages spilling data from a RowContainer.
+class Spiller {
+ public:
+  using SpillRows = std::vector<char*, memory::StlMappedMemoryAllocator<char*>>;
+  Spiller(
+      RowContainer& container,
+      RowContainer::Eraser eraser,
+      RowTypePtr rowType,
+      HashBitRange bits,
+      int32_t numSortingKeys,
+      const std::string& path,
+      int64_t targetFileSize,
+      memory::MemoryPool& pool,
+      folly::Executor* executor)
+      : container_(container),
+        eraser_(eraser),
+        rowType_(std::move(rowType)),
+        bits_(bits),
+        state_(
+            path,
+            bits.numPartitions(),
+            numSortingKeys,
+            targetFileSize,
+            pool,
+            spillMappedMemory()),
+        pool_(pool),
+        executor_(executor) {}
+
+  // Spills rows from 'this' until there are under 'targetRows' rows
+  // and 'targetBytes' of allocated variable length space in
+  // use. 'iterator' should be at the start of 'container_' on first
+  // call.  spill() starts with one spill partition and initializes
+  // more spill partitions as needed to hit the size target. If there
+  // is no more data to spill in one hash partition, it starts spilling
+  // another hash partition until all hash partitions are spilling. 'bits'
+  // specifies the bit field of the hash number of a row that determines which
+  // hash partition the row belongs to. A spillable hash partition has a
+  // SpillRun struct in 'spillRuns_' A targetRows of 0 causes all data to be
+  // spilled and 'container_' to become empty.
+  void spill(
+      uint64_t targetRows,
+      uint64_t targetBytes,
+      RowContainerIterator& iterator);
+
+  bool isSpilled(int32_t partition) const {
+    return state_.hasFiles(partition);
+  }
+
+  // Finishes spilling and returns the rows that are in partitions that have not
+  // started spilling.
+  SpillRows finishSpill();
+
+  RowContainer& container() const {
+    return container_;
+  }
+
+  // For testing.
+  SpillState& state() {
+    return state_;
+  }
+
+  std::unique_ptr<TreeOfLosers<SpillStream>> startMerge(int32_t partition) {
+    return state_.startMerge(partition, spillStreamOverRows(partition));
+  }
+
+  int64_t spilledBytes() const {
+    return state_.spilledBytes();
+  }
+
+  // Extracts the keys, dependents or accumulators for 'rows' into '*result'.
+  // Creates '*results' in spillPool() if nullptr. Used from Spiller and
+  // RowContainerSpillStream.
+  void extractSpill(folly::Range<char**> rows, RowVectorPtr& result);
+
+  // Extracts up to 'maxRows' or 'maxBytes' from 'rows' into
+  // 'spillVector'. The extract starts at nextBatchIndex and updates
+  // nextBatchIndex to be the index of the first non-extracted element
+  // of 'rows'. Returns the byte size of the extracted rows.
+  int64_t extractSpillVector(
+      SpillRows& rows_,
+      int32_t maxRows,
+      int64_t maxBytes,
+      RowVectorPtr& spillVector,
+      size_t& nextBatchIndex);
+
+  // Returns the MappedMemory to use for intermediate storage for
+  // spilling. This is not directly the RowContainer's memory because
+  // this is usually at limit when starting spilling.
+  static memory::MappedMemory& spillMappedMemory();
+
+  // Global memory pool for spill intermediates. ~1MB per spill executor thread
+  // is the expected peak utilization.
+  static memory::MemoryPool& spillPool();
+
+  // Returns a mergeable stream that goes over unspilled in-memory
+  // rows for the spill partition  'partition'. finishSpill()
+  // first and 'partition' must specify a partition that has started spilling.
+  std::unique_ptr<SpillStream> spillStreamOverRows(int32_t partition);
+
+ private:
+  // Represents a run of rows from a spillable partition of
+  // a RowContainer. Rows that hash to the same partition are accumulated here
+  // and sorted in the case of sorted spilling. The run is then
+  // spilled into storage as multiple batches. The rows are deleted
+  // from this and the RowContainer as they are written. When 'rows'
+  // goes empty this is refilled from the RowContainer for the next
+  // spill run from the same partition.
+  struct SpillRun {
+    explicit SpillRun(memory::MappedMemory& mappedMemory)
+        : rows(0, memory::StlMappedMemoryAllocator<char*>(&mappedMemory)) {}
+    // Spillable rows from the RowContainer.
+    SpillRows rows;
+    // The total byte size of rows referenced from 'rows'.
+    uint64_t numBytes{0};
+    // True if 'rows' are sorted on their key.
+    bool sorted{false};
+
+    void clear() {
+      rows.clear();
+      numBytes = 0;
+      sorted = false;
+    }
+  };
+
+  struct SpillStatus {
+    const int32_t partition;
+    const int32_t rowsWritten;
+    const std::exception_ptr error;
+
+    SpillStatus(
+        int32_t _partition,
+        int32_t _numWritten,
+        std::exception_ptr _error)
+        : partition(_partition), rowsWritten(_numWritten), error(_error) {}
+  };
+
+  // Prepares spill runs for the spillable hash number ranges in
+  // 'spill'. Returns true if at end of 'iterator'. Returns false
+  // before reaching end of iterator if found enough to spill. Adds spillable
+  // runs to 'pendingSpillPartitions_'.
+  bool fillSpillRuns(
+      RowContainerIterator& iterator,
+      uint64_t targetSize,
+      SpillRows* rowsFromNonSpillingPartitions = nullptr);
+
+  // Clears pending spill state.
+  void clearSpillRuns();
+
+  // Clears runs that have not started spilling.
+  void clearNonSpillingRuns();
+
+  // Sorts 'run' if not already sorted.
+  void ensureSorted(SpillRun& run);
+
+  // Function for writing a spill partition on an executor. Writes to
+  // 'partition' until all rows in spillRuns_[partition] are written
+  // or 'maxBytes' is exceeded. Returns the number of rows
+  // written.
+  std::unique_ptr<SpillStatus> writeSpill(int32_t partition, uint64_t maxBytes);
+
+  // Writes out  and erases rows marked for spilling.
+  void advanceSpill(uint64_t maxBytes);
+
+  RowContainer& container_;
+  const RowContainer::Eraser eraser_;
+  RowTypePtr rowType_;
+  const HashBitRange bits_;
+  SpillState state_;
+
+  // One spill run for each partition of spillable data.
+  std::vector<SpillRun> spillRuns_;
+
+  // Indices into 'spillRuns_' that are currently getting spilled.
+  std::unordered_set<int32_t> pendingSpillPartitions_;
+
+  // True if all rows of spilling partitions are in 'spillRuns_', so
+  // that one can start reading these back. This means that the rows
+  // that are not written out and deleted will be captured by
+  // spillStreamOverRows().
+  bool spillFinalized_{false};
+  memory::MemoryPool& pool_;
+  folly::Executor* const executor_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(
   FunctionSignatureBuilderTest.cpp
   SimpleFunctionResolutionTest.cpp
   SpillTest.cpp
+  "SpillerTest.cpp"
   UnnestTest.cpp
   AssignUniqueIdTest.cpp)
 

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Spiller.h"
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include "velox/exec/tests/utils/RowContainerTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class SpillerTest : public exec::test::RowContainerTestBase {
+ protected:
+  void testSpill(int32_t spillPct, bool makeError = false) {
+    constexpr int32_t kNumRows = 100000;
+    std::vector<char*> rows(kNumRows);
+    RowVectorPtr batch;
+    auto data = makeSpillData(kNumRows, rows, batch);
+    std::vector<uint64_t> hashes(kNumRows);
+    auto keys = data->keyTypes();
+    // Calculate a hash for every key in 'rows'.
+    for (auto i = 0; i < keys.size(); ++i) {
+      data->hash(
+          i, folly::Range<char**>(rows.data(), kNumRows), i > 0, hashes.data());
+    }
+
+    // We divide the rows in 4 partitions according to 2 low bits of the hash.
+    std::vector<std::vector<int32_t>> partitions(4);
+    for (auto i = 0; i < kNumRows; ++i) {
+      partitions[hashes[i] & 3].push_back(i);
+    }
+
+    // We sort the rows in each partition in key order.
+    for (auto& partition : partitions) {
+      std::sort(
+          partition.begin(),
+          partition.end(),
+          [&](int32_t leftIndex, int32_t rightIndex) {
+            return data->compareRows(rows[leftIndex], rows[rightIndex]) < 0;
+          });
+    }
+
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    // We spill 'data' in 4 sorted partitions.
+    auto spiller = std::make_unique<Spiller>(
+        *data,
+        [&](folly::Range<char**> rows) { data->eraseRows(rows); },
+        std::static_pointer_cast<const RowType>(batch->type()),
+        HashBitRange(0, 2),
+        keys.size(),
+        makeError ? "/bad/path" : tempDirectory->path,
+        2000000,
+        *pool_,
+        executor());
+
+    // We have a bit range of two bits , so up to 4 spilled partitions.
+    EXPECT_EQ(4, spiller->state().maxPartitions());
+
+    RowContainerIterator iter;
+
+    // We spill spillPct% of the data in 10% increments.
+    auto initialBytes = data->allocatedBytes();
+    auto initialRows = data->numRows();
+    for (int32_t pct = 10; pct <= spillPct; pct += 10) {
+      try {
+        spiller->spill(
+            initialRows - (initialRows * pct / 100),
+            initialBytes - (initialBytes * pct / 100),
+            iter);
+        EXPECT_FALSE(makeError);
+      } catch (const std::exception& e) {
+        if (!makeError) {
+          throw;
+        }
+        return;
+      }
+    }
+    auto unspilledPartitionRows = spiller->finishSpill();
+    if (spillPct == 100) {
+      EXPECT_TRUE(unspilledPartitionRows.empty());
+      EXPECT_EQ(0, data->numRows());
+    }
+    // We read back the spilled and not spilled data in each of the
+    // partitions. We check that the data comes back in key order.
+    for (auto partitionIndex = 0; partitionIndex < 4; ++partitionIndex) {
+      if (!spiller->isSpilled(partitionIndex)) {
+        continue;
+      }
+      // We make a merge reader that merges the spill files and the rows that
+      // are still in the RowContainer.
+      auto merge = spiller->startMerge(partitionIndex);
+
+      // We read the spilled data back and check that it matches the sorted
+      // order of the partition.
+      auto& indices = partitions[partitionIndex];
+      for (auto i = 0; i < indices.size(); ++i) {
+        auto stream = merge->next();
+        if (!stream) {
+          FAIL() << "Stream ends after " << i << " entries";
+          break;
+        }
+        EXPECT_TRUE(batch->equalValueAt(
+            &stream->current(), indices[i], stream->currentIndex()));
+        stream->pop();
+      }
+    }
+  }
+  std::unique_ptr<RowContainer> makeSpillData(
+      int32_t numRows,
+      std::vector<char*>& rows,
+      RowVectorPtr& batch) {
+    batch = makeDataset(
+        ROW({
+            {"bool_val", BOOLEAN()},
+            {"tiny_val", TINYINT()},
+            {"small_val", SMALLINT()},
+            {"int_val", INTEGER()},
+            {"long_val", BIGINT()},
+            {"ordinal", BIGINT()},
+            {"float_val", REAL()},
+            {"double_val", DOUBLE()},
+            {"string_val", VARCHAR()},
+            {"array_val", ARRAY(VARCHAR())},
+            {"struct_val",
+             ROW({{"s_int", INTEGER()}, {"s_array", ARRAY(REAL())}})},
+            {"map_val",
+             MAP(VARCHAR(),
+                 MAP(BIGINT(),
+                     ROW({{"s2_int", INTEGER()}, {"s2_string", VARCHAR()}})))},
+        }),
+        numRows,
+        [](RowVectorPtr /*rows&*/) {});
+    const auto& types = batch->type()->as<TypeKind::ROW>().children();
+    std::vector<TypePtr> keys;
+    keys.insert(keys.begin(), types.begin(), types.begin() + 6);
+
+    std::vector<TypePtr> dependents;
+    dependents.insert(dependents.begin(), types.begin() + 6, types.end());
+    // Set ordinal so that the sorted order is unambiguous
+
+    auto ordinal = batch->childAt(5)->as<FlatVector<int64_t>>();
+    for (auto i = 0; i < numRows; ++i) {
+      ordinal->set(i, i);
+    }
+    // Make non-join build container so that spill runs are sorted. Note
+    // that a distinct or group by hash table can have dependents if
+    // some keys are known to be unique by themselves. Aggregation
+    // spilling will be tested separately.
+    auto data = makeRowContainer(keys, dependents, false);
+    rows.resize(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      rows[i] = data->newRow();
+    }
+
+    SelectivityVector allRows(numRows);
+    for (auto column = 0; column < batch->childrenSize(); ++column) {
+      DecodedVector decoded(*batch->childAt(column), allRows);
+      for (auto index = 0; index < numRows; ++index) {
+        data->store(decoded, index, rows[index], column);
+      }
+    }
+
+    return data;
+  }
+
+  folly::IOThreadPoolExecutor* FOLLY_NONNULL executor() {
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> l(mutex);
+    if (!executor_) {
+      executor_ = std::make_unique<folly::IOThreadPoolExecutor>(8);
+    }
+    return executor_.get();
+  }
+
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+};
+
+TEST_F(SpillerTest, spilFew) {
+  testSpill(10);
+}
+
+TEST_F(SpillerTest, spilMost) {
+  testSpill(60);
+}
+
+TEST_F(SpillerTest, spillAll) {
+  testSpill(100);
+}
+
+TEST_F(SpillerTest, error) {
+  testSpill(100, true);
+}

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <array>
+#include <random>
+#include "velox/common/file/FileSystems.h"
+#include "velox/dwio/dwrf/test/utils/BatchMaker.h"
+#include "velox/exec/ContainerRowSerde.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/VectorHasher.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/tests/VectorMaker.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+
+class RowContainerTestBase : public testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = memory::getDefaultScopedMemoryPool();
+    mappedMemory_ = memory::MappedMemory::getInstance();
+    if (!isRegisteredVectorSerde()) {
+      facebook::velox::serializer::presto::PrestoVectorSerde::
+          registerVectorSerde();
+    }
+    filesystems::registerLocalFileSystem();
+  }
+
+  RowVectorPtr makeDataset(
+      const TypePtr& rowType,
+      const size_t size,
+      std::function<void(RowVectorPtr)> customizeData) {
+    auto batch = std::static_pointer_cast<RowVector>(
+        velox::test::BatchMaker::createBatch(rowType, size, *pool_));
+    if (customizeData) {
+      customizeData(batch);
+    }
+    return batch;
+  }
+
+  std::unique_ptr<RowContainer> makeRowContainer(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<TypePtr>& dependentTypes,
+      bool isJoinBuild = true) {
+    static const std::vector<std::unique_ptr<Aggregate>> kEmptyAggregates;
+    return std::make_unique<RowContainer>(
+        keyTypes,
+        !isJoinBuild,
+        kEmptyAggregates,
+        dependentTypes,
+        isJoinBuild,
+        isJoinBuild,
+        true,
+        true,
+        mappedMemory_,
+        ContainerRowSerde::instance());
+  }
+
+  std::unique_ptr<memory::MemoryPool> pool_;
+  memory::MappedMemory* mappedMemory_;
+};
+} // namespace facebook::velox::exec::test

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -242,7 +242,7 @@ static VectorPtr createEmpty(
 }
 
 // static
-VectorPtr BaseVector::create(
+VectorPtr BaseVector::createInternal(
     const TypePtr& type,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -531,10 +531,13 @@ class BaseVector {
     throw std::runtime_error("Vector is not a wrapper");
   }
 
-  static std::shared_ptr<BaseVector> create(
+  template <typename T = BaseVector>
+  static std::shared_ptr<T> create(
       const TypePtr& type,
       vector_size_t size,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool) {
+    return std::static_pointer_cast<T>(createInternal(type, size, pool));
+  }
 
   static std::shared_ptr<BaseVector> getOrCreateEmpty(
       std::shared_ptr<BaseVector> vector,
@@ -714,6 +717,11 @@ class BaseVector {
   ByteCount inMemoryBytes_ = 0;
 
  private:
+  static std::shared_ptr<BaseVector> createInternal(
+      const TypePtr& type,
+      vector_size_t size,
+      velox::memory::MemoryPool* pool);
+
   bool isCodegenOutput_ = false;
 
   friend class LazyVector;


### PR DESCRIPTION
Add a Spiller class to manage spilling rows from a RowContainer.

The spiller groups rows into a power of two number of partitions based 
on hash of the keys. One or more of these partitions can be spillable. 
More partitions become spillable as memory pressure demands.

Spilling trims the number of rows and the size of variable length data
in the RowContainer. This allows inserting more data in the freed
space but does not release the memory. Spilling with a target size of
0 writes out everything and releases the memory, leaving the
RowContainer in a post-construction state.

Spilling picks rows that fall in the same hash partition and sorts
them by their key columns. The runs are ideally at least a target file
size bytes in size. The runs go into one spill file. The file
internally consists of relatively short vectors, e.g. 1MB or 128 rows,
whichever comes first.

The data in a RowContainer can be read back partition by partition,
merging the rows in the container with spilled rows.

Spilling can write multiple partitions in parallel. This is useful
when needing to rapidly free up space under memory contention. This
also minimizes the stopping wall time for consuming data in a spilling
operator.
