### PR TITLE
Fix bug in FunctionSignature's parseTypeSignature

### DIFF
--- a/velox/exec/tests/ParseTypeSignatureTest.cpp
+++ b/velox/exec/tests/ParseTypeSignatureTest.cpp
@@ -77,6 +77,11 @@ TEST(ParseTypeSignatureTest, roundTrip) {
   ASSERT_EQ(roundTrip("map(K,V)"), "map(K,V)");
 
   ASSERT_EQ(roundTrip("function(S,R)"), "function(S,R)");
+
+  // Test a complex type as the second field in a row
+  ASSERT_EQ(
+      roundTrip("row(map(K,V),map(bigint,array(double)))"),
+      "row(map(K,V),map(bigint,array(double)))");
 }
 
 TEST(ParseTypeSignatureTest, invalidSignatures) {

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -84,7 +84,7 @@ TypeSignature parseTypeSignature(const std::string& signature) {
     nestedTypes.emplace_back(parseTypeSignature(token));
 
     prevPos = commaPos + 1;
-    commaPos = signature.find(',', prevPos);
+    commaPos = findNextComma(signature, prevPos);
   }
 
   auto token = signature.substr(prevPos, endParenPos - prevPos);

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -32,6 +32,10 @@ class TypeVariableConstraint {
     return name_;
   }
 
+  bool operator==(const TypeVariableConstraint& rhs) const {
+    return name_ == rhs.name_;
+  }
+
  private:
   const std::string name_;
 };
@@ -51,6 +55,10 @@ class TypeSignature {
   }
 
   std::string toString() const;
+
+  bool operator==(const TypeSignature& rhs) const {
+    return baseType_ == rhs.baseType_ && parameters_ == rhs.parameters_;
+  }
 
  private:
   const std::string baseType_;
@@ -94,6 +102,13 @@ class FunctionSignature {
   }
 
   std::string toString() const;
+
+  bool operator==(const FunctionSignature& rhs) const {
+    return typeVariableConstants_ == rhs.typeVariableConstants_ &&
+        returnType_ == rhs.returnType_ &&
+        argumentTypes_ == rhs.argumentTypes_ &&
+        variableArity_ == rhs.variableArity_;
+  }
 
  private:
   const std::vector<TypeVariableConstraint> typeVariableConstants_;
@@ -234,3 +249,57 @@ class AggregateFunctionSignatureBuilder {
 };
 
 } // namespace facebook::velox::exec
+
+namespace std {
+template <>
+struct hash<facebook::velox::exec::TypeVariableConstraint> {
+  using argument_type = facebook::velox::exec::TypeVariableConstraint;
+  using result_type = std::size_t;
+
+  result_type operator()(const argument_type& key) const noexcept {
+    return std::hash<std::string>{}(key.name());
+  }
+};
+
+template <>
+struct hash<facebook::velox::exec::TypeSignature> {
+  using argument_type = facebook::velox::exec::TypeSignature;
+  using result_type = std::size_t;
+
+  result_type operator()(const argument_type& key) const noexcept {
+    size_t val = std::hash<std::string>{}(key.baseType());
+    for (const auto& parameter : key.parameters()) {
+      val = val * 31 + this->operator()(parameter);
+    }
+    return val;
+  }
+};
+
+template <>
+struct hash<facebook::velox::exec::FunctionSignature> {
+  using argument_type = facebook::velox::exec::FunctionSignature;
+  using result_type = std::size_t;
+
+  result_type operator()(const argument_type& key) const noexcept {
+    auto typeVariableConstraintHasher =
+        std::hash<facebook::velox::exec::TypeVariableConstraint>{};
+    auto typeSignatureHasher =
+        std::hash<facebook::velox::exec::TypeSignature>{};
+
+    size_t val = 0;
+    for (const auto& constraint : key.typeVariableConstants()) {
+      val = val * 31 + typeVariableConstraintHasher(constraint);
+    }
+
+    val = val * 31 + typeSignatureHasher(key.returnType());
+
+    for (const auto& arg : key.argumentTypes()) {
+      val = val * 31 + typeSignatureHasher(arg);
+    }
+
+    val = val * 31 + (key.variableArity() ? 0 : 1);
+    return val;
+  }
+};
+
+} // namespace std


### PR DESCRIPTION
Summary:
There's a bug in FunctionSignature's parseTypeSignature function where it will not respect complex types when looking for the end of nested types.

For example:
row(map(K1, V1), map(K2, V2))

when parsing the inner types of the struct, it will parse map(K1, V1) just fine (recognizing the comma is part of the map's type signature), but when looking for the end of map(K2, V2) it will treat the inner comma as a separator between types in row's signature, and try to parse map(K2 as a type.  This of course leads to an error in parsing.

The fix is to call findNextComma in the for loop instead of signature.find(',' since findNextComma respects commas that are part of inner types.

Differential Revision: D33110432

