### PR TITLE
Improve VectorMaker's flatVector() API

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1375,6 +1375,9 @@ struct CppToType<velox::StringView> : public CppToTypeBase<TypeKind::VARCHAR> {
 };
 
 template <>
+struct CppToType<std::string_view> : public CppToTypeBase<TypeKind::VARCHAR> {};
+
+template <>
 struct CppToType<std::string> : public CppToTypeBase<TypeKind::VARCHAR> {};
 
 template <>

--- a/velox/vector/tests/VectorMaker-inl.h
+++ b/velox/vector/tests/VectorMaker-inl.h
@@ -270,19 +270,9 @@ FlatVectorPtr<VectorMaker::EvalType<T>> VectorMaker::flatVector(
     const std::vector<T>& data) {
   using TEvalType = EvalType<T>;
   BufferPtr dataBuffer = AlignedBuffer::allocate<TEvalType>(data.size(), pool_);
-  auto rawData = dataBuffer->asMutable<TEvalType>();
-
-  for (vector_size_t i = 0; i < data.size(); i++) {
-    // Using bitUtils for bool vectors.
-    if constexpr (std::is_same<T, bool>::value) {
-      bits::setBit(rawData, i, data[i]);
-    } else {
-      rawData[i] = TEvalType(data[i]);
-    }
-  }
 
   auto stats = genVectorMakerStats(data);
-  return std::make_shared<FlatVector<TEvalType>>(
+  auto flatVector = std::make_shared<FlatVector<TEvalType>>(
       pool_,
       CppToType<T>::create(),
       BufferPtr(nullptr),
@@ -293,6 +283,11 @@ FlatVectorPtr<VectorMaker::EvalType<T>> VectorMaker::flatVector(
       stats.distinctCount(),
       stats.nullCount,
       stats.isSorted);
+
+  for (vector_size_t i = 0; i < data.size(); i++) {
+    flatVector->set(i, TEvalType(data[i]));
+  }
+  return flatVector;
 }
 
 } // namespace facebook::velox::test

--- a/velox/vector/tests/VectorMaker.h
+++ b/velox/vector/tests/VectorMaker.h
@@ -126,37 +126,26 @@ class VectorMaker {
   }
 
   /// Create a FlatVector<T>
-  /// creates a FlatVector based on elements from the input std::vector.
+  /// creates a FlatVector based on elements from the input std::vector. String
+  /// vectors can be created using std::vector of char*, StringView,
+  /// std::string, or std::string_view as input. The string contents will be
+  /// copied to the flatvector's internal string buffer.
   ///
   /// Elements are non-nullable.
   ///
   /// Examples:
   ///   auto flatVector = flatVector({1, 2, 3, 4});
+  ///   auto flatVector2 = flatVector({"hello", "world"});
   template <typename T>
   FlatVectorPtr<EvalType<T>> flatVector(const std::vector<T>& data);
 
-  /// Create a FlatVector<StringView>
-  /// convenience function to create a FlatVector based on a vector of
-  /// std::string. Note that the lifetime of the StringViews on the the
-  /// returned FlatVector are bound to the lifetime of the vector input
-  /// strings, so be careful with temporaries.
-  ///
-  /// Elements are non-nullable.
-  ///
-  /// Examples:
-  ///   std::vector<std::string> data({"hello", "world"});
-  ///   auto flatVector = flatVector(data);
-  ///
-  /// but not:
-  ///
-  ///   auto flatVector2 = flatVector({"hello", "world"});
-  FlatVectorPtr<StringView> flatVector(const std::vector<std::string>& data) {
-    std::vector<StringView> stringViews;
-    stringViews.reserve(data.size());
-    for (const auto& str : data) {
-      stringViews.emplace_back(str);
-    }
-    return flatVector(stringViews);
+  // This overload allows users to use initializer list directly without
+  // explicitly specifying the template type, e.g:
+  //
+  //   auto flatVector2 = flatVector({"hello", "world"});
+  template <typename T>
+  FlatVectorPtr<EvalType<T>> flatVector(const std::initializer_list<T>& data) {
+    return flatVector(std::vector<T>(data));
   }
 
   /// Create a FlatVector<T>


### PR DESCRIPTION
Summary:
Improving VectorMaker's flatVector() API. Removing the non-templted
overload for StringView (which caused API inconsistencies), and ensuring any
input string types (char*, StringView, std::string, std::string_view) are
accepted and are correctly copied into the internal buffer.

Differential Revision: D33202680

