### PR TITLE
Abandon low value dictionary under memory pressure

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
@@ -729,7 +729,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
                 EXPECT_CALL(*mockIndexBuilderPtr, add(_, k))
                     .Times(positionCount - 4);
               }
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
               break;
             }
           }
@@ -752,7 +752,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
@@ -790,7 +790,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
@@ -1018,7 +1018,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
                 EXPECT_CALL(*mockIndexBuilderPtr, add(_, k))
                     .Times(positionCount - 4);
               }
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
               break;
             }
           }
@@ -1041,7 +1041,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
@@ -1079,7 +1079,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
-              columnWriter->abandonDictionaries();
+              columnWriter->tryAbandonDictionaries(true);
             }
           }
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -1619,7 +1619,7 @@ struct IntegerColumnWriterTypedTestCase {
       for (size_t j = 0; j != repetitionCount; ++j) {
         columnWriter->write(batch, Ranges::of(0, batch->size()));
         if (callAbandonDict(i, j)) {
-          columnWriter->abandonDictionaries();
+          columnWriter->tryAbandonDictionaries(true);
         }
         columnWriter->createIndexEntry();
       }
@@ -2486,7 +2486,7 @@ struct StringColumnWriterTestCase {
         // TODO: break the batch into multiple strides.
         columnWriter->write(batches[j], Ranges::of(0, size));
         if (callAbandonDict(i, j)) {
-          columnWriter->abandonDictionaries();
+          columnWriter->tryAbandonDictionaries(true);
         }
         columnWriter->createIndexEntry();
       }
@@ -3160,7 +3160,7 @@ struct DictColumnWriterTestCase {
 
     // Testing write direct paths
     if (writeDirect_) {
-      writer->abandonDictionaries();
+      writer->tryAbandonDictionaries(true);
     }
     writer->write(batch, Ranges::of(0, batch->size()));
     writer->createIndexEntry();

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -411,26 +411,26 @@ TEST(E2EWriterTests, FlushPolicyWithMemoryBudget) {
       FlushPolicyTestCase{
           /*stripeSize*/ 2 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 21,
-          /*numStripesUpper*/ 21,
+          /*numStripesLower*/ 20,
+          /*numStripesUpper*/ 20,
           /*seed*/ 1630160118},
       FlushPolicyTestCase{
           /*stripeSize*/ 2 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 21,
-          /*numStripesUpper*/ 21,
+          /*numStripesLower*/ 20,
+          /*numStripesUpper*/ 20,
           /*seed*/ 1630160118,
           13 * kSizeMB},
       FlushPolicyTestCase{
           /*stripeSize*/ 32 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 2,
-          /*numStripesUpper*/ 2,
+          /*numStripesLower*/ 1,
+          /*numStripesUpper*/ 1,
           /*seed*/ 1630160118},
       FlushPolicyTestCase{
           /*stripeSize*/ 32 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 3,
+          /*numStripesLower*/ 2,
           /*numStripesUpper*/ 3,
           /*seed*/ 1630160118,
           40 * kSizeMB});

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -119,9 +119,12 @@ class ColumnWriter {
     return size;
   }
 
-  virtual void abandonDictionaries() {
+  // Determine whether dictionary is the right encoding to use when writing
+  // the first stripe. We will continue using the same decision for all
+  // subsequent stripes.
+  virtual void tryAbandonDictionaries(bool force) {
     for (auto& child : children_) {
-      child->abandonDictionaries();
+      child->tryAbandonDictionaries(force);
     }
   }
 

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -39,7 +39,10 @@ void Writer::write(const VectorPtr& slice) {
     length = std::min(length, slice->size() - offset);
     VELOX_CHECK_GT(length, 0);
     if (shouldFlush(context, length)) {
-      flush();
+      abandonLowValueDictionaries();
+      if (shouldFlush(context, length)) {
+        flush();
+      }
     }
 
     auto rawSize = writer_->write(slice, Ranges::of(offset, offset + length));

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -66,8 +66,12 @@ class Writer : public WriterShared {
     writer_->writeFileStats(statsFactory);
   }
 
+  void abandonLowValueDictionaries() {
+    writer_->tryAbandonDictionaries(false);
+  }
+
   void abandonDictionariesImpl() override {
-    writer_->abandonDictionaries();
+    writer_->tryAbandonDictionaries(true);
   }
 
   void resetImpl() override {


### PR DESCRIPTION
Summary:
Currently in velox writer, we determine whether or not to use dictionary encoding right before the flush, but the encoding conversion introduces significant memory overhead and complicates memory management.

Instead, we now try to abandon low value dictionaries before we try to flush. This increases the granularity of writer memory increment, which both reduces the overhead we need to reserve for memory management and also allows us to delay premature flushes as much as possible without changing the current flow.

NOTE: `abandonDictionaries` can be called even after the first stripe and would do nothing in that case. `abandonDictionaries(false)` doesn't force abandon the dictionary and is natively used to determine whether to use dictionary encoding. The method exits early when we already determined not to use dictionary encoding for the column reader instance.

Differential Revision: D32874984

