### PR TITLE
Add SsdCache to CachedBufferedInput

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -123,6 +123,15 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key) {
   }
 }
 
+std::string AsyncDataCacheEntry::toString() const {
+  return fmt::format(
+      "<entry key:{}:{} size {} pins {}>",
+      key_.fileNum.id(),
+      key_.offset,
+      size_,
+      numPins_);
+}
+
 std::unique_ptr<AsyncDataCacheEntry> CacheShard::getFreeEntryWithSize(
     uint64_t /*sizeHint*/) {
   std::unique_ptr<AsyncDataCacheEntry> newEntry;
@@ -194,6 +203,7 @@ CachePin CacheShard::findOrCreate(
     // Inside the shard mutex.
     VELOX_CHECK_EQ(0, entryToInit->size_);
     entryToInit->size_ = size;
+    entryToInit->isFirstUse_ = true;
   }
   return initEntry(key, entryToInit);
 }

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -230,6 +230,8 @@ class AsyncDataCacheEntry {
     groupId_ = groupId;
   }
 
+  std::string toString() const;
+
  private:
   void release();
   void addReference();

--- a/velox/common/caching/FileGroupStats.h
+++ b/velox/common/caching/FileGroupStats.h
@@ -23,6 +23,26 @@ namespace facebook::velox::cache {
 // Dummy implementation of SsdCache admission stats.
 class FileGroupStats {
  public:
+  // Records ScanTracker::recordReference at group level
+  void recordReference(
+      uint64_t /*fileId*/,
+      uint64_t /*groupId*/,
+      TrackingId /*trackingId*/,
+      int32_t /*bytes*/) {}
+
+  // Records ScanTracker::recordRead at group level
+  void recordRead(
+      uint64_t /*fileId*/,
+      uint64_t /*groupId*/,
+      TrackingId /*trackingId*/,
+      int32_t /*bytes*/) {}
+
+  // Records the existence of a distinct file inside 'groupId'
+  void recordFile(
+      uint64_t /*fileId*/,
+      uint64_t /*groupId*/,
+      int32_t /*numStripes*/) {}
+
   // Returns true if groupId, trackingId qualify the data to be cached to SSD.
   bool shouldSaveToSsd(uint64_t /*groupId*/, TrackingId /*trackingId*/) const {
     return true;

--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/caching/FileGroupStats.h"
 
 #include <sstream>
 
@@ -25,7 +26,11 @@ namespace facebook::velox::cache {
 void ScanTracker::recordReference(
     const TrackingId id,
     uint64_t bytes,
-    uint64_t /*groupId*/) {
+    uint64_t fileId,
+    uint64_t groupId) {
+  if (fileGroupStats_) {
+    fileGroupStats_->recordReference(fileId, groupId, id, bytes);
+  }
   std::lock_guard<std::mutex> l(mutex_);
   data_[id].incrementReference(bytes, loadQuantum_);
   sum_.incrementReference(bytes, loadQuantum_);
@@ -34,7 +39,11 @@ void ScanTracker::recordReference(
 void ScanTracker::recordRead(
     const TrackingId id,
     uint64_t bytes,
-    uint64_t /*groupId*/) {
+    uint64_t fileId,
+    uint64_t groupId) {
+  if (fileGroupStats_) {
+    fileGroupStats_->recordRead(fileId, groupId, id, bytes);
+  }
   std::lock_guard<std::mutex> l(mutex_);
   data_[id].incrementRead(bytes);
   sum_.incrementRead(bytes);

--- a/velox/common/caching/StringIdMap.h
+++ b/velox/common/caching/StringIdMap.h
@@ -55,6 +55,14 @@ class StringIdMap {
   // Increments the use count of 'id'.
   void addReference(uint64_t id);
 
+  // Returns a copy of the string associated with id or empty string if id has
+  // no string.
+  std::string string(uint64_t id) {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto it = idToString_.find(id);
+    return it == idToString_.end() ? "" : it->second.string;
+  }
+
  private:
   struct Entry {
     std::string string;

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -49,8 +49,18 @@ class CacheInputStream : public SeekableInputStream {
       override;
 
  private:
+  // Ensures that the current position is covered by 'pin_'.
   void loadPosition();
+
+  // Synchronously sets 'pin_' to cover 'region'.
   void loadSync(dwio::common::Region region);
+
+  // Returns true if there is an SSD ache and 'entry' is present there and
+  // successfully loaded.
+  bool loadFromSsd(
+      dwio::common::Region region,
+      cache::AsyncDataCacheEntry& entry);
+
   CachedBufferedInput* const bufferedInput_;
   cache::AsyncDataCache* const cache_;
   dwio::common::IoStatistics* ioStats_;

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -30,6 +30,7 @@ using cache::LoadState;
 using cache::RawFileCacheKey;
 using cache::ScanTracker;
 using cache::SsdFile;
+using cache::SsdPin;
 using cache::TrackingId;
 using memory::MappedMemory;
 
@@ -48,7 +49,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
   VELOX_CHECK_LE(region.offset + region.length, fileSize_);
   requests_.emplace_back(
       RawFileCacheKey{fileNum_, region.offset}, region.length, id);
-  tracker_->recordReference(id, region.length, groupId_);
+  tracker_->recordReference(id, region.length, fileNum_, groupId_);
   auto stream = std::make_unique<CacheInputStream>(
       this,
       ioStats_.get(),
@@ -132,49 +133,90 @@ std::vector<CacheRequest*> makeRequestParts(
   }
   return parts;
 }
+
+int32_t adjustedReadPct(const cache::TrackingData& trackingData) {
+  // When called, there will be one more reference that read, since references
+  // are counted before readig.
+  if (trackingData.numReferences < 2) {
+    return 0;
+  }
+  return (100 * trackingData.numReads) / (trackingData.numReferences - 1);
+}
 } // namespace
 
 void CachedBufferedInput::load(const dwio::common::LogType) {
   // 'requests_ is cleared on exit.
   auto requests = std::move(requests_);
+  cache::SsdFile* FOLLY_NULLABLE ssdFile = nullptr;
+  auto ssdCache = cache_->ssdCache();
+  if (ssdCache) {
+    ssdFile = &ssdCache->file(fileNum_);
+  }
   // Extra requests made for preloadable regions that are larger then
   // 'loadQuantum'.
   std::vector<std::unique_ptr<CacheRequest>> extraRequests;
-  std::vector<CacheRequest*> storageLoad;
-  for (auto& request : requests) {
-    cache::TrackingData trackingData;
-    if (!request.trackingId.empty()) {
-      trackingData = tracker_->trackingData(request.trackingId);
-    }
-    // Gather frequently accessed items in a list and see if they should be
-    // loaded together.
-    if (request.trackingId.empty() ||
-        (100 * trackingData.numReads) / (1 + trackingData.numReferences) >=
-            80) {
-      auto parts =
-          makeRequestParts(request, trackingData, loadQuantum_, extraRequests);
-      for (auto part : parts) {
-        if (cache_->exists(part->key)) {
-          continue;
+  // We loop over access frequency buckets. For example readPct 80
+  // will get all streams where 80% or more of the referenced data is
+  // actually loaded.
+  for (auto readPct : std::vector<int32_t>{80, 50, 20, 0}) {
+    std::vector<CacheRequest*> storageLoad;
+    std::vector<CacheRequest*> ssdLoad;
+    for (auto& request : requests) {
+      if (request.processed) {
+        continue;
+      }
+      cache::TrackingData trackingData;
+      if (!request.trackingId.empty()) {
+        trackingData = tracker_->trackingData(request.trackingId);
+      }
+      if (request.trackingId.empty() ||
+          adjustedReadPct(trackingData) >= readPct) {
+        request.processed = true;
+        auto parts = makeRequestParts(
+            request, trackingData, loadQuantum_, extraRequests);
+        for (auto part : parts) {
+          if (cache_->exists(part->key)) {
+            continue;
+          }
+          if (ssdFile) {
+            part->ssdPin = ssdFile->find(part->key);
+            if (!part->ssdPin.empty() &&
+                part->ssdPin.run().size() < part->size) {
+              LOG(INFO) << "IOERR: Ignorin SSD  shorter than requested: "
+                        << part->ssdPin.run().size() << " vs " << part->size;
+              part->ssdPin.clear();
+            }
+            if (!part->ssdPin.empty()) {
+              ssdLoad.push_back(part);
+              continue;
+            }
+          }
+          storageLoad.push_back(part);
         }
-        storageLoad.push_back(part);
       }
     }
+    makeLoads(std::move(storageLoad), isPrefetchPct(readPct));
+    makeLoads(std::move(ssdLoad), isPrefetchPct(readPct));
   }
-  makeLoads(std::move(storageLoad), true);
 }
 
 void CachedBufferedInput::makeLoads(
     std::vector<CacheRequest*> requests,
     bool prefetch) {
-  if (requests.size() < 2) {
+  if (requests.empty() || (requests.size() < 2 && !prefetch)) {
     return;
   }
+  bool isSsd = !requests[0]->ssdPin.empty();
+  int32_t maxDistance = isSsd ? 20000 : maxCoalesceDistance_;
   std::sort(
       requests.begin(),
       requests.end(),
       [&](const CacheRequest* left, const CacheRequest* right) {
-        return left->key.offset < right->key.offset;
+        if (isSsd) {
+          return left->ssdPin.run().offset() < right->ssdPin.run().offset();
+        } else {
+          return left->key.offset < right->key.offset;
+        }
       });
   // Combine adjacent short reads.
 
@@ -182,10 +224,13 @@ void CachedBufferedInput::makeLoads(
 
   coalesceIo<CacheRequest*, CacheRequest*>(
       requests,
-      maxCoalesceDistance_,
+      maxDistance,
       // Break batches up. Better load more short ones i parallel.
       40,
-      [&](int32_t index) { return requests[index]->key.offset; },
+      [&](int32_t index) {
+        return isSsd ? requests[index]->ssdPin.run().offset()
+                     : requests[index]->key.offset;
+      },
       [&](int32_t index) { return requests[index]->size; },
       [&](int32_t index) {
         return requests[index]->coalesces ? 1 : kNoCoalesce;
@@ -252,17 +297,18 @@ class DwrfCoalescedLoadBase : public cache::CoalescedLoad {
   }
 
  protected:
-  void
-  updateStats(const CoalesceIoStats& stats, bool isPrefetch, bool /*isSsd*/) {
+  void updateStats(const CoalesceIoStats& stats, bool isPrefetch, bool isSsd) {
     if (ioStats_) {
       ioStats_->incRawOverreadBytes(stats.extraBytes);
-      // Reading the file increments rawReadBytes. Reverse this
-      // increment here because actually accessing the data via
-      // CacheInputStream will do the increment.
-      ioStats_->incRawBytesRead(-stats.payloadBytes);
-
-      ioStats_->read().increment(stats.payloadBytes);
-
+      if (isSsd) {
+        ioStats_->ssdRead().increment(stats.payloadBytes);
+      } else {
+        // Reading the file increments rawReadBytes. Reverse this
+        // increment here because actually accessing the data via
+        // CacheInputStream will do the increment.
+        ioStats_->incRawBytesRead(-stats.payloadBytes);
+        ioStats_->read().increment(stats.payloadBytes);
+      }
       if (isPrefetch) {
         ioStats_->prefetch().increment(stats.payloadBytes);
       }
@@ -340,6 +386,37 @@ class DwrfCoalescedLoad : public DwrfCoalescedLoadBase {
   std::unique_ptr<AbstractInputStreamHolder> input_;
   const int32_t maxCoalesceDistance_;
 };
+
+// Represents a CoalescedLoad from local SSD cache.
+class SsdLoad : public DwrfCoalescedLoadBase {
+ public:
+  SsdLoad(
+      cache::AsyncDataCache& cache,
+      std::shared_ptr<dwio::common::IoStatistics> ioStats,
+      uint64_t groupId,
+      std::vector<CacheRequest*> requests)
+      : DwrfCoalescedLoadBase(cache, ioStats, groupId, std::move(requests)) {}
+
+  std::vector<CachePin> loadData(bool isPrefetch) override {
+    std::vector<SsdPin> ssdPins;
+    std::vector<CachePin> pins;
+    cache_.makePins(
+        keys_,
+        [&](int32_t index) { return sizes_[index]; },
+        [&](int32_t index, CachePin pin) {
+          pins.push_back(std::move(pin));
+          ssdPins.push_back(std::move(requests_[index].ssdPin));
+        });
+    if (pins.empty()) {
+      return pins;
+    }
+    assert(!ssdPins.empty()); // for lint.
+    auto stats = ssdPins[0].file()->load(ssdPins, pins);
+    updateStats(stats, isPrefetch, true);
+    return pins;
+  }
+};
+
 } // namespace
 
 void CachedBufferedInput::readRegion(
@@ -349,13 +426,17 @@ void CachedBufferedInput::readRegion(
     return;
   }
   std::shared_ptr<cache::CoalescedLoad> load;
-  load = std::make_shared<DwrfCoalescedLoad>(
-      *cache_,
-      streamSource_(),
-      ioStats_,
-      groupId_,
-      requests,
-      maxCoalesceDistance_);
+  if (!requests[0]->ssdPin.empty()) {
+    load = std::make_shared<SsdLoad>(*cache_, ioStats_, groupId_, requests);
+  } else {
+    load = std::make_shared<DwrfCoalescedLoad>(
+        *cache_,
+        streamSource_(),
+        ioStats_,
+        groupId_,
+        requests,
+        maxCoalesceDistance_);
+  }
   allCoalescedLoads_.push_back(load);
   coalescedLoads_.withWLock([&](auto& loads) {
     for (auto& request : requests) {

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/caching/FileGroupStats.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/dwio/common/InputStream.h"
@@ -56,6 +57,8 @@ struct CacheRequest {
   uint64_t size;
   cache::TrackingId trackingId;
   cache::CachePin pin;
+  cache::SsdPin ssdPin;
+
   bool processed{false};
 
   // True if this should be coalesced into a CoalescedLoad with other
@@ -63,7 +66,7 @@ struct CacheRequest {
   // for sparsely accessed large columns where hitting one piece
   // should not load the adjacent pieces.
   bool coalesces{true};
-  const SeekableInputStream* stream;
+  const SeekableInputStream* FOLLY_NONNULL stream;
 };
 
 class CachedBufferedInput : public BufferedInput {
@@ -71,13 +74,13 @@ class CachedBufferedInput : public BufferedInput {
   CachedBufferedInput(
       dwio::common::InputStream& input,
       memory::MemoryPool& pool,
-      dwio::common::DataCacheConfig* dataCacheConfig,
-      cache::AsyncDataCache* cache,
+      dwio::common::DataCacheConfig* FOLLY_NONNULL dataCacheConfig,
+      cache::AsyncDataCache* FOLLY_NONNULL cache,
       std::shared_ptr<cache::ScanTracker> tracker,
       uint64_t groupId,
       StreamSource streamSource,
       std::shared_ptr<dwio::common::IoStatistics> ioStats,
-      folly::Executor* executor,
+      folly::Executor* FOLLY_NULLABLE executor,
       int32_t loadQuantum,
       int32_t maxCoalesceDistance)
       : BufferedInput(input, pool, dataCacheConfig),
@@ -104,7 +107,7 @@ class CachedBufferedInput : public BufferedInput {
 
   std::unique_ptr<SeekableInputStream> enqueue(
       dwio::common::Region region,
-      const StreamIdentifier* si) override;
+      const StreamIdentifier* FOLLY_NULLABLE si) override;
 
   void load(const dwio::common::LogType) override;
 
@@ -121,7 +124,13 @@ class CachedBufferedInput : public BufferedInput {
     return true;
   }
 
-  cache::AsyncDataCache* cache() const {
+  void setNumStripes(int32_t numStripes) override {
+    if (tracker_->fileGroupStats()) {
+      tracker_->fileGroupStats()->recordFile(fileNum_, groupId_, numStripes);
+    }
+  }
+
+  cache::AsyncDataCache* FOLLY_NONNULL cache() const {
     return cache_;
   }
 
@@ -130,7 +139,7 @@ class CachedBufferedInput : public BufferedInput {
   // call for 'stream' since the load is to be triggered by the first
   // access.
   std::shared_ptr<cache::CoalescedLoad> coalescedLoad(
-      const SeekableInputStream* stream);
+      const SeekableInputStream* FOLLY_NONNULL stream);
 
  private:
   // Sorts requests and makes CoalescedLoads for nearby requests. If 'prefetch'
@@ -141,15 +150,16 @@ class CachedBufferedInput : public BufferedInput {
   // IO is appropriate. If 'prefetch' is set, schedules the CoalescedLoad
   // on 'executor_'. Links the CoalescedLoad  to all CacheInputStreams that it
   // concerns.
+
   void readRegion(std::vector<CacheRequest*> requests, bool prefetch);
 
-  cache::AsyncDataCache* cache_;
+  cache::AsyncDataCache* FOLLY_NONNULL cache_;
   const uint64_t fileNum_;
   std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
   StreamSource streamSource_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
-  folly::Executor* const executor_;
+  folly::Executor* const FOLLY_NULLABLE executor_;
 
   // Regions that are candidates for loading.
   std::vector<CacheRequest> requests_;
@@ -171,12 +181,12 @@ class CachedBufferedInput : public BufferedInput {
 class CachedBufferedInputFactory : public BufferedInputFactory {
  public:
   CachedBufferedInputFactory(
-      cache::AsyncDataCache* cache,
+      cache::AsyncDataCache* FOLLY_NONNULL cache,
       std::shared_ptr<cache::ScanTracker> tracker,
       uint64_t groupId,
       StreamSource streamSource,
       std::shared_ptr<dwio::common::IoStatistics> ioStats,
-      folly::Executor* executor,
+      folly::Executor* FOLLY_NULLABLE executor,
       const dwio::common::ReaderOptions& readerOpts)
       : cache_(cache),
         tracker_(std::move(tracker)),
@@ -190,7 +200,8 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
   std::unique_ptr<BufferedInput> create(
       dwio::common::InputStream& input,
       velox::memory::MemoryPool& pool,
-      dwio::common::DataCacheConfig* dataCacheConfig = nullptr) const override {
+      dwio::common::DataCacheConfig* FOLLY_NULLABLE dataCacheConfig =
+          nullptr) const override {
     return std::make_unique<CachedBufferedInput>(
         input,
         pool,
@@ -212,13 +223,17 @@ class CachedBufferedInputFactory : public BufferedInputFactory {
     return "";
   }
 
+  folly::Executor* FOLLY_NULLABLE executor() const override {
+    return executor_;
+  }
+
  private:
-  cache::AsyncDataCache* const cache_;
+  cache::AsyncDataCache* const FOLLY_NONNULL cache_;
   std::shared_ptr<cache::ScanTracker> tracker_;
   const uint64_t groupId_;
   StreamSource streamSource_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
-  folly::Executor* executor_;
+  folly::Executor* FOLLY_NULLABLE executor_;
   int32_t loadQuantum_;
   int32_t maxCoalesceDistance_;
 };


### PR DESCRIPTION
Adds wiring to CacheInputStream and CachedBufferedInput for reading
from SsdCache where possible.  Adds accounting of file and file group
level access to ScanTracker/FileGroupStats. FileGroupStats is a
placeholder for logic for deciding which data to stage on SSD.

CachedBufferedInput divides enqueued regions between RAM, SSD and
storage. Such a division is made for different access frequency
buckets. Columns that are accessed at the same frequency are assumed
to be correlated. This is a reasonable assumption in uses that do a
conjunction of column filters. Loads are coalesced within these
buckets. Loads of the most densely accessed bucket are scheduled on an
executor for prefetching if the executor is supplied. Other loads are
made on first use, combining all nearby loads in one IO.

When accessing a single addressable unit, e.g. values or nulls of a
column, we look up the entry in the RAM cache, then in the SSD cache
and finally load from storage. An entry can be cached with a different
length than requested if we have loads using a different load
quantum. If the entry that is found in a cache is shorter than the
requested size, the entry is ignored and will be replaced by a fresh
longer entry. If loading an entry rom SSD fails, we log the error and
proceed to load the data from storage, We remove said entry from SSD
so as not to repeatedly hit the same error.