### PR TITLE
Add SsdFile - A Shard of a SSD cache for AsyncDataCache

### DIFF
--- a/velox/common/base/CoalesceIo.h
+++ b/velox/common/base/CoalesceIo.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+namespace facebook::velox {
+// Utility for combining IOs to nearby location into fewer coalesced
+// IOs. This may increase data transfer but generally reduces
+// latency and may reduce throttling.
+
+// Describes the outcome of coalescedIo().
+struct CoalesceIoStats {
+  // Number of distinct IOs.
+  int32_t numIos{0};
+
+  // Number of bytes read into pins.
+  int64_t payloadBytes{0};
+  // Number of bytes read and discarded due to coalescing.
+  int64_t extraBytes{0};
+};
+
+static constexpr int32_t kNoCoalesce = -1;
+
+// Generic template for grouping IOs into batches of <
+// rangesPerIo ranges separated by gaps of size >= maxGap. Element
+// represents the object of the IO, Range is the type representing the
+// IO, e.g. pointer + size, offsetFunc and SizeFunc return the offset
+// and size of an Element.  numRanges returns the number of ranges to
+// process for an element. It may return the special value kNoCoalesce
+// if the entry should not be coalesced.  AddRange adds the ranges
+// that correspond to an Element, skipRange adds a gap between
+// neighboring items, ioFunc takes the items, the first item to
+// process, the first item not to process, the offset of the first
+// item and a vector of Ranges.
+template <
+    typename Item,
+    typename Range,
+    typename ItemOffset,
+    typename ItemSize,
+    typename ItemNumRanges,
+    typename AddRanges,
+    typename SkipRange,
+    typename IoFunc>
+CoalesceIoStats coalesceIo(
+    const std::vector<Item>& items,
+    int32_t maxGap,
+    int32_t rangesPerIo,
+    ItemOffset offsetFunc,
+    ItemSize sizeFunc,
+    ItemNumRanges numRanges,
+    AddRanges addRanges,
+    SkipRange skipRange,
+    IoFunc ioFunc) {
+  std::vector<Range> buffers;
+  auto start = offsetFunc(0);
+  auto lastOffset = start;
+  std::vector<Range> ranges;
+  CoalesceIoStats result;
+  int32_t firstItem = 0;
+  for (int32_t i = 0; i < items.size(); ++i) {
+    auto& item = items[i];
+    auto startOffset = offsetFunc(i);
+    auto size = sizeFunc(i);
+    result.payloadBytes += size;
+    int32_t rangesForItem = numRanges(i);
+    bool enoughRanges = (rangesForItem == kNoCoalesce ||
+                         ranges.size() + rangesForItem >= rangesPerIo) &&
+        !ranges.empty();
+    if (lastOffset != startOffset || enoughRanges) {
+      int64_t gap = startOffset - lastOffset;
+      if (gap > 0 && gap < maxGap && !enoughRanges) {
+        // The next one is after the previous and no farther than maxGap bytes,
+        // we read the gap but drop the bytes.
+        result.extraBytes += gap;
+        skipRange(gap, ranges);
+      } else {
+        ioFunc(items, firstItem, i, start, ranges);
+        ranges.clear();
+        firstItem = i;
+        ++result.numIos;
+        start = startOffset;
+      }
+    }
+    addRanges(item, ranges);
+    lastOffset = startOffset + size;
+  }
+  ioFunc(items, firstItem, items.size(), start, ranges);
+  ++result.numIos;
+  return result;
+}
+
+} // namespace facebook::velox

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_caching DataCache.cpp FileIds.cpp StringIdMap.cpp
-                          AsyncDataCache.cpp ScanTracker.cpp)
-target_link_libraries(velox_caching velox_memory velox_exception glog::glog
-                      ${FOLLY_WITH_DEPENDENCIES})
+add_library(
+  velox_caching
+  DataCache.cpp
+  FileIds.cpp
+  StringIdMap.cpp
+  AsyncDataCache.cpp
+  SsdFile.cpp
+  SsdFileTracker.cpp
+  ScanTracker.cpp)
+target_link_libraries(velox_caching velox_memory velox_exception velox_file
+                      glog::glog ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/SsdFile.h"
+#include <folly/Executor.h>
+#include <folly/portability/SysUio.h>
+#include "velox/common/caching/FileIds.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <numeric>
+
+DEFINE_bool(ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
+DEFINE_bool(ssd_verify_write, false, "Read back data after writing to SSD");
+
+namespace facebook::velox::cache {
+
+SsdPin::SsdPin(SsdFile& file, SsdRun run) : file_(&file), run_(run) {
+  file_->checkPinned(run_.offset());
+}
+
+SsdPin::~SsdPin() {
+  if (file_) {
+    file_->unpinRegion(run_.offset());
+  }
+}
+
+void SsdPin::operator=(SsdPin&& other) {
+  if (file_) {
+    file_->unpinRegion(run_.offset());
+  }
+  file_ = other.file_;
+  other.file_ = nullptr;
+  run_ = other.run_;
+}
+
+SsdFile::SsdFile(
+    const std::string& filename,
+    int32_t shardId,
+    int32_t maxRegions)
+    : shardId_(shardId), maxRegions_(maxRegions), filename_(filename) {
+  int32_t oDirect = 0;
+#ifdef linux
+  oDirect = FLAGS_ssd_odirect ? O_DIRECT : 0;
+#endif
+  fd_ = open(filename.c_str(), O_CREAT | O_RDWR | oDirect, S_IRUSR | S_IWUSR);
+  if (fd_ < 0) {
+    LOG(ERROR) << "Cannot open or create " << filename << " error " << errno;
+    exit(1);
+  }
+  readFile_ = std::make_unique<LocalReadFile>(fd_);
+  uint64_t size = lseek(fd_, 0, SEEK_END);
+  numRegions_ = size / kRegionSize;
+  fileSize_ = numRegions_ * kRegionSize;
+  if (size % kRegionSize > 0) {
+    ftruncate(fd_, fileSize_);
+  }
+  // The existing regions in the file are writable.
+  writableRegions_.resize(numRegions_);
+  std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
+  tracker_.resize(maxRegions_);
+  regionSize_.resize(maxRegions_);
+  regionPins_.resize(maxRegions_);
+}
+
+void SsdFile::pinRegion(uint64_t offset) {
+  std::lock_guard<std::mutex> l(mutex_);
+  pinRegionLocked(offset);
+}
+
+void SsdFile::unpinRegion(uint64_t offset) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto count = --regionPins_[regionIndex(offset)];
+  VELOX_CHECK_LE(0, count);
+  if (suspended_ && count == 0) {
+    growOrEvictLocked();
+  }
+}
+
+namespace {
+void addEntryToIovecs(AsyncDataCacheEntry& entry, std::vector<iovec>& iovecs) {
+  if (entry.tinyData()) {
+    iovecs.push_back({entry.tinyData(), static_cast<size_t>(entry.size())});
+    return;
+  }
+  auto& data = entry.data();
+  iovecs.reserve(iovecs.size() + data.numRuns());
+  int64_t bytesLeft = entry.size();
+  for (auto i = 0; i < data.numRuns(); ++i) {
+    auto run = data.runAt(i);
+    iovecs.push_back(
+        {run.data<char>(), std::min<size_t>(bytesLeft, run.numBytes())});
+    bytesLeft -= run.numBytes();
+    if (bytesLeft <= 0) {
+      break;
+    };
+  }
+}
+} // namespace
+
+SsdPin SsdFile::find(RawFileCacheKey key) {
+  FileCacheKey ssdKey{StringIdLease(fileIds(), key.fileNum), key.offset};
+  SsdRun run;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (suspended_) {
+      return SsdPin();
+    }
+    tracker_.fileTouched(entries_.size());
+    auto it = entries_.find(ssdKey);
+    if (it == entries_.end()) {
+      return SsdPin();
+    }
+    run = it->second;
+    pinRegionLocked(run.offset());
+  }
+  return SsdPin(*this, run);
+}
+
+CoalesceIoStats SsdFile::load(
+    const std::vector<SsdPin>& ssdPins,
+    const std::vector<CachePin>& pins) {
+  VELOX_CHECK_EQ(ssdPins.size(), pins.size());
+  int payloadTotal = 0;
+  for (auto i = 0; i < pins.size(); ++i) {
+    auto runSize = ssdPins[i].run().size();
+    VELOX_CHECK_EQ(runSize, pins[i].entry()->size());
+    payloadTotal += runSize;
+    regionRead(regionIndex(ssdPins[i].run().offset()), runSize);
+    ++stats_.entriesRead;
+    stats_.bytesRead += runSize;
+  }
+  // Do coalesced IO for the pins. For short payloads, the break-even
+  // between discrete pread calls and a single preadv that discards
+  // gaps is ~25K per gap. For longer payloads this is ~50-100K.
+  auto stats = readPins(
+      pins,
+      payloadTotal / pins.size() < 10000 ? 25000 : 50000,
+      // Max ranges in one preadv call. Longest gap + longest cache
+      // entry are under 12 ranges. If a system has a limit of 1K
+      // ranges, coalesce limit of 1000 is safe.
+      900,
+      [&](int32_t index) { return ssdPins[index].run().offset(); },
+      [&](const std::vector<CachePin>& /*pins*/,
+          int32_t /*begin*/,
+          int32_t /*end*/,
+          uint64_t offset,
+          const std::vector<folly::Range<char*>>& buffers) {
+        read(offset, buffers);
+      });
+
+  for (auto i = 0; i < ssdPins.size(); ++i) {
+    pins[i].checkedEntry()->setSsdFile(this, ssdPins[i].run().offset());
+  }
+  return stats;
+}
+
+void SsdFile::read(
+    uint64_t offset,
+    const std::vector<folly::Range<char*>>& buffers) {
+  readFile_->preadv(offset, buffers);
+}
+
+std::optional<std::pair<uint64_t, int32_t>> SsdFile::getSpace(
+    const std::vector<CachePin>& pins,
+    int32_t begin) {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (;;) {
+    if (writableRegions_.empty()) {
+      if (!growOrEvictLocked()) {
+        return std::nullopt;
+        ;
+      }
+    }
+    auto region = writableRegions_[0];
+    auto offset = regionSize_[region];
+    auto available = kRegionSize - offset;
+    int64_t toWrite = 0;
+    for (; begin < pins.size(); ++begin) {
+      auto entry = pins[begin].checkedEntry();
+      if (entry->size() > available) {
+        break;
+      }
+      available -= entry->size();
+      toWrite += entry->size();
+    }
+    if (toWrite) {
+      // At least some pins got space from this region. If the region is full
+      // the next call will get space from another region.
+      regionSize_[region] += toWrite;
+      return std::make_pair<uint64_t, int32_t>(
+          region * kRegionSize + offset, toWrite);
+    }
+
+    tracker_.regionFilled(region);
+    writableRegions_.erase(writableRegions_.begin());
+  }
+}
+
+bool SsdFile::growOrEvictLocked() {
+  if (numRegions_ < maxRegions_) {
+    auto newSize = (numRegions_ + 1) * kRegionSize;
+    auto rc = ftruncate(fd_, newSize);
+    if (rc >= 0) {
+      fileSize_ = newSize;
+      writableRegions_.push_back(numRegions_);
+      regionSize_[numRegions_] = 0;
+      ++numRegions_;
+      return true;
+    } else {
+      LOG(ERROR) << "Failed to grow cache file " << filename_ << " to "
+                 << newSize;
+    }
+  }
+  auto candidates =
+      tracker_.findEvictionCandidates(3, numRegions_, regionPins_);
+  if (candidates.empty()) {
+    suspended_ = true;
+    return false;
+  }
+  clearRegionEntriesLocked(candidates);
+  writableRegions_ = std::move(candidates);
+  suspended_ = false;
+  return true;
+}
+
+void SsdFile::clearRegionEntriesLocked(
+    const std::vector<int32_t>& regionIndices) {
+  // Remove all 'entries_' where the dependent points one of 'regionIndices'.
+  auto it = entries_.begin();
+  while (it != entries_.end()) {
+    auto region = regionIndex(it->second.offset());
+    if (std::find(regionIndices.begin(), regionIndices.end(), region) !=
+        regionIndices.end()) {
+      it = entries_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto region : regionIndices) {
+    // While the region is being filled it may get score from
+    // hits. When it is full, it will get a score boost to be a little
+    // ahead of the best.
+    tracker_.regionCleared(region);
+    regionSize_[region] = 0;
+  }
+}
+
+void SsdFile::write(std::vector<CachePin>& pins) {
+  // Sorts the pins by their file/offset. In this way what is ajacent
+  // in storage is likely adjacent on SSD.
+  std::sort(pins.begin(), pins.end());
+  uint64_t total = 0;
+  for (auto& pin : pins) {
+    auto entry = pin.checkedEntry();
+    VELOX_CHECK_NULL(entry->ssdFile());
+    total += entry->size();
+  }
+  int32_t storeIndex = 0;
+  while (storeIndex < pins.size()) {
+    auto space = getSpace(pins, storeIndex);
+
+    if (!space.has_value()) {
+      // No space can be reclaimed. The pins are freed when the caller is freed.
+      return;
+    }
+    auto [offset, available] = space.value();
+    int32_t numWritten = 0;
+    int32_t bytes = 0;
+    std::vector<iovec> iovecs;
+    for (auto i = storeIndex; i < pins.size(); ++i) {
+      auto entry = pins[i].checkedEntry();
+      auto entrySize = entry->size();
+      if (bytes + entrySize > available) {
+        break;
+      }
+      addEntryToIovecs(*entry, iovecs);
+      bytes += entrySize;
+      ++numWritten;
+    }
+    VELOX_CHECK_GE(fileSize_, offset + bytes);
+    auto rc = folly::pwritev(fd_, iovecs.data(), iovecs.size(), offset);
+    if (rc != bytes) {
+      LOG(ERROR) << "Failed to write to SSD " << errno;
+      // If the write fails we return without adding the pins to the cache. The
+      // entries are unchanged.
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      for (auto i = storeIndex; i < storeIndex + numWritten; ++i) {
+        auto entry = pins[i].checkedEntry();
+        entry->setSsdFile(this, offset);
+        auto size = entry->size();
+        FileCacheKey key = {
+            entry->key().fileNum, static_cast<uint64_t>(entry->offset())};
+        entries_[std::move(key)] = SsdRun(offset, size);
+        if (FLAGS_ssd_verify_write) {
+          verifyWrite(*entry, SsdRun(offset, size));
+        }
+        offset += size;
+        ++stats_.entriesWritten;
+        stats_.bytesWritten += size;
+      }
+    }
+    storeIndex += numWritten;
+  }
+}
+
+namespace {
+int32_t indexOfFirstMismatch(char* x, char* y, int n) {
+  for (auto i = 0; i < n; ++i) {
+    if (x[i] != y[i]) {
+      return i;
+    }
+  }
+  return -1;
+}
+} // namespace
+
+void SsdFile::verifyWrite(AsyncDataCacheEntry& entry, SsdRun ssdRun) {
+  auto testData = std::make_unique<char[]>(entry.size());
+  auto rc = pread(fd_, testData.get(), entry.size(), ssdRun.offset());
+  VELOX_CHECK_EQ(rc, entry.size());
+  if (entry.tinyData()) {
+    if (0 != memcmp(testData.get(), entry.tinyData(), entry.size())) {
+      VELOX_FAIL("bad read back");
+    }
+  } else {
+    auto& data = entry.data();
+    int64_t bytesLeft = entry.size();
+    int64_t offset = 0;
+    for (auto i = 0; i < data.numRuns(); ++i) {
+      auto run = data.runAt(i);
+      auto compareSize = std::min<int64_t>(bytesLeft, run.numBytes());
+      auto badIndex = indexOfFirstMismatch(
+          run.data<char>(), testData.get() + offset, compareSize);
+      if (badIndex != -1) {
+        VELOX_FAIL("Bad read back");
+      }
+      bytesLeft -= run.numBytes();
+      offset += run.numBytes();
+      if (bytesLeft <= 0) {
+        break;
+      };
+    }
+  }
+}
+
+void SsdFile::updateStats(SsdCacheStats& stats) const {
+  stats.entriesWritten += stats_.entriesWritten;
+  stats.bytesWritten += stats_.bytesWritten;
+  stats.entriesRead += stats_.entriesRead;
+  stats.bytesRead += stats_.bytesRead;
+  stats.entriesCached += entries_.size();
+  for (auto& regionSize : regionSize_) {
+    stats.bytesCached += regionSize;
+  }
+}
+
+void SsdFile::clear() {
+  std::lock_guard<std::mutex> l(mutex_);
+  entries_.clear();
+  std::fill(regionSize_.begin(), regionSize_.end(), 0);
+  writableRegions_.resize(numRegions_);
+  std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/SsdFileTracker.h"
+#include "velox/common/file/File.h"
+
+#include <gflags/gflags.h>
+
+DECLARE_bool(ssd_odirect);
+DECLARE_bool(ssd_verify_write);
+
+namespace facebook::velox::cache {
+
+// A 64 bit word describing a SSD cache entry in an SsdFile. The low
+// 23 bits are the size, for a maximum entry size of 8MB. The high
+// bits are the offset.
+class SsdRun {
+ public:
+  static constexpr int32_t kSizeBits = 23;
+
+  SsdRun() : bits_(0) {}
+
+  SsdRun(uint64_t offset, uint32_t size)
+      : bits_((offset << kSizeBits) | ((size - 1))) {
+    VELOX_CHECK_LT(offset, 1L << (64 - kSizeBits));
+    VELOX_CHECK_LT(size - 1, 1 << kSizeBits);
+  }
+
+  SsdRun(const SsdRun& other) = default;
+  SsdRun(SsdRun&& other) = default;
+
+  void operator=(const SsdRun& other) {
+    bits_ = other.bits_;
+  }
+  void operator=(SsdRun&& other) {
+    bits_ = other.bits_;
+  }
+
+  uint64_t offset() const {
+    return (bits_ >> kSizeBits);
+  }
+
+  uint32_t size() const {
+    return (bits_ & ((1 << kSizeBits) - 1)) + 1;
+  }
+
+ private:
+  uint64_t bits_;
+};
+
+// Represents an SsdFile entry that is planned for load or being
+// loaded. This is destroyed after load. Destruction decrements the
+// pin count of the corresponding region of 'file_'. While there are
+// pins, the region cannot be evicted.
+class SsdPin {
+ public:
+  SsdPin() : file_(nullptr) {}
+
+  // Constructs a pin referencing 'run' in 'file'. The region must be
+  // pinned before constructing the pin.
+  SsdPin(SsdFile& file, SsdRun run);
+
+  SsdPin(const SsdPin& other) = delete;
+
+  void operator=(const SsdPin& OTHER) = delete;
+
+  SsdPin(SsdPin&& other) noexcept {
+    run_ = other.run_;
+    file_ = other.file_;
+    other.file_ = nullptr;
+  }
+
+  ~SsdPin();
+
+  void operator=(SsdPin&&);
+
+  bool empty() const {
+    return file_ == nullptr;
+  }
+  SsdFile* file() const {
+    return file_;
+  }
+
+  SsdRun run() const {
+    return run_;
+  }
+
+ private:
+  SsdFile* file_;
+  SsdRun run_;
+};
+
+// Metrics for SSD cache. Maintained by SsdFile and aggregated by SsdCache.
+struct SsdCacheStats {
+  uint64_t entriesWritten{0};
+  uint64_t bytesWritten{0};
+  uint64_t entriesRead{0};
+  uint64_t bytesRead{0};
+  uint64_t entriesCached{0};
+  uint64_t bytesCached{0};
+};
+
+// A shard of SsdCache. Corresponds to one file on SSD.  The data
+// backed by each SsdFile is selected on a hash of the storage file
+// number of the cached data. Each file consists of an integer number
+// of 64MB regions. Each region has a pin count and an read
+// count. Cache replacement takes place region by region, preferring
+// regions with a smaller read count. Entries do not span
+// regions. Otherwise entries are consecutive byte ranges inside
+// their region.
+class SsdFile {
+ public:
+  static constexpr uint64_t kRegionSize = 1 << 26; // 64MB
+
+  // Constructs a cache backed by filename. Discards any previous
+  // contents of filename.
+  SsdFile(const std::string& filename, int32_t shardId, int32_t maxRegions);
+
+  // Adds entries of  'pins'  to this file. 'pins' must be in read mode and
+  // those pins that are successfully added to SSD are marked as being on SSD.
+  // The file of the entries must be a file that is backed by 'this'.
+  void write(std::vector<CachePin>& pins);
+
+  // Finds an entry for 'key'. If no entry is found, the returned pin is empty.
+  SsdPin find(RawFileCacheKey key);
+
+  // Copies the data in 'ssdPins' into 'pins'. Coalesces IO for nearby
+  // entries if they are in ascending order and near enough.
+  CoalesceIoStats load(
+      const std::vector<SsdPin>& ssdPins,
+      const std::vector<CachePin>& pins);
+
+  // Increments the pin count of the region of 'offset'.
+  void pinRegion(uint64_t offset);
+
+  // Decrements the pin count of the region of 'offset'. If the pin
+  // count goes to zero and evict is due, starts the evict.
+  void unpinRegion(uint64_t offset);
+
+  // Asserts that the region of 'offset' is pinned. This is called by
+  // the pin holder. The pin count can be read without mutex.
+  void checkPinned(uint64_t offset) const {
+    VELOX_CHECK_LT(0, regionPins_[regionIndex(offset)]);
+  }
+
+  // Returns the region number corresponding to offset.
+  static int32_t regionIndex(uint64_t offset) {
+    return offset / kRegionSize;
+  }
+
+  // Updates the read count of a region.
+  void regionRead(int32_t region, int32_t size) {
+    tracker_.regionRead(region, size);
+  }
+
+  int32_t maxRegions() const {
+    return maxRegions_;
+  }
+
+  int32_t shardId() const {
+    return shardId_;
+  }
+
+  // Adds 'stats_' to 'stats'.
+  void updateStats(SsdCacheStats& stats) const;
+
+  // Resets this' to a post-construction empty state. See SsdCache::clear().
+  void clear();
+
+ private:
+  // Increments the pin count of the region of 'offset'. Caller must hold
+  // 'mutex_'.
+  void pinRegionLocked(uint64_t offset) {
+    ++regionPins_[regionIndex(offset)];
+  }
+
+  // Returns [offset, size] of contiguous space for storing data of a
+  // number of contiguous 'pins' starting with the pin at index
+  // 'begin'.  Returns nullopt if there is no space. The space does
+  // not necessarily cover all the pins, so multiple calls starting at
+  // the first unwritten pin may be needed.
+  std::optional<std::pair<uint64_t, int32_t>> getSpace(
+      const std::vector<CachePin>& pins,
+      int32_t begin);
+
+  // Removes all 'entries_' that reference data in regions described by
+  // 'regionIndices'.
+  void clearRegionEntriesLocked(const std::vector<int32_t>& regionIndices);
+
+  // Clears one or more  regions for accommodating new entries. The regions are
+  // added to 'writableRegions_'. Returns true if regions could be cleared.
+  bool growOrEvictLocked();
+
+  // Reads the backing file with ReadFile::preadv().
+  void read(uint64_t offset, const std::vector<folly::Range<char*>>& buffers);
+
+  // Verifies that 'entry' has the data at 'run'.
+  void verifyWrite(AsyncDataCacheEntry& entry, SsdRun run);
+
+  // Serializes access to all private data members.
+  std::mutex mutex_;
+
+  // Shard index within 'cache_'.
+  int32_t shardId_;
+
+  // Number of kRegionSize regions in the file.
+  int32_t numRegions_{0};
+
+  // True if stopped serving traffic. Happens if no evictions are
+  // possible due to everything being pinned. Clears when pins
+  // decrease and space can be cleared.
+  bool suspended_{false};
+
+  // Maximum size of the backing file in kRegionSize units.
+  const int32_t maxRegions_;
+
+  // Number of used bytes in in each region. A new entry must fit
+  // between the offset and the end of the region. This is subscripted
+  // with the region index. The regionIndex times kRegionSize is an
+  // offset into the file.
+  std::vector<uint32_t> regionSize_;
+
+  // Indices of regions available for writing new entries.
+  std::vector<int32_t> writableRegions_;
+
+  // Tracker for access frequencies and eviction.
+  SsdFileTracker tracker_;
+
+  // Pin count for each region.
+  std::vector<int32_t> regionPins_;
+
+  // Map of file number and offset to location in file.
+  folly::F14FastMap<FileCacheKey, SsdRun> entries_;
+
+  // Name of backing file.
+  const std::string filename_;
+
+  // File descriptor.
+  int32_t fd_;
+
+  // Size of the backing file in bytes. Must be multiple of kRegionSize.
+  uint64_t fileSize_{0};
+
+  // ReadFile made from 'fd_'.
+  std::unique_ptr<ReadFile> readFile_;
+
+  // Counters.
+  SsdCacheStats stats_;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdFileTracker.cpp
+++ b/velox/common/caching/SsdFileTracker.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/SsdFileTracker.h"
+#include <algorithm>
+
+namespace facebook::velox::cache {
+
+void SsdFileTracker::fileTouched(int32_t totalEntries) {
+  ++numTouches_;
+  if (numTouches_ > kDecayInterval && numTouches_ > totalEntries / 2) {
+    numTouches_ = 0;
+    for (auto& score : regionScores_) {
+      score = (score * 15) / 16;
+    }
+  }
+}
+
+void SsdFileTracker::regionFilled(int32_t region) {
+  uint64_t best = *std::max_element(regionScores_.begin(), regionScores_.end());
+  regionScores_[region] = std::max<int64_t>(regionScores_[region], best * 1.1);
+}
+
+std::vector<int32_t> SsdFileTracker::findEvictionCandidates(
+    int32_t numCandidates,
+    int32_t numRegions,
+    const std::vector<int32_t>& regionPins) {
+  // Calculates average score of regions wiht no pins. Returns up to
+  // 'numCandidates' unpinned regions with score <= average, lowest
+  // scoring region first.
+  int64_t scoreSum = 0;
+  int32_t numUnpinned = 0;
+  for (int i = 0; i < numRegions; ++i) {
+    if (regionPins[i]) {
+      continue;
+    }
+    ++numUnpinned;
+    scoreSum += regionScores_[i];
+  }
+  if (!numUnpinned) {
+    return {};
+  }
+  auto avg = scoreSum / numUnpinned;
+  std::vector<int32_t> candidates;
+  for (auto i = 0; i < regionScores_.size(); ++i) {
+    if (!regionPins[i] && regionScores_[i] <= avg) {
+      candidates.push_back(i);
+    }
+  }
+  // Sort by score to evict less read regions first.
+  std::sort(
+      candidates.begin(), candidates.end(), [&](int32_t left, int32_t right) {
+        return regionScores_[left] < regionScores_[right];
+      });
+  candidates.resize(std::min<int32_t>(candidates.size(), numCandidates));
+  return candidates;
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdFileTracker.h
+++ b/velox/common/caching/SsdFileTracker.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace facebook::velox::cache {
+
+// Tracks reads on an SsdFile. Reads are counted for fixed size regions and
+// periodically decayed. Not thread safe, synchronization is the caller's
+// responsibility.
+class SsdFileTracker {
+ public:
+  void resize(int32_t numRegions) {
+    regionScores_.resize(numRegions);
+  }
+
+  void regionRead(int32_t region, int32_t bytes) {
+    regionScores_[region] += bytes;
+  }
+
+  void regionCleared(int32_t region) {
+    regionScores_[region] = 0;
+  }
+
+  // Marks that a region has been filled and transits from writable to
+  // evictable. Set its score to be at least the best score +
+  // a small margin so that it gets time to live. Otherwise it has had
+  // the least time to get hits and would be the first evicted.
+  void regionFilled(int32_t region);
+
+  // Increments event count and periodically decays
+  // scores. 'totalEntries' is the count of distinct entries in the
+  // tracked file.
+  void fileTouched(int32_t totalEntries);
+
+  // Returns up to 'numCandidates' least used regions. 'numRegions' is
+  // the count of existing regions. This can be less than the size of
+  // the tracker if the file cannot grow to full size. Regions with a
+  // non-zero count in 'regionPins' are not considered.
+  std::vector<int32_t> findEvictionCandidates(
+      int32_t numCandidates,
+      int32_t numRegions,
+      const std::vector<int32_t>& regionPins);
+
+ private:
+  static constexpr int32_t kDecayInterval = 1000;
+
+  std::vector<int64_t> regionScores_;
+
+  // Count of lookups. The scores are decayed every time the count goes
+  // over kDecayInterval or half count of cache entries, whichever comes first.
+  uint64_t numTouches_{0};
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ add_test(simple_lru_cache_test simple_lru_cache_test)
 target_link_libraries(simple_lru_cache_test ${GTEST_BOTH_LIBRARIES} glog::glog
                       ${gflags_LIBRARIES} ${FOLLY_WITH_DEPENDENCIES})
 
-add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp)
+add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
+                                SsdFileTest.cpp SsdFileTrackerTest.cpp)
 add_test(velox_cache_test velox_cache_test)
 target_link_libraries(
   velox_cache_test

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/SsdFile.h"
+#include "velox/common/caching/FileIds.h"
+
+#include <folly/executors/QueuedImmediateExecutor.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+DECLARE_bool(ssd_odirect);
+DECLARE_bool(ssd_verify_write);
+
+using namespace facebook::velox;
+using namespace facebook::velox::cache;
+
+using facebook::velox::memory::MappedMemory;
+
+// Represents an entry written to SSD.
+struct TestEntry {
+  FileCacheKey key;
+  uint64_t ssdOffset;
+  int32_t size;
+
+  TestEntry(FileCacheKey _key, uint64_t _ssdOffset, int32_t _size)
+      : key(_key), ssdOffset(_ssdOffset), size(_size) {}
+};
+
+class SsdFileTest : public testing::Test {
+ protected:
+  static constexpr int64_t kMB = 1 << 20;
+
+  void initializeCache(int64_t maxBytes, int64_t ssdBytes = 0) {
+    // tmpfs does not support O_DIRECT, so turn this off for testing.
+    FLAGS_ssd_odirect = false;
+    cache_ = std::make_shared<AsyncDataCache>(
+        MappedMemory::createDefaultInstance(), maxBytes);
+
+    fileName_ = StringIdLease(fileIds(), "fileInStorage");
+
+    ssdFile_ = std::make_unique<SsdFile>(
+        "/tmp/ssdtest",
+        0,
+        bits::roundUp(ssdBytes, SsdFile::kRegionSize) / SsdFile::kRegionSize);
+  }
+
+  static void initializeContents(
+      int64_t sequence,
+      MappedMemory::Allocation& alloc) {
+    bool first = true;
+    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
+      MappedMemory::PageRun run = alloc.runAt(i);
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
+      int32_t numWords =
+          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+      for (int32_t offset = 0; offset < numWords; offset++) {
+        if (first) {
+          ptr[offset] = sequence;
+          first = false;
+        } else {
+          ptr[offset] = offset + sequence;
+        }
+      }
+    }
+  }
+
+  // Checks that the contents are consistent with what is set in
+  // initializeContents.
+  static void checkContents(
+      const MappedMemory::Allocation& alloc,
+      int32_t numBytes) {
+    bool first = true;
+    int64_t sequence;
+    int32_t bytesChecked = sizeof(int64_t);
+    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
+      MappedMemory::PageRun run = alloc.runAt(i);
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
+      int32_t numWords =
+          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+      for (int32_t offset = 0; offset < numWords; offset++) {
+        if (first) {
+          sequence = ptr[offset];
+          first = false;
+        } else {
+          bytesChecked += sizeof(int64_t);
+          if (bytesChecked >= numBytes) {
+            return;
+          }
+          ASSERT_EQ(ptr[offset], offset + sequence);
+        }
+      }
+    }
+  }
+
+  // Gets consecutive entries from file 'fileId' starting at 'startOffset'  with
+  // sizes between 'minSize' and 'maxSize'. Sizes start at 'minSize' and double
+  // each time and go back to 'minSize' after exceeding 'maxSize'. This stops
+  // after the total size has exceeded 'totalSize'. The entries are returned as
+  // pins. The pins are exclusive for newly created entries and shared for
+  // existing ones. New entries are deterministically  initialized from 'fileId'
+  // and the entry's offset.
+  std::vector<CachePin> makePins(
+      uint64_t fileId,
+      uint64_t startOffset,
+      int32_t minSize,
+      int32_t maxSize,
+      int64_t totalSize) {
+    auto offset = startOffset;
+    int64_t bytesFromCache = 0;
+    auto size = minSize;
+    std::vector<CachePin> pins;
+    while (bytesFromCache < totalSize) {
+      pins.push_back(
+          cache_->findOrCreate(RawFileCacheKey{fileId, offset}, size, nullptr));
+      bytesFromCache += size;
+      EXPECT_FALSE(pins.back().empty());
+      auto entry = pins.back().entry();
+      if (entry && entry->isExclusive()) {
+        initializeContents(fileId + offset, entry->data());
+      }
+      offset += size;
+      size *= 2;
+      if (size > maxSize) {
+        size = minSize;
+      }
+    }
+    return pins;
+  }
+
+  std::vector<SsdPin> pinAllRegions(const std::vector<TestEntry>& entries) {
+    std::vector<SsdPin> pins;
+    int32_t lastRegion = -1;
+    for (auto& entry : entries) {
+      if (entry.ssdOffset / SsdFile::kRegionSize != lastRegion) {
+        lastRegion = entry.key.offset / SsdFile::kRegionSize;
+        pins.push_back(
+            ssdFile_->find(RawFileCacheKey{fileName_.id(), entry.key.offset}));
+        EXPECT_FALSE(pins.back().empty());
+      }
+    }
+    return pins;
+  }
+
+  void readAndCheckPins(const std::vector<CachePin>& pins) {
+    std::vector<SsdPin> ssdPins;
+    ssdPins.reserve(pins.size());
+    for (auto& pin : pins) {
+      ssdPins.push_back(ssdFile_->find(
+          RawFileCacheKey{fileName_.id(), pin.entry()->key().offset}));
+      EXPECT_FALSE(ssdPins.back().empty());
+    }
+    ssdFile_->load(ssdPins, pins);
+    for (auto& pin : pins) {
+      checkContents(pin.entry()->data(), pin.entry()->size());
+    }
+  }
+
+  void checkEvictionBlocked(
+      std::vector<TestEntry>& allEntries,
+      uint64_t ssdSize) {
+    auto ssdPins = pinAllRegions(allEntries);
+    auto pins = makePins(fileName_.id(), ssdSize, 4096, 2048 * 1025, 62 * kMB);
+    ssdFile_->write(pins);
+    // Only Some pins get written because space cannot be cleared
+    // because all regions are pinned. The file will not give out new
+    // pins so that this situation is not continued
+    EXPECT_TRUE(
+        ssdFile_->find(RawFileCacheKey{fileName_.id(), ssdSize}).empty());
+    int32_t numWritten = 0;
+    for (auto& pin : pins) {
+      if (pin.entry()->ssdFile()) {
+        ++numWritten;
+        allEntries.emplace_back(
+            pin.entry()->key(), pin.entry()->ssdOffset(), pin.entry()->size());
+      }
+    }
+    EXPECT_LT(numWritten, pins.size());
+    ssdPins.clear();
+
+    // The pins were cleared and the file is no longer suspended. Check that the
+    // entry that was not found is found now.
+    EXPECT_FALSE(
+        ssdFile_->find(RawFileCacheKey{fileName_.id(), ssdSize}).empty());
+
+    pins.erase(pins.begin(), pins.begin() + numWritten);
+    ssdFile_->write(pins);
+    for (auto& pin : pins) {
+      if (pin.entry()->ssdFile()) {
+        allEntries.emplace_back(
+            pin.entry()->key(), pin.entry()->ssdOffset(), pin.entry()->size());
+      }
+    }
+    // Clear the pins and read back. Clear must complete before
+    // makePins so that there are no pre-existing exclusive pins for the same
+    // key.
+    pins.clear();
+    pins = makePins(fileName_.id(), ssdSize, 4096, 2048 * 1025, 62 * kMB);
+    readAndCheckPins(pins);
+  }
+
+  std::shared_ptr<AsyncDataCache> cache_;
+  StringIdLease fileName_;
+
+  std::unique_ptr<SsdFile> ssdFile_;
+};
+
+TEST_F(SsdFileTest, writeAndRead) {
+  constexpr int64_t kSsdSize = 16 * SsdFile::kRegionSize;
+  std::vector<TestEntry> allEntries;
+  initializeCache(128 * kMB, kSsdSize);
+  FLAGS_ssd_verify_write = true;
+  for (auto startOffset = 0; startOffset <= kSsdSize - SsdFile::kRegionSize;
+       startOffset += SsdFile::kRegionSize) {
+    auto pins =
+        makePins(fileName_.id(), startOffset, 4096, 2048 * 1025, 62 * kMB);
+    ssdFile_->write(pins);
+    for (auto& pin : pins) {
+      EXPECT_EQ(ssdFile_.get(), pin.entry()->ssdFile());
+      allEntries.emplace_back(
+          pin.entry()->key(), pin.entry()->ssdOffset(), pin.entry()->size());
+    };
+  }
+
+  // The SsdFile is almost full and the memory cache has the last batch written
+  // and a few entries from the batch before that.
+  // We read back the same batches and check
+  // contents.
+  for (auto startOffset = 0; startOffset <= kSsdSize - SsdFile::kRegionSize;
+       startOffset += SsdFile::kRegionSize) {
+    auto pins =
+        makePins(fileName_.id(), startOffset, 4096, 2048 * 1025, 62 * kMB);
+    readAndCheckPins(pins);
+  }
+  checkEvictionBlocked(allEntries, kSsdSize);
+  // We rewrite the cache with new entries.
+
+  for (auto startOffset = kSsdSize + SsdFile::kRegionSize;
+       startOffset <= kSsdSize * 2;
+       startOffset += SsdFile::kRegionSize) {
+    auto pins =
+        makePins(fileName_.id(), startOffset, 4096, 2048 * 1025, 62 * kMB);
+    ssdFile_->write(pins);
+    for (auto& pin : pins) {
+      EXPECT_EQ(ssdFile_.get(), pin.entry()->ssdFile());
+      allEntries.emplace_back(
+          pin.entry()->key(), pin.entry()->ssdOffset(), pin.entry()->size());
+    }
+  }
+
+  // We check howmany entries are found. The earliest writes will have been
+  // evicted. We read back the found entries and check their contents.
+  int32_t numFound = 0;
+  for (auto& entry : allEntries) {
+    std::vector<CachePin> pins;
+
+    pins.push_back(cache_->findOrCreate(
+        RawFileCacheKey{fileName_.id(), entry.key.offset},
+        entry.size,
+        nullptr));
+    if (pins.back().entry()->isExclusive()) {
+      std::vector<SsdPin> ssdPins;
+
+      ssdPins.push_back(
+          ssdFile_->find(RawFileCacheKey{fileName_.id(), entry.key.offset}));
+      if (!ssdPins.back().empty()) {
+        ++numFound;
+        ssdFile_->load(ssdPins, pins);
+        checkContents(pins[0].entry()->data(), pins[0].entry()->size());
+      }
+    }
+  }
+}

--- a/velox/common/caching/tests/SsdFileTrackerTest.cpp
+++ b/velox/common/caching/tests/SsdFileTrackerTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/SsdFileTracker.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox::cache;
+
+TEST(SsdFileTrackerTest, tracker) {
+  constexpr int32_t kNumRegions = 16;
+  SsdFileTracker tracker;
+  tracker.resize(kNumRegions);
+  // Simulate a sequence of access that periodically adds a new region and keeps
+  // accessing the 4 most recently added regions.
+  for (auto lastRegion = 0; lastRegion <= kNumRegions; ++lastRegion) {
+    tracker.regionFilled(lastRegion);
+    for (auto i = 0; i < 2000; ++i) {
+      for (auto region = std::max(lastRegion - 3, 0); region <= lastRegion;
+           ++region) {
+        // fileTouched means a lookup. This decays scores so that new uses are
+        // more relevant than old ones. The actual read is tracked by
+        // regionRead()..
+        tracker.fileTouched(10000);
+        tracker.regionRead(region, 100000);
+      }
+    }
+  }
+  std::vector<int32_t> pins(kNumRegions);
+  pins[2] = 1;
+  pins[3] = 2;
+  // Get up to 10 low-use regions out of kNumRegions used regions, excluding
+  // regions that have a non-zero in 'pins'.
+  auto candidates =
+      tracker.findEvictionCandidates(kNumRegions, kNumRegions, pins);
+  std::vector<int32_t> expected{0, 1, 4, 5, 6, 7, 8, 9};
+  EXPECT_EQ(candidates, expected);
+}

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -199,6 +199,8 @@ class LocalReadFile final : public ReadFile {
  public:
   explicit LocalReadFile(std::string_view path);
 
+  explicit LocalReadFile(int32_t fd);
+
   std::string_view pread(uint64_t offset, uint64_t length, Arena* arena)
       const final;
   std::string_view pread(uint64_t offset, uint64_t length, void* buf)

--- a/velox/common/tests/CMakeLists.txt
+++ b/velox/common/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   RangeTest.cpp
   BitUtilTest.cpp
   BloomFilterTest.cpp
+  CoalesceIoTest.cpp
   RawVectorTest.cpp
   StatsReporterTest.cpp
   SimdUtilTest.cpp

--- a/velox/common/tests/CoalesceIoTest.cpp
+++ b/velox/common/tests/CoalesceIoTest.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/CoalesceIo.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+// Mockup of a cache entry: Offset, size, number of elements in a
+// chained buffer.
+struct IoUnit {
+  explicit IoUnit(
+      int64_t _offset,
+      int32_t _size,
+      int32_t _numBuffers,
+      bool _mayCoalesce = true)
+      : offset(_offset),
+        size(_size),
+        numBuffers(_numBuffers),
+        mayCoalesce(_mayCoalesce) {}
+  const int64_t offset;
+  const int32_t size;
+  const int32_t numBuffers;
+  const bool mayCoalesce;
+};
+
+// Represents a data transfer. size is the number of bytes. numBuffers
+// is the number of chained buffers to process. If this is 0, Range
+// represents a skip of size bytes. This is for illustration only, so
+// does not mention the actual buffers.
+struct Range {
+  Range(int64_t _size, int32_t _numBuffers)
+      : size(_size), numBuffers(_numBuffers) {}
+  const int64_t size;
+  const int32_t numBuffers;
+};
+
+TEST(CoalesceIoTest, basic) {
+  std::vector<IoUnit> data;
+
+  //
+  // The first 3 are in close proximity. But the 4th is apart because
+  // bundling this with the 2 first would exceed the max batch size of 4.
+  data.emplace_back(1000, 100000, 3);
+  data.emplace_back(105000, 100000, 3);
+  data.emplace_back(220000, 100000, 3);
+  data.emplace_back(330000, 100000, 3);
+  data.emplace_back(700000, 100000, 3);
+  data.emplace_back(810000, 1000000, 1, false);
+  std::vector<int64_t> offsets;
+  // Vector where each element has the indices of the IoUnits to
+  // process together.
+  std::vector<std::vector<int32_t>> ioGroups;
+
+  auto stats = coalesceIo<IoUnit, Range>(
+      data,
+      20000,
+      8,
+      [&](int32_t index) { return data[index].offset; },
+      [&](int32_t index) { return data[index].size; },
+      [&](int32_t index) {
+        return data[index].mayCoalesce ? data[index].numBuffers : kNoCoalesce;
+      },
+      [&](const IoUnit& item, std::vector<Range>& ranges) {
+        // Add as many ranges as there are buffers. Make all but the last be 0
+        // bytes.
+        for (auto i = 0; i < item.numBuffers - 1; ++i) {
+          ranges.emplace_back(0, 0);
+        }
+        ranges.emplace_back(item.size, item.numBuffers);
+      },
+      [&](int32_t skip, std::vector<Range>& ranges) {
+        ranges.emplace_back(skip, 0);
+      },
+      [&](const std::vector<IoUnit>& items,
+          int32_t begin,
+          int32_t end,
+          uint64_t offset,
+          const std::vector<Range>& rages) {
+        offsets.push_back(offset);
+        ioGroups.emplace_back();
+        for (auto i = begin; i < end; ++i) {
+          ioGroups.back().push_back(i);
+        }
+      });
+
+  // We expect 4 IOs. The two first are coalesced because of a gap of
+  // under 30000. The third is not coalesced even though it is near
+  // because of the ranges per IO limit of 10. The fourth is too far
+  // from the third to coalesce.
+  EXPECT_EQ(4, stats.numIos);
+  EXPECT_EQ(1500000, stats.payloadBytes);
+  EXPECT_EQ(14000, stats.extraBytes);
+
+  std::vector<int64_t> expectedOffsets{1000, 220000, 700000, 810000};
+  EXPECT_EQ(expectedOffsets, offsets);
+  EXPECT_EQ(2, ioGroups[0].size());
+  EXPECT_EQ(2, ioGroups[1].size());
+  EXPECT_EQ(1, ioGroups[2].size());
+  EXPECT_EQ(1, ioGroups[3].size());
+}


### PR DESCRIPTION
Entries from AsyncDataCache can be written to and read from an
SsdFile. When writing, the file allocates space for the cache entries,
possibly growing the file or evicting older entries.  When reading,
the caller obtains SsdPins for the entries to be read. The entries are
guaranteed to stay live for the duration of their pin. The entries can
then be read with a coalesced IO.

The SsdFile is composed of regions. Each region has entries and
entries do not span regions. The region is the unit of eviction and
pinning and access tracking. When the cache is read from, region read
counts are updated and older counts are decayed. When needing to write
to a full SsdFile, we take the lowest score unpinned region and remove
the entries in this region from the key to entry map and rewrite the
region.

Adds a utility function readPins for coalescing read of multiple pins
from a file or other container supporting ReadFile::preadv or similar.