### PR TITLE
Rename modulus function to match Presto

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -52,7 +52,7 @@ std::string normalizeFuncName(std::string input) {
       {"-", "minus"},
       {"*", "multiply"},
       {"/", "divide"},
-      {"%", "modulus"},
+      {"%", "mod"},
       {"<", "lt"},
       {"<=", "lte"},
       {">", "gt"},

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -123,7 +123,7 @@ TEST(DuckParserTest, expressions) {
   EXPECT_EQ("minus(1,0)", parseExpr("1 - 0")->toString());
   EXPECT_EQ("multiply(1,0)", parseExpr("1 * 0")->toString());
   EXPECT_EQ("divide(1,0)", parseExpr("1 / 0")->toString());
-  EXPECT_EQ("modulus(1,0)", parseExpr("1 % 0")->toString());
+  EXPECT_EQ("mod(1,0)", parseExpr("1 % 0")->toString());
 
   // ANDs and ORs.
   EXPECT_EQ("and(1,0)", parseExpr("1 and 0")->toString());
@@ -139,7 +139,7 @@ TEST(DuckParserTest, expressions) {
 
   // Mix-and-match.
   EXPECT_EQ(
-      "gte(plus(modulus(\"c0\",10),0),multiply(f(100),9))",
+      "gte(plus(mod(\"c0\",10),0),multiply(f(100),9))",
       parseExpr("c0 % 10 + 0 >= f(100) * 9")->toString());
 }
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -76,9 +76,9 @@ TEST_F(PlanNodeToStringTest, recursiveAndDetailed) {
   auto output = plan_->toString(true, true);
   ASSERT_EQ(
       "->project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10)), ]\n"
-      "  ->filter[expression: lt(modulus(cast ROW[\"out1\"] as BIGINT,10),8)]\n"
-      "    ->project[expressions: (out1:INTEGER, ROW[\"c0\"]), (out2:BIGINT, plus(modulus(cast ROW[\"c0\"] as BIGINT,100),modulus(cast ROW[\"c1\"] as BIGINT,50))), ]\n"
-      "      ->filter[expression: lt(modulus(cast ROW[\"c0\"] as BIGINT,10),9)]\n"
+      "  ->filter[expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)]\n"
+      "    ->project[expressions: (out1:INTEGER, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50))), ]\n"
+      "      ->filter[expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)]\n"
       "        ->values[]\n",
       output);
 }

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -27,7 +27,7 @@ void registerSimpleFunctions() {
   registerBinaryFloatingPoint<MinusFunction>({"minus"});
   registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
   registerBinaryFloatingPoint<DivideFunction>({"divide"});
-  registerBinaryFloatingPoint<ModulusFunction>({"modulus"});
+  registerBinaryFloatingPoint<ModulusFunction>({"mod"});
   registerUnaryNumeric<udf_ceil>({"ceil", "ceiling"});
   registerUnaryNumeric<udf_floor>({});
   registerUnaryNumeric<udf_abs>({});

--- a/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
+++ b/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
@@ -23,7 +23,7 @@ void registerCheckedArithmeticFunctions() {
   registerBinaryIntegral<CheckedPlusFunction>({"plus"});
   registerBinaryIntegral<CheckedMinusFunction>({"minus"});
   registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
-  registerBinaryIntegral<CheckedModulusFunction>({"modulus"});
+  registerBinaryIntegral<CheckedModulusFunction>({"mod"});
   registerBinaryIntegral<CheckedDivideFunction>({"divide"});
   registerUnaryIntegral<udf_checked_negate>({"negate"});
 }

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -91,29 +91,29 @@ __attribute__((__no_sanitize__("float-divide-by-zero")))
       "c0 / c1", {10.5, 9.2, 0.0}, {2, 0, 0}, {5.25, kInf, kNan});
 }
 
-TEST_F(ArithmeticTest, modulus) {
+TEST_F(ArithmeticTest, mod) {
   std::vector<double> numerDouble = {0, 6, 0, -7, -1, -9, 9, 10.1};
   std::vector<double> denomDouble = {1, 2, -1, 3, -1, -3, -3, -99.9};
   std::vector<double> expectedDouble = {0, 0, 0, -1, 0, 0, 0, 10.1};
 
   // Check using function name and alias.
   assertExpression<double>(
-      "modulus(c0, c1)", numerDouble, denomDouble, expectedDouble);
+      "mod(c0, c1)", numerDouble, denomDouble, expectedDouble);
   assertExpression<double>(
-      "modulus(c0, c1)",
+      "mod(c0, c1)",
       {5.1, kNan, 5.1, kInf, 5.1},
       {0.0, 5.1, kNan, 5.1, kInf},
       {kNan, kNan, kNan, kNan, 5.1});
 }
 
-TEST_F(ArithmeticTest, modulusInt) {
+TEST_F(ArithmeticTest, modInt) {
   std::vector<int64_t> numerInt = {9, 10, 0, -9, -10, -11};
   std::vector<int64_t> denomInt = {3, -3, 11, -1, 199999, 77};
   std::vector<int64_t> expectedInt = {0, 1, 0, 0, -10, -11};
 
   assertExpression<int64_t, int64_t>(
-      "modulus(c0, c1)", numerInt, denomInt, expectedInt);
-  assertError<int64_t>("modulus(c0, c1)", {10}, {0}, "Cannot divide by 0");
+      "mod(c0, c1)", numerInt, denomInt, expectedInt);
+  assertError<int64_t>("mod(c0, c1)", {10}, {0}, "Cannot divide by 0");
 }
 
 TEST_F(ArithmeticTest, power) {


### PR DESCRIPTION
Summary: Rename modulus function to mod as this is the name used in Presto. This function already appears as mod in the documentation, hence, no change is needed.

Differential Revision: D33140391

