### PR TITLE
Change LEFT join to preserve the order of input rows in the output

### DIFF
--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -210,9 +210,6 @@ class HashProbe : public Operator {
     bool currentRowPassed{false};
   };
 
-  /// For left join, true if we received new 'input_'.
-  bool newInputForLeftJoin_{false};
-
   /// True if this is the last HashProbe operator in the pipeline. It is
   /// responsible for producing non-matching build-side rows for the right join.
   bool lastRightJoinProbe_{false};

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -68,17 +68,17 @@ class BaseHashTable {
       rows = &lookup.rows;
       hits = &lookup.hits;
       nextHit = nullptr;
-      lastRow = 0;
+      lastRowIndex = 0;
     }
 
     bool atEnd() const {
-      return lastRow == rows->size();
+      return lastRowIndex == rows->size();
     }
 
     const raw_vector<vector_size_t>* rows;
     const raw_vector<char*>* hits;
     char* nextHit{nullptr};
-    vector_size_t lastRow{0};
+    vector_size_t lastRowIndex{0};
   };
 
   struct NotProbedRowsIterator {
@@ -111,8 +111,13 @@ class BaseHashTable {
   /// of 'inputRows' is set to the corresponding row number in probe keys.
   /// Returns the number of hits produced. If this s less than hits.size() then
   /// all the hits have been produced.
+  /// Adds input rows without a match to 'inputRows' with corresponding hit
+  /// set to nullptr if 'includeMisses' is true. Otherwise, skips input rows
+  /// without a match. 'includeMisses' is set to true when listing results for
+  /// the LEFT join.
   virtual int32_t listJoinResults(
       JoinResultIterator& iter,
+      bool includeMisses,
       folly::Range<vector_size_t*> inputRows,
       folly::Range<char**> hits) = 0;
 
@@ -273,6 +278,7 @@ class HashTable : public BaseHashTable {
 
   int32_t listJoinResults(
       JoinResultIterator& iter,
+      bool includeMisses,
       folly::Range<vector_size_t*> inputRows,
       folly::Range<char**> hits) override;
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -760,17 +760,27 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
 TEST_F(HashJoinTest, leftJoin) {
   // Left side keys are [0, 1, 2,..10].
+  // Use 3-rd column as row number to allow for asserting the order of results.
   auto leftVectors = {
-      makeRowVector({
-          makeFlatVector<int32_t>(
-              1'234, [](auto row) { return row % 11; }, nullEvery(13)),
-          makeFlatVector<int32_t>(1'234, [](auto row) { return row; }),
-      }),
-      makeRowVector({
-          makeFlatVector<int32_t>(
-              2'222, [](auto row) { return (row + 3) % 11; }, nullEvery(13)),
-          makeFlatVector<int32_t>(2'222, [](auto row) { return row; }),
-      }),
+      makeRowVector(
+          {"c0", "c1", "row_number"},
+          {
+              makeFlatVector<int32_t>(
+                  1'234, [](auto row) { return row % 11; }, nullEvery(13)),
+              makeFlatVector<int32_t>(1'234, [](auto row) { return row; }),
+              makeFlatVector<int32_t>(1'234, [](auto row) { return row; }),
+          }),
+      makeRowVector(
+          {"c0", "c1", "row_number"},
+          {
+              makeFlatVector<int32_t>(
+                  2'222,
+                  [](auto row) { return (row + 3) % 11; },
+                  nullEvery(13)),
+              makeFlatVector<int32_t>(2'222, [](auto row) { return row; }),
+              makeFlatVector<int32_t>(
+                  2'222, [](auto row) { return 1'234 + row; }),
+          }),
   };
 
   // Right side keys are [0, 1, 2, 3, 4].
@@ -792,10 +802,14 @@ TEST_F(HashJoinTest, leftJoin) {
   auto op =
       PlanBuilder(10)
           .values(leftVectors)
-          .hashJoin({0}, {0}, buildSide, "", {0, 1, 3}, core::JoinType::kLeft)
+          .hashJoin(
+              {0}, {0}, buildSide, "", {2, 0, 1, 4}, core::JoinType::kLeft)
           .planNode();
 
-  assertQuery(op, "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0");
+  assertQueryOrdered(
+      op,
+      "SELECT t.row_number, t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 ORDER BY 1",
+      {0});
 
   // Empty build side.
   auto emptyBuildSide = PlanBuilder(0)
@@ -803,26 +817,30 @@ TEST_F(HashJoinTest, leftJoin) {
                             .filter("c0 < 0")
                             .project({"c0", "c1"}, {"u_c0", "u_c1"})
                             .planNode();
-  op = PlanBuilder(10)
-           .values(leftVectors)
-           .hashJoin({0}, {0}, emptyBuildSide, "", {1}, core::JoinType::kLeft)
-           .planNode();
+  op =
+      PlanBuilder(10)
+          .values(leftVectors)
+          .hashJoin({0}, {0}, emptyBuildSide, "", {2, 1}, core::JoinType::kLeft)
+          .planNode();
 
-  assertQuery(
+  assertQueryOrdered(
       op,
-      "SELECT t.c1 FROM t LEFT JOIN (SELECT c0 FROM u WHERE c0 < 0) u ON t.c0 = u.c0");
+      "SELECT t.row_number, t.c1 FROM t LEFT JOIN (SELECT c0 FROM u WHERE c0 < 0) u ON t.c0 = u.c0 ORDER BY 1",
+      {0});
 
   // All left-side rows have a match on the build side.
   op = PlanBuilder(10)
            .values(leftVectors)
            .filter("c0 < 5")
-           .hashJoin({0}, {0}, buildSide, "", {0, 1, 3}, core::JoinType::kLeft)
+           .hashJoin(
+               {0}, {0}, buildSide, "", {2, 0, 1, 4}, core::JoinType::kLeft)
            .planNode();
 
-  assertQuery(
+  assertQueryOrdered(
       op,
-      "SELECT t.c0, t.c1, u.c1 FROM (SELECT * FROM t WHERE c0 < 5) t"
-      " LEFT JOIN u ON t.c0 = u.c0");
+      "SELECT t.row_number, t.c0, t.c1, u.c1 FROM (SELECT * FROM t WHERE c0 < 5) t"
+      " LEFT JOIN u ON t.c0 = u.c0 ORDER BY t.row_number",
+      {0});
 
   // Additional filter.
   op = PlanBuilder(10)
@@ -832,13 +850,14 @@ TEST_F(HashJoinTest, leftJoin) {
                {0},
                buildSide,
                "(c1 + u_c1) % 2 = 1",
-               {0, 1, 3},
+               {2, 0, 1, 4},
                core::JoinType::kLeft)
            .planNode();
 
-  assertQuery(
+  assertQueryOrdered(
       op,
-      "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 1");
+      "SELECT t.row_number, t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 1 ORDER BY t.row_number",
+      {0});
 
   // No rows pass the additional filter.
   op = PlanBuilder(10)
@@ -847,14 +866,15 @@ TEST_F(HashJoinTest, leftJoin) {
                {0},
                {0},
                buildSide,
-               "(c1 + u_c1) % 2  = 3",
-               {0, 1, 3},
+               "(c1 + u_c1) % 2 = 3",
+               {2, 0, 1, 4},
                core::JoinType::kLeft)
            .planNode();
 
-  assertQuery(
+  assertQueryOrdered(
       op,
-      "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 3");
+      "SELECT t.row_number, t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 3 ORDER BY t.row_number",
+      {0});
 }
 
 TEST_F(HashJoinTest, rightJoin) {


### PR DESCRIPTION
Presto query planner relies on left join to preserve the order of probe-side rows, e.g. if probe-side rows are grouped or sorted on column A, the output will be also be grouped or sorted on column A. This is used when propagating "grouped" property of the probe-side columns for the purpose of enabling streaming aggregation.