### PR TITLE
Fix ScanSpec init for structs in list/map

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -67,23 +67,55 @@ namespace {
 static void makeFieldSpecs(
     const std::string& pathPrefix,
     int32_t level,
-    const std::shared_ptr<const RowType>& type,
+    const TypePtr& type,
     common::ScanSpec* spec) {
-  for (auto i = 0; i < type->size(); ++i) {
-    std::string path =
-        level == 0 ? type->nameOf(i) : pathPrefix + "." + type->nameOf(i);
-    common::Subfield subfield(path);
-    common::ScanSpec* fieldSpec = spec->getOrCreateChild(subfield);
+  constexpr int32_t kNoChannel = -1;
+  auto makeNestedSpec = [&](const std::string& name, int32_t channel) {
+    std::string path = level == 0 ? name : pathPrefix + "." + name;
+    auto fieldSpec = spec->getOrCreateChild(common::Subfield(path));
     fieldSpec->setProjectOut(true);
-    fieldSpec->setChannel(i);
-    auto fieldType = type->childAt(i);
-    if (fieldType->kind() == TypeKind::ROW) {
-      makeFieldSpecs(
-          path,
-          level + 1,
-          std::static_pointer_cast<const RowType>(fieldType),
-          spec);
+    if (channel != kNoChannel) {
+      fieldSpec->setChannel(channel);
     }
+    return path;
+  };
+
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      auto rowType = type->as<TypeKind::ROW>();
+      for (auto i = 0; i < type->size(); ++i) {
+        makeFieldSpecs(
+            makeNestedSpec(rowType.nameOf(i), i),
+            level + 1,
+            type->childAt(i),
+            spec);
+      }
+      break;
+    }
+    case TypeKind::MAP: {
+      makeFieldSpecs(
+          makeNestedSpec("keys", kNoChannel),
+          level + 1,
+          type->childAt(0),
+          spec);
+      makeFieldSpecs(
+          makeNestedSpec("elements", kNoChannel),
+          level + 1,
+          type->childAt(1),
+          spec);
+      break;
+    }
+    case TypeKind::ARRAY: {
+      makeFieldSpecs(
+          makeNestedSpec("elements", kNoChannel),
+          level + 1,
+          type->childAt(0),
+          spec);
+      break;
+    }
+
+    default:
+      break;
   }
 }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1735,6 +1735,52 @@ TEST_P(TableScanTest, structLazy) {
   assertQuery(op, {filePath}, "select c0 % 3 from tmp");
 }
 
+TEST_P(TableScanTest, structInArrayOrMap) {
+  vector_size_t size = 1'000;
+
+  auto rowNumbers = makeFlatVector<int64_t>(size, [](auto row) { return row; });
+  auto innerRow = makeRowVector({rowNumbers});
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(size, pool_.get());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  std::iota(rawOffsets, rawOffsets + size, 0);
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(size, pool_.get(), 1);
+  auto rowVector = makeRowVector(
+      {rowNumbers,
+       rowNumbers,
+       std::make_shared<MapVector>(
+           pool_.get(),
+           MAP(BIGINT(), innerRow->type()),
+           BufferPtr(nullptr),
+           size,
+           offsets,
+           sizes,
+           makeFlatVector<int64_t>(size, [](int32_t /*row*/) { return 1; }),
+           innerRow),
+       std::make_shared<ArrayVector>(
+           pool_.get(),
+           ARRAY(innerRow->type()),
+           BufferPtr(nullptr),
+           size,
+           offsets,
+           sizes,
+           innerRow)});
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, {rowVector});
+
+  // Exclude struct columns as DuckDB doesn't support complex types yet.
+  createDuckDbTable(
+      {makeRowVector({rowVector->childAt(0), rowVector->childAt(1)})});
+
+  auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
+  auto op = PlanBuilder()
+                .tableScan(rowType)
+                .project({"c2[1].c0", "c3[1].c0"})
+                .planNode();
+
+  assertQuery(op, {filePath}, "select c0, c0 from tmp");
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     TableScanTests,
     TableScanTest,


### PR DESCRIPTION
All columns of nested structs need to be projected out and therefore
need to have a ScanSpec.  This ScanSpec will be pruned by subfield
pruning as a next step.