### PR TITLE
Add utility for coalescing nearby IOs

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -678,4 +678,108 @@ T percentile(Next next, int32_t numSamples, int percent) {
   return values.empty() ? 0 : values[(values.size() * percent) / 100];
 }
 
+// Describes the outcome of coalescedIo().
+struct CoalescedIoStats {
+  // Number of distinct IOs.
+  int32_t numIos{0};
+
+  // Number of bytes read into pins.
+  int64_t payloadBytes{0};
+  // Number of bytes read and discarded due to coalescing.
+  int64_t extraBytes{0};
+};
+
+// Utility function for loading multiple pins with coalesced
+// IO. 'pins' is a vector of CachePins to fill. 'maxGap' is the
+// largest allowed distance in bytes between the end of one entry and
+// the start of the next. If the gap is larger or the next is before
+// the end of the previous, the entries will be fetched separately.
+//
+//'offsetFunc' returns the starting offset of the data in the
+// file given a pin and the pin's index in 'pins'. The pins are expected to be
+// sorted by this offset. 'readFunc' reads from the appropriate media. It gets
+// the 'pins' and the index of the first pin included in the read and the index
+// of the first pin not included. It gets the starting offset of the read and a
+// vector of memory ranges to fill by ReadFile::preadv or a similar
+// function.
+// The caller is responsible for calling setValid on the pins after a successful
+// read.
+//
+// Returns the number of distinct IOs, the number of bytes loaded into pins and
+// the number of extr bytes read.
+CoalescedIoStats readPins(
+    const std::vector<CachePin>& pins,
+    int32_t maxGap,
+    int32_t maxBatch,
+    std::function<uint64_t(int32_t index)> offsetFunc,
+    std::function<void(
+        const std::vector<CachePin>& pins,
+        int32_t begin,
+        int32_t end,
+        uint64_t offset,
+        const std::vector<folly::Range<char*>>& buffers)> readFunc);
+
+// Generic template for grouping IOs into batches of <
+// rangesPerIo ranges separated by gaps of size >= maxGap. Element
+// represents the object of the IO, Range is the type representing
+// the IO, e.g. pointer + size, offsetFunc and SizeFunc return the
+// offset and size of an Element, AddRange adds the ranges that
+// correspond to an Element, skipRange adds a gap between
+// neighboring items, ioFunc takes the items, the first item to
+// process, the first item not to process, the offset of the first
+// item and a vector of Ranges.
+template <
+    typename Item,
+    typename Range,
+    typename ItemOffset,
+    typename ItemSize,
+    typename ItemNumRanges,
+    typename AddRanges,
+    typename SkipRange,
+    typename IoFunc>
+CoalescedIoStats coalescedIo(
+    const std::vector<Item>& items,
+    int32_t maxGap,
+    int32_t rangesPerIo,
+    ItemOffset offsetFunc,
+    ItemSize sizeFunc,
+    ItemNumRanges numRanges,
+    AddRanges addRanges,
+    SkipRange skipRange,
+    IoFunc ioFunc) {
+  std::vector<Range> buffers;
+  auto start = offsetFunc(0);
+  auto lastOffset = start;
+  std::vector<Range> ranges;
+  CoalescedIoStats result;
+  int32_t firstItem = 0;
+  for (int32_t i = 0; i < items.size(); ++i) {
+    auto& item = items[i];
+    auto startOffset = offsetFunc(i);
+    auto size = sizeFunc(i);
+    result.payloadBytes += size;
+    bool enoughRanges = ranges.size() + numRanges(item) >= rangesPerIo;
+    if (lastOffset != startOffset || enoughRanges) {
+      int64_t gap = startOffset - lastOffset;
+      if (gap > 0 && gap < maxGap && !enoughRanges) {
+        // The next one is after the previous and no farther than maxGap bytes,
+        // we read the gap but do not retail the bytes.
+        result.extraBytes += gap;
+        skipRange(gap, ranges);
+      } else {
+        ioFunc(items, firstItem, i, start, ranges);
+        ranges.clear();
+        firstItem = i;
+        ++result.numIos;
+        start = startOffset;
+      }
+    }
+    addRanges(item, ranges);
+    lastOffset = startOffset + size;
+  }
+  ioFunc(items, firstItem, items.size(), start, ranges);
+  ++result.numIos;
+  return result;
+}
+
 } // namespace facebook::velox::cache


### PR DESCRIPTION
Adds a generic template for detecting coalescable IOs. Uses this to
make a function for reading multiple CachePins so that nearby pins go
in the same IO request.