### PR TITLE
Implement grouped execution

### DIFF
--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -95,7 +95,8 @@ void CrossJoinBuild::noMoreInput() {
   }
 
   operatorCtx_->task()
-      ->getCrossJoinBridge(planNodeId())
+      ->getCrossJoinBridge(
+          operatorCtx_->driverCtx()->splitGroupId, planNodeId())
       ->setData(std::move(data_));
 }
 

--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -62,9 +62,11 @@ BlockingReason CrossJoinProbe::isBlocked(ContinueFuture* future) {
     return BlockingReason::kNotBlocked;
   }
 
-  auto buildData = operatorCtx_->task()
-                       ->getCrossJoinBridge(planNodeId())
-                       ->dataOrFuture(future);
+  auto buildData =
+      operatorCtx_->task()
+          ->getCrossJoinBridge(
+              operatorCtx_->driverCtx()->splitGroupId, planNodeId())
+          ->dataOrFuture(future);
   if (!buildData.has_value()) {
     return BlockingReason::kWaitForJoinBuild;
   }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -61,7 +61,8 @@ DriverCtx::DriverCtx(
     std::shared_ptr<Task> _task,
     int _driverId,
     int _pipelineId,
-    int32_t _numDrivers)
+    uint32_t _splitGroupId,
+    uint32_t _partitionId)
     : task(_task),
       execCtx(std::make_unique<core::ExecCtx>(
           task->addDriverPool(),
@@ -70,7 +71,8 @@ DriverCtx::DriverCtx(
           std::make_unique<SimpleExpressionEvaluator>(execCtx.get())),
       driverId(_driverId),
       pipelineId(_pipelineId),
-      numDrivers(_numDrivers) {}
+      splitGroupId(_splitGroupId),
+      partitionId(_partitionId) {}
 
 velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
   return task->addOperatorPool(execCtx->pool());
@@ -625,7 +627,7 @@ std::string Driver::label() const {
   return fmt::format("<Driver {}:{}>", ctx_->task->taskId(), ctx_->driverId);
 }
 
-std::string BlockingReasonToString(BlockingReason reason) {
+std::string blockingReasonToString(BlockingReason reason) {
   switch (reason) {
     case BlockingReason::kNotBlocked:
       return "kNotBlocked";
@@ -640,7 +642,8 @@ std::string BlockingReasonToString(BlockingReason reason) {
     case BlockingReason::kWaitForMemory:
       return "kWaitForMemory";
   }
-  return "<Unknown Blocking Reason>";
+  VELOX_UNREACHABLE();
+  return "";
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -243,7 +243,7 @@ bool Exchange::getSplits(ContinueFuture* future) {
   for (;;) {
     exec::Split split;
     auto reason = operatorCtx_->task()->getSplitOrFuture(
-        operatorCtx_->driverCtx()->driverId, planNodeId_, split, *future);
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId_, split, *future);
     if (reason == BlockingReason::kNotBlocked) {
       if (split.hasConnectorSplit()) {
         auto remoteSplit = std::dynamic_pointer_cast<RemoteConnectorSplit>(

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -219,7 +219,8 @@ void HashBuild::noMoreInput() {
 
   if (antiJoinHasNullKeys_) {
     operatorCtx_->task()
-        ->getHashJoinBridge(planNodeId())
+        ->getHashJoinBridge(
+            operatorCtx_->driverCtx()->splitGroupId, planNodeId())
         ->setAntiJoinHasNullKeys();
   } else {
     table_->prepareJoinTable(std::move(otherTables));
@@ -227,7 +228,8 @@ void HashBuild::noMoreInput() {
     addRuntimeStats();
 
     operatorCtx_->task()
-        ->getHashJoinBridge(planNodeId())
+        ->getHashJoinBridge(
+            operatorCtx_->driverCtx()->splitGroupId, planNodeId())
         ->setHashTable(std::move(table_));
   }
 }

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -166,9 +166,11 @@ BlockingReason HashProbe::isBlocked(ContinueFuture* future) {
     return BlockingReason::kNotBlocked;
   }
 
-  auto hashBuildResult = operatorCtx_->task()
-                             ->getHashJoinBridge(planNodeId())
-                             ->tableOrFuture(future);
+  auto hashBuildResult =
+      operatorCtx_->task()
+          ->getHashJoinBridge(
+              operatorCtx_->driverCtx()->splitGroupId, planNodeId())
+          ->tableOrFuture(future);
   if (!hashBuildResult.has_value()) {
     return BlockingReason::kWaitForJoinBuild;
   }

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -188,9 +188,10 @@ LocalExchangeSourceOperator::LocalExchangeSourceOperator(
           planNodeId,
           "LocalExchangeSource"),
       partition_{partition},
-      source_{
-          operatorCtx_->task()->getLocalExchangeSource(planNodeId, partition)} {
-}
+      source_{operatorCtx_->task()->getLocalExchangeSource(
+          ctx->splitGroupId,
+          planNodeId,
+          partition)} {}
 
 BlockingReason LocalExchangeSourceOperator::isBlocked(ContinueFuture* future) {
   if (blockingReason_ != BlockingReason::kNotBlocked) {
@@ -230,7 +231,9 @@ LocalPartition::LocalPartition(
           operatorId,
           planNode->id(),
           "LocalPartition"),
-      localExchangeSources_{ctx->task->getLocalExchangeSources(planNode->id())},
+      localExchangeSources_{ctx->task->getLocalExchangeSources(
+          ctx->splitGroupId,
+          planNode->id())},
       numPartitions_{localExchangeSources_.size()},
       partitionFunction_(
           numPartitions_ == 1

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/LocalPlanner.h"
-#include "velox/exec/Aggregate.h"
+#include "velox/core/PlanFragment.h"
 #include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/CallbackSink.h"
 #include "velox/exec/CrossJoinBuild.h"
@@ -75,7 +75,8 @@ OperatorSupplier makeConsumerSupplier(
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
     return [](int32_t operatorId, DriverCtx* ctx) {
       auto consumer = [ctx](RowVectorPtr input, ContinueFuture* future) {
-        auto mergeSource = ctx->task->getLocalMergeSource(ctx->driverId);
+        auto mergeSource =
+            ctx->task->getLocalMergeSource(ctx->splitGroupId, ctx->partitionId);
         return mergeSource->enqueue(input, future);
       };
       return std::make_unique<CallbackSink>(operatorId, ctx, consumer);
@@ -108,7 +109,8 @@ OperatorSupplier makeConsumerSupplier(
           std::dynamic_pointer_cast<const core::MergeJoinNode>(planNode)) {
     auto planNodeId = planNode->id();
     return [planNodeId](int32_t operatorId, DriverCtx* ctx) {
-      auto source = ctx->task->getMergeJoinSource(planNodeId);
+      auto source =
+          ctx->task->getMergeJoinSource(ctx->splitGroupId, planNodeId);
       auto consumer = [source](RowVectorPtr input, ContinueFuture* future) {
         return source->enqueue(input, future);
       };
@@ -220,11 +222,12 @@ uint32_t maxDrivers(
 
 // static
 void LocalPlanner::plan(
-    const std::shared_ptr<const core::PlanNode>& planNode,
+    const core::PlanFragment& planFragment,
     ConsumerSupplier consumerSupplier,
-    std::vector<std::unique_ptr<DriverFactory>>* driverFactories) {
+    std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
+    uint32_t maxDrivers) {
   detail::plan(
-      planNode,
+      planFragment.planNode,
       nullptr,
       detail::makeConsumerSupplier(consumerSupplier),
       driverFactories);
@@ -233,6 +236,17 @@ void LocalPlanner::plan(
 
   for (auto& factory : *driverFactories) {
     factory->maxDrivers = detail::maxDrivers(factory->planNodes);
+    factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
+    // For grouped/bucketed execution we would have separate groups of drivers
+    // dealing with separate split groups (one driver can access splits from
+    // only one designated split group), hence we will have total number of
+    // drivers multiplied by the number of split groups.
+    if (planFragment.isGroupedExecution()) {
+      factory->numTotalDrivers =
+          factory->numDrivers * planFragment.numSplitGroups;
+    } else {
+      factory->numTotalDrivers = factory->numDrivers;
+    }
   }
 }
 
@@ -338,13 +352,16 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
       auto localMergeOp =
           std::make_unique<LocalMerge>(id, ctx.get(), numSources, localMerge);
       ctx->task->createLocalMergeSources(
-          numSources, localMergeOp->outputType(), localMergeOp->mappedMemory());
+          ctx->splitGroupId,
+          numSources,
+          localMergeOp->outputType(),
+          localMergeOp->mappedMemory());
       operators.push_back(std::move(localMergeOp));
     } else if (
         auto mergeJoin =
             std::dynamic_pointer_cast<const core::MergeJoinNode>(planNode)) {
       auto mergeJoinOp = std::make_unique<MergeJoin>(id, ctx.get(), mergeJoin);
-      ctx->task->createMergeJoinSource(mergeJoin->id());
+      ctx->task->createMergeJoinSource(ctx->splitGroupId, mergeJoin->id());
       operators.push_back(std::move(mergeJoinOp));
     } else if (
         auto localPartitionNode =
@@ -355,7 +372,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
           ctx.get(),
           localPartitionNode->outputType(),
           localPartitionNode->id(),
-          ctx->driverId));
+          ctx->partitionId));
     } else if (
         auto unnest =
             std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {

--- a/velox/exec/LocalPlanner.h
+++ b/velox/exec/LocalPlanner.h
@@ -15,16 +15,20 @@
  */
 #pragma once
 
-#include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
+
+namespace facebook::velox::core {
+struct PlanFragment;
+} // namespace facebook::velox::core
 
 namespace facebook::velox::exec {
 
 class LocalPlanner {
  public:
   static void plan(
-      const std::shared_ptr<const core::PlanNode>& planNode,
+      const core::PlanFragment& planFragment,
       ConsumerSupplier consumerSupplier,
-      std::vector<std::unique_ptr<DriverFactory>>* driverFactories);
+      std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
+      uint32_t maxDrivers);
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -183,7 +183,8 @@ BlockingReason LocalMerge::addMergeSources(ContinueFuture* /* future */) {
   if (sources_.size() != numSources_) {
     sources_.reserve(numSources_);
     for (auto i = 0; i < numSources_; ++i) {
-      sources_.emplace_back(operatorCtx_->task()->getLocalMergeSource(i));
+      sources_.emplace_back(operatorCtx_->task()->getLocalMergeSource(
+          operatorCtx_->driverCtx()->splitGroupId, i));
     }
   }
   return BlockingReason::kNotBlocked;
@@ -214,7 +215,7 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   for (;;) {
     exec::Split split;
     auto reason = operatorCtx_->task()->getSplitOrFuture(
-        operatorCtx_->driverCtx()->driverId, planNodeId_, split, *future);
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId_, split, *future);
     if (reason == BlockingReason::kNotBlocked) {
       if (split.hasConnectorSplit()) {
         auto remoteSplit = std::dynamic_pointer_cast<RemoteConnectorSplit>(

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -262,7 +262,8 @@ RowVectorPtr MergeJoin::getOutput() {
     // Check if we need to get more data from the right side.
     if (!noMoreRightInput_ && !future_.valid() && !rightInput_) {
       if (!rightSource_) {
-        rightSource_ = operatorCtx_->task()->getMergeJoinSource(planNodeId());
+        rightSource_ = operatorCtx_->task()->getMergeJoinSource(
+            operatorCtx_->driverCtx()->splitGroupId, planNodeId());
       }
       auto blockingReason = rightSource_->next(&future_, &rightInput_);
       if (blockingReason != BlockingReason::kNotBlocked) {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -45,7 +45,7 @@ RowVectorPtr TableScan::getOutput() {
     if (needNewSplit_) {
       exec::Split split;
       auto reason = driverCtx_->task->getSplitOrFuture(
-          driverCtx_->driverId, planNodeId_, split, blockingFuture_);
+          driverCtx_->splitGroupId, planNodeId_, split, blockingFuture_);
       if (reason != BlockingReason::kNotBlocked) {
         return nullptr;
       }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -113,7 +113,7 @@ class Task {
   // kWaitForSplit and sets a future that will complete when split becomes
   // available or no-more-splits signal is received.
   BlockingReason getSplitOrFuture(
-      int driverId,
+      uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
       exec::Split& split,
       ContinueFuture& future);
@@ -124,30 +124,41 @@ class Task {
 
   void updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
+  bool isGroupedExecution() const;
+
   void createLocalMergeSources(
+      uint32_t splitGroupId,
       unsigned numSources,
       const std::shared_ptr<const RowType>& rowType,
       memory::MappedMemory* FOLLY_NONNULL mappedMemory);
 
-  std::shared_ptr<MergeSource> getLocalMergeSource(int sourceId);
+  std::shared_ptr<MergeSource> getLocalMergeSource(
+      uint32_t splitGroupId,
+      int sourceId);
 
-  void createMergeJoinSource(const core::PlanNodeId& planNodeId);
+  void createMergeJoinSource(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
 
   std::shared_ptr<MergeJoinSource> getMergeJoinSource(
+      uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
   void createLocalExchangeSources(
       const core::PlanNodeId& planNodeId,
       int numPartitions);
 
-  void noMoreLocalExchangeProducers();
+  void noMoreLocalExchangeProducers(uint32_t splitGroupId);
 
   std::shared_ptr<LocalExchangeSource> getLocalExchangeSource(
+      uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
       int partition);
 
   const std::vector<std::shared_ptr<LocalExchangeSource>>&
-  getLocalExchangeSources(const core::PlanNodeId& planNodeId);
+  getLocalExchangeSources(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
 
   std::exception_ptr error() const {
     return exception_;
@@ -199,10 +210,12 @@ class Task {
   // separate probe and build. 'id' is the PlanNodeId shared between
   // the probe and build Operators of the join.
   std::shared_ptr<HashJoinBridge> getHashJoinBridge(
+      uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
   // Returns a CrossJoinBridge for 'planNodeId'.
   std::shared_ptr<CrossJoinBridge> getCrossJoinBridge(
+      uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
   // Sets this to a terminate requested
@@ -255,8 +268,28 @@ class Task {
   // timeout.
   ContinueFuture stateChangeFuture(uint64_t maxWaitMicros);
 
-  int32_t numDrivers() const {
-    return numDrivers_;
+  /// Returns the number of running drivers.
+  // TODO(spershin): Deprecate this method gradually.
+  uint32_t numDrivers() const {
+    std::lock_guard<std::mutex> taskLock(mutex_);
+    return numRunningDrivers_;
+  }
+
+  /// Returns the number of running drivers.
+  uint32_t numRunningDrivers() const {
+    std::lock_guard<std::mutex> taskLock(mutex_);
+    return numRunningDrivers_;
+  }
+
+  /// Returns the total number of drivers the task needs to run.
+  uint32_t numTotalDrivers() const {
+    return numTotalDrivers_;
+  }
+
+  /// Returns the number of finished drivers so far.
+  uint32_t numFinishedDrivers() const {
+    std::lock_guard<std::mutex> taskLock(mutex_);
+    return numFinishedDrivers_;
   }
 
   velox::memory::MemoryPool* FOLLY_NONNULL pool() const {
@@ -334,9 +367,33 @@ class Task {
   }
 
  private:
-  void driverClosedLocked();
+  template <class TBridgeType>
+  std::shared_ptr<TBridgeType> getJoinBridgeInternal(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
 
-  std::shared_ptr<ExchangeClient> addExchangeClient();
+  /// Retrieve a split or split future from the given split store structure.
+  BlockingReason getSplitOrFutureLocked(
+      SplitsStore& splitsStore,
+      exec::Split& split,
+      ContinueFuture& future);
+
+  /// Creates a bunch of drivers for the 'nextSplitGroupId_' and advances the
+  /// latter.
+  void createDrivers(
+      std::vector<std::shared_ptr<Driver>>& out,
+      std::shared_ptr<Task>& self);
+
+  /// Safely returns reference to the group splits store, ensuring before
+  /// accessing it that it is created.
+  inline SplitsStore& groupSplitsStoreSafe(
+      SplitsState& splitsState,
+      uint32_t splitGroupId) {
+    return splitsState.groupSplitsStores(
+        planFragment_.numSplitGroups)[splitGroupId];
+  }
+
+  void driverClosedLocked();
 
   void stateChangedLocked();
 
@@ -344,18 +401,26 @@ class Task {
   // splits coming for the task.
   bool isAllSplitsFinishedLocked();
 
+  /// See if we need to register a split group as completed.
   void checkGroupSplitsCompleteLocked(
-      std::unordered_map<int32_t, GroupSplitsInfo>& mapGroupSplits,
       int32_t splitGroupId,
-      std::unordered_map<int32_t, GroupSplitsInfo>::iterator it);
+      const SplitsStore& splitsStore);
 
   std::unique_ptr<ContinuePromise> addSplitLocked(
       SplitsState& splitsState,
       exec::Split&& split);
 
+  std::unique_ptr<ContinuePromise> addSplitToStoreLocked(
+      SplitsStore& splitsStore,
+      exec::Split&& split);
+
   void finished();
 
   StopReason shouldStopLocked();
+
+  void checkSplitGroupIndex(
+      uint32_t splitGroupId,
+      const char* FOLLY_NONNULL context);
 
  private:
   const std::string taskId_;
@@ -371,7 +436,8 @@ class Task {
   // kFinished.
   bool partitionedOutputConsumed_ = false;
 
-  // Exchange clients. One per pipeline / source.
+  /// Exchange clients. One per pipeline / source.
+  /// Null for pipelines, which don't need it.
   std::vector<std::shared_ptr<ExchangeClient>> exchangeClients_;
 
   // Set if terminated by an error. This is the first error reported
@@ -384,14 +450,30 @@ class Task {
 
   std::vector<std::unique_ptr<DriverFactory>> driverFactories_;
   std::vector<std::shared_ptr<Driver>> drivers_;
-  int32_t numDrivers_ = 0;
+  /// The total number of running drivers in all pipelines.
+  /// This number changes over time as drivers finish their work and maybe new
+  /// get created.
+  uint32_t numRunningDrivers_{0};
+  /// The total number of drivers we need to run in all pipelines. In normal
+  /// execution it is the sum of number of drivers for all pipelines. In grouped
+  /// execution we multiply that by the number of split groups.
+  uint32_t numTotalDrivers_{0};
+  /// The number of completed drivers so far.
+  /// This number increases over time as drivers finish their work.
+  /// We use this number to detect when the Task is completed.
+  uint32_t numFinishedDrivers_{0};
+  /// Reflects number of drivers required to process single split group during
+  /// grouped execution or the whole plan fragment during normal execution.
+  uint32_t numDriversPerSplitGroup_{0};
+  /// Used during grouped execution, indicates the next split group to process.
+  uint32_t nextSplitGroupId_{0};
+
   TaskState state_ = kRunning;
 
-  // We store separate splits state for each plan node.
+  /// Stores separate splits state for each plan node.
   std::unordered_map<core::PlanNodeId, SplitsState> splitsStates_;
 
-  // Holds states for pipelineBarrier(). Guarded by
-  // 'mutex_'.
+  // Holds states for pipelineBarrier(). Guarded by 'mutex_'.
   std::unordered_map<std::string, BarrierState> barriers_;
 
   std::vector<VeloxPromise<bool>> stateChangePromises_;
@@ -403,22 +485,9 @@ class Task {
   // allow for sharing vectors across drivers without copy.
   std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
 
-  // Map from the plan node id of the join to the corresponding JoinBridge.
-  // Guarded by 'mutex_'.
-  std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>> bridges_;
-
-  std::vector<std::shared_ptr<MergeSource>> localMergeSources_;
-
-  std::unordered_map<core::PlanNodeId, std::shared_ptr<MergeJoinSource>>
-      mergeJoinSources_;
-
-  struct LocalExchange {
-    std::unique_ptr<LocalExchangeMemoryManager> memoryManager;
-    std::vector<std::shared_ptr<LocalExchangeSource>> sources;
-  };
-
-  /// Map of local exchanges keyed on LocalPartition plan node ID.
-  std::unordered_map<core::PlanNodeId, LocalExchange> localExchanges_;
+  /// Stores inter-operator state (exchange, bridges) per split group.
+  /// During ungrouped execution we use the 1st entry in this vector.
+  std::vector<SplitGroupState> splitGroupStates_;
 
   std::weak_ptr<PartitionedOutputBufferManager> bufferManager_;
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -358,7 +358,7 @@ TEST_F(DriverTest, cancel) {
   auto future = tasks_[0]->finishFuture().via(&executor);
   future.wait();
   EXPECT_TRUE(stateFutures_.at(0).isReady());
-  EXPECT_EQ(tasks_[0]->numDrivers(), 0);
+  EXPECT_EQ(tasks_[0]->numRunningDrivers(), 0);
 }
 
 TEST_F(DriverTest, terminate) {
@@ -404,7 +404,7 @@ TEST_F(DriverTest, slow) {
   future.wait();
   // Note that the driver count drops after the last thread stops and
   // realizes the future.
-  EXPECT_WITH_DELAY(tasks_[0]->numDrivers() == 0);
+  EXPECT_WITH_DELAY(tasks_[0]->numRunningDrivers() == 0);
   const auto stats = tasks_[0]->taskStats().pipelineStats;
   ASSERT_TRUE(!stats.empty() && !stats[0].operatorStats.empty());
   // Check that the blocking of the CallbackSink at the end of the pipeline is
@@ -436,7 +436,7 @@ TEST_F(DriverTest, pause) {
   auto state = std::move(stateFuture).via(&executor);
   state.wait();
   EXPECT_EQ(state.value(), TaskState::kFinished);
-  EXPECT_EQ(tasks_[0]->numDrivers(), 0);
+  EXPECT_EQ(tasks_[0]->numRunningDrivers(), 0);
   const auto taskStats = tasks_[0]->taskStats();
   ASSERT_EQ(taskStats.pipelineStats.size(), 1);
   const auto& operators = taskStats.pipelineStats[0].operatorStats;


### PR DESCRIPTION
The first cut of support for grouped execution, when we receive splits in split groups and want to run each group separately to keep hashmaps smaller as in that cases the hash keys are guaranteed not to intersect between any two groups.

The change is somewhat larger than I would prefer due to me having little idea about how things worked prior to this diff and even now. :)

I will comment in one of the later versions of the diff why I did this or that.

The current implementation assumes that we only ever run single driver per whole split group and we can run multiple drivers each processing its own split group separately.
It is possible (with maybe some nor trivial nor super heavy changes) to support multiple drivers running one split group, but at the moment I think it would be best to make this version bullet proof.

There are no tests at the moment, except for single e2e test I've been running locally.
We'll hav to think what tests we want to subject this new functionality to.