### PR TITLE
Make RowVector::resize recursive

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -571,7 +571,7 @@ struct VectorWriter<Row<T...>> {
   void ensureSize(size_t size) {
     if (size > vector_->size()) {
       vector_->resize(size, /*setNotNull*/ false);
-      resizeVectorWritersInternal<0>(vector_->size());
+      initVectorWritersInternal<0, T...>();
     }
   }
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -22,14 +22,14 @@ namespace facebook::velox::aggregate::test {
 
 namespace {
 
-class AverageAggregation : public AggregationTestBase {
+class AverageAggregationTest : public AggregationTestBase {
  protected:
   std::shared_ptr<const RowType> rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
           {BIGINT(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()})};
 };
 
-TEST_F(AverageAggregation, avgConst) {
+TEST_F(AverageAggregationTest, avgConst) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -85,7 +85,7 @@ TEST_F(AverageAggregation, avgConst) {
   }
 }
 
-TEST_F(AverageAggregation, avgConstNull) {
+TEST_F(AverageAggregationTest, avgConstNull) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -130,7 +130,7 @@ TEST_F(AverageAggregation, avgConstNull) {
   }
 }
 
-TEST_F(AverageAggregation, avgNulls) {
+TEST_F(AverageAggregationTest, avgNulls) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -166,7 +166,7 @@ TEST_F(AverageAggregation, avgNulls) {
   }
 }
 
-TEST_F(AverageAggregation, avg) {
+TEST_F(AverageAggregationTest, avg) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
@@ -282,5 +282,16 @@ TEST_F(AverageAggregation, avg) {
   }
 }
 
+TEST_F(AverageAggregationTest, partialResults) {
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(100, [](auto row) { return row; })});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .partialAggregation({}, {"avg(c0)"})
+                  .planNode();
+
+  assertQuery(plan, "SELECT row(4950, 100)");
+}
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -206,6 +206,17 @@ void RowVector::copy(
   }
 }
 
+void RowVector::resize(vector_size_t size, bool setNotNull) {
+  // setNotNull flag applies to top-level vector only. Do not pass it when
+  // resizing child vectors.
+  for (auto& child : children_) {
+    if (child) {
+      child->resize(size);
+    }
+  }
+  BaseVector::resize(size, setNotNull);
+}
+
 void RowVector::move(vector_size_t source, vector_size_t target) {
   VELOX_CHECK_LT(source, size());
   VELOX_CHECK_LT(target, size());

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -120,6 +120,11 @@ class RowVector : public BaseVector {
     return children_;
   }
 
+  /// Recursively resizes this vector and all its children. setNotNull flag
+  /// applies only to resizing the top-level, e.g. this vector, and doesn't
+  /// apply when resizing child vectors.
+  void resize(vector_size_t size, bool setNotNull = true) override;
+
   void copy(
       const BaseVector* source,
       vector_size_t targetIndex,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -880,6 +880,33 @@ TEST_F(VectorTest, row) {
   testMove(baseRow, 5, 23);
 }
 
+// Test recursive resize of a RowVector.
+TEST_F(VectorTest, recursiveRowResize) {
+  auto row = BaseVector::create(
+      ROW({"a", "b"}, {BIGINT(), ROW({"c", "d"}, {DOUBLE(), VARCHAR()})}),
+      10,
+      pool_.get());
+  auto nestedRow = row->as<RowVector>()->childAt(1)->as<RowVector>();
+
+  // Newly created RowVector has the specified size, but all its children have
+  // size 0.
+  ASSERT_EQ(10, row->size());
+  ASSERT_EQ(0, row->as<RowVector>()->childAt(0)->size());
+
+  ASSERT_EQ(0, nestedRow->size());
+  ASSERT_EQ(0, nestedRow->childAt(0)->size());
+  ASSERT_EQ(0, nestedRow->childAt(1)->size());
+
+  row->resize(25);
+
+  ASSERT_EQ(25, row->size());
+  ASSERT_EQ(25, row->as<RowVector>()->childAt(0)->size());
+
+  ASSERT_EQ(25, nestedRow->size());
+  ASSERT_EQ(25, nestedRow->childAt(0)->size());
+  ASSERT_EQ(25, nestedRow->childAt(1)->size());
+}
+
 TEST_F(VectorTest, array) {
   auto baseArray = createArray(vectorSize_, false);
   testCopy(baseArray, numIterations_);


### PR DESCRIPTION
Modify RowVector::resize to add recursive resize for child vectors. This makes
it easier to build RowVectors for intermediate results in aggregate functions
and other places. Add a test to ensure intermediate results of an "avg" aggregate
function are correct. The bug in that function motivated this change.