### PR TITLE
Fix map() Presto function

### DIFF
--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -170,3 +170,43 @@ TEST_F(MapTest, encodings) {
       evaluate<MapVector>("map(c0, c1)", makeRowVector({keys, values}));
   assertEqualVectors(expectedMap, result);
 }
+
+// Test map function applied to a constant array of keys and flat array of
+// values.
+TEST_F(MapTest, constantKeys) {
+  auto size = 1'000;
+
+  auto sizeAt = [](vector_size_t /*row*/) { return 1; };
+  auto keyAt = [](vector_size_t /*row*/) { return "key"_sv; };
+  auto valueAt = [](vector_size_t row) { return row; };
+
+  auto expectedMap =
+      makeMapVector<StringView, int32_t>(size, sizeAt, keyAt, valueAt);
+
+  auto result = evaluate<MapVector>(
+      "map(array['key'], array_constructor(c0))",
+      makeRowVector({
+          makeFlatVector<int32_t>(size, valueAt),
+      }));
+  assertEqualVectors(expectedMap, result);
+}
+
+// Test map function applied to a flat array of keys and constant array of
+// values.
+TEST_F(MapTest, constantValues) {
+  auto size = 1'000;
+
+  auto sizeAt = [](vector_size_t /*row*/) { return 1; };
+  auto keyAt = [](vector_size_t row) { return row; };
+  auto valueAt = [](vector_size_t /*row*/) { return "value"_sv; };
+
+  auto expectedMap =
+      makeMapVector<int32_t, StringView>(size, sizeAt, keyAt, valueAt);
+
+  auto result = evaluate<MapVector>(
+      "map(array_constructor(c0), array['value'])",
+      makeRowVector({
+          makeFlatVector<int32_t>(size, keyAt),
+      }));
+  assertEqualVectors(expectedMap, result);
+}


### PR DESCRIPTION
Presto map() function applied to constant keys and flat values failed with an
error: `Malformed dictionary, index array is shorter than DictionaryVector`. It
also returned incorrect results when applied to flat keys and constant
values. 

The problem was due to result map re-using offsets from the keys vector. When
these offsets had duplicate values (due to having duplicate keys in case of a
constant or dictionary encoding) the resulting vector could only have duplicate
entries, e.g. it could not have two entries with same keys, but different
values.

The fix is to ensure that result map uses unique offset for each row and wrap
keys and values elements in a dictionary to translate the new offsets.