### PR TITLE
Removing the old Task constructor (from PlanNode).

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -30,40 +30,6 @@ namespace facebook::velox::exec {
 
 Task::Task(
     const std::string& taskId,
-    std::shared_ptr<const core::PlanNode> planNode,
-    int destination,
-    std::shared_ptr<core::QueryCtx> queryCtx,
-    Consumer consumer,
-    std::function<void(std::exception_ptr)> onError)
-    : Task{
-          taskId,
-          std::move(planNode),
-          destination,
-          std::move(queryCtx),
-          (consumer ? [c = std::move(consumer)]() { return c; }
-                    : ConsumerSupplier{}),
-          std::move(onError)} {}
-
-Task::Task(
-    const std::string& taskId,
-    std::shared_ptr<const core::PlanNode> planNode,
-    int destination,
-    std::shared_ptr<core::QueryCtx> queryCtx,
-    ConsumerSupplier consumerSupplier,
-    std::function<void(std::exception_ptr)> onError)
-    : taskId_(taskId),
-      destination_(destination),
-      queryCtx_(std::move(queryCtx)),
-      consumerSupplier_(std::move(consumerSupplier)),
-      onError_(onError),
-      pool_(queryCtx_->pool()->addScopedChild("task_root")),
-      bufferManager_(
-          PartitionedOutputBufferManager::getInstance(queryCtx_->host())) {
-  planFragment_.planNode = std::move(planNode);
-}
-
-Task::Task(
-    const std::string& taskId,
     core::PlanFragment planFragment,
     int destination,
     std::shared_ptr<core::QueryCtx> queryCtx,

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -86,22 +86,6 @@ class Task {
  public:
   Task(
       const std::string& taskId,
-      std::shared_ptr<const core::PlanNode> planNode,
-      int destination,
-      std::shared_ptr<core::QueryCtx> queryCtx,
-      Consumer consumer = nullptr,
-      std::function<void(std::exception_ptr)> onError = nullptr);
-
-  Task(
-      const std::string& taskId,
-      std::shared_ptr<const core::PlanNode> planNode,
-      int destination,
-      std::shared_ptr<core::QueryCtx> queryCtx,
-      ConsumerSupplier consumerSupplier,
-      std::function<void(std::exception_ptr)> onError = nullptr);
-
-  Task(
-      const std::string& taskId,
       core::PlanFragment planFragment,
       int destination,
       std::shared_ptr<core::QueryCtx> queryCtx,

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -64,8 +64,9 @@ class MultiFragmentTest : public OperatorTestBase {
       int destination) {
     auto queryCtx = core::QueryCtx::createForTest(
         std::make_shared<core::MemConfig>(configSettings_));
+    core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
-        taskId, planNode, destination, std::move(queryCtx));
+        taskId, std::move(planFragment), destination, std::move(queryCtx));
   }
 
   void writeToFile(const std::string& filePath, RowVectorPtr vector) {

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -42,7 +42,9 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       int numDrivers) {
     auto queryCtx = core::QueryCtx::createForTest();
     bufferManager_->removeTask(taskId);
-    auto task = std::make_shared<Task>(taskId, nullptr, 0, std::move(queryCtx));
+    core::PlanFragment emptyPlanFragment;
+    auto task = std::make_shared<Task>(
+        taskId, std::move(emptyPlanFragment), 0, std::move(queryCtx));
 
     bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
     return task;

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -32,7 +32,8 @@ TEST_F(TaskTest, splitGroup) {
       100);
   core::PlanNodeId planNodeId{"0"};
   auto queryCtx = core::QueryCtx::createForTest();
-  exec::Task task("0", nullptr, 0, queryCtx);
+  core::PlanFragment emptyPlanFragment;
+  exec::Task task("0", std::move(emptyPlanFragment), 0, std::move(queryCtx));
 
   // This is the set of completed groups we expect.
   std::unordered_set<int32_t> completedSplitGroups;

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -118,9 +118,10 @@ TaskCursor::TaskCursor(const CursorParameters& params)
   queue_ = std::make_shared<TaskQueue>(numProducers, params.bufferedBytes);
   // Captured as a shared_ptr by the consumer callback of task_.
   auto queue = queue_;
+  core::PlanFragment planFragment{params.planNode};
   task_ = std::make_shared<exec::Task>(
       fmt::format("test_cursor {}", ++serial_),
-      params.planNode,
+      std::move(planFragment),
       params.destination,
       std::move(queryCtx),
       // consumer


### PR DESCRIPTION
Summary:
Removing the old Task constructor (from PlanNode).
We will use constructor from PlanFragment.

Note: Not exporting this to GitHub until the previous diff is landed.

Differential Revision: D33345172

