### PR TITLE
Enhance prestoSQL array_min and array_max performance.

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -60,8 +60,8 @@ struct ArrayMinMaxFunction {
     if (!array.mayHaveNulls()) {
       // Input array does not have nulls.
       auto currentValue = *array[0];
-      for (const auto& item : array) {
-        update(currentValue, item.value());
+      for (auto i = 1; i < array.size(); i++) {
+        update(currentValue, array[i].value());
       }
       assign(out, currentValue);
       return true;
@@ -74,13 +74,13 @@ struct ArrayMinMaxFunction {
     }
 
     auto currentValue = it->value();
-    it++;
+    ++it;
     while (it != array.end()) {
       if (!it->has_value()) {
         return false;
       }
       update(currentValue, it->value());
-      it++;
+      ++it;
     }
 
     assign(out, currentValue);
@@ -156,17 +156,4 @@ FOLLY_ALWAYS_INLINE bool call(
 
 VELOX_UDF_END();
 
-template <typename T>
-inline void registerArrayMinMaxFunctions() {
-  registerFunction<ArrayMinFunction, T, Array<T>>({"array_min"});
-  registerFunction<ArrayMaxFunction, T, Array<T>>({"array_max"});
-}
-
-template <typename T>
-inline void registerArrayJoinFunctions() {
-  registerFunction<udf_array_join<T>, Varchar, Array<T>, Varchar>(
-      {"array_join"});
-  registerFunction<udf_array_join<T>, Varchar, Array<T>, Varchar, Varchar>(
-      {"array_join"});
-}
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -19,6 +19,19 @@
 #include "velox/functions/prestosql/WidthBucketArray.h"
 
 namespace facebook::velox::functions {
+template <typename T>
+inline void registerArrayMinMaxFunctions() {
+  registerFunction<ArrayMinFunction, T, Array<T>>({"array_min"});
+  registerFunction<ArrayMaxFunction, T, Array<T>>({"array_max"});
+}
+
+template <typename T>
+inline void registerArrayJoinFunctions() {
+  registerFunction<udf_array_join<T>, Varchar, Array<T>, Varchar>(
+      {"array_join"});
+  registerFunction<udf_array_join<T>, Varchar, Array<T>, Varchar, Varchar>(
+      {"array_join"});
+}
 
 void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");


### PR DESCRIPTION
Summary:
Avoid double reading the first element.
simple is even faster than vector now, considerably.

Reviewed By: mbasmanova

Differential Revision: D33555800

