### PR TITLE
Add a simple test to execute TableScan using Parquet files

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -180,6 +180,9 @@ class HiveDataSource : public DataSource {
       const std::string& partitionKey,
       const std::optional<std::string>& value) const;
 
+  /// Clear split_, reader_ and rowReader_ after split has been fully processed.
+  void resetSplit();
+
   const std::shared_ptr<const RowType> outputType_;
   // Column handles for the partition key columns keyed on partition key column
   // name.

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -51,3 +51,21 @@ target_link_libraries(
   ${ZSTD}
   ${ZLIB_LIBRARIES}
   ${TEST_LINK_LIBS})
+
+add_executable(velox_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
+add_test(
+  NAME velox_dwio_parquet_table_scan_test
+  COMMAND velox_dwio_parquet_table_scan_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(
+  velox_dwio_parquet_table_scan_test
+  velox_vector_test_lib
+  velox_exec_test_util
+  velox_exec
+  velox_hive_connector
+  velox_aggregates
+  ${VELOX_LINK_LIBS}
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${FMT}
+  ${TEST_LINK_LIBS})

--- a/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/test/utils/DataFiles.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/type/tests/FilterBuilder.h"
+#include "velox/type/tests/SubfieldFiltersBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+static const std::string kWriter = "ParquetTableScanTest.Writer";
+
+class ParquetTableScanTest : public HiveConnectorTestBase {
+ protected:
+  using OperatorTestBase::assertQuery;
+
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    parquet::registerParquetReaderFactory();
+  }
+
+  std::string getExampleFilePath(const std::string& fileName) {
+    return facebook::velox::test::getDataFilePath(
+        "velox/dwio/parquet/tests", "examples/" + fileName);
+  }
+
+  std::shared_ptr<connector::hive::HiveConnectorSplit> makeSplit(
+      const std::string& filePath) {
+    auto split = makeHiveConnectorSplit(filePath);
+    split->fileFormat = dwio::common::FileFormat::PARQUET;
+    return split;
+  }
+};
+
+TEST_F(ParquetTableScanTest, basic) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
+          makeFlatVector<double>(20, [](auto row) { return row + 1; }),
+      });
+  createDuckDbTable({data});
+
+  auto split = makeSplit(getExampleFilePath("sample.parquet"));
+
+  auto rowType = ROW({"a", "b"}, {BIGINT(), DOUBLE()});
+  auto plan = PlanBuilder().tableScan(rowType).planNode();
+
+  assertQuery(plan, {split}, "SELECT * FROM tmp");
+
+  // Add a filter on "a".
+  auto filters =
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3));
+
+  plan = PlanBuilder()
+             .tableScan(
+                 rowType,
+                 makeTableHandle(std::move(filters)),
+                 allRegularColumns(rowType))
+             .planNode();
+
+  assertQuery(plan, {split}, "SELECT * FROM tmp WHERE a < 3");
+
+  // Add an aggregation.
+  plan = PlanBuilder()
+             .tableScan(rowType)
+             .singleAggregation({}, {"min(a)", "max(b)"})
+             .planNode();
+
+  assertQuery(plan, {split}, "SELECT min(a), max(b) FROM tmp");
+}


### PR DESCRIPTION
- Add a small test to execute TableScan using Parquet files with a pushed down filter and an aggregation on top.
- Update HiveConnector to destroy RowReader before destroying Reader. ParquetRowReader holds an instance of an Allocator which needs to be alive as long as ParquetRowReader is alive.

Fixes #846