### PR TITLE
Fix S3FileSystem and CircleCI run for storage adapters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make release VELOX_ENABLE_ADAPTERS=ON AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
+            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_S3=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
             ccache -s
           no_output_timeout: 1h
       - store_artifacts:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -84,7 +84,7 @@ class S3ReadFile final : public ReadFile {
 
   uint64_t preadv(
       uint64_t offset,
-      const std::vector<folly::Range<char*>>& buffers) override {
+      const std::vector<folly::Range<char*>>& buffers) const override {
     VELOX_NYI();
   }
 


### PR DESCRIPTION
+ S3FileSystem change required due to https://github.com/facebookincubator/velox/pull/708
+ CircleCI storage adapters run did not enable the adapters since the changes from https://github.com/facebookincubator/velox/pull/404