### PR TITLE
Fix DriverTest end of result set

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -584,6 +584,7 @@ void Task::terminate(TaskState terminalState) {
   for (auto& pair : oldBridges) {
     pair.second->cancel();
   }
+  std::lock_guard<std::mutex> l(mutex_);
   stateChangedLocked();
 }
 

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -148,6 +148,9 @@ bool TaskCursor::moveNext() {
   if (task_->error()) {
     std::rethrow_exception(task_->error());
   }
+  if (!current_) {
+    atEnd_ = true;
+  }
   return current_ != nullptr;
 }
 

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -90,7 +90,7 @@ class TaskCursor {
 
   ~TaskCursor() {
     queue_->close();
-    if (task_) {
+    if (task_ && !atEnd_) {
       task_->requestTerminate();
     }
   }
@@ -114,6 +114,7 @@ class TaskCursor {
   std::shared_ptr<exec::Task> task_;
   RowVectorPtr current_;
   static std::atomic<int32_t> serial_;
+  bool atEnd_{false};
 };
 
 class RowCursor {


### PR DESCRIPTION
DriverTest.pause and possibly other tests can be flaky so that the end
state of the task may not be kFinished and the final Driver count may
not be 0. The flakiness happens because destruction of TaskCursor
calls requestTerminate on the Task after the end of the result set. At
this time, there can b threds inside the Task. If so, these take an
error path to exit and may leave the state to be kCancelled or
kFailed.  The fix is to request terminate on the Task tat TaskCursor
destruction only if there is unread output. If all output is consumed,
the Task will go off thread and transit to kFinished in a short time.

To check that the end state is correct, we take a stateChangeFuture()
and wait for a non-running state, which is the official API for
listening to state changes.