### PR TITLE
Fix: Set not nulls in vector adapter.

### DIFF
--- a/velox/expression/VectorFunctionAdapter.h
+++ b/velox/expression/VectorFunctionAdapter.h
@@ -251,6 +251,13 @@ class VectorAdapter : public VectorFunction {
               nn = applyContext.result->mutableRawNulls();
             }
             bits::setNull(nn, row);
+          } else {
+            if (applyContext.result->rawNulls()) {
+              if (!nn) {
+                nn = applyContext.result->mutableRawNulls();
+              }
+              bits::clearNull(nn, row);
+            }
           }
         });
       } else {
@@ -261,6 +268,13 @@ class VectorAdapter : public VectorFunction {
               nn = applyContext.result->mutableRawNulls();
             }
             bits::setNull(nn, row);
+          } else {
+            if (applyContext.result->rawNulls()) {
+              if (!nn) {
+                nn = applyContext.result->mutableRawNulls();
+              }
+              bits::clearNull(nn, row);
+            }
           }
         });
       }

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -114,6 +114,7 @@ struct VectorWriter {
     // in future, we want to eliminate this so all writes go directly to their
     // slice.
     data_[offset_] = data;
+    vector_->setNull(offset_, false);
   }
 
   void commitNull() {
@@ -124,6 +125,8 @@ struct VectorWriter {
     // this code path is called when the slice is top-level
     if (!isSet) {
       vector_->setNull(offset_, true);
+    } else {
+      vector_->setNull(offset_, false);
     }
   }
 
@@ -214,6 +217,7 @@ struct VectorWriter<Map<K, V>> {
       }
       ++childSize;
     }
+    vector_->setNull(offset_, false);
   }
 
   void commitNull() {
@@ -376,6 +380,7 @@ struct VectorWriter<Array<V>> {
         childWriter_.commitNull();
       }
     }
+    vector_->setNull(offset_, false);
   }
 
   void commitNull() {

--- a/velox/expression/tests/SimpleFunctionPrestNullsTest.cpp
+++ b/velox/expression/tests/SimpleFunctionPrestNullsTest.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <type_traits>
+#include "velox/expression/Expr.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/StringView.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox {
+namespace {
+
+class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
+  // Helper class to create the test function for type T.
+  template <typename T>
+  struct TestFunction {
+    template <typename ExecEnv>
+    struct udf {
+      VELOX_DEFINE_FUNCTION_TYPES(ExecEnv);
+      bool call(out_type<T>& out, const arg_type<T>& in) {
+        if constexpr (std::is_same<T, Varchar>::value) {
+          out.setEmpty();
+        } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+          out.append({1});
+        } else {
+          out = in;
+        }
+        return true;
+      }
+    };
+
+    static void registerUdf() {
+      registerFunction<udf, T, T>({"func"});
+    }
+  };
+
+ protected:
+  // Create vector of type T as input with arbitrary data.
+  template <typename T>
+  RowVectorPtr createInput(vector_size_t size) {
+    if constexpr (std::is_same<T, Varchar>::value) {
+      auto flatInput = makeFlatVector<StringView>(size);
+
+      for (auto i = 0; i < flatInput->size(); i++) {
+        flatInput->set(i, "test"_sv);
+      }
+      return makeRowVector({flatInput});
+    } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+      std::vector<std::vector<int64_t>> arrayData{(unsigned int)size, {1}};
+      auto input = vectorMaker_.arrayVector(arrayData);
+      return makeRowVector({input});
+    } else {
+      auto flatInput = makeFlatVector<T>(size);
+      for (auto i = 0; i < flatInput->size(); i++) {
+        flatInput->set(i, T());
+      }
+      return makeRowVector({flatInput});
+    }
+  }
+
+  // Create result vector for type T, and preset nulls to true.
+  template <typename T>
+  VectorPtr createResults(vector_size_t size) {
+    VectorPtr result;
+    if constexpr (std::is_same<T, Varchar>::value) {
+      result = makeFlatVector<StringView>(size);
+    } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+      std::vector<std::vector<int64_t>> arrayData{(unsigned int)size, {1}};
+      result = vectorMaker_.arrayVector(arrayData);
+    } else {
+      result = makeFlatVector<T>(size);
+    }
+
+    for (auto i = 0; i < result->size(); i++) {
+      result->setNull(i, true);
+    }
+    return result;
+  }
+
+  template <typename T>
+  void test(vector_size_t size = 10) {
+    TestFunction<T>::registerUdf();
+    SelectivityVector rows;
+    rows.resize(size);
+    rows.setAll();
+
+    auto input = createInput<T>(size);
+    auto result = createResults<T>(size);
+    evaluate<SimpleVector<T>>("func(c0)", input, rows, result);
+    auto expectedResult = evaluate("func(c0)", input);
+
+    assertEqualVectors(result, expectedResult);
+  }
+};
+
+TEST_F(SimpleFunctionPresetNullsTest, primitivesOutput) {
+  test<int64_t>();
+  test<double>();
+  test<int32_t>();
+  test<float>();
+}
+
+TEST_F(SimpleFunctionPresetNullsTest, boolOutput) {
+  test<bool>();
+}
+
+TEST_F(SimpleFunctionPresetNullsTest, stringOutput) {
+  test<Varchar>();
+}
+
+TEST_F(SimpleFunctionPresetNullsTest, arrayOutput) {
+  test<Array<int64_t>>();
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -16,8 +16,12 @@
 
 #include "glog/logging.h"
 #include "gtest/gtest.h"
+#include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace {
 


### PR DESCRIPTION
Summary:
Its not safe to set nullability only when the the output is not null.
it should always be set in general.

This adds runtime overhead, we should think about how to optimize
it, but this diff makes it not buggy.

Differential Revision: D32961810

