### PR TITLE
Add gitattributes to Velox external code

### DIFF
--- a/velox/.gitattributes
+++ b/velox/.gitattributes
@@ -1,2 +1,12 @@
-external/*       -diff -merge
-external/*       linguist-vendored=true
+external/**                 -diff -merge
+external/**                 linguist-vendored=true
+external/date/*             -diff -merge
+external/date/*             linguist-vendored=true
+external/duckdb/**          -diff -merge
+external/duckdb/**          linguist-vendored=true
+external/duckdb/tpch/**     -diff -merge
+external/duckdb/tpch/**     linguist-vendored=true
+external/md5/*              -diff -merge
+external/md5/*              linguist-vendored=true
+external/utf8proc/*         -diff -merge
+external/utf8proc/*         linguist-vendored=true

--- a/velox/.gitattributes
+++ b/velox/.gitattributes
@@ -1,0 +1,2 @@
+external/*       -diff -merge
+external/*       linguist-vendored=true


### PR DESCRIPTION
We should ideally not count generated, vendored code towards the project language statistics. gitattributes can be used to indicate such generated and vendored code. see https://github.com/github/linguist/blob/master/docs/overrides.md
In the Velox project, the whole `external` directory seems to be vendored.