### PR TITLE
Add filter check for SEMI/ANTI join

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -168,6 +168,9 @@ AbstractJoinNode::AbstractJoinNode(
       leftKeys_.size(),
       rightKeys_.size(),
       "HashJoinNode requires same number of join keys on probe and build sides");
+  if (isSemiJoin() || isAntiJoin()) {
+    VELOX_CHECK_NULL(filter, "Semi and anti join does not support filter");
+  }
   auto leftType = sources_[0]->outputType();
   for (auto key : leftKeys_) {
     VELOX_CHECK(


### PR DESCRIPTION
Summary: This change is to add an explicit filter check for SEMI/ANTI join, as in Velox we are not supporting SEMI/ANTI join with additional join filter condition.

Differential Revision: D33245671

