### PR TITLE
Efficient crc computation by skipping double memory allocation in PrestoSerializer

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -17,7 +17,7 @@
 #include "velox/common/memory/ByteStream.h"
 
 namespace facebook::velox {
-void ByteStream::flush(std::ostream* out) {
+void ByteStream::flush(OutputStream* out) {
   for (int32_t i = 0; i < ranges_.size(); ++i) {
     int32_t count = ranges_[i].position;
     int32_t bytes = isBits_ ? bits::nbytes(count) : count;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -46,7 +46,9 @@ class SerializedPage {
   static std::unique_ptr<SerializedPage> fromVectorStreamGroup(
       VectorStreamGroup* group) {
     std::stringstream out;
-    group->flush(&out);
+    OutputStreamListener listener;
+    OutputStream outputStream(&out, &listener);
+    group->flush(&outputStream);
     return std::make_unique<SerializedPage>(
         &out, out.tellp(), group->mappedMemory());
   }

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -60,7 +60,9 @@ class PrestoSerializerTest : public ::testing::Test {
     auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
 
     serializer->append(rowVector, folly::Range(rows.data(), numRows));
-    serializer->flush(output);
+    facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+    OutputStream out(output, &listener);
+    serializer->flush(&out);
   }
 
   std::unique_ptr<ByteStream> toByteStream(const std::string& input) {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -48,7 +48,7 @@ void VectorStreamGroup::append(
   serializer_->append(vector, ranges);
 }
 
-void VectorStreamGroup::flush(std::ostream* out) {
+void VectorStreamGroup::flush(OutputStream* out) {
   serializer_->flush(out);
 }
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -16,14 +16,14 @@
 #pragma once
 
 #include "velox/buffer/Buffer.h"
+#include "velox/common/memory/ByteStream.h"
 #include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/StreamArena.h"
 #include "velox/type/Type.h"
 #include "velox/vector/SelectivityVector.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 class BaseVector;
 class ByteStream;
@@ -43,7 +43,7 @@ class VectorSerializer {
       const folly::Range<const IndexRange*>& ranges) = 0;
 
   // Writes the contents to 'stream' in wire format
-  virtual void flush(std::ostream* stream) = 0;
+  virtual void flush(OutputStream* stream) = 0;
 };
 
 class VectorSerde {
@@ -101,7 +101,7 @@ class VectorStreamGroup : public StreamArena {
       const folly::Range<const IndexRange*>& ranges);
 
   // Writes the contents to 'stream' in wire format.
-  void flush(std::ostream* stream);
+  void flush(OutputStream* stream);
 
   // Reads data in wire format. Returns the RowVector in 'result'.
   static void read(
@@ -114,5 +114,4 @@ class VectorStreamGroup : public StreamArena {
   std::unique_ptr<VectorSerializer> serializer_;
 };
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -697,8 +697,10 @@ class VectorTest : public testing::Test {
             oddIndices.size() - oddIndices.size() / 2));
     std::stringstream evenStream;
     std::stringstream oddStream;
-    even.flush(&evenStream);
-    odd.flush(&oddStream);
+    OutputStream eventOutputStream(&evenStream);
+    OutputStream oddOutputStream(&oddStream);
+    even.flush(&eventOutputStream);
+    odd.flush(&oddOutputStream);
     ByteStream input;
     auto evenString = evenStream.str();
     checkSizes(source.get(), evenSizes, evenString);


### PR DESCRIPTION
Summary: In PrestoSerializer flush method, we compute CRC with incoming data. This data is copied to a string stream, and then CRC is computed. This is not efficient, as we already walk through the bytes during flush. In this diff, we create a "OutputStream" class, which works as a proxy on std::ostream. It also can keep a running checksum on the bytes that are processed. As a result, during Prestoserializer flush method, we no longer need to allocate memory for CRC computation on a temporary string buffer. Note that, we also expose underlying ostream object - as write pattern on the OutputStream is not in sync with CRC computation. For example, we write 0 to allocate space. To support this we directly access underlying osstream object.

Differential Revision: D33231829

