### PR TITLE
Throw on ambiguous function definitions

### DIFF
--- a/velox/common/serialization/Registry.h
+++ b/velox/common/serialization/Registry.h
@@ -56,6 +56,14 @@ class Registry {
       Creator creator,
       std::optional<std::string_view> helpMsg = std::nullopt) {
     std::lock_guard<std::mutex> lock(registerutex_);
+
+    if (Has(key)) {
+      VELOX_UNSUPPORTED(
+          "Reregestering key {}, original key {}",
+          key,
+          this->creatorMap_.find(key)->first);
+    }
+
     creatorMap_[key] = std::move(creator);
     if (helpMsg) {
       helpMessage_[key] = *helpMsg;

--- a/velox/common/serialization/tests/TestRegistry.cpp
+++ b/velox/common/serialization/tests/TestRegistry.cpp
@@ -21,7 +21,7 @@
 using namespace ::facebook::velox;
 
 namespace {
-TEST(Registry, SmartPointerFactoryWithNoArgument) {
+TEST(Registry, smartPointerFactoryWithNoArgument) {
   Registry<size_t, std::unique_ptr<size_t>()> registry;
 
   const size_t key = 0;
@@ -38,7 +38,7 @@ TEST(Registry, SmartPointerFactoryWithNoArgument) {
   EXPECT_EQ(*registry.Create(key), value);
 }
 
-TEST(Registry, ValueFactoryWithArguments) {
+TEST(Registry, valueFactoryWithArguments) {
   Registry<size_t, size_t(size_t, size_t)> registry;
 
   const size_t key = 0;
@@ -50,5 +50,32 @@ TEST(Registry, ValueFactoryWithArguments) {
 
   EXPECT_TRUE(registry.Has(key));
   EXPECT_EQ(registry.Create(key, 1, 1), 2);
+}
+
+TEST(FunctionRegistry, registerDifferentFunctions) {
+  Registry<ssize_t, std::unique_ptr<size_t>()> registry;
+  const size_t key1 = 0;
+  const size_t key2 = 1;
+
+  auto dummyFunction = []() -> std::unique_ptr<size_t> { return nullptr; };
+
+  // Test registering 2 functions with different keys (should succeed)
+  registry.Register(key1, dummyFunction);
+  registry.Register(key2, dummyFunction);
+
+  ASSERT_EQ(registry.Keys().size(), 2);
+  ASSERT_TRUE(registry.Has(key1));
+  ASSERT_TRUE(registry.Has(key2));
+}
+
+TEST(FunctionRegistry, registerSameFunction) {
+  Registry<ssize_t, std::unique_ptr<size_t>()> registry;
+  const size_t key = 0;
+
+  auto dummyFunction = []() -> std::unique_ptr<size_t> { return nullptr; };
+
+  // Test registering the same key twice, the second attempt should fail
+  registry.Register(key, dummyFunction);
+  ASSERT_THROW(registry.Register(key, dummyFunction), VeloxUserError);
 }
 } // namespace


### PR DESCRIPTION
Summary:
Today the Registry class will overwrite any entry in the CreatorMap if a duplicate key is used.

For UDF's in ScalarFunctionRegistry and AdaptedVectorFunctionRegistry this will become more error prone with the introduction of support for VariadicArgs in the function signature.  In order to facilitate UDF lookups, I plan to modify FunctionKey to treat compatible signatures  as equal (e.g. VariadicArgs<Varchar> will match Varchar, Varchar).

This will make it much easier to accidentally overwrite another function in the Registries.  To help catch this early, I've added a check in the Register function that throws an exception if an entry already exists in the Registry with the same key.

This will also impact the other Registries (DeserializationRegistryType and AggregateFunctionRegistry) but I think this makes sense (overwriting an existing key is probably a mistake).

Differential Revision: D32780498

