### PR TITLE
Fix batch size adaptation

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -556,6 +556,22 @@ std::unordered_map<std::string, int64_t> HiveDataSource::runtimeStats() {
   return res;
 }
 
+int64_t HiveDataSource::estimatedRowSize() {
+  if (!rowReader_ || errorInRowSize_) {
+    return kUnknownRowSize;
+  }
+  try {
+    return rowReader_->estimatedRowSize();
+  } catch (const std::exception& e) {
+    // Remember the error and do not try the other splits, they are
+    // likely to be broken the same way.
+    errorInRowSize_ = true;
+    LOG_EVERY_N(WARNING, 1000)
+        << "failed to get row size estimate for " << split_->toString();
+    return kUnknownRowSize;
+  }
+}
+
 HiveConnector::HiveConnector(
     const std::string& id,
     std::shared_ptr<const Config> properties,

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -158,12 +158,7 @@ class HiveDataSource : public DataSource {
 
   std::unordered_map<std::string, int64_t> runtimeStats() override;
 
-  int64_t estimatedRowSize() override {
-    if (!rowReader_) {
-      return kUnknownRowSize;
-    }
-    return rowReader_->estimatedRowSize();
-  }
+  int64_t estimatedRowSize() override;
 
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
@@ -219,6 +214,7 @@ class HiveDataSource : public DataSource {
   memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
   const std::string& scanId_;
   folly::Executor* FOLLY_NULLABLE executor_;
+  bool errorInRowSize_{false};
 };
 
 class HiveConnector final : public Connector {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -122,6 +122,7 @@ void TableScan::setBatchSize() {
   }
   if (estimate < 1024) {
     readBatchSize_ = 10000; // No more than 10MB of data per batch.
+    return;
   }
   readBatchSize_ = std::min<int64_t>(100, 10 * kMB / estimate);
 }


### PR DESCRIPTION
The DWIO reader throws if statistics are incomplete. Catch this and do
not ask again withinn the same scan.  Apparently Presto does not fill
in the statistics while the DWIO writer used in unit tests does.

Also fix missing return in  TableScan::setBatchSize().