### PR TITLE
Add from_base Presto function

### DIFF
--- a/velox/docs/functions/math.rst
+++ b/velox/docs/functions/math.rst
@@ -39,6 +39,10 @@ Mathematical Functions
 
     Returns ``x`` rounded down to the nearest integer.
 
+.. function:: from_base(string, radix) -> bigint
+
+    Returns the value of ``string`` interpreted as a base-``radix`` number. ``radix`` must be between 2 and 36.
+
 .. function:: ln(x) -> double
 
     Returns the natural logarithm of ``x``.

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -81,6 +81,7 @@ void registerSimpleFunctions() {
   registerFunction<IsNanFunction, bool, double>({"is_nan"});
   registerFunction<NanFunction, double>({"nan"});
   registerFunction<RandFunction, double>({"rand", "random"});
+  registerFunction<FromBaseFunction, int64_t, Varchar, int64_t>({"from_base"});
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Added the `from_base` Presto function: https://prestodb.io/docs/current/functions/math.html#from_base. Added in `Arithmetic.h` rather than `StringFunctions.h` because it is a mathematical function in the Presto documentation.

Reviewed By: mbasmanova

Differential Revision: D33034788

