### PR TITLE
Decouple feature project and struct encoding option

### DIFF
--- a/velox/dwio/common/ColumnSelector.cpp
+++ b/velox/dwio/common/ColumnSelector.cpp
@@ -321,7 +321,7 @@ const FilterTypePtr& ColumnSelector::process(const std::string& column, bool) {
   return findNode(column);
 }
 
-std::pair<std::string_view, std::string_view> ColumnSelector::extractColumnName(
+std::pair<std::string_view, std::string_view> extractColumnName(
     const std::string_view& name) {
   // right now this is the only supported expression for MAP key filter
   auto pos = name.find('#');

--- a/velox/dwio/common/ColumnSelector.h
+++ b/velox/dwio/common/ColumnSelector.h
@@ -27,6 +27,11 @@ namespace facebook::velox::dwio::common {
  */
 enum class ReadState { kPartial, kAll };
 
+// A utility function to extract column name and expression
+// from a augmented column names in current spec.
+std::pair<std::string_view, std::string_view> extractColumnName(
+    const std::string_view& name);
+
 class ColumnSelector {
  public:
   /**
@@ -268,11 +273,6 @@ class ColumnSelector {
       const std::shared_ptr<const velox::RowType>& fileSchema);
 
  private:
-  // A utility function to extract column name and expression
-  // from a augmented column names in current spec.
-  static std::pair<std::string_view, std::string_view> extractColumnName(
-      const std::string_view& name);
-
   // visit the tree with disk type
   static void copy(
       FilterTypePtr&,

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -96,7 +96,8 @@ class RowReaderOptions {
   ErrorTolerance errorTolerance_;
   std::shared_ptr<ColumnSelector> selector_;
   velox::common::ScanSpec* scanSpec_ = nullptr;
-  std::unordered_set<uint32_t> flatmapNodeIdAsStruct_;
+  // Node id for map column to a list of keys to be projected as a struct.
+  std::unordered_map<uint32_t, std::vector<std::string>> flatmapNodeIdAsStruct_;
 
  public:
   RowReaderOptions(const RowReaderOptions& other) {
@@ -236,11 +237,19 @@ class RowReaderOptions {
   }
 
   void setFlatmapNodeIdsAsStruct(
-      std::unordered_set<uint32_t> flatmapNodeIdsAsStruct) {
+      std::unordered_map<uint32_t, std::vector<std::string>>
+          flatmapNodeIdsAsStruct) {
+    VELOX_CHECK(
+        std::all_of(
+            flatmapNodeIdsAsStruct.begin(),
+            flatmapNodeIdsAsStruct.end(),
+            [](const auto& kv) { return !kv.second.empty(); }),
+        "To use struct encoding for flatmap, keys to project must be specified");
     flatmapNodeIdAsStruct_ = std::move(flatmapNodeIdsAsStruct);
   }
 
-  const std::unordered_set<uint32_t>& getMapColumnIdAsStruct() const {
+  const std::unordered_map<uint32_t, std::vector<std::string>>&
+  getMapColumnIdAsStruct() const {
     return flatmapNodeIdAsStruct_;
   }
 };

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -61,6 +61,16 @@ KeyValue<StringView> extractKey<StringView>(const proto::KeyInfo& info) {
 }
 
 template <typename T>
+KeyValue<T> parseKeyValue(std::string_view str) {
+  return KeyValue<T>(folly::to<T>(str));
+}
+
+template <>
+KeyValue<StringView> parseKeyValue<StringView>(std::string_view str) {
+  return KeyValue<StringView>(StringView(str));
+}
+
+template <typename T>
 struct KeyProjection {
   KeyProjectionMode mode = KeyProjectionMode::ALLOW;
   KeyValue<T> value;
@@ -74,11 +84,13 @@ KeyProjection<T> convertDynamic(const folly::dynamic& v) {
   if (!view.empty() && view.front() == reject_prefix) {
     return {
         .mode = KeyProjectionMode::REJECT,
-        .value = KeyValue<T>(folly::to<T>(view.substr(1)))};
+        .value = parseKeyValue<T>(view.substr(1)),
+    };
   } else {
     return {
         .mode = KeyProjectionMode::ALLOW,
-        .value = KeyValue<T>(folly::to<T>(view))};
+        .value = parseKeyValue<T>(view),
+    };
   }
 }
 
@@ -223,17 +235,19 @@ KeyPredicate<T> prepareKeyPredicate(
 template <typename T>
 std::vector<std::unique_ptr<KeyNode<T>>> rearrangeKeyNodesAsProjectedOrder(
     std::vector<std::unique_ptr<KeyNode<T>>>& availableKeyNodes,
-    const std::vector<KeyValue<T>>& keys) {
+    const std::vector<std::string>& keys) {
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes(keys.size());
 
   std::unordered_map<KeyValue<T>, size_t, KeyValueHash<T>> keyLookup;
   for (size_t i = 0; i < keys.size(); ++i) {
-    keyLookup[keys[i]] = i;
+    keyLookup[parseKeyValue<T>(keys[i])] = i;
   }
 
   for (auto& keyNode : availableKeyNodes) {
     const auto it = keyLookup.find(keyNode->getKey());
-    DWIO_ENSURE(it != keyLookup.end());
+    if (it == keyLookup.end()) {
+      continue;
+    }
     keyNodes[it->second] = std::move(keyNode);
   }
 
@@ -578,7 +592,6 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesForStructEncoding(
   // If the key is not found in the stripe, the key node will be nullptr.
 
   auto parsedKeyFilter = parseKeyFilter<T>(requestedType, stripe);
-  DWIO_ENSURE_EQ(parsedKeyFilter.mode, KeyProjectionMode::ALLOW);
 
   const KeyPredicate<T> keyPredicate(
       parsedKeyFilter.mode,
@@ -592,8 +605,12 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesForStructEncoding(
       stripe,
       memoryPool);
 
-  return rearrangeKeyNodesAsProjectedOrder<T>(
-      availableKeyNodes, parsedKeyFilter.keys);
+  const auto& mapColumnIdAsStruct =
+      stripe.getRowReaderOptions().getMapColumnIdAsStruct();
+  auto it = mapColumnIdAsStruct.find(requestedType->id);
+  DWIO_ENSURE(it != mapColumnIdAsStruct.end());
+
+  return rearrangeKeyNodesAsProjectedOrder<T>(availableKeyNodes, it->second);
 }
 
 template <typename T>

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -16,6 +16,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "folly/lang/Assume.h"
 #include "velox/common/base/test_utils/GTestUtils.h"
 #include "velox/common/caching/DataCache.h"
 #include "velox/dwio/common/MemoryInputStream.h"
@@ -440,29 +441,33 @@ TEST(TestReader, testReadFlatMapWithKeyRejectList) {
 }
 
 namespace {
-std::unordered_set<uint32_t> getNodeIdsFromColumnNames(
-    const std::vector<std::string>& columns,
-    const ColumnSelector& cs) {
+
+std::vector<std::string> stringify(const std::vector<int32_t>& values) {
+  std::vector<std::string> converted(values.size());
+  std::transform(
+      values.begin(), values.end(), converted.begin(), [](int32_t value) {
+        return folly::to<std::string>(value);
+      });
+  return converted;
+}
+
+std::unordered_map<uint32_t, std::vector<std::string>> makeStructEncodingOption(
+    const ColumnSelector& cs,
+    const std::string& columnName,
+    const std::vector<int32_t>& keys) {
   const auto schema = cs.getSchemaWithId();
   const auto names = schema->type->as<TypeKind::ROW>().names();
 
-  // Build name to id lookup
-  std::unordered_map<std::string, uint32_t> nameToIdLookup;
   for (uint32_t i = 0; i < names.size(); ++i) {
-    nameToIdLookup[names[i]] = schema->childAt(i)->id;
-  }
-
-  std::unordered_set<uint32_t> mapColumnIdAsStruct;
-
-  for (const auto& column : columns) {
-    const auto itName = nameToIdLookup.find(column);
-    if (itName != nameToIdLookup.end()) {
-      mapColumnIdAsStruct.insert(itName->second);
+    if (columnName == names[i]) {
+      std::unordered_map<uint32_t, std::vector<std::string>> config;
+      config[schema->childAt(i)->id] = stringify(keys);
+      return config;
     }
   }
 
-  return mapColumnIdAsStruct;
-};
+  folly::assume_unreachable();
+}
 
 void verifyMapColumnEqual(
     MapVector* mapVector,
@@ -496,15 +501,19 @@ void verifyMapColumnEqual(
 
 void verifyFlatmapStructEncoding(
     const std::string& filename,
+    const std::vector<int32_t>& keysAsFields,
+    const std::vector<int32_t>& keysToSelect,
     size_t batchSize = 1000) {
   ReaderOptions readerOpts;
   auto reader = DwrfReader::create(
       std::make_unique<FileInputStream>(filename), readerOpts);
 
-  const std::vector<int32_t> projections{
-      1, 2, 3, 4, 5, -99999999 /* does not exist */};
   const std::string projectedColumn = "map1";
   const vector_size_t projectedColumnIndex = 1;
+  const std::vector<std::string> columnSelections = keysToSelect.empty()
+      ? std::vector<std::string>{projectedColumn}
+      : std::vector<std::string>{
+            projectedColumn + "#[" + folly::join(", ", keysToSelect) + "]"};
 
   auto cs = std::make_shared<ColumnSelector>(
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
@@ -514,8 +523,7 @@ void verifyFlatmapStructEncoding(
       map3:map<int,int>,\
       map4:map<int,struct<field1:int,field2:float,field3:string>>,\
       memo:string>")),
-      std::vector<std::string>{
-          projectedColumn + "#[" + folly::join(", ", projections) + "]"});
+      columnSelections);
 
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.select(cs);
@@ -523,7 +531,7 @@ void verifyFlatmapStructEncoding(
   auto mapEncodingReader = reader->createRowReader(rowReaderOpts);
 
   rowReaderOpts.setFlatmapNodeIdsAsStruct(
-      getNodeIdsFromColumnNames({"map1"}, *cs));
+      makeStructEncodingOption(*cs, "map1", keysAsFields));
   auto structEncodingReader = reader->createRowReader(rowReaderOpts);
 
   const auto compare = [&]() {
@@ -545,11 +553,11 @@ void verifyFlatmapStructEncoding(
 
       EXPECT_EQ(rowMapEncoding->size(), rowStructEncoding->size());
 
-      for (size_t i = 0; i < projections.size(); ++i) {
+      for (size_t i = 0; i < keysAsFields.size(); ++i) {
         verifyMapColumnEqual(
             rowMapEncoding->childAt(projectedColumnIndex)->as<MapVector>(),
             rowStructEncoding->childAt(projectedColumnIndex)->as<RowVector>(),
-            projections[i],
+            keysAsFields[i],
             i);
       }
     } while (true);
@@ -559,43 +567,40 @@ void verifyFlatmapStructEncoding(
 } // namespace
 
 TEST(TestReader, testFlatmapAsStructSmall) {
-  verifyFlatmapStructEncoding(getExampleFilePath("fm_small.orc"));
+  verifyFlatmapStructEncoding(
+      getExampleFilePath("fm_small.orc"),
+      {1, 2, 3, 4, 5, -99999999 /* does not exist */},
+      {} /* no key filtering */);
 }
 
 TEST(TestReader, testFlatmapAsStructSmallEmptyInmap) {
-  verifyFlatmapStructEncoding(getExampleFilePath("fm_small.orc"), 2);
+  verifyFlatmapStructEncoding(
+      getExampleFilePath("fm_small.orc"),
+      {1, 2, 3, 4, 5, -99999999 /* does not exist */},
+      {} /* no key filtering */,
+      2);
 }
 
 TEST(TestReader, testFlatmapAsStructLarge) {
-  verifyFlatmapStructEncoding(getExampleFilePath("fm_large.orc"));
+  verifyFlatmapStructEncoding(
+      getExampleFilePath("fm_large.orc"),
+      {1, 2, 3, 4, 5, -99999999 /* does not exist */},
+      {} /* no key filtering */);
 }
 
-TEST(TestReader, testFlatmapAsStructRequiringProjection) {
-  const std::string fmSmall(getExampleFilePath("fm_small.orc"));
+TEST(TestReader, testFlatmapAsStructWithKeyProjection) {
+  verifyFlatmapStructEncoding(
+      getExampleFilePath("fm_small.orc"),
+      {1, 2, 3, 4, 5, -99999999 /* does not exist */},
+      {3, 5} /* select only these to read */);
+}
 
-  ReaderOptions readerOpts;
-  auto reader = DwrfReader::create(
-      std::make_unique<FileInputStream>(fmSmall), readerOpts);
-
-  auto cs = std::make_shared<ColumnSelector>(
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>")),
-      std::vector<std::string>{});
-
+TEST(TestReader, testFlatmapAsStructRequiringKeyList) {
+  const std::unordered_map<uint32_t, std::vector<std::string>> emptyKeys = {
+      {0, {}}};
   RowReaderOptions rowReaderOpts;
-  rowReaderOpts.select(cs);
-  rowReaderOpts.setFlatmapNodeIdsAsStruct(
-      getNodeIdsFromColumnNames({"map1"}, *cs));
-
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-
-  VectorPtr batch;
-  EXPECT_THROW(rowReader->next(1000, batch), VeloxException);
+  EXPECT_THROW(
+      rowReaderOpts.setFlatmapNodeIdsAsStruct(emptyKeys), VeloxException);
 }
 
 // TODO: replace with mock


### PR DESCRIPTION
Summary:
# Problem
`FlatMapColumnReader` supports reading a map column as a struct encoding with a given list of keys. However, it was using key filtering expression through `ColumnSelector`, as a way to pass the key list. This was working until we expanded the expression to support reject lists.

Now the expression cannot represent a list of keys to accept. We need an explicit way to pass a list of keys to construct a struct encoding, separately from the key filtering.

This is required to have a consistent output schema even with key filtering.

# Solution
I updated `RowReaderOption` to not only accept a list of nodes, but also a list of keys for each configured node. Now we can configure it to produce N fields struct but reading only a subset of them.

Differential Revision: D33352676

