### PR TITLE
Add streaming aggregation

### DIFF
--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -25,13 +25,13 @@ void AllocationPool::clear() {
 }
 
 char* AllocationPool::allocateFixed(uint64_t bytes) {
-  VELOX_CHECK(bytes > 0, "Cannot allocate zero bytes");
+  VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
   if (availableInRun() < bytes) {
     newRun(bytes);
   }
-  auto run = allocation_.runAt(currentRun_);
+  auto run = currentRun();
   uint64_t size = run.numBytes();
-  VELOX_CHECK(bytes + currentOffset_ <= size);
+  VELOX_CHECK_LE(bytes + currentOffset_, size);
   currentOffset_ += bytes;
   return reinterpret_cast<char*>(run.data() + currentOffset_ - bytes);
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -397,6 +397,8 @@ class TableWriteNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
+// TODO Split into AbstractAggregationNode and HashAggregation. Move Step one
+// level up.
 class AggregationNode : public PlanNode {
  public:
   enum class Step {
@@ -500,6 +502,32 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
   ss << step;
   return ss.str();
 }
+
+/// Represents streaming aggregation that assumes that input is already grouped
+/// on the grouping keys.
+class StreamingAggregationNode : public AggregationNode {
+ public:
+  StreamingAggregationNode(
+      const PlanNodeId& id,
+      Step step,
+      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
+          groupingKeys,
+      const std::vector<std::string>& aggregateNames,
+      const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
+      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
+          aggregateMasks,
+      bool ignoreNullKeys,
+      std::shared_ptr<const PlanNode> source)
+      : AggregationNode(
+            id,
+            step,
+            groupingKeys,
+            aggregateNames,
+            aggregates,
+            aggregateMasks,
+            ignoreNullKeys,
+            std::move(source)) {}
+};
 
 class ExchangeNode : public PlanNode {
  public:

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
   PartitionedOutput.cpp
   PartitionedOutputBufferManager.cpp
   RowContainer.cpp
+  StreamingAggregation.cpp
   TableScan.cpp
   TableWriter.cpp
   Task.cpp

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -30,6 +30,7 @@
 #include "velox/exec/MergeJoin.h"
 #include "velox/exec/OrderBy.h"
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/TopN.h"
@@ -306,6 +307,12 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::dynamic_pointer_cast<const core::CrossJoinNode>(planNode)) {
       operators.push_back(
           std::make_unique<CrossJoinProbe>(id, ctx.get(), joinNode));
+    } else if (
+        auto aggregationNode =
+            std::dynamic_pointer_cast<const core::StreamingAggregationNode>(
+                planNode)) {
+      operators.push_back(std::make_unique<StreamingAggregation>(
+          id, ctx.get(), aggregationNode));
     } else if (
         auto aggregationNode =
             std::dynamic_pointer_cast<const core::AggregationNode>(planNode)) {

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/StreamingAggregation.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/RowContainer.h"
+
+namespace facebook::velox::exec {
+
+StreamingAggregation::StreamingAggregation(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::StreamingAggregationNode>&
+        aggregationNode)
+    : Operator(
+          driverCtx,
+          aggregationNode->outputType(),
+          operatorId,
+          aggregationNode->id(),
+          aggregationNode->step() == core::AggregationNode::Step::kPartial
+              ? "PartialAggregation"
+              : "Aggregation"),
+      outputBatchSize_{
+          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()},
+      step_{aggregationNode->step()} {
+  auto numKeys = aggregationNode->groupingKeys().size();
+  decodedKeys_.resize(numKeys);
+
+  auto inputType = aggregationNode->sources()[0]->outputType();
+
+  std::vector<TypePtr> groupingKeyTypes;
+  groupingKeyTypes.reserve(numKeys);
+
+  groupingKeys_.reserve(numKeys);
+  for (const auto& key : aggregationNode->groupingKeys()) {
+    auto channel = exprToChannel(key.get(), inputType);
+    groupingKeys_.push_back(channel);
+    groupingKeyTypes.push_back(inputType->childAt(channel));
+  }
+
+  auto numAggregates = aggregationNode->aggregates().size();
+  aggregates_.reserve(numAggregates);
+  masks_.reserve(numAggregates);
+  for (auto i = 0; i < numAggregates; i++) {
+    const auto& aggregate = aggregationNode->aggregates()[i];
+
+    std::vector<ChannelIndex> channels;
+    std::vector<VectorPtr> constants;
+    std::vector<TypePtr> argTypes;
+    for (auto& arg : aggregate->inputs()) {
+      argTypes.push_back(arg->type());
+      channels.push_back(exprToChannel(arg.get(), inputType));
+      if (channels.back() == kConstantChannel) {
+        auto constant = static_cast<const core::ConstantTypedExpr*>(arg.get());
+        constants.push_back(BaseVector::createConstant(
+            constant->value(), 1, operatorCtx_->pool()));
+      } else {
+        constants.push_back(nullptr);
+      }
+    }
+
+    const auto& mask = aggregationNode->aggregateMasks()[i];
+    if (mask == nullptr) {
+      masks_.emplace_back(std::nullopt);
+    } else {
+      masks_.emplace_back(inputType->asRow().getChildIdx(mask->name()));
+      VELOX_NYI("Streaming aggregation doesn't support masks yet");
+    }
+
+    const auto& aggResultType = outputType_->childAt(numKeys + i);
+    aggregates_.push_back(Aggregate::create(
+        aggregate->name(), aggregationNode->step(), argTypes, aggResultType));
+    args_.push_back(channels);
+    constantArgs_.push_back(constants);
+  }
+
+  if (aggregationNode->ignoreNullKeys()) {
+    VELOX_NYI("Streaming aggregation doesn't support ignoring null keys yet");
+  }
+
+  rows_ = std::make_unique<RowContainer>(
+      groupingKeyTypes,
+      !aggregationNode->ignoreNullKeys(),
+      aggregates_,
+      std::vector<TypePtr>{},
+      false,
+      false,
+      false,
+      false,
+      operatorCtx_->mappedMemory(),
+      ContainerRowSerde::instance());
+}
+
+void StreamingAggregation::addInput(RowVectorPtr input) {
+  input_ = std::move(input);
+}
+
+namespace {
+// Compares a row in one vector with another row in another vector and returns
+// true if two rows match in all grouping key columns.
+bool equalKeys(
+    const std::vector<ChannelIndex>& keys,
+    const RowVectorPtr& batch,
+    vector_size_t index,
+    const RowVectorPtr& otherBatch,
+    vector_size_t otherIndex) {
+  for (auto key : keys) {
+    if (!batch->childAt(key)->equalValueAt(
+            otherBatch->childAt(key).get(), index, otherIndex)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+} // namespace
+
+char* StreamingAggregation::startNewGroup(vector_size_t index) {
+  if (numGroups_ < groups_.size()) {
+    auto group = groups_[numGroups_++];
+    rows_->initializeRow(group, true);
+    storeKeys(group, index);
+    return group;
+  }
+
+  auto* newGroup = rows_->newRow();
+  storeKeys(newGroup, index);
+
+  groups_.resize(numGroups_ + 1);
+  groups_[numGroups_++] = newGroup;
+  return newGroup;
+}
+
+void StreamingAggregation::storeKeys(char* group, vector_size_t index) {
+  for (auto i = 0; i < groupingKeys_.size(); ++i) {
+    rows_->store(decodedKeys_[i], index, group, i);
+  }
+}
+
+void StreamingAggregation::createOutput(size_t numGroups) {
+  output_ = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(outputType_, numGroups, pool()));
+
+  for (auto i = 0; i < groupingKeys_.size(); ++i) {
+    rows_->extractColumn(
+        groups_.data(), numGroups, groupingKeys_[i], output_->childAt(i));
+  }
+
+  auto numKeys = groupingKeys_.size();
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    auto& aggregate = aggregates_[i];
+    auto& result = output_->childAt(numKeys + i);
+    if (isPartialOutput(step_)) {
+      aggregate->extractAccumulators(groups_.data(), numGroups, &result);
+    } else {
+      aggregate->extractValues(groups_.data(), numGroups, &result);
+    }
+  }
+}
+
+void StreamingAggregation::assignGroups() {
+  auto numInput = input_->size();
+
+  inputGroups_.resize(numInput);
+
+  // Look for the end of the last group.
+  vector_size_t index = 0;
+  if (prevInput_) {
+    auto prevIndex = prevInput_->size() - 1;
+    auto* prevGroup = groups_[numGroups_ - 1];
+    for (; index < numInput; ++index) {
+      if (equalKeys(groupingKeys_, prevInput_, prevIndex, input_, index)) {
+        inputGroups_[index] = prevGroup;
+      } else {
+        break;
+      }
+    }
+  }
+
+  if (index < numInput) {
+    for (auto i = 0; i < groupingKeys_.size(); ++i) {
+      decodedKeys_[i].decode(*input_->childAt(groupingKeys_[i]), inputRows_);
+    }
+
+    auto* newGroup = startNewGroup(index);
+    inputGroups_[index] = newGroup;
+
+    for (auto i = index + 1; i < numInput; ++i) {
+      if (equalKeys(groupingKeys_, input_, index, input_, i)) {
+        inputGroups_[i] = inputGroups_[index];
+      } else {
+        newGroup = startNewGroup(i);
+        inputGroups_[i] = newGroup;
+        index = i;
+      }
+    }
+  }
+}
+
+void StreamingAggregation::evaluateAggregates() {
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    auto& aggregate = aggregates_[i];
+
+    std::vector<VectorPtr> args;
+    for (auto j = 0; j < args_[i].size(); ++j) {
+      if (args_[i][j] == kConstantChannel) {
+        args.push_back(constantArgs_[i][j]);
+      } else {
+        args.push_back(input_->childAt(args_[i][j]));
+      }
+    }
+
+    if (isRawInput(step_)) {
+      aggregate->addRawInput(inputGroups_.data(), inputRows_, args, false);
+    } else {
+      aggregate->addIntermediateResults(
+          inputGroups_.data(), inputRows_, args, false);
+    }
+  }
+}
+
+RowVectorPtr StreamingAggregation::getOutput() {
+  if (!input_) {
+    if (isFinishing() && numGroups_ > 0) {
+      createOutput(numGroups_);
+      numGroups_ = 0;
+      return std::move(output_);
+    }
+    return nullptr;
+  }
+
+  auto numInput = input_->size();
+  inputRows_.resize(numInput);
+  inputRows_.setAll();
+
+  auto numPrevGroups = numGroups_;
+
+  assignGroups();
+
+  // Initialize aggregates for the new groups.
+  std::vector<vector_size_t> newGroups;
+  newGroups.resize(numGroups_ - numPrevGroups);
+  std::iota(newGroups.begin(), newGroups.end(), numPrevGroups);
+
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    auto& aggregate = aggregates_[i];
+
+    aggregate->initializeNewGroups(
+        groups_.data(), folly::Range(newGroups.data(), newGroups.size()));
+  }
+
+  evaluateAggregates();
+
+  if (numGroups_ > outputBatchSize_) {
+    createOutput(outputBatchSize_);
+
+    // Rotate the entries in the groups_ vector to move the remaining groups to
+    // the beginning and place re-usable groups at the end.
+    std::vector<char*> copy(groups_.size());
+    std::copy(groups_.begin() + outputBatchSize_, groups_.end(), copy.begin());
+    std::copy(
+        groups_.begin(),
+        groups_.begin() + outputBatchSize_,
+        copy.begin() + groups_.size() - outputBatchSize_);
+    groups_ = std::move(copy);
+    numGroups_ -= outputBatchSize_;
+  }
+
+  prevInput_ = input_;
+  input_ = nullptr;
+
+  return std::move(output_);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class Aggregate;
+class RowContainer;
+
+class StreamingAggregation : public Operator {
+ public:
+  StreamingAggregation(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::StreamingAggregationNode>&
+          aggregationNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /* unused */) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+ private:
+  // Allocate new group or re-use previously allocated group that has been fully
+  // calculated and included in the output.
+  char* startNewGroup(vector_size_t index);
+
+  // Write grouping keys from the specified input row into specified group.
+  void storeKeys(char* group, vector_size_t index);
+
+  // Populate output_ vector using specified number of groups from the beginning
+  // of the groups_ vector.
+  void createOutput(size_t numGroups);
+
+  // Assign input rows to groups based on values of the grouping keys. Store the
+  // assignments in inputGroups_.
+  void assignGroups();
+
+  // Add input data to accumulators.
+  void evaluateAggregates();
+
+  /// Maximum number of rows in the output batch.
+  const uint32_t outputBatchSize_;
+
+  const core::AggregationNode::Step step_;
+
+  std::vector<ChannelIndex> groupingKeys_;
+  std::vector<std::unique_ptr<Aggregate>> aggregates_;
+  std::vector<std::optional<ChannelIndex>> masks_;
+  std::vector<std::vector<ChannelIndex>> args_;
+  std::vector<std::vector<VectorPtr>> constantArgs_;
+  std::vector<DecodedVector> decodedKeys_;
+
+  // Storage of grouping keys and accumulators.
+  std::unique_ptr<RowContainer> rows_;
+
+  // Previous input vector. Used to compare grouping keys for groups which span
+  // batches.
+  RowVectorPtr prevInput_;
+
+  // Unique groups.
+  std::vector<char*> groups_;
+
+  // Number of active entries at the beginning of the groups_ vector. The
+  // remaining entries are re-usable.
+  size_t numGroups_{0};
+
+  // Reusable memory.
+
+  // Pointers to groups for all input rows.
+  std::vector<char*> inputGroups_;
+
+  // A subset of input rows to evaluate the aggregate function on. Rows
+  // where aggregation mask is false are excluded.
+  SelectivityVector inputRows_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   ParseTypeSignatureTest.cpp
   PartitionedOutputBufferManagerTest.cpp
   RoundRobinPartitionFunctionTest.cpp
+  StreamingAggregationTest.cpp
   TableWriteTest.cpp
   TopNTest.cpp
   LimitTest.cpp


### PR DESCRIPTION
Add streaming aggregation operator that can be used when input is already
pre-grouped on the grouping keys. This operator is using less memory than hash
aggregation because it doesn't need to accumulate all groups in memory. The
input must be grouped on the grouping keys, but doesn't need to be sorted on 
these keys. 