### PR TITLE
Improve toString output for ranged vectors

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -15,10 +15,48 @@
  */
 
 #include "velox/vector/ComplexVector.h"
+#include <sstream>
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook {
 namespace velox {
+
+// Up to # of elements to show as debug string for `toString()`.
+constexpr vector_size_t LIMIT_ELEMENTS_TO_SHOW = 5;
+
+std::string stringifyTruncatedElementList(
+    vector_size_t start,
+    vector_size_t size,
+    vector_size_t limit,
+    std::string_view delimiter,
+    const std::function<void(std::stringstream&, vector_size_t)>&
+        stringifyElementCB) {
+  std::stringstream out;
+  if (size == 0) {
+    return "<empty>";
+  }
+  out << size << " elements starting at " << start << " {";
+
+  bool first = true;
+  const vector_size_t limitedSize = std::min(size, limit);
+  for (vector_size_t i = 0; i < limitedSize; ++i) {
+    if (first) {
+      first = false;
+    } else {
+      out << delimiter;
+    }
+    stringifyElementCB(out, start + i);
+  }
+
+  if (size > limitedSize) {
+    if (!first) {
+      out << delimiter;
+    }
+    out << "...";
+  }
+  out << "}";
+  return out.str();
+}
 
 // static
 std::shared_ptr<RowVector> RowVector::createEmpty(
@@ -487,21 +525,15 @@ std::string ArrayVector::toString(vector_size_t index) const {
   if (isNullAt(index)) {
     return "null";
   }
-  auto childIndex = rawOffsets_[index];
-  std::stringstream out;
-  auto size = rawSizes_[index];
-  out << size << " elements starting at " << childIndex << " {";
 
-  for (int32_t i = 0; i < size; ++i) {
-    out << elements_->toString(childIndex + i)
-        << ((i == 5)             ? "...}"
-                : (i < size - 1) ? ", "
-                                 : "}");
-    if (i == 5) {
-      break;
-    }
-  }
-  return out.str();
+  return stringifyTruncatedElementList(
+      rawOffsets_[index],
+      rawSizes_[index],
+      LIMIT_ELEMENTS_TO_SHOW,
+      ", ",
+      [this](std::stringstream& ss, vector_size_t index) {
+        ss << elements_->toString(index);
+      });
 }
 
 void ArrayVector::ensureWritable(const SelectivityVector& rows) {
@@ -825,22 +857,14 @@ std::string MapVector::toString(vector_size_t index) const {
   if (isNullAt(index)) {
     return "null";
   }
-  auto size = rawSizes_[index];
-  if (size == 0) {
-    return "<empty>";
-  }
-  auto childIndex = rawOffsets_[index];
-  std::stringstream out;
-  out << size << " elements starting at " << childIndex << " {";
-  for (int32_t i = 0; i < size; ++i) {
-    out << keys_->toString(childIndex + i) << " = "
-        << values_->toString(childIndex + i);
-    out << ((i == 5) ? "...}" : (i < size - 1) ? ",\n " : "}");
-    if (i == 5) {
-      break;
-    }
-  }
-  return out.str();
+  return stringifyTruncatedElementList(
+      rawOffsets_[index],
+      rawSizes_[index],
+      LIMIT_ELEMENTS_TO_SHOW,
+      ",\n ",
+      [this](std::stringstream& ss, vector_size_t index) {
+        ss << keys_->toString(index) << " = " << values_->toString(index);
+      });
 }
 
 void MapVector::ensureWritable(const SelectivityVector& rows) {

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
   ${FMT}
   dl)
 
-add_executable(simple_vector_test SimpleVectorTest.cpp)
+add_executable(simple_vector_test SimpleVectorTest.cpp ToStringUtilityTest.cpp)
 
 add_test(simple_vector_test simple_vector_test)
 

--- a/velox/vector/tests/ToStringUtilityTest.cpp
+++ b/velox/vector/tests/ToStringUtilityTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include "folly/Conv.h"
+#include "velox/vector/TypeAliases.h"
+
+namespace facebook::velox {
+
+// Forward declaration, which is defined in ComplexVector.cpp
+std::string stringifyTruncatedElementList(
+    vector_size_t start,
+    vector_size_t size,
+    vector_size_t limit,
+    std::string_view delimiter,
+    const std::function<void(std::stringstream&, vector_size_t)>&
+        stringifyElementCB);
+
+namespace {
+TEST(ToStringUtil, stringifyTruncatedElementList) {
+  const auto indexAsString = [](std::stringstream& ss, vector_size_t i) {
+    ss << folly::to<std::string>(i);
+  };
+
+  // no item
+  EXPECT_EQ(
+      stringifyTruncatedElementList(0, 0, 0, ", ", indexAsString), "<empty>");
+  // exact item
+  EXPECT_EQ(
+      stringifyTruncatedElementList(0, 5, 5, ", ", indexAsString),
+      "5 elements starting at 0 {0, 1, 2, 3, 4}");
+  // more items
+  EXPECT_EQ(
+      stringifyTruncatedElementList(1, 3, 2, ", ", indexAsString),
+      "3 elements starting at 1 {1, 2, ...}");
+  // less items
+  EXPECT_EQ(
+      stringifyTruncatedElementList(1, 3, 5, ", ", indexAsString),
+      "3 elements starting at 1 {1, 2, 3}");
+  // zero limit.
+  EXPECT_EQ(
+      stringifyTruncatedElementList(1, 5, 0, ", ", indexAsString),
+      "5 elements starting at 1 {...}");
+  // different delimiter
+  EXPECT_EQ(
+      stringifyTruncatedElementList(0, 3, 5, "<delimiter>", indexAsString),
+      "3 elements starting at 0 {0<delimiter>1<delimiter>2}");
+}
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
# Problem
`toString()` is used to peek what's inside of a vector. The current implementation is duplicated, and not so consistent. I'd like to make it one logic with consistent output.

The old logic did not close `}` if the element size is upto 5.

Differential Revision: D33804871

