### PR TITLE
maxDrivers() for custom translator

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -146,6 +146,7 @@ void plan(
 
 uint32_t maxDrivers(
     const std::vector<std::shared_ptr<const core::PlanNode>>& planNodes) {
+  uint32_t count = std::numeric_limits<uint32_t>::max();
   for (auto& node : planNodes) {
     if (auto aggregation =
             std::dynamic_pointer_cast<const core::AggregationNode>(node)) {
@@ -154,54 +155,65 @@ uint32_t maxDrivers(
         // final aggregations must run single-threaded
         return 1;
       }
-    }
-    if (auto topN = std::dynamic_pointer_cast<const core::TopNNode>(node)) {
+    } else if (
+        auto topN = std::dynamic_pointer_cast<const core::TopNNode>(node)) {
       if (!topN->isPartial()) {
         // final topN must run single-threaded
         return 1;
       }
-    }
-    if (auto values = std::dynamic_pointer_cast<const core::ValuesNode>(node)) {
+    } else if (
+        auto values = std::dynamic_pointer_cast<const core::ValuesNode>(node)) {
       // values node must run single-threaded, unless in test context
       if (!values->isParallelizable()) {
         return 1;
       }
-    }
-    if (auto limit = std::dynamic_pointer_cast<const core::LimitNode>(node)) {
+    } else if (
+        auto limit = std::dynamic_pointer_cast<const core::LimitNode>(node)) {
       // final limit must run single-threaded
       if (!limit->isPartial()) {
         return 1;
       }
-    }
-    if (auto orderBy =
+    } else if (
+        auto orderBy =
             std::dynamic_pointer_cast<const core::OrderByNode>(node)) {
       // final orderby must run single-threaded
       if (!orderBy->isPartial()) {
         return 1;
       }
-    }
-    if (auto localMerge =
+    } else if (
+        auto localMerge =
             std::dynamic_pointer_cast<const core::LocalMergeNode>(node)) {
       // Local merge must run single-threaded.
       return 1;
-    }
-
-    if (auto mergeExchange =
+    } else if (
+        auto mergeExchange =
             std::dynamic_pointer_cast<const core::MergeExchangeNode>(node)) {
       // MergeExchange must run single-threaded.
       return 1;
-    }
-
-    if (auto tableWrite =
+    } else if (
+        auto tableWrite =
             std::dynamic_pointer_cast<const core::TableWriteNode>(node)) {
       if (!tableWrite->insertTableHandle()
                ->connectorInsertTableHandle()
                ->supportsMultiThreading()) {
         return 1;
       }
+    } else {
+      auto result = Operator::maxDrivers(node);
+      if (result) {
+        VELOX_CHECK_GT(
+            *result,
+            0,
+            "maxDrivers must be greater than 0. Plan node: {}",
+            node->toString())
+        if (*result == 1) {
+          return 1;
+        }
+        count = std::min(*result, count);
+      }
     }
   }
-  return std::numeric_limits<uint32_t>::max();
+  return count;
 }
 } // namespace detail
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -191,12 +191,26 @@ class OperatorCtx {
 // Query operator
 class Operator {
  public:
-  // Function for mapping a user-registered PlanNode into the corresponding
+  // Factory class for mapping a user-registered PlanNode into the corresponding
   // Operator.
-  using PlanNodeTranslator = std::function<std::unique_ptr<Operator>(
-      DriverCtx* ctx,
-      int32_t id,
-      const std::shared_ptr<const core::PlanNode>& node)>;
+  class PlanNodeTranslator {
+   public:
+    virtual ~PlanNodeTranslator() = default;
+
+    // Translates plan node to operator. Returns nullptr if the plan node cannot
+    // be handled by this factory.
+    virtual std::unique_ptr<Operator> translate(
+        DriverCtx* ctx,
+        int32_t id,
+        const std::shared_ptr<const core::PlanNode>& node) = 0;
+
+    // Returns max driver count for the plan node. Returns std::nullopt if the
+    // plan node cannot be handled by this factory.
+    virtual std::optional<uint32_t> maxDrivers(
+        const std::shared_ptr<const core::PlanNode>& /* node */) {
+      return std::nullopt;
+    }
+  };
 
   // 'operatorId' is the initial index of the 'this' in the Driver's
   // list of Operators. This is used as in index into OperatorStats
@@ -322,7 +336,7 @@ class Operator {
 
   // Registers 'translator' for mapping user defined PlanNode subclass instances
   // to user-defined Operators.
-  static void registerOperator(PlanNodeTranslator translator) {
+  static void registerOperator(std::unique_ptr<PlanNodeTranslator> translator) {
     translators().emplace_back(std::move(translator));
   }
 
@@ -334,8 +348,13 @@ class Operator {
       int32_t id,
       const std::shared_ptr<const core::PlanNode>& planNode);
 
+  // Calls `maxDrivers` on all the registered PlanNodeTranslators and returns
+  // the first one that is not std::nullopt or std::nullopt otherwise.
+  static std::optional<uint32_t> maxDrivers(
+      const std::shared_ptr<const core::PlanNode>& planNode);
+
  protected:
-  static std::vector<PlanNodeTranslator>& translators();
+  static std::vector<std::unique_ptr<PlanNodeTranslator>>& translators();
 
   // Clears the columns of 'output_' that are projected from
   // 'input_'. This should be done when preparing to produce a next


### PR DESCRIPTION
Summary: PlanNodeTranslator supports translating custom plan node to operator. However, to match exactly the builtin ones, we also need the capability of telling maxDrivers of such custom operators. Turn PlanNodeTranslator from function to a factory.

Differential Revision: D32656508

