### PR TITLE
Rename concatrow to row_constructor

### DIFF
--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -230,7 +230,7 @@ TEST_F(FilterProjectTest, dereference) {
   auto plan = PlanBuilder()
                   .values(vectors)
                   .project(
-                      std::vector<std::string>{"concatRow(c1, c2)"},
+                      std::vector<std::string>{"row_constructor(c1, c2)"},
                       std::vector<std::string>{"c1_c2"})
                   .project(std::vector<std::string>{"c1_c2.c1", "c1_c2.c2"})
                   .planNode();
@@ -239,7 +239,7 @@ TEST_F(FilterProjectTest, dereference) {
   plan = PlanBuilder()
              .values(vectors)
              .project(
-                 std::vector<std::string>{"concatRow(c1, c2)"},
+                 std::vector<std::string>{"row_constructor(c1, c2)"},
                  std::vector<std::string>{"c1_c2"})
              .filter("c1_c2.c1 % 10 = 5")
              .project(std::vector<std::string>{"c1_c2.c1", "c1_c2.c2"})

--- a/velox/exec/tests/utils/FunctionUtils.cpp
+++ b/velox/exec/tests/utils/FunctionUtils.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<const Type> resolveType(
   }
 
   // TODO Replace with struct_pack
-  if (expr->getFunctionName() == "concatrow") {
+  if (expr->getFunctionName() == "row_constructor") {
     auto numInput = inputs.size();
     std::vector<TypePtr> types(numInput);
     std::vector<std::string> names(numInput);

--- a/velox/experimental/codegen/code_generator/ExprCodeGenerator.cpp
+++ b/velox/experimental/codegen/code_generator/ExprCodeGenerator.cpp
@@ -134,7 +134,7 @@ CodegenASTNode ExprCodeGenerator::convertVeloxExpressionToCodegenAST(
   if (auto callExpr =
           std::dynamic_pointer_cast<const core::CallTypedExpr>(node)) {
     // Make row expression
-    if (callExpr->name() == "concatRow") {
+    if (callExpr->name() == "row_constructor") {
       return std::make_shared<codegen::MakeRowExpression>(
           node->type(), codegenInputs);
     }

--- a/velox/experimental/codegen/code_generator/tests/ArithmeticFunctionsTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/ArithmeticFunctionsTest.cpp
@@ -205,7 +205,7 @@ TEST_F(ArithmeticFunctionsTest, complexExpression) {
     evaluateAndCompare<
         RowTypeTrait<TypeKind::BIGINT, TypeKind::BIGINT, TypeKind::BIGINT>,
         RowTypeTrait<TypeKind::BIGINT, TypeKind::BIGINT, TypeKind::BIGINT>>(
-        "concatRow(C0+C2, C0*C1, C2-C1+10)",
+        "row_constructor(C0+C2, C0*C1, C2-C1+10)",
         {{1, 2, 3}, {2, 3, 4}, {3, 5, std::nullopt}},
         {{4, 2, 11}, {6, 6, 11}, {std::nullopt, 15, std::nullopt}});
   };

--- a/velox/experimental/codegen/code_generator/tests/BasicExprCodeGeneratorTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/BasicExprCodeGeneratorTest.cpp
@@ -42,14 +42,14 @@ TEST_F(CodegenBasicExprTest, testInputRef) {
   evaluateAndCompare<
       RowTypeTrait<TypeKind::BIGINT, TypeKind::DOUBLE>,
       RowTypeTrait<TypeKind::BIGINT, TypeKind::DOUBLE>>(
-      "concatRow(C0, C1)",
+      "row_constructor(C0, C1)",
       {{1, 1.2}, {2, 1.3}, {3, 1.4}},
       {{1, 1.2}, {2, 1.3}, {3, 1.4}});
 
   evaluateAndCompare<
       RowTypeTrait<TypeKind::BIGINT, TypeKind::DOUBLE>,
       RowTypeTrait<TypeKind::BIGINT, TypeKind::DOUBLE, TypeKind::BIGINT>>(
-      "concatRow(C0, C1, C0)",
+      "row_constructor(C0, C1, C0)",
       {{std::nullopt, 1.2}, {2, 1.3}, {3, 1.4}},
       {{std::nullopt, 1.2, std::nullopt}, {2, 1.3, 2}, {3, 1.4, 3}});
 }

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -559,7 +559,7 @@ class ExpressionCodegenTestBase : public testing::Test {
 
     if (auto callExpr =
             std::dynamic_pointer_cast<const core::CallTypedExpr>(typedExpr)) {
-      if (callExpr->name() == "concatrow") {
+      if (callExpr->name() == "row_constructor") {
         std::vector<std::string> names;
         for (auto i = 0; i < typedExpr->inputs().size(); i++) {
           names.push_back(fmt::format("c{}", names.size()));

--- a/velox/experimental/codegen/code_generator/tests/StringExpressionsTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/StringExpressionsTest.cpp
@@ -41,7 +41,7 @@ TEST_F(StringExprTest, ifString) {
   evaluateAndCompare<
       RowTypeTrait<TypeKind::VARCHAR, TypeKind::VARCHAR>,
       RowTypeTrait<TypeKind::VARCHAR, TypeKind::VARCHAR>>(
-      "concatRow(C0,C1)",
+      "row_constructor(C0,C1)",
       {{StringView("one"), StringView("two")},
        {StringView("one"), StringView("two")},
        {StringView("one"), StringView("two")}});

--- a/velox/functions/prestosql/coverage/Coverage.cpp
+++ b/velox/functions/prestosql/coverage/Coverage.cpp
@@ -255,8 +255,7 @@ void printCoverageMap(
 /// Returns alphabetically sorted list of scalar functions available in Velox.
 std::vector<std::string> getSortedScalarNames() {
   // Do not print "internal" functions.
-  static const std::unordered_set<std::string> kBlockList = {
-      "ROW", "concatRow", "concatrow"};
+  static const std::unordered_set<std::string> kBlockList = {"row_constructor"};
 
   auto functions = getFunctionSignatures();
 

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -27,10 +27,7 @@ void registerGeneralFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_in, "in");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_cardinality, "cardinality");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, "filter");
-  // TODO Fix Koski parser and clean this up.
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "ROW");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "concatRow");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "concatrow");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "row_constructor");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_least, "least");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_greatest, "greatest");


### PR DESCRIPTION
Replace ROW, concatrow and concatRow with row_constructor. The choice of name is motivated by an existing array_constructor function and ROW_CONSTRUCTOR special form in Presto