### PR TITLE
Fix incorrect assert in SelectiveColumnReader and add seeds to BatchMaker::createBatch()

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -300,7 +300,7 @@ bool SelectiveColumnReader::shouldMoveNulls(RowSet rows) {
   if (anyNulls_) {
     VELOX_CHECK(
         resultNulls_ && resultNulls_->as<uint64_t>() == rawResultNulls_);
-    VELOX_CHECK_GT(resultNulls_->capacity() * 8, rows.back());
+    VELOX_CHECK_GT(resultNulls_->capacity() * 8, rows.size());
     return true;
   }
   return false;
@@ -3730,7 +3730,6 @@ void SelectiveStringDictionaryColumnReader::read(
   bool isDense = rows.back() == rows.size() - 1;
   const auto* nullsPtr =
       nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-  vector_size_t numRows = rows.back() + 1;
   // lazy loading dictionary data when first hit
   ensureInitialized();
 

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -89,7 +89,7 @@ class E2EFilterTest : public testing::Test {
     batches_.clear();
     for (size_t i = 0; i < batchCount; ++i) {
       batches_.push_back(std::static_pointer_cast<RowVector>(
-          BatchMaker::createBatch(rowType_, size, *pool_)));
+          BatchMaker::createBatch(rowType_, size, *pool_, nullptr, i)));
     }
     if (customizeData) {
       customizeData();

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <folly/Random.h>
+#include <random>
 #include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
@@ -79,7 +80,7 @@ TEST(E2EWriterTests, DISABLED_TestFileCreation) {
   auto& pool = *scopedPool;
   std::vector<VectorPtr> batches;
   for (size_t i = 0; i < batchCount; ++i) {
-    batches.push_back(BatchMaker::createBatch(type, size, pool));
+    batches.push_back(BatchMaker::createBatch(type, size, pool, nullptr, i));
   }
 
   auto sink = std::make_unique<FileSink>("/tmp/e2e_generated_file.orc");
@@ -141,7 +142,7 @@ TEST(E2EWriterTests, E2E) {
 
   std::vector<VectorPtr> batches;
   for (size_t i = 0; i < batchCount; ++i) {
-    batches.push_back(BatchMaker::createBatch(type, size, pool));
+    batches.push_back(BatchMaker::createBatch(type, size, pool, nullptr, i));
     size = 200;
   }
 
@@ -486,7 +487,7 @@ void testFlatMapConfig(
   Writer writer{options, std::move(sink), pool};
 
   for (size_t i = 0; i < stripes; ++i) {
-    writer.write(BatchMaker::createBatch(type, size, pool));
+    writer.write(BatchMaker::createBatch(type, size, pool, nullptr, i));
   }
 
   writer.close();
@@ -804,7 +805,7 @@ class E2EEncryptionTest : public Test {
     writer_ = std::make_unique<Writer>(options, std::move(sink), pool);
 
     for (size_t i = 0; i < batchCount_; ++i) {
-      auto batch = BatchMaker::createBatch(type, batchSize_, pool);
+      auto batch = BatchMaker::createBatch(type, batchSize_, pool, nullptr, i);
       writer_->write(batch);
       batches_.push_back(std::move(batch));
       if (i % flushInterval_ == flushInterval_ - 1) {

--- a/velox/dwio/dwrf/test/utils/BatchMaker.cpp
+++ b/velox/dwio/dwrf/test/utils/BatchMaker.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include <folly/Random.h>
 #include <algorithm>
+#include <random>
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -581,8 +582,9 @@ VectorPtr BatchMaker::createBatch(
     const std::shared_ptr<const Type>& type,
     uint64_t capacity,
     MemoryPool& memoryPool,
-    std::function<bool(vector_size_t /*index*/)> isNullAt) {
-  std::mt19937 gen;
+    std::function<bool(vector_size_t /*index*/)> isNullAt,
+    std::mt19937::result_type seed) {
+  std::mt19937 gen(seed);
   return createBatch(type, capacity, memoryPool, gen, isNullAt);
 }
 

--- a/velox/dwio/dwrf/test/utils/BatchMaker.h
+++ b/velox/dwio/dwrf/test/utils/BatchMaker.h
@@ -34,7 +34,8 @@ struct BatchMaker {
       const std::shared_ptr<const Type>& type,
       uint64_t capacity,
       memory::MemoryPool& memoryPool,
-      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr);
+      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr,
+      std::mt19937::result_type seed = std::mt19937::default_seed);
 
   template <TypeKind KIND>
   static VectorPtr createVector(
@@ -49,8 +50,9 @@ struct BatchMaker {
       const std::shared_ptr<const Type>& type,
       size_t size,
       memory::MemoryPool& pool,
-      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr) {
-    std::mt19937 gen;
+      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr,
+      std::mt19937::result_type seed = std::mt19937::default_seed) {
+    std::mt19937 gen{seed};
     return createVector<KIND>(type, size, pool, gen, isNullAt);
   }
 };


### PR DESCRIPTION
Summary:
BatchMaker::createBatch() internally creates a std::mt19937 object to generate
random numbers, however, each time it is called it uses the same default seed,
this causes it to generate multiple same batches, which makes it much less
useful to test multiple batches. This diff allows the caller to pass a seed
to this function to generate differet batches.

When using this fixed version of createBatch() in E2EFilterTest, I found that
one of the assert in SelectivecColumnReader was not correct, and was causing
crash. So fixed that as well.

Differential Revision: D33590384

