### PR TITLE
Ensure evaluation always returns a valid vector.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -168,6 +168,8 @@ void Expr::evalSimplifiedImpl(
     EvalCtx* context,
     VectorPtr* result) {
   if (!rows.hasSelections()) {
+    // empty input, return an empty vector of the right type
+    *result = BaseVector::createNullConstant(type(), 0, context->pool());
     return;
   }
 
@@ -219,6 +221,8 @@ void Expr::eval(
     EvalCtx* context,
     VectorPtr* result) {
   if (!rows.hasSelections()) {
+    // empty input, return an empty vector of the right type
+    *result = BaseVector::createNullConstant(type(), 0, context->pool());
     return;
   }
 
@@ -638,6 +642,8 @@ void Expr::evalWithNulls(
     EvalCtx* context,
     VectorPtr* result) {
   if (!rows.hasSelections()) {
+    // empty input, return an empty vector of the right type
+    *result = BaseVector::createNullConstant(type(), 0, context->pool());
     return;
   }
 
@@ -854,6 +860,8 @@ void Expr::evalAll(
     EvalCtx* context,
     VectorPtr* result) {
   if (!rows.hasSelections()) {
+    // empty input, return an empty vector of the right type
+    *result = BaseVector::createNullConstant(type(), 0, context->pool());
     return;
   }
   if (isSpecialForm()) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2418,3 +2418,9 @@ TEST_F(ExprTest, accessNestedConstantEncoding) {
 
   assertEqualVectors(makeConstantVector(3, 5), result);
 }
+
+TEST_F(ExprTest, testEmptyVectors) {
+  auto a = makeFlatVector<int32_t>({});
+  auto result = evaluate("c0 + c0", makeRowVector({a, a}));
+  assertEqualVectors(a, result);
+}


### PR DESCRIPTION
Summary:
Previously evaluating an expression with an empty vector / no
input rows doesn't populate result, leading to an easy source of SEGV
unless every client of Velox explicitly checks for, and works around
this. Here we simplify the client logic and make it safer by returning
an empty vector of the correct type rather than a null result.

A great live example of a SEGV in practice:
https://github.com/facebookresearch/torcharrow/issues/35

Reviewed By: pedroerp

Differential Revision: D33716916

