### PR TITLE
Improve usability of join methods in PlanBuilder

### DIFF
--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -119,14 +119,14 @@ class MergeJoinTest : public OperatorTestBase {
     auto plan = PlanBuilder()
                     .values(left)
                     .mergeJoin(
-                        {0},
-                        {0},
+                        {"c0"},
+                        {"u_c0"},
                         PlanBuilder()
                             .values(right)
                             .project({"c0", "c1"}, {"u_c0", "u_c1"})
                             .planNode(),
                         "",
-                        {0, 1, 3},
+                        {"c0", "c1", "u_c1"},
                         core::JoinType::kInner)
                     .planNode();
 
@@ -189,11 +189,11 @@ TEST_F(MergeJoinTest, aggregationOverJoin) {
   auto plan = PlanBuilder()
                   .values({left})
                   .mergeJoin(
-                      {0},
-                      {0},
+                      {"t_c0"},
+                      {"u_c0"},
                       PlanBuilder().values({right}).planNode(),
                       "",
-                      {0, 1},
+                      {"t_c0", "u_c0"},
                       core::JoinType::kInner)
                   .singleAggregation({}, {"count(1)"})
                   .planNode();

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -219,31 +219,31 @@ class PlanBuilder {
       const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
       const std::vector<ChannelIndex>& outputLayout = {});
 
-  // 'leftKeys' and 'rightKeys' are indices into the output type of the
-  // previous PlanNode and 'build', respectively.  'output' is indices
-  // into the concatenation of the previous node's output and the
-  // output of 'build'.  'filterText', if non-empty, is an expression over
+  // 'leftKeys' and 'rightKeys' are column names of the output of the
+  // previous PlanNode and 'build', respectively. 'output' is a subset of
+  // column names from the left and right sides of the join to project out.
+  // 'filterText', if non-empty, is an expression over
   // the concatenation of columns of the previous PlanNode and
   // 'build'. This may be wider than output.
   PlanBuilder& hashJoin(
-      const std::vector<ChannelIndex>& leftKeys,
-      const std::vector<ChannelIndex>& rightKeys,
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
       const std::shared_ptr<core::PlanNode>& build,
       const std::string& filterText,
-      const std::vector<ChannelIndex>& output,
+      const std::vector<std::string>& output,
       core::JoinType joinType = core::JoinType::kInner);
 
   PlanBuilder& mergeJoin(
-      const std::vector<ChannelIndex>& leftKeys,
-      const std::vector<ChannelIndex>& rightKeys,
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
       const std::shared_ptr<core::PlanNode>& build,
       const std::string& filterText,
-      const std::vector<ChannelIndex>& output,
+      const std::vector<std::string>& output,
       core::JoinType joinType = core::JoinType::kInner);
 
   PlanBuilder& crossJoin(
       const std::shared_ptr<core::PlanNode>& build,
-      const std::vector<ChannelIndex>& output);
+      const std::vector<std::string>& output);
 
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
@@ -270,15 +270,23 @@ class PlanBuilder {
       const std::vector<std::string>& names);
 
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
+      const RowTypePtr& inputType,
+      const std::vector<std::string>& names);
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
       const std::vector<ChannelIndex>& indices);
 
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
-      const RowTypePtr inputType,
+      const RowTypePtr& inputType,
       const std::vector<ChannelIndex>& indices);
 
   std::shared_ptr<const core::FieldAccessTypedExpr> field(
-      const RowTypePtr& outputType,
+      const RowTypePtr& inputType,
       int index);
+
+  std::shared_ptr<const core::FieldAccessTypedExpr> field(
+      const RowTypePtr& inputType,
+      const std::string& name);
 
   std::shared_ptr<core::PlanNode> createIntermediateOrFinalAggregation(
       core::AggregationNode::Step step,


### PR DESCRIPTION
Update PlanBuilder.{hashJoin, mergeJoin, crossJoin} methods to take join keys
and output columns by name instead of by index to improve readability of the
join tests.