### PR TITLE
Remove static driver executor from velox

### DIFF
--- a/velox/core/tests/TestQueryConfig.cpp
+++ b/velox/core/tests/TestQueryConfig.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,7 +26,7 @@ using ::facebook::velox::core::QueryCtx;
 TEST(TestQueryConfig, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = std::make_shared<QueryCtx>(queryCtxConfig);
+  auto queryCtx = QueryCtx::createForTest(queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_FALSE(config.codegenEnabled());
@@ -38,7 +40,7 @@ TEST(TestQueryConfig, setConfig) {
       {{QueryConfig::kCodegenEnabled, "true"},
        {QueryConfig::kCodegenConfigurationFilePath, path}});
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = std::make_shared<QueryCtx>(queryCtxConfig);
+  auto queryCtx = QueryCtx::createForTest(queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_TRUE(config.codegenEnabled());

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -67,7 +67,7 @@ class BaseDuckWrapperTest : public testing::Test {
         << "Query failed: " << result->errorMessage();
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
   // QueryCtx holds the metadata and configuration associated with a
   // particular query. This is shared between all threads of execution
   // for the same query (one object per query).
-  auto queryCtx = core::QueryCtx::create();
+  auto queryCtx = core::QueryCtx::createForTest();
 
   // ExecCtx holds structures associated with a single thread of execution
   // (one per thread). Each thread of execution requires a scoped memory pool,

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
       udf_map_resolver_vector, "map_resolver_vector");
 
   // Create memory pool and other query-related structures.
-  auto queryCtx = core::QueryCtx::create();
+  auto queryCtx = core::QueryCtx::createForTest();
   auto pool = memory::getDefaultScopedMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -24,11 +24,6 @@
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
 
-DEFINE_int32(
-    velox_num_query_threads,
-    std::thread::hardware_concurrency(),
-    "Process-wide number of query execution threads");
-
 namespace facebook::velox::exec {
 namespace {
 // Basic implementation of the connector::ExpressionEvaluator interface.
@@ -189,44 +184,15 @@ class CancelGuard {
 };
 } // namespace
 
-static std::unique_ptr<folly::CPUThreadPoolExecutor>& getExecutor() {
-  static std::unique_ptr<folly::CPUThreadPoolExecutor> executor;
-  return executor;
-}
-
-// static
-folly::CPUThreadPoolExecutor* Driver::executor(int32_t threads) {
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> l(mutex);
-  if (!getExecutor().get()) {
-    auto numThreads = threads > 0 ? threads : FLAGS_velox_num_query_threads;
-    auto queue = std::make_unique<
-        folly::UnboundedBlockingQueue<folly::CPUThreadPoolExecutor::CPUTask>>();
-    getExecutor().reset(new folly::CPUThreadPoolExecutor(
-        numThreads,
-        std::move(queue),
-        std::make_shared<folly::NamedThreadFactory>("velox_query")));
-  }
-  return getExecutor().get();
-}
-
-// static
-void Driver::testingJoinAndReinitializeExecutor(int32_t threads) {
-  executor()->join();
-  getExecutor().reset();
-  executor(threads);
-}
-
 // static
 void Driver::enqueue(std::shared_ptr<Driver> driver) {
   // This is expected to be called inside the Driver's Tasks's mutex.
   driver->enqueueInternal();
   auto& task = driver->task_;
-  auto executor = task ? task->queryCtx()->executor() : nullptr;
-  if (!executor) {
-    executor = Driver::executor();
+  if (!task) {
+    return;
   }
-  executor->add([driver]() { Driver::run(driver); });
+  task->queryCtx()->executor()->add([driver]() { Driver::run(driver); });
 }
 
 Driver::Driver(

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -190,9 +190,6 @@ class Driver {
     close();
   }
 
-  static folly::CPUThreadPoolExecutor* FOLLY_NONNULL
-  executor(int32_t threads = 0);
-
   static void run(std::shared_ptr<Driver> self);
 
   static void enqueue(std::shared_ptr<Driver> instance);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -421,7 +421,7 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
   // Set an artificially low limit on the amount of data to accumulate in
   // the partial aggregation.
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::create();
+  params.queryCtx = core::QueryCtx::createForTest();
 
   params.queryCtx->setConfigOverridesUnsafe({
       {core::QueryConfig::kMaxPartialAggregationMemory, "100"},

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -322,7 +322,6 @@ class DriverTest : public OperatorTestBase {
   expectWithDelay([&]() { return test; }, __FILE__, __LINE__, #test)
 
 TEST_F(DriverTest, error) {
-  Driver::testingJoinAndReinitializeExecutor(10);
   CursorParameters params;
   params.planNode = makeValuesFilterProject(rowType_, "m1 % 0", "", 100, 10);
   params.maxDrivers = 20;
@@ -342,8 +341,6 @@ TEST_F(DriverTest, error) {
 
 TEST_F(DriverTest, cancel) {
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::create();
-
   params.planNode = makeValuesFilterProject(
       rowType_,
       "m1 % 10 > 0",
@@ -368,8 +365,6 @@ TEST_F(DriverTest, cancel) {
 
 TEST_F(DriverTest, terminate) {
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::create();
-
   params.planNode = makeValuesFilterProject(
       rowType_,
       "m1 % 10 > 0",
@@ -645,7 +640,7 @@ TEST_F(DriverTest, pauserNode) {
   constexpr int32_t kNumTasks = 20;
   constexpr int32_t kThreadsPerTask = 5;
   // Run with a fraction of the testing threads fitting in the executor.
-  Driver::testingJoinAndReinitializeExecutor(20);
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(20);
   static std::atomic<int32_t> sequence{0};
   // Use a static variable to pass the test instance to the create
   // function of the testing operator. The testing operator registers
@@ -661,7 +656,8 @@ TEST_F(DriverTest, pauserNode) {
   params.resize(kNumTasks);
   int32_t hits;
   for (int32_t i = 0; i < kNumTasks; ++i) {
-    params[i].queryCtx = core::QueryCtx::create();
+    params[i].queryCtx = core::QueryCtx::createForTest(
+        std::make_shared<core::MemConfig>(), executor);
     params[i].planNode = makeValuesFilterProject(
         rowType_,
         "m1 % 10 > 0",
@@ -692,7 +688,6 @@ TEST_F(DriverTest, pauserNode) {
     EXPECT_EQ(counters[i], kThreadsPerTask * hits);
     EXPECT_TRUE(stateFutures_.at(i).isReady());
   }
-  Driver::testingJoinAndReinitializeExecutor(10);
 }
 
 int main(int argc, char** argv) {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -291,7 +291,7 @@ TEST_F(HashJoinTest, memory) {
                         .project({"t_k0 % 1000", "u_k0 % 1000"}, {"k1", "k2"})
                         .singleAggregation({}, {"sum(k1)", "sum(k2)"})
                         .planNode();
-  params.queryCtx = core::QueryCtx::create();
+  params.queryCtx = core::QueryCtx::createForTest();
   auto tracker = memory::MemoryUsageTracker::create();
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -201,7 +201,7 @@ TEST_F(LocalPartitionTest, maxBufferSizeGather) {
 
   CursorParameters params;
   params.planNode = op;
-  params.queryCtx = core::QueryCtx::create();
+  params.queryCtx = core::QueryCtx::createForTest();
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({
@@ -247,7 +247,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
   CursorParameters params;
   params.planNode = op;
   params.maxDrivers = 2;
-  params.queryCtx = core::QueryCtx::create();
+  params.queryCtx = core::QueryCtx::createForTest();
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -26,13 +26,13 @@ class MergeJoinTest : public OperatorTestBase {
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = core::QueryCtx::createForTest();
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kCreateEmptyFiles, "true"}});
 
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = std::make_shared<core::QueryCtx>();
+    params.queryCtx = core::QueryCtx::createForTest();
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -62,12 +62,8 @@ class MultiFragmentTest : public OperatorTestBase {
       const std::string& taskId,
       std::shared_ptr<const core::PlanNode> planNode,
       int destination) {
-    auto queryCtx = core::QueryCtx::create(
-        std::make_shared<core::MemConfig>(configSettings_),
-        std::unordered_map<std::string, std::shared_ptr<Config>>{},
-        memory::MappedMemory::getInstance(),
-        memory::getProcessDefaultMemoryManager().getRoot().addScopedChild(
-            "query_root"));
+    auto queryCtx = core::QueryCtx::createForTest(
+        std::make_shared<core::MemConfig>(configSettings_));
     return std::make_shared<Task>(
         taskId, planNode, destination, std::move(queryCtx));
   }

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -40,7 +40,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       const std::string& taskId,
       int numDestinations,
       int numDrivers) {
-    auto queryCtx = core::QueryCtx::create();
+    auto queryCtx = core::QueryCtx::createForTest();
     bufferManager_->removeTask(taskId);
     auto task = std::make_shared<Task>(taskId, nullptr, 0, std::move(queryCtx));
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -24,13 +24,13 @@ class StreamingAggregationTest : public OperatorTestBase {
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = std::make_shared<core::QueryCtx>();
+    auto queryCtx = core::QueryCtx::createForTest();
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kCreateEmptyFiles, "true"}});
 
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = std::make_shared<core::QueryCtx>();
+    params.queryCtx = core::QueryCtx::createForTest();
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -230,7 +230,7 @@ TEST_F(TableWriteTest, writeEmptyFile) {
 
   auto execute = [](const std::shared_ptr<const core::PlanNode>& plan,
                     std::shared_ptr<core::QueryCtx> queryCtx =
-                        core::QueryCtx::create()) {
+                        core::QueryCtx::createForTest()) {
     CursorParameters params;
     params.planNode = plan;
     params.queryCtx = queryCtx;
@@ -240,7 +240,7 @@ TEST_F(TableWriteTest, writeEmptyFile) {
   execute(plan);
   ASSERT_FALSE(fs::exists(outputFile));
 
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kCreateEmptyFiles, "true"}});
   execute(plan, queryCtx);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -31,7 +31,7 @@ TEST_F(TaskTest, splitGroup) {
       0,
       100);
   core::PlanNodeId planNodeId{"0"};
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::createForTest();
   exec::Task task("0", nullptr, 0, queryCtx);
 
   // This is the set of completed groups we expect.

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -110,7 +110,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
   if (params.queryCtx) {
     queryCtx = params.queryCtx;
   } else {
-    queryCtx = core::QueryCtx::create();
+    queryCtx = core::QueryCtx::createForTest();
   }
   auto numProducers = params.numResultDrivers.has_value()
       ? params.numResultDrivers.value()

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -40,7 +40,6 @@ OperatorTestBase::OperatorTestBase() {
 }
 
 OperatorTestBase::~OperatorTestBase() {
-  exec::Driver::testingJoinAndReinitializeExecutor();
   // Revert to default process-wide MappedMemory.
   memory::MappedMemory::setDefaultInstance(nullptr);
 }

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -123,7 +123,7 @@ class CodegenBenchmark : public CodegenTestCore {
 
   CodegenBenchmark() {
     CodegenTestCore::init();
-    queryCtx = std::make_shared<core::QueryCtx>();
+    queryCtx = core::QueryCtx::createForTest();
     pool = memory::getDefaultScopedMemoryPool();
     execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
@@ -270,7 +270,6 @@ class CodegenBenchmark : public CodegenTestCore {
       info.referenceResults = runQuery(
           info.refPlanNodes,
           this->benchmarkInfos[benchmarkIndex].referenceTaskCursors);
-      Driver::testingJoinAndReinitializeExecutor();
       return numberIteration;
     };
 
@@ -280,7 +279,6 @@ class CodegenBenchmark : public CodegenTestCore {
       info.compiledResults.clear();
       info.compiledResults =
           runQuery(info.compiledPlanNodes, info.compiledTaskCursors);
-      Driver::testingJoinAndReinitializeExecutor();
       return numberIteration;
     };
 

--- a/velox/experimental/codegen/benchmark/TARGETS_disabled
+++ b/velox/experimental/codegen/benchmark/TARGETS_disabled
@@ -25,7 +25,6 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -50,7 +49,6 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -75,7 +73,6 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -89,7 +86,6 @@ cpp_unittest(
     linker_flags = ["--export-dynamic"],
     deps = [
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -139,7 +135,6 @@ cpp_binary(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
-              "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -164,6 +159,5 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
-              "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -579,7 +579,7 @@ class ExpressionCodegenTestBase : public testing::Test {
         core::ConcatTypedExpr({"c0"}, {typedExpr}));
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -103,7 +103,7 @@ class CodegenTestCore {
             useSymbolForArithmetic_,
             eventSequence_);
     pool_ = memory::getDefaultScopedMemoryPool();
-    queryCtx_ = std::make_shared<core::QueryCtx>();
+    queryCtx_ = core::QueryCtx::createForTest();
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
     exec::test::registerTypeResolver();
@@ -415,10 +415,6 @@ class CodegenTestBase : public CodegenTestCore, public testing::Test {
 
   virtual void SetUp() override {
     init();
-  }
-
-  void TearDown() override {
-    Driver::testingJoinAndReinitializeExecutor();
   }
 };
 }; // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/tests/TARGETS_disabled
+++ b/velox/experimental/codegen/tests/TARGETS_disabled
@@ -11,7 +11,7 @@ cpp_library(
         "include": "//velox/experimental/codegen/code_generator/tests:copy_dependencies[include]",
         "package_json": "//velox/experimental/codegen/code_generator/tests:copy_dependencies[package.json]",
     },
-    deps = [
+    exported_deps = [
         "//folly:benchmark",
         "//velox/core:velox_core",
         "//velox/dwio/dwrf/test/utils:lib_test_batch_maker",
@@ -21,12 +21,12 @@ cpp_library(
         "//velox/experimental/codegen:velox_experimental_codegen_impl",
         "//velox/experimental/codegen/code_generator:velox_codegen_code_generator",
         "//velox/experimental/codegen/utils/resources:velox_experimental_codegen_utils_resource_path",
-              "//velox/functions/prestosql/registration:velox_functions_prestosql",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
         "//velox/parse:velox_parse",
         "//velox/parse:velox_parse_expression",
         "//velox/type:velox_type",
     ],
-    external_deps = [
+    exported_external_deps = [
         "glog",
         ("googletest", None, "gtest"),
     ],
@@ -48,7 +48,7 @@ cpp_unittest(
         "//velox/experimental/codegen:velox_experimental_codegen_exceptions",
         "//velox/experimental/codegen:velox_experimental_codegen_impl",
         "//velox/experimental/codegen/utils/timer:velox_codegen_utils_timer",
-              "//velox/functions/prestosql/registration:velox_functions_prestosql",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
         "//velox/type:velox_type",
     ],
 )

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -103,7 +103,7 @@ TEST(TestConcat, EvalConcatFunction) {
   in2->addNulls(nullptr, rows);
 
   std::vector<VectorPtr> in{in1, in2};
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::createForTest();
   auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
   exec::EvalCtx context(execCtx.get(), nullptr, inRowVector->as<RowVector>());
   GeneratedVectorFunction<GeneratedVectorFunctionConfigDouble> vectorFunction;
@@ -195,7 +195,7 @@ TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   auto pool_ = memory::getDefaultScopedMemoryPool();
   auto pool = pool_.get();
   const size_t vectorSize = 1000;
-  auto queryCtx = std::make_shared<core::QueryCtx>();
+  auto queryCtx = core::QueryCtx::createForTest();
   auto execCtx = std::make_unique<core::ExecCtx>(pool, queryCtx.get());
 
   auto inRowType =

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -688,7 +688,7 @@ class ExprTest : public testing::Test {
     return indicesBuffer;
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -598,7 +598,7 @@ class ExpressionFuzzer {
       const CallableSignature& input)>;
   std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -55,7 +55,7 @@ class FunctionBenchmarkBase {
   }
 
  protected:
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -640,7 +640,7 @@ class FunctionBaseTest : public testing::Test {
     return pool_.get();
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -161,7 +161,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
   }
 
   // Boiler plate structures required by vectorMaker.
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};


### PR DESCRIPTION
Summary: Velox used to have default cpu executor. We've decided to remove that and instead have it supplied by user through QueryCtx. Executor is not required if velox is only used for expression eval, so we still have default nullptr in the constructor. The check against null happens at that time when the executor is used by Driver.

Differential Revision: D33299548

