### PR TITLE
Fix Ceil/Floor mapping for Spark

### DIFF
--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -65,16 +65,17 @@ struct UnaryMinusFunction {
   }
 };
 
-VELOX_UDF_BEGIN(divide)
-FOLLY_ALWAYS_INLINE bool
-call(double& result, const double num, const double denom) {
-  if (UNLIKELY(denom == 0)) {
-    return false;
+template <typename T>
+struct DivideFunction {
+  FOLLY_ALWAYS_INLINE bool
+  call(double& result, const double num, const double denom) {
+    if (UNLIKELY(denom == 0)) {
+      return false;
+    }
+    result = num / denom;
+    return true;
   }
-  result = num / denom;
-  return true;
-}
-VELOX_UDF_END();
+};
 
 /*
   In Spark both ceil and floor must return Long type
@@ -105,26 +106,29 @@ inline int64_t safeDoubleToInt64(const int64_t& arg) {
 }
 
 template <typename T>
-VELOX_UDF_BEGIN(ceil)
-FOLLY_ALWAYS_INLINE bool call(int64_t& result, const T value) {
-  if constexpr (std::is_integral_v<T>) {
-    result = value;
-  } else {
-    result = safeDoubleToInt64(std::ceil(value));
+struct CeilFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const TInput value) {
+    if constexpr (std::is_integral_v<TInput>) {
+      result = value;
+    } else {
+      result = safeDoubleToInt64(std::ceil(value));
+    }
+    return true;
   }
-  return true;
-}
-VELOX_UDF_END();
+};
 
 template <typename T>
-VELOX_UDF_BEGIN(floor)
-FOLLY_ALWAYS_INLINE bool call(int64_t& result, const T value) {
-  if constexpr (std::is_integral_v<T>) {
-    result = value;
-  } else {
-    result = safeDoubleToInt64(std::floor(value));
+struct FloorFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const TInput value) {
+    if constexpr (std::is_integral_v<TInput>) {
+      result = value;
+    } else {
+      result = safeDoubleToInt64(std::floor(value));
+    }
+    return true;
   }
-  return true;
-}
-VELOX_UDF_END();
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -26,7 +26,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerBinaryNumeric<PlusFunction>({prefix + "add"});
   registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
   registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
-  registerFunction<udf_divide, double, double, double>({prefix + "divide"});
+  registerFunction<DivideFunction, double, double, double>({prefix + "divide"});
   registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});
   // Math functions.
@@ -45,10 +45,12 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<RoundFunction, double, double, int32_t>({prefix + "round"});
   registerFunction<RoundFunction, float, float, int32_t>({prefix + "round"});
   // In Spark only long, double, and decimal have ceil/floor
-  registerFunction<CeilFunction, int64_t, int64_t>({prefix + "ceil"});
-  registerFunction<CeilFunction, int64_t, double>({prefix + "ceil"});
-  registerFunction<FloorFunction, int64_t, int64_t>({prefix + "floor"});
-  registerFunction<FloorFunction, int64_t, double>({prefix + "floor"});
+  registerFunction<sparksql::CeilFunction, int64_t, int64_t>({prefix + "ceil"});
+  registerFunction<sparksql::CeilFunction, int64_t, double>({prefix + "ceil"});
+  registerFunction<sparksql::FloorFunction, int64_t, int64_t>(
+      {prefix + "floor"});
+  registerFunction<sparksql::FloorFunction, int64_t, double>(
+      {prefix + "floor"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -201,6 +201,21 @@ TEST_F(CeilFloorTest, Limits) {
   EXPECT_EQ(
       std::numeric_limits<int64_t>::min(),
       floor<int64_t>(std::numeric_limits<int64_t>::min()));
+
+  // Very large double values are truncated to int64_t::max/min.
+  EXPECT_EQ(
+      std::numeric_limits<int64_t>::max(),
+      ceil<double>(std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(
+      std::numeric_limits<int64_t>::max(),
+      floor<double>(std::numeric_limits<double>::infinity()));
+
+  EXPECT_EQ(
+      std::numeric_limits<int64_t>::min(),
+      ceil<double>(-std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(
+      std::numeric_limits<int64_t>::min(),
+      floor<double>(-std::numeric_limits<double>::infinity()));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Fix Ceil/Floor mapping for Spark. Adding a "Spark" suffix to make it
explicit since there's a presto and a spark version of this function.

Reviewed By: syscl, funrollloops

Differential Revision: D33271540

