### PR TITLE
Add option to resize without initializing nulls.

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -109,7 +109,7 @@ struct VectorWriter {
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
       init(*vector_);
     }
   }
@@ -205,7 +205,7 @@ struct VectorWriter<Map<K, V>> {
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
       init(*vector_);
     }
   }
@@ -373,7 +373,7 @@ struct VectorWriter<Array<V>> {
   void ensureSize(size_t size) {
     // todo(youknowjack): optimize the excessive ensureSize calls
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
       init(*vector_);
     }
   }
@@ -486,7 +486,7 @@ struct VectorWriter<Row<T...>> {
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
       resizeVectorWritersInternal<0>(vector_->size());
     }
   }
@@ -803,7 +803,7 @@ struct VectorWriter<
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
     }
   }
 
@@ -860,7 +860,7 @@ struct VectorWriter<T, std::enable_if_t<std::is_same_v<T, bool>>> {
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
     }
   }
 
@@ -912,7 +912,7 @@ struct VectorWriter<std::shared_ptr<T>> {
 
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
-      vector_->resize(size);
+      vector_->resize(size, /*setNotNull*/ false);
     }
   }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -72,7 +72,7 @@ uint64_t BaseVector::byteSize<bool>(vector_size_t count) {
   return bits::nbytes(count);
 }
 
-void BaseVector::resize(vector_size_t size) {
+void BaseVector::resize(vector_size_t size, bool setNotNull) {
   if (nulls_) {
     auto bytes = byteSize<bool>(size);
     if (length_ < size) {
@@ -80,7 +80,7 @@ void BaseVector::resize(vector_size_t size) {
         AlignedBuffer::reallocate<char>(&nulls_, bytes);
         rawNulls_ = nulls_->as<uint64_t>();
       }
-      if (size > length_) {
+      if (setNotNull && size > length_) {
         bits::fillBits(
             const_cast<uint64_t*>(rawNulls_), length_, size, bits::kNotNull);
       }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -337,7 +337,9 @@ class BaseVector {
 
   // Sets the size to 'size' and ensures there is space for the
   // indicated number of nulls and top level values.
-  virtual void resize(vector_size_t newSize);
+  // 'setNotNull' indicates if nulls in range [oldSize, newSize) should be set
+  // to not null.
+  virtual void resize(vector_size_t newSize, bool setNotNull = true);
 
   // Sets the rows of 'this' given by 'rows' to
   // 'source.valueAt(toSourceRow ? toSourceRow[row] : row)', where
@@ -466,6 +468,7 @@ class BaseVector {
   virtual BaseVector* loadedVector() {
     return this;
   }
+
   virtual const BaseVector* loadedVector() const {
     return this;
   }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -270,12 +270,12 @@ class ArrayVector : public BaseVector {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
       resizeIndices(size, 0, &offsets_, &rawOffsets_);
       resizeIndices(size, 0, &sizes_, &rawSizes_);
     }
-    BaseVector::resize(size);
+    BaseVector::resize(size, setNotNull);
   }
 
   void
@@ -425,12 +425,12 @@ class MapVector : public BaseVector {
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
       resizeIndices(size, 0, &offsets_, &rawOffsets_);
       resizeIndices(size, 0, &sizes_, &rawSizes_);
     }
-    BaseVector::resize(size);
+    BaseVector::resize(size, setNotNull);
   }
 
   const VectorPtr& mapKeys() const {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -283,7 +283,7 @@ class ConstantVector final : public SimpleVector<T> {
     return index_;
   }
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     BaseVector::length_ = size;
   }
 

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -281,9 +281,9 @@ void FlatVector<T>::copyValuesAndNulls(
 }
 
 template <typename T>
-void FlatVector<T>::resize(vector_size_t size) {
+void FlatVector<T>::resize(vector_size_t size, bool setNotNull) {
   auto previousSize = BaseVector::length_;
-  BaseVector::resize(size);
+  BaseVector::resize(size, setNotNull);
   if (!values_) {
     return;
   }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -244,7 +244,7 @@ class FlatVector final : public SimpleVector<T> {
     copyValuesAndNulls(source, targetIndex, sourceIndex, count);
   }
 
-  void resize(vector_size_t size) override;
+  void resize(vector_size_t size, bool setNotNull = true) override;
 
   bool isScalar() const override {
     return true;

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -216,7 +216,7 @@ class SimpleVector : public BaseVector {
     return max_;
   }
 
-  void resize(vector_size_t size) override {
+  void resize(vector_size_t size, bool setNotNull = true) override {
     VELOX_CHECK(false, "Can only resize flat vectors.");
   }
 


### PR DESCRIPTION
Resizing a vector sets all the nulls to not null in the new added rows.
However, in cases such as in vector function adapter that writes the nullity twice.

Setting nulls cant be avoided because sometimes the vector is pre-allocated with undefined null state.
Also resize(0) and resize(X) does not work because sometimes we need to keep previously written data to be valid.

This diff adds a flag to BaseVector::resize() that can tell the function not to set nulls.
Also change the usages in the vector adapter to resize with out setting nulls.

It is expected that scalar functions producing complex type results would resize without setting nulls.
A series of follow-up diffs is needed to revisit the usage of resize() in existing function and change as appropriate. 