### PR TITLE
Make StringView implicitly convertible from char*

### DIFF
--- a/velox/functions/lib/JodaDateTime.h
+++ b/velox/functions/lib/JodaDateTime.h
@@ -97,6 +97,10 @@ struct JodaResult {
 /// Compiles a Joda-compatible datetime format string.
 class JodaFormatter {
  public:
+  explicit JodaFormatter(const char* data) : format_(data) {
+    initialize();
+  }
+
   explicit JodaFormatter(std::string format) : format_(std::move(format)) {
     initialize();
   }

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -377,11 +377,11 @@ struct Converter<TypeKind::TIMESTAMP> {
   }
 
   static T cast(const StringView& v, bool& nullOutput) {
-    return fromTimestampString(v);
+    return fromTimestampString(v.data(), v.size());
   }
 
   static T cast(const std::string& v, bool& nullOutput) {
-    return fromTimestampString(v);
+    return fromTimestampString(v.data(), v.size());
   }
 
   static T cast(const Date& d, bool& nullOutput) {
@@ -404,11 +404,11 @@ struct Converter<TypeKind::DATE> {
   }
 
   static T cast(const StringView& v, bool& nullOutput) {
-    return fromDateString(v);
+    return fromDateString(v.data(), v.size());
   }
 
   static T cast(const std::string& v, bool& nullOutput) {
-    return fromDateString(v);
+    return fromDateString(v.data(), v.size());
   }
 
   static T cast(const Timestamp& t, bool& nullOutput) {

--- a/velox/type/Date.cpp
+++ b/velox/type/Date.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox {
 
 void parseTo(folly::StringPiece in, Date& out) {
-  auto daysSinceEpoch = util::fromDateString(in.data());
+  auto daysSinceEpoch = util::fromDateString(in.data(), in.size());
   out = Date(daysSinceEpoch);
 }
 

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -74,7 +74,16 @@ struct StringView {
       value_.data = data;
     }
   }
-  explicit StringView(const char* data) : StringView(data, strlen(data)) {}
+
+  // Making StringView implicitly constructible/convertible from char* and
+  // string literals, in order to allow for a more flexible API and optional
+  // interoperability. E.g:
+  //
+  //   StringView sv = "literal";
+  //   std::optional<StringView> osv = "literal";
+  //
+  /* implicit */ StringView(const char* data)
+      : StringView(data, strlen(data)) {}
   explicit StringView(const folly::fbstring& value)
       : StringView(value.data(), value.size()) {}
   explicit StringView(const std::string& value)

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -33,10 +33,6 @@ int32_t fromDate(int32_t year, int32_t month, int32_t day);
 /// Throws VeloxUserError if the format or date is invalid.
 int32_t fromDateString(const char* buf, size_t len);
 
-inline int32_t fromDateString(const std::string& str) {
-  return fromDateString(str.data(), str.size());
-}
-
 inline int32_t fromDateString(const StringView& str) {
   return fromDateString(str.data(), str.size());
 }
@@ -54,10 +50,6 @@ fromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds);
 /// Throws VeloxUserError if the format or time is invalid.
 int64_t fromTimeString(const char* buf, size_t len);
 
-inline int64_t fromTimeString(const std::string& str) {
-  return fromTimeString(str.data(), str.size());
-}
-
 inline int64_t fromTimeString(const StringView& str) {
   return fromTimeString(str.data(), str.size());
 }
@@ -67,10 +59,6 @@ inline int64_t fromTimeString(const StringView& str) {
 /// Parses a full ISO 8601 timestamp string, following the format
 /// "YYYY-MM-DD HH:MM:SS[.MS] +00:00"
 Timestamp fromTimestampString(const char* buf, size_t len);
-
-inline Timestamp fromTimestampString(const std::string& str) {
-  return fromTimestampString(str.data(), str.size());
-}
 
 inline Timestamp fromTimestampString(const StringView& str) {
   return fromTimestampString(str.data(), str.size());

--- a/velox/type/tests/StringViewTest.cpp
+++ b/velox/type/tests/StringViewTest.cpp
@@ -20,7 +20,7 @@
 
 using namespace facebook::velox;
 
-TEST(Type, StringView) {
+TEST(StringView, basic) {
   std::string text = "We are stardust, we are golden...";
   for (int32_t i = 0; i < text.size(); ++i) {
     std::string subText(text.data(), i);
@@ -43,7 +43,7 @@ TEST(Type, StringView) {
   }
 }
 
-TEST(Type, StringViewContainer) {
+TEST(StringView, comparison) {
   // Differ in prefix.
   EXPECT_LT(StringView(" ab"), StringView("ab"));
   // Differ in inlined part.
@@ -52,7 +52,9 @@ TEST(Type, StringViewContainer) {
   EXPECT_LT(
       StringView("In hoc signo"),
       StringView("in hoc signo vinces, Constantinus"));
+}
 
+TEST(StringView, container) {
   std::vector<std::string> strings = {
       "May",
       "I walk",
@@ -77,7 +79,7 @@ TEST(Type, StringViewContainer) {
   }
 }
 
-TEST(Type, StringViewSelfComparison) {
+TEST(StringView, selfComparison) {
   std::vector<std::string> texts{
       "USA", // Within prefix
       "CUBA", // Exactly prefix
@@ -114,9 +116,37 @@ TEST(Type, StringViewSelfComparison) {
   }
 }
 
-TEST(Type, StringViewLiteral) {
+TEST(StringView, literal) {
   EXPECT_EQ("ab"_sv, StringView("ab"));
 
   std::vector<StringView> vec = {"a"_sv, "b"_sv};
   EXPECT_THAT(vec, ::testing::ElementsAre("a"_sv, "b"_sv));
+}
+
+TEST(StringView, implicitConstructionAndConversion) {
+  StringView sv1("literal");
+  EXPECT_EQ(sv1, "literal");
+
+  StringView sv2{"literal"};
+  EXPECT_EQ(sv2, "literal");
+
+  StringView sv3 = "literal";
+  EXPECT_EQ(sv3, "literal");
+
+  std::optional<StringView> sv4 = "literal";
+  EXPECT_TRUE(sv4.has_value());
+  EXPECT_EQ(*sv4, "literal");
+
+  std::optional<StringView> sv5("literal");
+  EXPECT_TRUE(sv5.has_value());
+  EXPECT_EQ(*sv5, "literal");
+
+  auto testRegularConversion = [](StringView sv) { EXPECT_EQ(sv, "literal"); };
+  testRegularConversion("literal");
+
+  auto testOptionalConversion = [](std::optional<StringView> sv) {
+    EXPECT_TRUE(sv.has_value());
+    EXPECT_EQ(sv, "literal");
+  };
+  testOptionalConversion("literal");
 }

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -87,7 +87,6 @@ TEST(DateTimeUtilTest, fromDateString) {
   EXPECT_EQ(-719162, fromDateString("1\\1\\1"));
 
   // Other string types.
-  EXPECT_EQ(0, fromDateString(std::string("1970-01-01")));
   EXPECT_EQ(0, fromDateString(StringView("1970-01-01")));
 }
 


### PR DESCRIPTION
Summary:
Making StringView implicitly constructible/convertible from char* and
string literals, in order to allow for a more flexible API and optional
interoperability. E.g:
.
  StringView sv = "literal";
  std::optional<StringView> osv = "literal";
.
Also a small re-organization on string view unit tests

Differential Revision: D33264121

