### PR TITLE
Refactor VectorHasher for clarity

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -150,6 +150,12 @@ AbstractJoinNode::AbstractJoinNode(
         "Build side join key not found in build side output: {}",
         key->name());
   }
+  for (auto i = 0; i < leftKeys_.size(); ++i) {
+    VELOX_CHECK_EQ(
+        leftKeys_[i]->type()->kind(),
+        rightKeys_[i]->type()->kind(),
+        "Join key types on the probe and build sides must match");
+  }
   for (auto i = 0; i < outputType_->size(); ++i) {
     auto name = outputType_->nameOf(i);
     if (leftType->containsChild(name)) {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -132,11 +132,11 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
     for (int32_t i = 0; i < hashers.size(); ++i) {
       auto key = input->loadedChildAt(hashers[i]->channel());
       if (mode != BaseHashTable::HashMode::kHash) {
-        if (!hashers[i]->computeValueIds(*key, activeRows_, &lookup_->hashes)) {
+        if (!hashers[i]->computeValueIds(*key, activeRows_, lookup_->hashes)) {
           rehash = true;
         }
       } else {
-        hashers[i]->hash(*key, activeRows_, i > 0, &lookup_->hashes);
+        hashers[i]->hash(*key, activeRows_, i > 0, lookup_->hashes);
       }
     }
     lookup_->rows.clear();
@@ -149,11 +149,11 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
     for (int32_t i = 0; i < hashers.size(); ++i) {
       auto key = input->loadedChildAt(hashers[i]->channel());
       if (mode != BaseHashTable::HashMode::kHash) {
-        if (!hashers[i]->computeValueIds(*key, activeRows_, &lookup_->hashes)) {
+        if (!hashers[i]->computeValueIds(*key, activeRows_, lookup_->hashes)) {
           rehash = true;
         }
       } else {
-        hashers[i]->hash(*key, activeRows_, i > 0, &lookup_->hashes);
+        hashers[i]->hash(*key, activeRows_, i > 0, lookup_->hashes);
       }
     }
     std::iota(lookup_->rows.begin(), lookup_->rows.end(), 0);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -147,7 +147,7 @@ void HashBuild::addInput(RowVectorPtr input) {
     // TODO: Load only for active rows, except if right/full outer join.
     if (analyzeKeys_) {
       hasher->computeValueIds(
-          *input->loadedChildAt(hasher->channel()), activeRows_, &hashes_);
+          *input->loadedChildAt(hasher->channel()), activeRows_, hashes_);
       analyzeKeys_ = hasher->mayUseValueIds();
     } else {
       hasher->decode(*input->loadedChildAt(hasher->channel()), activeRows_);

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -39,7 +39,7 @@ void HashPartitionFunction::partition(
 
   hashes_.resize(size);
   for (auto i = 0; i < keyChannels_.size(); ++i) {
-    hashers_[i]->hash(*input.childAt(keyChannels_[i]), rows_, i > 0, &hashes_);
+    hashers_[i]->hash(*input.childAt(keyChannels_[i]), rows_, i > 0, hashes_);
   }
 
   partitions.resize(size);

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -262,15 +262,14 @@ void HashProbe::addInput(RowVectorPtr input) {
         dynamicFilterBuilder->addInput(activeRows_.countSelected());
       }
 
-      valueIdDecoder_.decode(*key, activeRows_);
       buildHashers[i]->lookupValueIds(
-          valueIdDecoder_, activeRows_, deduppedHashes_, &lookup_->hashes);
+          *key, activeRows_, scratchMemory_, lookup_->hashes);
 
       if (dynamicFilterBuilder) {
         dynamicFilterBuilder->addOutput(activeRows_.countSelected());
       }
     } else {
-      hashers_[i]->hash(*key, activeRows_, i > 0, &lookup_->hashes);
+      hashers_[i]->hash(*key, activeRows_, i > 0, lookup_->hashes);
     }
   }
   lookup_->rows.clear();

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -140,11 +140,7 @@ class HashProbe : public Operator {
   // same pipeline.
   std::shared_ptr<BaseHashTable> table_;
 
-  // Decodes probe keys when 'table_' is in normalized key  or array hash mode.
-  DecodedVector valueIdDecoder_;
-
-  // Temporary for de-duplicating value ids for dictionary inputs.
-  raw_vector<uint64_t> deduppedHashes_;
+  VectorHasher::ScratchMemory scratchMemory_;
 
   // Rows to apply 'filter_' to.
   SelectivityVector filterRows_;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -368,7 +368,8 @@ class HashTable : public BaseHashTable {
   // Computes hash numbers of the appropriate hash mode for 'groups',
   // stores these in 'hashes' and inserts the groups using
   // insertForJoin or insertForGroupBy.
-  bool insertBatch(char** groups, uint64_t* hashes, int32_t numGroups);
+  bool
+  insertBatch(char** groups, int32_t numGroups, raw_vector<uint64_t>& hashes);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
   // contents in a RowContainer owned by 'this'. 'hashes' are te hash

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -21,6 +21,34 @@
 
 namespace facebook::velox::exec {
 
+#define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)             \
+  [&]() {                                                                \
+    switch (typeKind) {                                                  \
+      case TypeKind::BOOLEAN: {                                          \
+        return TEMPLATE_FUNC<TypeKind::BOOLEAN>(__VA_ARGS__);            \
+      }                                                                  \
+      case TypeKind::TINYINT: {                                          \
+        return TEMPLATE_FUNC<TypeKind::TINYINT>(__VA_ARGS__);            \
+      }                                                                  \
+      case TypeKind::SMALLINT: {                                         \
+        return TEMPLATE_FUNC<TypeKind::SMALLINT>(__VA_ARGS__);           \
+      }                                                                  \
+      case TypeKind::INTEGER: {                                          \
+        return TEMPLATE_FUNC<TypeKind::INTEGER>(__VA_ARGS__);            \
+      }                                                                  \
+      case TypeKind::BIGINT: {                                           \
+        return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);             \
+      }                                                                  \
+      case TypeKind::VARCHAR:                                            \
+      case TypeKind::VARBINARY: {                                        \
+        return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);            \
+      }                                                                  \
+      default:                                                           \
+        VELOX_UNREACHABLE(                                               \
+            "Unsupported value ID type: ", mapTypeKindToName(typeKind)); \
+    }                                                                    \
+  }()
+
 using V32 = simd::Vectors<int32_t>;
 using V64 = simd::Vectors<int64_t>;
 
@@ -86,15 +114,15 @@ bool VectorHasher::makeValueIds(
   using T = typename TypeTraits<Kind>::NativeType;
 
   if (decoded_.isConstantMapping()) {
-    uint64_t hash = decoded_.isNullAt(rows.begin())
+    uint64_t id = decoded_.isNullAt(rows.begin())
         ? 0
         : valueId(decoded_.valueAt<T>(rows.begin()));
-    if (hash == kUnmappable) {
+    if (id == kUnmappable) {
       analyzeValue(decoded_.valueAt<T>(rows.begin()));
       return false;
     }
     rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
-      result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+      result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
     });
     return true;
   }
@@ -121,8 +149,8 @@ bool VectorHasher::makeValueIdsFlatNoNulls<bool>(
   const auto* values = decoded_.data<uint64_t>();
   rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
     bool value = bits::isBitSet(values, row);
-    uint64_t hash = valueId(value);
-    result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+    uint64_t id = valueId(value);
+    result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
   });
   return true;
 }
@@ -141,8 +169,8 @@ bool VectorHasher::makeValueIdsFlatWithNulls<bool>(
       return;
     }
     bool value = bits::isBitSet(values, row);
-    uint64_t hash = valueId(value);
-    result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+    uint64_t id = valueId(value);
+    result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
   });
   return true;
 }
@@ -165,13 +193,13 @@ bool VectorHasher::makeValueIdsFlatNoNulls(
       analyzeValue(value);
       return;
     }
-    uint64_t hash = valueId(value);
-    if (hash == kUnmappable) {
+    uint64_t id = valueId(value);
+    if (id == kUnmappable) {
       success = false;
       analyzeValue(value);
       return;
     }
-    result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+    result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
   });
 
   return success;
@@ -199,13 +227,13 @@ bool VectorHasher::makeValueIdsFlatWithNulls(
       analyzeValue(value);
       return;
     }
-    uint64_t hash = valueId(value);
-    if (hash == kUnmappable) {
+    uint64_t id = valueId(value);
+    if (id == kUnmappable) {
       success = false;
       analyzeValue(value);
       return;
     }
-    result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+    result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
   });
   return success;
 }
@@ -256,15 +284,32 @@ bool VectorHasher::makeValueIdsDecoded(
 
 bool VectorHasher::computeValueIds(
     const BaseVector& values,
-    SelectivityVector& rows,
-    raw_vector<uint64_t>* result) {
+    const SelectivityVector& rows,
+    raw_vector<uint64_t>& result) {
   decoded_.decode(values, rows);
+  return VALUE_ID_TYPE_DISPATCH(makeValueIds, typeKind_, rows, result.data());
+}
+
+bool VectorHasher::computeValueIdsForRows(
+    char** groups,
+    int32_t numGroups,
+    int32_t offset,
+    int32_t nullByte,
+    uint8_t nullMask,
+    raw_vector<uint64_t>& result) {
   return VALUE_ID_TYPE_DISPATCH(
-      makeValueIds, values.typeKind(), rows, result->data());
+      makeValueIdsForRows,
+      typeKind_,
+      groups,
+      numGroups,
+      offset,
+      nullByte,
+      nullMask,
+      result.data());
 }
 
 template <>
-bool VectorHasher::computeValueIdForRows<StringView>(
+bool VectorHasher::makeValueIdsForRows<TypeKind::VARCHAR>(
     char** groups,
     int32_t numGroups,
     int32_t offset,
@@ -293,20 +338,26 @@ template <TypeKind Kind>
 void VectorHasher::lookupValueIdsTyped(
     const DecodedVector& decoded,
     SelectivityVector& rows,
-    raw_vector<uint64_t>& cachedHashes,
+    raw_vector<uint64_t>& hashes,
     uint64_t* result) const {
   using T = typename TypeTraits<Kind>::NativeType;
   if (decoded.isConstantMapping()) {
-    uint64_t hash = decoded.isNullAt(rows.begin())
-        ? 0
-        : lookupValueId(decoded.valueAt<T>(rows.begin()));
-    if (hash == kUnmappable) {
-      rows.clearAll();
+    if (decoded.isNullAt(rows.begin())) {
+      if (multiplier_ == 1) {
+        rows.applyToSelected([&](vector_size_t row)
+                                 INLINE_LAMBDA { result[row] = 0; });
+      }
       return;
     }
-    rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
-      result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
-    });
+
+    uint64_t id = lookupValueId(decoded.valueAt<T>(rows.begin()));
+    if (id == kUnmappable) {
+      rows.clearAll();
+    } else {
+      rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
+        result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
+      });
+    }
   } else if (decoded.isIdentityMapping()) {
     rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
       if (decoded.isNullAt(row)) {
@@ -316,17 +367,17 @@ void VectorHasher::lookupValueIdsTyped(
         return;
       }
       T value = decoded.valueAt<T>(row);
-      uint64_t hash = lookupValueId(value);
-      if (hash == kUnmappable) {
+      uint64_t id = lookupValueId(value);
+      if (id == kUnmappable) {
         rows.setValid(row, false);
         return;
       }
-      result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+      result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
     });
     rows.updateBounds();
   } else {
-    cachedHashes.resize(decoded.base()->size());
-    std::fill(cachedHashes.begin(), cachedHashes.end(), 0);
+    hashes.resize(decoded.base()->size());
+    std::fill(hashes.begin(), hashes.end(), 0);
     rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
       if (decoded.isNullAt(row)) {
         if (multiplier_ == 1) {
@@ -335,7 +386,7 @@ void VectorHasher::lookupValueIdsTyped(
         return;
       }
       auto baseIndex = decoded.index(row);
-      uint64_t id = cachedHashes[baseIndex];
+      uint64_t id = hashes[baseIndex];
       if (id == 0) {
         T value = decoded.valueAt<T>(row);
         id = lookupValueId(value);
@@ -343,7 +394,7 @@ void VectorHasher::lookupValueIdsTyped(
           rows.setValid(row, false);
           return;
         }
-        cachedHashes[baseIndex] = id;
+        hashes[baseIndex] = id;
       }
       result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
     });
@@ -352,27 +403,38 @@ void VectorHasher::lookupValueIdsTyped(
 }
 
 void VectorHasher::lookupValueIds(
-    const DecodedVector& decoded,
+    const BaseVector& values,
     SelectivityVector& rows,
-    raw_vector<uint64_t>& cachedHashes,
-    raw_vector<uint64_t>* result) const {
+    ScratchMemory& scratchMemory,
+    raw_vector<uint64_t>& result) const {
+  scratchMemory.decoded.decode(values, rows);
   VALUE_ID_TYPE_DISPATCH(
       lookupValueIdsTyped,
-      decoded.base()->typeKind(),
-      decoded,
+      typeKind_,
+      scratchMemory.decoded,
       rows,
-      cachedHashes,
-      result->data());
+      scratchMemory.hashes,
+      result.data());
 }
 
 void VectorHasher::hash(
     const BaseVector& values,
     const SelectivityVector& rows,
     bool mix,
-    raw_vector<uint64_t>* result) {
+    raw_vector<uint64_t>& result) {
   decoded_.decode(values, rows);
   return VELOX_DYNAMIC_TYPE_DISPATCH(
-      hashValues, values.typeKind(), rows, mix, result->data());
+      hashValues, typeKind_, rows, mix, result.data());
+}
+
+void VectorHasher::analyze(
+    char** groups,
+    int32_t numGroups,
+    int32_t offset,
+    int32_t nullByte,
+    uint8_t nullMask) {
+  return VALUE_ID_TYPE_DISPATCH(
+      analyzeTyped, typeKind_, groups, numGroups, offset, nullByte, nullMask);
 }
 
 template <>

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -71,12 +71,12 @@ void benchmarkComputeValueIds(bool withNulls) {
 
   raw_vector<uint64_t> hashes(size);
   SelectivityVector rows(size);
-  hasher.computeValueIds(*values, rows, &hashes);
+  hasher.computeValueIds(*values, rows, hashes);
   hasher.enableValueRange(1, 0);
   suspender.dismiss();
 
   for (int i = 0; i < 10'000; i++) {
-    bool ok = hasher.computeValueIds(*values, rows, &hashes);
+    bool ok = hasher.computeValueIds(*values, rows, hashes);
     folly::doNotOptimizeAway(ok);
   }
 }
@@ -149,7 +149,7 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
   for (int i = 0; i < 4; i++) {
     auto hasher = hashers[i].get();
     raw_vector<uint64_t> result(size);
-    auto ok = hasher->computeValueIds(*vectors[i], allRows, &result);
+    auto ok = hasher->computeValueIds(*vectors[i], allRows, result);
     folly::doNotOptimizeAway(ok);
 
     multiplier = hasher->enableValueIds(multiplier, 0);
@@ -161,7 +161,7 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
     for (int j = 0; j < 4; j++) {
       auto hasher = hashers[j].get();
       auto vector = vectors[j];
-      bool ok = hasher->computeValueIds(*vector, allRows, &result);
+      bool ok = hasher->computeValueIds(*vector, allRows, result);
       folly::doNotOptimizeAway(ok);
     }
   }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -689,7 +689,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     auto op = PlanBuilder(10)
                   .tableScan(probeType)
-                  .project({"c0 + 1", "c1"})
+                  .project({"cast(c0 + 1 as integer)", "c1"})
                   .hashJoin({0}, {0}, buildSide, "", {1})
                   .project({"p1 + 1"})
                   .planNode();

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -357,7 +357,7 @@ TEST_F(RowContainerTest, types) {
     auto source = batch->childAt(column);
     auto columnType = batch->type()->as<TypeKind::ROW>().childAt(column);
     VectorHasher hasher(columnType, column);
-    hasher.hash(*source, allRows, false, &hashes);
+    hasher.hash(*source, allRows, false, hashes);
     DecodedVector decoded(*extracted, allRows);
     std::vector<uint64_t> rowHashes(kNumRows);
     data->hash(


### PR DESCRIPTION
- Change hash, computeValueIds and lookupValueIds methods to take 'result' by reference.
- Change lookupValueIds method to take BaseVector instead of DecodedVector.
- Replace 'cachedHashes' parameter in lookupValueIds with an opaque 'scratchMemory' that must be provided by the caller to allow this method to be called concurrently from multiple threads.
- Replace template computeValueIdForRows<T> method with non-template method to match computeValueIds.
- Replace valueIdDecoder_ and deduppedHashes_ member variables in HashProbe.h with an instance of VectorHasher::ScratchMemory for better encapsulation.
- Replace template analyze<T> method with non-template method.
- Move VALUE_ID_TYPE_DISPATCH macro from VectorHasher.h to VectorHasher.cpp.