### PR TITLE
Initial ArrayProxy implementation.

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/vector/TypeAliases.h"
+#include "velox/vector/VectorTypeUtils.h"
+
+namespace facebook::velox::exec {
+
+template <typename T>
+struct VectorReader;
+
+template <typename T, typename B>
+struct VectorWriter;
+
+// Lightweight object that can be used as a proxy for array primitive elements.
+// It is returned by ArrayProxy::operator()[].
+template <typename T>
+struct PrimitiveWriterProxy {
+  using vector_t = typename TypeToFlatVector<T>::type;
+  using element_t = typename CppToType<T>::NativeType;
+
+  PrimitiveWriterProxy(vector_t* flatVector, vector_size_t index)
+      : flatVector_(flatVector), index_(index) {}
+
+  void operator=(std::nullopt_t) {
+    flatVector_->setNull(index_, true);
+  }
+
+  void operator=(element_t value) {
+    flatVector_->set(index_, value);
+  }
+
+  void operator=(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      flatVector_->set(index_, value);
+    } else {
+      flatVector_->setNull(index_, true);
+    }
+  }
+
+ private:
+  vector_t* flatVector_;
+  vector_size_t index_;
+};
+
+// The object passed to the simple function interface that represent a single
+// array entry.
+// ## General Interface:
+// - add_item()  : Add not null item and return proxy to the value to be
+// written.
+// - add_null()  : Add null item.
+// - size()      : Return the size of the array.
+
+// ## Special std::like interfaces when V is primitive:
+// - resize(n)         : Resize to n, nullity not written.
+// - operator[](index) : Returns PrimitiveWriterProxy which can be used to write
+// value and nullity at index.
+// - push_back(std::optional<v> value) : Increase size by 1, adding a value or
+// null.
+// - back() : Return PrimitiveWriterProxy for the last element in the array.
+template <typename V>
+class ArrayProxy {
+  using child_writer_t = VectorWriter<V, void>;
+  using element_t = typename child_writer_t::exec_out_t;
+
+ public:
+  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
+
+  ArrayProxy<V>& operator=(const ArrayProxy<V>&) = delete;
+
+  // String and bool not yet supported, this probably wont work for string.
+  static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
+      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+
+  // Note: size is with respect to the current size of this array being written.
+  FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
+    if (size > capacity_) {
+      while (capacity_ < size) {
+        capacity_ = 2 * capacity_ + 1;
+      }
+      childWriter_->ensureSize(valuesOffset_ + capacity_);
+    }
+  }
+
+  // Add a new not null item to the array, increasing its size by 1.
+  FOLLY_ALWAYS_INLINE element_t& add_item() {
+    commitMostRecentChildItem();
+    auto index = valuesOffset_ + length_;
+    length_++;
+    reserve(length_);
+
+    if constexpr (!provide_std_interface) {
+      childWriter_->setOffset(index);
+      needCommit_ = true;
+      return childWriter_->current();
+    } else {
+      childWriter_->vector().setNull(index, false);
+      return childWriter_->data_[index];
+    }
+  }
+
+  // Add a new null item to the array.
+  FOLLY_ALWAYS_INLINE void add_null() {
+    commitMostRecentChildItem();
+    auto index = valuesOffset_ + length_;
+    length_++;
+    reserve(length_);
+    childWriter_->vector().setNull(index, true);
+    // Note: no need to commit the null item.
+  }
+
+  // Should be called by the user (VectorWriter) when writing is done to commit
+  // last item if needed.
+  void finalize() {
+    commitMostRecentChildItem();
+    // Downsize to the actual size used in the underlying vector.
+    // Some vector-writer's logic depend on the previous size to append data.
+    childWriter_->vector().resize(valuesOffset_ + length_);
+  }
+
+  vector_size_t size() {
+    return length_;
+  }
+
+  // Functions below provide an std::like interface, and are enabled only when
+  // the array element is primitive that is not string or bool.
+
+  // 'size' is with respect to the current size of the array being written.
+  FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
+  resize(vector_size_t size) {
+    commitMostRecentChildItem();
+    reserve(size);
+    length_ = size;
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(element_t value) {
+    auto& item = add_item();
+    item = value;
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(std::nullopt_t) {
+    add_null();
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(const std::optional<element_t>& value) {
+    if (value) {
+      push_back(*value);
+    } else {
+      add_null();
+    }
+  }
+
+  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<V>>::type
+  operator[](vector_size_t index_) {
+    return PrimitiveWriterProxy<V>{
+        &childWriter_->vector(), valuesOffset_ + index_};
+  }
+
+  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<V>>::type
+  back() {
+    return PrimitiveWriterProxy<V>{
+        &childWriter_->vector(), valuesOffset_ + size() - 1};
+  }
+
+ private:
+  ArrayProxy<V>() {}
+
+  FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
+    if constexpr (!provide_std_interface) {
+      if (needCommit_) {
+        childWriter_->commit(true);
+        needCommit_ = false;
+      }
+    }
+  }
+
+  // Prepare the proxy for a new element.
+  FOLLY_ALWAYS_INLINE void init(vector_size_t valuesOffset) {
+    valuesOffset_ = valuesOffset;
+    length_ = 0;
+    capacity_ = 0;
+    needCommit_ = false;
+  }
+
+  void setChildWriter(child_writer_t* childWriter) {
+    childWriter_ = childWriter;
+  }
+
+  // Pointer to child vector writer.
+  child_writer_t* childWriter_ = nullptr;
+
+  // Indicate if commit needs to be called on the childWriter_ before adding a
+  // new element or when finalize is called.
+  bool needCommit_ = false;
+
+  // Length of the array.
+  vector_size_t length_ = 0;
+
+  // The offset within the child vector at which this array starts.
+  vector_size_t valuesOffset_ = 0;
+
+  // Virtual capacity for the current array.
+  // childWriter guaranteed to be safely writable at indices [valuesOffset_,
+  // valuesOffset_ + capacity_).
+  vector_size_t capacity_ = 0;
+
+  template <typename A, typename B>
+  friend struct VectorWriter;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <iterator>
 #include <optional>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/vector/TypeAliases.h"

--- a/velox/expression/tests/ArrayProxyTest.cpp
+++ b/velox/expression/tests/ArrayProxyTest.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/core.h>
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+namespace {
+// Function that creates array with values 0...n-1.
+// Uses all possible functions in the array proxy interface.
+template <typename T>
+struct Func {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      switch (i % 5) {
+        case 0:
+          out.add_item() = i;
+          break;
+        case 1:
+          out.push_back(i);
+          break;
+        case 2:
+          out.add_null();
+          break;
+        case 3:
+          out.resize(out.size() + 1);
+          out[out.size() - 1] = i;
+          break;
+        case 4:
+          out.resize(out.size() + 1);
+          out.back() = std::nullopt;
+          break;
+      }
+    }
+    return true;
+  }
+};
+
+class ArrayProxyTest : public functions::test::FunctionBaseTest {
+ public:
+  VectorPtr prepareResult(const TypePtr& arrayType, vector_size_t size = 1) {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(size), arrayType, this->execCtx_.pool(), &result);
+    return result;
+  }
+
+  template <typename T>
+  void testE2E(const std::string& testFunctionName) {
+    registerFunction<Func, ArrayProxyT<T>, int64_t>({testFunctionName});
+
+    auto result = evaluate(
+        fmt::format("{}(c0)", testFunctionName),
+        makeRowVector(
+            {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+
+    std::vector<std::vector<std::optional<T>>> expected;
+    for (auto i = 1; i <= 10; i++) {
+      expected.push_back({});
+      auto& currentExpected = expected[expected.size() - 1];
+      for (auto j = 0; j < i; j++) {
+        switch (j % 5) {
+          case 0:
+            currentExpected.push_back(j);
+            break;
+          case 1:
+            currentExpected.push_back(j);
+            break;
+          case 2:
+            currentExpected.push_back(std::nullopt);
+            break;
+          case 3:
+            currentExpected.push_back(j);
+            break;
+          case 4:
+            currentExpected.push_back(std::nullopt);
+            break;
+        }
+      }
+    }
+    assertEqualVectors(result, makeNullableArrayVector(expected));
+  }
+
+  struct TestWriter {
+    VectorPtr result;
+    std::unique_ptr<exec::VectorWriter<ArrayProxyT<int64_t>>> writer =
+        std::make_unique<exec::VectorWriter<ArrayProxyT<int64_t>>>();
+  };
+
+  TestWriter makeTestWriter() {
+    TestWriter writer;
+
+    writer.result =
+        prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+    writer.writer->init(*writer.result.get()->as<ArrayVector>());
+    writer.writer->setOffset(0);
+    return writer;
+  }
+};
+
+TEST_F(ArrayProxyTest, addNull) {
+  auto [result, writer] = makeTestWriter();
+
+  auto& proxy = writer->current();
+  proxy.add_null();
+  proxy.add_null();
+  proxy.add_null();
+  writer->commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, pushBackNull) {
+  auto [result, writer] = makeTestWriter();
+
+  auto& proxy = writer->current();
+  proxy.push_back(std::nullopt);
+  proxy.push_back(std::optional<int64_t>{std::nullopt});
+  proxy.push_back(std::nullopt);
+  writer->commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, emptyArray) {
+  auto [result, writer] = makeTestWriter();
+
+  writer->commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, pushBack) {
+  auto [result, writer] = makeTestWriter();
+
+  auto& proxy = writer->current();
+  proxy.push_back(1);
+  proxy.push_back(2);
+  proxy.push_back(std::optional<int64_t>{3});
+  writer->commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, addItem) {
+  auto [result, writer] = makeTestWriter();
+
+  auto& arrayProxy = writer->current();
+  {
+    auto& intProxy = arrayProxy.add_item();
+    intProxy = 1;
+  }
+
+  {
+    auto& intProxy = arrayProxy.add_item();
+    intProxy = 2;
+  }
+
+  {
+    auto& intProxy = arrayProxy.add_item();
+    intProxy = 3;
+  }
+
+  writer->commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, subscript) {
+  auto [result, writer] = makeTestWriter();
+
+  auto& arrayProxy = writer->current();
+  arrayProxy.resize(3);
+  arrayProxy[0] = std::nullopt;
+  arrayProxy[1] = 2;
+  arrayProxy[2] = 3;
+
+  writer->commit();
+
+  auto expected =
+      std::vector<std::vector<std::optional<int64_t>>>{{std::nullopt, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, multipleRows) {
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {1, 2, 3},
+      {},
+      {1, 2, 3, 4, 5, 6, 7},
+      {std::nullopt, std::nullopt, 1, 2},
+      {},
+      {}};
+  auto result = prepareResult(
+      std::make_shared<ArrayType>(ArrayType(BIGINT())), expected.size());
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+
+  for (auto i = 0; i < expected.size(); i++) {
+    writer.setOffset(i);
+    auto& proxy = writer.current();
+    // The simple function interface will receive a proxy.
+    for (auto j = 0; j < expected[i].size(); j++) {
+      proxy.push_back(expected[i][j]);
+    }
+    // This commit is called by the vector function adapter.
+    writer.commit(true);
+  }
+
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, e2e) {
+  testE2E<int8_t>("f_int6");
+  testE2E<int16_t>("f_int16");
+  testE2E<int32_t>("f_int32");
+  testE2E<int64_t>("f_int64");
+  testE2E<float>("f_float");
+  testE2E<double>("f_double");
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
   ArrayViewTest.cpp
+  ArrayProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
   VariadicViewTest.cpp)

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -14,9 +14,8 @@
 
 add_library(velox_functions_test_lib FunctionBaseTest.cpp)
 
-target_link_libraries(
-  velox_functions_test_lib velox_exec velox_functions_prestosql
-  velox_exec_test_util velox_vector_test_lib velox_parse_parser)
+target_link_libraries(velox_functions_test_lib velox_exec velox_exec_test_util
+                      velox_vector_test_lib velox_parse_parser)
 
 add_executable(
   velox_functions_test

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1300,6 +1300,22 @@ struct Array {
   Array() {}
 };
 
+// This is a temporary type to be used when ArrayProxy is requested by the user
+// to represent an Array output type in the simple function interface.
+// Eventually this will be removed and Array will be ArrayProxyT once all proxy
+// types are implemented.
+template <typename ELEMENT>
+struct ArrayProxyT {
+  using element_type = ELEMENT;
+
+  static_assert(
+      !isVariadicType<element_type>::value,
+      "Array elements cannot be Variadic");
+
+ private:
+  ArrayProxyT() {}
+};
+
 template <typename... T>
 struct Row {
   template <size_t idx>
@@ -1422,6 +1438,13 @@ struct CppToType<Map<KEY, VAL>> : public TypeTraits<TypeKind::MAP> {
 
 template <typename ELEMENT>
 struct CppToType<Array<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
+  static auto create() {
+    return ARRAY(CppToType<ELEMENT>::create());
+  }
+};
+
+template <typename ELEMENT>
+struct CppToType<ArrayProxyT<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
   static auto create() {
     return ARRAY(CppToType<ELEMENT>::create());
   }


### PR DESCRIPTION
Add initial basic implementation of ArrayProxy. 
- Tested for primitives.
- The current proxy does not replace old output types yet, instead `VectorWriter <ArrayProxyT>` is created, 
eventually` VectorWriter<ArrayProxyT> `will replace` VectorWriter<Array> `once all types are converted to 
use proxies, and all functionalities of arrayProxy are tested and completed.

- Note: The VectorWriter protocol is not changed which is:
1. call init() on the vectorWriter with the results vectors.
then for each row:
1. setOffset()
2. pass current() to simple function.
3. call commit(bool isNull) .

- The ArrayProxy utilizes the same protocol to write to children. Note that this protocol allows for 
out of order writes, but arrayProxy writes things in order.

- Array proxy has the following general interface:
1 - addItem : add not null item , returns reference to the inner item proxy.
2 - addNull: add null item.

For primitives the following are enabled:
- push_back
- resize
- operator[]

```
proxy.resize(10); 
proxy[0]=1;
proxy[1] = std::nullopt;
..etc
```
Example of function using array proxy:
```
template <typename T>
struct SimpleFunctionArrayProxyPushBack {
  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
    for (int i = 0; i < n; i++) {
      if (WITH_NULLS && i % 5) {
        out.push_back(std::nullopt);
      } else {
        out.push_back(i);
      }
    }
    return true;
  }
};
registerFunction<
        SimpleFunctionArrayProxyPushBack,
        ArrayProxyT<int64_t>,
        int64_t>({"simple_proxy_resize"});
```
