### PR TITLE
Fix left join with a filter that may return null

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -548,7 +548,8 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
       rawMapping[numPassed++] = row;
     };
     for (auto i = 0; i < numRows; ++i) {
-      const bool passed = decodedFilterResult_.valueAt<bool>(i);
+      const bool passed = !decodedFilterResult_.isNullAt(i) &&
+          decodedFilterResult_.valueAt<bool>(i);
       leftJoinTracker_.advance(rawMapping[i], passed, addMiss);
       if (passed) {
         outputRows_[numPassed] = outputRows_[i];


### PR DESCRIPTION
Left join needs to process null filter results as 'false'. This bug was fixed for other join types in #359.