### PR TITLE
Set icu4c path in CMAKE_PREFIX_PATH only when it's not there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,10 @@ jobs:
           command: |
             set -xu
             if [[ ! -e ~/deps ]]; then
+              export PATH=~/deps/bin:${PATH}
               mkdir ~/deps ~/deps-src
               curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C ~/deps
-              PATH=~/deps/bin:${PATH} DEPENDENCY_DIR=~/deps-src INSTALL_PREFIX=~/deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-macos.sh
+              DEPENDENCY_DIR=~/deps-src INSTALL_PREFIX=~/deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-macos.sh
               # Calculate the prefix path before we delete brew's repos and taps.
               echo "$(pwd)/deps;$(brew --prefix openssl@1.1);$(brew --prefix icu4c)" > ~/deps/PREFIX_PATH
               rm -rf ~/deps/.git ~/deps/Library/Taps/  # Reduce cache size by 70%.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
               mkdir ~/deps ~/deps-src
               curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C ~/deps
               PATH=~/deps/bin:${PATH} DEPENDENCY_DIR=~/deps-src INSTALL_PREFIX=~/deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-macos.sh
+              # Calculate the prefix path before we delete brew's repos and taps.
+              echo "$(pwd)/deps;$(brew --prefix openssl@1.1);$(brew --prefix icu4c)" > ~/deps/PREFIX_PATH
               rm -rf ~/deps/.git ~/deps/Library/Taps/  # Reduce cache size by 70%.
             fi
       - save_cache:
@@ -88,7 +90,7 @@ jobs:
             mkdir -p .ccache
             export CCACHE_DIR=$(pwd)/.ccache
             ccache -sz -M 5Gi
-            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=~/deps -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(cat ~/deps/PREFIX_PATH) -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             ninja -C _build/debug
             ccache -s
           no_output_timeout: 1h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,8 +220,8 @@ find_library(SNAPPY snappy)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   if(NOT CMAKE_PREFIX_PATH MATCHES ".*\/icu4c.*")
-    # icu4c is not found in CMAKE_PREFIX_PATH
-    # defaults to "/usr/local/opt/icu4c" for MacOS
+    # icu4c is not found in CMAKE_PREFIX_PATH, defaults to "/usr/local/opt/icu4c"
+    # for MacOS
     set(CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" ${CMAKE_PREFIX_PATH})
   endif()
   find_package(ICU REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,8 +220,8 @@ find_library(SNAPPY snappy)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   if(NOT CMAKE_PREFIX_PATH MATCHES ".*\/icu4c.*")
-    # icu4c is not found in CMAKE_PREFIX_PATH, defaults to "/usr/local/opt/icu4c"
-    # for MacOS
+    # icu4c is not found in CMAKE_PREFIX_PATH, defaults to
+    # "/usr/local/opt/icu4c" for MacOS
     set(CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" ${CMAKE_PREFIX_PATH})
   endif()
   find_package(ICU REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,11 @@ find_package(ZLIB)
 find_library(SNAPPY snappy)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" ${CMAKE_PREFIX_PATH})
+  if(NOT CMAKE_PREFIX_PATH MATCHES ".*\/icu4c.*")
+    # icu4c is not found in CMAKE_PREFIX_PATH
+    # defaults to "/usr/local/opt/icu4c" for MacOS
+    set(CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" ${CMAKE_PREFIX_PATH})
+  endif()
   find_package(ICU REQUIRED)
   include_directories(${ICU_INCLUDE_DIRS})
   link_directories("${ICU_INCLUDE_DIRS}/../lib")


### PR DESCRIPTION
This is for the cmake to pick the icu4c installed under ~/deps for our circle ci runs. Or it will use the one under /usr/local/opt/icu4c