### PR TITLE
Honor ascending flag when comparing CompexVector arrays

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -319,7 +319,8 @@ int compareArrays(
       return result;
     }
   }
-  return leftRange.size - rightRange.size;
+  int result = leftRange.size - rightRange.size;
+  return flags.ascending ? result : result * -1;
 }
 
 int compareArrays(
@@ -339,7 +340,8 @@ int compareArrays(
       return result;
     }
   }
-  return leftRange.size() - rightRange.size();
+  int result = leftRange.size() - rightRange.size();
+  return flags.ascending ? result : result * -1;
 }
 } // namespace
 


### PR DESCRIPTION
Summary:
We encouter this bug when comparing arrays of different size and one array is
prefix of another. Example {1, 3, 5} and {1, 3}

Differential Revision: D33251388

