### PR TITLE
Simplify FusedLoad and CachedBufferedInput

### DIFF
--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -20,13 +20,15 @@
 
 namespace facebook::velox::cache {
 
+// Marks that 'bytes' worth of data may be accessed in the
+// future. See TrackingData for meaning of quantum.
 void ScanTracker::recordReference(
     const TrackingId id,
     uint64_t bytes,
     uint64_t /*groupId*/) {
   std::lock_guard<std::mutex> l(mutex_);
-  data_[id].incrementReference(bytes);
-  sum_.incrementReference(bytes);
+  data_[id].incrementReference(bytes, loadQuantum_);
+  sum_.incrementReference(bytes, loadQuantum_);
 }
 
 void ScanTracker::recordRead(

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -17,19 +17,32 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 
+#include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+
+DECLARE_bool(ssd_odirect);
+DECLARE_bool(ssd_verify_write);
+DECLARE_bool(velox_exception_stacktrace);
 
 using namespace facebook::velox;
 using namespace facebook::velox::cache;
 
 using facebook::velox::memory::MappedMemory;
 
+// Represents a planned load from a file. Many of these constitute a load plan.
+struct Request {
+  Request(uint64_t _offset, uint64_t _size) : offset(_offset), size(_size) {}
+
+  uint64_t offset;
+  uint64_t size;
+};
+
 class AsyncDataCacheTest : public testing::Test {
  protected:
   static constexpr int32_t kNumFiles = 100;
-  void initializeCache(int64_t maxBytes) {
+  void initializeCache(int64_t maxBytes, int64_t ssdBytes = 0) {
     cache_ = std::make_shared<AsyncDataCache>(
         MappedMemory::createDefaultInstance(), maxBytes);
     for (auto i = 0; i < kNumFiles; ++i) {
@@ -38,10 +51,51 @@ class AsyncDataCacheTest : public testing::Test {
     }
   }
 
+  // Finds one entry from RAM, SSD or storage. Throws if the data
+  // cannot be read, otherwise request.pin is a loaded CachePin with
+  // the data for the range of 'request.size' bytes starting at
+  // 'request.offset'.
+  void loadOne(uint64_t fileNum, Request& request, bool injectError);
+
+  // Brings the data for the ranges in 'requests' into cache. The individual
+  // entries should be accessed with loadOne().
+  void
+  loadBatch(uint64_t fileNum, std::vector<Request>& requests, bool injectError);
+
+  // Gets a pin on each of 'requests'individually. This checks the
+  // contents via cache_'s verifyHook.
+  void checkBatch(
+      uint64_t fileNum,
+      std::vector<Request>& requests,
+      bool injectError) {
+    for (auto& request : requests) {
+      loadOne(fileNum, request, injectError);
+    }
+  }
+
   // Loads a sequence of entries from a number of files. Looks up a
   // number of entries, then loads the ones that nobody else is
-  // loading.
-  void loadLoop();
+  // loading. Stops after loading 'loadBytes' worth of entries. If
+  // 'errorEveryNBatches' is non-0, every nth load batch will have a
+  // bad read and wil be dropped. The entries of the failed batch read
+  // will still be accessed one by one.
+  void loadLoop(
+      int64_t startOffset,
+      int64_t loadBytes,
+      int32_t errorEveryNBatches = 0);
+
+  // Calls func on 'numThreads' in parallel.
+  template <typename Func>
+  void runThreads(int32_t numThreads, Func func) {
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    for (int32_t i = 0; i < numThreads; ++i) {
+      threads.push_back(std::thread([this, i, func]() { func(i); }));
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
 
  public:
   // Deterministically fills 'allocation'  based on 'sequence'
@@ -51,15 +105,43 @@ class AsyncDataCacheTest : public testing::Test {
     bool first = true;
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
       MappedMemory::PageRun run = alloc.runAt(i);
-      void** ptr = reinterpret_cast<void**>(run.data());
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
           run.numPages() * MappedMemory::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
-          ptr[offset] = reinterpret_cast<void*>(sequence);
+          ptr[offset] = sequence;
           first = false;
         } else {
-          ptr[offset] = ptr + offset + sequence;
+          ptr[offset] = offset + sequence;
+        }
+      }
+    }
+  }
+
+  // Checks that the contents are consistent with what is set in
+  // initializeContents.
+  static void checkContents(
+      const MappedMemory::Allocation& alloc,
+      int32_t numBytes) {
+    bool first = true;
+    int64_t sequence;
+    int32_t bytesChecked = sizeof(int64_t);
+    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
+      MappedMemory::PageRun run = alloc.runAt(i);
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
+      int32_t numWords =
+          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+      for (int32_t offset = 0; offset < numWords; offset++) {
+        if (first) {
+          sequence = ptr[offset];
+          first = false;
+        } else {
+          bytesChecked += sizeof(int64_t);
+          if (bytesChecked >= numBytes) {
+            return;
+          }
+          ASSERT_EQ(ptr[offset], offset + sequence);
         }
       }
     }
@@ -80,78 +162,162 @@ class AsyncDataCacheTest : public testing::Test {
   }
 
  protected:
-  // Checks that the contents are consistent with what is set in
-  // initializeContents.
-  static void checkContents(MappedMemory::Allocation& alloc) {
-    bool first = true;
-    long sequence;
-    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
-      void** ptr = reinterpret_cast<void**>(run.data());
-      int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
-      for (int32_t offset = 0; offset < numWords; offset++) {
-        if (first) {
-          sequence = reinterpret_cast<long>(ptr[offset]);
-          first = false;
-        } else {
-          ASSERT_EQ(ptr[offset], ptr + offset + sequence);
-        }
-      }
-    }
+  static folly::Executor* executor() {
+    static auto executor = std::make_unique<folly::IOThreadPoolExecutor>(4);
+    return executor.get();
   }
 
   std::shared_ptr<AsyncDataCache> cache_;
   std::vector<StringIdLease> filenames_;
 };
 
-class TestingFusedLoad : public FusedLoad {
+class TestingCoalescedLoad : public CoalescedLoad {
  public:
-  void loadData(bool /*isPrefetch*/) override {
-    for (auto& pin : pins_) {
+  TestingCoalescedLoad(
+      std::vector<RawFileCacheKey> keys,
+      std::vector<int32_t> sizes,
+      AsyncDataCache& cache)
+      : CoalescedLoad(std::move(keys), std::move(sizes)), cache_(cache) {}
+
+  void injectError(bool error) {
+    injectError_ = error;
+  }
+
+  std::vector<CachePin> loadData(bool /*isPrefetch*/) override {
+    std::vector<CachePin> pins;
+    cache_.makePins(
+        keys_,
+        [&](int32_t index) { return sizes_[index]; },
+        [&](int32_t index, CachePin pin) { pins.push_back(std::move(pin)); });
+    for (auto& pin : pins) {
       auto& buffer = pin.entry()->data();
       AsyncDataCacheTest::initializeContents(
           pin.entry()->key().offset + pin.entry()->key().fileNum.id(), buffer);
-      pin.entry()->setValid();
     }
+    VELOX_CHECK(!injectError_, "Testing error");
+    return pins;
   }
+
+ protected:
+  AsyncDataCache& cache_;
+  std::vector<Request> requests_;
+  bool injectError_{false};
 };
 
-void AsyncDataCacheTest::loadLoop() {
-  constexpr int32_t kBatch = 8;
-  std::vector<CachePin> batch;
+namespace {
+int64_t sizeAtOffset(int64_t offset) {
+  return offset % 100000;
+}
+} // namespace
+
+void AsyncDataCacheTest::loadOne(
+    uint64_t fileNum,
+    Request& request,
+    bool injectError) {
+  // Pattern for loading one pin.
+  RawFileCacheKey key{fileNum, request.offset};
+  for (;;) {
+    folly::SemiFuture<bool> loadFuture(false);
+    auto pin = cache_->findOrCreate(key, request.size, &loadFuture);
+    if (pin.empty()) {
+      // The pin was exclusive on another thread. Wait until it is no longer so
+      // and retry.
+      auto& exec = folly::QueuedImmediateExecutor::instance();
+      std::move(loadFuture).via(&exec).wait();
+      continue;
+    }
+    auto entry = pin.checkedEntry();
+    if (entry->isShared()) {
+      // The entry has data. In this case the entry was checked by verifyHook,
+      // so no action here.
+      VELOX_CHECK(!injectError, "Testing error");
+      return;
+    }
+    // We have an uninitialized entry in exclusive mode. We fill it with data
+    // and set it to shared. If we release this pin while still in exclusive
+    // mode, the entry will be erased.
+
+    // Load from storage.
+    initializeContents(
+        entry->key().offset + entry->key().fileNum.id(), entry->data());
+    // The entry is filled and will be made visible. 'pin' is released on
+    // return.
+    entry->setExclusiveToShared();
+    return;
+  }
+}
+
+void AsyncDataCacheTest::loadBatch(
+    uint64_t fileNum,
+    std::vector<Request>& requests,
+    bool injectError) {
+  // Pattern for loading a set of buffers from a file: Divide the requested
+  // ranges between already loaded and loadeable from
+  // storage.
+  std::vector<Request*> fromStorage;
+  for (auto& request : requests) {
+    RawFileCacheKey key{fileNum, request.offset};
+    if (cache_->exists(key)) {
+      continue;
+    }
+    // Schedule a CoalescedLoad with other keys that need loading from the same
+    // source.
+    fromStorage.push_back(&request);
+  }
+
+  // Make CoalescedLoads for pins from different sources.
+  if (!fromStorage.empty()) {
+    std::vector<CachePin> pins;
+    std::vector<RawFileCacheKey> keys;
+    std::vector<int32_t> sizes;
+    for (auto request : fromStorage) {
+      keys.push_back(RawFileCacheKey{fileNum, request->offset});
+      sizes.push_back(request->size);
+    }
+    auto load = std::make_shared<TestingCoalescedLoad>(
+        std::move(keys), std::move(sizes), *cache_);
+    load->injectError(injectError);
+    executor()->add([load]() { load->loadOrFuture(nullptr); });
+  }
+}
+
+void AsyncDataCacheTest::loadLoop(
+    int64_t startOffset,
+    int64_t loadBytes,
+    int32_t errorEveryNBatches) {
+  int64_t maxOffset =
+      std::max<int64_t>(100000, (startOffset + loadBytes) / filenames_.size());
+  int64_t skippedBytes = 0;
+  int64_t loadedBytes = 0;
+  int32_t errorCounter = 0;
+  std::vector<Request> batch;
   for (auto file = 0; file < filenames_.size(); ++file) {
-    for (uint64_t offset = 100; offset < 10000000; offset += 100000) {
-      RawFileCacheKey key{filenames_[file].id(), offset};
-      for (;;) {
-        folly::SemiFuture<bool> wait(false);
-        auto pin = cache_->findOrCreate(key, offset % 1000000, &wait);
-        if (pin.empty()) {
-          // Another thread has the pin as exclusive.
-          auto& exec = folly::QueuedImmediateExecutor::instance();
-          std::move(wait).via(&exec).wait();
-          continue;
-        }
-        if (pin.entry()->isExclusive()) {
-          // Entry is new. This thread has it as exclusive.
-          batch.push_back(std::move(pin));
-          if (batch.size() < kBatch) {
-            break; // will load when we have enough entries for a batch.
+    auto fileNum = filenames_[file].id();
+    for (uint64_t offset = 100; offset < maxOffset;
+         offset += sizeAtOffset(offset)) {
+      auto size = sizeAtOffset(offset);
+      if (skippedBytes < startOffset) {
+        skippedBytes += size;
+        continue;
+      }
+
+      batch.emplace_back(offset, size);
+      if (batch.size() >= 8) {
+        for (;;) {
+          bool injectError =
+              errorEveryNBatches && (++errorCounter % errorEveryNBatches == 0);
+          loadBatch(fileNum, batch, injectError);
+          try {
+            checkBatch(fileNum, batch, injectError);
+          } catch (std::exception& e) {
+            continue;
           }
-          auto load = std::make_shared<TestingFusedLoad>();
-          load->initialize(std::move(batch));
-          // The batch is now loadable. Re-get so it loads.
-          continue;
-        } else {
-          // the pin is in shared mode. Ensure the data is loaded.
-          pin.entry()->ensureLoaded(true);
+          batch.clear();
           break;
         }
       }
     }
   }
-  // Drop possibly unloaded exclusive entries.
-  batch.clear();
 }
 
 TEST_F(AsyncDataCacheTest, pin) {
@@ -184,32 +350,30 @@ TEST_F(AsyncDataCacheTest, pin) {
   EXPECT_TRUE(otherPin.empty());
   bool noLongerExclusive = false;
   std::move(wait).via(&exec).thenValue([&](bool) { noLongerExclusive = true; });
-
-  std::vector<CachePin> pins;
-  pins.push_back(std::move(pin));
+  initializeContents(key.fileNum + key.offset, pin.checkedEntry()->data());
+  pin.checkedEntry()->setExclusiveToShared();
+  pin.clear();
   EXPECT_TRUE(pin.empty());
 
-  auto load = std::make_shared<TestingFusedLoad>();
-  load->initialize(std::move(pins));
   EXPECT_TRUE(noLongerExclusive);
 
-  pin.clear();
   pin = cache_->findOrCreate(key, kSize, &wait);
-  EXPECT_FALSE(pin.entry()->dataValid());
   EXPECT_TRUE(pin.entry()->isShared());
   EXPECT_TRUE(pin.entry()->getAndClearFirstUseFlag());
   EXPECT_FALSE(pin.entry()->getAndClearFirstUseFlag());
-  pin.entry()->ensureLoaded(true);
-  checkContents(pin.entry()->data());
+  checkContents(pin.entry()->data(), pin.entry()->size());
   otherPin = pin;
   EXPECT_EQ(2, pin.entry()->numPins());
   EXPECT_FALSE(pin.entry()->isPrefetch());
-  pin.entry()->setValid(false);
   pin.clear();
   otherPin.clear();
+  stats = cache_->refreshStats();
+  EXPECT_LE(kSize, stats.largeSize);
+  EXPECT_EQ(1, stats.numEntries);
+  EXPECT_EQ(0, stats.numShared);
+  EXPECT_EQ(0, stats.numExclusive);
 
-  // Since the pins were cleared with the data not valid, the entry is expected
-  // to be gone.
+  cache_->clear();
   stats = cache_->refreshStats();
   EXPECT_EQ(0, stats.largeSize);
   EXPECT_EQ(0, stats.numEntries);
@@ -218,8 +382,10 @@ TEST_F(AsyncDataCacheTest, pin) {
 
 TEST_F(AsyncDataCacheTest, replace) {
   constexpr int64_t kMaxBytes = 16 << 20;
+  FLAGS_velox_exception_stacktrace = false;
   initializeCache(kMaxBytes);
-  loadLoop();
+  // Load 10x the max size, inject an error every 21 batches.
+  loadLoop(0, kMaxBytes * 10, 21);
   auto stats = cache_->refreshStats();
   EXPECT_LT(0, stats.numEvict);
   EXPECT_GE(

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -83,18 +83,20 @@ void Connector::unregisterTracker(cache::ScanTracker* tracker) {
 }
 
 std::shared_ptr<cache::ScanTracker> Connector::getTracker(
-    const std::string& scanId) {
+    const std::string& scanId,
+    int32_t loadQuantum) {
   return trackers_.withWLock([&](auto& trackers) -> auto {
     auto it = trackers.find(scanId);
     if (it == trackers.end()) {
-      auto newTracker =
-          std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      auto newTracker = std::make_shared<cache::ScanTracker>(
+          scanId, unregisterTracker, loadQuantum);
       trackers[newTracker->id()] = newTracker;
       return newTracker;
     }
     std::shared_ptr<cache::ScanTracker> tracker = it->second.lock();
     if (!tracker) {
-      tracker = std::make_shared<cache::ScanTracker>(scanId, unregisterTracker);
+      tracker = std::make_shared<cache::ScanTracker>(
+          scanId, unregisterTracker, loadQuantum);
       trackers[tracker->id()] = tracker;
     }
     return tracker;

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -236,8 +236,13 @@ class Connector {
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx) = 0;
 
+  // Returns a ScanTracker for 'id'. 'id' uniquely identifies the
+  // tracker and different threads will share the same
+  // instance. 'loadQuantum' is the largest single IO for the query
+  // being tracked.
   static std::shared_ptr<cache::ScanTracker> getTracker(
-      const std::string& scanId);
+      const std::string& scanId,
+      int32_t loadQuantum);
 
  private:
   static void unregisterTracker(cache::ScanTracker* tracker);

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -364,13 +364,14 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
     readerOpts_.getDataCacheConfig()->filenum = fileHandle_->uuid.id();
     bufferedInputFactory_ = std::make_unique<dwrf::CachedBufferedInputFactory>(
         (asyncCache),
-        Connector::getTracker(scanId_),
+        Connector::getTracker(scanId_, readerOpts_.loadQuantum()),
         fileHandle_->groupId.id(),
         [factory = fileHandleFactory_,
          path = split_->filePath,
          stats = ioStats_]() { return makeStreamHolder(factory, path, stats); },
         ioStats_,
-        executor_);
+        executor_,
+        readerOpts_);
     readerOpts_.setBufferedInputFactory(bufferedInputFactory_.get());
   } else if (dataCache_) {
     auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -87,6 +87,10 @@ class IoStatistics {
     return ramHit_;
   }
 
+  IoCounter& queryThreadIoLatency() {
+    return queryThreadIoLatency_;
+  }
+
   void incOperationCounters(
       const std::string& operation,
       const uint64_t resourceThrottleCount,
@@ -117,6 +121,10 @@ class IoStatistics {
   // Read from SSD cache instead of storage. Includes both random and planned
   // reads.
   IoCounter ssdRead_;
+
+  // Time spent by a query processing thread waiting for synchronously
+  // issued IO or for an in-progress read-ahead to finish.
+  IoCounter queryThreadIoLatency_;
 
   std::unordered_map<std::string, OperationCounters> operationStats_;
   mutable std::mutex operationStatsMutex_;

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -301,12 +301,17 @@ class ReaderOptions {
   std::shared_ptr<const velox::RowType> fileSchema;
   uint64_t autoPreloadLength;
   PrefetchMode prefetchMode;
+  int32_t loadQuantum_{kDefaultLoadQuantum};
+  int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
   SerDeOptions serDeOptions;
   std::shared_ptr<DataCacheConfig> dataCacheConfig_;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
   velox::dwrf::BufferedInputFactory* bufferedInputFactory_ = nullptr;
 
  public:
+  static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
+  static constexpr int32_t kDefaultCoalesceDistance = 512 << 10; // 512K
+
   ReaderOptions(
       velox::memory::MemoryPool* pool =
           &facebook::velox::memory::getProcessDefaultMemoryManager().getRoot())
@@ -408,6 +413,21 @@ class ReaderOptions {
   }
 
   /**
+   * Modify the load quantum.
+   */
+  ReaderOptions& setLoadQuantum(int32_t quantum) {
+    loadQuantum_ = quantum;
+    return *this;
+  }
+  /**
+   * Modify the maximum load coalesce distance.
+   */
+  ReaderOptions& setMaxCoalesceDistance(int32_t distance) {
+    maxCoalesceDistance_ = distance;
+    return *this;
+  }
+
+  /**
    * Modify the serialization-deserialization options.
    */
   ReaderOptions& setSerDeOptions(const SerDeOptions& sdo) {
@@ -469,6 +489,14 @@ class ReaderOptions {
 
   PrefetchMode getPrefetchMode() const {
     return prefetchMode;
+  }
+
+  int32_t loadQuantum() const {
+    return loadQuantum_;
+  }
+
+  int32_t maxCoalesceDistance() const {
+    return maxCoalesceDistance_;
   }
 
   SerDeOptions& getSerDeOptions() {

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -16,6 +16,11 @@
 
 #include "velox/dwio/dwrf/common/CacheInputStream.h"
 #include <folly/executors/QueuedImmediateExecutor.h>
+#include "velox/common/process/TraceContext.h"
+#include "velox/common/time/Timer.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
+
+DECLARE_int32(cache_load_quantum);
 
 namespace facebook::velox::dwrf {
 
@@ -24,22 +29,25 @@ using velox::cache::TrackingId;
 using velox::memory::MappedMemory;
 
 CacheInputStream::CacheInputStream(
-    cache::AsyncDataCache* cache,
+    CachedBufferedInput* bufferedInput,
     dwio::common::IoStatistics* ioStats,
     const dwio::common::Region& region,
     dwio::common::InputStream& input,
     uint64_t fileNum,
     std::shared_ptr<ScanTracker> tracker,
     TrackingId trackingId,
-    uint64_t groupId)
-    : cache_(cache),
+    uint64_t groupId,
+    int32_t loadQuantum)
+    : bufferedInput_(bufferedInput),
+      cache_(bufferedInput_->cache()),
       ioStats_(ioStats),
       input_(input),
       region_(region),
       fileNum_(fileNum),
       tracker_(std::move(tracker)),
       trackingId_(trackingId),
-      groupId_(groupId) {}
+      groupId_(groupId),
+      loadQuantum_(loadQuantum) {}
 
 bool CacheInputStream::Next(const void** buffer, int32_t* size) {
   if (position_ >= region_.length) {
@@ -125,6 +133,12 @@ std::vector<folly::Range<char*>> makeRanges(
 } // namespace
 
 void CacheInputStream::loadSync(dwio::common::Region region) {
+  // rawBytesRead is the number of bytes touched. Whether they come
+  // from disk, ssd or memory is itemized in different counters. A
+  // coalesced read ofrom InputStream removes itself from this count
+  // so as not to double count when the individual parts are
+  // hit.
+  ioStats_->incRawBytesRead(region.length);
   do {
     folly::SemiFuture<bool> wait(false);
     cache::RawFileCacheKey key{fileNum_, region.offset};
@@ -133,23 +147,35 @@ void CacheInputStream::loadSync(dwio::common::Region region) {
     if (pin_.empty()) {
       VELOX_CHECK(wait.valid());
       auto& exec = folly::QueuedImmediateExecutor::instance();
-      std::move(wait).via(&exec).wait();
+      uint64_t usec = 0;
+      {
+        MicrosecondTimer timer(&usec);
+        std::move(wait).via(&exec).wait();
+      }
+      ioStats_->queryThreadIoLatency().increment(usec);
       continue;
     }
-    if (pin_.entry()->isExclusive()) {
-      auto ranges = makeRanges(pin_.entry(), region.length);
-      input_.read(ranges, region.offset, dwio::common::LogType::FILE);
-      ioStats_->read().increment(region.length);
-      pin_.entry()->setValid(true);
-      pin_.entry()->setExclusiveToShared();
-    } else {
-      if (pin_.entry()->dataValid()) {
-        if (!pin_.entry()->getAndClearFirstUseFlag()) {
-          ioStats_->ramHit().increment(pin_.entry()->size());
-        }
-      } else {
-        pin_.entry()->ensureLoaded(true);
+    auto entry = pin_.checkedEntry();
+    if (entry->isExclusive()) {
+      entry->setGroupId(groupId_);
+      entry->setTrackingId(trackingId_);
+      auto ranges = makeRanges(entry, region.length);
+      uint64_t usec = 0;
+      {
+        MicrosecondTimer timer(&usec);
+        input_.read(ranges, region.offset, dwio::common::LogType::FILE);
       }
+      // Already incremented on entry, so revert the increment by read()
+      // above.
+      ioStats_->incRawBytesRead(-region.length);
+      ioStats_->read().increment(region.length);
+      ioStats_->queryThreadIoLatency().increment(usec);
+      entry->setExclusiveToShared();
+    } else {
+      if (!entry->getAndClearFirstUseFlag()) {
+        ioStats_->ramHit().increment(pin_.entry()->size());
+      }
+      return;
     }
   } while (pin_.empty());
 }
@@ -157,6 +183,25 @@ void CacheInputStream::loadSync(dwio::common::Region region) {
 void CacheInputStream::loadPosition() {
   auto offset = region_.offset;
   if (pin_.empty()) {
+    auto load = bufferedInput_->coalescedLoad(this);
+    if (load) {
+      folly::SemiFuture<bool> waitFuture(false);
+      uint64_t usec = 0;
+      {
+        MicrosecondTimer timer(&usec);
+        try {
+          if (!load->loadOrFuture(&waitFuture)) {
+            auto& exec = folly::QueuedImmediateExecutor::instance();
+            std::move(waitFuture).via(&exec).wait();
+          }
+        } catch (const std::exception& e) {
+          // Log the error and continue. The error, if it persists,  will be hit
+          // again in looking up the specific entry and thrown from there.
+          LOG(ERROR) << "IOERR: error in coalesced load " << e.what();
+        }
+      }
+      ioStats_->queryThreadIoLatency().increment(usec);
+    }
     auto loadRegion = region_;
     // Quantize position to previous multiple of 'loadQuantum_'.
     loadRegion.offset += (position_ / loadQuantum_) * loadQuantum_;
@@ -166,7 +211,7 @@ void CacheInputStream::loadPosition() {
         loadQuantum_, region_.length - (loadRegion.offset - region_.offset));
     loadSync(loadRegion);
   }
-  auto* entry = pin_.entry();
+  auto* entry = pin_.checkedEntry();
   uint64_t positionInFile = offset + position_;
   if (entry->offset() <= positionInFile &&
       entry->offset() + entry->size() > positionInFile) {

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -13,19 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 #pragma once
 
@@ -37,18 +24,20 @@
 
 namespace facebook::velox::dwrf {
 
+class CachedBufferedInput;
+
 class CacheInputStream : public SeekableInputStream {
  public:
-  static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
   CacheInputStream(
-      cache::AsyncDataCache* cache,
+      CachedBufferedInput* cache,
       dwio::common::IoStatistics* ioStats,
       const dwio::common::Region& region,
       dwio::common::InputStream& input,
       uint64_t fileNum,
       std::shared_ptr<cache::ScanTracker> tracker,
       cache::TrackingId trackingId,
-      uint64_t groupId);
+      uint64_t groupId,
+      int32_t loadQuantum);
 
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
@@ -62,6 +51,7 @@ class CacheInputStream : public SeekableInputStream {
  private:
   void loadPosition();
   void loadSync(dwio::common::Region region);
+  CachedBufferedInput* const bufferedInput_;
   cache::AsyncDataCache* const cache_;
   dwio::common::IoStatistics* ioStats_;
   dwio::common::InputStream& input_;
@@ -74,7 +64,7 @@ class CacheInputStream : public SeekableInputStream {
 
   // Maximum number of bytes read from 'input' at a time. This gives the maximum
   // pin_.entry()->size().
-  int32_t loadQuantum_{kDefaultLoadQuantum};
+  const int32_t loadQuantum_;
 
   // Handle of cache entry.
   cache::CachePin pin_;

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -15,7 +15,13 @@
  */
 
 #include "velox/dwio/dwrf/common/CachedBufferedInput.h"
+#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/dwrf/common/CacheInputStream.h"
+
+DEFINE_int32(
+    cache_prefetch_min_pct,
+    80,
+    "Minimum percentage of actual uses over references to a column for prefetching. No prefetch if > 100");
 
 namespace facebook::velox::dwrf {
 
@@ -23,6 +29,7 @@ using cache::CachePin;
 using cache::LoadState;
 using cache::RawFileCacheKey;
 using cache::ScanTracker;
+using cache::SsdFile;
 using cache::TrackingId;
 using memory::MappedMemory;
 
@@ -38,11 +45,22 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
   if (si) {
     id = TrackingId(si->node, si->kind);
   }
-  requests_.emplace_back(CacheRequest{
-      RawFileCacheKey{fileNum_, region.offset}, region.length, id, CachePin()});
+  VELOX_CHECK_LE(region.offset + region.length, fileSize_);
+  requests_.emplace_back(
+      RawFileCacheKey{fileNum_, region.offset}, region.length, id);
   tracker_->recordReference(id, region.length, groupId_);
-  return std::make_unique<CacheInputStream>(
-      cache_, ioStats_.get(), region, input_, fileNum_, tracker_, id, groupId_);
+  auto stream = std::make_unique<CacheInputStream>(
+      this,
+      ioStats_.get(),
+      region,
+      input_,
+      fileNum_,
+      tracker_,
+      id,
+      groupId_,
+      loadQuantum_);
+  requests_.back().stream = stream.get();
+  return stream;
 }
 
 bool CachedBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)
@@ -59,8 +77,7 @@ bool CachedBufferedInput::shouldPreload() {
   int32_t numPages = 0;
   for (auto& request : requests_) {
     numPages += bits::roundUp(
-                    std::min<int32_t>(
-                        request.size, CacheInputStream::kDefaultLoadQuantum),
+                    std::min<int32_t>(request.size, loadQuantum_),
                     MappedMemory::kPageSize) /
         MappedMemory::kPageSize;
   }
@@ -68,194 +85,313 @@ bool CachedBufferedInput::shouldPreload() {
   auto maxPages = cache_->maxBytes() / MappedMemory::kPageSize;
   auto allocatedPages = cache_->numAllocated();
   if (numPages < maxPages - allocatedPages) {
+    // There is free space for the read-ahead.
     return true;
   }
   auto prefetchPages = cache_->incrementPrefetchPages(0);
   if (numPages + prefetchPages < cachePages / 2) {
+    // The planned prefetch plus other prefetches are under half the cache.
     return true;
   }
-  return false;
-}
-
-void CachedBufferedInput::load(const dwio::common::LogType) {
-  std::vector<CacheRequest*> toLoad;
-  // 'requests_ is cleared on exit.
-  int32_t numNewLoads = 0;
-  auto requests = std::move(requests_);
-  for (auto& request : requests) {
-    if (request.trackingId.empty() ||
-        tracker_->shouldPrefetch(request.trackingId, prefetchThreshold_)) {
-      request.pin = cache_->findOrCreate(request.key, request.size, nullptr);
-      if (request.pin.empty()) {
-        // Already loading for another thread.
-        continue;
-      }
-      if (request.pin.entry()->isExclusive()) {
-        // A new entry to be filled.
-        request.pin.entry()->setPrefetch();
-        toLoad.push_back(&request);
-      } else {
-        // Already in cache, access time is refreshed.
-        request.pin.clear();
-      }
-    }
-  }
-  if (toLoad.empty()) {
-    return;
-  }
-  loadFromSsd(toLoad);
-  if (toLoad.empty()) {
-    return;
-  }
-  std::sort(
-      toLoad.begin(),
-      toLoad.end(),
-      [&](const CacheRequest* left, const CacheRequest* right) {
-        return left->key.offset < right->key.offset;
-      });
-  // Combine adjacent short reads.
-  dwio::common::Region last = {0, 0};
-  std::vector<CachePin> readBatch;
-
-  for (const auto& request : toLoad) {
-    auto* entry = request->pin.entry();
-    auto entryRegion = dwio::common::Region{
-        static_cast<uint64_t>(entry->offset()),
-        static_cast<uint64_t>(entry->size())};
-    VELOX_CHECK_LT(0, entryRegion.length);
-    if (last.length == 0) {
-      // first region
-      last = entryRegion;
-    } else if (!tryMerge(last, entryRegion)) {
-      ++numNewLoads;
-      readRegion(std::move(readBatch));
-      last = entryRegion;
-    }
-    readBatch.push_back(std::move(request->pin));
-  }
-  ++numNewLoads;
-  readRegion(std::move(readBatch));
-  if (executor_ && numNewLoads > 1) {
-    for (auto& load : fusedLoads_) {
-      if (load->state() == LoadState::kPlanned) {
-        executor_->add(
-            [pendingLoad = load]() { pendingLoad->loadOrFuture(nullptr); });
-      }
-    }
-  }
-}
-
-bool CachedBufferedInput::tryMerge(
-    dwio::common::Region& first,
-    const dwio::common::Region& second) {
-  DWIO_ENSURE_GE(second.offset, first.offset, "regions should be sorted.");
-  int64_t gap = second.offset - first.offset - first.length;
-  if (gap < 0) {
-    // We do not support one region going to two target buffers.
-    return false;
-  }
-  // compare with 0 since it's comparison in different types
-  if (gap <= kMaxMergeDistance) {
-    int64_t extension = gap + second.length;
-
-    if (extension > 0) {
-      first.length += extension;
-      if (gap > 0) {
-        ioStats_->incRawOverreadBytes(gap);
-        if (input_.getStats() != nullptr) {
-          input_.getStats()->incRawOverreadBytes(gap);
-        }
-      }
-    }
-
-    return true;
-  }
-
   return false;
 }
 
 namespace {
-class DwrfFusedLoad : public cache::FusedLoad {
- public:
-  void initialize(
-      std::vector<CachePin>&& pins,
-      std::unique_ptr<AbstractInputStreamHolder> input,
-      std::shared_ptr<dwio::common::IoStatistics> ioStats) {
-    input_ = std::move(input);
-    ioStats_ = std::move(ioStats);
-    // Initialize the base class last because as soon as the pins are
-    // placed and set to shared mode other threads can load 'this'.
-    cache::FusedLoad::initialize(std::move(pins));
+
+bool isPrefetchPct(int32_t pct) {
+  return pct >= FLAGS_cache_prefetch_min_pct;
+}
+
+std::vector<CacheRequest*> makeRequestParts(
+    CacheRequest& request,
+    const cache::TrackingData& trackingData,
+    int32_t loadQuantum,
+    std::vector<std::unique_ptr<CacheRequest>>& extraRequests) {
+  if (request.size <= loadQuantum) {
+    return {&request};
   }
 
-  void loadData(bool isPrefetch) override {
-    auto& stream = input_->get();
-    std::vector<folly::Range<char*>> buffers;
-    uint64_t start = pins_[0].entry()->offset();
-    uint64_t lastOffset = start;
-    uint64_t totalRead = 0;
-    for (auto& pin : pins_) {
-      auto& buffer = pin.entry()->data();
-      uint64_t startOffset = pin.entry()->offset();
-      totalRead += pin.entry()->size();
-      if (lastOffset < startOffset) {
-        buffers.push_back(
-            folly::Range<char*>(nullptr, startOffset - lastOffset));
-      }
+  // Large columns will be part of coalesced reads if the access frequency
+  // qualifies for read ahead and if over 80% of the column gets accessed. Large
+  // metadata columns (empty no trackingData) always coalesce.
+  auto readPct =
+      (100 * trackingData.numReads) / (1 + trackingData.numReferences);
+  auto readDensity =
+      (100 * trackingData.readBytes) / (1 + trackingData.referencedBytes);
+  bool prefetch = trackingData.referencedBytes > 0 &&
+      (isPrefetchPct(readPct) && readDensity >= 80);
+  std::vector<CacheRequest*> parts;
+  for (uint64_t offset = 0; offset < request.size; offset += loadQuantum) {
+    int32_t size = std::min<int32_t>(loadQuantum, request.size - offset);
+    extraRequests.push_back(std::make_unique<CacheRequest>(
+        RawFileCacheKey{request.key.fileNum, request.key.offset + offset},
+        size,
+        request.trackingId));
+    parts.push_back(extraRequests.back().get());
+    parts.back()->coalesces = prefetch;
+  }
+  return parts;
+}
+} // namespace
 
-      auto size = pin.entry()->size();
-      uint64_t offsetInRuns = 0;
-      if (buffer.numPages() == 0) {
-        buffers.push_back(folly::Range<char*>(pin.entry()->tinyData(), size));
-        offsetInRuns = size;
-      } else {
-        for (int i = 0; i < buffer.numRuns(); ++i) {
-          velox::memory::MappedMemory::PageRun run = buffer.runAt(i);
-          uint64_t bytes = run.numBytes();
-          uint64_t readSize = std::min(bytes, size - offsetInRuns);
-          buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
-          offsetInRuns += readSize;
+void CachedBufferedInput::load(const dwio::common::LogType) {
+  // 'requests_ is cleared on exit.
+  auto requests = std::move(requests_);
+  // Extra requests made for preloadable regions that are larger then
+  // 'loadQuantum'.
+  std::vector<std::unique_ptr<CacheRequest>> extraRequests;
+  std::vector<CacheRequest*> storageLoad;
+  for (auto& request : requests) {
+    cache::TrackingData trackingData;
+    if (!request.trackingId.empty()) {
+      trackingData = tracker_->trackingData(request.trackingId);
+    }
+    // Gather frequently accessed items in a list and see if they should be
+    // loaded together.
+    if (request.trackingId.empty() ||
+        (100 * trackingData.numReads) / (1 + trackingData.numReferences) >=
+            80) {
+      auto parts =
+          makeRequestParts(request, trackingData, loadQuantum_, extraRequests);
+      for (auto part : parts) {
+        if (cache_->exists(part->key)) {
+          continue;
         }
+        storageLoad.push_back(part);
       }
-      DWIO_ENSURE(offsetInRuns == size);
-      lastOffset = startOffset + size;
     }
-    if (isPrefetch) {
-      ioStats_->prefetch().increment(totalRead);
-    } else {
-      ioStats_->read().increment(totalRead);
+  }
+  makeLoads(std::move(storageLoad), true);
+}
+
+void CachedBufferedInput::makeLoads(
+    std::vector<CacheRequest*> requests,
+    bool prefetch) {
+  if (requests.size() < 2) {
+    return;
+  }
+  std::sort(
+      requests.begin(),
+      requests.end(),
+      [&](const CacheRequest* left, const CacheRequest* right) {
+        return left->key.offset < right->key.offset;
+      });
+  // Combine adjacent short reads.
+
+  int32_t numNewLoads = 0;
+
+  coalesceIo<CacheRequest*, CacheRequest*>(
+      requests,
+      maxCoalesceDistance_,
+      // Break batches up. Better load more short ones i parallel.
+      40,
+      [&](int32_t index) { return requests[index]->key.offset; },
+      [&](int32_t index) { return requests[index]->size; },
+      [&](int32_t index) {
+        return requests[index]->coalesces ? 1 : kNoCoalesce;
+      },
+      [&](CacheRequest* request, std::vector<CacheRequest*>& ranges) {
+        ranges.push_back(request);
+      },
+      [&](int32_t /*gap*/, std::vector<CacheRequest*> /*ranges*/) { /*no op*/ },
+      [&](const std::vector<CacheRequest*>& /*requests*/,
+          int32_t /*begin*/,
+          int32_t /*end*/,
+          uint64_t /*offset*/,
+          const std::vector<CacheRequest*>& ranges) {
+        ++numNewLoads;
+        readRegion(ranges, prefetch);
+      });
+  if (prefetch && executor_) {
+    for (auto& load : allCoalescedLoads_) {
+      if (load->state() == LoadState::kPlanned) {
+        executor_->add([pendingLoad = load]() {
+          process::TraceContext trace("Read Ahead");
+          pendingLoad->loadOrFuture(nullptr);
+        });
+      }
     }
-    stream.read(buffers, start, dwio::common::LogType::FILE);
+  }
+}
+
+namespace {
+// Base class for CoalescedLoads for different storage types.
+class DwrfCoalescedLoadBase : public cache::CoalescedLoad {
+ public:
+  DwrfCoalescedLoadBase(
+      cache::AsyncDataCache& cache,
+      std::shared_ptr<dwio::common::IoStatistics> ioStats,
+      uint64_t groupId,
+      std::vector<CacheRequest*> requests)
+      : CoalescedLoad(makeKeys(requests), makeSizes(requests)),
+        cache_(cache),
+        ioStats_(std::move(ioStats)),
+        groupId_(groupId) {
+    for (auto& request : requests) {
+      requests_.push_back(std::move(*request));
+    }
   }
 
- private:
-  std::unique_ptr<AbstractInputStreamHolder> input_;
+  const std::vector<CacheRequest>& requests() {
+    return requests_;
+  }
+
+  std::string toString() const override {
+    int32_t payload = 0;
+    int32_t total = requests_.back().key.offset + requests_.back().size -
+        requests_[0].key.offset;
+    for (auto& request : requests_) {
+      payload += request.size;
+    }
+    return fmt::format(
+        "<CoalescedLoad: {} entries, {} total {} extra>",
+        requests_.size(),
+        total,
+        total - payload);
+  }
+
+ protected:
+  void updateStats(const CoalesceIoStats& stats, bool isPrefetch, bool isSsd) {
+    if (ioStats_) {
+      ioStats_->incRawOverreadBytes(stats.extraBytes);
+      // Reading the file increments rawReadBytes. Reverse this
+      // increment here because actually accessing the data via
+      // CacheInputStream will do the increment.
+      ioStats_->incRawBytesRead(-stats.payloadBytes);
+
+      ioStats_->read().increment(stats.payloadBytes);
+
+      if (isPrefetch) {
+        ioStats_->prefetch().increment(stats.payloadBytes);
+      }
+    }
+  }
+
+  static std::vector<RawFileCacheKey> makeKeys(
+      std::vector<CacheRequest*>& requests) {
+    std::vector<RawFileCacheKey> keys;
+    keys.reserve(requests.size());
+    for (auto& request : requests) {
+      keys.push_back(request->key);
+    }
+    return keys;
+  }
+
+  std::vector<int32_t> makeSizes(std::vector<CacheRequest*> requests) {
+    std::vector<int32_t> sizes;
+    sizes.reserve(requests.size());
+    for (auto& request : requests) {
+      sizes.push_back(request->size);
+    }
+    return sizes;
+  }
+
+  cache::AsyncDataCache& cache_;
+  std::vector<CacheRequest> requests_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
+  const uint64_t groupId_;
+};
+
+// Represents a CoalescedLoad from ReadFile, e.g. disagg disk.
+class DwrfCoalescedLoad : public DwrfCoalescedLoadBase {
+ public:
+  DwrfCoalescedLoad(
+      cache::AsyncDataCache& cache,
+      std::unique_ptr<AbstractInputStreamHolder> input,
+      std::shared_ptr<dwio::common::IoStatistics> ioStats,
+      uint64_t groupId,
+      std::vector<CacheRequest*> requests,
+      int32_t maxCoalesceDistance)
+      : DwrfCoalescedLoadBase(cache, ioStats, groupId, std::move(requests)),
+        input_(std::move(input)),
+        maxCoalesceDistance_(maxCoalesceDistance) {}
+
+  std::vector<CachePin> loadData(bool isPrefetch) override {
+    auto& stream = input_->get();
+    std::vector<CachePin> pins;
+    pins.reserve(keys_.size());
+    cache_.makePins(
+        keys_,
+        [&](int32_t index) { return sizes_[index]; },
+        [&](int32_t index, CachePin pin) {});
+    if (pins.empty()) {
+      return pins;
+    }
+    auto stats = cache::readPins(
+        pins,
+        maxCoalesceDistance_,
+        1000,
+        [&](int32_t i) { return pins[i].entry()->offset(); },
+        [&](const std::vector<CachePin>& pins,
+            int32_t begin,
+            int32_t end,
+            uint64_t offset,
+            const std::vector<folly::Range<char*>>& buffers) {
+          stream.read(buffers, offset, dwio::common::LogType::FILE);
+        });
+    updateStats(stats, isPrefetch, false);
+    return pins;
+  }
+
+  std::unique_ptr<AbstractInputStreamHolder> input_;
+  const int32_t maxCoalesceDistance_;
 };
 } // namespace
 
-void CachedBufferedInput::readRegion(std::vector<CachePin> pins) {
-  auto load = std::make_shared<DwrfFusedLoad>();
-  load->initialize(std::move(pins), streamSource_(), ioStats_);
-  fusedLoads_.push_back(load);
+void CachedBufferedInput::readRegion(
+    std::vector<CacheRequest*> requests,
+    bool prefetch) {
+  if (requests.empty() || (requests.size() == 1 && !prefetch)) {
+    return;
+  }
+  std::shared_ptr<cache::CoalescedLoad> load;
+  load = std::make_shared<DwrfCoalescedLoad>(
+      *cache_,
+      streamSource_(),
+      ioStats_,
+      groupId_,
+      requests,
+      maxCoalesceDistance_);
+  allCoalescedLoads_.push_back(load);
+  coalescedLoads_.withWLock([&](auto& loads) {
+    for (auto& request : requests) {
+      loads[request->stream] = load;
+    }
+  });
+}
+
+std::shared_ptr<cache::CoalescedLoad> CachedBufferedInput::coalescedLoad(
+    const SeekableInputStream* stream) {
+  return coalescedLoads_.withWLock(
+      [&](auto& loads) -> std::shared_ptr<cache::CoalescedLoad> {
+        auto it = loads.find(stream);
+        if (it == loads.end()) {
+          return nullptr;
+        }
+        auto load = std::move(it->second);
+        auto dwrfLoad = dynamic_cast<DwrfCoalescedLoadBase*>(load.get());
+        for (auto& request : dwrfLoad->requests()) {
+          loads.erase(request.stream);
+        }
+        return load;
+      });
 }
 
 std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
     uint64_t offset,
     uint64_t length,
     dwio::common::LogType /*logType*/) const {
+  VELOX_CHECK_LE(offset + length, fileSize_);
   return std::make_unique<CacheInputStream>(
-      cache_,
+      const_cast<CachedBufferedInput*>(this),
       ioStats_.get(),
       dwio::common::Region{offset, length},
       input_,
       fileNum_,
       nullptr,
       TrackingId(),
-      0);
+      0,
+      loadQuantum_);
 }
 
-void CachedBufferedInput::loadFromSsd(std::vector<CacheRequest*> /*requests*/) {
-  // No op placeholder.
-}
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -20,8 +20,11 @@
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/dwrf/common/BufferedInput.h"
+#include "velox/dwio/dwrf/common/CacheInputStream.h"
 
 #include <folly/Executor.h>
+
+DECLARE_int32(cache_load_quantum);
 
 namespace facebook::velox::dwrf {
 
@@ -42,6 +45,27 @@ class AbstractInputStreamHolder {
 using StreamSource =
     std::function<std::unique_ptr<AbstractInputStreamHolder>()>;
 
+struct CacheRequest {
+  CacheRequest(
+      cache::RawFileCacheKey _key,
+      uint64_t _size,
+      cache::TrackingId _trackingId)
+      : key(_key), size(_size), trackingId(_trackingId) {}
+
+  cache::RawFileCacheKey key;
+  uint64_t size;
+  cache::TrackingId trackingId;
+  cache::CachePin pin;
+  bool processed{false};
+
+  // True if this should be coalesced into a CoalescedLoad with other
+  // nearby requests with a similar load probability. This is false
+  // for sparsely accessed large columns where hitting one piece
+  // should not load the adjacent pieces.
+  bool coalesces{true};
+  const SeekableInputStream* stream;
+};
+
 class CachedBufferedInput : public BufferedInput {
  public:
   CachedBufferedInput(
@@ -53,7 +77,9 @@ class CachedBufferedInput : public BufferedInput {
       uint64_t groupId,
       StreamSource streamSource,
       std::shared_ptr<dwio::common::IoStatistics> ioStats,
-      folly::Executor* executor)
+      folly::Executor* executor,
+      int32_t loadQuantum,
+      int32_t maxCoalesceDistance)
       : BufferedInput(input, pool, dataCacheConfig),
         cache_(cache),
         fileNum_(dataCacheConfig->filenum),
@@ -61,10 +87,13 @@ class CachedBufferedInput : public BufferedInput {
         groupId_(groupId),
         streamSource_(streamSource),
         ioStats_(std::move(ioStats)),
-        executor_(executor) {}
+        executor_(executor),
+        fileSize_(input.getLength()),
+        loadQuantum_(loadQuantum),
+        maxCoalesceDistance_(maxCoalesceDistance) {}
 
   ~CachedBufferedInput() override {
-    for (auto& load : fusedLoads_) {
+    for (auto& load : allCoalescedLoads_) {
       load->cancel();
     }
   }
@@ -92,28 +121,27 @@ class CachedBufferedInput : public BufferedInput {
     return true;
   }
 
+  cache::AsyncDataCache* cache() const {
+    return cache_;
+  }
+
+  // Returns the CoalescedLoad that contains the correlated loads for
+  // 'stream' or nullptr if none. Returns nullptr on all but first
+  // call for 'stream' since the load is to be triggered by the first
+  // access.
+  std::shared_ptr<cache::CoalescedLoad> coalescedLoad(
+      const SeekableInputStream* stream);
+
  private:
-  struct CacheRequest {
-    cache::RawFileCacheKey key;
-    uint64_t size;
-    cache::TrackingId trackingId;
-    cache::CachePin pin;
-  };
+  // Sorts requests and makes CoalescedLoads for nearby requests. If 'prefetch'
+  // is true, starts background loading.
+  void makeLoads(std::vector<CacheRequest*> requests, bool prefetch);
 
-  // Updates first  to include second if they are near enough to justify merging
-  // the IO.
-  bool tryMerge(
-      dwio::common::Region& first,
-      const dwio::common::Region& second);
-
-  // Schedules 'pins' to be read in a single IO covering
-  // 'region'. 'pins are sorted and non-overlapping and do not have
-  // excessive gaps between the end of one and the start of the next.
-  void readRegion(std::vector<cache::CachePin> pins);
-
-  // Removes the requests from 'toLoad' if they hit SSD cache. May start
-  // background load from SSD.
-  void loadFromSsd(std::vector<CacheRequest*> requests);
+  // Makes a CoalescedLoad for 'requests' to be read together, coalescing
+  // IO is appropriate. If 'prefetch' is set, schedules the CoalescedLoad
+  // on 'executor_'. Links the CoalescedLoad  to all CacheInputStreams that it
+  // concerns.
+  void readRegion(std::vector<CacheRequest*> requests, bool prefetch);
 
   cache::AsyncDataCache* cache_;
   const uint64_t fileNum_;
@@ -123,15 +151,21 @@ class CachedBufferedInput : public BufferedInput {
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
   folly::Executor* const executor_;
 
-  //  Percentage of reads over enqueues that qualifies a stream to be
-  //  coalesced with nearby streams and prefetched. Anything read less
-  //  frequently will be synchronously read on first use.
-  int32_t prefetchThreshold_ = 60;
-
   // Regions that are candidates for loading.
   std::vector<CacheRequest> requests_;
+
   // Coalesced loads spanning multiple cache entries in one IO.
-  std::vector<std::shared_ptr<cache::FusedLoad>> fusedLoads_;
+  folly::Synchronized<folly::F14FastMap<
+      const SeekableInputStream*,
+      std::shared_ptr<cache::CoalescedLoad>>>
+      coalescedLoads_;
+
+  // Distinct coalesced loads in 'coalescedLoads_'.
+  std::vector<std::shared_ptr<cache::CoalescedLoad>> allCoalescedLoads_;
+
+  const uint64_t fileSize_;
+  const int32_t loadQuantum_;
+  const int32_t maxCoalesceDistance_;
 };
 
 class CachedBufferedInputFactory : public BufferedInputFactory {
@@ -142,13 +176,16 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
       uint64_t groupId,
       StreamSource streamSource,
       std::shared_ptr<dwio::common::IoStatistics> ioStats,
-      folly::Executor* executor)
+      folly::Executor* executor,
+      const dwio::common::ReaderOptions& readerOpts)
       : cache_(cache),
         tracker_(std::move(tracker)),
         groupId_(groupId),
         streamSource_(streamSource),
         ioStats_(ioStats),
-        executor_(executor) {}
+        executor_(executor),
+        loadQuantum_(readerOpts.loadQuantum()),
+        maxCoalesceDistance_(readerOpts.maxCoalesceDistance()) {}
 
   std::unique_ptr<BufferedInput> create(
       dwio::common::InputStream& input,
@@ -163,7 +200,9 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
         groupId_,
         streamSource_,
         ioStats_,
-        executor_);
+        executor_,
+        loadQuantum_,
+        maxCoalesceDistance_);
   }
 
   std::string toString() const {
@@ -180,5 +219,7 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
   StreamSource streamSource_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
   folly::Executor* executor_;
+  int32_t loadQuantum_;
+  int32_t maxCoalesceDistance_;
 };
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
The IO pattern for Velox file readers is to register the pieces of file to be
accessed, then to access some or all of these pieces. Pieces that are in close
proximity get loaded with a single IO. The definition of close depends on the
media.

This removes the load_ member from AsyncDataCacheEntry. The cache entry no
longer references the FusedLoad that will be invoked to fill it. Instead, the
CacheInputStream  that will load a piece of file coalesced with other pieces
references the FusedLoad.

The API contract of CachePin is simplified: If findOrCreate returns an exclusive
pin, the caller is responsible for filling the entry and calling
setExclusiveToShared when done. This makes the data visible to other threads.
There is no more a concept of dataValid or ensureLoaded for shared mode pins
that have uninitialized data.

We add tests for checking a consistent after state for errors in loading data
into CachePins. AsyncDataCacheTest adds error injection in FusedLoads and
single pin loading. The code is also more representative of the intended usage
pattern.

CachedBufferedInput is adapted to use the changed AsyncDataCache API.
CacheInputStream looks for its FusedLoad instead of the FusedLoad being
recorded in a cache entry. Cache entries for FusedLoads are made right before
loading the FusedLoad. CoalesceIO.h is used systematically to detect and
coalesce coalesced loads.

ScanTracker exports TrackingData so that columns can be more accurately sorted
in different load frequency buckets.