### PR TITLE
Add owner semantic import

### DIFF
--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -114,9 +114,24 @@ TypePtr importFromArrow(const ArrowSchema& arrowSchema);
 ///   auto vector = arrow::importToArrow(arrowSchema, arrowArray, pool);
 ///   ... // ensure buffers in arrowArray remain alive while vector is used.
 ///
-VectorPtr importFromArrow(
+VectorPtr importFromArrowAsViewer(
     const ArrowSchema& arrowSchema,
     const ArrowArray& arrowArray,
+    memory::MemoryPool* pool);
+
+/// Import an ArrowArray and ArrowSchema into a Velox vector, acquiring
+/// ownership over the input data.
+///
+/// Similar to importFromArrowAsViewer but the ownership of arrowSchema and
+/// arrowArray will be taken over. Specifically, the returned Vector will own a
+/// copy of arrowSchema and arrowArray. The inputs arrowSchema and arrowArray
+/// will be marked as released by setting their release callback to nullptr
+/// (https://arrow.apache.org/docs/format/CDataInterface.html). Afterwards, the
+/// returned Vector will be responsible for calling the release callbacks when
+/// destructed.
+VectorPtr importFromArrowAsOwner(
+    ArrowSchema& arrowSchema,
+    ArrowArray& arrowArray,
     memory::MemoryPool* pool);
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Rename the existing importFromArrow to importFromArrowAsViewer and add a new importFromArrowAsOwner that will take over the ownership of the input ArrowArray and ArrowSchema data and call release when the Velox vector is destructed.

This owner semantic is also what pyarrow and Arrow cpp lib provides (e.g. when it imports an ArrowArray it copies over the struct and then marks the input as released: https://github.com/apache/arrow/blob/8e43f23dcc6a9e630516228f110c48b64d13cec6/cpp/src/arrow/c/bridge.cc#L1204 and https://github.com/apache/arrow/blob/8e43f23dcc6a9e630516228f110c48b64d13cec6/cpp/src/arrow/c/helpers.h#L74). The semantic of the export API of those libs is release the ownership, and then the import will naturally take over the released ownership. Providing this owner semantic import clients will be able to glue everything more easily.

How the Arrow buffers are passed to Velox vector is the same as the existing viewer implementation. The reference counting and release calling are implemented using shared_ptr kept in BufferView Releaser.

This diff also adds check for released structures, which are indicated by null release callback, and so should be treated as invalid input.

Differential Revision: D32327305

