### PR TITLE
Use Future::valid() method instead of an extra boolean

### DIFF
--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -59,11 +59,10 @@ void CrossJoinBuild::addInput(RowVectorPtr input) {
 }
 
 BlockingReason CrossJoinBuild::isBlocked(ContinueFuture* future) {
-  if (!hasFuture_) {
+  if (!future_.valid()) {
     return BlockingReason::kNotBlocked;
   }
   *future = std::move(future_);
-  hasFuture_ = false;
   return BlockingReason::kWaitForJoinBuild;
 }
 
@@ -78,7 +77,6 @@ void CrossJoinBuild::noMoreInput() {
   // build pipeline.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
-    hasFuture_ = true;
     return;
   }
 
@@ -102,6 +100,6 @@ void CrossJoinBuild::noMoreInput() {
 }
 
 bool CrossJoinBuild::isFinished() {
-  return !hasFuture_ && noMoreInput_;
+  return !future_.valid() && noMoreInput_;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/CrossJoinBuild.h
+++ b/velox/exec/CrossJoinBuild.h
@@ -63,8 +63,7 @@ class CrossJoinBuild : public Operator {
 
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making data available for the probe side.
-  ContinueFuture future_{false};
-  bool hasFuture_ = false;
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -312,11 +312,9 @@ class Exchange : public SourceOperator {
   const core::PlanNodeId planNodeId_;
   bool noMoreSplits_ = false;
 
-  /// Boolean indicating that we received a future from Task::getSplitOrFuture.
-  /// That future will be complete when there are more splits available or
-  /// no-more-splits signal has arrived.
-  bool hasSplitFuture_{false};
-  ContinueFuture splitFuture_{false};
+  /// A future received from Task::getSplitOrFuture(). It will be complete when
+  /// there are more splits available or no-more-splits signal has arrived.
+  ContinueFuture splitFuture_{ContinueFuture::makeEmpty()};
 
   RowVectorPtr result_;
   std::shared_ptr<ExchangeClient> exchangeClient_;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -191,7 +191,6 @@ void HashBuild::noMoreInput() {
   // build pipeline.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
-    hasFuture_ = true;
     return;
   }
 
@@ -250,16 +249,15 @@ void HashBuild::addRuntimeStats() {
 }
 
 BlockingReason HashBuild::isBlocked(ContinueFuture* future) {
-  if (!hasFuture_) {
+  if (!future_.valid()) {
     return BlockingReason::kNotBlocked;
   }
   *future = std::move(future_);
-  hasFuture_ = false;
   return BlockingReason::kWaitForJoinBuild;
 }
 
 bool HashBuild::isFinished() {
-  return !hasFuture_ && noMoreInput_;
+  return !future_.valid() && noMoreInput_;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -105,8 +105,7 @@ class HashBuild final : public Operator {
 
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making the hash table.
-  ContinueFuture future_{false};
-  bool hasFuture_ = false;
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
 
   // True if we are considering use of normalized keys or array hash tables. Set
   // to false when the dataset is no longer suitable.

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -205,10 +205,7 @@ class MergeJoin : public Operator {
   vector_size_t outputSize_;
 
   /// A future that will be completed when right side input becomes available.
-  ContinueFuture future_{false};
-
-  /// Boolean indicating whether 'future_' is set.
-  bool hasFuture_{false};
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
 
   /// True if all the right side data has been received.
   bool noMoreRightInput_{false};

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -47,7 +47,6 @@ RowVectorPtr TableScan::getOutput() {
       auto reason = driverCtx_->task->getSplitOrFuture(
           planNodeId_, split, blockingFuture_);
       if (reason != BlockingReason::kNotBlocked) {
-        hasBlockingFuture_ = true;
         return nullptr;
       }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -30,8 +30,7 @@ class TableScan : public SourceOperator {
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* future) override {
-    if (hasBlockingFuture_) {
-      hasBlockingFuture_ = false;
+    if (blockingFuture_.valid()) {
       *future = std::move(blockingFuture_);
       return BlockingReason::kWaitForSplit;
     }
@@ -61,8 +60,7 @@ class TableScan : public SourceOperator {
       unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
           columnHandles_;
   DriverCtx* driverCtx_;
-  ContinueFuture blockingFuture_;
-  bool hasBlockingFuture_ = false;
+  ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
   bool needNewSplit_ = true;
   std::shared_ptr<connector::Connector> connector_;
   std::unique_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -536,7 +536,6 @@ class TestingPauser : public Operator {
     // Block for a time quantum evern 10th time.
     if (counter_ % 10 == 0) {
       test_->registerForWakeup(&future_);
-      hasFuture_ = true;
       return nullptr;
     }
     {
@@ -567,8 +566,7 @@ class TestingPauser : public Operator {
 
   BlockingReason isBlocked(ContinueFuture* future) override {
     VELOX_CHECK(!operatorCtx_->driver()->state().isSuspended);
-    if (hasFuture_) {
-      hasFuture_ = false;
+    if (future_.valid()) {
       *future = std::move(future_);
       return BlockingReason::kWaitForConsumer;
     }
@@ -594,8 +592,7 @@ class TestingPauser : public Operator {
 
   // Counter deciding the next action in getOutput().
   int32_t counter_;
-  bool hasFuture_{false};
-  ContinueFuture future_;
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
 
 std::mutex TestingPauser ::pauseMutex_;


### PR DESCRIPTION
We can use SemiFuture::valid() method to determine whether a future is set or
not. Hence, the extra booleans are not needed. Removed these.