### PR TITLE
Allocate vector when vectorptr passed to SelectiveColumnReader is nullptr

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -3995,6 +3995,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     if (childSpec->isConstant()) {
       continue;
     }
+
     auto childDataType = nodeType_->childByName(childSpec->fieldName());
     auto childRequestedType =
         requestedType_->childByName(childSpec->fieldName());
@@ -4055,6 +4056,9 @@ void SelectiveStructColumnReader::next(
     VectorPtr& result,
     const uint64_t* incomingNulls) {
   VELOX_CHECK(!incomingNulls, "next may only be called for the root reader.");
+  if (result == nullptr) {
+    result = velox::BaseVector::create(type_, numValues, &memoryPool_);
+  }
   if (children_.empty()) {
     // no readers
     // This can be either count(*) query or a query that select only

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
@@ -213,6 +213,16 @@ std::string FilterGenerator::specsToString(
   return out.str();
 }
 
+SubfieldFilters FilterGenerator::cloneSubfieldFilters(
+    const SubfieldFilters& src) {
+  SubfieldFilters copy;
+  for (const auto& sf : src) {
+    copy[Subfield(sf.first.toString())] = sf.second->clone();
+  }
+
+  return copy;
+}
+
 void FilterGenerator::collectFilterableSubFields(
     const RowType* rowType,
     std::vector<std::string>& subFields) {

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.h
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.h
@@ -312,6 +312,7 @@ std::unique_ptr<AbstractColumnStats> makeStats(
 class FilterGenerator {
  public:
   static std::string specsToString(const std::vector<FilterSpec>& specs);
+  static SubfieldFilters cloneSubfieldFilters(const SubfieldFilters& src);
 
   explicit FilterGenerator(std::shared_ptr<const RowType>& rowType)
       : rowType_(rowType) {


### PR DESCRIPTION
Summary: Allocate vector when VectorPtr passed to SelectiveColumnReader is nullptr.

Differential Revision: D33744747

