### PR TITLE
Fix Expr bug on peeling encoding for single-arg deterministic func

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -937,7 +937,15 @@ bool Expr::applyFunctionWithPeeling(
         continue;
       }
       if (numLevels == 0 && leaf->isConstant(rows)) {
-        setPeeledArg(leaf, i, numArgs, maybePeeled);
+        if (leaf->isConstantEncoding()) {
+          setPeeledArg(leaf, i, numArgs, maybePeeled);
+        } else {
+          setPeeledArg(
+              BaseVector::wrapInConstant(leaf->size(), rows.begin(), leaf),
+              i,
+              numArgs,
+              maybePeeled);
+        }
         constantArgs.resize(numArgs);
         constantArgs.at(i) = true;
         continue;


### PR DESCRIPTION
Summary:
Motivation:
A crash was hit when running expression `not(contains(...))` and the root cause is nullptr reference in casting the input to flat vector. This indicates that a bug on argument encoding peeling of `Expr`.

Fix:
The reproduce scenario is turned into a test case of ExprTest where the input is dictionary vector but with `DictionaryVector::isConstant(rows)` equals to true. We handled this by creating a ConstantVector of out it so that the further execution can go into `applySingleConstArgVectorFunction`.

Reviewed By: mbasmanova

Differential Revision: D33523786

