### PR TITLE
Update CircleCI runs to use ctest command and clean up excluded tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            ctest --test-dir _build/debug -j 16 -VV --output-on-failure
+            cd _build/debug && ctest -j 16 -VV --output-on-failure
           no_output_timeout: 1h
       - run:
           name: "Run Fuzzer Tests"
@@ -215,6 +215,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
+            cmake --version
             make release EXTRA_CMAKE_FLAGS=" -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_S3=ON " AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
             ccache -s
           no_output_timeout: 1h
@@ -229,7 +230,7 @@ jobs:
           name: "Run Unit Tests"
           command: |
             export PATH=~/adapter-deps/install/bin:${PATH}
-            ctest --test-dir _build/release -j 16 -VV --output-on-failure
+            cd _build/release && ctest -j 16 -VV --output-on-failure
           no_output_timeout: 1h
 
   format-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,12 +129,12 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            make unittestonly BUILD_DIR=debug NUM_THREADS=16
+            ctest --test-dir=_build/debug -j 16 -VV --output-on-failure
           no_output_timeout: 1h
       - run:
           name: "Run Fuzzer Tests"
           command: |
-            make fuzzertest
+            _build/debug/velox/expression/tests/velox_expression_fuzzer_test --steps 100000 --logtostderr=1 --minloglevel=0
           no_output_timeout: 5m
       - run:
          name: "Run the velox examples"
@@ -229,7 +229,7 @@ jobs:
           name: "Run Unit Tests"
           command: |
             export PATH=~/adapter-deps/install/bin:${PATH}
-            make unittestonly BUILD_DIR=release NUM_THREADS=16
+            ctest --test-dir=_build/release -j 16 -VV --output-on-failure
           no_output_timeout: 1h
 
   format-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            make unittest NUM_THREADS=16
+            make unittestonly BUILD_DIR=debug NUM_THREADS=16
           no_output_timeout: 1h
       - run:
           name: "Run Fuzzer Tests"
@@ -229,7 +229,7 @@ jobs:
           name: "Run Unit Tests"
           command: |
             export PATH=~/adapter-deps/install/bin:${PATH}
-            make unittestrel VELOX_ENABLE_ADAPTERS=ON AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16
+            make unittestonly BUILD_DIR=release NUM_THREADS=16
           no_output_timeout: 1h
 
   format-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: "Run Unit Tests"
           command: |
-            ctest --test-dir=_build/debug -j 16 -VV --output-on-failure
+            ctest --test-dir _build/debug -j 16 -VV --output-on-failure
           no_output_timeout: 1h
       - run:
           name: "Run Fuzzer Tests"
@@ -229,7 +229,7 @@ jobs:
           name: "Run Unit Tests"
           command: |
             export PATH=~/adapter-deps/install/bin:${PATH}
-            ctest --test-dir=_build/release -j 16 -VV --output-on-failure
+            ctest --test-dir _build/release -j 16 -VV --output-on-failure
           no_output_timeout: 1h
 
   format-check:

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ min_debug:				#: Minimal build with debugging symbols
 unittest: debug			#: Build with debugging and run unit tests
 	cd $(BUILD_BASE_DIR)/debug && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
 
-unittestrel: release    	#: Build with release and run unit tests
-	cd $(BUILD_BASE_DIR)/release && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
+unittestonly:    	       #: Run unit tests
+	cd $(BUILD_BASE_DIR)/$(BUILD_DIR) && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
 
 fuzzertest: debug		#: Build with debugging and run expression fuzzer test.
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test --steps 100000 --logtostderr=1 --minloglevel=0

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,7 @@ min_debug:				#: Minimal build with debugging symbols
 	$(MAKE) build BUILD_DIR=debug
 
 unittest: debug			#: Build with debugging and run unit tests
-	cd $(BUILD_BASE_DIR)/debug && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
-
-unittestonly:    	       #: Run unit tests
-	cd $(BUILD_BASE_DIR)/$(BUILD_DIR) && ctest -j ${NUM_THREADS} -VV --output-on-failure --exclude-regex "MemoryMemoryHeaderTest\.getDefaultScopedMemoryPool|MemoryManagerTest\.GlobalMemoryManager"
+	ctest --test-dir=$(BUILD_BASE_DIR)/debug -j ${NUM_THREADS} -VV --output-on-failure
 
 fuzzertest: debug		#: Build with debugging and run expression fuzzer test.
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test --steps 100000 --logtostderr=1 --minloglevel=0

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ min_debug:				#: Minimal build with debugging symbols
 	$(MAKE) build BUILD_DIR=debug
 
 unittest: debug			#: Build with debugging and run unit tests
-	ctest --test-dir $(BUILD_BASE_DIR)/debug -j ${NUM_THREADS} -VV --output-on-failure
+	cd $(BUILD_BASE_DIR)/debug && ctest -j ${NUM_THREADS} -VV --output-on-failure
 
 fuzzertest: debug		#: Build with debugging and run expression fuzzer test.
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test --steps 100000 --logtostderr=1 --minloglevel=0

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ min_debug:				#: Minimal build with debugging symbols
 	$(MAKE) build BUILD_DIR=debug
 
 unittest: debug			#: Build with debugging and run unit tests
-	ctest --test-dir=$(BUILD_BASE_DIR)/debug -j ${NUM_THREADS} -VV --output-on-failure
+	ctest --test-dir $(BUILD_BASE_DIR)/debug -j ${NUM_THREADS} -VV --output-on-failure
 
 fuzzertest: debug		#: Build with debugging and run expression fuzzer test.
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test --steps 100000 --logtostderr=1 --minloglevel=0

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/VeloxException.h"


### PR DESCRIPTION
The current CircleCI run first builds the Velox library and then involves `make unittest`
However, `unittest` target depends on the `debug` target. Now if the `unittest` CMake arguments do not match those from the previous build step, it ends up building the `debug` target again. This can cause subtle bugs.
We also have been excluding two tests (`MemoryMemoryHeaderTest.getDefaultScopedMemoryPool, MemoryManagerTest.GlobalMemoryManager`) in our unittest target. These have been enabled.
