### PR TITLE
Introduce FunctionRegistry for Signature based registration of Scalar/AdaptedVector Functions

### DIFF
--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+class FunctionSignature;
+
+template <typename Function>
+class FunctionRegistry {
+  using FunctionFactory = std::function<std::unique_ptr<Function>()>;
+  using FunctionEntry =
+      std::unordered_map<std::shared_ptr<FunctionSignature>, FunctionFactory>;
+  using FunctionMap = std::unordered_map<std::string, FunctionEntry>;
+
+ public:
+  template <typename UDF>
+  void registerFunction(
+      const std::vector<std::string>& aliases = {},
+      std::shared_ptr<const Type> returnType = nullptr) {
+    auto metadata =
+        GetSingletonUdfMetadata<typename UDF::Metadata>(std::move(returnType));
+    auto&& names = aliases.empty()
+        ? std::vector<std::string>{metadata->getName()}
+        : aliases;
+
+    registerFunctionInternal(names, metadata->signature(), [metadata]() {
+      return CreateUdf<UDF>(metadata->returnType());
+    });
+  }
+
+  std::vector<std::string> getFunctionNames() {
+    std::vector<std::string> result;
+    result.reserve(registeredFunctions_.size());
+
+    for (const auto& entry : registeredFunctions_) {
+      result.push_back(entry.first);
+    }
+
+    return result;
+  }
+
+  std::vector<FunctionSignature*> getFunctionSignatures(
+      const std::string& name) {
+    std::vector<FunctionSignature*> signatures;
+    if (auto entry = getFunctionEntry(name)) {
+      signatures.reserve(entry->size());
+      for (const auto& pair : *entry) {
+        signatures.emplace_back(pair.first.get());
+      }
+    }
+
+    return signatures;
+  }
+
+  std::unique_ptr<Function> createFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes) {
+    if (auto entry = getFunctionEntry(name)) {
+      for (const auto& [candidateSignature, functionFactory] : *entry) {
+        if (SignatureBinder(*candidateSignature, argTypes).tryBind()) {
+          return functionFactory();
+        }
+      }
+    }
+
+    return nullptr;
+  }
+
+ private:
+  template <typename T>
+  static std::shared_ptr<const Function> GetSingletonUdfMetadata(
+      std::shared_ptr<const Type> returnType) {
+    static auto instance = std::make_shared<const T>(std::move(returnType));
+    return instance;
+  }
+
+  template <typename T>
+  static std::unique_ptr<T> CreateUdf(std::shared_ptr<const Type> returnType) {
+    return std::make_unique<T>(std::move(returnType));
+  }
+
+  void registerFunctionInternal(
+      const std::vector<std::string>& names,
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const FunctionFactory& factory) {
+    for (const auto& name : names) {
+      if (auto entry = getFunctionEntry(name)) {
+        entry->insert({signature, factory});
+      } else {
+        registeredFunctions_[name] = {{signature, factory}};
+      }
+    }
+  }
+
+  FunctionEntry* getFunctionEntry(const std::string& name) {
+    auto it = registeredFunctions_.find(name);
+    if (it != registeredFunctions_.end()) {
+      return &it->second;
+    }
+
+    return nullptr;
+  }
+
+  FunctionMap registeredFunctions_;
+};
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
High Level Goal:

I want to change ScalarFunctions and AdaptedVectorFunctions to do function call lookups based on FunctionSignatures.

This is primarily because the current solution of doing exact match lookups against the argument types is overly restrictive and makes adding features like VariadicArgs difficult.  SignatureBinder is much more flexible and has the flexibility to allow for more features in the future.

With VectorFunctions already using FunctionSignatures, and AggregateFunctions in the process of migrating, this also represents a step towards consistency in behavior.

This change:
This change introduces the FunctionRegistry which will handle registration and lookups for Scalar and AdaptedVector Functions.  (Note, it's not used yet, that will come in future diffs)

At it's heart, it's just a wrapper around a map from function name, to a map of signature to factory.

The reason for the inner map is to allow quick deduping when an identical function signature is registered (which unfortunately seems to happen frequently).

It exposes the same sort of functions ScalarFunctionRegistry exposed, except as class member functions rather than raw top level functions.  Notably registerFunction and createFunction.  In addition, to support cases that need to expose available functions, it supports fetching all available function names, and all available signatures for a given name.

The major difference with ScalarFunctionRegistry is that it uses SignatureBinder to find the corresponding signature for a given function call, rather than checking strict argument equality.

Differential Revision: D33078596

