### PR TITLE
Fix multi-threaded cross join

### DIFF
--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -30,7 +30,7 @@ std::optional<std::vector<VectorPtr>> CrossJoinBridge::dataOrFuture(
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");
   if (data_.has_value()) {
-    return std::move(data_);
+    return data_;
   }
   promises_.emplace_back("CrossJoinBridge::tableOrFuture");
   *future = promises_.back().getSemiFuture();

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -44,8 +44,6 @@ class HashProbe : public Operator {
 
   void clearDynamicFilters() override;
 
-  void close() override {}
-
  private:
   // Sets up 'filter_' and related members.
   void initializeFilter(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -546,9 +546,6 @@ class Task {
   // Holds states for pipelineBarrier(). Guarded by
   // 'mutex_'.
   std::unordered_map<std::string, BarrierState> barriers_;
-  // Map from the plan node id of the join to the corresponding JoinBridge.
-  // Guarded by 'mutex_'.
-  std::unordered_map<std::string, std::shared_ptr<JoinBridge>> bridges_;
 
   std::vector<VeloxPromise<bool>> stateChangePromises_;
 
@@ -558,6 +555,10 @@ class Task {
   // Keep driver and operator memory pools alive for the duration of the task to
   // allow for sharing vectors across drivers without copy.
   std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
+
+  // Map from the plan node id of the join to the corresponding JoinBridge.
+  // Guarded by 'mutex_'.
+  std::unordered_map<std::string, std::shared_ptr<JoinBridge>> bridges_;
 
   std::vector<std::shared_ptr<MergeSource>> localMergeSources_;
 

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -220,3 +220,27 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
 
   assertQuery(op, "SELECT * FROM t");
 }
+
+// Test multi-threaded build and probe sides.
+TEST_F(CrossJoinTest, parallelism) {
+  // Setup 5 threads for build and probe. Each build thread gets 3 identical
+  // rows of input from the Values operator. The build thread that finishes last
+  // combines data from all other threads making it 3x5=15 rows and puts them
+  // into the CrossJoinBridge. All probe threads get 2 identical ros of input
+  // from the Values operator and join them with 15 rows of build side data from
+  // the bridge. Each probe thread is expected to produce 30 rows.
+
+  auto left = {makeRowVector({sequence<int32_t>(2)})};
+  auto right = {makeRowVector({sequence<int32_t>(3)})};
+
+  CursorParameters params;
+  params.maxDrivers = 5;
+  params.planNode =
+      PlanBuilder(10)
+          .values({left}, true)
+          .crossJoin(PlanBuilder().values({right}, true).planNode(), {0, 1})
+          .partialAggregation({}, {"count(1)"})
+          .planNode();
+
+  OperatorTestBase::assertQuery(params, "VALUES (30), (30), (30), (30), (30)");
+}


### PR DESCRIPTION
When cross join runs multi-threaded, multiple CrossJoinProbe operators get build side data from the CrossJoinBridge. Before this change, the bridge used std::move to move the data into the caller, hence, only one probe side operator could get the data. The fix is to keep the data in the bridge to allow multiple callers to fetch it.

Fixed destruction order in the Task to ensure that join bridges are destroyed before the memory pools.

Fixed HashProbe to clear state on close().