### PR TITLE
Update Operator interface and fix Driver to allow for pipeline to finish early

### DIFF
--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -66,6 +66,10 @@ RowVectorPtr AssignUniqueId::getOutput() {
   return output;
 }
 
+bool AssignUniqueId::isFinished() {
+  return noMoreInput_ && input_ == nullptr;
+}
+
 void AssignUniqueId::generateIdColumn(vector_size_t size) {
   auto result = results_[0];
   if (!result || !BaseVector::isReusableFlatVector(result)) {

--- a/velox/exec/AssignUniqueId.h
+++ b/velox/exec/AssignUniqueId.h
@@ -48,6 +48,8 @@ class AssignUniqueId : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override;
+
  private:
   void generateIdColumn(vector_size_t size);
 

--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -41,8 +41,8 @@ class CallbackSink : public Operator {
     return callback_ != nullptr;
   }
 
-  void finish() override {
-    Operator::finish();
+  void noMoreInput() override {
+    Operator::noMoreInput();
     close();
   }
 
@@ -53,6 +53,10 @@ class CallbackSink : public Operator {
       return BlockingReason::kWaitForConsumer;
     }
     return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_;
   }
 
  private:

--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -67,8 +67,8 @@ BlockingReason CrossJoinBuild::isBlocked(ContinueFuture* future) {
   return BlockingReason::kWaitForJoinBuild;
 }
 
-void CrossJoinBuild::finish() {
-  Operator::finish();
+void CrossJoinBuild::noMoreInput() {
+  Operator::noMoreInput();
   std::vector<VeloxPromise<bool>> promises;
   std::vector<std::shared_ptr<Driver>> peers;
   // The last Driver to hit CrossJoinBuild::finish gathers the data from
@@ -99,5 +99,9 @@ void CrossJoinBuild::finish() {
   operatorCtx_->task()
       ->getCrossJoinBridge(planNodeId())
       ->setData(std::move(data_));
+}
+
+bool CrossJoinBuild::isFinished() {
+  return !hasFuture_ && noMoreInput_;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/CrossJoinBuild.h
+++ b/velox/exec/CrossJoinBuild.h
@@ -44,12 +44,14 @@ class CrossJoinBuild : public Operator {
   }
 
   bool needsInput() const override {
-    return !isFinishing_;
+    return !noMoreInput_;
   }
 
-  void finish() override;
+  void noMoreInput() override;
 
   BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
 
   void close() override {
     data_.clear();

--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -74,7 +74,7 @@ BlockingReason CrossJoinProbe::isBlocked(ContinueFuture* future) {
   if (buildData_->empty()) {
     // Build side is empty. Return empty set of rows and  terminate the pipeline
     // early.
-    isFinishing_ = true;
+    buildSideEmpty_ = true;
   }
 
   return BlockingReason::kNotBlocked;
@@ -151,6 +151,10 @@ RowVectorPtr CrossJoinProbe::getOutput() {
     }
   }
   return output;
+}
+
+bool CrossJoinProbe::isFinished() {
+  return buildSideEmpty_ || (noMoreInput_ && input_ == nullptr);
 }
 
 void CrossJoinProbe::close() {

--- a/velox/exec/CrossJoinProbe.h
+++ b/velox/exec/CrossJoinProbe.h
@@ -31,10 +31,12 @@ class CrossJoinProbe : public Operator {
   RowVectorPtr getOutput() override;
 
   bool needsInput() const override {
-    return !isFinishing_ && !input_;
+    return !noMoreInput_ && !input_ && !buildSideEmpty_;
   }
 
   BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
 
   void close() override;
 
@@ -52,5 +54,7 @@ class CrossJoinProbe : public Operator {
 
   // Input row to process on next call to getOutput().
   vector_size_t probeRow_{0};
+
+  bool buildSideEmpty_{false};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/EnforceSingleRow.cpp
+++ b/velox/exec/EnforceSingleRow.cpp
@@ -48,15 +48,15 @@ void EnforceSingleRow::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr EnforceSingleRow::getOutput() {
-  if (!isFinishing()) {
+  if (!noMoreInput_) {
     return nullptr;
   }
 
   return std::move(input_);
 }
 
-void EnforceSingleRow::finish() {
-  if (!isFinishing_ && input_ == nullptr) {
+void EnforceSingleRow::noMoreInput() {
+  if (!noMoreInput_ && input_ == nullptr) {
     // We have not seen any data. Return a single row of all nulls.
     input_ = std::dynamic_pointer_cast<RowVector>(
         BaseVector::create(outputType_, 1, pool()));
@@ -65,6 +65,10 @@ void EnforceSingleRow::finish() {
       child->setNull(0, true);
     }
   }
-  Operator::finish();
+  Operator::noMoreInput();
+}
+
+bool EnforceSingleRow::isFinished() {
+  return noMoreInput_ && input_ == nullptr;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/EnforceSingleRow.h
+++ b/velox/exec/EnforceSingleRow.h
@@ -39,9 +39,11 @@ class EnforceSingleRow : public Operator {
 
   void addInput(RowVectorPtr input) override;
 
+  void noMoreInput() override;
+
   RowVectorPtr getOutput() override;
 
-  void finish() override;
+  bool isFinished() override;
 
   BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return BlockingReason::kNotBlocked;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -287,8 +287,6 @@ class Exchange : public SourceOperator {
     close();
   }
 
-  void finish() override;
-
   RowVectorPtr getOutput() override;
 
   void close() override {
@@ -298,6 +296,8 @@ class Exchange : public SourceOperator {
   }
 
   BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
 
  private:
   /// Fetches splits from the task until there are no more splits or task
@@ -322,7 +322,7 @@ class Exchange : public SourceOperator {
   std::shared_ptr<ExchangeClient> exchangeClient_;
   std::unique_ptr<SerializedPage> currentPage_;
   std::unique_ptr<ByteStream> inputStream_;
-  bool atEnd_ = false;
+  bool atEnd_{false};
   size_t numSplits_{0}; // Number of splits we took to process so far.
 };
 

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -107,6 +107,10 @@ bool FilterProject::allInputProcessed() {
   return false;
 }
 
+bool FilterProject::isFinished() {
+  return noMoreInput_ && allInputProcessed();
+}
+
 RowVectorPtr FilterProject::getOutput() {
   if (allInputProcessed()) {
     clearIdentityProjectedOutput();

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -49,6 +49,8 @@ class FilterProject : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override;
+
   void close() override {
     Operator::close();
     exprs_->clear();

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -139,14 +139,14 @@ void HashAggregation::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr HashAggregation::getOutput() {
-  if (finished_ || (!isFinishing_ && !partialFull_ && !newDistincts_)) {
+  if (finished_ || (!noMoreInput_ && !partialFull_ && !newDistincts_)) {
     input_ = nullptr;
     return nullptr;
   }
 
   if (isDistinct_) {
     if (!newDistincts_) {
-      if (isFinishing_) {
+      if (noMoreInput_) {
         finished_ = true;
       }
       return nullptr;
@@ -184,7 +184,7 @@ RowVectorPtr HashAggregation::getOutput() {
     if (isPartialOutput_) {
       partialFull_ = false;
       groupingSet_->resetPartial();
-      if (isFinishing_) {
+      if (noMoreInput_) {
         finished_ = true;
       }
     } else {
@@ -195,4 +195,7 @@ RowVectorPtr HashAggregation::getOutput() {
   return result;
 }
 
+bool HashAggregation::isFinished() {
+  return finished_;
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -32,16 +32,14 @@ class HashAggregation : public Operator {
   RowVectorPtr getOutput() override;
 
   bool needsInput() const override {
-    return !isFinishing_ && !partialFull_;
-  }
-
-  void finish() override {
-    Operator::finish();
+    return !noMoreInput_ && !partialFull_;
   }
 
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {
     return BlockingReason::kNotBlocked;
   }
+
+  bool isFinished() override;
 
   void close() override {
     Operator::close();

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -72,12 +72,14 @@ class HashBuild final : public Operator {
   }
 
   bool needsInput() const override {
-    return !isFinishing_;
+    return !noMoreInput_;
   }
 
-  void finish() override;
+  void noMoreInput() override;
 
   BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
 
   void close() override {}
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -30,17 +30,19 @@ class HashProbe : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::HashJoinNode>& hashJoinNode);
 
+  bool needsInput() const override {
+    return !finished_ && !noMoreInput_ && !input_;
+  }
+
   void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
 
   RowVectorPtr getOutput() override;
 
-  bool needsInput() const override {
-    return !isFinishing_ && !input_;
-  }
-
   BlockingReason isBlocked(ContinueFuture* future) override;
 
-  void finish() override;
+  bool isFinished() override;
 
   void clearDynamicFilters() override;
 
@@ -230,6 +232,8 @@ class HashProbe : public Operator {
   // Input rows with a hash match. This is a subset of rows with no nulls in the
   // join keys and a superset of rows that have a match on the build side.
   SelectivityVector activeRows_;
+
+  bool finished_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Limit.cpp
+++ b/velox/exec/Limit.cpp
@@ -38,7 +38,7 @@ Limit::Limit(
 }
 
 bool Limit::needsInput() const {
-  return (remainingOffset_ > 0 || remainingLimit_ > 0) && input_ == nullptr;
+  return !finished_ && input_ == nullptr;
 }
 
 void Limit::addInput(RowVectorPtr input) {
@@ -72,13 +72,13 @@ RowVectorPtr Limit::getOutput() {
     remainingLimit_ -= outputSize;
     input_ = nullptr;
     if (remainingLimit_ == 0) {
-      isFinishing_ = true;
+      finished_ = true;
     }
     return output;
   }
 
   if (remainingLimit_ <= inputSize) {
-    isFinishing_ = true;
+    finished_ = true;
   }
 
   if (remainingLimit_ >= inputSize) {

--- a/velox/exec/Limit.h
+++ b/velox/exec/Limit.h
@@ -34,8 +34,13 @@ class Limit : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override {
+    return finished_ || (noMoreInput_ && input_ == nullptr);
+  }
+
  private:
   int32_t remainingOffset_;
   int32_t remainingLimit_;
+  bool finished_{false};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -165,6 +165,16 @@ BlockingReason LocalExchangeSource::isFinished(ContinueFuture* future) {
   });
 }
 
+bool LocalExchangeSource::isFinished() {
+  return queue_.withWLock([&](auto& queue) {
+    if (noMoreProducers_ && pendingProducers_ == 0 && queue.empty()) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
 LocalExchangeSourceOperator::LocalExchangeSourceOperator(
     int32_t operatorId,
     DriverCtx* ctx,
@@ -204,6 +214,10 @@ RowVectorPtr LocalExchangeSourceOperator::getOutput() {
     stats().inputBytes += data->retainedSize();
   }
   return data;
+}
+
+bool LocalExchangeSourceOperator::isFinished() {
+  return source_->isFinished();
 }
 
 LocalPartition::LocalPartition(
@@ -354,7 +368,7 @@ BlockingReason LocalPartition::isBlocked(ContinueFuture* future) {
     return blockingReasons_[numBlockedPartitions_];
   }
 
-  if (isFinishing()) {
+  if (noMoreInput_) {
     for (const auto& source : localExchangeSources_) {
       auto reason = source->isFinished(future);
       if (reason != BlockingReason::kNotBlocked) {
@@ -366,10 +380,24 @@ BlockingReason LocalPartition::isBlocked(ContinueFuture* future) {
   return BlockingReason::kNotBlocked;
 }
 
-void LocalPartition::finish() {
-  Operator::finish();
+void LocalPartition::noMoreInput() {
+  Operator::noMoreInput();
   for (const auto& source : localExchangeSources_) {
     source->noMoreData();
   }
+}
+
+bool LocalPartition::isFinished() {
+  if (numBlockedPartitions_ || !noMoreInput_) {
+    return false;
+  }
+
+  for (const auto& source : localExchangeSources_) {
+    if (!source->isFinished()) {
+      return false;
+    }
+  }
+
+  return true;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -85,6 +85,8 @@ class LocalExchangeSource {
   /// copied into the consumers memory pool.
   BlockingReason isFinished(ContinueFuture* future);
 
+  bool isFinished();
+
   void close() {
     queue_.withWLock([](auto& queue) {
       while (!queue.empty()) {
@@ -128,6 +130,8 @@ class LocalExchangeSourceOperator : public SourceOperator {
 
   RowVectorPtr getOutput() override;
 
+  bool isFinished() override;
+
  private:
   const int partition_;
   const std::shared_ptr<LocalExchangeSource> source_{nullptr};
@@ -162,7 +166,9 @@ class LocalPartition : public Operator {
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
-  void finish() override;
+  void noMoreInput() override;
+
+  bool isFinished() override;
 
   void close() override {
     Operator::close();

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -39,6 +39,8 @@ class Merge : public SourceOperator {
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
+  bool isFinished() override;
+
   RowVectorPtr getOutput() override;
 
   const std::shared_ptr<const RowType> outputType() const {
@@ -130,8 +132,6 @@ class MergeExchange : public Merge {
       int32_t operatorId,
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::MergeExchangeNode>& orderByNode);
-
-  void finish() override;
 
  protected:
   BlockingReason addMergeSources(ContinueFuture* future) override;

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -33,6 +33,8 @@ class MergeJoin : public Operator {
 
   RowVectorPtr getOutput() override;
 
+  bool isFinished() override;
+
   void close() override {
     if (rightSource_) {
       rightSource_->close();

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -58,8 +58,8 @@ void OrderBy::addInput(RowVectorPtr input) {
   numRows_ += allRows.size();
 }
 
-void OrderBy::finish() {
-  Operator::finish();
+void OrderBy::noMoreInput() {
+  Operator::noMoreInput();
 
   // No data.
   if (numRows_ == 0) {
@@ -91,7 +91,7 @@ void OrderBy::finish() {
 }
 
 RowVectorPtr OrderBy::getOutput() {
-  if (finished_ || !isFinishing_ || returningRows_.size() == numRowsReturned_) {
+  if (finished_ || !noMoreInput_ || returningRows_.size() == numRowsReturned_) {
     return nullptr;
   }
 

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -43,14 +43,18 @@ class OrderBy : public Operator {
     return !finished_;
   }
 
-  void finish() override;
-
   void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
 
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return finished_;
   }
 
  private:

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -211,7 +211,7 @@ void PartitionedOutput::collectNullRows() {
 }
 
 RowVectorPtr PartitionedOutput::getOutput() {
-  if (isFinished_) {
+  if (finished_) {
     return nullptr;
   }
 
@@ -262,7 +262,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
   // All of 'output_' is written into the destinations. We are finishing, hence
   // move all the destinations to the output queue. This will not grow memory
   // and hence does not need blocking.
-  if (isFinishing_) {
+  if (noMoreInput_) {
     for (auto& destination : destinations_) {
       if (destination->isFinished()) {
         continue;
@@ -272,12 +272,16 @@ RowVectorPtr PartitionedOutput::getOutput() {
     }
 
     bufferManager->noMoreData(operatorCtx_->task()->taskId());
-    isFinished_ = true;
+    finished_ = true;
   }
   // The input is fully processed, drop the reference to allow reuse.
   input_ = nullptr;
   output_ = nullptr;
   return nullptr;
+}
+
+bool PartitionedOutput::isFinished() {
+  return finished_;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -146,6 +146,8 @@ class PartitionedOutput : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override;
+
   void close() override {
     destinations_.clear();
   }
@@ -173,7 +175,7 @@ class PartitionedOutput : public Operator {
   const std::vector<ChannelIndex> outputChannels_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
   ContinueFuture future_;
-  bool isFinished_{false};
+  bool finished_{false};
   // top-level row numbers used as input to
   // VectorStreamGroup::estimateSerializedSize member variable is used to avoid
   // re-allocating memory

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -242,9 +242,13 @@ void StreamingAggregation::evaluateAggregates() {
   }
 }
 
+bool StreamingAggregation::isFinished() {
+  return noMoreInput_ && input_ == nullptr && numGroups_ == 0;
+}
+
 RowVectorPtr StreamingAggregation::getOutput() {
   if (!input_) {
-    if (isFinishing() && numGroups_ > 0) {
+    if (noMoreInput_ && numGroups_ > 0) {
       createOutput(numGroups_);
       numGroups_ = 0;
       return std::move(output_);

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -43,6 +43,8 @@ class StreamingAggregation : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override;
+
  private:
   // Returns the rows to aggregate with masking applied if applicable.
   const SelectivityVector& getSelectivityVector(size_t aggregateIndex) const;

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -113,6 +113,10 @@ RowVectorPtr TableScan::getOutput() {
   }
 }
 
+bool TableScan::isFinished() {
+  return noMoreSplits_;
+}
+
 void TableScan::setBatchSize() {
   constexpr int64_t kMB = 1 << 20;
   auto estimate = dataSource_->estimatedRowSize();

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -38,6 +38,8 @@ class TableScan : public SourceOperator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool isFinished() override;
+
   bool canAddDynamicFilter() const override {
     // TODO Consult with the connector. Return true only if connector can accept
     // dynamic filters.

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -96,7 +96,7 @@ void TableWriter::addInput(RowVectorPtr input) {
 
 RowVectorPtr TableWriter::getOutput() {
   // Making sure the output is read only once after the write is fully done
-  if (!isFinishing_ || finished_) {
+  if (!noMoreInput_ || finished_) {
     return nullptr;
   }
   finished_ = true;

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -37,8 +37,8 @@ class TableWriter : public Operator {
 
   void addInput(RowVectorPtr input) override;
 
-  void finish() override {
-    Operator::finish();
+  void noMoreInput() override {
+    Operator::noMoreInput();
     close();
   }
 
@@ -56,6 +56,10 @@ class TableWriter : public Operator {
   }
 
   RowVectorPtr getOutput() override;
+
+  bool isFinished() override {
+    return finished_;
+  }
 
  private:
   void createDataSink();

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -89,7 +89,7 @@ void TopN::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr TopN::getOutput() {
-  if (finished_ || !isFinishing_) {
+  if (finished_ || !noMoreInput_) {
     return nullptr;
   }
 
@@ -112,8 +112,8 @@ RowVectorPtr TopN::getOutput() {
   return result;
 }
 
-void TopN::finish() {
-  Operator::finish();
+void TopN::noMoreInput() {
+  Operator::noMoreInput();
   if (topRows_.empty()) {
     finished_ = true;
     return;
@@ -123,5 +123,9 @@ void TopN::finish() {
     rows_[i - 1] = topRows_.top();
     topRows_.pop();
   }
+}
+
+bool TopN::isFinished() {
+  return finished_;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/TopN.h
+++ b/velox/exec/TopN.h
@@ -28,18 +28,20 @@ class TopN : public Operator {
       const std::shared_ptr<const core::TopNNode>& topNNode);
 
   bool needsInput() const override {
-    return !isFinishing_;
+    return !noMoreInput_;
   }
 
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;
 
-  void finish() override;
+  void noMoreInput() override;
 
   BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return BlockingReason::kNotBlocked;
   }
+
+  bool isFinished() override;
 
  private:
   static constexpr size_t kMaxNumRowsToReturn = 1024;

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -142,4 +142,8 @@ RowVectorPtr Unnest::getOutput() {
   return std::make_shared<RowVector>(
       pool(), outputType_, BufferPtr(nullptr), numElements, std::move(outputs));
 }
+
+bool Unnest::isFinished() {
+  return noMoreInput_ && input_ == nullptr;
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -36,6 +36,8 @@ class Unnest : public Operator {
 
   RowVectorPtr getOutput() override;
 
+  bool isFinished() override;
+
  private:
   ChannelIndex unnestChannel_;
 

--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -48,4 +48,8 @@ void Values::close() {
   current_ = values_.size();
 }
 
+bool Values::isFinished() {
+  return current_ >= values_.size();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/Values.h
+++ b/velox/exec/Values.h
@@ -31,10 +31,12 @@ class Values : public SourceOperator {
     return BlockingReason::kNotBlocked;
   }
 
-  void finish() override {
-    Operator::finish();
+  void noMoreInput() override {
+    Operator::noMoreInput();
     close();
   }
+
+  bool isFinished() override;
 
   void close() override;
 


### PR DESCRIPTION
- Renamed Operator::finish() method to noMoreInput() for clarify. Also, renamed isFinished_ member variable to noMoreInput_.
- Replaced Operator::isFinishing() method with isFinished().
- Updated the Driver to transition to closed state when sink operator is finished. 