### PR TITLE
Require resultTypes for PlanBuilder::finalAggregation

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -90,7 +90,7 @@ class PlanBuilder {
   PlanBuilder& finalAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::vector<TypePtr>& resultTypes = {}) {
+      const std::vector<TypePtr>& resultTypes) {
     return aggregation(
         groupingKeys,
         aggregates,
@@ -108,7 +108,7 @@ class PlanBuilder {
   PlanBuilder& intermediateAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::vector<TypePtr>& resultTypes = {}) {
+      const std::vector<TypePtr>& resultTypes) {
     return aggregation(
         groupingKeys,
         aggregates,
@@ -120,15 +120,13 @@ class PlanBuilder {
 
   PlanBuilder& singleAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
-      const std::vector<std::string>& aggregates,
-      const std::vector<TypePtr>& resultTypes = {}) {
+      const std::vector<std::string>& aggregates) {
     return aggregation(
         groupingKeys,
         aggregates,
         {},
         core::AggregationNode::Step::kSingle,
-        false,
-        resultTypes);
+        false);
   }
 
   PlanBuilder& aggregation(

--- a/velox/functions/prestosql/aggregates/benchmarks/PushdownBenchmark.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/PushdownBenchmark.cpp
@@ -73,7 +73,7 @@ class PushdownBenchmark : public HiveConnectorTestBase {
     return PlanBuilder()
         .tableScan(rowType_, tableHandle, assignments)
         .partialAggregation({0}, {fmt::format("{}(c1)", aggName)})
-        .finalAggregation({0}, {fmt::format("{}(a0)", aggName)})
+        .finalAggregation()
         .planNode();
   }
 


### PR DESCRIPTION
Type inference for aggregations is possible only if raw input types are known, e.g. it is possible for partial and single aggregations and final and intermediate aggregations that follow partial aggregation. Final and intermediate aggregations that appear on their own must specify result types explicitly.