### PR TITLE
Add aggregate function signatures to the registry

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -18,6 +18,7 @@
 #include <velox/exec/Aggregate.h>
 #include <velox/exec/HashPartitionFunction.h>
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/expression/SignatureBinder.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 
@@ -171,6 +172,24 @@ TypePtr nameToType() {
   return CppToType<T>::create();
 }
 
+TypePtr resolveAggregateType(
+    const std::string& aggregateName,
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& rawInputTypes) {
+  if (auto signatures = exec::getAggregateFunctionSignatures(aggregateName)) {
+    for (const auto& signature : signatures.value()) {
+      exec::SignatureBinder binder(*signature, rawInputTypes);
+      if (binder.tryBind()) {
+        return binder.tryResolveType(
+            exec::isPartialOutput(step) ? signature->intermediateType()
+                                        : signature->returnType());
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 class AggregateTypeResolver {
  public:
   explicit AggregateTypeResolver(core::AggregationNode::Step step)
@@ -203,6 +222,15 @@ class AggregateTypeResolver {
     }
 
     auto functionName = expr->getFunctionName();
+
+    // Use raw input types (if available) to resolve intermediate and final
+    // result types.
+    if (exec::isRawInput(step_)) {
+      if (auto type = resolveAggregateType(functionName, step_, types)) {
+        return type;
+      }
+    }
+
     auto aggregate =
         exec::Aggregate::create(functionName, step_, types, UNKNOWN());
     if (aggregate) {
@@ -217,6 +245,63 @@ class AggregateTypeResolver {
 };
 
 } // namespace
+
+PlanBuilder& PlanBuilder::finalAggregation() {
+  // Current plan node must be a partial aggregation.
+  auto* aggNode = dynamic_cast<core::AggregationNode*>(planNode_.get());
+  VELOX_CHECK_NOT_NULL(
+      aggNode, "Current plan node must be a partial aggregation.");
+
+  VELOX_CHECK(exec::isRawInput(aggNode->step()));
+  VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
+
+  auto step = core::AggregationNode::Step::kFinal;
+
+  // Create final aggregation using same grouping keys and same aggregate
+  // function names.
+  const auto& aggregates = aggNode->aggregates();
+  const auto& groupingKeys = aggNode->groupingKeys();
+
+  auto numAggregates = aggregates.size();
+  auto numGroupingKeys = groupingKeys.size();
+
+  auto names = makeNames("a", numAggregates);
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> masks(
+      numAggregates);
+
+  std::vector<std::shared_ptr<const core::CallTypedExpr>> finalAggregates;
+  finalAggregates.reserve(numAggregates);
+  for (auto i = 0; i < numAggregates; i++) {
+    // Resolve final aggregation result type using raw input types for the
+    // partial aggregation.
+    auto name = aggregates[i]->name();
+    auto rawInputs = aggregates[i]->inputs();
+
+    std::vector<TypePtr> rawInputTypes;
+    for (auto& rawInput : rawInputs) {
+      rawInputTypes.push_back(rawInput->type());
+    }
+
+    auto type = resolveAggregateType(name, step, rawInputTypes);
+    VELOX_CHECK_NOT_NULL(
+        type, "Failed to resolve result type for aggregate function {}", name);
+    std::vector<std::shared_ptr<const core::ITypedExpr>> inputs = {
+        field(numGroupingKeys + i)};
+    finalAggregates.emplace_back(
+        std::make_shared<core::CallTypedExpr>(type, std::move(inputs), name));
+  }
+
+  planNode_ = std::make_shared<core::AggregationNode>(
+      nextPlanNodeId(),
+      step,
+      groupingKeys,
+      names,
+      finalAggregates,
+      masks,
+      aggNode->ignoreNullKeys(),
+      planNode_);
+  return *this;
+}
 
 PlanBuilder& PlanBuilder::aggregation(
     const std::vector<ChannelIndex>& groupingKeys,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -80,6 +80,10 @@ class PlanBuilder {
         resultTypes);
   }
 
+  /// Add final aggregation plan node to match the current partial aggregation
+  /// node. Should be called directly after partialAggregation() method.
+  PlanBuilder& finalAggregation();
+
   // @param resultTypes Optional list of result types for the aggregates. Use it
   // to specify the result types for aggregates which cannot infer result type
   // solely from the types of the intermediate results.

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -183,4 +183,16 @@ std::shared_ptr<FunctionSignature> FunctionSignatureBuilder::build() {
       variableArity_);
 }
 
+std::shared_ptr<AggregateFunctionSignature>
+AggregateFunctionSignatureBuilder::build() {
+  VELOX_CHECK(returnType_.has_value());
+  VELOX_CHECK(intermediateType_.has_value());
+  return std::make_shared<AggregateFunctionSignature>(
+      std::move(typeVariableConstants_),
+      returnType_.value(),
+      intermediateType_.value(),
+      std::move(argumentTypes_),
+      variableArity_);
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -130,7 +130,7 @@ class VectorAdapterFactory {
   virtual const TypePtr returnType() const = 0;
 };
 
-/// Returns a list of signatures supposed by VectorFunction with the specified
+/// Returns a list of signatures supported by VectorFunction with the specified
 /// name. Returns std::nullopt if there is no function with the specified name.
 std::optional<std::vector<std::shared_ptr<FunctionSignature>>>
 getVectorFunctionSignatures(const std::string& name);

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -27,17 +27,13 @@ class CovarianceAggregationTest
  protected:
   void testGroupBy(const std::string& aggName, const RowVectorPtr& data) {
     auto partialAgg = fmt::format("{}(c1, c2)", aggName);
-    auto finalAgg = fmt::format("{}(a0)", aggName);
     auto sql = fmt::format(
         "SELECT c0, round({}(c1, c2), 2) FROM tmp GROUP BY 1", aggName);
-
-    // DOUBLE inputs produce DOUBLE results. REAL inputs produce REAL results.
-    auto finalResultType = data->childAt(1)->type();
 
     auto op = PlanBuilder()
                   .values({data})
                   .partialAggregation({0}, {partialAgg})
-                  .finalAggregation({0}, {finalAgg}, {finalResultType})
+                  .finalAggregation()
                   .project({"c0", "round(a0, cast(2 as integer))"})
                   .planNode();
 
@@ -45,7 +41,7 @@ class CovarianceAggregationTest
 
     op = PlanBuilder()
              .values({data})
-             .singleAggregation({0}, {partialAgg}, {finalResultType})
+             .singleAggregation({0}, {partialAgg})
              .project({"c0", "round(a0, cast(2 as integer))"})
              .planNode();
 
@@ -54,16 +50,12 @@ class CovarianceAggregationTest
 
   void testGlobalAgg(const std::string& aggName, const RowVectorPtr& data) {
     auto partialAgg = fmt::format("{}(c1, c2)", aggName);
-    auto finalAgg = fmt::format("{}(a0)", aggName);
     auto sql = fmt::format("SELECT round({}(c1, c2), 2) FROM tmp", aggName);
-
-    // DOUBLE inputs produce DOUBLE results. REAL inputs produce REAL results.
-    auto finalResultType = data->childAt(1)->type();
 
     auto op = PlanBuilder()
                   .values({data})
                   .partialAggregation({}, {partialAgg})
-                  .finalAggregation({}, {finalAgg}, {finalResultType})
+                  .finalAggregation()
                   .project({"round(a0, cast(2 as integer))"})
                   .planNode();
 
@@ -71,7 +63,7 @@ class CovarianceAggregationTest
 
     op = PlanBuilder()
              .values({data})
-             .singleAggregation({}, {partialAgg}, {finalResultType})
+             .singleAggregation({}, {partialAgg})
              .project({"round(a0, cast(2 as integer))"})
              .planNode();
 


### PR DESCRIPTION
Introduce new registry for aggregate functions. Each function is identified by the name, specifies a list of signatures it supports and provides a function function to create an instance for execution.

Migrate corr, covar_samp and covar_pop aggregate functions to the new registry.

Update PlanBuilder to use the signatures in the new registry to resolve intermediate and final result types for aggregate functions. Introduce a new PlanBuilder::finalAggregate() method to simplify adding matching final aggregation on top of a partial aggregation. Simplify tests for corr, covar_samp and covar_pop aggregate functions to use the new method.

Update aggregate function lookup to check the new registry first, then check legacy registry if not found.

I plan to migrate all of aggregate functions one by one or in small batches in a series of follow-up PRs to keep each PR small-ish. I also plan to remove the legacy registry after all aggregate functions are migrated.