### PR TITLE
Fix Task initialization order

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -55,9 +55,9 @@ Task::Task(
       planFragment_(std::move(planFragment)),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
+      pool_(queryCtx_->pool()->addScopedChild("task_root")),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
-      pool_(queryCtx_->pool()->addScopedChild("task_root")),
       bufferManager_(
           PartitionedOutputBufferManager::getInstance(queryCtx_->host())) {}
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -509,6 +509,12 @@ class Task {
   core::PlanFragment planFragment_;
   const int destination_;
   std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::unique_ptr<velox::memory::MemoryPool> pool_;
+
+  // Keep driver and operator memory pools alive for the duration of the task to
+  // allow for sharing vectors across drivers without copy.
+  std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
+
   // True if produces output via PartitionedOutputBufferManager.
   bool hasPartitionedOutput_ = false;
   // Set to true by PartitionedOutputBufferManager when all output is
@@ -544,12 +550,6 @@ class Task {
   std::vector<VeloxPromise<bool>> stateChangePromises_;
 
   TaskStats taskStats_;
-  std::unique_ptr<velox::memory::MemoryPool> pool_;
-
-  // Keep driver and operator memory pools alive for the duration of the task to
-  // allow for sharing vectors across drivers without copy.
-  std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
-
   // Map from the plan node id of the join to the corresponding JoinBridge.
   // Guarded by 'mutex_'.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>> bridges_;


### PR DESCRIPTION
Declare queryCtx_ ahead of pool_. Move pool_ and queryCtx_ up in
declaration order so that pool_ is before items that may be allocated
from it, meaning that pool_ will be destructed after the items.
Move pool_ initialization in constructor to match declaration
order. Initializers are generally expected to reflect the order of
declaration.

Previous Task construction crashes at least with gcc 10.3.1.

