### PR TITLE
Guard Parquet reader tests build.

### DIFF
--- a/velox/dwio/parquet/CMakeLists.txt
+++ b/velox/dwio/parquet/CMakeLists.txt
@@ -13,4 +13,7 @@
 # limitations under the License.
 
 add_subdirectory(reader)
-add_subdirectory(tests)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
This patch fixes build when Parquet reader is enabled and tests build is disabled.