### PR TITLE
ArrayProxy V1

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <iterator>
+#include <optional>
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/vector/TypeAliases.h"
+
+namespace facebook::velox::exec {
+
+template <typename T>
+struct VectorReader;
+
+template <typename T, typename B>
+struct VectorWriter;
+
+// The object passed to the simple function interface that represent a single
+// array entry.
+template <typename V>
+class ArrayProxy {
+  using child_writer_t = VectorWriter<V, void>;
+  using element_t = typename child_writer_t::exec_out_t;
+
+ public:
+  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
+
+  element_t& addItem() {
+    commitMostRecentChildItem();
+    prepareNextChildItem();
+    needCommit_ = true;
+    return childWriter_->current();
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(typename CppToType<V>::NativeType value) {
+    auto& ref = addItem();
+    ref = value;
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(std::nullopt_t) {
+    addNull();
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(const std::optional<typename CppToType<V>::NativeType>& value) {
+    if (value) {
+      push_back(*value);
+    } else {
+      addNull();
+    }
+  }
+
+  void addNull() {
+    prepareNextChildItem();
+    childWriter_->commitNull();
+    needCommit_ = false;
+  }
+
+  void prepareNextChildItem() {
+    // TODO: make sure its growing exponentially or manage size and avoid keep
+    // calling it.
+    childWriter_->ensureSize(valuesOffset_ + length_ + 1);
+    childWriter_->setOffset(valuesOffset_ + length_);
+    length_++;
+  }
+
+  void commitMostRecentChildItem() {
+    if (LIKELY(needCommit_)) {
+      childWriter_->commit(true);
+    }
+  }
+
+  // Should be called by the user(VectorWriter) when writing is done to commit
+  // last item if needed.
+  void finalize() {
+    commitMostRecentChildItem();
+  }
+
+  vector_size_t getLength() {
+    return length_;
+  }
+
+ private:
+  // Prepare the proxy for a new element.
+  // TODO: childWriter does not change.
+  void setUp(child_writer_t* childWriter, vector_size_t valuesOffset) {
+    childWriter_ = childWriter;
+    valuesOffset_ = valuesOffset;
+    length_ = 0;
+    needCommit_ = false;
+  }
+
+  ArrayProxy<V>() {}
+
+  template <typename A, typename B>
+  friend class VectorWriter;
+
+  // Pointer to child vector writer.
+  child_writer_t* childWriter_;
+
+  // Indicate if commit need to be called on the childWriter_ before addign a
+  // new element or when finalize is called.
+  bool needCommit_ = false;
+
+  // Length of the array.
+  vector_size_t length_;
+
+  // The offset within the child vector at which this array starts.
+  vector_size_t valuesOffset_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/ArrayProxyTest.cpp
+++ b/velox/expression/tests/ArrayProxyTest.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+
+class ArrayProxyTest : public functions::test::FunctionBaseTest {
+ public:
+  VectorPtr prepareResult(
+      const std::shared_ptr<Type>& arrayType,
+      vector_size_t size_ = 1) {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(size_), arrayType, this->execCtx_.pool(), &result);
+    return result;
+  }
+};
+
+TEST_F(ArrayProxyTest, intArrayAddNull) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.addNull();
+  proxy.addNull();
+  proxy.addNull();
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intArrayPushBackNull) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.push_back(std::nullopt);
+  proxy.push_back(std::optional<int64_t>{std::nullopt});
+  proxy.push_back(std::nullopt);
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intEmptyArray) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intPushBack) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.push_back(1);
+  proxy.push_back(2);
+  proxy.push_back(std::optional<int64_t>{3});
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intAddItem) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+  auto& arrayProxy = writer.current();
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 1;
+  }
+
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 2;
+  }
+
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 3;
+  }
+
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intMultipleRows) {
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {1, 2, 3},
+      {},
+      {1, 2, 3, 4, 5, 6, 7},
+      {std::nullopt, std::nullopt, 1, 2},
+      {},
+      {}};
+  auto result = prepareResult(
+      std::make_shared<ArrayType>(ArrayType(BIGINT())), expected.size());
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+
+  for (auto i = 0; i < expected.size(); i++) {
+    writer.setOffset(i);
+    auto& proxy = writer.current();
+    // The simple function interface will receive a proxy.
+    for (auto j = 0; j < expected[i].size(); j++) {
+      proxy.push_back(expected[i][j]);
+    }
+    // This commit is called by the vector function adapter.
+    writer.commit(true);
+  }
+
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+// Fucntion that creates array with values 0...n-1.
+template <typename T>
+struct Func {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      out.push_back(i);
+    }
+    return true;
+  }
+};
+
+TEST_F(ArrayProxyTest, intE2E) {
+  registerFunction<Func, ArrayProxyT<int64_t>, int64_t>({"build_array"});
+  auto result = evaluate(
+      "build_array(c0)",
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+
+  std::vector<std::vector<std::optional<int64_t>>> expected;
+  for (auto i = 1; i <= 10; i++) {
+    expected.push_back({});
+    for (auto j = 0; j < i; j++) {
+      expected[expected.size() - 1].push_back(j);
+    }
+  }
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+} // namespace facebook::velox

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
   ArrayViewTest.cpp
+  ArrayProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
   VariadicViewTest.cpp)

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1300,6 +1300,18 @@ struct Array {
   Array() {}
 };
 
+template <typename ELEMENT>
+struct ArrayProxyT {
+  using element_type = ELEMENT;
+
+  static_assert(
+      !isVariadicType<element_type>::value,
+      "Array elements cannot be Variadic");
+
+ private:
+  ArrayProxyT() {}
+};
+
 template <typename... T>
 struct Row {
   template <size_t idx>
@@ -1422,6 +1434,13 @@ struct CppToType<Map<KEY, VAL>> : public TypeTraits<TypeKind::MAP> {
 
 template <typename ELEMENT>
 struct CppToType<Array<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
+  static auto create() {
+    return ARRAY(CppToType<ELEMENT>::create());
+  }
+};
+
+template <typename ELEMENT>
+struct CppToType<ArrayProxyT<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
   static auto create() {
     return ARRAY(CppToType<ELEMENT>::create());
   }


### PR DESCRIPTION
Add ArrayProxy initial basic implementation of ArrayProxy. 
- Tested for BigInt, which cover primitives.
- The current proxy does not replace old output types yet.
-  instead VectorWriter <ArrayProxy> is created, eventually VectorWriter<ArrayProxy> will replace 
VectorWriter<Array> once all types are converted to use proxies, and all functionalities of
arrayProxy are tested and completed.

Note: The VectorWriter protocol is not changed which is:
call init on the vectorWriter with the results pre-prepared to be written for X rows.
for each row:
1. setOffset()
2. pass current() to simple function.
3. call commit(bool isNull) .

The ArrayProxy utilizes the same protocol to write to children. Note that this protocol allows for 
out of order writes, but arrayProxy writes things in order.

Next steps:
- Add benchmark.
- Add tests and support for bool and string.
- Add tests and support for nested arrays. 
- Add mapProxy. 
- Add rowProxy.
- Replace existing types with proxy types.  

In the meanwhile until all proxies are implemented and tests new simple functions 
if want to use the new interface can do that using ArrayProxy instead of Array as a type.
