### PR TITLE
Fix cardinality of Boolean in VectorHasher

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -585,6 +585,10 @@ void VectorHasher::cardinality(uint64_t& asRange, uint64_t& asDistincts) {
 }
 
 uint64_t VectorHasher::enableValueIds(uint64_t multiplier, int64_t reserve) {
+  VELOX_CHECK_NE(
+      typeKind_,
+      TypeKind::BOOLEAN,
+      "A boolean VectorHasher should  always be by range");
   multiplier_ = multiplier;
   rangeSize_ = uniqueValues_.size() + 1 + reserve;
   isRange_ = false;
@@ -614,7 +618,11 @@ uint64_t VectorHasher::enableValueRange(uint64_t multiplier, int64_t reserve) {
   }
   isRange_ = true;
   // No overflow because max range is under 63 bits.
-  rangeSize_ = (max_ - min_) + 2;
+  if (typeKind_ == TypeKind::BOOLEAN) {
+    rangeSize_ = 3;
+  } else {
+    rangeSize_ = (max_ - min_) + 2;
+  }
   uint64_t result;
   if (__builtin_mul_overflow(multiplier_, rangeSize_, &result)) {
     return kRangeTooLarge;

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -586,10 +586,17 @@ TEST_F(VectorHasherTest, computeValueIdsBoolDictionary) {
 
   SelectivityVector allRows(size);
   auto hasher = exec::VectorHasher::create(BOOLEAN(), 0);
+  uint64_t rangeSize;
+  uint64_t distinctSize;
+  hasher->cardinality(rangeSize, distinctSize);
+  EXPECT_EQ(3, rangeSize);
+  EXPECT_EQ(3, distinctSize);
   raw_vector<uint64_t> result(size);
   std::fill(result.begin(), result.end(), 0);
   auto ok = hasher->computeValueIds(*vector, allRows, result);
   ASSERT_TRUE(ok);
+  // A boolean counts as as a range of 3 and the extra margin has no effect.
+  EXPECT_EQ(6, hasher->enableValueRange(2, 11));
 }
 
 TEST_F(VectorHasherTest, computeValueIdsStrings) {


### PR DESCRIPTION
Fix a bug with array/normalized key aggregation with boolean keys.

When the data is all false for the creation of the hash table, the
column has a cardinality of 1 by max-min. When a true value comes
along, this is mapped to a constant without looking at the min-max and
indices go out of range. So a boolean key will have a cardinality of 3
for either range or value ids. A boolean key is always expected to
have a range mapping. cardinality() was correct but enableValueRange()
was not consistent with it.