### PR TITLE
Honor ascending flag in SimpleVector::compare method

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -319,7 +319,8 @@ int compareArrays(
       return result;
     }
   }
-  return leftRange.size - rightRange.size;
+  int result = leftRange.size - rightRange.size;
+  return flags.ascending ? result : result * -1;
 }
 
 int compareArrays(
@@ -339,7 +340,8 @@ int compareArrays(
       return result;
     }
   }
-  return leftRange.size() - rightRange.size();
+  int result = leftRange.size() - rightRange.size();
+  return flags.ascending ? result : result * -1;
 }
 } // namespace
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -192,7 +192,8 @@ class SimpleVector : public BaseVector {
     auto simpleVector = reinterpret_cast<const SimpleVector<T>*>(other);
     auto thisValue = valueAt(index);
     auto otherValue = simpleVector->valueAt(otherIndex);
-    return thisValue == otherValue ? 0 : thisValue < otherValue ? -1 : 1;
+    auto result = comparePrimitiveAsc(thisValue, otherValue);
+    return flags.ascending ? result : result * -1;
   }
 
   /**
@@ -389,6 +390,20 @@ class SimpleVector : public BaseVector {
   void setMinMax(const folly::F14FastMap<std::string, std::string>& metaData) {
     min_ = getMetaDataValue<T>(metaData, META_MIN);
     max_ = getMetaDataValue<T>(metaData, META_MAX);
+  }
+
+  int comparePrimitiveAsc(const T& left, const T& right) const {
+    if constexpr (std::is_floating_point<T>::value) {
+      bool isLeftNan = std::isnan(left);
+      bool isRightNan = std::isnan(right);
+      if (isLeftNan) {
+        return isRightNan ? 0 : 1;
+      }
+      if (isRightNan) {
+        return -1;
+      }
+    }
+    return left < right ? -1 : left == right ? 0 : 1;
   }
 
  protected:

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -513,6 +513,85 @@ TYPED_TEST(SimpleVectorUnaryTypedTest, hashAll) {
   this->runTest(hashTest);
 }
 
+template <typename T>
+class SimpleVectorCompareTest : public SimpleVectorTest {
+ protected:
+  void runTest(const CompareFlags& flags) {
+    ExpectedData<T> input = {
+        max(), std::nullopt, nan(), lowest(), inf(), -1, 1, 0, max(), lowest()};
+    auto vector = maker_.encodedVector(VectorEncoding::Simple::FLAT, input);
+    std::vector<int> indices(input.size());
+    for (int i = 0; i < input.size(); ++i) {
+      indices[i] = i;
+    }
+    std::sort(indices.begin(), indices.end(), [&](int a, int b) {
+      return vector->compare(vector.get(), a, b, flags) < 0;
+    });
+    ExpectedData<T> expected = {
+        std::nullopt, lowest(), lowest(), -1, 0, 1, max(), max(), inf(), nan()};
+    if (!flags.ascending) {
+      std::reverse(expected.begin() + 1, expected.end());
+    }
+    if (!flags.nullsFirst) {
+      // Move null to end of vector.
+      expected.erase(expected.begin());
+      expected.push_back(std::nullopt);
+    }
+    ExpectedData<T> actual;
+    for (int i = 0; i < input.size(); ++i) {
+      std::optional<T> v = std::nullopt;
+      if (not vector->isNullAt(indices[i])) {
+        v = vector->valueAt(indices[i]);
+      }
+      actual.push_back(v);
+    }
+    assertVector(
+        expected, maker_.encodedVector(VectorEncoding::Simple::FLAT, actual));
+  }
+
+  T max() {
+    return std::numeric_limits<T>::max();
+  }
+
+  T lowest() {
+    return std::numeric_limits<T>::lowest();
+  }
+
+  T inf() {
+    if constexpr (std::is_floating_point<T>::value) {
+      return std::numeric_limits<T>::infinity();
+    }
+    return std::numeric_limits<T>::max();
+  }
+
+  T nan() {
+    if constexpr (std::is_floating_point<T>::value) {
+      return std::numeric_limits<T>::quiet_NaN();
+    }
+    return std::numeric_limits<T>::max();
+  }
+};
+
+using NumericTypes =
+    ::testing::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
+VELOX_TYPED_TEST_SUITE(SimpleVectorCompareTest, NumericTypes);
+
+TYPED_TEST(SimpleVectorCompareTest, compareAscNullsFirst) {
+  this->runTest({/*nullsFirst=*/true, /*ascending=*/true});
+}
+
+TYPED_TEST(SimpleVectorCompareTest, compareAscNullsLast) {
+  this->runTest({/*nullsFirst=*/false, /*ascending=*/true});
+}
+
+TYPED_TEST(SimpleVectorCompareTest, compareDescNullsFirst) {
+  this->runTest({/*nullsFirst=*/true, /*ascending=*/false});
+}
+
+TYPED_TEST(SimpleVectorCompareTest, compareDescNullsLast) {
+  this->runTest({/*nullsFirst=*/false, /*ascending=*/false});
+}
+
 template <typename T, int32_t offset>
 inline T simd256_extract_value(__m256i& simdValue) {
   // hack to work around error: argument to '__builtin_ia32_vec_ext_v4di'

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -217,7 +217,15 @@ void assertVector(
       if (dbgPrintVec) {
         LOG(INFO) << "[" << i << "]:" << *optionalValue;
       }
-      EXPECT_EQ(*optionalValue, outVector->valueAt(i));
+      if constexpr (std::is_floating_point<T>::value) {
+        if (auto isNan = std::isnan(*optionalValue)) {
+          EXPECT_EQ(isNan, std::isnan(outVector->valueAt(i)));
+        } else {
+          EXPECT_EQ(*optionalValue, outVector->valueAt(i));
+        }
+      } else {
+        EXPECT_EQ(*optionalValue, outVector->valueAt(i));
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
Fix following bugs in SimpleVector::compare
1) Honor ascending flag from CompareFlags
2) Add proper handling of NaN values and sort them in following ascending
   order: -inf < inf < nan

Differential Revision: D33251386

