### PR TITLE
Add support for AWS S3 IAM Roles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(VELOX_ENABLE_S3)
   if(AWSSDK_ROOT_DIR)
     set(CMAKE_PREFIX_PATH ${AWSSDK_ROOT_DIR})
   endif()
-  find_package(AWSSDK REQUIRED COMPONENTS s3)
+  find_package(AWSSDK REQUIRED COMPONENTS s3;identity-management)
   add_definitions(-DVELOX_ENABLE_S3)
 endif()
 

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -32,7 +32,7 @@ function install_aws-sdk-cpp {
   cmake ../"${NAME}" \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DBUILD_ONLY:STRING=s3 \
+    -DBUILD_ONLY:STRING="s3;identity-management" \
     -DBUILD_SHARED_LIBS:BOOL=OFF \
     -DMINIMIZE_SIZE:BOOL=ON \
     -DENABLE_TESTING:BOOL=OFF \

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -150,19 +150,77 @@ TEST_F(S3FileSystemTest, fileHandle) {
 }
 
 TEST_F(S3FileSystemTest, invalidCredentialsConfig) {
-  const std::unordered_map<std::string, std::string> config(
-      {{"hive.s3.use-instance-credentials", "true"},
-       {"hive.s3.iam-role", "dummy-iam-role"}});
-  auto hiveConfig = std::make_shared<const core::MemConfig>(std::move(config));
-  filesystems::S3FileSystem s3fs(hiveConfig);
-  // Both instance credentials and iam-role cannot be specified
-  try {
-    s3fs.initializeClient();
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(
-        err.message(),
-        std::string(
-            "Invalid configuration: either use instance credentials or specify an iam role"));
+  {
+    const std::unordered_map<std::string, std::string> config(
+        {{"hive.s3.use-instance-credentials", "true"},
+         {"hive.s3.iam-role", "dummy-iam-role"}});
+    auto hiveConfig =
+        std::make_shared<const core::MemConfig>(std::move(config));
+    filesystems::S3FileSystem s3fs(hiveConfig);
+    // Both instance credentials and iam-role cannot be specified
+    try {
+      s3fs.initializeClient();
+      FAIL() << "Expected VeloxException";
+    } catch (VeloxException const& err) {
+      EXPECT_EQ(
+          err.message(),
+          std::string(
+              "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'"));
+    }
+  }
+  {
+    const std::unordered_map<std::string, std::string> config(
+        {{"hive.s3.aws-secret-key", "dummy-key"},
+         {"hive.s3.aws-access-key", "dummy-key"},
+         {"hive.s3.iam-role", "dummy-iam-role"}});
+    auto hiveConfig =
+        std::make_shared<const core::MemConfig>(std::move(config));
+    filesystems::S3FileSystem s3fs(hiveConfig);
+    // Both access/secret keys and iam-role cannot be specified
+    try {
+      s3fs.initializeClient();
+      FAIL() << "Expected VeloxException";
+    } catch (VeloxException const& err) {
+      EXPECT_EQ(
+          err.message(),
+          std::string(
+              "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'"));
+    }
+  }
+  {
+    const std::unordered_map<std::string, std::string> config(
+        {{"hive.s3.aws-secret-key", "dummy"},
+         {"hive.s3.aws-access-key", "dummy"},
+         {"hive.s3.use-instance-credentials", "true"}});
+    auto hiveConfig =
+        std::make_shared<const core::MemConfig>(std::move(config));
+    filesystems::S3FileSystem s3fs(hiveConfig);
+    // Both access/secret keys and instance credentials cannot be specified
+    try {
+      s3fs.initializeClient();
+      FAIL() << "Expected VeloxException";
+    } catch (VeloxException const& err) {
+      EXPECT_EQ(
+          err.message(),
+          std::string(
+              "Invalid configuration: specify only one among 'access/secret keys', 'use instance credentials', 'IAM role'"));
+    }
+  }
+  {
+    const std::unordered_map<std::string, std::string> config(
+        {{"hive.s3.aws-secret-key", "dummy"}});
+    auto hiveConfig =
+        std::make_shared<const core::MemConfig>(std::move(config));
+    filesystems::S3FileSystem s3fs(hiveConfig);
+    // Both access key and secret key must be specified
+    try {
+      s3fs.initializeClient();
+      FAIL() << "Expected VeloxException";
+    } catch (VeloxException const& err) {
+      EXPECT_EQ(
+          err.message(),
+          std::string(
+              "Invalid configuration: both access key and secret key must be specified"));
+    }
   }
 }


### PR DESCRIPTION
AWS supports IAM roles that allow users to be restricted to certain AWS resources (eg. S3). More details on IAM Roles are available in the AWS guide: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html

This PR extends Velox to support these IAM roles for S3. If you have an IAM role associated with S3, you can specify that using `hive.s3.iam-role`.
Optionally, you can specify `hive.s3.iam-role-session-name` to uniquely identify the session as described under the `RoleSessionName` in the AWS API reference: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

Testing Approach
Since Minio does not support Roles, I tested this change on my local machine with AWS S3 as below
1) Setup a catalog (say `hive.properties`) with TPC-H SF10 data on an AWS S3 bucket  as follows
```
connector.name=hive-hadoop2
hive.metastore=file
hive.metastore.catalog.dir=s3://foodata/hive_data/
hive.s3.ssl.enabled=false
hive.pushdown-filter-enabled=true
```
2) Setup AWS credentials locally (~/.aws/credentials) for an AWS user (say `bar`) who does not have access to the above S3 bucket.
Now running a query failed since the user `bar` does not have access to the S3 bucket. The error was
```
select count(nationkey) from hive.tpch10.nation

Query 20220107_170907_00001_ctpvx failed:  Failed to initialize S3 file with bucket 'foodata' and key 'hive_data/tpch10/nation/20211202_232845_00006_ncbbk_66a67b60-d4e4-4885-920e-4f0a1a1dc75a' due to 15:No response body.
```
3) Next, create an AWS role (say `XYZ:role/access-S3-role`) with S3 access to user `bar`.
4) Set `hive.s3.iam-role=XYZ:role/access-S3-role` in the catalog file.
Now the same query is successfully executed.

Resolves https://github.com/facebookincubator/velox/issues/836