### PR TITLE
Add mayNotBeNullFree function to Vectors

### DIFF
--- a/velox/core/CoreTypeSystem.h
+++ b/velox/core/CoreTypeSystem.h
@@ -326,11 +326,30 @@ class SlowMapWriter : public IMapVal<KEY, VAL> {
   // once we implement writer proxies.
   template <template <typename, typename> typename T>
   SlowMapWriter& operator=(const T<KEY, VAL>& rh) {
+    assignFrom(rh);
+
+    return *this;
+  }
+
+  // Allow Velox's MapView to be assigned to a map writer.  This should also
+  // change once we implement writer proxies.
+  template <bool nullFree, template <bool, typename, typename> typename T>
+  SlowMapWriter& operator=(const T<nullFree, KEY, VAL>& rh) {
+    assignFrom(rh);
+
+    return *this;
+  }
+
+ private:
+  // This allows us to share code between assignment operators.
+  // Ensure rh supports a map-like iterator interface before calling this
+  // function.
+  template <typename T>
+  inline void assignFrom(const T& rh) {
     IMapVal<KEY, VAL>::clear();
     for (const auto& it : rh) {
       IMapVal<KEY, VAL>::emplace(it.first, it.second);
     }
-    return *this;
   }
 };
 

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -189,10 +189,6 @@ class SkipNullsIterator {
   const BaseIterator end_;
 };
 
-// TODO: evaluate wrapping primitives with lazy access using benchmarks
-template <typename T>
-using VectorValueAccessor = typename T::exec_in_t;
-
 // Given a vectorReader T, this class represents a lazy access optional wrapper
 // around an element in the vectorReader with interface similar to
 // std::optional<T::exec_in_t>. This is used to represent elements of ArrayView
@@ -263,16 +259,16 @@ class VectorOptionalValueAccessor {
   // Index of element within the reader.
   int64_t index_;
 
-  template <typename V>
+  template <bool nullable, typename V>
   friend class ArrayView;
 
-  template <typename K, typename V>
+  template <bool nullable, typename K, typename V>
   friend class MapView;
 
-  template <typename... U>
+  template <bool nullable, typename... U>
   friend class RowView;
 
-  template <typename U>
+  template <bool nullable, typename U>
   friend class VariadicView;
 };
 
@@ -378,16 +374,25 @@ operator!=(const VectorOptionalValueAccessor<U>& lhs, const T& rhs) {
 }
 
 // Represents an array of elements with an interface similar to std::vector.
-template <typename V>
+// When returnsOptionalValues is true, the interface is like
+// std::vector<std::optional<V>>.
+// When returnsOptionalValues is false, the interface is like std::vector<V>.
+template <bool returnsOptionalValues, typename V>
 class ArrayView {
   using reader_t = VectorReader<V>;
-  using element_t = typename reader_t::exec_in_t;
+  using element_t = typename std::conditional<
+      returnsOptionalValues,
+      typename reader_t::exec_in_t,
+      typename reader_t::exec_null_free_in_t>::type;
 
  public:
   ArrayView(const reader_t* reader, vector_size_t offset, vector_size_t size)
       : reader_(reader), offset_(offset), size_(size) {}
 
-  using Element = VectorOptionalValueAccessor<reader_t>;
+  using Element = typename std::conditional<
+      returnsOptionalValues,
+      VectorOptionalValueAccessor<reader_t>,
+      element_t>::type;
 
   class Iterator : public IndexBasedIterator<Element, vector_size_t> {
    public:
@@ -395,11 +400,19 @@ class ArrayView {
         : IndexBasedIterator<Element, vector_size_t>(index), reader_(reader) {}
 
     PointerWrapper<Element> operator->() const {
-      return PointerWrapper(Element{reader_, this->index_});
+      if constexpr (returnsOptionalValues) {
+        return PointerWrapper(Element{reader_, this->index_});
+      } else {
+        return PointerWrapper(reader_->readNullFree(this->index_));
+      }
     }
 
     Element operator*() const {
-      return Element{reader_, this->index_};
+      if constexpr (returnsOptionalValues) {
+        return Element{reader_, this->index_};
+      } else {
+        return reader_->readNullFree(this->index_);
+      }
     }
 
    protected:
@@ -453,11 +466,19 @@ class ArrayView {
   // Returns true if any of the arrayViews in the vector might have null
   // element.
   bool mayHaveNulls() const {
-    return reader_->mayHaveNulls();
+    if constexpr (returnsOptionalValues) {
+      return reader_->mayHaveNulls();
+    } else {
+      return false;
+    }
   }
 
   Element operator[](vector_size_t index) const {
-    return Element{reader_, index + offset_};
+    if constexpr (returnsOptionalValues) {
+      return Element{reader_, index + offset_};
+    } else {
+      return reader_->readNullFree(index + offset_);
+    }
   }
 
   Element at(vector_size_t index) const {
@@ -469,7 +490,14 @@ class ArrayView {
   }
 
   SkipNullsContainer skipNulls() const {
-    return SkipNullsContainer{this};
+    if constexpr (returnsOptionalValues) {
+      return SkipNullsContainer{this};
+    }
+
+    VELOX_UNSUPPORTED(
+        "ArrayViews over NULL-free data do not support skipNulls().  It's "
+        "already been checked that this object contains no NULLs, it's more "
+        "efficient to use the standard iterator interface.");
   }
 
  private:
@@ -480,7 +508,10 @@ class ArrayView {
 
 // This class is used to represent map inputs in simple functions with an
 // interface similar to std::map.
-template <typename K, typename V>
+// When returnsOptionalValues is true, the interface is like std::map<K,
+// std::optional<V>>.
+// When returnsOptionalValues is false, the interface is like std::map<K, V>.
+template <bool returnsOptionalValues, typename K, typename V>
 class MapView {
  public:
   using key_reader_t = VectorReader<K>;
@@ -497,8 +528,15 @@ class MapView {
         offset_(offset),
         size_(size) {}
 
-  using ValueAccessor = VectorOptionalValueAccessor<value_reader_t>;
-  using KeyAccessor = VectorValueAccessor<key_reader_t>;
+  using ValueAccessor = typename std::conditional<
+      returnsOptionalValues,
+      VectorOptionalValueAccessor<value_reader_t>,
+      typename value_reader_t::exec_null_free_in_t>::type;
+
+  using KeyAccessor = typename std::conditional<
+      returnsOptionalValues,
+      typename key_reader_t::exec_in_t,
+      typename key_reader_t::exec_null_free_in_t>::type;
 
   class Element {
    public:
@@ -506,7 +544,8 @@ class MapView {
         const key_reader_t* keyReader,
         const value_reader_t* valueReader,
         int64_t index)
-        : first((*keyReader)[index]), second(valueReader, index) {}
+        : first(getFirst(keyReader, index)),
+          second(getSecond(valueReader, index)) {}
     const KeyAccessor first;
     const ValueAccessor second;
 
@@ -524,6 +563,25 @@ class MapView {
     template <typename T>
     bool operator!=(const T& other) const {
       return !(*this == other);
+    }
+
+   private:
+    // Helper functions to allow us to use "if constexpr" when initializing the
+    // values.
+    KeyAccessor getFirst(const key_reader_t* keyReader, int64_t index) {
+      if constexpr (returnsOptionalValues) {
+        return (*keyReader)[index];
+      } else {
+        return keyReader->readNullFree(index);
+      }
+    }
+
+    ValueAccessor getSecond(const value_reader_t* valueReader, int64_t index) {
+      if constexpr (returnsOptionalValues) {
+        return ValueAccessor(valueReader, index);
+      } else {
+        return valueReader->readNullFree(index);
+      }
     }
   };
 
@@ -585,12 +643,16 @@ class MapView {
   vector_size_t size_;
 };
 
-template <typename... T>
+template <bool returnsOptionalValues, typename... T>
 class RowView {
   using reader_t = std::tuple<std::unique_ptr<VectorReader<T>>...>;
   template <size_t N>
-  using elem_n_t = VectorOptionalValueAccessor<
-      typename std::tuple_element<N, reader_t>::type::element_type>;
+  using elem_n_t = typename std::conditional<
+      returnsOptionalValues,
+      VectorOptionalValueAccessor<
+          typename std::tuple_element<N, reader_t>::type::element_type>,
+      typename std::tuple_element<N, reader_t>::type::element_type::
+          exec_null_free_in_t>::type;
 
  public:
   RowView(const reader_t* childReaders, vector_size_t offset)
@@ -598,7 +660,11 @@ class RowView {
 
   template <size_t N>
   elem_n_t<N> at() const {
-    return elem_n_t<N>{std::get<N>(*childReaders_).get(), offset_};
+    if constexpr (returnsOptionalValues) {
+      return elem_n_t<N>{std::get<N>(*childReaders_).get(), offset_};
+    } else {
+      return std::get<N>(*childReaders_)->readNullFree(offset_);
+    }
   }
 
  private:
@@ -606,8 +672,8 @@ class RowView {
   vector_size_t offset_;
 };
 
-template <size_t I, class... Types>
-auto get(const RowView<Types...>& row) {
+template <size_t I, bool returnsOptionalValues, class... Types>
+auto get(const RowView<returnsOptionalValues, Types...>& row) {
   return row.template at<I>();
 }
 

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -48,7 +48,8 @@ struct resolver {
 
 template <typename K, typename V>
 struct resolver<Map<K, V>> {
-  using in_type = MapView<K, V>;
+  using in_type = MapView<true, K, V>;
+  using null_free_in_type = MapView<false, K, V>;
   using out_type = core::SlowMapWriter<
       typename resolver<K>::out_type,
       typename resolver<V>::out_type>;
@@ -56,13 +57,15 @@ struct resolver<Map<K, V>> {
 
 template <typename... T>
 struct resolver<Row<T...>> {
-  using in_type = RowView<T...>;
+  using in_type = RowView<true, T...>;
+  using null_free_in_type = RowView<false, T...>;
   using out_type = core::RowWriter<typename resolver<T>::out_type...>;
 };
 
 template <typename V>
 struct resolver<Array<V>> {
-  using in_type = ArrayView<V>;
+  using in_type = ArrayView<true, V>;
+  using null_free_in_type = ArrayView<false, V>;
   using out_type = core::ArrayValWriter<typename resolver<V>::out_type>;
 };
 
@@ -91,7 +94,8 @@ struct resolver<std::shared_ptr<T>> {
 
 template <typename T>
 struct resolver<Variadic<T>> {
-  using in_type = VariadicView<T>;
+  using in_type = VariadicView<true, T>;
+  using null_free_in_type = VariadicView<false, T>;
   // Variadic cannot be used as an out_type
 };
 } // namespace detail
@@ -163,6 +167,10 @@ struct VectorWriter {
 template <typename T>
 struct VectorReader {
   using exec_in_t = typename VectorExec::template resolver<T>::in_type;
+  // Types without views cannot contain null, they can only be null, so they're
+  // in_type is already null_free.
+  using exec_null_free_in_t =
+      typename VectorExec::template resolver<T>::in_type;
 
   explicit VectorReader(const DecodedVector* decoded) : decoded_(*decoded) {}
 
@@ -171,6 +179,10 @@ struct VectorReader {
 
   exec_in_t operator[](size_t offset) const {
     return decoded_.template valueAt<exec_in_t>(offset);
+  }
+
+  exec_null_free_in_t readNullFree(size_t offset) const {
+    return decoded_.template valueAt<exec_null_free_in_t>(offset);
   }
 
   bool isSet(size_t offset) const {
@@ -287,6 +299,8 @@ template <typename K, typename V>
 struct VectorReader<Map<K, V>> {
   using in_vector_t = typename TypeToFlatVector<Map<K, V>>::type;
   using exec_in_t = typename VectorExec::template resolver<Map<K, V>>::in_type;
+  using exec_null_free_in_t =
+      typename VectorExec::template resolver<Map<K, V>>::null_free_in_type;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_{*decoded},
@@ -301,7 +315,12 @@ struct VectorReader<Map<K, V>> {
 
   exec_in_t operator[](size_t offset) const {
     auto index = decoded_.index(offset);
-    return MapView{&keyReader_, &valReader_, offsets_[index], lengths_[index]};
+    return {&keyReader_, &valReader_, offsets_[index], lengths_[index]};
+  }
+
+  exec_null_free_in_t readNullFree(size_t offset) const {
+    auto index = decoded_.index(offset);
+    return {&keyReader_, &valReader_, offsets_[index], lengths_[index]};
   }
 
   bool isSet(size_t offset) const {
@@ -324,6 +343,8 @@ struct VectorReader<Array<V>> {
   using in_vector_t = typename TypeToFlatVector<Array<V>>::type;
   using child_vector_t = typename TypeToFlatVector<V>::type;
   using exec_in_t = typename VectorExec::template resolver<Array<V>>::in_type;
+  using exec_null_free_in_t =
+      typename VectorExec::template resolver<Array<V>>::null_free_in_type;
   using exec_in_child_t = typename VectorExec::template resolver<V>::in_type;
 
   explicit VectorReader(const DecodedVector* decoded)
@@ -343,7 +364,12 @@ struct VectorReader<Array<V>> {
 
   exec_in_t operator[](size_t offset) const {
     auto index = decoded_.index(offset);
-    return ArrayView{&childReader_, offsets_[index], lengths_[index]};
+    return {&childReader_, offsets_[index], lengths_[index]};
+  }
+
+  exec_null_free_in_t readNullFree(size_t offset) const {
+    auto index = decoded_.index(offset);
+    return {&childReader_, offsets_[index], lengths_[index]};
   }
 
   DecodedVector arrayValuesDecoder_;
@@ -512,6 +538,8 @@ template <typename... T>
 struct VectorReader<Row<T...>> {
   using in_vector_t = typename TypeToFlatVector<Row<T...>>::type;
   using exec_in_t = typename VectorExec::resolver<Row<T...>>::in_type;
+  using exec_null_free_in_t =
+      typename VectorExec::template resolver<Row<T...>>::null_free_in_type;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_(*decoded),
@@ -523,7 +551,12 @@ struct VectorReader<Row<T...>> {
 
   exec_in_t operator[](size_t offset) const {
     auto index = decoded_.index(offset);
-    return RowView{&childReaders_, index};
+    return {&childReaders_, index};
+  }
+
+  exec_null_free_in_t readNullFree(size_t offset) const {
+    auto index = decoded_.index(offset);
+    return {&childReaders_, index};
   }
 
   bool isSet(size_t offset) const {
@@ -672,13 +705,19 @@ struct VectorWriter<Row<T...>> {
 template <typename T>
 struct VectorReader<Variadic<T>> {
   using in_vector_t = typename TypeToFlatVector<T>::type;
-  using exec_in_t = VariadicView<T>;
+  using exec_in_t = typename VectorExec::resolver<Variadic<T>>::in_type;
+  using exec_null_free_in_t =
+      typename VectorExec::template resolver<Variadic<T>>::null_free_in_type;
 
   explicit VectorReader(const DecodedArgs& decodedArgs, int32_t startPosition)
       : childReaders_{prepareChildReaders(decodedArgs, startPosition)} {}
 
   exec_in_t operator[](vector_size_t offset) const {
-    return VariadicView<T>{&childReaders_, offset};
+    return {&childReaders_, offset};
+  }
+
+  exec_null_free_in_t readNullFree(vector_size_t offset) const {
+    return {&childReaders_, offset};
   }
 
   bool isSet(size_t /*unused*/) const {

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -31,17 +31,27 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   return &decoder;
 }
 
+template <bool returnsOptionalValues>
 class MapViewTest : public functions::test::FunctionBaseTest {
+  using ViewType = exec::MapView<returnsOptionalValues, int64_t, int64_t>;
+  using ReadFunction = std::function<
+      ViewType(exec::VectorReader<Map<int64_t, int64_t>>&, size_t)>;
+
  protected:
   using map_type = std::vector<std::pair<int64_t, std::optional<int64_t>>>;
+
+  // What value to use for NULL in the test data.  If the view type is
+  // not returnsOptionalValues, we use 0 as an arbitrary value.
+  std::optional<int64_t> nullValue =
+      returnsOptionalValues ? std::nullopt : std::make_optional(0);
   map_type map1 = {};
-  map_type map2 = {{1, 4}, {3, 3}, {4, std::nullopt}};
+  map_type map2 = {{1, 4}, {3, 3}, {4, nullValue}};
   map_type map3 = {
       {10, 10},
-      {4, std::nullopt},
+      {4, nullValue},
       {1, 4},
       {10, 4},
-      {10, std::nullopt},
+      {10, nullValue},
   };
 
   std::vector<map_type> mapsData = {map1, map2, map3};
@@ -49,241 +59,347 @@ class MapViewTest : public functions::test::FunctionBaseTest {
   MapVectorPtr createTestMapVector() {
     return makeMapVector<int64_t, int64_t>(mapsData);
   }
+
+  ViewType read(
+      exec::VectorReader<Map<int64_t, int64_t>>& reader,
+      size_t offset) {
+    if constexpr (returnsOptionalValues) {
+      return reader[offset];
+    } else {
+      return reader.readNullFree(offset);
+    }
+  }
+
+  bool mapValueHasValue(typename ViewType::ValueAccessor value) {
+    if constexpr (returnsOptionalValues) {
+      return value.has_value();
+    } else {
+      return true;
+    }
+  }
+
+  int64_t mapValueValue(typename ViewType::ValueAccessor value) {
+    if constexpr (returnsOptionalValues) {
+      return value.value();
+    } else {
+      return value;
+    }
+  }
+
+  void readingRangeLoopTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < mapsData.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapsData[i].begin();
+      int count = 0;
+      ASSERT_EQ(mapsData[i].size(), mapView.size());
+      for (const auto& entry : mapView) {
+        ASSERT_EQ(entry.first, it->first);
+        ASSERT_EQ(mapValueHasValue(entry.second), it->second.has_value());
+        if (it->second.has_value()) {
+          ASSERT_EQ(mapValueValue(entry.second), it->second.value());
+        }
+        ASSERT_EQ(entry.second, it->second);
+        it++;
+        count++;
+      }
+      ASSERT_EQ(count, mapsData[i].size());
+    }
+  }
+
+  void readingIteratorLoopTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < mapsData.size(); ++i) {
+      auto mapView = read(reader, i);
+      auto it = mapsData[i].begin();
+      int count = 0;
+      ASSERT_EQ(mapsData[i].size(), mapView.size());
+      for (auto itView = mapView.begin(); itView != mapView.end(); ++itView) {
+        ASSERT_EQ(itView->first, it->first);
+        ASSERT_EQ(mapValueHasValue(itView->second), it->second.has_value());
+        if (it->second.has_value()) {
+          ASSERT_EQ(mapValueValue(itView->second), it->second.value());
+        }
+        ASSERT_EQ(itView->second, it->second);
+        it++;
+        count++;
+      }
+      ASSERT_EQ(count, mapsData[i].size());
+    }
+  }
+
+  // MapView can be seen as std::vector<pair<key, value>>.
+  void indexedLoopTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < mapsData.size(); ++i) {
+      auto mapView = read(reader, i);
+      auto it = mapsData[i].begin();
+      int count = 0;
+      ASSERT_EQ(mapsData[i].size(), mapView.size());
+      for (int j = 0; j < mapView.size(); j++) {
+        ASSERT_EQ(mapView[j].first, it->first);
+        ASSERT_EQ(mapValueHasValue(mapView[j].second), it->second.has_value());
+        if (it->second.has_value()) {
+          ASSERT_EQ(mapValueValue(mapView[j].second), it->second.value());
+        }
+        ASSERT_EQ(mapView[j].second, it->second);
+        it++;
+        count++;
+      }
+      ASSERT_EQ(count, mapsData[i].size());
+    }
+  }
+
+  void encodedTest() {
+    VectorPtr mapVector = createTestMapVector();
+    // Wrap in dictionary.
+    auto vectorSize = mapVector->size();
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(vectorSize, pool_.get());
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    // Assign indices such that array is reversed.
+    for (size_t i = 0; i < vectorSize; ++i) {
+      rawIndices[i] = vectorSize - 1 - i;
+    }
+    mapVector = BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), indices, vectorSize, mapVector);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector));
+
+    ASSERT_EQ(read(reader, 0).size(), 5);
+    ASSERT_EQ(read(reader, 1).size(), 3);
+    ASSERT_EQ(read(reader, 2).size(), 0);
+  }
+
+  void compareLazyValueAccessTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    // Compare LazyValueAccess with constant.
+    ASSERT_EQ(read(reader, 1)[0].first, 1);
+    ASSERT_NE(read(reader, 1)[0].first, 10);
+    ASSERT_EQ(1, read(reader, 1)[0].first);
+    ASSERT_NE(10, read(reader, 1)[0].first);
+
+    // Compare LazyValueAccess with LazyValueAccess.
+    ASSERT_EQ(read(reader, 2)[2].first, read(reader, 1)[0].first);
+    ASSERT_NE(read(reader, 2)[2].first, read(reader, 1)[1].first);
+
+    // Compare LazyValueAccess with VectorOptionalValueAccessor value.
+    ASSERT_EQ(
+        read(reader, 2)[1].first, mapValueValue(read(reader, 1)[0].second));
+    ASSERT_NE(
+        read(reader, 2)[2].first, mapValueValue(read(reader, 1)[1].second));
+    ASSERT_EQ(
+        mapValueValue(read(reader, 1)[0].second), read(reader, 2)[1].first);
+    ASSERT_NE(
+        mapValueValue(read(reader, 1)[1].second), read(reader, 2)[2].first);
+
+    // Compare null VectorOptionalValueAccessor with LazyValueAccess.
+    ASSERT_NE(
+        mapValueValue(read(reader, 1)[1].second), read(reader, 1)[2].first);
+  }
+
+  void compareVectorOptionalValueAccessorTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    // Compare VectorOptionalValueAccessor with std::optional.
+    ASSERT_EQ(read(reader, 2)[2].second, std::optional(4));
+    ASSERT_EQ(read(reader, 2)[2].second, std::optional(4l));
+    ASSERT_EQ(read(reader, 2)[2].second, std::optional(4ll));
+    ASSERT_EQ(read(reader, 2)[2].second, std::optional(4.0F));
+
+    ASSERT_NE(read(reader, 2)[2].second, std::optional(4.01F));
+    ASSERT_NE(read(reader, 2)[2].second, std::optional(8));
+
+    ASSERT_EQ(std::optional(4), read(reader, 2)[2].second);
+    ASSERT_EQ(std::optional(4l), read(reader, 2)[2].second);
+    ASSERT_EQ(std::optional(4ll), read(reader, 2)[2].second);
+
+    ASSERT_NE(std::optional(4.01F), read(reader, 2)[2].second);
+
+    if constexpr (returnsOptionalValues) {
+      ASSERT_EQ(std::nullopt, read(reader, 1)[2].second);
+      ASSERT_NE(std::nullopt, read(reader, 1)[1].second);
+
+      std::optional<int64_t> nullOpt;
+      ASSERT_EQ(read(reader, 1)[2].second, std::nullopt);
+      ASSERT_NE(read(reader, 1)[1].second, std::nullopt);
+
+      ASSERT_EQ(read(reader, 1)[2].second, nullOpt);
+      ASSERT_NE(read(reader, 1)[1].second, nullOpt);
+    }
+
+    // Compare VectorOptionalValueAccessor<T> with T::exec_t.
+    ASSERT_EQ(read(reader, 2)[2].second, 4);
+    ASSERT_EQ(read(reader, 2)[2].second, 4l);
+    ASSERT_EQ(read(reader, 2)[2].second, 4ll);
+    ASSERT_EQ(read(reader, 2)[2].second, 4.0F);
+
+    ASSERT_NE(read(reader, 2)[2].second, 4.01F);
+    ASSERT_NE(read(reader, 2)[2].second, 8);
+
+    ASSERT_EQ(4, read(reader, 2)[2].second);
+    ASSERT_EQ(4l, read(reader, 2)[2].second);
+    ASSERT_EQ(4ll, read(reader, 2)[2].second);
+    ASSERT_NE(4.01F, read(reader, 2)[2].second);
+
+    // VectorOptionalValueAccessor is null here.
+    ASSERT_NE(4.01F, read(reader, 1)[2].second);
+    ASSERT_NE(read(reader, 1)[2].second, 4);
+
+    // Compare VectorOptionalValueAccessor with VectorOptionalValueAccessor.
+    ASSERT_EQ(read(reader, 2)[2].second, read(reader, 2)[3].second);
+    ASSERT_NE(read(reader, 2)[2].second, read(reader, 2)[0].second);
+
+    // Compare with empty VectorOptionalValueAccessor.
+    // One null and one not null.
+    ASSERT_NE(read(reader, 1)[1].second, read(reader, 1)[2].second);
+    ASSERT_NE(read(reader, 1)[2].second, read(reader, 1)[1].second);
+    // Both are null.
+    ASSERT_EQ(read(reader, 2)[1].second, read(reader, 1)[2].second);
+  }
+
+  void compareMapViewElementTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    // Compare VectorOptionalValueAccessor with constant.
+    ASSERT_NE(read(reader, 2)[2], read(reader, 2)[1]);
+    ASSERT_EQ(read(reader, 1)[0], read(reader, 2)[2]);
+  }
+
+  void assignToOptionalTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    std::optional<int64_t> element = read(reader, 2)[2].second;
+    std::optional<int64_t> element2 = read(reader, 2)[1].second;
+    ASSERT_EQ(element, read(reader, 2)[2].second);
+    ASSERT_EQ(element2, read(reader, 2)[1].second);
+    ASSERT_NE(element2, element);
+  }
+
+  void findTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    ASSERT_EQ(read(reader, 1).find(5), read(reader, 1).end());
+    ASSERT_NE(read(reader, 1).find(4), read(reader, 1).end());
+    ASSERT_EQ(read(reader, 1).find(4)->first, 4);
+
+    ASSERT_EQ(read(reader, 1).find(4)->second, nullValue);
+  }
+
+  void atTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    ASSERT_THROW(read(reader, 1).at(5), VeloxException);
+
+    ASSERT_EQ(read(reader, 1).at(4), nullValue);
+
+    ASSERT_EQ(read(reader, 1).at(3), 3);
+  }
+
+  void readingStructureBindingLoopTest() {
+    auto mapVector = createTestMapVector();
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < mapsData.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapsData[i].begin();
+      int count = 0;
+      ASSERT_EQ(mapsData[i].size(), mapView.size());
+      for (const auto& [key, value] : mapView) {
+        ASSERT_EQ(key, it->first);
+        ASSERT_EQ(mapValueHasValue(value), it->second.has_value());
+        if (it->second.has_value()) {
+          ASSERT_EQ(mapValueValue(value), it->second.value());
+        }
+        ASSERT_EQ(value, it->second);
+        it++;
+        count++;
+      }
+      ASSERT_EQ(count, mapsData[i].size());
+    }
+  }
 };
 
-TEST_F(MapViewTest, testReadingRangeLoop) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
+class NullableMapViewTest : public MapViewTest<true> {};
 
-  for (auto i = 0; i < mapsData.size(); i++) {
-    auto mapView = reader[i];
-    auto it = mapsData[i].begin();
-    int count = 0;
-    ASSERT_EQ(mapsData[i].size(), mapView.size());
-    for (const auto& entry : mapView) {
-      ASSERT_EQ(entry.first, it->first);
-      ASSERT_EQ(entry.second.has_value(), it->second.has_value());
-      if (it->second.has_value()) {
-        ASSERT_EQ(entry.second.value(), it->second.value());
-      }
-      ASSERT_EQ(entry.second, it->second);
-      it++;
-      count++;
-    }
-    ASSERT_EQ(count, mapsData[i].size());
-  }
+class NullFreeMapViewTest : public MapViewTest<false> {};
+
+TEST_F(NullableMapViewTest, testReadingRangeLoop) {
+  readingRangeLoopTest();
 }
 
-TEST_F(MapViewTest, testReadingIteratorLoop) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  for (auto i = 0; i < mapsData.size(); ++i) {
-    auto mapView = reader[i];
-    auto it = mapsData[i].begin();
-    int count = 0;
-    ASSERT_EQ(mapsData[i].size(), mapView.size());
-    for (auto itView = mapView.begin(); itView != mapView.end(); ++itView) {
-      ASSERT_EQ(itView->first, it->first);
-      ASSERT_EQ(itView->second.has_value(), it->second.has_value());
-      if (it->second.has_value()) {
-        ASSERT_EQ(itView->second.value(), it->second.value());
-      }
-      ASSERT_EQ(itView->second, it->second);
-      it++;
-      count++;
-    }
-    ASSERT_EQ(count, mapsData[i].size());
-  }
+TEST_F(NullableMapViewTest, testReadingIteratorLoop) {
+  readingIteratorLoopTest();
 }
 
-// MapView can be seen as std::vector<pair<key, value>>.
-TEST_F(MapViewTest, testIndexedLoop) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  for (auto i = 0; i < mapsData.size(); ++i) {
-    auto mapView = reader[i];
-    auto it = mapsData[i].begin();
-    int count = 0;
-    ASSERT_EQ(mapsData[i].size(), mapView.size());
-    for (int j = 0; j < mapView.size(); j++) {
-      ASSERT_EQ(mapView[j].first, it->first);
-      ASSERT_EQ(mapView[j].second.has_value(), it->second.has_value());
-      if (it->second.has_value()) {
-        ASSERT_EQ(mapView[j].second.value(), it->second.value());
-      }
-      ASSERT_EQ(mapView[j].second, it->second);
-      it++;
-      count++;
-    }
-    ASSERT_EQ(count, mapsData[i].size());
-  }
+TEST_F(NullableMapViewTest, testIndexedLoop) {
+  indexedLoopTest();
 }
 
-TEST_F(MapViewTest, encoded) {
-  VectorPtr mapVector = createTestMapVector();
-  // Wrap in dictionary.
-  auto vectorSize = mapVector->size();
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(vectorSize, pool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  // Assign indices such that array is reversed.
-  for (size_t i = 0; i < vectorSize; ++i) {
-    rawIndices[i] = vectorSize - 1 - i;
-  }
-  mapVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, vectorSize, mapVector);
-
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(decode(decoded, *mapVector));
-
-  ASSERT_EQ(reader[0].size(), 5);
-  ASSERT_EQ(reader[1].size(), 3);
-  ASSERT_EQ(reader[2].size(), 0);
+TEST_F(NullableMapViewTest, encoded) {
+  encodedTest();
 }
 
-TEST_F(MapViewTest, testCompareLazyValueAccess) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  // Compare LazyValueAccess with constant.
-  ASSERT_EQ(reader[1][0].first, 1);
-  ASSERT_NE(reader[1][0].first, 10);
-  ASSERT_EQ(1, reader[1][0].first);
-  ASSERT_NE(10, reader[1][0].first);
-
-  // Compare LazyValueAccess with LazyValueAccess.
-  ASSERT_EQ(reader[2][2].first, reader[1][0].first);
-  ASSERT_NE(reader[2][2].first, reader[1][1].first);
-
-  // Compare LazyValueAccess with VectorOptionalValueAccessor value.
-  ASSERT_EQ(reader[2][1].first, reader[1][0].second.value());
-  ASSERT_NE(reader[2][2].first, reader[1][1].second.value());
-  ASSERT_EQ(reader[1][0].second.value(), reader[2][1].first);
-  ASSERT_NE(reader[1][1].second.value(), reader[2][2].first);
-
-  // Compare null VectorOptionalValueAccessor with LazyValueAccess.
-  ASSERT_NE(reader[1][1].second.value(), reader[1][2].first);
+TEST_F(NullableMapViewTest, testCompareLazyValueAccess) {
+  compareLazyValueAccessTest();
 }
 
-TEST_F(MapViewTest, testCompareVectorOptionalValueAccessor) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  // Compare VectorOptionalValueAccessor with std::optional.
-  ASSERT_EQ(reader[2][2].second, std::optional(4));
-  ASSERT_EQ(reader[2][2].second, std::optional(4l));
-  ASSERT_EQ(reader[2][2].second, std::optional(4ll));
-  ASSERT_EQ(reader[2][2].second, std::optional(4.0F));
-
-  ASSERT_NE(reader[2][2].second, std::optional(4.01F));
-  ASSERT_NE(reader[2][2].second, std::optional(8));
-
-  ASSERT_EQ(std::optional(4), reader[2][2].second);
-  ASSERT_EQ(std::optional(4l), reader[2][2].second);
-  ASSERT_EQ(std::optional(4ll), reader[2][2].second);
-
-  ASSERT_NE(std::optional(4.01F), reader[2][2].second);
-
-  ASSERT_EQ(std::nullopt, reader[1][2].second);
-  ASSERT_NE(std::nullopt, reader[1][1].second);
-
-  std::optional<int64_t> nullOpt;
-  ASSERT_EQ(reader[1][2].second, std::nullopt);
-  ASSERT_NE(reader[1][1].second, std::nullopt);
-
-  ASSERT_EQ(reader[1][2].second, nullOpt);
-  ASSERT_NE(reader[1][1].second, nullOpt);
-
-  // Compare VectorOptionalValueAccessor<T> with T::exec_t.
-  ASSERT_EQ(reader[2][2].second, 4);
-  ASSERT_EQ(reader[2][2].second, 4l);
-  ASSERT_EQ(reader[2][2].second, 4ll);
-  ASSERT_EQ(reader[2][2].second, 4.0F);
-
-  ASSERT_NE(reader[2][2].second, 4.01F);
-  ASSERT_NE(reader[2][2].second, 8);
-
-  ASSERT_EQ(4, reader[2][2].second);
-  ASSERT_EQ(4l, reader[2][2].second);
-  ASSERT_EQ(4ll, reader[2][2].second);
-  ASSERT_NE(4.01F, reader[2][2].second);
-
-  // VectorOptionalValueAccessor is null here.
-  ASSERT_NE(4.01F, reader[1][2].second);
-  ASSERT_NE(reader[1][2].second, 4);
-
-  // Compare VectorOptionalValueAccessor with VectorOptionalValueAccessor.
-  ASSERT_EQ(reader[2][2].second, reader[2][3].second);
-  ASSERT_NE(reader[2][2].second, reader[2][0].second);
-
-  // Compare with empty VectorOptionalValueAccessor.
-  // One null and one not null.
-  ASSERT_NE(reader[1][1].second, reader[1][2].second);
-  ASSERT_NE(reader[1][2].second, reader[1][1].second);
-  // Both are null.
-  ASSERT_EQ(reader[2][1].second, reader[1][2].second);
+TEST_F(NullableMapViewTest, testCompareVectorOptionalValueAccessor) {
+  compareVectorOptionalValueAccessorTest();
 }
 
-TEST_F(MapViewTest, testCompareMapViewElement) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  // Compare VectorOptionalValueAccessor with constant.
-  ASSERT_NE(reader[2][2], reader[2][1]);
-  ASSERT_EQ(reader[1][0], reader[2][2]);
+TEST_F(NullableMapViewTest, testCompareMapViewElement) {
+  compareMapViewElementTest();
 }
 
-TEST_F(MapViewTest, testAssignToOptional) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  std::optional<int64_t> element = reader[2][2].second;
-  std::optional<int64_t> element2 = reader[2][1].second;
-  ASSERT_EQ(element, reader[2][2].second);
-  ASSERT_EQ(element2, reader[2][1].second);
-  ASSERT_NE(element2, element);
+TEST_F(NullableMapViewTest, testAssignToOptional) {
+  assignToOptionalTest();
 }
 
-TEST_F(MapViewTest, testFind) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  ASSERT_EQ(reader[1].find(5), reader[1].end());
-  ASSERT_NE(reader[1].find(4), reader[1].end());
-  ASSERT_EQ(reader[1].find(4)->first, 4);
-  ASSERT_EQ(reader[1].find(4)->second, std::nullopt);
+TEST_F(NullableMapViewTest, testFind) {
+  findTest();
 }
 
-TEST_F(MapViewTest, testAt) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
-
-  ASSERT_THROW(reader[1].at(5), VeloxException);
-  ASSERT_EQ(reader[1].at(4), std::nullopt);
-  ASSERT_EQ(reader[1].at(3), 3);
+TEST_F(NullableMapViewTest, testAt) {
+  atTest();
 }
 
-TEST_F(MapViewTest, testValueOr) {
+TEST_F(NullableMapViewTest, testValueOr) {
   auto mapVector = createTestMapVector();
   DecodedVector decoded;
   exec::VectorReader<Map<int64_t, int64_t>> reader(
@@ -322,7 +438,7 @@ struct MapComplexKeyF {
   }
 };
 
-TEST_F(MapViewTest, mapCoplexKey) {
+TEST_F(NullableMapViewTest, mapCoplexKey) {
   registerFunction<MapComplexKeyF, double, Map<Array<double>, double>>(
       {"func"});
 
@@ -350,29 +466,52 @@ TEST_F(MapViewTest, mapCoplexKey) {
   }
 }
 
-TEST_F(MapViewTest, testReadingStructureBindingLoop) {
-  auto mapVector = createTestMapVector();
-  DecodedVector decoded;
-  exec::VectorReader<Map<int64_t, int64_t>> reader(
-      decode(decoded, *mapVector.get()));
+TEST_F(NullableMapViewTest, testReadingStructureBindingLoop) {
+  readingStructureBindingLoopTest();
+}
 
-  for (auto i = 0; i < mapsData.size(); i++) {
-    auto mapView = reader[i];
-    auto it = mapsData[i].begin();
-    int count = 0;
-    ASSERT_EQ(mapsData[i].size(), mapView.size());
-    for (const auto& [key, value] : mapView) {
-      ASSERT_EQ(key, it->first);
-      ASSERT_EQ(value.has_value(), it->second.has_value());
-      if (it->second.has_value()) {
-        ASSERT_EQ(value.value(), it->second.value());
-      }
-      ASSERT_EQ(value, it->second);
-      it++;
-      count++;
-    }
-    ASSERT_EQ(count, mapsData[i].size());
-  }
+TEST_F(NullFreeMapViewTest, testReadingRangeLoop) {
+  readingRangeLoopTest();
+}
+
+TEST_F(NullFreeMapViewTest, testReadingIteratorLoop) {
+  readingIteratorLoopTest();
+}
+
+TEST_F(NullFreeMapViewTest, testIndexedLoop) {
+  indexedLoopTest();
+}
+
+TEST_F(NullFreeMapViewTest, encoded) {
+  encodedTest();
+}
+
+TEST_F(NullFreeMapViewTest, testCompareLazyValueAccess) {
+  compareLazyValueAccessTest();
+}
+
+TEST_F(NullFreeMapViewTest, testCompareVectorOptionalValueAccessor) {
+  compareVectorOptionalValueAccessorTest();
+}
+
+TEST_F(NullFreeMapViewTest, testCompareMapViewElement) {
+  compareMapViewElementTest();
+}
+
+TEST_F(NullFreeMapViewTest, testAssignToOptional) {
+  assignToOptionalTest();
+}
+
+TEST_F(NullFreeMapViewTest, testFind) {
+  findTest();
+}
+
+TEST_F(NullFreeMapViewTest, testAt) {
+  atTest();
+}
+
+TEST_F(NullFreeMapViewTest, testReadingStructureBindingLoop) {
+  readingStructureBindingLoopTest();
 }
 
 } // namespace

--- a/velox/expression/tests/RowViewTest.cpp
+++ b/velox/expression/tests/RowViewTest.cpp
@@ -28,7 +28,16 @@ DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   return &decoder;
 }
 
+template <bool returnsOptionalValues>
 class RowViewTest : public functions::test::FunctionBaseTest {
+  using ViewType = exec::RowView<returnsOptionalValues, int32_t, float>;
+  using ReadFunction =
+      std::function<ViewType(exec::VectorReader<Row<int32_t, float>>&, size_t)>;
+
+  static bool isNullAt(vector_size_t i) {
+    return returnsOptionalValues && i % 2 == 0;
+  }
+
  protected:
   VectorPtr makeTestRowVector() {
     std::vector<int32_t> data1;
@@ -39,69 +48,128 @@ class RowViewTest : public functions::test::FunctionBaseTest {
       data2.push_back(size - i);
     };
     return makeRowVector(
-        {makeFlatVector(data1), makeFlatVector(data2)},
-        [](auto i) { return i % 2 == 0; });
+        {makeFlatVector(data1), makeFlatVector(data2)}, isNullAt);
+  }
+
+  ViewType read(
+      exec::VectorReader<Row<int32_t, float>>& reader,
+      size_t offset) {
+    if constexpr (returnsOptionalValues) {
+      return reader[offset];
+    } else {
+      return reader.readNullFree(offset);
+    }
+  }
+
+  template <typename T, size_t N>
+  T at(const exec::RowView<returnsOptionalValues, int32_t, float>& row) {
+    auto value = row.template at<N>();
+
+    if constexpr (returnsOptionalValues) {
+      return *value;
+    } else {
+      return value;
+    }
+  }
+
+  template <typename T, size_t N>
+  T get(const exec::RowView<returnsOptionalValues, int32_t, float>& row) {
+    auto value = exec::get<N>(row);
+
+    if constexpr (returnsOptionalValues) {
+      return *value;
+    } else {
+      return value;
+    }
+  }
+
+  void basicTest() {
+    auto rowVector = makeTestRowVector();
+    DecodedVector decoded;
+    exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
+
+    for (auto i = 0; i < rowVector->size(); ++i) {
+      auto isSet = reader.isSet(i);
+      ASSERT_EQ(isSet, !isNullAt(i));
+      if (isSet) {
+        auto&& r = read(reader, i);
+        ASSERT_EQ((at<int32_t, 0>(r)), i);
+        ASSERT_EQ((at<float, 1>(r)), rowVector->size() - i);
+      }
+    }
+  }
+
+  void encodedTest() {
+    auto rowVector = makeTestRowVector();
+    // Wrap in dictionary.
+    auto vectorSize = rowVector->size();
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(vectorSize, pool_.get());
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    // Assign indices such that array is reversed.
+    for (size_t i = 0; i < vectorSize; ++i) {
+      rawIndices[i] = vectorSize - 1 - i;
+    }
+    rowVector = BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), indices, vectorSize, rowVector);
+
+    DecodedVector decoded;
+    exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
+
+    for (auto i = 0; i < rowVector->size(); ++i) {
+      auto isSet = reader.isSet(i);
+      ASSERT_EQ(isSet, !isNullAt(vectorSize - 1 - i));
+      if (isSet) {
+        auto&& r = read(reader, i);
+        ASSERT_EQ((at<int32_t, 0>(r)), rowVector->size() - i - 1);
+        ASSERT_EQ((at<float, 1>(r)), i + 1);
+      }
+    }
+  }
+
+  void getTest() {
+    auto rowVector = makeTestRowVector();
+    DecodedVector decoded;
+    exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
+
+    for (auto i = 0; i < rowVector->size(); ++i) {
+      auto isSet = reader.isSet(i);
+      ASSERT_EQ(isSet, !isNullAt(i));
+      if (isSet) {
+        auto&& r = read(reader, i);
+        ASSERT_EQ((get<int32_t, 0>(r)), i);
+        ASSERT_EQ((get<float, 1>(r)), rowVector->size() - i);
+      }
+    }
   }
 };
 
-TEST_F(RowViewTest, basic) {
-  auto rowVector = makeTestRowVector();
-  DecodedVector decoded;
-  exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
+class NullableRowViewTest : public RowViewTest<true> {};
 
-  for (auto i = 0; i < rowVector->size(); ++i) {
-    auto isSet = reader.isSet(i);
-    ASSERT_EQ(isSet, i % 2 == 1);
-    if (isSet) {
-      auto&& r = reader[i];
-      ASSERT_EQ(*r.at<0>(), i);
-      ASSERT_EQ(*r.at<1>(), rowVector->size() - i);
-    }
-  }
+class NullFreeRowViewTest : public RowViewTest<false> {};
+
+TEST_F(NullableRowViewTest, basic) {
+  basicTest();
 }
 
-TEST_F(RowViewTest, encoded) {
-  auto rowVector = makeTestRowVector();
-  // Wrap in dictionary.
-  auto vectorSize = rowVector->size();
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(vectorSize, pool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  // Assign indices such that array is reversed.
-  for (size_t i = 0; i < vectorSize; ++i) {
-    rawIndices[i] = vectorSize - 1 - i;
-  }
-  rowVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, vectorSize, rowVector);
-
-  DecodedVector decoded;
-  exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
-
-  for (auto i = 0; i < rowVector->size(); ++i) {
-    auto isSet = reader.isSet(i);
-    ASSERT_EQ(isSet, i % 2 == 0);
-    if (isSet) {
-      auto&& r = reader[i];
-      ASSERT_EQ(*r.at<0>(), rowVector->size() - i - 1);
-      ASSERT_EQ(*r.at<1>(), i + 1);
-    }
-  }
+TEST_F(NullableRowViewTest, encoded) {
+  encodedTest();
 }
 
-TEST_F(RowViewTest, get) {
-  auto rowVector = makeTestRowVector();
-  DecodedVector decoded;
-  exec::VectorReader<Row<int32_t, float>> reader(decode(decoded, *rowVector));
+TEST_F(NullableRowViewTest, get) {
+  getTest();
+}
 
-  for (auto i = 0; i < rowVector->size(); ++i) {
-    auto isSet = reader.isSet(i);
-    ASSERT_EQ(isSet, i % 2 == 1);
-    if (isSet) {
-      auto&& r = reader[i];
-      ASSERT_EQ(*exec::get<0>(r), i);
-      ASSERT_EQ(*exec::get<1>(r), rowVector->size() - i);
-    }
-  }
+TEST_F(NullFreeRowViewTest, basic) {
+  basicTest();
+}
+
+TEST_F(NullFreeRowViewTest, encoded) {
+  encodedTest();
+}
+
+TEST_F(NullFreeRowViewTest, get) {
+  getTest();
 }
 
 } // namespace

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -95,6 +95,14 @@ class BaseVector {
     return rawNulls_;
   }
 
+  // Returns false if this vector and all of its children have no nulls. Returns
+  // true if this vector or any of its children may have nulls.
+  // When this method returns true, flatRawNulls called on this vector or any
+  // of its children is guaranteed to return non-null.
+  virtual bool mayHaveNullsRecursive() const {
+    return mayHaveNulls();
+  }
+
   // Returns raw nulls or nullptr with one bit per logical position in
   // the vector, with valid values at least for the rows selected in
   // 'rows'. Dictionaries, sequences and constants may calculate this on

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -159,6 +159,11 @@ class ConstantVector final : public SimpleVector<T> {
     return isNull_;
   }
 
+  bool mayHaveNullsRecursive() const override {
+    VELOX_DCHECK(initialized_);
+    return isNull_ || (valueVector_ && valueVector_->mayHaveNullsRecursive());
+  }
+
   const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
     VELOX_DCHECK(initialized_);
     if (isNull_) {

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -74,6 +74,12 @@ class DictionaryVector : public SimpleVector<T> {
     return BaseVector::nulls() || dictionaryValues_->mayHaveNulls();
   }
 
+  bool mayHaveNullsRecursive() const override {
+    VELOX_DCHECK(initialized_);
+    return BaseVector::mayHaveNullsRecursive() ||
+        dictionaryValues_->mayHaveNullsRecursive();
+  }
+
   bool isNullAt(vector_size_t idx) const override;
 
   const uint64_t* flatRawNulls(const SelectivityVector& rows) override;

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -240,6 +240,10 @@ class LazyVector : public BaseVector {
     return loadedVector()->mayHaveNulls();
   }
 
+  bool mayHaveNullsRecursive() const override {
+    return loadedVector()->mayHaveNullsRecursive();
+  }
+
   bool isNullAt(vector_size_t index) const override {
     return loadedVector()->isNullAt(index);
   }

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -63,6 +63,10 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_->mayHaveNulls();
   }
 
+  bool mayHaveNullsRecursive() const override {
+    return sequenceValues_->mayHaveNullsRecursive();
+  }
+
   const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
     if (flatNullsBuffer_) {
       return flatNullsBuffer_->as<uint64_t>();

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -16,8 +16,10 @@ add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 target_link_libraries(velox_vector_test_lib velox_vector)
 
 add_executable(
-  velox_vector_test VectorMakerTest.cpp VectorTest.cpp DecodedVectorTest.cpp
-                    SelectivityVectorTest.cpp EnsureWritableVectorTest.cpp)
+  velox_vector_test
+  VectorMakerTest.cpp VectorTest.cpp DecodedVectorTest.cpp
+  SelectivityVectorTest.cpp EnsureWritableVectorTest.cpp
+  MayHaveNullsRecursiveTest.cpp)
 
 add_test(velox_vector_test velox_vector_test)
 

--- a/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
+++ b/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/vector/tests/VectorMaker.h"
+
+namespace facebook::velox::test {
+
+class MayHaveNullsRecursiveTest : public testing::Test {
+ protected:
+  std::unique_ptr<velox::memory::ScopedMemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  VectorMaker vectorMaker_{pool_.get()};
+
+  enum class TestOptions {
+    WITH_NULL_CONTAINERS,
+    WITH_NULL_VALUES,
+  };
+
+  std::vector<std::optional<int32_t>> generateIntInput() {
+    return generateIntInput(false);
+  }
+
+  std::vector<std::optional<int32_t>> generateIntInputWithNulls() {
+    return generateIntInput(true);
+  }
+
+  ArrayVectorPtr generateArrayVector(
+      const std::unordered_set<TestOptions>& testOptions = {}) {
+    std::function<bool(vector_size_t)> noNulls = nullptr;
+
+    return vectorMaker_.arrayVector<int32_t>(
+        10,
+        [](vector_size_t row) { return row; },
+        [](vector_size_t idx) { return idx; },
+        testOptions.count(TestOptions::WITH_NULL_CONTAINERS) > 0
+            ? [](vector_size_t row) { return row % 5 == 0; }
+            : noNulls,
+        testOptions.count(TestOptions::WITH_NULL_VALUES) > 0
+            ? [](vector_size_t idx) { return idx % 7 == 0; }
+            : noNulls);
+  }
+
+  MapVectorPtr generateMapVector(
+      const std::unordered_set<TestOptions>& testOptions = {}) {
+    std::function<bool(vector_size_t)> noNulls = nullptr;
+
+    return vectorMaker_.mapVector<int32_t, int32_t>(
+        10,
+        [](vector_size_t row) { return row; },
+        [](vector_size_t idx) { return idx; },
+        [](vector_size_t idx) { return idx % 10; },
+        testOptions.count(TestOptions::WITH_NULL_CONTAINERS) > 0
+            ? [&](vector_size_t row) { return row % 5 == 0; }
+            : noNulls,
+        testOptions.count(TestOptions::WITH_NULL_VALUES) > 0
+            ? [&](vector_size_t row) { return row % 7 == 0; }
+            : noNulls);
+  }
+
+ private:
+  std::vector<std::optional<int32_t>> generateIntInput(bool withNulls) {
+    std::vector<std::optional<int32_t>> input;
+    for (int32_t i = 0; i < 10; ++i) {
+      if (withNulls && i % 5 == 0) {
+        input.push_back(std::nullopt);
+      } else {
+        input.push_back(i);
+      }
+    }
+
+    return input;
+  }
+};
+
+TEST_F(MayHaveNullsRecursiveTest, biasHasNulls) {
+  auto biasVector = vectorMaker_.biasVector(generateIntInputWithNulls());
+
+  ASSERT_TRUE(biasVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, biasNullFree) {
+  auto biasVector = vectorMaker_.biasVector(generateIntInput());
+
+  ASSERT_FALSE(biasVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, arrayHasNulls) {
+  auto arrayVector = generateArrayVector({TestOptions::WITH_NULL_CONTAINERS});
+
+  ASSERT_TRUE(arrayVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, arrayHasNullElements) {
+  auto arrayVector = generateArrayVector({TestOptions::WITH_NULL_VALUES});
+
+  ASSERT_TRUE(arrayVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, arrayNullFree) {
+  auto arrayVector = generateArrayVector();
+
+  ASSERT_FALSE(arrayVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, mapHasNulls) {
+  auto mapVector = generateMapVector({TestOptions::WITH_NULL_CONTAINERS});
+
+  ASSERT_TRUE(mapVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, mapHasNullValues) {
+  auto mapVector = generateMapVector({TestOptions::WITH_NULL_VALUES});
+
+  ASSERT_TRUE(mapVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, mapNullFree) {
+  auto mapVector = generateMapVector();
+
+  ASSERT_FALSE(mapVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, rowHasNulls) {
+  auto rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector(),
+       generateMapVector()});
+
+  rowVector->setNull(3, true);
+
+  ASSERT_TRUE(rowVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, rowChildrenHaveNulls) {
+  auto rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInputWithNulls()),
+       generateArrayVector(),
+       generateMapVector()});
+
+  ASSERT_TRUE(rowVector->mayHaveNullsRecursive());
+
+  rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector({TestOptions::WITH_NULL_VALUES}),
+       generateMapVector()});
+
+  ASSERT_TRUE(rowVector->mayHaveNullsRecursive());
+
+  rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector(),
+       generateMapVector({TestOptions::WITH_NULL_CONTAINERS})});
+
+  ASSERT_TRUE(rowVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, rowNullFree) {
+  auto rowVector = vectorMaker_.rowVector(
+      {vectorMaker_.flatVectorNullable(generateIntInput()),
+       generateArrayVector(),
+       generateMapVector()});
+
+  ASSERT_FALSE(rowVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, constantNull) {
+  auto constantVector = vectorMaker_.constantVector<int32_t>({std::nullopt});
+
+  ASSERT_TRUE(constantVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, constantNullFree) {
+  auto constantVector = vectorMaker_.constantVector<int32_t>({1});
+
+  ASSERT_FALSE(constantVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, dictionaryHasNulls) {
+  auto dictionaryVector =
+      vectorMaker_.dictionaryVector(generateIntInputWithNulls());
+
+  ASSERT_TRUE(dictionaryVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, dictionaryNullFree) {
+  auto dictionaryVector = vectorMaker_.dictionaryVector(generateIntInput());
+
+  ASSERT_FALSE(dictionaryVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, flatHasNulls) {
+  auto flatVector =
+      vectorMaker_.flatVectorNullable(generateIntInputWithNulls());
+
+  ASSERT_TRUE(flatVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, flatNullFree) {
+  auto flatVector = vectorMaker_.flatVectorNullable(generateIntInput());
+
+  ASSERT_FALSE(flatVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, lazyHasNulls) {
+  auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(
+      10,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 3 == 0; });
+
+  ASSERT_TRUE(lazyVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, lazyNullFree) {
+  auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(
+      10, [](vector_size_t row) { return row; });
+
+  ASSERT_FALSE(lazyVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, sequenceHasNulls) {
+  auto sequenceVector =
+      vectorMaker_.sequenceVector(generateIntInputWithNulls());
+
+  ASSERT_TRUE(sequenceVector->mayHaveNullsRecursive());
+}
+
+TEST_F(MayHaveNullsRecursiveTest, sequenceNullFree) {
+  auto sequenceVector = vectorMaker_.sequenceVector(generateIntInput());
+
+  ASSERT_FALSE(sequenceVector->mayHaveNullsRecursive());
+}
+} // namespace facebook::velox::test

--- a/velox/vector/tests/VectorMaker.h
+++ b/velox/vector/tests/VectorMaker.h
@@ -277,7 +277,8 @@ class VectorMaker {
       vector_size_t size,
       std::function<vector_size_t(vector_size_t /* row */)> sizeAt,
       std::function<T(vector_size_t /* idx */)> valueAt,
-      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
+      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr,
+      std::function<bool(vector_size_t /* idx */)> valueIsNullAt = nullptr) {
     BufferPtr nulls;
     BufferPtr offsets;
     BufferPtr sizes;
@@ -291,7 +292,7 @@ class VectorMaker {
         size,
         offsets,
         sizes,
-        flatVector<T>(numElements, valueAt),
+        flatVector<T>(numElements, valueAt, valueIsNullAt),
         BaseVector::countNulls(nulls, 0, size));
   }
 


### PR DESCRIPTION
Summary:
# High Level Goal:
We've identified some use cases where they want UDFs to return NULL not only if any of the values of the arguments to a function are NULL, but also if any of those arguments are complex types containing NULLs.

In these cases these UDFs they want a variant of the call function which receive views that don't expose nullity (since there are guaranteed to be no NULLs).  E.g. for Array<int64_t> instead of getting an ArrayView that offers an interface similar to std::vector<std::optional<int64_t>, they want an ArrayView that offers an interface like std::vector<int64_t>.

I plan to augment the SimpleFunction interface to offer a callNullFree function, which is only called if the arguments are not NULL and do not contain NULLs.  This function exposes Views with the desired interface as described above.  If only callNullFree is implemented, SimpleFunctions will return NULL in the if callNullFree cannot be invoked, otherwise it acts like a fast path if we can quickly determine the inputs do not contain NULLs and otherwise we defer to call or callNullable.

# This Diff
I add a function mayNotBeNullFree to Vectors which returns false iff we can be sure that the vector and all of its children have nullptr for nulls_ (or isNull_ == true for constants).  This gives us a quick check we'll be able to apply in the SimpleFunctionAdapter to determine if we can call the callNullFree function, or if we need to do a slower thorough search for nulls if only callNullFree is implemented.

On a side note, mayContainNullData was suggested as a name for this function. I opted for mayNotBeNullFree as https://github.com/facebookincubator/velox/pull/926 established NullFree as meaning not being or containing NULL, but I'm open to changing it back if anyone feels differently.

Differential Revision: D33829875

