### PR TITLE
Templatize byte column readers

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -36,9 +36,9 @@ class ColumnReader {
   explicit ColumnReader(
       memory::MemoryPool& memoryPool,
       const std::shared_ptr<const dwio::common::TypeWithId>& type)
-      : notNullDecoder{},
+      : notNullDecoder_{},
         nodeType_{type},
-        memoryPool{memoryPool},
+        memoryPool_{memoryPool},
         flatMapContext_{FlatMapContext::nonFlatMapContext()} {}
 
   // Reads nulls, if any. Sets '*nulls' to nullptr if void
@@ -58,9 +58,9 @@ class ColumnReader {
       VectorPtr& result,
       const uint64_t* incomingNulls);
 
-  std::unique_ptr<ByteRleDecoder> notNullDecoder;
+  std::unique_ptr<ByteRleDecoder> notNullDecoder_;
   const std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
-  memory::MemoryPool& memoryPool;
+  memory::MemoryPool& memoryPool_;
   FlatMapContext flatMapContext_;
 
  public:

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -18,12 +18,12 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 #include "velox/dwio/dwrf/common/Compression.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/reader/EncodingContext.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
-#include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::dwrf {
@@ -33,9 +33,11 @@ namespace facebook::velox::dwrf {
  */
 class ColumnReader {
  protected:
-  explicit ColumnReader(memory::MemoryPool& memoryPool)
+  explicit ColumnReader(
+      memory::MemoryPool& memoryPool,
+      const std::shared_ptr<const dwio::common::TypeWithId>& type)
       : notNullDecoder{},
-        encodingKey{0},
+        nodeType_{type},
         memoryPool{memoryPool},
         flatMapContext_{FlatMapContext::nonFlatMapContext()} {}
 
@@ -57,13 +59,13 @@ class ColumnReader {
       const uint64_t* incomingNulls);
 
   std::unique_ptr<ByteRleDecoder> notNullDecoder;
-  EncodingKey encodingKey;
+  const std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
   memory::MemoryPool& memoryPool;
   FlatMapContext flatMapContext_;
 
  public:
   ColumnReader(
-      const EncodingKey& ek,
+      std::shared_ptr<const dwio::common::TypeWithId> nodeId,
       StripeStreams& stripe,
       FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
 

--- a/velox/dwio/dwrf/reader/ConstantColumnReader.h
+++ b/velox/dwio/dwrf/reader/ConstantColumnReader.h
@@ -26,7 +26,9 @@ class NullColumnReader : public ColumnReader {
   NullColumnReader(
       const StripeStreams& stripe,
       const std::shared_ptr<const Type>& type)
-      : ColumnReader(stripe.getMemoryPool()), type_{type} {}
+      : ColumnReader(
+            stripe.getMemoryPool(),
+            dwio::common::TypeWithId::create(type)) {}
   ~NullColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override {
@@ -40,14 +42,11 @@ class NullColumnReader : public ColumnReader {
       // If vector already exists and contains the right value, resize.
       result->resize(numValues);
     } else {
-      auto valueVector = BaseVector::create(type_, 1, &memoryPool);
+      auto valueVector = BaseVector::create(nodeType_->type, 1, &memoryPool);
       valueVector->setNull(0, true);
       result = BaseVector::wrapInConstant(numValues, 0, valueVector);
     }
   }
-
- private:
-  const std::shared_ptr<const Type> type_;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/ConstantColumnReader.h
+++ b/velox/dwio/dwrf/reader/ConstantColumnReader.h
@@ -42,7 +42,7 @@ class NullColumnReader : public ColumnReader {
       // If vector already exists and contains the right value, resize.
       result->resize(numValues);
     } else {
-      auto valueVector = BaseVector::create(nodeType_->type, 1, &memoryPool);
+      auto valueVector = BaseVector::create(nodeType_->type, 1, &memoryPool_);
       valueVector->setNull(0, true);
       result = BaseVector::wrapInConstant(numValues, 0, valueVector);
     }

--- a/velox/dwio/dwrf/reader/EncodingContext.h
+++ b/velox/dwio/dwrf/reader/EncodingContext.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/common/ByteRLE.h"
+
+namespace facebook::velox::dwrf {
+struct FlatMapContext {
+ public:
+  explicit FlatMapContext(uint32_t sequence, BooleanRleDecoder* inMapDecoder)
+      : sequence{sequence}, inMapDecoder{inMapDecoder} {}
+
+  static FlatMapContext nonFlatMapContext() {
+    return FlatMapContext{0, nullptr};
+  }
+
+  uint32_t sequence;
+  // Kept alive by key nodes
+  BooleanRleDecoder* inMapDecoder;
+};
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -138,16 +138,19 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesFiltered(
           // check if we have key filter passed through read schema
           if (keyPredicate(key)) {
             // fetch reader, in map bitmap and key object.
-            // std::unique_ptr<ColumnReader>
-            auto valueReader = ColumnReader::build(
-                requestedValueType, dataValueType, stripe, sequence);
-
             auto inMap = stripe.getStream(
                 seqEk.forKind(proto::Stream_Kind_IN_MAP), true);
             DWIO_ENSURE_NOT_NULL(inMap, "In map stream is required");
             // build seekable
             auto inMapDecoder =
                 createBooleanRleDecoder(std::move(inMap), seqEk);
+
+            // std::unique_ptr<ColumnReader>
+            auto valueReader = ColumnReader::build(
+                requestedValueType,
+                dataValueType,
+                stripe,
+                FlatMapContext{sequence, inMapDecoder.get()});
 
             keyNodes.push_back(std::make_unique<KeyNode<T>>(
                 std::move(valueReader),

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -18,6 +18,7 @@
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DataBuffer.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
 #include "velox/dwio/dwrf/utils/BitIterator.h"
@@ -201,10 +202,10 @@ template <typename T>
 class FlatMapColumnReader : public ColumnReader {
  public:
   FlatMapColumnReader(
-      EncodingKey& ek,
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe);
+      StripeStreams& stripe,
+      FlatMapContext flatMapContext);
   ~FlatMapColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -215,7 +216,7 @@ class FlatMapColumnReader : public ColumnReader {
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
  private:
-  const std::shared_ptr<const dwio::common::TypeWithId> type_;
+  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
@@ -229,10 +230,10 @@ template <typename T>
 class FlatMapStructEncodingColumnReader : public ColumnReader {
  public:
   FlatMapStructEncodingColumnReader(
-      EncodingKey& ek,
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe);
+      StripeStreams& stripe,
+      FlatMapContext flatMapContext);
   ~FlatMapStructEncodingColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -243,7 +244,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       const uint64_t* FOLLY_NULLABLE nulls) override;
 
  private:
-  const std::shared_ptr<const dwio::common::TypeWithId> type_;
+  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<NullColumnReader> nullColumnReader_;
   BufferPtr mergedNulls_;
@@ -252,10 +253,10 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
 class FlatMapColumnReaderFactory {
  public:
   static std::unique_ptr<ColumnReader> create(
-      EncodingKey& ek,
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe);
+      StripeStreams& stripe,
+      FlatMapContext flatMapContext);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -35,7 +35,7 @@ class SelectiveColumnReader : public ColumnReader {
   static constexpr uint64_t kStringBufferSize = 16 * 1024;
 
   SelectiveColumnReader(
-      const EncodingKey& ek,
+      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
       StripeStreams& stripe,
       common::ScanSpec* scanSpec,
       const TypePtr& type,

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -38,7 +38,8 @@ class SelectiveColumnReader : public ColumnReader {
       const EncodingKey& ek,
       StripeStreams& stripe,
       common::ScanSpec* scanSpec,
-      const TypePtr& type);
+      const TypePtr& type,
+      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
 
   /**
    * Read the next group of values into a RowVector.
@@ -58,7 +59,7 @@ class SelectiveColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
       common::ScanSpec* scanSpec,
-      uint32_t sequence = 0);
+      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
 
   // Called when filters in ScanSpec change, e.g. a new filter is pushed down
   // from a downstream operator.
@@ -410,9 +411,9 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
-      uint32_t sequence) override {
+      FlatMapContext flatMapContext) override {
     auto reader = SelectiveColumnReader::build(
-        requestedType, dataType, stripe, scanSpec_, sequence);
+        requestedType, dataType, stripe, scanSpec_, std::move(flatMapContext));
     reader->setIsTopLevel();
     return reader;
   }

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -95,7 +95,12 @@ class TestStripeStreams : public StripeStreamsBase {
     }
     if (!stream || stream->isSuppressed()) {
       if (throwIfNotFound) {
-        DWIO_RAISE("stream not found");
+        DWIO_RAISE(fmt::format(
+            "stream (node = {}, seq = {}, column = {}, kind = {}) not found",
+            si.node,
+            si.sequence,
+            si.column,
+            si.kind));
       } else {
         return nullptr;
       }
@@ -318,7 +323,8 @@ void testDataTypeWriter(
     TestStripeStreams streams(context, sf, rowType);
     auto typeWithId = TypeWithId::create(rowType);
     auto reqType = typeWithId->childAt(0);
-    auto reader = ColumnReader::build(reqType, reqType, streams, sequence);
+    auto reader = ColumnReader::build(
+        reqType, reqType, streams, FlatMapContext{sequence, nullptr});
     VectorPtr out;
     for (auto strideI = 0; strideI < strideCount; ++strideI) {
       reader->next(size, out);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -230,8 +230,6 @@ std::shared_ptr<T> getOnlyChild(const std::shared_ptr<F>& batch) {
   EXPECT_TRUE(rowVector.get() != nullptr)
       << "Vector is not a struct: " << typeid(F).name();
   auto child = std::dynamic_pointer_cast<T>(rowVector->loadedChildAt(0));
-  LOG(INFO) << "child type: "
-            << rowVector->loadedChildAt(0)->type()->toString();
   EXPECT_TRUE(child.get() != nullptr)
       << "Child vector type doesn't match " << typeid(T).name();
   return child;

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -230,6 +230,8 @@ std::shared_ptr<T> getOnlyChild(const std::shared_ptr<F>& batch) {
   EXPECT_TRUE(rowVector.get() != nullptr)
       << "Vector is not a struct: " << typeid(F).name();
   auto child = std::dynamic_pointer_cast<T>(rowVector->loadedChildAt(0));
+  LOG(INFO) << "child type: "
+            << rowVector->loadedChildAt(0)->type()->toString();
   EXPECT_TRUE(child.get() != nullptr)
       << "Child vector type doesn't match " << typeid(T).name();
   return child;
@@ -4249,8 +4251,10 @@ class SchemaMismatchTest : public TestWithParam<bool> {
       bool returnFlatVector = false,
       const std::shared_ptr<const Type>& dataType = nullptr) {
     if (useSelectiveReader()) {
+      LOG(INFO) << "Using selective reader";
       return builder.build(requestedType, stripe, nodes, dataType);
     } else {
+      LOG(INFO) << "Using normal reader";
       return buildColumnReader(
           requestedType, stripe, nodes, returnFlatVector, dataType);
     }
@@ -4284,8 +4288,8 @@ class SchemaMismatchTest : public TestWithParam<bool> {
     asIsReader->next(size, asIsBatch, nullptr);
 
     ASSERT_EQ(asIsBatch->size(), mismatchBatch->size());
-    auto asIsField = getOnlyChild<SimpleVector<From>>(asIsBatch);
     auto mismatchField = getOnlyChild<SimpleVector<To>>(mismatchBatch);
+    auto asIsField = getOnlyChild<SimpleVector<From>>(asIsBatch);
     for (auto i = 0; i < asIsBatch->size(); ++i) {
       auto isNull = asIsField->isNullAt(i);
       EXPECT_EQ(isNull, mismatchField->isNullAt(i));

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -104,7 +104,11 @@ class SelectiveColumnReaderBuilder {
     makeFieldSpecs("", 0, rowType, scanSpec_.get());
 
     return SelectiveColumnReader::build(
-        cs.getSchemaWithId(), dataTypeWithId, stripe, scanSpec_.get(), 0);
+        cs.getSchemaWithId(),
+        dataTypeWithId,
+        stripe,
+        scanSpec_.get(),
+        FlatMapContext::nonFlatMapContext());
   }
 
  private:

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -855,7 +855,10 @@ TEST(TestReader, testUpcastBoolean) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams, false);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      FlatMapContext::nonFlatMapContext());
 
   VectorPtr batch;
   reader->next(104, batch);
@@ -899,7 +902,10 @@ TEST(TestReader, testUpcastIntDirect) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams, false);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      FlatMapContext::nonFlatMapContext());
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -960,7 +966,10 @@ TEST(TestReader, testUpcastIntDict) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams, false);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      FlatMapContext::nonFlatMapContext());
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1009,7 +1018,10 @@ TEST(TestReader, testUpcastFloat) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams, false);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      FlatMapContext::nonFlatMapContext());
 
   VectorPtr batch;
   reader->next(100, batch);


### PR DESCRIPTION
Summary: Templatize byte column reader types and fully remove the intermediate node type.

Differential Revision: D32868569

