### PR TITLE
Add error message to VELOX_MEM_CAP_EXCEEDED

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -563,7 +563,7 @@ MemoryPoolImpl<Allocator, ALIGNMENT>::MemoryPoolImpl(
 template <typename Allocator, uint16_t ALIGNMENT>
 void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
   if (this->isMemoryCapped()) {
-    VELOX_MEM_CAP_EXCEEDED();
+    VELOX_MEM_CAP_EXCEEDED(cap_);
   }
   auto alignedSize = sizeAlign<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, size);
   reserve(alignedSize);
@@ -577,7 +577,7 @@ void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
   VELOX_USER_CHECK_EQ(sizeEach, 1);
   auto alignedSize = sizeAlign<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, numMembers);
   if (this->isMemoryCapped()) {
-    VELOX_MEM_CAP_EXCEEDED();
+    VELOX_MEM_CAP_EXCEEDED(cap_);
   }
   reserve(alignedSize * sizeEach);
   return allocator_.allocZeroFilled(alignedSize, sizeEach);
@@ -602,7 +602,7 @@ void* MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
       ALIGNER<ALIGNMENT>{}, p, alignedSize, alignedNewSize);
   if (UNLIKELY(!newP)) {
     free(p, alignedSize);
-    VELOX_MEM_CAP_EXCEEDED();
+    VELOX_MEM_CAP_EXCEEDED(cap_);
   }
 
   return newP;
@@ -758,7 +758,7 @@ void MemoryPoolImpl<Allocator, ALIGNMENT>::reserve(int64_t size) {
     // is low-pri because we can only have inflated aggregates, and be on the
     // more conservative side.
     release(size);
-    VELOX_MEM_CAP_EXCEEDED();
+    VELOX_MEM_CAP_EXCEEDED(cap_);
   }
 }
 

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -67,7 +67,7 @@ void MemoryUsageTracker::updateInternal(UsageType type, int64_t size) {
     usage(currentUsageInBytes_, type)
         .fetch_add(-size, std::memory_order_relaxed);
     checkNonNegativeSizes("after exceeding cap");
-    VELOX_MEM_CAP_EXCEEDED();
+    VELOX_MEM_CAP_EXCEEDED(usage(maxMemory_, type));
   }
 
   maySetMax(type, newPeak);

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -27,12 +27,14 @@
 namespace facebook::velox::memory {
 constexpr int64_t kMaxMemory = std::numeric_limits<int64_t>::max();
 
-#define VELOX_MEM_CAP_EXCEEDED()                                    \
+#define VELOX_MEM_CAP_EXCEEDED(cap)                                 \
   _VELOX_THROW(                                                     \
       ::facebook::velox::VeloxRuntimeError,                         \
       ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
       ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true);
+      /* isRetriable */ true,                                       \
+      "Exceeded memory cap of {} MB",                               \
+      (cap) / 1024 / 1024);
 
 struct MemoryUsageConfig {
   std::optional<int64_t> maxUserMemory;


### PR DESCRIPTION
Add error message which specified the cap exceeded in MB, e.g. Exceeded memory cap of 64 MB.