### PR TITLE
Modify SkipNullsIterator to wrap another Iterator

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -70,6 +70,18 @@ class IndexBasedIterator {
     return index_ < rhs.index_;
   }
 
+  bool operator>(const Iterator& rhs) const {
+    return index_ > rhs.index_;
+  }
+
+  bool operator<=(const Iterator& rhs) const {
+    return index_ <= rhs.index_;
+  }
+
+  bool operator>=(const Iterator& rhs) const {
+    return index_ >= rhs.index_;
+  }
+
   // Implement post increment.
   Iterator operator++(int) {
     Iterator old = *this;
@@ -87,41 +99,42 @@ class IndexBasedIterator {
   vector_size_t index_;
 };
 
-// Implements an iterator for values stored in the reader T
-// that skip nulls and provides direct access to the value.
-template <typename T>
-class SkipNullsIterator;
-
-template <typename T>
+// Implements an iterator for values that skips nulls and provides direct access
+// to those values by wrapping another iterator of type BaseIterator.
+//
+// BaseIterator must implement the following functions:
+//   hasValue() : Returns whether the current value pointed at by the iterator
+//                is a null.
+//   value()    : Returns the non-null value pointed at by the iterator.
+template <typename BaseIterator>
 class SkipNullsIterator {
-  using Iterator = SkipNullsIterator<T>;
+  using Iterator = SkipNullsIterator<BaseIterator>;
   using iterator_category = std::input_iterator_tag;
-  using value_type = typename T::exec_in_t;
+  using value_type = typename std::result_of<decltype (&BaseIterator::value)(
+      BaseIterator)>::type;
   using difference_type = int;
   using pointer = PointerWrapper<value_type>;
-  using reference = T;
+  using reference = value_type;
 
  public:
-  SkipNullsIterator<T>(
-      const T* reader,
-      vector_size_t index,
-      vector_size_t lasIndex)
-      : reader_(reader), index_(index), endIndex_(lasIndex) {}
+  SkipNullsIterator<BaseIterator>(
+      const BaseIterator& begin,
+      const BaseIterator& end)
+      : iter_(begin), end_(end) {}
 
   // Given an element, return an iterator to the first not-null element starting
   // from the element itself.
   static Iterator initialize(
-      const T* reader_,
-      vector_size_t startIndex,
-      vector_size_t endIndex) {
-    auto it = Iterator{reader_, startIndex, endIndex};
+      const BaseIterator& begin,
+      const BaseIterator& end) {
+    auto it = Iterator{begin, end};
 
     // The container is empty.
-    if (startIndex >= endIndex) {
+    if (begin >= end) {
       return it;
     }
 
-    if (reader_->isSet(startIndex)) {
+    if (begin.hasValue()) {
       return it;
     }
 
@@ -131,24 +144,24 @@ class SkipNullsIterator {
   }
 
   value_type operator*() const {
-    // Always return a copy, its guaranteed to be cheap object.
-    return reader_->operator[](index_);
+    // Always return a copy, it's guaranteed to be cheap object.
+    return iter_.value();
   }
 
   PointerWrapper<value_type> operator->() const {
-    return PointerWrapper(reader_->operator[](index_));
+    return PointerWrapper(iter_.value());
   }
 
   bool operator<(const Iterator& rhs) const {
-    return index_ < rhs.index_;
+    return iter_ < rhs.iter_;
   }
 
   bool operator!=(const Iterator& rhs) const {
-    return index_ != rhs.index_;
+    return iter_ != rhs.iter_;
   }
 
   bool operator==(const Iterator& rhs) const {
-    return index_ == rhs.index_;
+    return iter_ == rhs.iter_;
   }
 
   // Implement post increment.
@@ -160,21 +173,20 @@ class SkipNullsIterator {
 
   // Implement pre increment.
   Iterator& operator++() {
-    index_++;
-    while (index_ != endIndex_) {
-      if (reader_->isSet(index_)) {
+    iter_++;
+    while (iter_ != end_) {
+      if (iter_.hasValue()) {
         break;
       }
-      index_++;
+      iter_++;
     }
     return *this;
   }
 
  private:
-  const T* reader_;
-  vector_size_t index_;
-  // First index outside the container.
-  vector_size_t endIndex_;
+  BaseIterator iter_;
+  // Iterator pointing just beyond the range to expose.
+  const BaseIterator end_;
 };
 
 // TODO: evaluate wrapping primitives with lazy access using benchmarks
@@ -387,7 +399,7 @@ class ArrayView {
       return Element{reader_, this->index_};
     }
 
-   private:
+   protected:
     const reader_t* reader_;
   };
 
@@ -400,17 +412,35 @@ class ArrayView {
   }
 
   struct SkipNullsContainer {
-    using Iterator = SkipNullsIterator<reader_t>;
+    class SkipNullsBaseIterator : public Iterator {
+     public:
+      SkipNullsBaseIterator(const reader_t* reader, vector_size_t index)
+          : Iterator(reader, index) {}
+
+      bool hasValue() const {
+        return this->reader_->isSet(this->index_);
+      }
+
+      element_t value() const {
+        return (*this->reader_)[this->index_];
+      }
+    };
+
     explicit SkipNullsContainer(const ArrayView* array_) : array_(array_) {}
 
-    Iterator begin() {
-      auto endIndex = array_->offset_ + array_->size_;
-      return Iterator::initialize(array_->reader_, array_->offset_, endIndex);
+    SkipNullsIterator<SkipNullsBaseIterator> begin() {
+      return SkipNullsIterator<SkipNullsBaseIterator>::initialize(
+          SkipNullsBaseIterator{array_->reader_, array_->offset_},
+          SkipNullsBaseIterator{
+              array_->reader_, array_->offset_ + array_->size_});
     }
 
-    Iterator end() {
-      auto endIndex = array_->offset_ + array_->size_;
-      return Iterator{array_->reader_, endIndex, endIndex};
+    SkipNullsIterator<SkipNullsBaseIterator> end() {
+      return SkipNullsIterator<SkipNullsBaseIterator>{
+          SkipNullsBaseIterator{
+              array_->reader_, array_->offset_ + array_->size_},
+          SkipNullsBaseIterator{
+              array_->reader_, array_->offset_ + array_->size_}};
     }
 
    private:
@@ -435,7 +465,7 @@ class ArrayView {
     return size_;
   }
 
-  SkipNullsContainer skipNulls() {
+  SkipNullsContainer skipNulls() const {
     return SkipNullsContainer{this};
   }
 

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -132,6 +132,39 @@ struct ArrayMinSimpleFunctionIterator {
   }
 };
 
+// Returns the minimum value in an array ignoring nulls.
+// The point of this is to exercise SkipNullsIterator.
+template <typename T>
+struct ArrayMinSimpleFunctionSkipNullIterator {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& out,
+      const arg_type<Array<TInput>>& array) {
+    const auto size = array.size();
+    if (size == 0) {
+      return false; // NULL
+    }
+
+    bool hasValue = false;
+    auto min = INT32_MAX;
+    for (const auto& item : array.skipNulls()) {
+      hasValue = true;
+      if (item < min) {
+        min = item;
+      }
+    }
+
+    if (!hasValue) {
+      return false;
+    }
+
+    out = min;
+    return true;
+  }
+};
+
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_array_min_basic,
     functions::signatures(),
@@ -147,6 +180,10 @@ class ArrayMinMaxBenchmark : public functions::test::FunctionBenchmarkBase {
         {"array_min_simple"});
     registerFunction<ArrayMinSimpleFunctionIterator, int32_t, Array<int32_t>>(
         {"array_min_simple_iterator"});
+    registerFunction<
+        ArrayMinSimpleFunctionSkipNullIterator,
+        int32_t,
+        Array<int32_t>>({"array_min_simple_skip_null_iterator"});
   }
 
   RowVectorPtr makeData() {
@@ -210,6 +247,11 @@ BENCHMARK_RELATIVE(vectorMinIntegerNoFastPath) {
 BENCHMARK_RELATIVE(simpleMinIntegerIterator) {
   ArrayMinMaxBenchmark benchmark;
   benchmark.runInteger("array_min_simple_iterator");
+}
+
+BENCHMARK_RELATIVE(simpleMinIntegerSkipNullIterator) {
+  ArrayMinMaxBenchmark benchmark;
+  benchmark.runInteger("array_min_simple_skip_null_iterator");
 }
 
 BENCHMARK_RELATIVE(simpleMinInteger) {


### PR DESCRIPTION
Summary:
Today SkipNullsIterator manages a reader_ and index directly, duplicating some of the work already done in IndexBasedIterator, its subclasses, and VectorOptionalValueAccessor.  This also makes it hard to share in cases like VariadicView which behave slightly differently.

By wrapping around the existing subclasses of IndexBasedIterator we can take advantage of the behavior they already provide reducing the duplication, and making it easier to reuse, since we already specialize those classes.

Note, for performance's sake, I further subclassed IndexBasedIterator and duplicated a small amount of code in SkipNullsBaseIterator.  This provides a fast path for accessing the value from the iterator, and checking if its null that avoids the overhead of creating VectorOptionalValueAccessor objects that showed a 20% regression in benchmarks.

Differential Revision: D32968719

