### PR TITLE
Fix ConstantVector::toString for complex types

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -821,7 +821,7 @@ BufferPtr MapVector::elementIndices() const {
 
 std::string MapVector::toString(vector_size_t index) const {
   if (isNullAt(index)) {
-    return "<null>";
+    return "null";
   }
   auto size = rawSizes_[index];
   if (size == 0) {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -309,7 +309,7 @@ class ConstantVector final : public SimpleVector<T> {
       return SimpleVector<T>::toString(index);
     }
 
-    return valueVector_->toString(index);
+    return valueVector_->toString(index_);
   }
 
  private:


### PR DESCRIPTION
Summary: toString() uses a wrong index.

Reviewed By: laithsakka

Differential Revision: D32972940

