### PR TITLE
Flush writer sink upon writer close

### DIFF
--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -319,4 +319,28 @@ TEST_F(WriterTest, DoNotCrashDbgModeOnAbort) {
   EXPECT_THROW(abandonWriterWithoutClosing(), std::runtime_error);
 }
 
+class MockDataSink : public dwio::common::DataSink {
+ public:
+  explicit MockDataSink() : DataSink("mock_data_sink", nullptr) {}
+  virtual ~MockDataSink() = default;
+
+  MOCK_METHOD(uint64_t, size, (), (const override));
+  MOCK_METHOD(bool, isBuffered, (), (const override));
+  MOCK_METHOD(void, write, (std::vector<DataBuffer<char>>&));
+};
+
+TEST(WriterBaseTest, FlushWriterSinkUponClose) {
+  auto config = std::make_shared<Config>();
+  auto pool = getDefaultScopedMemoryPool();
+  auto sink = std::make_unique<MockDataSink>();
+  MockDataSink* sinkPtr = sink.get();
+  EXPECT_CALL(*sinkPtr, write(_)).Times(1);
+  EXPECT_CALL(*sinkPtr, isBuffered()).WillOnce(Return(false));
+  {
+    auto writer = std::make_unique<WriterBase>(std::move(sink));
+    writer->initContext(config, pool->addScopedChild("test_writer_pool"));
+    writer->close();
+  }
+}
+
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -32,6 +32,9 @@ class WriterBase {
   virtual ~WriterBase() = default;
 
   virtual void close() {
+    if (writerSink_) {
+      writerSink_->flush();
+    }
     sink_->close();
   }
 
@@ -155,6 +158,7 @@ class WriterBase {
   void writeUserMetadata(uint32_t writerVersion);
 
   friend class WriterTest;
+  FRIEND_TEST(WriterBaseTest, FlushWriterSinkUponClose);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterSink.h
+++ b/velox/dwio/dwrf/writer/WriterSink.h
@@ -60,7 +60,11 @@ class WriterSink {
     addBuffer(pool, ORC_MAGIC.data(), ORC_MAGIC_LEN);
   }
 
-  ~WriterSink() = default;
+  ~WriterSink() {
+    if (!buffers_.empty() || size_ != 0) {
+      LOG(WARNING) << "Unflushed data in writer sink!";
+    }
+  }
 
   uint64_t size() const {
     return sink_.size() + size_;


### PR DESCRIPTION
Summary: We detected issue with file merge writer working with WS data sink where the footer was not flushed. Turns out a flush call is missing upon closing of the FileMergeWriter class. This diff fixes this behavior for all of WriterBase.

Differential Revision: D33822993

