### PR TITLE
Fix Parquet reader filter index

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
@@ -25,8 +25,6 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
-static const std::string kWriter = "ParquetTableScanTest.Writer";
-
 class ParquetTableScanTest : public HiveConnectorTestBase {
  protected:
   using OperatorTestBase::assertQuery;
@@ -41,6 +39,71 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     HiveConnectorTestBase::TearDown();
   }
 
+  void assertSelect(
+      std::vector<std::string>&& outputColumnNames,
+      const std::string& sql) {
+    auto plan = PlanBuilder()
+                    .tableScan(getRowType(std::move(outputColumnNames)))
+                    .planNode();
+
+    assertQuery(plan, splits_, sql);
+  }
+
+  void assertSelectWithFilter(
+      std::vector<std::string>&& outputColumnNames,
+      common::test::SubfieldFilters filters,
+      const std::string& sql) {
+    auto rowType = getRowType(std::move(outputColumnNames));
+
+    auto plan = PlanBuilder()
+                    .tableScan(
+                        rowType,
+                        makeTableHandle(std::move(filters)),
+                        allRegularColumns(rowType))
+                    .planNode();
+
+    assertQuery(plan, splits_, sql);
+  }
+
+  void assertSelectWithAgg(
+      std::vector<std::string>&& outputColumnNames,
+      const std::vector<std::string>& aggregates,
+      const std::vector<ChannelIndex>& groupingKeys,
+      const std::string& sql) {
+    auto plan = PlanBuilder()
+                    .tableScan(getRowType(std::move(outputColumnNames)))
+                    .singleAggregation(groupingKeys, aggregates)
+                    .planNode();
+
+    assertQuery(plan, splits_, sql);
+  }
+
+  void assertSelectWithFilterAndAgg(
+      std::vector<std::string>&& outputColumnNames,
+      common::test::SubfieldFilters filters,
+      const std::vector<std::string>& aggregates,
+      const std::vector<ChannelIndex>& groupingKeys,
+      const std::string& sql) {
+    auto rowType = getRowType(std::move(outputColumnNames));
+
+    auto plan = PlanBuilder()
+                    .tableScan(
+                        rowType,
+                        makeTableHandle(std::move(filters)),
+                        allRegularColumns(rowType))
+                    .singleAggregation(groupingKeys, aggregates)
+                    .planNode();
+
+    assertQuery(plan, splits_, sql);
+  }
+
+  void
+  loadData(const std::string& filePath, RowTypePtr rowType, RowVectorPtr data) {
+    splits_ = {makeSplit(filePath)};
+    rowType_ = rowType;
+    createDuckDbTable({data});
+  }
+
   std::string getExampleFilePath(const std::string& fileName) {
     return facebook::velox::test::getDataFilePath(
         "velox/dwio/parquet/tests", "examples/" + fileName);
@@ -52,44 +115,97 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     split->fileFormat = dwio::common::FileFormat::PARQUET;
     return split;
   }
+
+ private:
+  RowTypePtr getRowType(std::vector<std::string>&& outputColumnNames) const {
+    std::vector<TypePtr> types;
+    for (auto colName : outputColumnNames) {
+      types.push_back(rowType_->findChild(colName));
+    }
+
+    return ROW(std::move(outputColumnNames), std::move(types));
+  }
+
+  RowTypePtr rowType_;
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits_;
 };
 
 TEST_F(ParquetTableScanTest, basic) {
-  auto data = makeRowVector(
+  loadData(
+      getExampleFilePath("sample.parquet"),
+      ROW({"a", "b"}, {BIGINT(), DOUBLE()}),
+      makeRowVector(
+          {"a", "b"},
+          {
+              makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
+              makeFlatVector<double>(20, [](auto row) { return row + 1; }),
+          }));
+
+  // Plain select
+  assertSelect({"a"}, "SELECT a FROM tmp");
+  assertSelect({"b"}, "SELECT b FROM tmp");
+  assertSelect({"a", "b"}, "SELECT a, b FROM tmp");
+  assertSelect({"b", "a"}, "SELECT b, a FROM tmp");
+
+  // With filters
+  assertSelectWithFilter(
+      {"a"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      "SELECT a FROM tmp WHERE a < 3");
+  assertSelectWithFilter(
+      {"b"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      "SELECT b FROM tmp WHERE a < 3");
+  assertSelectWithFilter(
       {"a", "b"},
-      {
-          makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
-          makeFlatVector<double>(20, [](auto row) { return row + 1; }),
-      });
-  createDuckDbTable({data});
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      "SELECT a, b FROM tmp WHERE a < 3");
+  assertSelectWithFilter(
+      {"b", "a"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      "SELECT b, a FROM tmp WHERE a < 3");
+  assertSelectWithFilter(
+      {"b"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(0)),
+      "SELECT b FROM tmp WHERE a < 0");
 
-  auto split = makeSplit(getExampleFilePath("sample.parquet"));
+  // TODO: Add filter on b after double filters are supported
 
-  auto rowType = ROW({"a", "b"}, {BIGINT(), DOUBLE()});
-  auto plan = PlanBuilder().tableScan(rowType).planNode();
+  // With aggregations
+  assertSelectWithAgg({"a"}, {"sum(a)"}, {}, "SELECT sum(a) FROM tmp");
+  assertSelectWithAgg({"b"}, {"max(b)"}, {}, "SELECT max(b) FROM tmp");
+  assertSelectWithAgg(
+      {"a", "b"}, {"min(a)", "max(b)"}, {}, "SELECT min(a), max(b) FROM tmp");
+  assertSelectWithAgg(
+      {"b", "a"}, {"max(b)"}, {0}, "SELECT max(b), a FROM tmp group by a");
+  assertSelectWithAgg(
+      {"a", "b"}, {"max(a)"}, {1}, "SELECT max(a), b FROM tmp group by b");
 
-  assertQuery(plan, {split}, "SELECT * FROM tmp");
-
-  // Add a filter on "a".
-  auto filters =
-      common::test::singleSubfieldFilter("a", common::test::lessThan(3));
-
-  plan = PlanBuilder()
-             .tableScan(
-                 rowType,
-                 makeTableHandle(std::move(filters)),
-                 allRegularColumns(rowType))
-             .planNode();
-
-  assertQuery(plan, {split}, "SELECT * FROM tmp WHERE a < 3");
-
-  // Add an aggregation.
-  plan = PlanBuilder()
-             .tableScan(rowType)
-             .singleAggregation({}, {"min(a)", "max(b)"})
-             .planNode();
-
-  assertQuery(plan, {split}, "SELECT min(a), max(b) FROM tmp");
+  // With filter and aggregation
+  assertSelectWithFilterAndAgg(
+      {"a"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      {"sum(a)"},
+      {},
+      "SELECT sum(a) FROM tmp WHERE a < 3");
+  assertSelectWithFilterAndAgg(
+      {"b"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      {"sum(b)"},
+      {},
+      "SELECT sum(b) FROM tmp WHERE a < 3");
+  assertSelectWithFilterAndAgg(
+      {"a", "b"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      {"min(a)", "max(b)"},
+      {},
+      "SELECT min(a), max(b) FROM tmp WHERE a < 3");
+  assertSelectWithFilterAndAgg(
+      {"b", "a"},
+      common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
+      {"max(b)"},
+      {0},
+      "SELECT max(b), a FROM tmp WHERE a < 3 group by a");
 }
 
 TEST_F(ParquetTableScanTest, countStar) {


### PR DESCRIPTION
The filter column Id passed to DuckDB Parquet reader should be the
relative index to the projection list. If a filter column is not
included in the projection list, it is still included in the columnIds
array and the output from the reader will include this column. It will
be discarded in HiveConnector later when outputColumns is being built.

Resolves https://github.com/facebookincubator/velox/issues/865
