### PR TITLE
Do not ignore errors in RowReader::estimatedRowSize

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -598,19 +598,14 @@ std::unordered_map<std::string, int64_t> HiveDataSource::runtimeStats() {
 }
 
 int64_t HiveDataSource::estimatedRowSize() {
-  if (!rowReader_ || errorInRowSize_) {
+  if (!rowReader_) {
     return kUnknownRowSize;
   }
-  try {
-    return rowReader_->estimatedRowSize();
-  } catch (const std::exception& e) {
-    // Remember the error and do not try the other splits, they are
-    // likely to be broken the same way.
-    errorInRowSize_ = true;
-    LOG_EVERY_N(WARNING, 1000)
-        << "failed to get row size estimate for " << split_->toString();
-    return kUnknownRowSize;
+  auto size = rowReader_->estimatedRowSize();
+  if (size.has_value()) {
+    return size.value();
   }
+  return kUnknownRowSize;
 }
 
 HiveConnector::HiveConnector(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -218,7 +218,6 @@ class HiveDataSource : public DataSource {
   memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
   const std::string& scanId_;
   folly::Executor* FOLLY_NULLABLE executor_;
-  bool errorInRowSize_{false};
 };
 
 class HiveConnector final : public Connector {

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -66,9 +66,9 @@ class RowReader {
   /**
    * Get an estimated row size basing on available statistics. Can
    * differ from the actual row size due to variable-length values.
-   * @return estimated row size
+   * @return Estimate of the row size or std::nullopt if cannot estimate.
    */
-  virtual size_t estimatedRowSize() const = 0;
+  virtual std::optional<size_t> estimatedRowSize() const = 0;
 };
 
 /**

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/dwio/dwrf/reader/DwrfReaderShared.h"
 #include <exception>
+#include <optional>
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/dwio/dwrf/common/Statistics.h"
@@ -28,7 +29,6 @@ using dwio::common::ColumnSelector;
 using dwio::common::InputStream;
 using dwio::common::ReaderOptions;
 using dwio::common::RowReaderOptions;
-using dwio::common::StatsError;
 using dwio::common::TypeWithId;
 using dwio::common::typeutils::CompatChecker;
 
@@ -417,7 +417,7 @@ size_t DwrfRowReaderShared::estimatedReaderMemory() const {
   return 2 * DwrfReaderShared::getMemoryUse(getReader(), -1, *columnSelector_);
 }
 
-size_t DwrfRowReaderShared::estimatedRowSizeHelper(
+std::optional<size_t> DwrfRowReaderShared::estimatedRowSizeHelper(
     const proto::Footer& footer,
     const dwio::common::Statistics& stats,
     uint32_t nodeId) const {
@@ -426,7 +426,7 @@ size_t DwrfRowReaderShared::estimatedRowSizeHelper(
   const auto& s = stats.getColumnStatistics(nodeId);
   const auto& t = footer.types(nodeId);
   if (!s.getNumberOfValues()) {
-    throw StatsError("numberofvalues unavailable");
+    return std::nullopt;
   }
   auto valueCount = s.getNumberOfValues().value();
   if (valueCount < 1) {
@@ -458,11 +458,11 @@ size_t DwrfRowReaderShared::estimatedRowSizeHelper(
       auto stringStats =
           dynamic_cast<const dwio::common::StringColumnStatistics*>(&s);
       if (!stringStats) {
-        throw StatsError("stringstatistics unavailable");
+        return std::nullopt;
       }
       auto length = stringStats->getTotalLength();
       if (!length) {
-        throw StatsError("stringstatistics unavailable");
+        return std::nullopt;
       }
       return length.value();
     }
@@ -470,11 +470,11 @@ size_t DwrfRowReaderShared::estimatedRowSizeHelper(
       auto binaryStats =
           dynamic_cast<const dwio::common::BinaryColumnStatistics*>(&s);
       if (!binaryStats) {
-        throw StatsError("binarystatistics unavailable");
+        return std::nullopt;
       }
       auto length = binaryStats->getTotalLength();
       if (!length) {
-        throw StatsError("binarystatistics unavailable");
+        return std::nullopt;
       }
       return length.value();
     }
@@ -492,23 +492,27 @@ size_t DwrfRowReaderShared::estimatedRowSizeHelper(
            ++i) {
         auto subtypeEstimate =
             estimatedRowSizeHelper(footer, stats, t.subtypes(i));
-        totalEstimate = t.kind() == proto::Type_Kind_UNION
-            ? std::max(totalEstimate, subtypeEstimate)
-            : (totalEstimate + subtypeEstimate);
+        if (subtypeEstimate.has_value()) {
+          totalEstimate = t.kind() == proto::Type_Kind_UNION
+              ? std::max(totalEstimate, subtypeEstimate.value())
+              : (totalEstimate + subtypeEstimate.value());
+        } else {
+          return std::nullopt;
+        }
       }
       return totalEstimate;
     }
     default:
-      throw StatsError("unexpected type");
+      return std::nullopt;
   }
 }
 
-size_t DwrfRowReaderShared::estimatedRowSize() const {
+std::optional<size_t> DwrfRowReaderShared::estimatedRowSize() const {
   auto& reader = getReader();
   auto& footer = reader.getFooter();
 
   if (!footer.has_numberofrows()) {
-    throw StatsError("numberofrows unavailable");
+    return std::nullopt;
   }
 
   if (footer.numberofrows() < 1) {
@@ -518,9 +522,12 @@ size_t DwrfRowReaderShared::estimatedRowSize() const {
   // Estimate with projections
   constexpr uint32_t ROOT_NODE_ID = 0;
   auto stats = reader.getStatistics();
-  size_t projectedSize = estimatedRowSizeHelper(footer, *stats, ROOT_NODE_ID);
+  auto projectedSize = estimatedRowSizeHelper(footer, *stats, ROOT_NODE_ID);
+  if (projectedSize.has_value()) {
+    return projectedSize.value() / footer.numberofrows();
+  }
 
-  return projectedSize / footer.numberofrows();
+  return std::nullopt;
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.h
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.h
@@ -51,7 +51,7 @@ class DwrfRowReaderShared : public StrideIndexProvider,
   // internal methods
   void startNextStripe();
 
-  size_t estimatedRowSizeHelper(
+  std::optional<size_t> estimatedRowSizeHelper(
       const proto::Footer& footer,
       const dwio::common::Statistics& stats,
       uint32_t nodeId) const;
@@ -125,7 +125,7 @@ class DwrfRowReaderShared : public StrideIndexProvider,
   size_t estimatedReaderMemory() const;
 
   // Estimate the row size for projected columns
-  size_t estimatedRowSize() const override;
+  std::optional<size_t> estimatedRowSize() const override;
 };
 
 class DwrfReaderShared : public dwio::common::Reader {
@@ -207,8 +207,9 @@ class DwrfReaderShared : public dwio::common::Reader {
 
   std::optional<uint64_t> numberOfRows() const override {
     auto& footer = readerBase_->getFooter();
-    if (footer.has_numberofrows())
+    if (footer.has_numberofrows()) {
       return footer.numberofrows();
+    }
     return std::nullopt;
   }
 

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -176,9 +176,9 @@ void ParquetRowReader::resetFilterCaches() {
   VELOX_FAIL("ParquetRowReader::resetFilterCaches is NYI");
 }
 
-size_t ParquetRowReader::estimatedRowSize() const {
-  VELOX_FAIL("ParquetRowReader::estimatedRowSize is NYI");
-  return 0;
+std::optional<size_t> ParquetRowReader::estimatedRowSize() const {
+  // TODO Implement.
+  return std::nullopt;
 }
 
 ParquetReader::ParquetReader(

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -39,7 +39,7 @@ class ParquetRowReader : public dwio::common::RowReader {
 
   void resetFilterCaches() override;
 
-  size_t estimatedRowSize() const override;
+  std::optional<size_t> estimatedRowSize() const override;
 
  private:
   ::duckdb::TableFilterSet filters_;


### PR DESCRIPTION
- Fail fast if RowReader::estimatedRowSize returns an error.
- Change the API to return std::optional to allow for the reader to indicate that estimate is not available.