### PR TITLE
Migrate variance aggregate functions to the new registry

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -81,7 +81,9 @@ class PlanBuilder {
   }
 
   /// Add final aggregation plan node to match the current partial aggregation
-  /// node. Should be called directly after partialAggregation() method.
+  /// node. Should be called directly after partialAggregation() method or
+  /// directly after intermediateAggregation() that follows
+  /// partialAggregation().
   PlanBuilder& finalAggregation();
 
   // @param resultTypes Optional list of result types for the aggregates. Use it
@@ -99,6 +101,11 @@ class PlanBuilder {
         false,
         resultTypes);
   }
+
+  /// Add intermediate aggregation plan node to match the current partial
+  /// aggregation node. Should be called directly after partialAggregation()
+  /// method.
+  PlanBuilder& intermediateAggregation();
 
   PlanBuilder& intermediateAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
@@ -237,6 +244,10 @@ class PlanBuilder {
   std::shared_ptr<const core::FieldAccessTypedExpr> field(
       const RowTypePtr& outputType,
       int index);
+
+  std::shared_ptr<core::PlanNode> createIntermediateOrFinalAggregation(
+      core::AggregationNode::Step step,
+      const core::AggregationNode* partialAggNode);
 
   int planNodeId_;
   std::shared_ptr<core::PlanNode> planNode_;

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -79,7 +79,7 @@ TEST_F(VarianceAggregationTest, varianceConst) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c1), {0}(c2) FROM tmp", aggrName);
     assertQuery(agg, sql);
@@ -87,7 +87,7 @@ TEST_F(VarianceAggregationTest, varianceConst) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({0}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({0}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0, {0}(c1), {0}(c2) FROM tmp group by c0", aggrName);
@@ -96,7 +96,7 @@ TEST_F(VarianceAggregationTest, varianceConst) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c0")})
-              .finalAggregation({}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c0) FROM tmp", aggrName);
     assertQuery(agg, sql);
@@ -107,7 +107,7 @@ TEST_F(VarianceAggregationTest, varianceConst) {
                   std::vector<std::string>{"c0 % 2", "c0"},
                   std::vector<std::string>{"c0_mod_2", "c0"})
               .partialAggregation({0}, {GEN_AGG("c0")})
-              .finalAggregation({0}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT c0 % 2, {0}(c0) FROM tmp group by 1", aggrName);
     assertQuery(agg, sql);
@@ -137,7 +137,7 @@ TEST_F(VarianceAggregationTest, varianceConstNull) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c1), {0}(c2) FROM tmp", aggrName);
     assertQuery(agg, sql);
@@ -145,7 +145,7 @@ TEST_F(VarianceAggregationTest, varianceConstNull) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({0}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({0}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0, {0}(c1), {0}(c2) FROM tmp group by c0", aggrName);
@@ -154,7 +154,7 @@ TEST_F(VarianceAggregationTest, varianceConstNull) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c0")})
-              .finalAggregation({}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c0) FROM tmp", aggrName);
     assertQuery(agg, sql);
@@ -184,7 +184,7 @@ TEST_F(VarianceAggregationTest, varianceNulls) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c1), {0}(c2) FROM tmp", aggrName);
     assertQuery(agg, sql);
@@ -192,7 +192,7 @@ TEST_F(VarianceAggregationTest, varianceNulls) {
     agg = PlanBuilder()
               .values(vectors)
               .partialAggregation({0}, {GEN_AGG("c1"), GEN_AGG("c2")})
-              .finalAggregation({0}, {GEN_AGG("a0"), GEN_AGG("a1")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0, {0}(c1), {0}(c2) FROM tmp group by c0", aggrName);
@@ -213,9 +213,7 @@ TEST_F(VarianceAggregationTest, variance) {
               .partialAggregation(
                   {},
                   {GEN_AGG("c1"), GEN_AGG("c2"), GEN_AGG("c4"), GEN_AGG("c5")})
-              .finalAggregation(
-                  {},
-                  {GEN_AGG("a0"), GEN_AGG("a1"), GEN_AGG("a2"), GEN_AGG("a3")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT {0}(c1), {0}(c2), {0}(c4), {0}(c5) FROM tmp", aggrName);
@@ -236,12 +234,8 @@ TEST_F(VarianceAggregationTest, variance) {
               .partialAggregation(
                   {},
                   {GEN_AGG("c1"), GEN_AGG("c2"), GEN_AGG("c4"), GEN_AGG("c5")})
-              .intermediateAggregation(
-                  {},
-                  {GEN_AGG("a0"), GEN_AGG("a1"), GEN_AGG("a2"), GEN_AGG("a3")})
-              .finalAggregation(
-                  {},
-                  {GEN_AGG("a0"), GEN_AGG("a1"), GEN_AGG("a2"), GEN_AGG("a3")})
+              .intermediateAggregation()
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT {0}(c1), {0}(c2), {0}(c4), {0}(c5) FROM tmp", aggrName);
@@ -252,7 +246,7 @@ TEST_F(VarianceAggregationTest, variance) {
               .values(vectors)
               .filter("c0 % 2 = 5")
               .partialAggregation({}, {GEN_AGG("c0")})
-              .finalAggregation({}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c0) FROM tmp WHERE c0 % 2 = 5", aggrName);
     assertQuery(agg, sql);
@@ -262,7 +256,7 @@ TEST_F(VarianceAggregationTest, variance) {
               .values(vectors)
               .filter("c0 % 5 = 3")
               .partialAggregation({}, {GEN_AGG("c1")})
-              .finalAggregation({}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery("SELECT {0}(c1) FROM tmp WHERE c0 % 5 = 3", aggrName);
     assertQuery(agg, sql);
@@ -282,13 +276,7 @@ TEST_F(VarianceAggregationTest, variance) {
                    GEN_AGG("c3"),
                    GEN_AGG("c4"),
                    GEN_AGG("c5")})
-              .finalAggregation(
-                  {0},
-                  {GEN_AGG("a0"),
-                   GEN_AGG("a1"),
-                   GEN_AGG("a2"),
-                   GEN_AGG("a3"),
-                   GEN_AGG("a4")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0 % 10, {0}(c1), {0}(c2), {0}(c3::DOUBLE), {0}(c4), {0}(c5) "
@@ -331,20 +319,8 @@ TEST_F(VarianceAggregationTest, variance) {
                    GEN_AGG("c3"),
                    GEN_AGG("c4"),
                    GEN_AGG("c5")})
-              .intermediateAggregation(
-                  {0},
-                  {GEN_AGG("a0"),
-                   GEN_AGG("a1"),
-                   GEN_AGG("a2"),
-                   GEN_AGG("a3"),
-                   GEN_AGG("a4")})
-              .finalAggregation(
-                  {0},
-                  {GEN_AGG("a0"),
-                   GEN_AGG("a1"),
-                   GEN_AGG("a2"),
-                   GEN_AGG("a3"),
-                   GEN_AGG("a4")})
+              .intermediateAggregation()
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0 % 10, {0}(c1), {0}(c2), {0}(c3::DOUBLE), {0}(c4), {0}(c5) "
@@ -360,7 +336,7 @@ TEST_F(VarianceAggregationTest, variance) {
                   std::vector<std::string>{"c0_mod_10", "c1"})
               .filter("c0_mod_10 > 10")
               .partialAggregation({0}, {GEN_AGG("c1")})
-              .finalAggregation({0}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0 % 10, {0}(c1) FROM tmp WHERE c0 % 10 > 10 GROUP BY 1",
@@ -375,7 +351,7 @@ TEST_F(VarianceAggregationTest, variance) {
                   std::vector<std::string>{"c0 % 10", "c1"},
                   std::vector<std::string>{"c0_mod_10", "c1"})
               .partialAggregation({0}, {GEN_AGG("c1")})
-              .finalAggregation({0}, {GEN_AGG("a0")})
+              .finalAggregation()
               .planNode();
     sql = genAggrQuery(
         "SELECT c0 % 10, {0}(c1) FROM tmp WHERE c2 % 5 = 3 GROUP BY 1",


### PR DESCRIPTION
Provide static signatures for aggregate functions stddev, stddev_pop, stddev_samp, variance, var_pop, and var_sampl.

Introduce a new PlanBuilder::intermediateAggregate() method to simplify adding matching intermediate aggregation on top of a partial aggregation. Also, enhance the existing PlanBuilder::finalAggregate() to support being called on top of intermediateAggregation() following partialAggregation().