### PR TITLE
Add support for AS statement to PlanBuilder

### DIFF
--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -244,3 +244,14 @@ TEST(DuckParserTest, structExtract) {
   EXPECT_EQ("dot(dot(\"a\",\"b\"),\"c\")", parseExpr("(a).b.c")->toString());
   EXPECT_EQ("dot(dot(\"a\",\"b\"),\"c\")", parseExpr("(a.b).c")->toString());
 }
+
+TEST(DuckParserTest, alias) {
+  EXPECT_EQ("plus(\"a\",\"b\") AS sum", parseExpr("a + b AS sum")->toString());
+  EXPECT_EQ(
+      "gt(\"a\",\"b\") AS result", parseExpr("a > b AS result")->toString());
+  EXPECT_EQ("2 AS multiplier", parseExpr("2 AS multiplier")->toString());
+  EXPECT_EQ(
+      "cast(\"a\", DOUBLE) AS a_double",
+      parseExpr("cast(a AS DOUBLE) AS a_double")->toString());
+  EXPECT_EQ("\"a\" AS b", parseExpr("a AS b")->toString());
+}

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -64,7 +64,7 @@ TEST_F(CrossJoinTest, basic) {
                     PlanBuilder(0)
                         .values({rightVectors})
                         .filter("c0 < 13")
-                        .project({"c0"}, {"u_c0"})
+                        .project({"c0 AS u_c0"})
                         .planNode(),
                     {"c0", "u_c0"})
                 .planNode();
@@ -78,7 +78,7 @@ TEST_F(CrossJoinTest, basic) {
            .crossJoin(
                PlanBuilder(0)
                    .values({rightVectors})
-                   .project({"c0"}, {"u_c0"})
+                   .project({"c0 AS u_c0"})
                    .planNode(),
                {"c0", "u_c0"})
            .planNode();
@@ -119,7 +119,7 @@ TEST_F(CrossJoinTest, basic) {
                PlanBuilder(0)
                    .values({rightVectors})
                    .filter("c0 < 0")
-                   .project({"c0"}, {"u_c0"})
+                   .project({"c0 AS u_c0"})
                    .planNode(),
                {"c0", "u_c0"})
            .planNode();
@@ -136,7 +136,7 @@ TEST_F(CrossJoinTest, basic) {
                             PlanBuilder(0, pool_.get())
                                 .values({rightVectors}, true)
                                 .filter("c0 in (10, 17)")
-                                .project({"c0"}, {"u_c0"})
+                                .project({"c0 AS u_c0"})
                                 .planNode(),
                             {"c0", "u_c0"})
                         .limit(0, 100'000, false)
@@ -170,7 +170,7 @@ TEST_F(CrossJoinTest, lazyVectors) {
                 .crossJoin(
                     PlanBuilder(0)
                         .values({rightVectors})
-                        .project({"c0"}, {"u_c0"})
+                        .project({"c0 AS u_c0"})
                         .planNode(),
                     {"c0", "u_c0"})
                 .filter("c0 + u_c0 < 100")

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -125,12 +125,10 @@ class DriverTest : public OperatorTestBase {
     }
 
     if (!project.empty()) {
-      auto projectNames = rowType->names();
-      auto expressions = projectNames;
-      projectNames.push_back("expr");
-      expressions.push_back(project);
+      auto expressions = rowType->names();
+      expressions.push_back(fmt::format("{} AS expr", project));
 
-      planBuilder.project(expressions, projectNames);
+      planBuilder.project(expressions);
     }
     if (addTestingPauser) {
       planBuilder.addNode(

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -124,7 +124,7 @@ class MergeJoinTest : public OperatorTestBase {
                         {"u_c0"},
                         PlanBuilder()
                             .values(right)
-                            .project({"c0", "c1"}, {"u_c0", "u_c1"})
+                            .project({"c0 AS u_c0", "c1 AS u_c1"})
                             .planNode(),
                         "",
                         {"c0", "c1", "u_c1"},
@@ -154,7 +154,7 @@ class MergeJoinTest : public OperatorTestBase {
                    {"u_c0"},
                    PlanBuilder()
                        .values(right)
-                       .project({"c0", "c1"}, {"u_c0", "u_c1"})
+                       .project({"c0 as u_c0", "c1 as u_c1"})
                        .planNode(),
                    "",
                    {"c0", "c1", "u_c1"},

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -176,13 +176,12 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
   auto leafTaskId = makeTaskId("leaf", 0);
   std::shared_ptr<core::PlanNode> partialAggPlan;
   {
-    partialAggPlan =
-        PlanBuilder()
-            .tableScan(rowType_)
-            .project(std::vector<std::string>{"c0 % 10", "c1"}, {"c0", "c1"})
-            .partialAggregation({0}, {"sum(c1)"})
-            .partitionedOutput({0}, 3)
-            .planNode();
+    partialAggPlan = PlanBuilder()
+                         .tableScan(rowType_)
+                         .project({"c0 % 10 AS c0", "c1"})
+                         .partialAggregation({0}, {"sum(c1)"})
+                         .partitionedOutput({0}, 3)
+                         .planNode();
 
     auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
@@ -218,15 +217,12 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
   auto leafTaskId = makeTaskId("leaf", 0);
   std::shared_ptr<core::PlanNode> partialAggPlan;
   {
-    partialAggPlan =
-        PlanBuilder()
-            .tableScan(rowType_)
-            .project(
-                std::vector<std::string>{"c0 % 10", "c1 % 2", "c2"},
-                {"c0", "c1", "c2"})
-            .partialAggregation({0, 1}, {"sum(c2)"})
-            .partitionedOutput({0, 1}, 3)
-            .planNode();
+    partialAggPlan = PlanBuilder()
+                         .tableScan(rowType_)
+                         .project({"c0 % 10 AS c0", "c1 % 2 AS c1", "c2"})
+                         .partialAggregation({0, 1}, {"sum(c2)"})
+                         .partitionedOutput({0, 1}, 3)
+                         .planNode();
 
     auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
@@ -267,11 +263,10 @@ TEST_F(MultiFragmentTest, distributedTableScan) {
     std::shared_ptr<core::PlanNode> leafPlan;
     {
       PlanBuilder builder;
-      leafPlan =
-          builder.tableScan(rowType_)
-              .project(std::vector<std::string>{"c0 % 10", "c1 % 2", "c2"})
-              .partitionedOutput({}, 1, {2, 1, 0})
-              .planNode();
+      leafPlan = builder.tableScan(rowType_)
+                     .project({"c0 % 10", "c1 % 2", "c2"})
+                     .partitionedOutput({}, 1, {2, 1, 0})
+                     .planNode();
 
       auto leafTask = makeTask(leafTaskId, leafPlan, 0);
       tasks.push_back(leafTask);
@@ -477,7 +472,7 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
     finalAggPlan =
         PlanBuilder()
             .exchange(leafPlan->outputType())
-            .project({"c0 is null"}, {"co_is_null"})
+            .project({"c0 is null AS co_is_null"})
             .partialAggregation({}, {"count_if(co_is_null)", "count(1)"})
             .partitionedOutput({}, 1)
             .planNode();

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -31,14 +31,9 @@ class PlanNodeToStringTest : public OperatorTestBase {
     plan_ = exec::test::PlanBuilder()
                 .values(vectors_)
                 .filter("c0 % 10 < 9")
-                .project(
-                    {"c0", "c0 % 100 + c1 % 50"},
-                    {
-                        "out1",
-                        "out2",
-                    })
+                .project({"c0 AS out1", "c0 % 100 + c1 % 50 AS out2"})
                 .filter("out1 % 10 < 8")
-                .project({"out1 + 10"}, {"out3"})
+                .project({"out1 + 10 AS out3"})
                 .planNode();
   }
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -67,9 +67,7 @@ class StreamingAggregationTest : public OperatorTestBase {
     // mask, one with a different mask.
     plan = PlanBuilder()
                .values(data)
-               .project(
-                   {"c0", "c1", "c1 % 7 = 0", "c1 % 11 = 0"},
-                   {"c0", "c1", "m1", "m2"})
+               .project({"c0", "c1", "c1 % 7 = 0 AS m1", "c1 % 11 = 0 AS m2"})
                .partialStreamingAggregation(
                    {0},
                    {"count(1)", "min(c1)", "max(c1)", "sum(c1)"},

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1650,7 +1650,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   // touch columns being aggregated
   op = PlanBuilder()
            .tableScan(rowType_, tableHandle, assignments)
-           .project({"c0 % 5", "c1"}, {"c0_mod_5", "c1"})
+           .project({"c0 % 5", "c1"})
            .singleAggregation({0}, {"sum(c1)"})
            .planNode();
 
@@ -1679,7 +1679,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
 
   op = PlanBuilder()
            .tableScan(rowType_, tableHandle, assignments)
-           .project({"c5", "c0", "c0 + c1"}, {"c5", "c0", "c0_plus_c1"})
+           .project({"c5", "c0", "c0 + c1 AS c0_plus_c1"})
            .singleAggregation({0}, {"min(c0)", "max(c0_plus_c1)"})
            .planNode();
   assertQuery(

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -19,6 +19,10 @@
 #include <velox/core/PlanNode.h>
 #include "velox/common/memory/Memory.h"
 
+namespace facebook::velox::core {
+class IExpr;
+}
+
 namespace facebook::velox::exec::test {
 
 class PlanBuilder {
@@ -49,9 +53,26 @@ class PlanBuilder {
       const std::vector<ChannelIndex>& keyIndices,
       const std::vector<core::SortOrder>& sortOrder);
 
-  PlanBuilder& project(
-      const std::vector<std::string>& projections,
-      const std::vector<std::string>& names = {});
+  /// Adds a ProjectNode using specified SQL expressions.
+  ///
+  /// For example,
+  ///
+  ///     .project({"a + b", "c * 3"})
+  ///
+  /// The names of the projections can be specified using SQL statement AS:
+  ///
+  ///     .project({"a + b AS sum_ab", "c * 3 AS triple_c"})
+  ///
+  /// If AS statement is not used, the names of the projections will be
+  /// generated as p0, p1, p2, etc. Names of columns projected as is will be
+  /// preserved.
+  ///
+  /// For example,
+  ///
+  ///     project({"a + b AS sum_ab", "c", "d * 7")
+  ///
+  /// will produce projected columns named sum_ab, c and p2.
+  PlanBuilder& project(const std::vector<std::string>& projections);
 
   PlanBuilder& filter(const std::string& filter);
 
@@ -66,6 +87,27 @@ class PlanBuilder {
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
       const std::string& rowCountColumnName = "rowCount");
 
+  /// Adds an AggregationNode representing partial aggregation with the
+  /// specified grouping keys, aggregates and optional masks.
+  ///
+  /// Grouping keys are specified using zero-based indices into the input
+  /// columns.
+  ///
+  /// Aggregates are specified as function calls over unmodified input columns,
+  /// e.g. sum(a), avg(b), min(c). SQL statement AS can be used to specify names
+  /// for the aggregation result columns. In the absence of AS statement, result
+  /// columns are named a0, a1, a2, etc.
+  ///
+  /// For example,
+  ///
+  ///     partialAggregation({}, {"min(a) AS min_a", "max(b)"})
+  ///
+  /// will produce output columns min_a and a1, while
+  ///
+  ///     partialAggregation({0, 1}, {"min(a) AS min_a", "max(b)"})
+  ///
+  /// will produce output columns k1, k2, min_a and a1, assuming the names of
+  /// the first two input columns are k1 and k2.
   PlanBuilder& partialAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
       const std::vector<std::string>& aggregates,
@@ -293,8 +335,15 @@ class PlanBuilder {
       const core::AggregationNode* partialAggNode,
       bool streaming);
 
-  std::vector<std::shared_ptr<const core::CallTypedExpr>>
-  createAggregateExpressions(
+  std::shared_ptr<const core::ITypedExpr> inferTypes(
+      const std::shared_ptr<const core::IExpr>& untypedExpr);
+
+  struct AggregateExpressionsAndNames {
+    std::vector<std::shared_ptr<const core::CallTypedExpr>> aggregates;
+    std::vector<std::string> names;
+  };
+
+  AggregateExpressionsAndNames createAggregateExpressionsAndNames(
       const std::vector<std::string>& aggregates,
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& resultTypes);

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -59,9 +59,7 @@ TEST_F(ArbitraryTest, noNulls) {
   // Group by partial aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project(
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"},
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
+            .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
             .partialAggregation(
                 {0},
                 {"arbitrary(c1)",
@@ -97,9 +95,7 @@ TEST_F(ArbitraryTest, noNulls) {
   // Group by final aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project(
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"},
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
+            .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
             .partialAggregation(
                 {0},
                 {"arbitrary(c1)",
@@ -119,9 +115,7 @@ TEST_F(ArbitraryTest, noNulls) {
   agg = PlanBuilder()
             .values(vectors)
             .filter("c0 % 2 = 0")
-            .project(
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"},
-                {"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
+            .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5", "c6"})
             .partialAggregation(
                 {0},
                 {"arbitrary(c1)",
@@ -213,7 +207,7 @@ TEST_F(ArbitraryTest, varchar) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+                .project({"c0 % 11", "c1"})
                 .partialAggregation({0}, {"arbitrary(c1)"})
                 .planNode();
 
@@ -231,7 +225,7 @@ TEST_F(ArbitraryTest, varchar) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c0 % 2 = 0")
-           .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+           .project({"c0 % 11", "c1"})
            .partialAggregation({0}, {"arbitrary(c1)"})
            .planNode();
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -77,9 +77,7 @@ TEST_F(AverageAggregation, avgConst) {
   {
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project(
-                       std::vector<std::string>{"c0 % 2", "c0"},
-                       std::vector<std::string>{"c0_mod_2", "c0"})
+                   .project({"c0 % 2 AS c0_mod_2", "c0"})
                    .partialAggregation({0}, {"avg(c0)"})
                    .finalAggregation()
                    .planNode();
@@ -226,11 +224,7 @@ TEST_F(AverageAggregation, avg) {
     auto agg =
         PlanBuilder()
             .values(vectors)
-            .project(
-                std::vector<std::string>{
-                    "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                std::vector<std::string>{
-                    "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+            .project({"c0 % 10 AS c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
             .partialAggregation(
                 {0}, {"avg(c1)", "avg(c2)", "avg(c3)", "avg(c4)", "avg(c5)"})
             .finalAggregation()
@@ -241,11 +235,7 @@ TEST_F(AverageAggregation, avg) {
 
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{
-                      "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                  std::vector<std::string>{
-                      "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+              .project({"c0 % 10 AS c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
               .singleAggregation(
                   {0}, {"avg(c1)", "avg(c2)", "avg(c3)", "avg(c4)", "avg(c5)"})
               .planNode();
@@ -255,11 +245,7 @@ TEST_F(AverageAggregation, avg) {
 
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{
-                      "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                  std::vector<std::string>{
-                      "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+              .project({"c0 % 10 AS c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
               .partialAggregation(
                   {0}, {"avg(c1)", "avg(c2)", "avg(c3)", "avg(c4)", "avg(c5)"})
               .intermediateAggregation()
@@ -274,9 +260,7 @@ TEST_F(AverageAggregation, avg) {
   {
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project(
-                       std::vector<std::string>{"c0 % 10", "c1"},
-                       std::vector<std::string>{"c0_mod_10", "c1"})
+                   .project({"c0 % 10 AS c0_mod_10", "c1"})
                    .filter("c0_mod_10 > 10")
                    .partialAggregation({0}, {"avg(c1)"})
                    .finalAggregation()
@@ -289,9 +273,7 @@ TEST_F(AverageAggregation, avg) {
     auto agg = PlanBuilder()
                    .values(vectors)
                    .filter("c2 % 5 = 3")
-                   .project(
-                       std::vector<std::string>{"c0 % 10", "c1"},
-                       std::vector<std::string>{"c0_mod_10", "c1"})
+                   .project({"c0 % 10 AS c0_mod_10", "c1"})
                    .partialAggregation({0}, {"avg(c1)"})
                    .finalAggregation()
                    .planNode();

--- a/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
@@ -69,9 +69,7 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
   {
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project(
-                       {"c0 % 10", "c1", "c2", "c3", "c4"},
-                       {"c0 % 10", "c1", "c2", "c3", "c4"})
+                   .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                    .partialAggregation(
                        {0},
                        {"bitwise_or_agg(c1)",
@@ -88,9 +86,7 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
   {
     auto finalAgg = PlanBuilder()
                         .values(vectors)
-                        .project(
-                            {"c0 % 10", "c1", "c2", "c3", "c4"},
-                            {"c0 % 10", "c1", "c2", "c3", "c4"})
+                        .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                         .partialAggregation(
                             {0},
                             {"bitwise_or_agg(c1)",
@@ -146,9 +142,7 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
   {
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project(
-                       {"c0 % 10", "c1", "c2", "c3", "c4"},
-                       {"c0 % 10", "c1", "c2", "c3", "c4"})
+                   .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                    .partialAggregation(
                        {0},
                        {"bitwise_and_agg(c1)",
@@ -165,9 +159,7 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
   {
     auto finalAgg = PlanBuilder()
                         .values(vectors)
-                        .project(
-                            {"c0 % 10", "c1", "c2", "c3", "c4"},
-                            {"c0 % 10", "c1", "c2", "c3", "c4"})
+                        .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                         .partialAggregation(
                             {0},
                             {"bitwise_and_agg(c1)",

--- a/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
@@ -63,7 +63,7 @@ TEST_P(BoolAndOrTest, basic) {
   // Group by partial aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+            .project({"c0 % 10", "c1"})
             .partialAggregation({0}, {partialAgg})
             .planNode();
   assertQuery(
@@ -74,7 +74,7 @@ TEST_P(BoolAndOrTest, basic) {
   // Group by final aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+            .project({"c0 % 10", "c1"})
             .partialAggregation({0}, {partialAgg})
             .finalAggregation()
             .planNode();
@@ -87,7 +87,7 @@ TEST_P(BoolAndOrTest, basic) {
   agg = PlanBuilder()
             .values(vectors)
             .filter("c0 % 2 = 0")
-            .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+            .project({"c0 % 11", "c1"})
             .partialAggregation({0}, {partialAgg})
             .planNode();
 

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -73,7 +73,7 @@ TEST_F(CountAggregation, count) {
     // final count aggregation is a sum of partial counts
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project({"cast(c1 as bigint)"}, {"c1_bigint"})
+                   .project({"cast(c1 as bigint) AS c1_bigint"})
                    .finalAggregation({}, {"count(c1_bigint)"}, {BIGINT()})
                    .planNode();
     assertQuery(agg, "SELECT sum(c1) FROM tmp");
@@ -92,7 +92,7 @@ TEST_F(CountAggregation, count) {
   {
     auto agg = PlanBuilder()
                    .values(vectors)
-                   .project({"c0 % 10", "c7"}, {"c0_mod_10", "c7"})
+                   .project({"c0 % 10 AS c0_mod_10", "c7"})
                    .partialAggregation({0}, {"count(c7)"})
                    .planNode();
     assertQuery(agg, "SELECT c0 % 10, count(c7) FROM tmp GROUP BY 1");

--- a/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
@@ -130,7 +130,7 @@ TEST_F(CountIfAggregationTest, twoAggregatesMultipleGroupsWrapped) {
   auto agg = PlanBuilder()
                  .values(vectors)
                  .filter("c0 % 2 = 0")
-                 .project({"c0 % 11", "c1", "c2"}, {"c0_mod_11", "c1", "c2"})
+                 .project({"c0 % 11 AS c0_mod_11", "c1", "c2"})
                  .partialAggregation({0}, {"count_if(c1)", "count_if(c2)"})
                  .finalAggregation()
                  .planNode();

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -60,7 +60,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     // Group by partial aggregation.
     op = PlanBuilder()
              .values(vectors)
-             .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+             .project({"c0 % 10", "c1"})
              .partialAggregation({0}, {agg(c1)})
              .planNode();
     assertQuery(
@@ -69,7 +69,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     // Group by final aggregation.
     op = PlanBuilder()
              .values(vectors)
-             .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+             .project({"c0 % 10", "c1"})
              .partialAggregation({0}, {agg(c1)})
              .finalAggregation()
              .planNode();
@@ -80,7 +80,7 @@ class MinMaxTest : public aggregate::test::AggregationTestBase {
     op = PlanBuilder()
              .values(vectors)
              .filter("c0 % 2 = 0")
-             .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+             .project({"c0 % 11", "c1"})
              .partialAggregation({0}, {agg(c1)})
              .planNode();
 
@@ -141,7 +141,7 @@ TEST_F(MinMaxTest, maxVarchar) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+                .project({"c0 % 11", "c1"})
                 .partialAggregation({0}, {"max(c1)"})
                 .planNode();
   assertQuery(op, "SELECT c0 % 11, max(c1) FROM tmp GROUP BY 1");
@@ -156,7 +156,7 @@ TEST_F(MinMaxTest, maxVarchar) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c0 % 2 = 0")
-           .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+           .project({"c0 % 11", "c1"})
            .partialAggregation({0}, {"max(c1)"})
            .planNode();
   assertQuery(
@@ -165,7 +165,7 @@ TEST_F(MinMaxTest, maxVarchar) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c0 % 2 = 0")
-           .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+           .project({"c0 % 11", "c1"})
            .partialAggregation({0}, {"max(c1)"})
            .finalAggregation()
            .planNode();
@@ -197,7 +197,7 @@ TEST_F(MinMaxTest, minVarchar) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .project({"c0 % 17", "c1"}, {"c0_mod_17", "c1"})
+                .project({"c0 % 17", "c1"})
                 .partialAggregation({0}, {"min(c1)"})
                 .planNode();
   assertQuery(op, "SELECT c0 % 17, min(c1) FROM tmp GROUP BY 1");
@@ -212,7 +212,7 @@ TEST_F(MinMaxTest, minVarchar) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c0 % 2 = 0")
-           .project({"c0 % 17", "c1"}, {"c0_mod_17", "c1"})
+           .project({"c0 % 17", "c1"})
            .partialAggregation({0}, {"min(c1)"})
            .planNode();
   assertQuery(
@@ -221,7 +221,7 @@ TEST_F(MinMaxTest, minVarchar) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c0 % 2 = 0")
-           .project({"c0 % 17", "c1"}, {"c0_mod_17", "c1"})
+           .project({"c0 % 17", "c1"})
            .partialAggregation({0}, {"min(c1)"})
            .finalAggregation()
            .planNode();

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -48,7 +48,7 @@ TEST_F(SumTest, sumTinyint) {
   // Group by partial aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+            .project({"c0 % 10", "c1"})
             .partialAggregation({0}, {"sum(c1)"})
             .planNode();
   assertQuery(agg, "SELECT c0 % 10, sum(c1) FROM tmp GROUP BY 1");
@@ -56,7 +56,7 @@ TEST_F(SumTest, sumTinyint) {
   // Group by final aggregation.
   agg = PlanBuilder()
             .values(vectors)
-            .project({"c0 % 10", "c1"}, {"c0 % 10", "c1"})
+            .project({"c0 % 10", "c1"})
             .partialAggregation({0}, {"sum(c1)"})
             .finalAggregation()
             .planNode();
@@ -66,7 +66,7 @@ TEST_F(SumTest, sumTinyint) {
   agg = PlanBuilder()
             .values(vectors)
             .filter("c0 % 2 = 0")
-            .project({"c0 % 11", "c1"}, {"c0_mod_11", "c1"})
+            .project({"c0 % 11", "c1"})
             .partialAggregation({0}, {"sum(c1)"})
             .planNode();
   assertQuery(
@@ -110,9 +110,7 @@ TEST_F(SumTest, sumWithMask) {
   // Global partial+final aggregation.
   op = PlanBuilder()
            .values(vectors)
-           .project(
-               {"c0", "c1", "c2 % 2 = 0", "c3 % 3 = 0"},
-               {"c0", "c1", "m0", "m1"})
+           .project({"c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
                {}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()
@@ -128,9 +126,7 @@ TEST_F(SumTest, sumWithMask) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c3 % 2 = 0")
-           .project(
-               {"c0", "c1", "c2 % 2 = 0", "c3 % 3 = 0"},
-               {"c0", "c1", "m0", "m1"})
+           .project({"c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
                {}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()
@@ -144,9 +140,7 @@ TEST_F(SumTest, sumWithMask) {
   // Group by partial+final aggregation.
   op = PlanBuilder()
            .values(vectors)
-           .project(
-               {"c4", "c0", "c1", "c2 % 2 = 0", "c3 % 3 = 0"},
-               {"c4", "c0", "c1", "m0", "m1"})
+           .project({"c4", "c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
                {0}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()
@@ -162,9 +156,7 @@ TEST_F(SumTest, sumWithMask) {
   op = PlanBuilder()
            .values(vectors)
            .filter("c3 % 2 = 0")
-           .project(
-               {"c4", "c0", "c1", "c2 % 2 = 0", "c3 % 3 = 0"},
-               {"c4", "c0", "c1", "m0", "m1"})
+           .project({"c4", "c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
                {0}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -103,9 +103,7 @@ TEST_F(VarianceAggregationTest, varianceConst) {
 
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{"c0 % 2", "c0"},
-                  std::vector<std::string>{"c0_mod_2", "c0"})
+              .project({"c0 % 2 AS c0_mod_2", "c0"})
               .partialAggregation({0}, {GEN_AGG("c0")})
               .finalAggregation()
               .planNode();
@@ -265,11 +263,7 @@ TEST_F(VarianceAggregationTest, variance) {
     // Group by
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{
-                      "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                  std::vector<std::string>{
-                      "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+              .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5"})
               .partialAggregation(
                   {0},
                   {GEN_AGG("c1"),
@@ -287,11 +281,7 @@ TEST_F(VarianceAggregationTest, variance) {
 
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{
-                      "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                  std::vector<std::string>{
-                      "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+              .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5"})
               .singleAggregation(
                   {0},
                   {GEN_AGG("c1"),
@@ -308,11 +298,7 @@ TEST_F(VarianceAggregationTest, variance) {
 
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{
-                      "c0 % 10", "c1", "c2", "c3", "c4", "c5"},
-                  std::vector<std::string>{
-                      "c0_mod_10", "c1", "c2", "c3", "c4", "c5"})
+              .project({"c0 % 10", "c1", "c2", "c3", "c4", "c5"})
               .partialAggregation(
                   {0},
                   {GEN_AGG("c1"),
@@ -332,9 +318,7 @@ TEST_F(VarianceAggregationTest, variance) {
     // Group by; no input
     agg = PlanBuilder()
               .values(vectors)
-              .project(
-                  std::vector<std::string>{"c0 % 10", "c1"},
-                  std::vector<std::string>{"c0_mod_10", "c1"})
+              .project({"c0 % 10 AS c0_mod_10", "c1"})
               .filter("c0_mod_10 > 10")
               .partialAggregation({0}, {GEN_AGG("c1")})
               .finalAggregation()
@@ -348,9 +332,7 @@ TEST_F(VarianceAggregationTest, variance) {
     agg = PlanBuilder()
               .values(vectors)
               .filter("c2 % 5 = 3")
-              .project(
-                  std::vector<std::string>{"c0 % 10", "c1"},
-                  std::vector<std::string>{"c0_mod_10", "c1"})
+              .project({"c0 % 10", "c1"})
               .partialAggregation({0}, {GEN_AGG("c1")})
               .finalAggregation()
               .planNode();

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -28,6 +28,9 @@ namespace core {
 /* an implicitly-typed expression, such as function call, literal, etc... */
 class IExpr : public ISerializable {
  public:
+  explicit IExpr(std::optional<std::string> alias = std::nullopt)
+      : alias_{std::move(alias)} {}
+
   virtual const std::vector<std::shared_ptr<const IExpr>>& getInputs()
       const = 0;
 
@@ -47,11 +50,25 @@ class IExpr : public ISerializable {
     return false;
   }
 
+  const std::optional<std::string>& alias() const {
+    return alias_;
+  }
+
  protected:
   static const std::vector<std::shared_ptr<const IExpr>>& EMPTY() {
     static const std::vector<std::shared_ptr<const IExpr>> empty{};
     return empty;
   }
+
+  std::string appendAliasIfExists(std::string s) const {
+    if (!alias_.has_value()) {
+      return s;
+    }
+
+    return fmt::format("{} AS {}", std::move(s), alias_.value());
+  }
+
+  std::optional<std::string> alias_;
 };
 
 } // namespace core


### PR DESCRIPTION
Allow for using standard SQL aliasing construct to specify output columns for
projections and aggregations.