### PR TITLE
Add Reader for Variadic Type

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -55,8 +55,7 @@ class IndexBasedIterator {
   using pointer = PointerWrapper<value_type>;
   using reference = T;
 
-  explicit IndexBasedIterator<value_type>(vector_size_t index)
-      : index_(index) {}
+  explicit IndexBasedIterator<value_type>(int64_t index) : index_(index) {}
 
   bool operator!=(const Iterator& rhs) const {
     return index_ != rhs.index_;
@@ -96,7 +95,7 @@ class IndexBasedIterator {
   }
 
  protected:
-  vector_size_t index_;
+  int64_t index_;
 };
 
 // Implements an iterator for values that skips nulls and provides direct access
@@ -256,11 +255,11 @@ class VectorOptionalValueAccessor {
   }
 
  private:
-  VectorOptionalValueAccessor<T>(const T* reader, vector_size_t index)
+  VectorOptionalValueAccessor<T>(const T* reader, int64_t index)
       : reader_(reader), index_(index) {}
   const T* reader_;
   // Index of element within the reader.
-  vector_size_t index_;
+  int64_t index_;
 
   template <typename V>
   friend class ArrayView;
@@ -270,6 +269,9 @@ class VectorOptionalValueAccessor {
 
   template <typename... U>
   friend class RowView;
+
+  template <typename U>
+  friend class VariadicView;
 };
 
 template <typename T, typename U>
@@ -501,7 +503,7 @@ class MapView {
     Element(
         const key_reader_t* keyReader,
         const value_reader_t* valueReader,
-        vector_size_t index)
+        int64_t index)
         : first((*keyReader)[index]), second(valueReader, index) {}
     const KeyAccessor first;
     const ValueAccessor second;

--- a/velox/expression/DecodedArgs.h
+++ b/velox/expression/DecodedArgs.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "velox/expression/EvalCtx.h"
+
+namespace facebook::velox::exec {
+
+/// A helper class to decode VectorFunction arguments.
+/// Example:
+///    DecodedArgs decodedArgs(rows, args, context);
+///    auto base = decodedArgs.at(0);
+///    auto exp = decodedArgs.at(1);
+///
+///    rows.applyToSelected([&](int row) {
+///      rawResults[row] =
+///        std::pow(base->valueAt<double>(row), exp->valueAt<double>(row));
+///    });
+///
+class DecodedArgs {
+ public:
+  DecodedArgs(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      exec::EvalCtx* context) {
+    for (auto& arg : args) {
+      holders_.emplace_back(context, *arg.get(), rows);
+    }
+  }
+
+  DecodedVector* at(int i) const {
+    return const_cast<exec::LocalDecodedVector*>(&holders_[i])->get();
+  }
+
+  size_t size() const {
+    return holders_.size();
+  }
+
+ private:
+  std::vector<exec::LocalDecodedVector> holders_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -21,40 +21,11 @@
 #include <folly/container/F14Map.h>
 
 #include "velox/core/Expressions.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::exec {
-
-/// A helper class to decode VectorFunction arguments.
-/// Example:
-///    DecodedArgs decodedArgs(rows, args, context);
-///    auto base = decodedArgs.at(0);
-///    auto exp = decodedArgs.at(1);
-///
-///    rows.applyToSelected([&](int row) {
-///      rawResults[row] =
-///        std::pow(base->valueAt<double>(row), exp->valueAt<double>(row));
-///    });
-///
-class DecodedArgs {
- public:
-  DecodedArgs(
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      exec::EvalCtx* context) {
-    for (auto& arg : args) {
-      holders_.emplace_back(context, *arg.get(), rows);
-    }
-  }
-
-  DecodedVector* at(int i) const {
-    return const_cast<exec::LocalDecodedVector*>(&holders_[i])->get();
-  }
-
- private:
-  std::vector<exec::LocalDecodedVector> holders_;
-};
 
 class ExprSet;
 class FieldReference;

--- a/velox/expression/VariadicView.h
+++ b/velox/expression/VariadicView.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/vector/TypeAliases.h"
+
+namespace facebook::velox::exec {
+template <typename T>
+struct VectorReader;
+
+// Represents an arbitrary number of arguments of the same type with an
+// interface similar to std::vector.
+template <typename T>
+class VariadicView {
+  using reader_t = VectorReader<T>;
+  using element_t = typename reader_t::exec_in_t;
+
+ public:
+  VariadicView(
+      const std::vector<std::unique_ptr<reader_t>>* readers,
+      vector_size_t offset)
+      : readers_(readers), offset_(offset) {}
+
+  using Element = VectorOptionalValueAccessor<reader_t>;
+
+  class Iterator : public IndexBasedIterator<Element> {
+   public:
+    Iterator(
+        const std::vector<std::unique_ptr<reader_t>>* readers,
+        size_t readerIndex,
+        vector_size_t offset)
+        : IndexBasedIterator<Element>(readerIndex),
+          readers_(readers),
+          offset_(offset) {}
+
+    PointerWrapper<Element> operator->() const {
+      return PointerWrapper(Element{(*readers_)[this->index_].get(), offset_});
+    }
+
+    Element operator*() const {
+      return Element{(*readers_)[this->index_].get(), offset_};
+    }
+
+   protected:
+    const std::vector<std::unique_ptr<reader_t>>* readers_;
+    const vector_size_t offset_;
+  };
+
+  Iterator begin() const {
+    return Iterator{readers_, 0, offset_};
+  }
+
+  Iterator end() const {
+    return Iterator{readers_, readers_->size(), offset_};
+  }
+
+  struct SkipNullsContainer {
+    class SkipNullsBaseIterator : public Iterator {
+     public:
+      SkipNullsBaseIterator(
+          const std::vector<std::unique_ptr<reader_t>>* readers,
+          size_t readerIndex,
+          vector_size_t offset)
+          : Iterator(readers, readerIndex, offset) {}
+
+      bool hasValue() const {
+        const auto& currReader = this->readers_->operator[](this->index_);
+        return currReader->isSet(this->offset_);
+      }
+
+      element_t value() const {
+        const auto& currReader = this->readers_->operator[](this->index_);
+        return (*currReader)[this->offset_];
+      }
+    };
+
+    explicit SkipNullsContainer(const VariadicView<T>* view) : view_(view) {}
+
+    SkipNullsIterator<SkipNullsBaseIterator> begin() {
+      return SkipNullsIterator<SkipNullsBaseIterator>::initialize(
+          SkipNullsBaseIterator{view_->readers_, 0, view_->offset_},
+          SkipNullsBaseIterator{
+              view_->readers_, view_->readers_->size(), view_->offset_});
+    }
+
+    SkipNullsIterator<SkipNullsBaseIterator> end() {
+      return SkipNullsIterator<SkipNullsBaseIterator>{
+          SkipNullsBaseIterator{
+              view_->readers_, view_->readers_->size(), view_->offset_},
+          SkipNullsBaseIterator{
+              view_->readers_, view_->readers_->size(), view_->offset_}};
+    }
+
+   private:
+    const VariadicView<T>* view_;
+  };
+
+  // Returns true if any of the arguments in the vector might have null
+  // element.
+  bool mayHaveNulls() const {
+    for (const auto* reader : readers_) {
+      if (reader->mayHaveNulls()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  Element operator[](size_t index) const {
+    return Element{(*readers_)[index].get(), offset_};
+  }
+
+  Element at(size_t index) const {
+    return (*this)[index];
+  }
+
+  size_t size() const {
+    return readers_->size();
+  }
+
+  SkipNullsContainer skipNulls() {
+    return SkipNullsContainer{this};
+  }
+
+ private:
+  const std::vector<std::unique_ptr<reader_t>>* readers_;
+  const vector_size_t offset_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ add_executable(
   SimpleFunctionTest.cpp
   ArrayViewTest.cpp
   MapViewTest.cpp
-  RowViewTest.cpp)
+  RowViewTest.cpp
+  VariadicViewTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/VariadicViewTest.cpp
+++ b/velox/expression/tests/VariadicViewTest.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace {
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class VariadicViewTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::vector<std::vector<std::optional<int64_t>>> bigIntVectors = {
+      {std::nullopt, std::nullopt, std::nullopt},
+      {0, 1, 2},
+      {99, 98, std::nullopt},
+      {101, std::nullopt, 102},
+      {std::nullopt, 10001, 12345676},
+      {std::nullopt, std::nullopt, 3},
+      {std::nullopt, 4, std::nullopt},
+      {5, std::nullopt, std::nullopt},
+  };
+
+  void testVariadicView(const std::vector<VectorPtr>& additionalVectors = {}) {
+    std::vector<VectorPtr> vectors(
+        additionalVectors.begin(), additionalVectors.end());
+    for (const auto& vector : bigIntVectors) {
+      vectors.emplace_back(makeNullableFlatVector(vector));
+    }
+    SelectivityVector rows(vectors[0]->size());
+    EvalCtx ctx(&execCtx_, nullptr, nullptr);
+    DecodedArgs args(rows, vectors, &ctx);
+
+    size_t startIndex = additionalVectors.size();
+    VectorReader<Variadic<int64_t>> reader(args, startIndex);
+
+    auto testItem = [&](int row, int arg, auto item) {
+      // Test has_value.
+      ASSERT_EQ(bigIntVectors[arg][row].has_value(), item.has_value());
+
+      // Test bool implicit cast.
+      ASSERT_EQ(bigIntVectors[arg][row].has_value(), static_cast<bool>(item));
+
+      if (bigIntVectors[arg][row].has_value()) {
+        // Test * operator.
+        ASSERT_EQ(bigIntVectors[arg][row].value(), *item);
+
+        // Test value().
+        ASSERT_EQ(bigIntVectors[arg][row].value(), item.value());
+      }
+      // Test == with std::optional
+      ASSERT_EQ(item, bigIntVectors[arg][row]);
+    };
+
+    for (auto row = 0; row < vectors[0]->size(); ++row) {
+      auto variadicView = reader[row];
+      auto arg = 0;
+
+      // Test iterate loop.
+      for (auto item : variadicView) {
+        testItem(row, arg, item);
+        arg++;
+      }
+      ASSERT_EQ(arg, bigIntVectors.size());
+
+      // Test iterate loop explicit begin & end.
+      auto it = variadicView.begin();
+      arg = 0;
+      while (it != variadicView.end()) {
+        testItem(row, arg, *it);
+        arg++;
+        ++it;
+      }
+      ASSERT_EQ(arg, bigIntVectors.size());
+
+      // Test index based loop.
+      for (arg = 0; arg < variadicView.size(); arg++) {
+        testItem(row, arg, variadicView[arg]);
+      }
+      ASSERT_EQ(arg, bigIntVectors.size());
+
+      // Test loop iterator with <.
+      arg = 0;
+      for (auto it2 = variadicView.begin(); it2 < variadicView.end(); it2++) {
+        testItem(row, arg, *it2);
+        arg++;
+      }
+      ASSERT_EQ(arg, bigIntVectors.size());
+    }
+  }
+};
+
+TEST_F(VariadicViewTest, variadicInt) {
+  testVariadicView();
+}
+
+TEST_F(VariadicViewTest, variadicIntMoreArgs) {
+  // Test accessing Variadic args when there are other args before it.
+  testVariadicView(
+      {makeNullableFlatVector(std::vector<std::optional<int64_t>>{-1, -2, -3}),
+       makeNullableFlatVector(
+           std::vector<std::optional<int64_t>>{-4, std::nullopt, -6}),
+       makeNullableFlatVector(std::vector<std::optional<int64_t>>{
+           std::nullopt, std::nullopt, std::nullopt})});
+}
+
+TEST_F(VariadicViewTest, notNullContainer) {
+  std::vector<VectorPtr> vectors;
+  for (const auto& vector : bigIntVectors) {
+    vectors.emplace_back(makeNullableFlatVector(vector));
+  }
+  SelectivityVector rows(vectors[0]->size());
+  EvalCtx ctx(&execCtx_, nullptr, nullptr);
+  DecodedArgs args(rows, vectors, &ctx);
+
+  VectorReader<Variadic<int64_t>> reader(args, 0);
+
+  for (auto row = 0; row < vectors[0]->size(); ++row) {
+    auto variadicView = reader[row];
+    int arg = 0;
+    for (auto value : variadicView.skipNulls()) {
+      while (arg < bigIntVectors.size() &&
+             bigIntVectors[arg][row] == std::nullopt) {
+        arg++;
+      }
+      ASSERT_EQ(value, bigIntVectors[arg][row].value());
+      arg++;
+    }
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
This diff adds an implementation of VectorReader<Variadic<T>>, which returns a VariadicView<T> for accessing the values of individual arguments.

VariadicView<T> exposes an interface similar to std::vector and heavily based on ArrayView<T>.  VariadicView<T> maintains pointers to a collection of readers and allows access to the value from each of these readers at the current offset, either directly or by iterating over the readers in turn.

I split out DedodedArgs into its own header file because VectorReader<Variadic<T>> takes an instance of DedodedArgs in its constructor.  Adding the Expr.h header to VectorUdfTypeSystem.h caused issues in presto_cpp because Expr.h includes the Expressions.h header which calls the isRow() function on a Type in one of its functions.  presto_cpp defines a macro isRow() which conflicts with this function name.  Splitting out DedodedArgs into its own header file and including that in Expr.h works around this issue.

Another option would be to pass in a vector<DecodedVector*> instead of DecodedArgs (which would be nicer in other ways too), but comes at the cost of having to build that vector.

I will integrate the Reader into UDFs in a following diff.

Differential Revision: D32840896

