### PR TITLE
Remove check for `Nulls buffer` when null_count = 0

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -669,17 +669,17 @@ VectorPtr importFromArrowImpl(
   // needs to be at least one bit per element.
   BufferPtr nulls = nullptr;
 
-  // If either greater than zero or -1 (unknown).
+  // If null_count is greater than zero or -1 (unknown), nulls buffer has to
+  // present.
+  // Otherwise, when null_count is zero, it's legit for the arrow array to have
+  // non-null nulls buffer, in that case the converted Velox vector will not
+  // have null buffer.
   if (arrowArray.null_count != 0) {
     VELOX_USER_CHECK_NOT_NULL(
         arrowArray.buffers[0],
         "Nulls buffer can't be null unless null_count is zero.");
     nulls = wrapInBufferView(
         arrowArray.buffers[0], bits::nbytes(arrowArray.length));
-  } else {
-    VELOX_USER_CHECK_NULL(
-        arrowArray.buffers[0],
-        "Nulls buffer must be nullptr when null_count is zero.");
   }
 
   // String data types (VARCHAR and VARBINARY).


### PR DESCRIPTION
Summary:
In PyArrow 6.0, it's legit for an arrow array to have non-null NullBuffer while null_count is zero (see also https://github.com/facebookresearch/torcharrow/pull/109) :
```
import pyarrow as pa
>>> pa.__version__
'6.0.0'
>>> a = pa.array([1, 2, None, 3])
>>> a = a.fill_null(12)
>>> a.buffers()
[<pyarrow.lib.Buffer object at 0x7fe688222330>, <pyarrow.lib.Buffer object at 0x7fe6680c2ef0>]
```

User also reports similiar issue when converting arrow array reading from Parquet, see https://github.com/facebookresearch/torcharrow/issues/146#issuecomment-1023873632

Differential Revision: D33836988

