### PR TITLE
Fix avg, variance and covariance aggregate Presto functions

### DIFF
--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -131,4 +131,23 @@ void OperatorTestBase::assertEqualVectors(
   }
 }
 
+RowVectorPtr OperatorTestBase::getResults(
+    std::shared_ptr<const core::PlanNode> planNode) {
+  CursorParameters params;
+  params.planNode = std::move(planNode);
+  auto [cursor, results] = readCursor(params, [](auto) {});
+
+  auto totalCount = 0;
+  for (const auto& result : results) {
+    totalCount += result->size();
+  }
+
+  auto copy = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(params.planNode->outputType(), totalCount, pool()));
+  for (const auto& result : results) {
+    copy->copy(result.get(), 0, 0, result->size());
+  }
+  return copy;
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -93,6 +93,8 @@ class OperatorTestBase : public testing::Test,
       const std::string& duckDbSql,
       std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
 
+  RowVectorPtr getResults(std::shared_ptr<const core::PlanNode> planNode);
+
   static std::shared_ptr<const RowType> makeRowType(
       std::vector<std::shared_ptr<const Type>>&& types) {
     return velox::test::VectorMaker::rowType(

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -79,6 +79,8 @@ class AverageAggregate : public exec::Aggregate {
     auto countVector = rowVector->childAt(1)->asFlatVector<int64_t>();
 
     rowVector->resize(numGroups);
+    sumVector->resize(numGroups);
+    countVector->resize(numGroups);
     uint64_t* rawNulls = getRawNulls(rowVector);
 
     int64_t* rawCounts = countVector->mutableRawValues();

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -414,6 +414,9 @@ class CovarianceAggregate : public exec::Aggregate {
       override {
     auto rowVector = (*result)->as<RowVector>();
     rowVector->resize(numGroups);
+    for (auto& child : rowVector->children()) {
+      child->resize(numGroups);
+    }
 
     uint64_t* rawNulls = getRawNulls(rowVector);
 

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -160,6 +160,9 @@ class VarianceAggregate : public exec::Aggregate {
     auto m2Vector = rowVector->childAt(kM2Idx)->asFlatVector<double>();
 
     rowVector->resize(numGroups);
+    for (auto& child : rowVector->children()) {
+      child->resize(numGroups);
+    }
     uint64_t* rawNulls = getRawNulls(rowVector);
 
     int64_t* rawCounts = countVector->mutableRawValues();

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -22,14 +22,14 @@ namespace facebook::velox::aggregate::test {
 
 namespace {
 
-class AverageAggregation : public AggregationTestBase {
+class AverageAggregationTest : public AggregationTestBase {
  protected:
   std::shared_ptr<const RowType> rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
           {BIGINT(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()})};
 };
 
-TEST_F(AverageAggregation, avgConst) {
+TEST_F(AverageAggregationTest, avgConst) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -85,7 +85,7 @@ TEST_F(AverageAggregation, avgConst) {
   }
 }
 
-TEST_F(AverageAggregation, avgConstNull) {
+TEST_F(AverageAggregationTest, avgConstNull) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -130,7 +130,7 @@ TEST_F(AverageAggregation, avgConstNull) {
   }
 }
 
-TEST_F(AverageAggregation, avgNulls) {
+TEST_F(AverageAggregationTest, avgNulls) {
   // Have two row vectors a lest as it triggers different code paths.
   auto vectors = {
       makeRowVector({
@@ -166,7 +166,7 @@ TEST_F(AverageAggregation, avgNulls) {
   }
 }
 
-TEST_F(AverageAggregation, avg) {
+TEST_F(AverageAggregationTest, avg) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
@@ -282,5 +282,16 @@ TEST_F(AverageAggregation, avg) {
   }
 }
 
+TEST_F(AverageAggregationTest, partialResults) {
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(100, [](auto row) { return row; })});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .partialAggregation({}, {"avg(c0)"})
+                  .planNode();
+
+  assertQuery(plan, "SELECT row(4950, 100)");
+}
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -46,6 +46,21 @@ class CovarianceAggregationTest
              .planNode();
 
     assertQuery(op, sql);
+
+    op = PlanBuilder()
+             .values({data})
+             .partialAggregation({0}, {partialAgg})
+             .planNode();
+
+    auto partialResults = getResults(op);
+
+    op =
+        PlanBuilder()
+            .values({partialResults})
+            .finalAggregation({0}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
+            .project({"c0", "round(a0, cast(2 as integer))"})
+            .planNode();
+    assertQuery(op, sql);
   }
 
   void testGlobalAgg(const std::string& aggName, const RowVectorPtr& data) {
@@ -64,6 +79,21 @@ class CovarianceAggregationTest
     op = PlanBuilder()
              .values({data})
              .singleAggregation({}, {partialAgg})
+             .project({"round(a0, cast(2 as integer))"})
+             .planNode();
+
+    assertQuery(op, sql);
+
+    op = PlanBuilder()
+             .values({data})
+             .partialAggregation({}, {partialAgg})
+             .planNode();
+
+    auto partialResults = getResults(op);
+
+    op = PlanBuilder()
+             .values({partialResults})
+             .finalAggregation({}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
              .project({"round(a0, cast(2 as integer))"})
              .planNode();
 

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -224,8 +224,24 @@ TEST_F(VarianceAggregationTest, variance) {
                   {},
                   {GEN_AGG("c1"), GEN_AGG("c2"), GEN_AGG("c4"), GEN_AGG("c5")})
               .planNode();
-    sql = genAggrQuery(
-        "SELECT {0}(c1), {0}(c2), {0}(c4), {0}(c5) FROM tmp", aggrName);
+    assertQuery(agg, sql);
+
+    agg = PlanBuilder()
+              .values(vectors)
+              .partialAggregation(
+                  {},
+                  {GEN_AGG("c1"), GEN_AGG("c2"), GEN_AGG("c4"), GEN_AGG("c5")})
+              .planNode();
+
+    auto partialResults = getResults(agg);
+
+    agg = PlanBuilder()
+              .values({partialResults})
+              .finalAggregation(
+                  {},
+                  {GEN_AGG("a0"), GEN_AGG("a1"), GEN_AGG("a2"), GEN_AGG("a3")},
+                  {DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE()})
+              .planNode();
     assertQuery(agg, sql);
 
     agg = PlanBuilder()


### PR DESCRIPTION
These aggregate functions use RowVector for intermediate results.
RowVector::resize is not recursive, hence, when resizing RowVector one needs to
resize child vectors as well.