### PR TITLE
Avoid allocating nulls in BaseVector::setNull when writing not null

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -155,8 +155,9 @@ TEST_F(VarianceAggregationTest, varianceConstNull) {
               .values(vectors)
               .partialAggregation({}, {GEN_AGG("c0")})
               .finalAggregation()
+              .project({"round(a0, cast (10 as int))"})
               .planNode();
-    sql = genAggrQuery("SELECT {0}(c0) FROM tmp", aggrName);
+    sql = genAggrQuery("SELECT round({0}(c0), 10) FROM tmp", aggrName);
     assertQuery(agg, sql);
   }
 }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -304,9 +304,15 @@ class BaseVector {
   }
 
   // Sets the null indicator at 'idx'. 'true' means null.
-  virtual void setNull(vector_size_t idx, bool value) {
+  FOLLY_ALWAYS_INLINE virtual void setNull(vector_size_t idx, bool value) {
     VELOX_DCHECK(idx >= 0 && idx < length_);
-    ensureNulls();
+    if (!nulls_) {
+      if (!value) {
+        return;
+      }
+      allocateNulls();
+    }
+
     bits::setBit(
         nulls_->asMutable<uint64_t>(), idx, bits::kNull ? value : !value);
   }


### PR DESCRIPTION
When setNull is used to set an index to not null, it should not allocate nulls if they are not already allocated.

