### PR TITLE
Migrate bool_xxx and bitwise_xxx aggregates to the new registry

### DIFF
--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1697,7 +1697,7 @@ TEST_P(TableScanTest, bitwiseAggregationPushdown) {
 
   auto op = PlanBuilder()
                 .tableScan(rowType_, tableHandle, assignments)
-                .finalAggregation(
+                .singleAggregation(
                     {5},
                     {"bitwise_and_agg(c0)",
                      "bitwise_and_agg(c1)",
@@ -1712,7 +1712,7 @@ TEST_P(TableScanTest, bitwiseAggregationPushdown) {
 
   op = PlanBuilder()
            .tableScan(rowType_, tableHandle, assignments)
-           .finalAggregation(
+           .singleAggregation(
                {5},
                {"bitwise_or_agg(c0)",
                 "bitwise_or_agg(c1)",

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/SimpleNumericAggregate.h"
 #include "velox/vector/FlatVector.h"
@@ -177,8 +178,17 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 
 template <class T>
 bool registerBoolAggregate(const std::string& name) {
-  exec::AggregateFunctions().Register(
+  // TODO Fix signature to match Presto.
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("boolean")
+          .intermediateType("boolean")
+          .argumentType("boolean")
+          .build()};
+
+  exec::registerAggregateFunction(
       name,
+      std::move(signatures),
       [name](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,

--- a/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
@@ -50,22 +50,15 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
 
   // Global final aggregation.
   {
-    PlanBuilder builder;
-    auto partialAgg = builder.values(vectors)
-                          .partialAggregation(
-                              {},
-                              {"bitwise_or_agg(c1)",
-                               "bitwise_or_agg(c2)",
-                               "bitwise_or_agg(c3)",
-                               "bitwise_or_agg(c4)"})
-                          .planNode();
-    auto finalAgg = builder
-                        .finalAggregation(
+    auto finalAgg = PlanBuilder()
+                        .values(vectors)
+                        .partialAggregation(
                             {},
-                            {"bitwise_or_agg(a0)",
-                             "bitwise_or_agg(a1)",
-                             "bitwise_or_agg(a2)",
-                             "bitwise_or_agg(a3)"})
+                            {"bitwise_or_agg(c1)",
+                             "bitwise_or_agg(c2)",
+                             "bitwise_or_agg(c3)",
+                             "bitwise_or_agg(c4)"})
+                        .finalAggregation()
                         .planNode();
     assertQuery(
         finalAgg,
@@ -93,25 +86,18 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
 
   // Group by final aggregation.
   {
-    PlanBuilder builder;
-    auto partialAgg = builder.values(vectors)
-                          .project(
-                              {"c0 % 10", "c1", "c2", "c3", "c4"},
-                              {"c0 % 10", "c1", "c2", "c3", "c4"})
-                          .partialAggregation(
-                              {0},
-                              {"bitwise_or_agg(c1)",
-                               "bitwise_or_agg(c2)",
-                               "bitwise_or_agg(c3)",
-                               "bitwise_or_agg(c4)"})
-                          .planNode();
-    auto finalAgg = builder
-                        .finalAggregation(
+    auto finalAgg = PlanBuilder()
+                        .values(vectors)
+                        .project(
+                            {"c0 % 10", "c1", "c2", "c3", "c4"},
+                            {"c0 % 10", "c1", "c2", "c3", "c4"})
+                        .partialAggregation(
                             {0},
-                            {"bitwise_or_agg(a0)",
-                             "bitwise_or_agg(a1)",
-                             "bitwise_or_agg(a2)",
-                             "bitwise_or_agg(a3)"})
+                            {"bitwise_or_agg(c1)",
+                             "bitwise_or_agg(c2)",
+                             "bitwise_or_agg(c3)",
+                             "bitwise_or_agg(c4)"})
+                        .finalAggregation()
                         .planNode();
     assertQuery(
         finalAgg,
@@ -141,22 +127,15 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
 
   // Global final aggregation.
   {
-    PlanBuilder builder;
-    auto partialAgg = builder.values(vectors)
-                          .partialAggregation(
-                              {},
-                              {"bitwise_and_agg(c1)",
-                               "bitwise_and_agg(c2)",
-                               "bitwise_and_agg(c3)",
-                               "bitwise_and_agg(c4)"})
-                          .planNode();
-    auto finalAgg = builder
-                        .finalAggregation(
+    auto finalAgg = PlanBuilder()
+                        .values(vectors)
+                        .partialAggregation(
                             {},
-                            {"bitwise_and_agg(a0)",
-                             "bitwise_and_agg(a1)",
-                             "bitwise_and_agg(a2)",
-                             "bitwise_and_agg(a3)"})
+                            {"bitwise_and_agg(c1)",
+                             "bitwise_and_agg(c2)",
+                             "bitwise_and_agg(c3)",
+                             "bitwise_and_agg(c4)"})
+                        .finalAggregation()
                         .planNode();
     assertQuery(
         finalAgg,
@@ -184,25 +163,18 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
 
   // Group by final aggregation.
   {
-    PlanBuilder builder;
-    auto partialAgg = builder.values(vectors)
-                          .project(
-                              {"c0 % 10", "c1", "c2", "c3", "c4"},
-                              {"c0 % 10", "c1", "c2", "c3", "c4"})
-                          .partialAggregation(
-                              {0},
-                              {"bitwise_and_agg(c1)",
-                               "bitwise_and_agg(c2)",
-                               "bitwise_and_agg(c3)",
-                               "bitwise_and_agg(c4)"})
-                          .planNode();
-    auto finalAgg = builder
-                        .finalAggregation(
+    auto finalAgg = PlanBuilder()
+                        .values(vectors)
+                        .project(
+                            {"c0 % 10", "c1", "c2", "c3", "c4"},
+                            {"c0 % 10", "c1", "c2", "c3", "c4"})
+                        .partialAggregation(
                             {0},
-                            {"bitwise_and_agg(a0)",
-                             "bitwise_and_agg(a1)",
-                             "bitwise_and_agg(a2)",
-                             "bitwise_and_agg(a3)"})
+                            {"bitwise_and_agg(c1)",
+                             "bitwise_and_agg(c2)",
+                             "bitwise_and_agg(c3)",
+                             "bitwise_and_agg(c4)"})
+                        .finalAggregation()
                         .planNode();
     assertQuery(
         finalAgg,

--- a/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
@@ -44,7 +44,6 @@ TEST_P(BoolAndOrTest, basic) {
   const auto duckDbName = GetParam().duckDbName;
 
   const auto partialAgg = fmt::format("{}(c1)", veloxName);
-  const auto finalAgg = fmt::format("{}(a0)", veloxName);
 
   // Global partial aggregation.
   auto agg = PlanBuilder()
@@ -57,7 +56,7 @@ TEST_P(BoolAndOrTest, basic) {
   agg = PlanBuilder()
             .values(vectors)
             .partialAggregation({}, {partialAgg})
-            .finalAggregation({}, {finalAgg})
+            .finalAggregation()
             .planNode();
   assertQuery(agg, fmt::format("SELECT {}(c1::TINYINT) FROM tmp", duckDbName));
 
@@ -77,7 +76,7 @@ TEST_P(BoolAndOrTest, basic) {
             .values(vectors)
             .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
             .partialAggregation({0}, {partialAgg})
-            .finalAggregation({0}, {finalAgg})
+            .finalAggregation()
             .planNode();
   assertQuery(
       agg,


### PR DESCRIPTION
Migrate bool_and, bool_or, bitwise_and_agg and bitwise_or_agg aggregate functions to the new registry. Note that intermediate types of these aggregates do not appear to match Presto and need to be updated in a future PR.