### PR TITLE
Add more comments to Operator interface

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -137,8 +137,4 @@ void TableScan::addDynamicFilter(
   }
 }
 
-void TableScan::close() {
-  // TODO Implement
-}
-
 } // namespace facebook::velox::exec

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -38,11 +38,6 @@ class TableScan : public SourceOperator {
     return BlockingReason::kNotBlocked;
   }
 
-  void finish() override {
-    Operator::finish();
-    close();
-  }
-
   bool canAddDynamicFilter() const override {
     // TODO Consult with the connector. Return true only if connector can accept
     // dynamic filters.
@@ -52,8 +47,6 @@ class TableScan : public SourceOperator {
   void addDynamicFilter(
       ChannelIndex outputChannel,
       const std::shared_ptr<common::Filter>& filter) override;
-
-  void close() override;
 
  private:
   static constexpr int32_t kDefaultBatchSize = 1024;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -558,7 +558,7 @@ class Task {
 
   // Map from the plan node id of the join to the corresponding JoinBridge.
   // Guarded by 'mutex_'.
-  std::unordered_map<std::string, std::shared_ptr<JoinBridge>> bridges_;
+  std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>> bridges_;
 
   std::vector<std::shared_ptr<MergeSource>> localMergeSources_;
 


### PR DESCRIPTION
Update TableScan operator to use default implementations for finish() and close().