### PR TITLE
FIX: Reusing vectors requires reset nulls.

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -368,6 +368,13 @@ class ExprSet {
       const SelectivityVector& rows,
       EvalCtx* ctx,
       std::vector<VectorPtr>* result) {
+    if (result) {
+      for (auto& vector : *result) {
+        if (vector) {
+          vector->clear();
+        }
+      }
+    }
     eval(0, exprs_.size(), true, rows, ctx, result);
   }
 

--- a/velox/functions/lib/StringEncodingUtils.cpp
+++ b/velox/functions/lib/StringEncodingUtils.cpp
@@ -19,12 +19,15 @@
 
 namespace facebook::velox::functions {
 
+VectorPtr emptyVectorPtr;
 bool prepareFlatResultsVector(
     VectorPtr* result,
     const SelectivityVector& rows,
     exec::EvalCtx* context,
-    VectorPtr& argToReuse) {
-  if (!*result && BaseVector::isReusableFlatVector(argToReuse)) {
+    VectorPtr& argToReuse = emptyVectorPtr) {
+  // TODO: Re-enable after a better holistic clear reuse approach is added.
+  if (false && !*result && argToReuse &&
+      BaseVector::isReusableFlatVector(argToReuse)) {
     // Move input vector to result
     VELOX_CHECK(
         VectorEncoding::isFlat(argToReuse.get()->encoding()) &&
@@ -39,5 +42,4 @@ bool prepareFlatResultsVector(
   VELOX_CHECK(VectorEncoding::isFlat((*result).get()->encoding()));
   return false;
 }
-
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/StringEncodingUtils.h
+++ b/velox/functions/lib/StringEncodingUtils.h
@@ -23,7 +23,7 @@ namespace facebook::velox::functions {
 
 /// Helper function that prepares a string result vector and initializes it.
 /// It will use the input argToReuse vector instead of creating new one when
-/// possible. Returns true if argToReuse vector was moved to results
+/// possible. Returns true if argToReuse vector was moved to results.
 bool prepareFlatResultsVector(
     VectorPtr* result,
     const SelectivityVector& rows,

--- a/velox/functions/lib/tests/IsNotNullTest.cpp
+++ b/velox/functions/lib/tests/IsNotNullTest.cpp
@@ -16,6 +16,8 @@
 #include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::functions {
 void registerIsNotNull() {
@@ -89,32 +91,12 @@ TEST_F(IsNotNullTest, somePositions) {
       size,
       [](vector_size_t row) { return row; },
       vectorMaker_.nullEvery(2, 1));
-  auto result = BaseVector::create(BOOLEAN(), size, execCtx_.pool());
-  auto flatResult = std::dynamic_pointer_cast<FlatVector<bool>>(result);
-  for (int i = 0; i < size; i++) {
-    flatResult->set(i, true);
-  }
 
-  // select odd rows 1, 3, 5,...
-  SelectivityVector oddRows(size);
-  for (int i = 0; i < size; i++) {
-    oddRows.setValid(i, i % 2 == 1);
-  }
+  auto isOdd = [](int i) { return i % 2; };
 
-  flatResult = evaluate<FlatVector<bool>>(
-      "isnotnull(c0)", makeRowVector({oddNulls}), oddRows, result);
-  for (int i = 0; i < size; i += 2) {
-    EXPECT_EQ(flatResult->valueAt(i), i % 2 == 0) << "at " << i;
-  }
-
-  // select even rows 0, 2, 4...
-  SelectivityVector evenRows(size);
+  auto result =
+      evaluate<SimpleVector<bool>>("isnotnull(c0)", makeRowVector({oddNulls}));
   for (int i = 0; i < size; i++) {
-    evenRows.setValid(i, i % 2 == 0);
-  }
-  flatResult = evaluate<FlatVector<bool>>(
-      "isnotnull(c0)", makeRowVector({oddNulls}), evenRows, result);
-  for (int i = 0; i < size; ++i) {
-    EXPECT_TRUE(flatResult->valueAt(i)) << "at " << i;
+    EXPECT_EQ(result->valueAt(i), !isOdd(i)) << "at " << i;
   }
 }

--- a/velox/functions/lib/tests/IsNullTest.cpp
+++ b/velox/functions/lib/tests/IsNullTest.cpp
@@ -60,32 +60,12 @@ TEST_F(IsNullTest, somePositions) {
       size,
       [](vector_size_t row) { return row; },
       vectorMaker_.nullEvery(2, 1));
-  auto result = BaseVector::create(BOOLEAN(), size, execCtx_.pool());
-  auto flatResult = std::dynamic_pointer_cast<FlatVector<bool>>(result);
-  for (int i = 0; i < size; i++) {
-    flatResult->set(i, true);
-  }
 
-  // select odd rows 1, 3, 5,...
-  SelectivityVector oddRows(size);
-  for (int i = 0; i < size; i++) {
-    oddRows.setValid(i, i % 2 == 1);
-  }
+  auto isOdd = [](int i) { return i % 2; };
 
-  flatResult = evaluate<FlatVector<bool>>(
-      "is_null(c0)", makeRowVector({oddNulls}), oddRows, result);
-  for (int i = 0; i < size; ++i) {
-    EXPECT_TRUE(flatResult->valueAt(i)) << "at " << i;
-  }
-
-  // select even rows 0, 2, 4...
-  SelectivityVector evenRows(size);
+  auto result =
+      evaluate<SimpleVector<bool>>("is_null(c0)", makeRowVector({oddNulls}));
   for (int i = 0; i < size; i++) {
-    evenRows.setValid(i, i % 2 == 0);
-  }
-  flatResult = evaluate<FlatVector<bool>>(
-      "is_null(c0)", makeRowVector({oddNulls}), evenRows, result);
-  for (int i = 0; i < size; ++i) {
-    EXPECT_EQ(flatResult->valueAt(i), i % 2 == 1) << "at " << i;
+    EXPECT_EQ(result->valueAt(i), isOdd(i)) << "at " << i;
   }
 }

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -39,30 +39,6 @@ bool hasSingleReferencedBuffers(const FlatVector<StringView>* vec) {
 };
 } // namespace
 
-/// Helper function that prepares a string result vector and initializes it.
-/// It will use the input argToReuse vector instead of creating new one when
-/// possible. Returns true if argToReuse vector was moved to results
-VectorPtr emptyVectorPtr;
-bool prepareFlatResultsVector(
-    VectorPtr* result,
-    const SelectivityVector& rows,
-    exec::EvalCtx* context,
-    VectorPtr& argToReuse = emptyVectorPtr) {
-  if (!*result && argToReuse && argToReuse.unique()) {
-    // Move input vector to result
-    VELOX_CHECK(
-        argToReuse.get()->encoding() == VectorEncoding::Simple::FLAT &&
-        argToReuse.get()->typeKind() == TypeKind::VARCHAR);
-    *result = std::move(argToReuse);
-    return true;
-  }
-  // This will allocate results if not allocated
-  BaseVector::ensureWritable(rows, VARCHAR(), context->pool(), result);
-
-  VELOX_CHECK_EQ((*result).get()->encoding(), VectorEncoding::Simple::FLAT);
-  return false;
-}
-
 namespace {
 /**
  * Upper and Lower functions have a fast path for ascii where the functions

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -33,17 +33,23 @@ FOLLY_ALWAYS_INLINE bool call(
   if (array.mayHaveNulls()) {
     auto nullFound = false;
     for (const auto& item : array) {
-      if (item && (*item == key)) {
-        out = true;
-        return true;
+      if (item.has_value()) {
+        if (*item == key) {
+          out = true;
+          return true;
+        }
+        continue;
       }
-      nullFound |= !item.has_value();
+      nullFound = true;
     }
+
     if (!nullFound) {
       out = false;
+      return true;
     }
-    return !nullFound;
+    return false;
   }
+
   // Not nulls path
   for (const auto& item : array) {
     if (*item == key) {

--- a/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "folly/Random.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/SimpleFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+
+class CompareBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  CompareBenchmark() : FunctionBenchmarkBase() {
+    functions::registerFunctions();
+  }
+
+  VectorPtr makeData() {
+    constexpr vector_size_t size = 1000;
+
+    return vectorMaker_.flatVector<int64_t>(
+        size,
+        [](auto row) { return row % 2 ? row : folly::Random::rand32() % size; },
+        VectorMaker::nullEvery(5));
+  }
+
+  void run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto inputs = vectorMaker_.rowVector({makeData(), makeData()});
+
+    auto exprSet = compileExpression(
+        fmt::format("c0 {} c1", functionName), inputs->type());
+    suspender.dismiss();
+
+    doRun(exprSet, inputs);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(Eq_Velox) {
+  CompareBenchmark benchmark;
+  benchmark.run("==");
+}
+
+BENCHMARK(Neq_Velox) {
+  CompareBenchmark benchmark;
+  benchmark.run("=");
+}
+
+BENCHMARK(Gt_Velox) {
+  CompareBenchmark benchmark;
+  benchmark.run(">");
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Many functions are implemented with the assumption that
not-null do not need to be set, since null are initialized
 with all not null.

In HashJoin, a single vector is re-used for the filter results.
This diff reset nulls of the vector before evaluation.

Same thing is changed for vector re-use in string functions.

prepareFlatResultsVector was defined twice, one
definition is kept.

We should look at other places where vector reuse
happens and make sure it's safe if any.

Differential Revision: D32677187

