### PR TITLE
Migrate last Spark functions to new API

### DIFF
--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -70,8 +70,8 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "get_json_object"});
 
   // Register string functions.
-  registerFunction<udf_chr, Varchar, int64_t>();
-  registerFunction<udf_ascii, int32_t, Varchar>();
+  registerFunction<sparksql::ChrFunction, Varchar, int64_t>({prefix + "chr"});
+  registerFunction<AsciiFunction, int32_t, Varchar>({prefix + "ascii"});
 
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});
@@ -82,8 +82,7 @@ void registerFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       "length", lengthSignatures(), makeLength);
 
-  registerFunction<udf_md5<Varchar, Varbinary>, Varchar, Varbinary>(
-      {prefix + "md5"});
+  registerFunction<Md5Function, Varchar, Varbinary>({prefix + "md5"});
 
   exec::registerStatefulVectorFunction(
       prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
@@ -120,11 +119,12 @@ void registerFunctions(const std::string& prefix) {
   registerCompareFunctions(prefix);
 
   // String sreach function
-  registerFunction<udf_starts_with, bool, Varchar, Varchar>(
+  registerFunction<StartsWithFunction, bool, Varchar, Varchar>(
       {prefix + "startswith"});
-  registerFunction<udf_ends_with, bool, Varchar, Varchar>(
+  registerFunction<EndsWithFunction, bool, Varchar, Varchar>(
       {prefix + "endswith"});
-  registerFunction<udf_contains, bool, Varchar, Varchar>({prefix + "contains"});
+  registerFunction<ContainsFunction, bool, Varchar, Varchar>(
+      {prefix + "contains"});
 
   // Register array sort functions.
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -22,33 +22,41 @@
 
 namespace facebook::velox::functions::sparksql {
 
-VELOX_UDF_BEGIN(ascii)
-FOLLY_ALWAYS_INLINE bool call(int32_t& result, const arg_type<Varchar>& s) {
-  result = s.empty() ? 0 : s.data()[0];
-  return true;
-}
-VELOX_UDF_END();
+template <typename T>
+struct AsciiFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
-VELOX_UDF_BEGIN(chr)
-FOLLY_ALWAYS_INLINE bool call(out_type<Varchar>& result, int64_t ord) {
-  if (ord < 0) {
-    result.resize(0);
-  } else {
-    result.resize(1);
-    *result.data() = ord;
+  FOLLY_ALWAYS_INLINE bool call(int32_t& result, const arg_type<Varchar>& s) {
+    result = s.empty() ? 0 : s.data()[0];
+    return true;
   }
-  return true;
-}
-VELOX_UDF_END();
+};
 
-template <typename To, typename From>
-VELOX_UDF_BEGIN(md5)
-FOLLY_ALWAYS_INLINE
-    bool call(out_type<To>& result, const arg_type<From>& input) {
-  stringImpl::md5_radix(result, input, 16);
-  return true;
-}
-VELOX_UDF_END();
+template <typename T>
+struct ChrFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(out_type<Varchar>& result, int64_t ord) {
+    if (ord < 0) {
+      result.resize(0);
+    } else {
+      result.resize(1);
+      *result.data() = ord;
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct Md5Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TTo, typename TFrom>
+  FOLLY_ALWAYS_INLINE bool call(TTo& result, const TFrom& input) {
+    stringImpl::md5_radix(result, input, 16);
+    return true;
+  }
+};
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> instrSignatures();
 
@@ -66,59 +74,69 @@ std::shared_ptr<exec::VectorFunction> makeLength(
 /// contains(string, string) -> bool
 /// Searches the second argument in the first one.
 /// Returns true if it is found
-VELOX_UDF_BEGIN(contains)
-FOLLY_ALWAYS_INLINE bool call(
-    out_type<bool>& result,
-    const arg_type<Varchar>& str,
-    const arg_type<Varchar>& pattern) {
-  result = std::string_view(str).find(std::string_view(pattern)) !=
-      std::string_view::npos;
-  return true;
-}
-VELOX_UDF_END();
+template <typename T>
+struct ContainsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& str,
+      const arg_type<Varchar>& pattern) {
+    result = std::string_view(str).find(std::string_view(pattern)) !=
+        std::string_view::npos;
+    return true;
+  }
+};
 
 /// startsWith function
 /// startsWith(string, string) -> bool
 /// Returns true if the first string starts with the second string
-VELOX_UDF_BEGIN(starts_with)
-FOLLY_ALWAYS_INLINE bool call(
-    out_type<bool>& result,
-    const arg_type<Varchar>& str,
-    const arg_type<Varchar>& pattern) {
-  auto str1 = std::string_view(str);
-  auto str2 = std::string_view(pattern);
-  // TODO: Once C++20 supported we may want to replace this with
-  // string_view::starts_with
+template <typename T>
+struct StartsWithFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  if (str2.length() > str1.length()) {
-    result = false;
-  } else {
-    result = str1.substr(0, str2.length()) == str2;
-    ;
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& str,
+      const arg_type<Varchar>& pattern) {
+    auto str1 = std::string_view(str);
+    auto str2 = std::string_view(pattern);
+    // TODO: Once C++20 supported we may want to replace this with
+    // string_view::starts_with
+
+    if (str2.length() > str1.length()) {
+      result = false;
+    } else {
+      result = str1.substr(0, str2.length()) == str2;
+      ;
+    }
+    return true;
   }
-  return true;
-}
-VELOX_UDF_END();
+};
 
 /// endsWith function
 /// endsWith(string, string) -> bool
 /// Returns true if the first string ends with the second string
-VELOX_UDF_BEGIN(ends_with)
-FOLLY_ALWAYS_INLINE bool call(
-    out_type<bool>& result,
-    const arg_type<Varchar>& str,
-    const arg_type<Varchar>& pattern) {
-  auto str1 = std::string_view(str);
-  auto str2 = std::string_view(pattern);
-  // TODO Once C++20 supported we may want to replace this with
-  // string_view::ends_with
-  if (str2.length() > str1.length()) {
-    result = false;
-  } else {
-    result = str1.substr(str1.length() - str2.length(), str2.length()) == str2;
+template <typename T>
+struct EndsWithFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& str,
+      const arg_type<Varchar>& pattern) {
+    auto str1 = std::string_view(str);
+    auto str2 = std::string_view(pattern);
+    // TODO Once C++20 supported we may want to replace this with
+    // string_view::ends_with
+    if (str2.length() > str1.length()) {
+      result = false;
+    } else {
+      result =
+          str1.substr(str1.length() - str2.length(), str2.length()) == str2;
+    }
+    return true;
   }
-  return true;
-}
-VELOX_UDF_END();
+};
 
 } // namespace facebook::velox::functions::sparksql


### PR DESCRIPTION
Summary: Migrate last Spark functions to new API

Reviewed By: funrollloops

Differential Revision: D33271846

