### PR TITLE
Add more checks and threads to AsyncDataCacheTest.ssd

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -131,4 +131,10 @@ std::string SsdCache::toString() const {
   return out.str();
 }
 
+void SsdCache::deleteFiles() {
+  for (auto& file : files_) {
+    file->deleteFile();
+  }
+}
+
 } // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -72,6 +72,9 @@ class SsdCache {
   // until new content is stored.
   void clear();
 
+  // Deletes backing files. Used in testing.
+  void deleteFiles();
+
   std::string toString() const;
 
  private:

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -73,7 +73,7 @@ SsdFile::SsdFile(
 #ifdef linux
   oDirect = FLAGS_ssd_odirect ? O_DIRECT : 0;
 #endif
-  fd_ = open(filename.c_str(), O_CREAT | O_RDWR | oDirect, S_IRUSR | S_IWUSR);
+  fd_ = open(filename_.c_str(), O_CREAT | O_RDWR | oDirect, S_IRUSR | S_IWUSR);
   if (fd_ < 0) {
     LOG(ERROR) << "Cannot open or create " << filename << " error " << errno;
     exit(1);
@@ -423,6 +423,17 @@ void SsdFile::clear() {
   std::fill(regionSize_.begin(), regionSize_.end(), 0);
   writableRegions_.resize(numRegions_);
   std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
+}
+
+void SsdFile::deleteFile() {
+  if (fd_) {
+    close(fd_);
+    fd_ = 0;
+  }
+  auto rc = unlink(filename_.c_str());
+  if (rc < 0) {
+    LOG(ERROR) << "Error deleting cache file " << filename_ << " rc: " << rc;
+  }
 }
 
 } // namespace facebook::velox::cache

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -192,6 +192,9 @@ class SsdFile {
   // Resets this' to a post-construction empty state. See SsdCache::clear().
   void clear();
 
+  // Deletes the backing file. Used in testing.
+  void deleteFile();
+
  private:
   // Increments the pin count of the region of 'offset'. Caller must hold
   // 'mutex_'.
@@ -260,8 +263,8 @@ class SsdFile {
   // Name of backing file.
   const std::string filename_;
 
-  // File descriptor.
-  int32_t fd_;
+  // File descriptor. 0 (stdin) means file not open.
+  int32_t fd_{0};
 
   // Size of the backing file in bytes. Must be multiple of kRegionSize.
   uint64_t fileSize_{0};

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
   velox_caching
   velox_memory
   velox_exception
+  velox_temp_path
   ${GTEST_BOTH_LIBRARIES}
   glog::glog
   ${gflags_LIBRARIES}

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -122,8 +122,9 @@ target_link_libraries(velox_dwio_dwrf_buffered_input_test ${VELOX_LINK_LIBS}
 add_executable(velox_dwio_dwrf_cache_input_test CacheInputTest.cpp)
 add_test(velox_dwio_dwrf_cache_input_test velox_dwio_dwrf_cache_input_test)
 
-target_link_libraries(velox_dwio_dwrf_cache_input_test ${VELOX_LINK_LIBS}
-                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(
+  velox_dwio_dwrf_cache_input_test ${VELOX_LINK_LIBS} velox_temp_path
+  ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_dictionary_encoder_test
                TestIntegerDictionaryEncoder.cpp TestStringDictionaryEncoder.cpp)

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(velox_temp_path TempFilePath.cpp TempDirectoryPath.cpp)
+
 add_library(
   velox_exec_test_util
-  FunctionUtils.cpp
-  TempFilePath.cpp
-  TempDirectoryPath.cpp
-  PlanBuilder.cpp
-  QueryAssertions.cpp
-  Cursor.cpp
-  OperatorTestBase.cpp
-  HiveConnectorTestBase.cpp)
+  FunctionUtils.cpp PlanBuilder.cpp QueryAssertions.cpp Cursor.cpp
+  OperatorTestBase.cpp HiveConnectorTestBase.cpp)
 
 target_link_libraries(
   velox_exec_test_util
+  velox_temp_path
   duckdb
   velox_core
   velox_exception


### PR DESCRIPTION
Fix flaky SSD cache tests.

Make all tests use unique file paths.

Add a deleteFiles() method to SsdCache.

Add more checks and threads to AsyncDataCacheTest.ssd.

Check each retrieved entry for internal consistency and for the content matching
the deterministic content given by the key. The executor must have more threads
than the multithreaded test cases so that there are threads left over for
background write.

Tested to run without flaky errors for 200 repeats in fbcode.

The likely reason for flakiness in automatic test runs in fbcode is having
multiple instances run with the same file.