### PR TITLE
FIX: evaluate in FunctionBaseTest should reassign results

### DIFF
--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -412,8 +412,10 @@ class FunctionBaseTest : public testing::Test {
         {makeTypedExpr(expression, rowType)}, &execCtx_);
 
     facebook::velox::exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
-    std::vector<VectorPtr> results{result};
+    std::vector<VectorPtr> results{std::move(result)};
     exprSet.eval(rows, &evalCtx, &results);
+    result = results[0];
+
     return std::dynamic_pointer_cast<T>(results[0]);
   }
 


### PR DESCRIPTION
Summary:
The core evaluation can overwrite the result's vector pointers
in such case the top level eval call wont get the evaluation results.
this diff fix that.

Differential Revision: D32772419

