### PR TITLE
Add Nested STD vectors as compare point to Array Proxy Benchmark

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <iterator>
+#include <optional>
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/vector/TypeAliases.h"
+
+namespace facebook::velox::exec {
+
+template <typename T>
+struct VectorReader;
+
+template <typename T, typename B>
+struct VectorWriter;
+
+// The object passed to the simple function interface that represent a single
+// array entry.
+template <typename V>
+class ArrayProxy {
+  using child_writer_t = VectorWriter<V, void>;
+  using element_t = typename child_writer_t::exec_out_t;
+
+ public:
+  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
+
+  element_t& addItem() {
+    commitMostRecentChildItem();
+    prepareNextChildItem();
+    needCommit_ = true;
+    return childWriter_->current();
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(typename CppToType<V>::NativeType value) {
+    auto& ref = addItem();
+    ref = value;
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(std::nullopt_t) {
+    addNull();
+  }
+
+  typename std::enable_if<
+      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
+  push_back(const std::optional<typename CppToType<V>::NativeType>& value) {
+    if (value) {
+      push_back(*value);
+    } else {
+      addNull();
+    }
+  }
+
+  void addNull() {
+    prepareNextChildItem();
+    childWriter_->commitNull();
+    needCommit_ = false;
+  }
+
+  void prepareNextChildItem() {
+    // TODO: make sure its growing exponentially or manage size and avoid keep
+    // calling it.
+    childWriter_->ensureSize(valuesOffset_ + length_ + 1);
+    childWriter_->setOffset(valuesOffset_ + length_);
+    length_++;
+  }
+
+  void commitMostRecentChildItem() {
+    if (LIKELY(needCommit_)) {
+      childWriter_->commit(true);
+    }
+  }
+
+  // Should be called by the user(VectorWriter) when writing is done to commit
+  // last item if needed.
+  void finalize() {
+    commitMostRecentChildItem();
+  }
+
+  vector_size_t getLength() {
+    return length_;
+  }
+
+ private:
+  // Prepare the proxy for a new element.
+  // TODO: childWriter does not change.
+  void setUp(child_writer_t* childWriter, vector_size_t valuesOffset) {
+    childWriter_ = childWriter;
+    valuesOffset_ = valuesOffset;
+    length_ = 0;
+    needCommit_ = false;
+  }
+
+  ArrayProxy<V>() {}
+
+  template <typename A, typename B>
+  friend class VectorWriter;
+
+  // Pointer to child vector writer.
+  child_writer_t* childWriter_;
+
+  // Indicate if commit need to be called on the childWriter_ before addign a
+  // new element or when finalize is called.
+  bool needCommit_ = false;
+
+  // Length of the array.
+  vector_size_t length_;
+
+  // The offset within the child vector at which this array starts.
+  vector_size_t valuesOffset_;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -24,39 +24,39 @@
 
 namespace facebook::velox::exec {
 
-template <typename T>
+template<typename T>
 struct VectorReader;
 
-template <typename T, typename B>
+template<typename T, typename B>
 struct VectorWriter;
 
 // Lightweight object that can be used as a proxy for array primitive elements.
 // It can writes both value and nullability, returned by operator[].
-template <typename T>
+template<typename T>
 struct PrimitiveNullableWriterProxy {
   using vector_t = typename TypeToFlatVector<T>::type;
   using element_t = typename CppToType<T>::NativeType;
 
-  PrimitiveNullableWriterProxy(vector_t* flatVector, vector_size_t index)
-      : flatVector_(flatVector), index_(index) {}
+  PrimitiveNullableWriterProxy(vector_t *flatVector, vector_size_t index)
+	  : flatVector_(flatVector), index_(index) {}
   void operator=(std::nullopt_t) {
-    flatVector_->setNull(index_, true);
+	flatVector_->setNull(index_, true);
   }
 
   void operator=(element_t value) {
-    flatVector_->set(index_, value);
+	flatVector_->set(index_, value);
   }
 
-  void operator=(const std::optional<element_t>& value) {
-    if (value.has_value()) {
-      flatVector_->set(index_, value);
-    } else {
-      flatVector_->setNull(index_, true);
-    }
+  void operator=(const std::optional<element_t> &value) {
+	if (value.has_value()) {
+	  flatVector_->set(index_, value);
+	} else {
+	  flatVector_->setNull(index_, true);
+	}
   }
 
- private:
-  vector_t* flatVector_;
+private:
+  vector_t *flatVector_;
   vector_size_t index_;
 };
 
@@ -74,55 +74,55 @@ struct PrimitiveNullableWriterProxy {
 // to write value or nullability at index.
 // - push_back(std::optional<v> value) : increase size by 1, adding a value
 // or null.
-template <typename V>
+template<typename V>
 class ArrayProxy {
   using child_writer_t = VectorWriter<V, void>;
   using element_t = typename child_writer_t::exec_out_t;
 
- public:
-  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
+public:
+  ArrayProxy<V>(const ArrayProxy<V> &) = delete;
 
   // String and bool not yet supported, this probably wont work for string.
   static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
-      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+	  !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
 
   // Add a new not null item to the array, increasing its size by 1.
-  FOLLY_ALWAYS_INLINE element_t& add_item() {
-    commitMostRecentChildItem();
-    auto index = valuesOffset_ + length_;
-    reserve(index + 1);
-    length_++;
+  FOLLY_ALWAYS_INLINE element_t &add_item() {
+	commitMostRecentChildItem();
+	auto index = valuesOffset_ + length_;
+	reserve(index + 1);
+	length_++;
 
-    if constexpr (!provide_std_interface) {
-      childWriter_->setOffset(index);
-      needCommit_ = true;
-      return childWriter_->current();
-    } else {
-      childWriter_->vector().setNull(index, false);
-      return childWriter_->data_[index];
-    }
+	if constexpr (!provide_std_interface) {
+	  childWriter_->setOffset(index);
+	  needCommit_ = true;
+	  return childWriter_->current();
+	} else {
+	  childWriter_->vector().setNull(index, false);
+	  return childWriter_->data_[index];
+	}
   }
 
   // Add a new null item to the array.
   FOLLY_ALWAYS_INLINE void add_null() {
-    commitMostRecentChildItem();
-    reserve(valuesOffset_ + length_ + 1);
-    childWriter_->vector().setNull(valuesOffset_ + length_, true);
-    length_++;
-    // Note: no need to commit the null item.
+	commitMostRecentChildItem();
+	reserve(valuesOffset_ + length_ + 1);
+	childWriter_->vector().setNull(valuesOffset_ + length_, true);
+	length_++;
+	// Note: no need to commit the null item.
   }
 
   // Should be called by the user (VectorWriter) when writing is done to commit
   // last item if needed.
   void finalize() {
-    commitMostRecentChildItem();
-    // Downsize to the actual size used in the underlying vector.
-    // Some writer's logic depend on the previous size to append data.
-    childWriter_->vector().resize(valuesOffset_ + length_);
+	commitMostRecentChildItem();
+	// Downsize to the actual size used in the underlying vector.
+	// Some writer's logic depend on the previous size to append data.
+	childWriter_->vector().resize(valuesOffset_ + length_);
   }
 
   vector_size_t size() {
-    return length_;
+	return length_;
   }
 
   // Functions below provides an std::like interface, and are enabled only when
@@ -131,91 +131,92 @@ class ArrayProxy {
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
   resize(vector_size_t size) {
-    commitMostRecentChildItem();
-    reserve(size);
-    length_ = size;
+	commitMostRecentChildItem();
+	reserve(size);
+	length_ = size;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(element_t value) {
-    auto& item = add_item();
-    item = value;
+	auto &item = add_item();
+	item = value;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(std::nullopt_t) {
-    add_null();
+	add_null();
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
-  push_back(const std::optional<element_t>& value) {
-    if (value) {
-      push_back(*value);
-    } else {
-      add_null();
-    }
+  push_back(const std::optional<element_t> &value) {
+	if (value.has_value()) {
+	  push_back(*value);
+	} else {
+	  add_null();
+	}
   }
 
   typename std::
-      enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
-      operator[](vector_size_t index_) {
-    return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
-                                           valuesOffset_ + index_};
+  enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>
+  ::type
+  operator[](vector_size_t index_) {
+	return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
+										   valuesOffset_ + index_};
   }
 
- private:
+private:
   ArrayProxy<V>() {}
 
-  // Note: size is with respect to the current size of this array being written.
+// Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
-    if (UNLIKELY(size > capacity_)) {
-      while (capacity_ < size) {
-        capacity_ = 1.5 * capacity_ + 1;
-      }
-      childWriter_->ensureSize(valuesOffset_ + capacity_);
-    }
+	if (UNLIKELY(size > capacity_)) {
+	  while (capacity_ < size) {
+		capacity_ = 1.5 * capacity_ + 1;
+	  }
+	  childWriter_->ensureSize(valuesOffset_ + capacity_);
+	}
   }
 
   FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
-    if constexpr (!provide_std_interface) {
-      if (needCommit_) {
-        childWriter_->commit(true);
-        needCommit_ = false;
-      }
-    }
+	if constexpr (!provide_std_interface) {
+	  if (needCommit_) {
+		childWriter_->commit(true);
+		needCommit_ = false;
+	  }
+	}
   }
 
-  // Prepare the proxy for a new element.
-  // TODO: childWriter does not change.
+// Prepare the proxy for a new element.
+// TODO: childWriter does not change.
   FOLLY_ALWAYS_INLINE void setUp(
-      child_writer_t* childWriter,
-      vector_size_t valuesOffset) {
-    childWriter_ = childWriter;
-    valuesOffset_ = valuesOffset;
-    length_ = 0;
-    capacity_ = 0;
-    needCommit_ = false;
+	  child_writer_t *childWriter,
+	  vector_size_t valuesOffset) {
+	childWriter_ = childWriter;
+	valuesOffset_ = valuesOffset;
+	length_ = 0;
+	capacity_ = 0;
+	needCommit_ = false;
   }
 
-  // Pointer to child vector writer.
-  child_writer_t* childWriter_;
+// Pointer to child vector writer.
+  child_writer_t *childWriter_;
 
-  // Indicate if commit need to be called on the childWriter_ before adding a
-  // new element or when finalize is called.
+// Indicate if commit need to be called on the childWriter_ before adding a
+// new element or when finalize is called.
   bool needCommit_ = false;
 
-  // Length of the array.
+// Length of the array.
   vector_size_t length_;
 
-  // The offset within the child vector at which this array starts.
+// The offset within the child vector at which this array starts.
   vector_size_t valuesOffset_;
 
-  // Virtual capacity for the current array.
-  // childWriter guaranteed to be safely writable at indices [valuesOffset_,
-  // valuesOffset_ + capacity_].
+// Virtual capacity for the current array.
+// childWriter guaranteed to be safely writable at indices [valuesOffset_,
+// valuesOffset_ + capacity_].
   vector_size_t capacity_ = 0;
 
-  template <typename A, typename B>
+  template<typename A, typename B>
   friend class VectorWriter;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -20,6 +20,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox::exec {
 
@@ -29,8 +30,50 @@ struct VectorReader;
 template <typename T, typename B>
 struct VectorWriter;
 
+// Lightweight object that can be used as a proxy for array primitive elements.
+// It can writes both value and nullability, returned by operator[].
+template <typename T>
+struct PrimitiveNullableWriterProxy {
+  using vector_t = typename TypeToFlatVector<T>::type;
+  using element_t = typename CppToType<T>::NativeType;
+
+  PrimitiveNullableWriterProxy(vector_t* flatVector, vector_size_t index)
+      : flatVector_(flatVector), index_(index) {}
+  void operator=(std::nullopt_t) {
+    flatVector_->setNull(index_, true);
+  }
+
+  void operator=(element_t value) {
+    flatVector_->set(index_, value);
+  }
+
+  void operator=(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      flatVector_->set(index_, value);
+    } else {
+      flatVector_->setNull(index_, true);
+    }
+  }
+
+ private:
+  vector_t* flatVector_;
+  vector_size_t index_;
+};
+
 // The object passed to the simple function interface that represent a single
 // array entry.
+// 1. General Interface:
+// - add_item()  : Add not null item and return proxy to the value to be
+// written.
+// - add_null()  : Add null item.
+// - size()     : return the size of the array.
+
+// 2. Special std::like interfaces when V is primitive:
+// - resize(n): create x items, nullability not decided yet.
+// - operator[](index): returns PrimitiveNullableWriterProxy which can be used
+// to write value or nullability at index.
+// - push_back(std::optional<v> value) : increase size by 1, adding a value
+// or null.
 template <typename V>
 class ArrayProxy {
   using child_writer_t = VectorWriter<V, void>;
@@ -39,85 +82,125 @@ class ArrayProxy {
  public:
   ArrayProxy<V>(const ArrayProxy<V>&) = delete;
 
-  element_t& addItem() {
+  // String and bool not yet supported, this probably wont work for string.
+  static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
+      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+
+  // Add a new not null item to the array, increasing its size by 1.
+  FOLLY_ALWAYS_INLINE element_t& add_item() {
     commitMostRecentChildItem();
-    prepareNextChildItem();
-    needCommit_ = true;
-    return childWriter_->current();
-  }
-
-  typename std::enable_if<
-      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
-  push_back(typename CppToType<V>::NativeType value) {
-    auto& ref = addItem();
-    ref = value;
-  }
-
-  typename std::enable_if<
-      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
-  push_back(std::nullopt_t) {
-    addNull();
-  }
-
-  typename std::enable_if<
-      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value>::type
-  push_back(const std::optional<typename CppToType<V>::NativeType>& value) {
-    if (value) {
-      push_back(*value);
-    } else {
-      addNull();
-    }
-  }
-
-  void addNull() {
-    prepareNextChildItem();
-    childWriter_->commitNull();
-    needCommit_ = false;
-  }
-
-  void prepareNextChildItem() {
-    // TODO: make sure its growing exponentially or manage size and avoid keep
-    // calling it.
-    childWriter_->ensureSize(valuesOffset_ + length_ + 1);
-    childWriter_->setOffset(valuesOffset_ + length_);
+    auto index = valuesOffset_ + length_;
+    reserve(index + 1);
     length_++;
-  }
 
-  void commitMostRecentChildItem() {
-    if (LIKELY(needCommit_)) {
-      childWriter_->commit(true);
+    if constexpr (!provide_std_interface) {
+      childWriter_->setOffset(index);
+      needCommit_ = true;
+      return childWriter_->current();
+    } else {
+      childWriter_->vector().setNull(index, false);
+      return childWriter_->data_[index];
     }
   }
 
-  // Should be called by the user(VectorWriter) when writing is done to commit
+  // Add a new null item to the array.
+  FOLLY_ALWAYS_INLINE void add_null() {
+    commitMostRecentChildItem();
+    reserve(valuesOffset_ + length_ + 1);
+    childWriter_->vector().setNull(valuesOffset_ + length_, true);
+    length_++;
+    // Note: no need to commit the null item.
+  }
+
+  // Should be called by the user (VectorWriter) when writing is done to commit
   // last item if needed.
   void finalize() {
     commitMostRecentChildItem();
+    // Downsize to the actual size used in the underlying vector.
+    // Some writer's logic depend on the previous size to append data.
+    childWriter_->vector().resize(valuesOffset_ + length_);
   }
 
-  vector_size_t getLength() {
+  vector_size_t size() {
     return length_;
   }
 
+  // Functions below provides an std::like interface, and are enabled only when
+  // the array element is primitive that is not string or bool.
+
+  // Note: size is with respect to the current size of this array being written.
+  FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
+  resize(vector_size_t size) {
+    commitMostRecentChildItem();
+    reserve(size);
+    length_ = size;
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(element_t value) {
+    auto& item = add_item();
+    item = value;
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(std::nullopt_t) {
+    add_null();
+  }
+
+  typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
+  push_back(const std::optional<element_t>& value) {
+    if (value) {
+      push_back(*value);
+    } else {
+      add_null();
+    }
+  }
+
+  typename std::
+      enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
+      operator[](vector_size_t index_) {
+    return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
+                                           valuesOffset_ + index_};
+  }
+
  private:
+  ArrayProxy<V>() {}
+
+  // Note: size is with respect to the current size of this array being written.
+  FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
+    if (UNLIKELY(size > capacity_)) {
+      while (capacity_ < size) {
+        capacity_ = 1.5 * capacity_ + 1;
+      }
+      childWriter_->ensureSize(valuesOffset_ + capacity_);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
+    if constexpr (!provide_std_interface) {
+      if (needCommit_) {
+        childWriter_->commit(true);
+        needCommit_ = false;
+      }
+    }
+  }
+
   // Prepare the proxy for a new element.
   // TODO: childWriter does not change.
-  void setUp(child_writer_t* childWriter, vector_size_t valuesOffset) {
+  FOLLY_ALWAYS_INLINE void setUp(
+      child_writer_t* childWriter,
+      vector_size_t valuesOffset) {
     childWriter_ = childWriter;
     valuesOffset_ = valuesOffset;
     length_ = 0;
+    capacity_ = 0;
     needCommit_ = false;
   }
-
-  ArrayProxy<V>() {}
-
-  template <typename A, typename B>
-  friend class VectorWriter;
 
   // Pointer to child vector writer.
   child_writer_t* childWriter_;
 
-  // Indicate if commit need to be called on the childWriter_ before addign a
+  // Indicate if commit need to be called on the childWriter_ before adding a
   // new element or when finalize is called.
   bool needCommit_ = false;
 
@@ -126,5 +209,13 @@ class ArrayProxy {
 
   // The offset within the child vector at which this array starts.
   vector_size_t valuesOffset_;
+
+  // Virtual capacity for the current array.
+  // childWriter guaranteed to be safely writable at indices [valuesOffset_,
+  // valuesOffset_ + capacity_].
+  vector_size_t capacity_ = 0;
+
+  template <typename A, typename B>
+  friend class VectorWriter;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -24,39 +24,39 @@
 
 namespace facebook::velox::exec {
 
-template<typename T>
+template <typename T>
 struct VectorReader;
 
-template<typename T, typename B>
+template <typename T, typename B>
 struct VectorWriter;
 
 // Lightweight object that can be used as a proxy for array primitive elements.
 // It can writes both value and nullability, returned by operator[].
-template<typename T>
+template <typename T>
 struct PrimitiveNullableWriterProxy {
   using vector_t = typename TypeToFlatVector<T>::type;
   using element_t = typename CppToType<T>::NativeType;
 
-  PrimitiveNullableWriterProxy(vector_t *flatVector, vector_size_t index)
-	  : flatVector_(flatVector), index_(index) {}
+  PrimitiveNullableWriterProxy(vector_t* flatVector, vector_size_t index)
+      : flatVector_(flatVector), index_(index) {}
   void operator=(std::nullopt_t) {
-	flatVector_->setNull(index_, true);
+    flatVector_->setNull(index_, true);
   }
 
   void operator=(element_t value) {
-	flatVector_->set(index_, value);
+    flatVector_->set(index_, value);
   }
 
-  void operator=(const std::optional<element_t> &value) {
-	if (value.has_value()) {
-	  flatVector_->set(index_, value);
-	} else {
-	  flatVector_->setNull(index_, true);
-	}
+  void operator=(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      flatVector_->set(index_, value);
+    } else {
+      flatVector_->setNull(index_, true);
+    }
   }
 
-private:
-  vector_t *flatVector_;
+ private:
+  vector_t* flatVector_;
   vector_size_t index_;
 };
 
@@ -74,55 +74,55 @@ private:
 // to write value or nullability at index.
 // - push_back(std::optional<v> value) : increase size by 1, adding a value
 // or null.
-template<typename V>
+template <typename V>
 class ArrayProxy {
   using child_writer_t = VectorWriter<V, void>;
   using element_t = typename child_writer_t::exec_out_t;
 
-public:
-  ArrayProxy<V>(const ArrayProxy<V> &) = delete;
+ public:
+  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
 
   // String and bool not yet supported, this probably wont work for string.
   static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
-	  !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
 
   // Add a new not null item to the array, increasing its size by 1.
-  FOLLY_ALWAYS_INLINE element_t &add_item() {
-	commitMostRecentChildItem();
-	auto index = valuesOffset_ + length_;
-	reserve(index + 1);
-	length_++;
+  FOLLY_ALWAYS_INLINE element_t& add_item() {
+    commitMostRecentChildItem();
+    auto index = valuesOffset_ + length_;
+    reserve(index + 1);
+    length_++;
 
-	if constexpr (!provide_std_interface) {
-	  childWriter_->setOffset(index);
-	  needCommit_ = true;
-	  return childWriter_->current();
-	} else {
-	  childWriter_->vector().setNull(index, false);
-	  return childWriter_->data_[index];
-	}
+    if constexpr (!provide_std_interface) {
+      childWriter_->setOffset(index);
+      needCommit_ = true;
+      return childWriter_->current();
+    } else {
+      childWriter_->vector().setNull(index, false);
+      return childWriter_->data_[index];
+    }
   }
 
   // Add a new null item to the array.
   FOLLY_ALWAYS_INLINE void add_null() {
-	commitMostRecentChildItem();
-	reserve(valuesOffset_ + length_ + 1);
-	childWriter_->vector().setNull(valuesOffset_ + length_, true);
-	length_++;
-	// Note: no need to commit the null item.
+    commitMostRecentChildItem();
+    reserve(valuesOffset_ + length_ + 1);
+    childWriter_->vector().setNull(valuesOffset_ + length_, true);
+    length_++;
+    // Note: no need to commit the null item.
   }
 
   // Should be called by the user (VectorWriter) when writing is done to commit
   // last item if needed.
   void finalize() {
-	commitMostRecentChildItem();
-	// Downsize to the actual size used in the underlying vector.
-	// Some writer's logic depend on the previous size to append data.
-	childWriter_->vector().resize(valuesOffset_ + length_);
+    commitMostRecentChildItem();
+    // Downsize to the actual size used in the underlying vector.
+    // Some writer's logic depend on the previous size to append data.
+    childWriter_->vector().resize(valuesOffset_ + length_);
   }
 
   vector_size_t size() {
-	return length_;
+    return length_;
   }
 
   // Functions below provides an std::like interface, and are enabled only when
@@ -131,92 +131,91 @@ public:
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
   resize(vector_size_t size) {
-	commitMostRecentChildItem();
-	reserve(size);
-	length_ = size;
+    commitMostRecentChildItem();
+    reserve(size);
+    length_ = size;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(element_t value) {
-	auto &item = add_item();
-	item = value;
+    auto& item = add_item();
+    item = value;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(std::nullopt_t) {
-	add_null();
+    add_null();
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
-  push_back(const std::optional<element_t> &value) {
-	if (value.has_value()) {
-	  push_back(*value);
-	} else {
-	  add_null();
-	}
+  push_back(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      push_back(*value);
+    } else {
+      add_null();
+    }
   }
 
   typename std::
-  enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>
-  ::type
-  operator[](vector_size_t index_) {
-	return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
-										   valuesOffset_ + index_};
+      enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
+      operator[](vector_size_t index_) {
+    return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
+                                           valuesOffset_ + index_};
   }
 
-private:
+ private:
   ArrayProxy<V>() {}
 
-// Note: size is with respect to the current size of this array being written.
+  // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
-	if (UNLIKELY(size > capacity_)) {
-	  while (capacity_ < size) {
-		capacity_ = 1.5 * capacity_ + 1;
-	  }
-	  childWriter_->ensureSize(valuesOffset_ + capacity_);
-	}
+    if (UNLIKELY(size > capacity_)) {
+      while (capacity_ < size) {
+        capacity_ = 1.5 * capacity_ + 1;
+      }
+      childWriter_->ensureSize(valuesOffset_ + capacity_);
+    }
   }
 
   FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
-	if constexpr (!provide_std_interface) {
-	  if (needCommit_) {
-		childWriter_->commit(true);
-		needCommit_ = false;
-	  }
-	}
+    if constexpr (!provide_std_interface) {
+      if (needCommit_) {
+        childWriter_->commit(true);
+        needCommit_ = false;
+      }
+    }
   }
 
-// Prepare the proxy for a new element.
-// TODO: childWriter does not change.
+  // Prepare the proxy for a new element.
+  // TODO: childWriter does not change.
   FOLLY_ALWAYS_INLINE void setUp(
-	  child_writer_t *childWriter,
-	  vector_size_t valuesOffset) {
-	childWriter_ = childWriter;
-	valuesOffset_ = valuesOffset;
-	length_ = 0;
-	capacity_ = 0;
-	needCommit_ = false;
+      child_writer_t* childWriter,
+      vector_size_t valuesOffset) {
+    childWriter_ = childWriter;
+    valuesOffset_ = valuesOffset;
+    length_ = 0;
+    capacity_ = 0;
+    needCommit_ = false;
   }
 
-// Pointer to child vector writer.
-  child_writer_t *childWriter_;
+  // Pointer to child vector writer.
+  child_writer_t* childWriter_;
 
-// Indicate if commit need to be called on the childWriter_ before adding a
-// new element or when finalize is called.
+  // Indicate if commit need to be called on the childWriter_ before adding a
+  // new element or when finalize is called.
   bool needCommit_ = false;
 
-// Length of the array.
+  // Length of the array.
   vector_size_t length_;
 
-// The offset within the child vector at which this array starts.
+  // The offset within the child vector at which this array starts.
   vector_size_t valuesOffset_;
 
-// Virtual capacity for the current array.
-// childWriter guaranteed to be safely writable at indices [valuesOffset_,
-// valuesOffset_ + capacity_].
+  // Virtual capacity for the current array.
+  // childWriter guaranteed to be safely writable at indices [valuesOffset_,
+  // valuesOffset_ + capacity_].
   vector_size_t capacity_ = 0;
 
-  template<typename A, typename B>
+  template <typename A, typename B>
   friend class VectorWriter;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -24,39 +24,39 @@
 
 namespace facebook::velox::exec {
 
-template<typename T>
+template <typename T>
 struct VectorReader;
 
-template<typename T, typename B>
+template <typename T, typename B>
 struct VectorWriter;
 
 // Lightweight object that can be used as a proxy for array primitive elements.
 // It can writes both value and nullability, returned by operator[].
-template<typename T>
+template <typename T>
 struct PrimitiveNullableWriterProxy {
   using vector_t = typename TypeToFlatVector<T>::type;
   using element_t = typename CppToType<T>::NativeType;
 
-  PrimitiveNullableWriterProxy(vector_t *flatVector, vector_size_t index)
-	  : flatVector_(flatVector), index_(index) {}
+  PrimitiveNullableWriterProxy(vector_t* flatVector, vector_size_t index)
+      : flatVector_(flatVector), index_(index) {}
   void operator=(std::nullopt_t) {
-	flatVector_->setNull(index_, true);
+    flatVector_->setNull(index_, true);
   }
 
   void operator=(element_t value) {
-	flatVector_->set(index_, value);
+    flatVector_->set(index_, value);
   }
 
-  void operator=(const std::optional<element_t> &value) {
-	if (value.has_value()) {
-	  flatVector_->set(index_, value);
-	} else {
-	  flatVector_->setNull(index_, true);
-	}
+  void operator=(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      flatVector_->set(index_, value);
+    } else {
+      flatVector_->setNull(index_, true);
+    }
   }
 
-private:
-  vector_t *flatVector_;
+ private:
+  vector_t* flatVector_;
   vector_size_t index_;
 };
 
@@ -74,48 +74,47 @@ private:
 // to write value or nullability at index.
 // - push_back(std::optional<v> value) : increase size by 1, adding a value
 // or null.
-template<typename V>
+template <typename V>
 class ArrayProxy {
   using child_writer_t = VectorWriter<V, void>;
   using element_t = typename child_writer_t::exec_out_t;
 
-public:
-  ArrayProxy<V>(const ArrayProxy<V> &) = delete;
+ public:
+  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
 
   // String and bool not yet supported, this probably wont work for string.
   static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
-	  !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
 
   // Add a new not null item to the array, increasing its size by 1.
-  FOLLY_ALWAYS_INLINE element_t &add_item() {
-	commitMostRecentChildItem();
-	auto index = valuesOffset_ + length_;
-	reserve(index + 1);
-	length_++;
+  FOLLY_ALWAYS_INLINE element_t& add_item() {
+    commitMostRecentChildItem();
+    auto index = valuesOffset_ + length_;
+    reserve(index + 1);
+    length_++;
 
-	if constexpr (!provide_std_interface) {
-	  childWriter_->setOffset(index);
-	  needCommit_ = true;
-	  return childWriter_->current();
-	} else {
-	  childWriter_->vector().setNull(index, false);
-	  return childWriter_->data_[index];
-	}
+    if constexpr (!provide_std_interface) {
+      childWriter_->setOffset(index);
+      needCommit_ = true;
+      return childWriter_->current();
+    } else {
+      childWriter_->vector().setNull(index, false);
+      return childWriter_->data_[index];
+    }
   }
 
   // Add a new null item to the array.
   FOLLY_ALWAYS_INLINE void add_null() {
-	commitMostRecentChildItem();
-	reserve(valuesOffset_ + length_ + 1);
-	childWriter_->vector().setNull(valuesOffset_ + length_, true);
-	length_++;
-	// Note: no need to commit the null item.
+    commitMostRecentChildItem();
+    reserve(valuesOffset_ + length_ + 1);
+    childWriter_->vector().setNull(valuesOffset_ + length_, true);
+    length_++;
+    // Note: no need to commit the null item.
   }
 
   vector_size_t size() {
-	return length_;
+    return length_;
   }
-
 
   // Functions below provides an std::like interface, and are enabled only when
   // the array element is primitive that is not string or bool.
@@ -123,84 +122,83 @@ public:
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
   resize(vector_size_t size) {
-	commitMostRecentChildItem();
-	reserve(size);
-	length_ = size;
+    commitMostRecentChildItem();
+    reserve(size);
+    length_ = size;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(element_t value) {
-	auto &item = add_item();
-	item = value;
+    auto& item = add_item();
+    item = value;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(std::nullopt_t) {
-	add_null();
+    add_null();
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
-  push_back(const std::optional<element_t> &value) {
-	if (value.has_value()) {
-	  push_back(*value);
-	} else {
-	  add_null();
-	}
+  push_back(const std::optional<element_t>& value) {
+    if (value.has_value()) {
+      push_back(*value);
+    } else {
+      add_null();
+    }
   }
 
   typename std::
-  enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
-  operator[](vector_size_t index_) {
-	return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
-										   valuesOffset_ + index_};
+      enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
+      operator[](vector_size_t index_) {
+    return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
+                                           valuesOffset_ + index_};
   }
 
-private:
+ private:
   ArrayProxy<V>() {}
 
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
-	if (UNLIKELY(size > capacity_)) {
-	  while (capacity_ < size) {
-		capacity_ = 1.5 * capacity_ + 1;
-
-	  }
-	  childWriter_->ensureSize(valuesOffset_ + capacity_);
-	}
+    if (UNLIKELY(size > capacity_)) {
+      while (capacity_ < size) {
+        capacity_ = 2 * capacity_ + 1;
+      }
+      childWriter_->ensureSize(valuesOffset_ + capacity_);
+    }
   }
 
   FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
-	if constexpr (!provide_std_interface) {
-	  if (needCommit_) {
-		childWriter_->commit(true);
-		needCommit_ = false;
-	  }
-	}
+    if constexpr (!provide_std_interface) {
+      if (needCommit_) {
+        childWriter_->commit(true);
+        needCommit_ = false;
+      }
+    }
   }
 
-// Should be called by the user (VectorWriter) when writing is done to commit
-// last item if needed.
+  // Should be called by the user (VectorWriter) when writing is done to commit
+  // last item if needed.
   void finalize() {
-	commitMostRecentChildItem();
-	// Downsize to the actual size used in the underlying vector.
-	// Some writer's logic depend on the previous size to append data.
-	childWriter_->vector().resize(valuesOffset_ + length_);
+    commitMostRecentChildItem();
+    // Downsize to the actual size used in the underlying vector.
+    // Some writer's logic depend on the previous size to append data.
+    childWriter_->vector().resize(valuesOffset_ + length_);
   }
 
   // Prepare the proxy for a new element.
   // TODO: childWriter does not change.
   FOLLY_ALWAYS_INLINE void setUp(
-	  child_writer_t *childWriter,
-	  vector_size_t valuesOffset) {
-	childWriter_ = childWriter;
-	valuesOffset_ = valuesOffset;
-	length_ = 0;
-	capacity_ = 0;
-	needCommit_ = false;
+      child_writer_t* childWriter,
+      vector_size_t valuesOffset) {
+    childWriter_ = childWriter;
+    valuesOffset_ = valuesOffset;
+    length_ = 0;
+    capacity_ = 0;
+    needCommit_ = false;
   }
 
   // Pointer to child vector writer.
-  child_writer_t *childWriter_;
+  child_writer_t* childWriter_;
 
   // Indicate if commit need to be called on the childWriter_ before adding a
   // new element or when finalize is called.
@@ -217,7 +215,7 @@ private:
   // valuesOffset_ + capacity_].
   vector_size_t capacity_ = 0;
 
-  template<typename A, typename B>
+  template <typename A, typename B>
   friend class VectorWriter;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -24,39 +24,39 @@
 
 namespace facebook::velox::exec {
 
-template <typename T>
+template<typename T>
 struct VectorReader;
 
-template <typename T, typename B>
+template<typename T, typename B>
 struct VectorWriter;
 
 // Lightweight object that can be used as a proxy for array primitive elements.
 // It can writes both value and nullability, returned by operator[].
-template <typename T>
+template<typename T>
 struct PrimitiveNullableWriterProxy {
   using vector_t = typename TypeToFlatVector<T>::type;
   using element_t = typename CppToType<T>::NativeType;
 
-  PrimitiveNullableWriterProxy(vector_t* flatVector, vector_size_t index)
-      : flatVector_(flatVector), index_(index) {}
+  PrimitiveNullableWriterProxy(vector_t *flatVector, vector_size_t index)
+	  : flatVector_(flatVector), index_(index) {}
   void operator=(std::nullopt_t) {
-    flatVector_->setNull(index_, true);
+	flatVector_->setNull(index_, true);
   }
 
   void operator=(element_t value) {
-    flatVector_->set(index_, value);
+	flatVector_->set(index_, value);
   }
 
-  void operator=(const std::optional<element_t>& value) {
-    if (value.has_value()) {
-      flatVector_->set(index_, value);
-    } else {
-      flatVector_->setNull(index_, true);
-    }
+  void operator=(const std::optional<element_t> &value) {
+	if (value.has_value()) {
+	  flatVector_->set(index_, value);
+	} else {
+	  flatVector_->setNull(index_, true);
+	}
   }
 
- private:
-  vector_t* flatVector_;
+private:
+  vector_t *flatVector_;
   vector_size_t index_;
 };
 
@@ -74,56 +74,48 @@ struct PrimitiveNullableWriterProxy {
 // to write value or nullability at index.
 // - push_back(std::optional<v> value) : increase size by 1, adding a value
 // or null.
-template <typename V>
+template<typename V>
 class ArrayProxy {
   using child_writer_t = VectorWriter<V, void>;
   using element_t = typename child_writer_t::exec_out_t;
 
- public:
-  ArrayProxy<V>(const ArrayProxy<V>&) = delete;
+public:
+  ArrayProxy<V>(const ArrayProxy<V> &) = delete;
 
   // String and bool not yet supported, this probably wont work for string.
   static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
-      !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
+	  !std::is_same<Varchar, V>::value && !std::is_same<bool, V>::value;
 
   // Add a new not null item to the array, increasing its size by 1.
-  FOLLY_ALWAYS_INLINE element_t& add_item() {
-    commitMostRecentChildItem();
-    auto index = valuesOffset_ + length_;
-    reserve(index + 1);
-    length_++;
+  FOLLY_ALWAYS_INLINE element_t &add_item() {
+	commitMostRecentChildItem();
+	auto index = valuesOffset_ + length_;
+	reserve(index + 1);
+	length_++;
 
-    if constexpr (!provide_std_interface) {
-      childWriter_->setOffset(index);
-      needCommit_ = true;
-      return childWriter_->current();
-    } else {
-      childWriter_->vector().setNull(index, false);
-      return childWriter_->data_[index];
-    }
+	if constexpr (!provide_std_interface) {
+	  childWriter_->setOffset(index);
+	  needCommit_ = true;
+	  return childWriter_->current();
+	} else {
+	  childWriter_->vector().setNull(index, false);
+	  return childWriter_->data_[index];
+	}
   }
 
   // Add a new null item to the array.
   FOLLY_ALWAYS_INLINE void add_null() {
-    commitMostRecentChildItem();
-    reserve(valuesOffset_ + length_ + 1);
-    childWriter_->vector().setNull(valuesOffset_ + length_, true);
-    length_++;
-    // Note: no need to commit the null item.
-  }
-
-  // Should be called by the user (VectorWriter) when writing is done to commit
-  // last item if needed.
-  void finalize() {
-    commitMostRecentChildItem();
-    // Downsize to the actual size used in the underlying vector.
-    // Some writer's logic depend on the previous size to append data.
-    childWriter_->vector().resize(valuesOffset_ + length_);
+	commitMostRecentChildItem();
+	reserve(valuesOffset_ + length_ + 1);
+	childWriter_->vector().setNull(valuesOffset_ + length_, true);
+	length_++;
+	// Note: no need to commit the null item.
   }
 
   vector_size_t size() {
-    return length_;
+	return length_;
   }
+
 
   // Functions below provides an std::like interface, and are enabled only when
   // the array element is primitive that is not string or bool.
@@ -131,74 +123,84 @@ class ArrayProxy {
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE typename std::enable_if<provide_std_interface>::type
   resize(vector_size_t size) {
-    commitMostRecentChildItem();
-    reserve(size);
-    length_ = size;
+	commitMostRecentChildItem();
+	reserve(size);
+	length_ = size;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(element_t value) {
-    auto& item = add_item();
-    item = value;
+	auto &item = add_item();
+	item = value;
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
   push_back(std::nullopt_t) {
-    add_null();
+	add_null();
   }
 
   typename std::enable_if<provide_std_interface>::type FOLLY_ALWAYS_INLINE
-  push_back(const std::optional<element_t>& value) {
-    if (value.has_value()) {
-      push_back(*value);
-    } else {
-      add_null();
-    }
+  push_back(const std::optional<element_t> &value) {
+	if (value.has_value()) {
+	  push_back(*value);
+	} else {
+	  add_null();
+	}
   }
 
   typename std::
-      enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
-      operator[](vector_size_t index_) {
-    return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
-                                           valuesOffset_ + index_};
+  enable_if<provide_std_interface, PrimitiveNullableWriterProxy<V>>::type
+  operator[](vector_size_t index_) {
+	return PrimitiveNullableWriterProxy<V>{&childWriter_->vector(),
+										   valuesOffset_ + index_};
   }
 
- private:
+private:
   ArrayProxy<V>() {}
 
   // Note: size is with respect to the current size of this array being written.
   FOLLY_ALWAYS_INLINE void reserve(vector_size_t size) {
-    if (UNLIKELY(size > capacity_)) {
-      while (capacity_ < size) {
-        capacity_ = 1.5 * capacity_ + 1;
-      }
-      childWriter_->ensureSize(valuesOffset_ + capacity_);
-    }
+	if (UNLIKELY(size > capacity_)) {
+	  while (capacity_ < size) {
+		capacity_ = 1.5 * capacity_ + 1;
+
+	  }
+	  childWriter_->ensureSize(valuesOffset_ + capacity_);
+	}
   }
 
   FOLLY_ALWAYS_INLINE void commitMostRecentChildItem() {
-    if constexpr (!provide_std_interface) {
-      if (needCommit_) {
-        childWriter_->commit(true);
-        needCommit_ = false;
-      }
-    }
+	if constexpr (!provide_std_interface) {
+	  if (needCommit_) {
+		childWriter_->commit(true);
+		needCommit_ = false;
+	  }
+	}
+  }
+
+// Should be called by the user (VectorWriter) when writing is done to commit
+// last item if needed.
+  void finalize() {
+	commitMostRecentChildItem();
+	// Downsize to the actual size used in the underlying vector.
+	// Some writer's logic depend on the previous size to append data.
+	childWriter_->vector().resize(valuesOffset_ + length_);
   }
 
   // Prepare the proxy for a new element.
   // TODO: childWriter does not change.
   FOLLY_ALWAYS_INLINE void setUp(
-      child_writer_t* childWriter,
-      vector_size_t valuesOffset) {
-    childWriter_ = childWriter;
-    valuesOffset_ = valuesOffset;
-    length_ = 0;
-    capacity_ = 0;
-    needCommit_ = false;
+	  child_writer_t *childWriter,
+	  vector_size_t valuesOffset) {
+	childWriter_ = childWriter;
+	valuesOffset_ = valuesOffset;
+	length_ = 0;
+	capacity_ = 0;
+	needCommit_ = false;
   }
 
   // Pointer to child vector writer.
-  child_writer_t* childWriter_;
+  child_writer_t *childWriter_;
 
   // Indicate if commit need to be called on the childWriter_ before adding a
   // new element or when finalize is called.
@@ -215,7 +217,7 @@ class ArrayProxy {
   // valuesOffset_ + capacity_].
   vector_size_t capacity_ = 0;
 
-  template <typename A, typename B>
+  template<typename A, typename B>
   friend class VectorWriter;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -119,7 +119,7 @@ struct VectorWriter {
 
   VectorWriter() {}
 
-  exec_out_t& current() {
+  FOLLY_ALWAYS_INLINE exec_out_t& current() {
     return data_[offset_];
   }
 
@@ -144,11 +144,11 @@ struct VectorWriter {
     }
   }
 
-  void setOffset(int32_t offset) {
+  FOLLY_ALWAYS_INLINE void setOffset(int32_t offset) {
     offset_ = offset;
   }
 
-  vector_t& vector() {
+  FOLLY_ALWAYS_INLINE vector_t& vector() {
     return *vector_;
   }
 
@@ -452,6 +452,7 @@ struct VectorWriter<ArrayProxyT<V>> {
     return *arrayVector_;
   }
 
+  // Make sure the vector can be written for size x.
   void ensureSize(size_t size) {
     if (size > arrayVector_->size()) {
       arrayVector_->resize(size);
@@ -459,15 +460,16 @@ struct VectorWriter<ArrayProxyT<V>> {
     }
   }
 
+  // Commit a not null value.
   void commit() {
     proxy_.finalize();
-    arrayVector_->setOffsetAndSize(
-        index_, currentValueOffset_, proxy_.getLength());
+    arrayVector_->setOffsetAndSize(index_, currentValueOffset_, proxy_.size());
     // Next array will be written at the new offset.
-    currentValueOffset_ += proxy_.getLength();
+    currentValueOffset_ += proxy_.size();
     arrayVector_->setNull(index_, false);
   }
 
+  // Commit a null value.
   void commitNull() {
     arrayVector_->setNull(index_, true);
   }
@@ -495,7 +497,7 @@ struct VectorWriter<ArrayProxyT<V>> {
 
   VectorWriter<V> childWriter_;
 
-  // The index being written int the array vector.
+  // The index being written in the array vector.
   size_t index_ = 0;
 
   // The offset of the current array being written in the child vector.

--- a/velox/expression/tests/ArrayProxyTest.cpp
+++ b/velox/expression/tests/ArrayProxyTest.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+
+class ArrayProxyTest : public functions::test::FunctionBaseTest {
+ public:
+  VectorPtr prepareResult(
+      const std::shared_ptr<Type>& arrayType,
+      vector_size_t size_ = 1) {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(size_), arrayType, this->execCtx_.pool(), &result);
+    return result;
+  }
+};
+
+TEST_F(ArrayProxyTest, intArrayAddNull) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.addNull();
+  proxy.addNull();
+  proxy.addNull();
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intArrayPushBackNull) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.push_back(std::nullopt);
+  proxy.push_back(std::optional<int64_t>{std::nullopt});
+  proxy.push_back(std::nullopt);
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {std::nullopt, std::nullopt, std::nullopt}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intEmptyArray) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intPushBack) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+
+  auto& proxy = writer.current();
+  proxy.push_back(1);
+  proxy.push_back(2);
+  proxy.push_back(std::optional<int64_t>{3});
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intAddItem) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+  auto& arrayProxy = writer.current();
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 1;
+  }
+
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 2;
+  }
+
+  {
+    auto& intProxy = arrayProxy.addItem();
+    intProxy = 3;
+  }
+
+  writer.commit();
+
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intMultipleRows) {
+  auto expected = std::vector<std::vector<std::optional<int64_t>>>{
+      {1, 2, 3},
+      {},
+      {1, 2, 3, 4, 5, 6, 7},
+      {std::nullopt, std::nullopt, 1, 2},
+      {},
+      {}};
+  auto result = prepareResult(
+      std::make_shared<ArrayType>(ArrayType(BIGINT())), expected.size());
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+
+  for (auto i = 0; i < expected.size(); i++) {
+    writer.setOffset(i);
+    auto& proxy = writer.current();
+    // The simple function interface will receive a proxy.
+    for (auto j = 0; j < expected[i].size(); j++) {
+      proxy.push_back(expected[i][j]);
+    }
+    // This commit is called by the vector function adapter.
+    writer.commit(true);
+  }
+
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+// Fucntion that creates array with values 0...n-1.
+template <typename T>
+struct Func {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      out.push_back(i);
+    }
+    return true;
+  }
+};
+
+TEST_F(ArrayProxyTest, intE2E) {
+  registerFunction<Func, ArrayProxyT<int64_t>, int64_t>({"build_array"});
+  auto result = evaluate(
+      "build_array(c0)",
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+
+  std::vector<std::vector<std::optional<int64_t>>> expected;
+  for (auto i = 1; i <= 10; i++) {
+    expected.push_back({});
+    for (auto j = 0; j < i; j++) {
+      expected[expected.size() - 1].push_back(j);
+    }
+  }
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+} // namespace facebook::velox

--- a/velox/expression/tests/ArrayProxyTest.cpp
+++ b/velox/expression/tests/ArrayProxyTest.cpp
@@ -42,9 +42,9 @@ TEST_F(ArrayProxyTest, intArrayAddNull) {
   writer.setOffset(0);
 
   auto& proxy = writer.current();
-  proxy.addNull();
-  proxy.addNull();
-  proxy.addNull();
+  proxy.add_null();
+  proxy.add_null();
+  proxy.add_null();
   writer.commit();
 
   auto expected = std::vector<std::vector<std::optional<int64_t>>>{
@@ -109,23 +109,42 @@ TEST_F(ArrayProxyTest, intAddItem) {
   writer.setOffset(0);
   auto& arrayProxy = writer.current();
   {
-    auto& intProxy = arrayProxy.addItem();
+    auto& intProxy = arrayProxy.add_item();
     intProxy = 1;
   }
 
   {
-    auto& intProxy = arrayProxy.addItem();
+    auto& intProxy = arrayProxy.add_item();
     intProxy = 2;
   }
 
   {
-    auto& intProxy = arrayProxy.addItem();
+    auto& intProxy = arrayProxy.add_item();
     intProxy = 3;
   }
 
   writer.commit();
 
   auto expected = std::vector<std::vector<std::optional<int64_t>>>{{1, 2, 3}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, intSubscript) {
+  auto result = prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+  exec::VectorWriter<ArrayProxyT<int64_t>> writer;
+  writer.init(*result.get()->as<ArrayVector>());
+  writer.setOffset(0);
+  auto& arrayProxy = writer.current();
+  arrayProxy.resize(3);
+  arrayProxy[0] = std::nullopt;
+  arrayProxy[1] = 2;
+  arrayProxy[2] = 3;
+
+  writer.commit();
+
+  auto expected =
+      std::vector<std::vector<std::optional<int64_t>>>{{std::nullopt, 2, 3}};
   assertEqualVectors(result, makeNullableArrayVector(expected));
 }
 
@@ -157,7 +176,7 @@ TEST_F(ArrayProxyTest, intMultipleRows) {
   assertEqualVectors(result, makeNullableArrayVector(expected));
 }
 
-// Fucntion that creates array with values 0...n-1.
+// Function that creates array with values 0...n-1.
 template <typename T>
 struct Func {
   bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
   ArrayViewTest.cpp
+  ArrayProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
   VariadicViewTest.cpp)

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -46,6 +46,16 @@ class FunctionBenchmarkBase {
     return results[0];
   }
 
+  VectorPtr evaluate(
+      exec::ExprSet& exprSet,
+      const RowVectorPtr& data,
+      std::vector<VectorPtr>& results) {
+    SelectivityVector rows(data->size());
+    exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
+    exprSet.eval(rows, &evalCtx, &results);
+    return results[0];
+  }
+
   facebook::velox::test::VectorMaker& maker() {
     return vectorMaker_;
   }

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -23,6 +23,15 @@ set(BENCHMARK_DEPENDENCIES
     ${FOLLY_WITH_DEPENDENCIES}
     ${FOLLY_BENCHMARK})
 
+set(BENCHMARK_DEPENDENCIES_NO_FUNC
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_util
+    ${GTEST_BOTH_LIBRARIES}
+    ${gflags_LIBRARIES}
+    ${FOLLY_WITH_DEPENDENCIES}
+    ${FOLLY_BENCHMARK})
+
 add_executable(velox_functions_prestosql_benchmarks_array_contains
                ArrayContainsBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains
@@ -69,3 +78,7 @@ target_link_libraries(velox_functions_prestosql_benchmarks_map_input
 
 add_executable(velox_functions_benchmarks_url URLBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_benchmark_int_array_proxy IntArrayProxyBenchmark.cpp)
+target_link_libraries(velox_benchmark_int_array_proxy
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})

--- a/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#define WITH_NULLS true
+
+// Benchmark a function that constructs an array of size n with values 0...n.
+namespace facebook::velox::exec {
+
+namespace {
+
+template <bool optimizeResize>
+class VectorFunctionImpl : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    LocalDecodedVector decoded_(context, *args[0], rows);
+
+    // Prepare results
+    BaseVector::ensureWritable(rows, ARRAY(BIGINT()), context->pool(), result);
+    auto flatResult = (*result)->as<ArrayVector>();
+    auto currentOffset = 0;
+    auto elementsFlat = flatResult->elements()->asFlatVector<int64_t>();
+
+    // Compute total size needed for elements.
+    auto totalSize = 0;
+
+    if constexpr (optimizeResize) {
+      // Note: this is an optimization that is special for the logic of this
+      // function and not general, hence cant be done in the simple function
+      // interface.
+      rows.applyToSelected([&](vector_size_t row) {
+        totalSize += decoded_->valueAt<int64_t>(row);
+      });
+      elementsFlat->resize(totalSize);
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto length = decoded_->valueAt<int64_t>(row);
+
+      flatResult->setOffsetAndSize(row, currentOffset, length);
+      flatResult->setNull(row, false);
+
+      if constexpr (!optimizeResize) {
+        totalSize += length;
+        elementsFlat->resize(totalSize);
+      }
+
+      for (auto i = 0; i < length; i++) {
+        if (WITH_NULLS && i % 5) {
+          elementsFlat->setNull(currentOffset + i, true);
+        } else {
+          elementsFlat->set(currentOffset + i, i);
+        }
+      }
+
+      currentOffset += length;
+    });
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayProxyResize {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    out.resize(n);
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out[i] = std::nullopt;
+      } else {
+        out[i] = i;
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayProxyPushBack {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.push_back(std::nullopt);
+      } else {
+        out.push_back(i);
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionGeneralInterface {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.add_null();
+      } else {
+        auto& item = out.add_item();
+        item = i;
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayWriter {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.append(std::nullopt);
+      } else {
+        out.append(i);
+      }
+    }
+    return true;
+  }
+};
+} // namespace
+
+class ArrayProxyBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  ArrayProxyBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<
+        SimpleFunctionArrayProxyResize,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_proxy_resize"});
+    registerFunction<
+        SimpleFunctionArrayProxyPushBack,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_proxy_push_back"});
+    registerFunction<
+        SimpleFunctionGeneralInterface,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_general"});
+    registerFunction<SimpleFunctionArrayWriter, Array<int64_t>, int64_t>(
+        {"simple_old"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_resize_optimized",
+        {exec::FunctionSignatureBuilder()
+             .returnType("array(bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<true>>());
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_basic",
+        {exec::FunctionSignatureBuilder()
+             .returnType("array(bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<false>>());
+  }
+
+  vector_size_t size = 1'000;
+  size_t totalItemsCount = (size - 1) * size / 2;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  size_t run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+
+    doRun(exprSet, input);
+    return totalItemsCount;
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool
+  hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool test() {
+    auto input = makeInput();
+    auto exprSetRef = compileExpression("vector_basic(c0)", input->type());
+    std::vector<std::string> functions = {
+        "vector_resize_optimized",
+        "simple_proxy_push_back",
+        "simple_proxy_resize",
+        "simple_old",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+BENCHMARK_MULTI(VectorBasic) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("vector_basic");
+}
+
+BENCHMARK_MULTI(VectorResizeOptimized) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("vector_resize_optimized");
+}
+
+BENCHMARK_MULTI(SimpleProxyWithResize) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_proxy_resize");
+}
+
+BENCHMARK_MULTI(SimpleProxyPushBack) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_proxy_push_back");
+}
+
+BENCHMARK_MULTI(SimpleGeneral) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_general");
+}
+
+BENCHMARK_MULTI(SimpleOld) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_old");
+}
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::ArrayProxyBenchmark benchmark;
+  if (benchmark.test()) {
+    folly::runBenchmarks();
+  } else {
+    VELOX_UNREACHABLE("testing failed!")
+  }
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
@@ -206,6 +206,25 @@ class ArrayProxyBenchmark : public functions::test::FunctionBenchmarkBase {
     folly::doNotOptimizeAway(cnt);
   }
 
+  size_t runStdRef() {
+    for (auto k = 0; k < 100; k++) {
+      std::vector<std::vector<std::optional<int>>> arrayVector;
+      for (auto i = 0; i < 1000; i++) {
+        arrayVector.push_back({});
+        auto current = arrayVector[arrayVector.size() - 1];
+        for (int j = 0; j < i; j++) {
+          if (WITH_NULLS && i % 5) {
+            current.push_back(std::nullopt);
+          } else {
+            current.push_back(j);
+          }
+        }
+      }
+      folly::doNotOptimizeAway(arrayVector);
+    }
+    return totalItemsCount;
+  }
+
   bool
   hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
     auto result1 = evaluate(expr1, input);
@@ -272,6 +291,11 @@ BENCHMARK_MULTI(SimpleGeneral) {
 BENCHMARK_MULTI(SimpleOld) {
   ArrayProxyBenchmark benchmark;
   return benchmark.run("simple_old");
+}
+
+BENCHMARK_MULTI(NestedSTDVectorPushBack) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.runStdRef();
 }
 } // namespace facebook::velox::exec
 

--- a/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
@@ -18,7 +18,7 @@
 #include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
-#define WITH_NULLS false
+#define WITH_NULLS true
 
 // Benchmark a function that constructs an array of size n with values 0...n.
 namespace facebook::velox::exec {
@@ -52,7 +52,7 @@ class VectorFunctionImpl : public exec::VectorFunction {
       rows.applyToSelected([&](vector_size_t row) {
         totalSize += decoded_->valueAt<int64_t>(row);
       });
-      elementsFlat->resize(totalSize);
+      elementsFlat->resize(totalSize, false);
     }
 
     rows.applyToSelected([&](vector_size_t row) {
@@ -63,7 +63,7 @@ class VectorFunctionImpl : public exec::VectorFunction {
 
       if constexpr (!optimizeResize) {
         totalSize += length;
-        elementsFlat->resize(totalSize);
+        elementsFlat->resize(totalSize, false);
       }
 
       for (auto i = 0; i < length; i++) {

--- a/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/IntArrayProxyBenchmark.cpp
@@ -18,7 +18,7 @@
 #include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
-#define WITH_NULLS true
+#define WITH_NULLS false
 
 // Benchmark a function that constructs an array of size n with values 0...n.
 namespace facebook::velox::exec {

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -14,9 +14,8 @@
 
 add_library(velox_functions_test_lib FunctionBaseTest.cpp)
 
-target_link_libraries(
-  velox_functions_test_lib velox_exec velox_functions_prestosql
-  velox_exec_test_util velox_vector_test_lib velox_parse_parser)
+target_link_libraries(velox_functions_test_lib velox_exec velox_exec_test_util
+                      velox_vector_test_lib velox_parse_parser)
 
 add_executable(
   velox_functions_test

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1300,6 +1300,18 @@ struct Array {
   Array() {}
 };
 
+template <typename ELEMENT>
+struct ArrayProxyT {
+  using element_type = ELEMENT;
+
+  static_assert(
+      !isVariadicType<element_type>::value,
+      "Array elements cannot be Variadic");
+
+ private:
+  ArrayProxyT() {}
+};
+
 template <typename... T>
 struct Row {
   template <size_t idx>
@@ -1422,6 +1434,13 @@ struct CppToType<Map<KEY, VAL>> : public TypeTraits<TypeKind::MAP> {
 
 template <typename ELEMENT>
 struct CppToType<Array<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
+  static auto create() {
+    return ARRAY(CppToType<ELEMENT>::create());
+  }
+};
+
+template <typename ELEMENT>
+struct CppToType<ArrayProxyT<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
   static auto create() {
     return ARRAY(CppToType<ELEMENT>::create());
   }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -72,7 +72,7 @@ uint64_t BaseVector::byteSize<bool>(vector_size_t count) {
   return bits::nbytes(count);
 }
 
-void BaseVector::resize(vector_size_t size) {
+void BaseVector::resize(vector_size_t size, bool setNotNull) {
   if (nulls_) {
     auto bytes = byteSize<bool>(size);
     if (length_ < size) {
@@ -80,7 +80,7 @@ void BaseVector::resize(vector_size_t size) {
         AlignedBuffer::reallocate<char>(&nulls_, bytes);
         rawNulls_ = nulls_->as<uint64_t>();
       }
-      if (size > length_) {
+      if (setNotNull && size > length_) {
         bits::fillBits(
             const_cast<uint64_t*>(rawNulls_), length_, size, bits::kNotNull);
       }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -304,9 +304,15 @@ class BaseVector {
   }
 
   // Sets the null indicator at 'idx'. 'true' means null.
-  virtual void setNull(vector_size_t idx, bool value) {
+  FOLLY_ALWAYS_INLINE virtual void setNull(vector_size_t idx, bool value) {
     VELOX_DCHECK(idx >= 0 && idx < length_);
-    ensureNulls();
+    if (!nulls_) {
+      if (!value) {
+        return;
+      }
+      allocateNulls();
+    }
+
     bits::setBit(
         nulls_->asMutable<uint64_t>(), idx, bits::kNull ? value : !value);
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -343,7 +343,9 @@ class BaseVector {
 
   // Sets the size to 'size' and ensures there is space for the
   // indicated number of nulls and top level values.
-  virtual void resize(vector_size_t newSize);
+  // setNotNull indicates if nulls in range [oldSize, newSize) should be set to
+  // not null.
+  virtual void resize(vector_size_t newSize, bool setNotNull = true);
 
   // Sets the rows of 'this' given by 'rows' to
   // 'source.valueAt(toSourceRow ? toSourceRow[row] : row)', where
@@ -472,6 +474,7 @@ class BaseVector {
   virtual BaseVector* loadedVector() {
     return this;
   }
+
   virtual const BaseVector* loadedVector() const {
     return this;
   }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -270,12 +270,12 @@ class ArrayVector : public BaseVector {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
       resizeIndices(size, 0, &offsets_, &rawOffsets_);
       resizeIndices(size, 0, &sizes_, &rawSizes_);
     }
-    BaseVector::resize(size);
+    BaseVector::resize(size, setNotNull);
   }
 
   void
@@ -425,12 +425,12 @@ class MapVector : public BaseVector {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
       resizeIndices(size, 0, &offsets_, &rawOffsets_);
       resizeIndices(size, 0, &sizes_, &rawSizes_);
     }
-    BaseVector::resize(size);
+    BaseVector::resize(size, setNotNull);
   }
 
   const VectorPtr& mapKeys() const {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -283,7 +283,7 @@ class ConstantVector final : public SimpleVector<T> {
     return index_;
   }
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool /*unused*/) override {
     BaseVector::length_ = size;
   }
 

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -281,9 +281,9 @@ void FlatVector<T>::copyValuesAndNulls(
 }
 
 template <typename T>
-void FlatVector<T>::resize(vector_size_t size) {
+void FlatVector<T>::resize(vector_size_t size, bool setNotNull) {
   auto previousSize = BaseVector::length_;
-  BaseVector::resize(size);
+  BaseVector::resize(size, setNotNull);
   if (!values_) {
     return;
   }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -244,7 +244,7 @@ class FlatVector final : public SimpleVector<T> {
     copyValuesAndNulls(source, targetIndex, sourceIndex, count);
   }
 
-  void resize(vector_size_t size) override;
+  void resize(vector_size_t size, bool setNotNull = true) override;
 
   bool isScalar() const override {
     return true;

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -215,7 +215,7 @@ class SimpleVector : public BaseVector {
     return max_;
   }
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     VELOX_CHECK(false, "Can only resize flat vectors.");
   }
 


### PR DESCRIPTION
### **ONLY LAST COMMIT BELONGS TO THIS DIFF**


I thought the numbers we are getting are slow, so i added comparison with the same work done 
in c++ and stored in nested std::vector, with nullability represented with std::optional.
it turns out we are not bad, specially for the not null case we are faster.

With nulls
```
  ============================================================================
VectorBasic                                                369.84ns    2.70M
VectorResizeOptimized                                      250.81ns    3.99M
SimpleProxyWithResize                                      245.34ns    4.08M
SimpleProxyPushBack                                        343.25ns    2.91M
SimpleGeneral                                              264.64ns    3.78M
SimpleOld                                                  615.63ns    1.62M
NestedSTDVectorPushBack                                    303.60ns    3.29M
============================================================================
```
No nulls
```
============================================================================
VectorBasic                                                132.25ns    7.56M
VectorResizeOptimized                                       96.54ns   10.36M
SimpleProxyWithResize                                      152.92ns    6.54M
SimpleProxyPushBack                                        230.86ns    4.33M
SimpleGeneral                                              292.36ns    3.42M
SimpleOld                                                  645.38ns    1.55M
NestedSTDVectorPushBack                                    270.19ns    3.70M
============================================================================
```