### PR TITLE
Do not use MapVector::canonicalize outside of construction

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -660,6 +660,20 @@ inline uint64_t hashMix(const uint64_t upper, const uint64_t lower) noexcept {
   return b;
 }
 
+// Order-independent way to reduce multiple 64 bit hashes into a
+// single hash. Copied from folly/hash/Hash.h because this is not
+// defined in some versions of folly.
+#if defined(FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER("unsigned-integer-overflow")
+#endif
+inline uint64_t commutativeHashMix(
+    const uint64_t upper,
+    const uint64_t lower) noexcept {
+  // Commutative accumulator taken from this paper:
+  // https://www.preprints.org/manuscript/201710.0192/v1/download
+  return 3860031 + (upper + lower) * 2779 + (upper * lower * 2);
+}
+
 inline uint64_t loadPartialWord(const uint8_t* data, int32_t size) {
   // Must be declared volatile, else gcc misses aliasing in optimized mode.
   volatile uint64_t result = 0;

--- a/velox/common/tests/BitUtilTest.cpp
+++ b/velox/common/tests/BitUtilTest.cpp
@@ -625,6 +625,11 @@ TEST_F(BitUtilTest, scatterBits) {
   }
 }
 
+TEST_F(BitUtilTest, hashMix) {
+  EXPECT_NE(bits::hashMix(123, 321), bits::hashMix(321, 123));
+  EXPECT_EQ(
+      bits::commutativeHashMix(123, 321), bits::commutativeHashMix(321, 123));
+}
 } // namespace bits
 } // namespace velox
 } // namespace facebook

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -161,6 +161,10 @@ class Aggregate {
   // @param groups Pointers to the start of the group rows.
   // @param numGroups Number of groups to extract results from.
   // @param result The result vector to store the results in.
+  //
+  // 'result' and its parts are expected to be singly referenced. If
+  // other threads or operators hold references that they would use
+  // after 'result' has been updated by this, effects will b unpredictable.
   virtual void
   extractValues(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 
@@ -168,6 +172,8 @@ class Aggregate {
   // @param groups Pointers to the start of the group rows.
   // @param numGroups Number of groups to extract results from.
   // @param result The result vector to store the results in.
+  //
+  // See comment on 'result' in extractValues().
   virtual void
   extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -325,7 +325,7 @@ bool GroupingSet::getOutput(
   }
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     aggregates_[i]->finalize(groups, numGroups);
-    auto aggregateVector = result->childAt(i + totalKeys);
+    auto& aggregateVector = result->childAt(i + totalKeys);
     if (isPartial) {
       aggregates_[i]->extractAccumulators(groups, numGroups, &aggregateVector);
     } else {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -366,7 +366,9 @@ TEST_F(RowContainerTest, types) {
         false,
         rowHashes.data());
     for (auto i = 0; i < kNumRows; ++i) {
-      EXPECT_EQ(hashes[i], rowHashes[i]);
+      if (column) {
+        EXPECT_EQ(hashes[i], rowHashes[i]);
+      }
       EXPECT_TRUE(source->equalValueAt(extracted.get(), i, i));
       EXPECT_EQ(source->compare(extracted.get(), i, i), 0);
       EXPECT_EQ(source->hashValueAt(i), hashes[i]);

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -122,7 +122,7 @@ class MapFunction : public exec::VectorFunction {
 
     if constexpr (!AllowDuplicateKeys) {
       // Check for duplicate keys
-      mapVector->canonicalize();
+      MapVector::canonicalize(mapVector);
 
       auto offsets = mapVector->rawOffsets();
       auto sizes = mapVector->rawSizes();

--- a/velox/functions/prestosql/MapConcat.cpp
+++ b/velox/functions/prestosql/MapConcat.cpp
@@ -101,7 +101,7 @@ class MapConcatFunction : public exec::VectorFunction {
         combinedKeys,
         combinedValues);
 
-    combinedMap->canonicalize(true);
+    MapVector::canonicalize(combinedMap, true);
 
     combinedKeys = combinedMap->mapKeys();
     combinedValues = combinedMap->mapValues();


### PR DESCRIPTION
Comparing or serializing data to RowContainer must not mutate the
source data. Maps must be compared and serialized in key order but
canonicalize cannot be used for this because this will lead to flaky
crashes if different threads handle one MapVector, which can happen
for example with local exchange.

Use a commutative hash mix for maps since the key order is uncertain.

Covered by exec/tests/RowContainerTest and vector/tests/VectorTest.cpp.