### PR TITLE
Fix on DecodedVector.wrap

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -432,6 +432,10 @@ VectorPtr DecodedVector::wrap(
     return data;
   }
   if (wrapper.isConstantEncoding()) {
+    if (wrapper.isNullAt(0)) {
+      return BaseVector::createNullConstant(
+          data->type(), rows.end(), data->pool());
+    }
     return BaseVector::wrapInConstant(
         rows.end(), wrapper.wrappedIndex(0), data);
   }


### PR DESCRIPTION
Summary:
When RowVector has all rows to be null, it's ok for its children vector to be empty. This is not handled in `DecodedVector::wrap`.

The issue surfaced when executing FieldReference expression, specifically in [this code piece](https://www.internalfb.com/code/fbsource/[b941d1df992a3de6c505d3aeec1ef381e77e090c]/fbcode/velox/expression/ControlExpr.cpp?lines=119-120).

Differential Revision: D33484269

