### PR TITLE
Support string elements in array proxy.

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -18,6 +18,7 @@
 #include <folly/Likely.h>
 
 #include <velox/common/base/Exceptions.h>
+#include <velox/type/Type.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/vector/TypeAliases.h"
@@ -83,11 +84,12 @@ class ArrayProxy {
   using element_t = typename child_writer_t::exec_out_t;
 
  public:
-  static bool constexpr provide_std_interface =
-      CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value;
+  static bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
+      !std::is_same<Varchar, V>::value && !std::is_same<Varbinary, V>::value;
 
   static bool constexpr requires_commit = !CppToType<V>::isPrimitiveType ||
-      std::is_same<Varchar, V>::value || std::is_same<bool, V>::value;
+      std::is_same<Varchar, V>::value || std::is_same<bool, V>::value ||
+      std::is_same<Varbinary, V>::value;
 
   // Note: size is with respect to the current size of this array being written.
   void reserve(vector_size_t size) {
@@ -141,37 +143,41 @@ class ArrayProxy {
   // the array element is primitive that is not string or bool.
 
   // 'size' is with respect to the current size of the array being written.
-  typename std::enable_if<provide_std_interface>::type resize(
-      vector_size_t size) {
+  void resize(vector_size_t size) {
     commitMostRecentChildItem();
     reserve(size);
     length_ = size;
   }
 
-  typename std::enable_if<provide_std_interface>::type push_back(
-      element_t value) {
+  void push_back(element_t value) {
+    static_assert(
+        provide_std_interface, "push_back not allowed for this array");
     resize(length_ + 1);
     back() = value;
   }
 
-  typename std::enable_if<provide_std_interface>::type push_back(
-      std::nullopt_t) {
+  void push_back(std::nullopt_t) {
+    static_assert(
+        provide_std_interface, "push_back not allowed for this array");
     resize(length_ + 1);
     back() = std::nullopt;
   }
 
-  typename std::enable_if<provide_std_interface>::type push_back(
-      const std::optional<element_t>& value) {
+  void push_back(const std::optional<element_t>& value) {
+    static_assert(
+        provide_std_interface, "push_back not allowed for this array");
     resize(length_ + 1);
     back() = value;
   }
 
-  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<V>>::type
+  template <typename T = V>
+  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<T>>::type
   operator[](vector_size_t index_) {
     return PrimitiveWriterProxy<V>{elementsVector_, valuesOffset_ + index_};
   }
 
-  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<V>>::type
+  template <typename T = V>
+  typename std::enable_if<provide_std_interface, PrimitiveWriterProxy<T>>::type
   back() {
     return PrimitiveWriterProxy<V>{
         elementsVector_, valuesOffset_ + length_ - 1};

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include <velox/expression/ComplexProxyTypes.h>
 #include "velox/common/base/Portability.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
@@ -25,6 +26,16 @@
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox::exec {
+
+template <typename T>
+struct IsArrayProxy {
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct IsArrayProxy<ArrayProxy<T>> {
+  static constexpr bool value = true;
+};
 
 template <typename FUNC>
 class SimpleFunctionAdapter : public VectorFunction {
@@ -303,27 +314,44 @@ class SimpleFunctionAdapter : public VectorFunction {
     } else {
       if (allNotNull) {
         if (applyContext.allAscii) {
-          applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
-            applyContext.resultWriter.setOffset(row);
-            applyContext.resultWriter.commit(
-                static_cast<char>(doApplyAsciiNotNull<0>(
-                    row, applyContext.resultWriter.current(), readers...)));
+          applyUdf(applyContext, [&](auto& out, auto row) INLINE_LAMBDA {
+            return doApplyAsciiNotNull<0>(row, out, readers...);
           });
         } else {
-          applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
-            applyContext.resultWriter.setOffset(row);
-            applyContext.resultWriter.commit(
-                static_cast<char>(doApplyNotNull<0>(
-                    row, applyContext.resultWriter.current(), readers...)));
+          applyUdf(applyContext, [&](auto& out, auto row) INLINE_LAMBDA {
+            return doApplyNotNull<0>(row, out, readers...);
           });
         }
       } else {
-        applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
-          applyContext.resultWriter.setOffset(row);
-          applyContext.resultWriter.commit(static_cast<char>(doApply<0>(
-              row, applyContext.resultWriter.current(), readers...)));
+        applyUdf(applyContext, [&](auto& out, auto row) INLINE_LAMBDA {
+          return doApply<0>(row, out, readers...);
         });
       }
+    }
+  }
+
+  template <typename Func>
+  void applyUdf(ApplyContext& applyContext, Func func) const {
+    if constexpr (IsArrayProxy<T>::value) {
+      // An optimization for arrayProxy that force the localization of the
+      // output proxy.
+      auto& writerProxy = applyContext.resultWriter.proxy_;
+
+      applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
+        applyContext.resultWriter.setOffset(row);
+        // Force proxy to materliaze here.
+        auto localProxy = writerProxy;
+        auto notNull = func(localProxy, row);
+        writerProxy = localProxy;
+        applyContext.resultWriter.commit(notNull);
+      });
+      applyContext.resultWriter.finish();
+    } else {
+      applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
+        applyContext.resultWriter.setOffset(row);
+        applyContext.resultWriter.commit(
+            func(applyContext.resultWriter.current(), row));
+      });
     }
   }
 

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -116,7 +116,7 @@ struct VectorWriter {
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
       vector_->resize(size, /*setNotNull*/ false);
-      init(*vector_);
+      data_ = vector_->mutableRawValues();
     }
   }
 

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -937,6 +937,7 @@ struct VectorWriter<
 template <typename T>
 struct VectorWriter<T, std::enable_if_t<std::is_same_v<T, bool>>> {
   using vector_t = typename TypeToFlatVector<T>::type;
+  using exec_out_t = bool;
 
   void init(vector_t& vector) {
     vector_ = &vector;

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -882,7 +882,7 @@ struct VectorWriter<
     std::enable_if_t<
         std::is_same_v<T, Varchar> | std::is_same_v<T, Varbinary>>> {
   using vector_t = typename TypeToFlatVector<T>::type;
-  using proxy_t = StringProxy<FlatVector<StringView>, false>;
+  using exec_out_t = StringProxy<FlatVector<StringView>, false>;
 
   void init(vector_t& vector) {
     vector_ = &vector;
@@ -896,12 +896,12 @@ struct VectorWriter<
 
   VectorWriter() {}
 
-  proxy_t& current() {
-    proxy_ = proxy_t(vector_, offset_);
+  exec_out_t& current() {
+    proxy_ = exec_out_t(vector_, offset_);
     return proxy_;
   }
 
-  void copyCommit(const proxy_t& data) {
+  void copyCommit(const exec_out_t& data) {
     // If not initialized for zero-copy writes, copy the value into the vector.
     if (!proxy_.initialized()) {
       vector_->set(offset_, StringView(data.value()));
@@ -932,7 +932,7 @@ struct VectorWriter<
     return *vector_;
   }
 
-  proxy_t proxy_;
+  exec_out_t proxy_;
   vector_t* vector_;
   size_t offset_ = 0;
 };

--- a/velox/expression/tests/ArrayProxyTest.cpp
+++ b/velox/expression/tests/ArrayProxyTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/core.h>
+#include <velox/type/StringView.h>
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
@@ -111,7 +112,7 @@ class ArrayProxyTest : public functions::test::FunctionBaseTest {
 
     writer.result =
         prepareResult(std::make_shared<ArrayType>(ArrayType(BIGINT())));
-    writer.writer->init(*writer.result.get()->as<ArrayVector>());
+    writer.writer->init(*writer.result->as<ArrayVector>());
     writer.writer->setOffset(0);
     return writer;
   }
@@ -220,7 +221,7 @@ TEST_F(ArrayProxyTest, multipleRows) {
       std::make_shared<ArrayType>(ArrayType(BIGINT())), expected.size());
 
   exec::VectorWriter<ArrayProxyT<int64_t>> writer;
-  writer.init(*result.get()->as<ArrayVector>());
+  writer.init(*result->as<ArrayVector>());
 
   for (auto i = 0; i < expected.size(); i++) {
     writer.setOffset(i);
@@ -251,7 +252,7 @@ TEST_F(ArrayProxyTest, testTimeStamp) {
       prepareResult(std::make_shared<ArrayType>(ArrayType(TIMESTAMP())));
 
   exec::VectorWriter<ArrayProxyT<Timestamp>> writer;
-  writer.init(*result.get()->as<ArrayVector>());
+  writer.init(*result->as<ArrayVector>());
   writer.setOffset(0);
   auto& arrayProxy = writer.current();
   // General interface.
@@ -277,5 +278,91 @@ TEST_F(ArrayProxyTest, testTimeStamp) {
        Timestamp::fromMillis(3)}};
   assertEqualVectors(result, makeNullableArrayVector(expected));
 }
+
+TEST_F(ArrayProxyTest, testVarChar) {
+  auto result =
+      prepareResult(std::make_shared<ArrayType>(ArrayType(VARCHAR())));
+
+  exec::VectorWriter<ArrayProxyT<Varchar>> writer;
+  writer.init(*result->as<ArrayVector>());
+  writer.setOffset(0);
+  auto& arrayProxy = writer.current();
+  // General interface is allowed only for arrays of strings.
+  {
+    auto& string = arrayProxy.add_item();
+    string.resize(2);
+    string.data()[0] = 'h';
+    string.data()[1] = 'i';
+  }
+
+  arrayProxy.add_null();
+
+  {
+    auto& string = arrayProxy.add_item();
+    UDFOutputString::assign(string, "welcome");
+  }
+
+  {
+    auto& string = arrayProxy.add_item();
+    UDFOutputString::assign(
+        string,
+        "test a long string, a bit longer than that, longer, and longer");
+  }
+  writer.commit();
+  auto expected = std::vector<std::vector<std::optional<StringView>>>{
+      {"hi"_sv,
+       std::nullopt,
+       "welcome"_sv,
+       "test a long string, a bit longer than that, longer, and longer"_sv}};
+  assertEqualVectors(result, makeNullableArrayVector(expected));
+}
+
+TEST_F(ArrayProxyTest, testVarBinary) {
+  auto result =
+      prepareResult(std::make_shared<ArrayType>(ArrayType(VARBINARY())));
+
+  exec::VectorWriter<ArrayProxyT<Varbinary>> writer;
+  writer.init(*result->as<ArrayVector>());
+  writer.setOffset(0);
+  auto& arrayProxy = writer.current();
+  // General interface is allowed only for arrays of strings.
+  {
+    auto& string = arrayProxy.add_item();
+    string.resize(2);
+    string.data()[0] = 'h';
+    string.data()[1] = 'i';
+  }
+
+  arrayProxy.add_null();
+
+  {
+    auto& string = arrayProxy.add_item();
+    UDFOutputString::assign(string, "welcome");
+  }
+
+  {
+    auto& string = arrayProxy.add_item();
+    UDFOutputString::assign(
+        string,
+        "test a long string, a bit longer than that, longer, and longer");
+  }
+  writer.commit();
+  auto expected = std::vector<std::vector<std::optional<StringView>>>{
+      {"hi"_sv,
+       std::nullopt,
+       "welcome"_sv,
+       "test a long string, a bit longer than that, longer, and longer"_sv}};
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  exec::VectorReader<Array<Varbinary>> reader(&decoded);
+  ASSERT_EQ(reader[0].size(), expected[0].size());
+  for (auto i = 0; i < reader[0].size(); i++) {
+    ASSERT_EQ(reader[0][i], expected[0][i]);
+  }
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/functions/prestosql/benchmarks/ArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayProxyBenchmark.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#define WITH_NULLS false
+
+// Benchmark a function that constructs an array of size n with values 0...n.
+namespace facebook::velox::exec {
+
+namespace {
+
+template <bool optimizeResize>
+class VectorFunctionImpl : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    LocalDecodedVector decoded_(context, *args[0], rows);
+
+    // Prepare results.
+    BaseVector::ensureWritable(rows, ARRAY(BIGINT()), context->pool(), result);
+    auto flatResult = (*result)->as<ArrayVector>();
+    auto currentOffset = 0;
+    auto elementsFlat = flatResult->elements()->asFlatVector<int64_t>();
+
+    // Compute total size needed for elements.
+    auto totalSize = 0;
+
+    if constexpr (optimizeResize) {
+      // Note: this is an optimization that is special for the logic of this
+      // function and not general, hence cant be done in the simple function
+      // interface.
+      rows.applyToSelected([&](vector_size_t row) {
+        totalSize += decoded_->valueAt<int64_t>(row);
+      });
+      elementsFlat->resize(totalSize, false);
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto length = decoded_->valueAt<int64_t>(row);
+
+      flatResult->setOffsetAndSize(row, currentOffset, length);
+      flatResult->setNull(row, false);
+
+      if constexpr (!optimizeResize) {
+        totalSize += length;
+        elementsFlat->resize(totalSize, false);
+      }
+
+      for (auto i = 0; i < length; i++) {
+        if (WITH_NULLS && i % 5) {
+          elementsFlat->setNull(currentOffset + i, true);
+        } else {
+          elementsFlat->set(currentOffset + i, i);
+        }
+      }
+
+      currentOffset += length;
+    });
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayProxyResize {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    out.resize(n);
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out[i] = std::nullopt;
+      } else {
+        out[i] = i;
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayProxyPushBack {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.push_back(std::nullopt);
+      } else {
+        out.push_back(i);
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionGeneralInterface {
+  bool call(exec::ArrayProxy<int64_t>& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.add_null();
+      } else {
+        auto& item = out.add_item();
+        item = i;
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionArrayWriter {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.append(std::nullopt);
+      } else {
+        out.append(i);
+      }
+    }
+    return true;
+  }
+};
+
+class ArrayProxyBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  ArrayProxyBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<
+        SimpleFunctionArrayProxyResize,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_proxy_resize"});
+    registerFunction<
+        SimpleFunctionArrayProxyPushBack,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_proxy_push_back"});
+    registerFunction<
+        SimpleFunctionGeneralInterface,
+        ArrayProxyT<int64_t>,
+        int64_t>({"simple_general"});
+    registerFunction<SimpleFunctionArrayWriter, Array<int64_t>, int64_t>(
+        {"simple_old"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_resize_optimized",
+        {exec::FunctionSignatureBuilder()
+             .returnType("array(bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<true>>());
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_basic",
+        {exec::FunctionSignatureBuilder()
+             .returnType("array(bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<false>>());
+  }
+
+  vector_size_t size = 1'000;
+  size_t totalItemsCount = (size) * (size + 1) / 2;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  size_t run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+
+    doRun(exprSet, input);
+    return totalItemsCount;
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool
+  hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool test() {
+    auto input = makeInput();
+    auto exprSetRef = compileExpression("vector_basic(c0)", input->type());
+    std::vector<std::string> functions = {
+        "vector_resize_optimized",
+        "simple_proxy_push_back",
+        "simple_proxy_resize",
+        "simple_old",
+        "simple_general",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+BENCHMARK_MULTI(VectorBasic) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("vector_basic");
+}
+
+BENCHMARK_MULTI(VectorResizeOptimized) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("vector_resize_optimized");
+}
+
+BENCHMARK_MULTI(SimpleProxyWithResize) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_proxy_resize");
+}
+
+BENCHMARK_MULTI(SimpleProxyPushBack) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_proxy_push_back");
+}
+
+BENCHMARK_MULTI(SimpleGeneral) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_general");
+}
+
+BENCHMARK_MULTI(SimpleOld) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_old");
+}
+} // namespace
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::ArrayProxyBenchmark benchmark;
+  if (benchmark.test()) {
+    folly::runBenchmarks();
+  } else {
+    VELOX_UNREACHABLE("testing failed!")
+  }
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/ArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayProxyBenchmark.cpp
@@ -243,6 +243,27 @@ class ArrayProxyBenchmark : public functions::test::FunctionBenchmarkBase {
 
     return true;
   }
+
+  size_t runStdRef() {
+    for (auto k = 0; k < 100; k++) {
+      std::vector<std::optional<std::vector<std::optional<int>>>> arrayVector;
+      arrayVector.resize(1000);
+      for (auto i = 0; i < 1000; i++) {
+        arrayVector[i] = std::vector<std::optional<int>>();
+        auto& current = *arrayVector[i];
+        current.resize(i);
+        for (int j = 0; j < i; j++) {
+          if (WITH_NULLS && i % 5) {
+            current[j] = std::nullopt;
+          } else {
+            current[j] = j;
+          }
+        }
+      }
+      folly::doNotOptimizeAway(arrayVector);
+    }
+    return totalItemsCount;
+  }
 };
 
 BENCHMARK_MULTI(VectorBasic) {
@@ -273,6 +294,11 @@ BENCHMARK_MULTI(SimpleGeneral) {
 BENCHMARK_MULTI(SimpleOld) {
   ArrayProxyBenchmark benchmark;
   return benchmark.run("simple_old");
+}
+
+BENCHMARK_MULTI(StdBasedImplementation) {
+  ArrayProxyBenchmark benchmark;
+  return benchmark.runStdRef();
 }
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -23,6 +23,15 @@ set(BENCHMARK_DEPENDENCIES
     ${FOLLY_WITH_DEPENDENCIES}
     ${FOLLY_BENCHMARK})
 
+set(BENCHMARK_DEPENDENCIES_NO_FUNC
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_util
+    ${GTEST_BOTH_LIBRARIES}
+    ${gflags_LIBRARIES}
+    ${FOLLY_WITH_DEPENDENCIES}
+    ${FOLLY_BENCHMARK})
+
 add_executable(velox_functions_prestosql_benchmarks_array_contains
                ArrayContainsBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains
@@ -73,3 +82,7 @@ target_link_libraries(velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})
 add_executable(velox_functions_benchmarks_compare CompareBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_compare
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_benchmark_array_proxy ArrayProxyBenchmark.cpp)
+target_link_libraries(velox_benchmark_array_proxy
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})


### PR DESCRIPTION
### **ONLY LAST COMMIT BELONGS TO THIS DIFF**
- This diff support string type elements for array proxy.
- std::enable_if should be dependent on a function template argument, 
hence some changes on this diff fixes that for the std::like interface
of the array proxy.