### PR TITLE
Add PlanFragment structure.

### DIFF
--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <memory>
+#include <vector>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::core {
+
+/// Gives hints on how to execute the fragment of a plan.
+enum class ExecutionStrategy {
+  /// Process splits as they come in any available driver.
+  kUngrouped,
+  /// Process splits from each split group only in one driver.
+  /// It is used when split groups represent separate partitions of the data on
+  /// the grouping keys or join keys. In that case it is sufficient to keep only
+  /// the keys from a single split group in a hash table used by group-by or
+  /// join.
+  kGrouped,
+};
+
+/// Contains some information on how to execute the fragment of a plan.
+/// Used to construct Task.
+struct PlanFragment {
+  /// Top level (root) Plan Node.
+  std::shared_ptr<const core::PlanNode> planNode;
+  ExecutionStrategy executionStrategy{ExecutionStrategy::kUngrouped};
+  int numSplitGroups{0};
+
+  PlanFragment() {}
+
+  explicit PlanFragment(std::shared_ptr<const core::PlanNode> topNode)
+      : planNode(std::move(topNode)) {}
+
+  PlanFragment(
+      std::shared_ptr<const core::PlanNode> topNode,
+      ExecutionStrategy strategy,
+      int numberOfSplitGroups)
+      : planNode(std::move(topNode)),
+        executionStrategy(strategy),
+        numSplitGroups(numberOfSplitGroups) {}
+};
+
+} // namespace facebook::velox::core

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -242,8 +242,8 @@ bool Exchange::getSplits(ContinueFuture* future) {
   }
   for (;;) {
     exec::Split split;
-    auto reason =
-        operatorCtx_->task()->getSplitOrFuture(planNodeId_, split, *future);
+    auto reason = operatorCtx_->task()->getSplitOrFuture(
+        operatorCtx_->driverCtx()->driverId, planNodeId_, split, *future);
     if (reason == BlockingReason::kNotBlocked) {
       if (split.hasConnectorSplit()) {
         auto remoteSplit = std::dynamic_pointer_cast<RemoteConnectorSplit>(

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -213,8 +213,8 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   }
   for (;;) {
     exec::Split split;
-    auto reason =
-        operatorCtx_->task()->getSplitOrFuture(planNodeId_, split, *future);
+    auto reason = operatorCtx_->task()->getSplitOrFuture(
+        operatorCtx_->driverCtx()->driverId, planNodeId_, split, *future);
     if (reason == BlockingReason::kNotBlocked) {
       if (split.hasConnectorSplit()) {
         auto remoteSplit = std::dynamic_pointer_cast<RemoteConnectorSplit>(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -190,7 +190,8 @@ std::string Operator::toString() {
   std::stringstream out;
   if (auto task = operatorCtx_->task()) {
     auto driverCtx = operatorCtx_->driverCtx();
-    out << "<" << task->taskId() << ":" << driverCtx->pipelineId << "."
+    out << stats_.operatorType << "(" << stats_.operatorId << ")<"
+        << task->taskId() << ":" << driverCtx->pipelineId << "."
         << driverCtx->driverId << " " << this;
   } else {
     out << "<Terminated, no task>";

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -45,7 +45,7 @@ RowVectorPtr TableScan::getOutput() {
     if (needNewSplit_) {
       exec::Split split;
       auto reason = driverCtx_->task->getSplitOrFuture(
-          planNodeId_, split, blockingFuture_);
+          driverCtx_->driverId, planNodeId_, split, blockingFuture_);
       if (reason != BlockingReason::kNotBlocked) {
         return nullptr;
       }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -33,10 +33,60 @@ Task::Task(
     std::shared_ptr<const core::PlanNode> planNode,
     int destination,
     std::shared_ptr<core::QueryCtx> queryCtx,
+    Consumer consumer,
+    std::function<void(std::exception_ptr)> onError)
+    : Task{
+          taskId,
+          std::move(planNode),
+          destination,
+          std::move(queryCtx),
+          (consumer ? [c = std::move(consumer)]() { return c; }
+                    : ConsumerSupplier{}),
+          std::move(onError)} {}
+
+Task::Task(
+    const std::string& taskId,
+    std::shared_ptr<const core::PlanNode> planNode,
+    int destination,
+    std::shared_ptr<core::QueryCtx> queryCtx,
     ConsumerSupplier consumerSupplier,
     std::function<void(std::exception_ptr)> onError)
     : taskId_(taskId),
-      planNode_(planNode),
+      destination_(destination),
+      queryCtx_(std::move(queryCtx)),
+      consumerSupplier_(std::move(consumerSupplier)),
+      onError_(onError),
+      pool_(queryCtx_->pool()->addScopedChild("task_root")),
+      bufferManager_(
+          PartitionedOutputBufferManager::getInstance(queryCtx_->host())) {
+  planFragment_.planNode = std::move(planNode);
+}
+
+Task::Task(
+    const std::string& taskId,
+    core::PlanFragment planFragment,
+    int destination,
+    std::shared_ptr<core::QueryCtx> queryCtx,
+    Consumer consumer,
+    std::function<void(std::exception_ptr)> onError)
+    : Task{
+          taskId,
+          std::move(planFragment),
+          destination,
+          std::move(queryCtx),
+          (consumer ? [c = std::move(consumer)]() { return c; }
+                    : ConsumerSupplier{}),
+          std::move(onError)} {}
+
+Task::Task(
+    const std::string& taskId,
+    core::PlanFragment planFragment,
+    int destination,
+    std::shared_ptr<core::QueryCtx> queryCtx,
+    ConsumerSupplier consumerSupplier,
+    std::function<void(std::exception_ptr)> onError)
+    : taskId_(taskId),
+      planFragment_(std::move(planFragment)),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
       consumerSupplier_(std::move(consumerSupplier)),
@@ -74,13 +124,16 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
     auto lazyLoading = config.codegenLazyLoading();
     codegen.initializeFromFile(
         config.codegenConfigurationFilePath(), lazyLoading);
-    auto newPlanNode = codegen.compile(*(self->planNode_));
-    self->planNode_ = newPlanNode != nullptr ? newPlanNode : self->planNode_;
+    auto newPlanNode = codegen.compile(*(self->planFragment_.planNode));
+    self->planFragment_.planNode =
+        newPlanNode != nullptr ? newPlanNode : self->planFragment_.planNode;
   }
 #endif
 
   LocalPlanner::plan(
-      self->planNode_, self->consumerSupplier(), &self->driverFactories_);
+      self->planFragment_.planNode,
+      self->consumerSupplier(),
+      &self->driverFactories_);
 
   for (auto& factory : self->driverFactories_) {
     self->numDrivers_ += std::min(factory->maxDrivers, maxDrivers);
@@ -321,6 +374,7 @@ bool Task::isAllSplitsFinishedLocked() {
 }
 
 BlockingReason Task::getSplitOrFuture(
+    int /*driverId*/,
     const core::PlanNodeId& planNodeId,
     exec::Split& split,
     ContinueFuture& future) {
@@ -650,8 +704,8 @@ std::string Task::toString() {
     out << "Error: " << errorMessage() << std::endl;
   }
 
-  if (planNode_) {
-    out << "Plan: " << planNode_->toString() << std::endl;
+  if (planFragment_.planNode) {
+    out << "Plan: " << planFragment_.planNode->toString() << std::endl;
   }
 
   out << " drivers:\n";

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <velox/core/Expressions.h>
 #include <velox/core/ITypedExpr.h>
+#include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
 #include "velox/common/memory/Memory.h"
 
@@ -27,7 +28,7 @@ namespace facebook::velox::exec::test {
 
 class PlanBuilder {
  public:
-  PlanBuilder(int planNodeId = 0, memory::MemoryPool* pool = nullptr)
+  explicit PlanBuilder(int planNodeId = 0, memory::MemoryPool* pool = nullptr)
       : planNodeId_{planNodeId}, pool_{pool} {}
 
   explicit PlanBuilder(memory::MemoryPool* pool)
@@ -294,6 +295,10 @@ class PlanBuilder {
 
   const std::shared_ptr<core::PlanNode>& planNode() const {
     return planNode_;
+  }
+
+  core::PlanFragment planFragment() const {
+    return core::PlanFragment{planNode_};
   }
 
   // Adds a user defined PlanNode as the root of the plan. 'func' takes


### PR DESCRIPTION
- Add PlanFragment structure, which would hold some hints on how to execute the Task.
- Require DriverId from anyone who tries to get a Split from the Task.
- Not using any of these yet.

This is a first change in the series of upcoming changes.

We need to implement DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION strategy where we would process Splits in Split Groups, cleaning hash generators after each Split Group.

This is useful for certain scenarios where Split Groups are isolated so the hashes don't intersect between the Split Groups and allows us to use less memory.