### PR TITLE
Selective Reader Integration with Validation Service: create filters in

### DIFF
--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -485,7 +485,7 @@ class E2EFilterTest : public testing::Test {
   void testFilterSpecs(const std::vector<FilterSpec>& filterSpecs) {
     std::vector<uint32_t> hitRows;
     auto filters =
-        FilterGenerator::makeSubfieldFilters(filterSpecs, batches_, hitRows);
+        filterGenerator->makeSubfieldFilters(filterSpecs, batches_, hitRows);
     auto spec = filterGenerator->makeScanSpec(std::move(filters));
     uint64_t timeWithFilter = 0;
     readWithFilter(spec.get(), batches_, hitRows, timeWithFilter, false);
@@ -563,7 +563,7 @@ class E2EFilterTest : public testing::Test {
         makeDataset(customize);
         for (auto i = 0; i < numCombinations; ++i) {
           std::vector<FilterSpec> specs =
-              filterGenerator->makeRandomSpecs(filterable);
+              filterGenerator->makeRandomSpecs(filterable, 125);
           std::cout << i << ": Testing "
                     << FilterGenerator::specsToString(specs) << std::endl;
           testFilterSpecs(specs);

--- a/velox/dwio/dwrf/test/utils/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/utils/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   velox_dwrf_test_utils
   ${FOLLY_WITH_DEPENDENCIES}
   velox_dwio_common
+  velox_dwio_common_exception
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
   velox_exception

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -527,7 +527,7 @@ class BoolValue final : public Filter {
 class BigintRange final : public Filter {
  public:
   /// @param lower Lower end of the range, inclusive.
-  /// @param lower Upper end of the range, inclusive.
+  /// @param upper Upper end of the range, inclusive.
   /// @param nullAllowed Null values are passing the filter if true.
   BigintRange(int64_t lower, int64_t upper, bool nullAllowed)
       : Filter(true, nullAllowed, FilterKind::kBigintRange),


### PR DESCRIPTION
Summary:
create filters in checksum tool.
When "pushdown" flag is passed to the checksum tool, it will first generate random filters and use the filters to create ScanSpec, use the ScanSpec to read the data, compute checksums.

Then it will load the data unfiltered, then apply the filters (vs the previous method us using ScanSpec to filter the result), then compute the checksums again.

The returned value will be the diff of the

Differential Revision: D33346809

