### PR TITLE
Add nested complex type support for array_intersect() Presto simple function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -10,6 +10,16 @@ Array Functions
         SELECT array_intersect(ARRAY [1, 2, 2], ARRAY[1, 1, 2]); -- [1, 2]
         SELECT array_intersect(ARRAY [1, NULL, NULL], ARRAY[1, 1, NULL]); -- [1, NULL]
 
+.. function:: array_intersect(array(array(E))) -> array(E)
+
+    Returns an array of the elements in the intersection of all arrays in the given array, without duplicates.
+    E must be coercible to double. Returns bigint if E is coercible to bigint. Otherwise, returns double. ::
+
+        SELECT array_intersect(ARRAY[ ARRAY [1, 2, 3], ARRAY[4, 5, 6]]); -- []
+        SELECT array_intersect(ARRAY[ ARRAY [1, 2, 2], ARRAY[0, 1, 1, 2], ARRAY[1, 1, 2, 3]]); -- [1, 2]
+        SELECT array_intersect(ARRAY[ ARRAY [1, NULL, NULL], ARRAY[1, 1, NULL]]); -- [1, NULL]
+
+
 .. function:: array_except(array(E) x, array(E) y) -> array(E)
 
     Returns an array of the elements in array ``x`` but not in array ``y``, without duplicates. ::

--- a/velox/functions/prestosql/ArrayIntersectWithComplexTypeFunction.h
+++ b/velox/functions/prestosql/ArrayIntersectWithComplexTypeFunction.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+template <typename T>
+struct ArrayIntersectWithComplexTypeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Array<int64_t>>& out,
+      const arg_type<Array<Array<int64_t>>>& in) {
+    return callByType<int64_t>(out, in);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Array<double>>& out,
+      const arg_type<Array<Array<double>>>& in) {
+    return callByType<double>(out, in);
+  }
+
+  template <typename U>
+  FOLLY_ALWAYS_INLINE bool callByType(
+      out_type<Array<U>>& out,
+      const arg_type<Array<Array<U>>>& in) {
+    std::unordered_set<U> intersectedSet;
+    bool hasNullFinal = false;
+    bool isInitialized = false;
+
+    if (in.size() == 1) {
+      // special case: if the size of input's innermost array is 1, no need to
+      // intersect, just return the only innermost array
+      for (const auto& element : *in[0]) {
+        out.append(std::optional<U>(element));
+      }
+      return true;
+    }
+
+    for (const auto& innerArrayViewPtr : in) {
+      if (!isInitialized) {
+        // 1. initialize the intersectedSet with values from the first innermost
+        // array
+        for (const auto& element : *innerArrayViewPtr) {
+          if (element) { // non-null, aka. has_value() is True
+            intersectedSet.insert(*element);
+          } else {
+            hasNullFinal = true;
+          }
+        }
+        isInitialized = true;
+      } else {
+        // 2. intersect each innermost array into the intersectedSet
+        bool hasNullTemp = false;
+        std::unordered_set<U> setToIntersect;
+        for (const auto& element : *innerArrayViewPtr) {
+          if (element) {
+            if (intersectedSet.count(*element) > 0) {
+              setToIntersect.insert(*element);
+            }
+          } else {
+            hasNullTemp = true;
+          }
+        }
+        intersectedSet = setToIntersect;
+        hasNullFinal &= hasNullTemp;
+      }
+    }
+
+    // 3. populate the result elements from set to the final output Array
+    if (hasNullFinal) {
+      out.append(std::nullopt);
+    }
+    for (const auto& element : intersectedSet) {
+      out.append(element);
+    }
+    // 3.1 ensuring output ordering
+    std::sort(out.begin(), out.end());
+
+    return true;
+  }
+};
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
* Adding nested complex type support for the array_intersect() in Velox

`array_intersect(array(array(T))`

> Returns array(bigint/double): an array of the elements in the intersection of all arrays in the given array, without duplicates. E must be coercible to double. Returns bigint if T is coercible to bigint. Otherwise, returns double.

See presto [doc](https://prestodb.io/docs/current/functions/array.html#id1)

For example:
```
select ARRAY_INTERSECT(ARRAY [ ARRAY [2, 3, 4, null], ARRAY [1, 2, 3, 3, null, null]])); -- ARRAY [null, 2, 3]
select ARRAY_INTERSECT(ARRAY [ ARRAY [1.0, 2.0, 3.0, 5.0], ARRAY [2.0, 3.0, 4.0, null], ARRAY [1.0, 2.0, 3.0]])); -- ARRAY [2.0, 3.0]
select ARRAY_INTERSECT(ARRAY [ ARRAY [1, 2, 3, 3, null, null]])); -- ARRAY [1, 2, 3, 3, null, null]
```

Diff: D32998850
