### PR TITLE
Revert "Remove static driver executor (#820)"

### DIFF
--- a/velox/core/tests/TestQueryConfig.cpp
+++ b/velox/core/tests/TestQueryConfig.cpp
@@ -26,7 +26,7 @@ using ::facebook::velox::core::QueryCtx;
 TEST(TestQueryConfig, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = QueryCtx::createForTest(queryCtxConfig);
+  auto queryCtx = std::make_shared<QueryCtx>(queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_FALSE(config.codegenEnabled());
@@ -40,7 +40,7 @@ TEST(TestQueryConfig, setConfig) {
       {{QueryConfig::kCodegenEnabled, "true"},
        {QueryConfig::kCodegenConfigurationFilePath, path}});
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = QueryCtx::createForTest(queryCtxConfig);
+  auto queryCtx = std::make_shared<QueryCtx>(queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_TRUE(config.codegenEnabled());

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -67,7 +67,7 @@ class BaseDuckWrapperTest : public testing::Test {
         << "Query failed: " << result->errorMessage();
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
   // QueryCtx holds the metadata and configuration associated with a
   // particular query. This is shared between all threads of execution
   // for the same query (one object per query).
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = core::QueryCtx::create();
 
   // ExecCtx holds structures associated with a single thread of execution
   // (one per thread). Each thread of execution requires a scoped memory pool,

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
       udf_map_resolver_vector, "map_resolver_vector");
 
   // Create memory pool and other query-related structures.
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = core::QueryCtx::create();
   auto pool = memory::getDefaultScopedMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -190,6 +190,9 @@ class Driver {
     close();
   }
 
+  static folly::CPUThreadPoolExecutor* FOLLY_NONNULL
+  executor(int32_t threads = 0);
+
   static void run(std::shared_ptr<Driver> self);
 
   static void enqueue(std::shared_ptr<Driver> instance);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -421,7 +421,7 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
   // Set an artificially low limit on the amount of data to accumulate in
   // the partial aggregation.
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = core::QueryCtx::create();
 
   params.queryCtx->setConfigOverridesUnsafe({
       {core::QueryConfig::kMaxPartialAggregationMemory, "100"},

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -291,7 +291,7 @@ TEST_F(HashJoinTest, memory) {
                         .project({"t_k0 % 1000", "u_k0 % 1000"}, {"k1", "k2"})
                         .singleAggregation({}, {"sum(k1)", "sum(k2)"})
                         .planNode();
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = core::QueryCtx::create();
   auto tracker = memory::MemoryUsageTracker::create();
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -201,7 +201,7 @@ TEST_F(LocalPartitionTest, maxBufferSizeGather) {
 
   CursorParameters params;
   params.planNode = op;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = core::QueryCtx::create();
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({
@@ -247,7 +247,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
   CursorParameters params;
   params.planNode = op;
   params.maxDrivers = 2;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = core::QueryCtx::create();
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
   params.queryCtx->setConfigOverridesUnsafe({

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -26,13 +26,13 @@ class MergeJoinTest : public OperatorTestBase {
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>();
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kCreateEmptyFiles, "true"}});
 
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = core::QueryCtx::createForTest();
+    params.queryCtx = std::make_shared<core::QueryCtx>();
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -62,8 +62,12 @@ class MultiFragmentTest : public OperatorTestBase {
       const std::string& taskId,
       std::shared_ptr<const core::PlanNode> planNode,
       int destination) {
-    auto queryCtx = core::QueryCtx::createForTest(
-        std::make_shared<core::MemConfig>(configSettings_));
+    auto queryCtx = core::QueryCtx::create(
+        std::make_shared<core::MemConfig>(configSettings_),
+        std::unordered_map<std::string, std::shared_ptr<Config>>{},
+        memory::MappedMemory::getInstance(),
+        memory::getProcessDefaultMemoryManager().getRoot().addScopedChild(
+            "query_root"));
     return std::make_shared<Task>(
         taskId, planNode, destination, std::move(queryCtx));
   }

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -40,7 +40,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       const std::string& taskId,
       int numDestinations,
       int numDrivers) {
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = core::QueryCtx::create();
     bufferManager_->removeTask(taskId);
     auto task = std::make_shared<Task>(taskId, nullptr, 0, std::move(queryCtx));
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -24,13 +24,13 @@ class StreamingAggregationTest : public OperatorTestBase {
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>();
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kCreateEmptyFiles, "true"}});
 
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = core::QueryCtx::createForTest();
+    params.queryCtx = std::make_shared<core::QueryCtx>();
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -230,7 +230,7 @@ TEST_F(TableWriteTest, writeEmptyFile) {
 
   auto execute = [](const std::shared_ptr<const core::PlanNode>& plan,
                     std::shared_ptr<core::QueryCtx> queryCtx =
-                        core::QueryCtx::createForTest()) {
+                        core::QueryCtx::create()) {
     CursorParameters params;
     params.planNode = plan;
     params.queryCtx = queryCtx;
@@ -240,7 +240,7 @@ TEST_F(TableWriteTest, writeEmptyFile) {
   execute(plan);
   ASSERT_FALSE(fs::exists(outputFile));
 
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>();
   queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kCreateEmptyFiles, "true"}});
   execute(plan, queryCtx);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -31,7 +31,7 @@ TEST_F(TaskTest, splitGroup) {
       0,
       100);
   core::PlanNodeId planNodeId{"0"};
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>();
   exec::Task task("0", nullptr, 0, queryCtx);
 
   // This is the set of completed groups we expect.

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -110,7 +110,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
   if (params.queryCtx) {
     queryCtx = params.queryCtx;
   } else {
-    queryCtx = core::QueryCtx::createForTest();
+    queryCtx = core::QueryCtx::create();
   }
   auto numProducers = params.numResultDrivers.has_value()
       ? params.numResultDrivers.value()

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -40,6 +40,7 @@ OperatorTestBase::OperatorTestBase() {
 }
 
 OperatorTestBase::~OperatorTestBase() {
+  exec::Driver::testingJoinAndReinitializeExecutor();
   // Revert to default process-wide MappedMemory.
   memory::MappedMemory::setDefaultInstance(nullptr);
 }

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -123,7 +123,7 @@ class CodegenBenchmark : public CodegenTestCore {
 
   CodegenBenchmark() {
     CodegenTestCore::init();
-    queryCtx = core::QueryCtx::createForTest();
+    queryCtx = std::make_shared<core::QueryCtx>();
     pool = memory::getDefaultScopedMemoryPool();
     execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
@@ -270,6 +270,7 @@ class CodegenBenchmark : public CodegenTestCore {
       info.referenceResults = runQuery(
           info.refPlanNodes,
           this->benchmarkInfos[benchmarkIndex].referenceTaskCursors);
+      Driver::testingJoinAndReinitializeExecutor();
       return numberIteration;
     };
 
@@ -279,6 +280,7 @@ class CodegenBenchmark : public CodegenTestCore {
       info.compiledResults.clear();
       info.compiledResults =
           runQuery(info.compiledPlanNodes, info.compiledTaskCursors);
+      Driver::testingJoinAndReinitializeExecutor();
       return numberIteration;
     };
 

--- a/velox/experimental/codegen/benchmark/TARGETS_disabled
+++ b/velox/experimental/codegen/benchmark/TARGETS_disabled
@@ -25,6 +25,7 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -49,6 +50,7 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -73,6 +75,7 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -86,6 +89,7 @@ cpp_unittest(
     linker_flags = ["--export-dynamic"],
     deps = [
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
+        "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -135,6 +139,7 @@ cpp_binary(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
+              "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )
 
@@ -159,5 +164,6 @@ cpp_unittest(
         "//velox/experimental/codegen/tests:velox_experimental_codegen_test_utils",
         "//velox/experimental/codegen/transform:velox_transform",
         "//velox/experimental/codegen/transform/utils:velox_transform_utils",
+              "//velox/functions/prestosql/registration:velox_functions_prestosql",
     ],
 )

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -579,7 +579,7 @@ class ExpressionCodegenTestBase : public testing::Test {
         core::ConcatTypedExpr({"c0"}, {typedExpr}));
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -103,7 +103,7 @@ class CodegenTestCore {
             useSymbolForArithmetic_,
             eventSequence_);
     pool_ = memory::getDefaultScopedMemoryPool();
-    queryCtx_ = core::QueryCtx::createForTest();
+    queryCtx_ = std::make_shared<core::QueryCtx>();
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
     exec::test::registerTypeResolver();
@@ -415,6 +415,10 @@ class CodegenTestBase : public CodegenTestCore, public testing::Test {
 
   virtual void SetUp() override {
     init();
+  }
+
+  void TearDown() override {
+    Driver::testingJoinAndReinitializeExecutor();
   }
 };
 }; // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/tests/TARGETS_disabled
+++ b/velox/experimental/codegen/tests/TARGETS_disabled
@@ -11,7 +11,7 @@ cpp_library(
         "include": "//velox/experimental/codegen/code_generator/tests:copy_dependencies[include]",
         "package_json": "//velox/experimental/codegen/code_generator/tests:copy_dependencies[package.json]",
     },
-    exported_deps = [
+    deps = [
         "//folly:benchmark",
         "//velox/core:velox_core",
         "//velox/dwio/dwrf/test/utils:lib_test_batch_maker",
@@ -21,12 +21,12 @@ cpp_library(
         "//velox/experimental/codegen:velox_experimental_codegen_impl",
         "//velox/experimental/codegen/code_generator:velox_codegen_code_generator",
         "//velox/experimental/codegen/utils/resources:velox_experimental_codegen_utils_resource_path",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
+              "//velox/functions/prestosql/registration:velox_functions_prestosql",
         "//velox/parse:velox_parse",
         "//velox/parse:velox_parse_expression",
         "//velox/type:velox_type",
     ],
-    exported_external_deps = [
+    external_deps = [
         "glog",
         ("googletest", None, "gtest"),
     ],
@@ -48,7 +48,7 @@ cpp_unittest(
         "//velox/experimental/codegen:velox_experimental_codegen_exceptions",
         "//velox/experimental/codegen:velox_experimental_codegen_impl",
         "//velox/experimental/codegen/utils/timer:velox_codegen_utils_timer",
-        "//velox/functions/prestosql/registration:velox_functions_prestosql",
+              "//velox/functions/prestosql/registration:velox_functions_prestosql",
         "//velox/type:velox_type",
     ],
 )

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -103,7 +103,7 @@ TEST(TestConcat, EvalConcatFunction) {
   in2->addNulls(nullptr, rows);
 
   std::vector<VectorPtr> in{in1, in2};
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>();
   auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
   exec::EvalCtx context(execCtx.get(), nullptr, inRowVector->as<RowVector>());
   GeneratedVectorFunction<GeneratedVectorFunctionConfigDouble> vectorFunction;
@@ -195,7 +195,7 @@ TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   auto pool_ = memory::getDefaultScopedMemoryPool();
   auto pool = pool_.get();
   const size_t vectorSize = 1000;
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>();
   auto execCtx = std::make_unique<core::ExecCtx>(pool, queryCtx.get());
 
   auto inRowType =

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -688,7 +688,7 @@ class ExprTest : public testing::Test {
     return indicesBuffer;
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -598,7 +598,7 @@ class ExpressionFuzzer {
       const CallableSignature& input)>;
   std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -55,7 +55,7 @@ class FunctionBenchmarkBase {
   }
 
  protected:
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -640,7 +640,7 @@ class FunctionBaseTest : public testing::Test {
     return pool_.get();
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -161,7 +161,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
   }
 
   // Boiler plate structures required by vectorMaker.
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};


### PR DESCRIPTION
This reverts commit 55812a98aa175b810f0928c61d2b6b35497a48b9.
55812a98 is causing build break on presto_cpp:
```
/Users/yingsu/repo/presto_cpp3/presto_cpp/presto_cpp/main/PrestoServer.cpp:228:28: error: no member named 'executor' in 'facebook::velox::exec::Driver'
      velox::exec::Driver::executor(),
      ~~~~~~~~~~~~~~~~~~~~~^
/Users/yingsu/repo/presto_cpp3/presto_cpp/presto_cpp/main/PrestoServer.cpp:258:43: error: no member named 'executor' in 'facebook::velox::exec::Driver'
  auto cpuExecutor = velox::exec::Driver::executor();
                     ~~~~~~~~~~~~~~~~~~~~~^
```