### PR TITLE
Add support for partition key aliases to Hive Connector

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -181,11 +181,12 @@ class HiveDataSource : public DataSource {
       const std::optional<std::string>& value) const;
 
   const std::shared_ptr<const RowType> outputType_;
+  // Column handles for the partition key columns keyed on partition key column
+  // name.
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
-      columnHandles_;
+      partitionKeys_;
   FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
   velox::memory::MemoryPool* FOLLY_NONNULL pool_;
-  std::vector<std::string> regularColumns_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
   std::unique_ptr<dwrf::BufferedInputFactory> bufferedInputFactory_;
   std::unique_ptr<common::ScanSpec> scanSpec_;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -154,6 +154,8 @@ HiveConnectorTestBase::makeHiveSplits(
 std::shared_ptr<connector::hive::HiveConnectorSplit>
 HiveConnectorTestBase::makeHiveConnectorSplit(
     const std::string& filePath,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKeys,
     uint64_t start,
     uint64_t length) {
   return std::make_shared<connector::hive::HiveConnectorSplit>(
@@ -161,7 +163,8 @@ HiveConnectorTestBase::makeHiveConnectorSplit(
       "file:" + filePath,
       dwio::common::FileFormat::ORC,
       start,
-      length);
+      length,
+      partitionKeys);
 }
 
 exec::Split HiveConnectorTestBase::makeHiveSplit(

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -81,6 +81,16 @@ class HiveConnectorTestBase : public OperatorTestBase {
   makeHiveConnectorSplit(
       const std::string& filePath,
       uint64_t start = 0,
+      uint64_t length = std::numeric_limits<uint64_t>::max()) {
+    return makeHiveConnectorSplit(filePath, {}, 0, length);
+  }
+
+  static std::shared_ptr<connector::hive::HiveConnectorSplit>
+  makeHiveConnectorSplit(
+      const std::string& filePath,
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys,
+      uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max());
 
   static exec::Split makeHiveSplit(


### PR DESCRIPTION
Also, remove unused regularColumns_ member variable.