### PR TITLE
Add VariadicType

### DIFF
--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -540,3 +540,11 @@ TEST(Type, unknown) {
   auto unknownArray = ARRAY(UNKNOWN());
   EXPECT_TRUE(unknownArray->containsUnknown());
 }
+
+TEST(Type, isVariadicType) {
+  EXPECT_TRUE(isVariadicType<Variadic<int64_t>>::value);
+  EXPECT_TRUE(isVariadicType<Variadic<Array<float>>>::value);
+  EXPECT_FALSE(isVariadicType<velox::StringView>::value);
+  EXPECT_FALSE(isVariadicType<bool>::value);
+  EXPECT_FALSE((isVariadicType<Map<int8_t, Date>>::value));
+}


### PR DESCRIPTION
Summary:
This diff adds a new Type to the Velox Type system to support adding a variable number of arguments of the same type at the end of a function's list of arguments.

This diff only adds the Type and does not add any of the necessary logic to use this type in functions, that will be done in subsequent diffs.

Since this type can only be used as the function argument to a function, I also added a new field canBeInContainer to TypeTraits (in an attempt to add generic checks).  The constructors for ARRAY, MAP, and ROW Types check that none of their child Types have this field set to false.  (Only VARIADIC and INVALID types have this set to false).

In addition, I added logic to the FUNCTION Type to verify only the last argument (if any) is VARIADIC.  And the VARIADIC Type checks that it's underlying Type is not VARIADIC (i.e. no VARIADIC<VARIADIC<...>>)

I did not add support for VARIADIC in Variants.  I'm not sure where Variants are used but that seemed like the right choice.

Differential Revision: D32814045

