### PR TITLE
Fix column ordering bug in HashJoin filter

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -129,6 +129,7 @@ void HashProbe::initializeFilter(
   std::vector<std::shared_ptr<const core::ITypedExpr>> filters = {filter};
   filter_ =
       std::make_unique<ExprSet>(std::move(filters), operatorCtx_->execCtx());
+
   ChannelIndex filterChannel = 0;
   std::vector<std::string> names;
   std::vector<TypePtr> types;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -130,34 +130,33 @@ void HashProbe::initializeFilter(
   filter_ =
       std::make_unique<ExprSet>(std::move(filters), operatorCtx_->execCtx());
   ChannelIndex filterChannel = 0;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  auto numFields = filter_->expr(0)->distinctFields().size();
+  names.reserve(numFields);
+  types.reserve(numFields);
   for (auto& field : filter_->expr(0)->distinctFields()) {
     const auto& name = field->field();
     auto channel = probeType->getChildIdxIfExists(name);
     if (channel.has_value()) {
-      filterProbeInputs_.emplace_back(channel.value(), filterChannel++);
+      auto channelValue = channel.value();
+      filterProbeInputs_.emplace_back(channelValue, filterChannel++);
+      names.emplace_back(probeType->nameOf(channelValue));
+      types.emplace_back(probeType->childAt(channelValue));
       continue;
     }
     channel = tableType->getChildIdxIfExists(name);
     if (channel.has_value()) {
-      filterBuildInputs_.emplace_back(channel.value(), filterChannel++);
+      auto channelValue = channel.value();
+      filterBuildInputs_.emplace_back(channelValue, filterChannel++);
+      names.emplace_back(tableType->nameOf(channelValue));
+      types.emplace_back(tableType->childAt(channelValue));
       continue;
     }
     VELOX_FAIL(
         "Join filter field {} not in probe or build input", field->toString());
   }
-  std::vector<std::string> names;
-  std::vector<TypePtr> types;
-  auto numFields = filterProbeInputs_.size() + filterBuildInputs_.size();
-  names.reserve(numFields);
-  types.reserve(numFields);
-  for (auto projection : filterProbeInputs_) {
-    names.emplace_back(probeType->nameOf(projection.inputChannel));
-    types.emplace_back(probeType->childAt(projection.inputChannel));
-  }
-  for (auto projection : filterBuildInputs_) {
-    names.emplace_back(tableType->nameOf(projection.inputChannel));
-    types.emplace_back(tableType->childAt(projection.inputChannel));
-  }
+
   filterInputType_ = ROW(std::move(names), std::move(types));
 }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -219,8 +219,11 @@ TEST_F(HashJoinTest, joinSidesDifferentSchema) {
   std::vector<std::string> stringVector = {"aaa", "bbb", "ccc", "ddd", "eee"};
   auto leftVectors = makeRowVector({
       makeFlatVector<int32_t>(batchSize, [](auto row) { return row; }),
-      makeFlatVector<StringView>(batchSize,
-                                 [&](auto row) { return StringView(stringVector[row % stringVector.size()]); }),
+      makeFlatVector<StringView>(
+          batchSize,
+          [&](auto row) {
+            return StringView(stringVector[row % stringVector.size()]);
+          }),
       makeFlatVector<int32_t>(batchSize, [](auto row) { return row; }),
   });
   auto rightVectors = makeRowVector({

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -71,7 +71,7 @@ class HashJoinTest : public HiveConnectorTestBase {
 
   // This function sets up a hashJoin between tables with different schema.
   // For the purpose of simplicity, it is assumed that the key columns
-  // `numJoinKeys` appear at the beginning of the table.
+  // `numJoinKeys` appear at the beginning of the tables.
   void testJoinTablesDifferentSchemas(
       const std::vector<TypePtr>& leftColTypes,
       const std::vector<TypePtr>& rightColTypes,
@@ -249,7 +249,7 @@ TEST_F(HashJoinTest, filter) {
 TEST_F(HashJoinTest, filterOrder) {
   // In this join, the tables have different schema. The filter predicate uses
   // a column from the right table before the left and the corresponding
-  // columns at the same channel number have different types. This has been
+  // columns at the same channel number(1) have different types. This has been
   // a source of errors in the join logic.
   testJoinTablesDifferentSchemas(
       {BIGINT(), VARCHAR(), BIGINT()},

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -223,7 +223,7 @@ TEST_F(HashJoinTest, joinSidesDifferentSchema) {
   createDuckDbTable("u", {rightBatch});
 
   std::string referenceQuery =
-      "SELECT t_k0 FROM "
+      "SELECT t_k0 * t_k2/2 FROM "
       "  t, u "
       "  WHERE t_k0 = u_k0 AND "
       "  u_k2 > 10 AND ltrim(t_k1) = 'a%'";
@@ -237,7 +237,8 @@ TEST_F(HashJoinTest, joinSidesDifferentSchema) {
                             {0},
                             PlanBuilder().values({rightBatch}).planNode(),
                             "u_k2 > 10 AND ltrim(t_k1) = 'a%'",
-                            {0})
+                            {0, 2})
+                        .project({"t_k0 * t_k2/2"}, {"k1"})
                         .planNode();
 
   ::assertQuery(


### PR DESCRIPTION
In the HashJoin filter if the build columns appeared intermixed with
the probe columns, there was a bug in how the ROW structure for the
filter evaluation was built. It presumed that all the probe columns
come before the build columns which resulted in the channels being
wired incorrectly for picking values during filter evaluation. This
caused errors and crashes if the types of the columns in the same
channel position of the input tables had incompatible types.

This bug showed up in TPC-H query 19 where the build and probe side
columns were intermixed in the filter it used.