### PR TITLE
Use configuration property for output batch size

### DIFF
--- a/velox/exec/CrossJoinProbe.h
+++ b/velox/exec/CrossJoinProbe.h
@@ -39,6 +39,9 @@ class CrossJoinProbe : public Operator {
   void close() override;
 
  private:
+  /// Maximum number of rows in the output batch.
+  const uint32_t outputBatchSize_;
+
   std::vector<IdentityProjection> buildProjections_;
 
   std::optional<std::vector<VectorPtr>> buildData_;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -49,13 +49,17 @@ class HashAggregation : public Operator {
   }
 
  private:
-  static constexpr int32_t kOutputBatchSize = 10'000;
+  /// Maximum number of rows in the output batch.
+  const uint32_t outputBatchSize_;
 
-  std::unique_ptr<GroupingSet> groupingSet_;
+  const int64_t maxPartialAggregationMemoryUsage_;
+
   const bool isPartialOutput_;
   const bool isDistinct_;
   const bool isGlobal_;
-  const int64_t maxPartialAggregationMemoryUsage_;
+
+  std::unique_ptr<GroupingSet> groupingSet_;
+
   bool partialFull_ = false;
   bool newDistincts_ = false;
   bool finished_ = false;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -47,9 +47,6 @@ class HashProbe : public Operator {
   void close() override {}
 
  private:
-  // TODO: Define batch size as bytes based on RowContainer row sizes.
-  static constexpr int32_t kOutputBatchSize = 1'000;
-
   // Sets up 'filter_' and related members.
   void initializeFilter(
       const std::shared_ptr<const core::ITypedExpr>& filter,
@@ -72,6 +69,9 @@ class HashProbe : public Operator {
   // Applies 'filter_' to 'outputRows_' and updates 'outputRows_' and
   // 'rowNumberMapping_'. Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows);
+
+  // TODO: Define batch size as bytes based on RowContainer row sizes.
+  const uint32_t outputBatchSize_;
 
   const core::JoinType joinType_;
 


### PR DESCRIPTION
Replace hard-coded output batch sizes with a configuration property.