### PR TITLE
Support getting a FunctionSignature from IScalarFunction

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -21,5 +21,11 @@ target_link_libraries(velox_config ${FOLLY_WITH_DEPENDENCIES})
 add_library(velox_core PlanNode.cpp ScalarFunction.cpp
                        ScalarFunctionRegistry.cpp)
 
-target_link_libraries(velox_core velox_config velox_type velox_serialization
-                      velox_vector ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(
+  velox_core
+  velox_config
+  velox_expression_functions
+  velox_type
+  velox_serialization
+  velox_vector
+  ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/core/ScalarFunction.h
+++ b/velox/core/ScalarFunction.h
@@ -20,6 +20,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/core/Metaprogramming.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
 
@@ -165,7 +166,8 @@ class IScalarFunction {
   virtual int32_t reuseStringsFromArg() const = 0;
 
   FunctionKey key() const;
-  std::string signature(const std::string& name) const;
+  std::shared_ptr<exec::FunctionSignature> signature() const;
+  std::string helpMessage(const std::string& name) const;
 
   virtual ~IScalarFunction() = default;
 };

--- a/velox/core/ScalarFunctionRegistry.h
+++ b/velox/core/ScalarFunctionRegistry.h
@@ -48,7 +48,7 @@ void registerFunctionInternal(
   ScalarFunctions().Register(
       key,
       [metadata]() { return CreateUdf<UDF>(metadata->returnType()); },
-      metadata->signature(key.name()));
+      metadata->helpMessage(key.name()));
 }
 
 // This function should be called once and alone.

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+add_library(velox_expression_functions FunctionRegistry.h FunctionSignature.cpp
+                                       SignatureBinder.cpp)
+
+target_link_libraries(velox_expression_functions velox_common_base)
+
 add_library(
   velox_expression
   CastExpr.cpp
@@ -18,13 +24,11 @@ add_library(
   EvalCtx.cpp
   Expr.cpp
   ExprCompiler.cpp
-  FunctionSignature.cpp
-  SignatureBinder.cpp
   VectorFunction.cpp
   VectorFunctionRegistry.cpp)
 
 target_link_libraries(velox_expression velox_core velox_vector
-                      velox_common_base)
+                      velox_common_base velox_expression_functions)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -17,7 +17,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include "velox/common/base/Exceptions.h"
-#include "velox/expression/VectorFunction.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/expression/SignatureBinder.h"
 #include <boost/algorithm/string.hpp>
-#include "velox/expression/VectorFunction.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/expression/VectorFunctionBindings.h
+++ b/velox/expression/VectorFunctionBindings.h
@@ -30,7 +30,7 @@ void registerVectorFunctionInternal(
         return std::make_unique<VectorAdapterFactoryImpl<UDF>>(
             metadata->returnType());
       },
-      metadata->signature(key.name()));
+      metadata->helpMessage(key.name()));
 }
 
 // This function should be called once and alone.


### PR DESCRIPTION
Summary:
High Level Goal:

I want to change ScalarFunctions and AdaptedVectorFunctions to do function call lookups based on FunctionSignatures.

This is primarily because the current solution of doing exact match lookups against the argument types is overly restrictive and makes adding features like VariadicArgs difficult.  SignatureBinder is much more flexible and has the flexibility to allow for more features in the future.

With VectorFunctions already using FunctionSignatures, and AggregateFunctions in the process of migrating, this also represents a step towards consistency in behavior.

This change:
The goal of this change is just to add a signature() function to IScalarFunction that will return a FunctionSignature object for the given Function.

FunctionSignature is under velox/expressions and IScalarFunction in ScalarFunction in velox/core.  The flow of dependencies seems to be that velox/expressions depends on velox/core, not the other way around.

Since this means ScalarFunction now depends on FunctionSignature, that means I need to move ScalarFunction into velox/expressions (and ScalarFunctionRegistry which depends on ScalarFunction).

Conceptually at least this seems like the right thing to do given that VectorFunctionRegistry and VectorFunctionAdapter (both for AdaptedVectorFunctions), are already under velox/expressions.

Differential Revision: D33078846

