### PR TITLE
Fix bad reserve in merge of BigintValuesUsingHashTable

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -830,7 +830,7 @@ std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(
   }
 
   std::vector<int64_t> valuesToKeep;
-  valuesToKeep.reserve(max - min + 1);
+  valuesToKeep.reserve(values_.size());
   if (containsEmptyMarker_ && other->testInt64(kEmptyMarker)) {
     valuesToKeep.emplace_back(kEmptyMarker);
   }

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -976,8 +976,8 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(between(150, 500, true));
 
   // IN-list.
-  filters.push_back(in({1, 2, 3, 67, 134}));
-  filters.push_back(in({1, 2, 3, 67, 134}, true));
+  filters.push_back(in({1, 2, 3, 67'000'000'000, 134}));
+  filters.push_back(in({1, 2, 3, 67'000'000'000, 134}, true));
   filters.push_back(in({-7, -6, -5, -4, -3, -2}));
   filters.push_back(in({-7, -6, -5, -4, -3, -2}, true));
   filters.push_back(in({1, 2, 3, 67, 10'134}));


### PR DESCRIPTION
The spread between min and max for an IN can be large and has nothing
to do with the number of elements in the filter, so do not use it in
sizing an intermediate result.