### PR TITLE
Fix output layout handling in LocalPartition operator

### DIFF
--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -172,6 +172,9 @@ class LocalPartition : public Operator {
   }
 
  private:
+  BlockingReason
+  enqueue(int32_t source, RowVectorPtr data, ContinueFuture* future);
+
   const std::vector<std::shared_ptr<LocalExchangeSource>> localExchangeSources_;
   const size_t numPartitions_;
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
@@ -183,7 +186,6 @@ class LocalPartition : public Operator {
   std::vector<ContinueFuture> futures_;
 
   /// Reusable memory for hash calculation.
-  SelectivityVector allRows_;
   std::vector<uint32_t> partitions_;
 };
 


### PR DESCRIPTION
Output layout (the order of columns in the output) applies to results, but LocalPartition was applying it to input. In case when partitioning key had a different position in the output, hashing was applied to the wrong column potentially of the wrong type leading to a crash in DecodedVector::valueAt<T>(). 