### PR TITLE
Specialize VectorHasher::makeValueIdsDecoded for bool type

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -607,6 +607,16 @@ bool VectorHasher::makeValueIdsFlatWithNulls<bool>(
     const SelectivityVector& rows,
     uint64_t* result);
 
+template <>
+bool VectorHasher::makeValueIdsDecoded<bool, true>(
+    const SelectivityVector& rows,
+    uint64_t* result);
+
+template <>
+bool VectorHasher::makeValueIdsDecoded<bool, false>(
+    const SelectivityVector& rows,
+    uint64_t* result);
+
 } // namespace facebook::velox::exec
 
 #include "velox/exec/VectorHasher-inl.h"


### PR DESCRIPTION
Summary:
Fix crash in TPC-H query 21:

velox/exec/VectorHasher.cpp:236:17: runtime error: load of value 255, which is not a valid value for type 'const bool'

Differential Revision: D32747705

