### PR TITLE
Initialize FilterGenerator with a seed

### DIFF
--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -546,7 +546,9 @@ class E2EFilterTest : public testing::Test {
       bool tryNoNulls = false,
       bool tryNoVInts = false) {
     makeRowType(columns, wrapInStruct);
-    filterGenerator = std::make_unique<FilterGenerator>(rowType_);
+    // TODO: Seed was hard coded as 1 to make it behave the same as before.
+    // Change to use random seed (like current timestamp).
+    filterGenerator = std::make_unique<FilterGenerator>(rowType_, 1);
     for (int32_t noVInts = 0; noVInts < (tryNoVInts ? 2 : 1); ++noVInts) {
       useVInts_ = !noVInts;
       for (int32_t noNulls = 0; noNulls < (tryNoNulls ? 2 : 1); ++noNulls) {

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
@@ -55,15 +55,14 @@ VectorPtr getChildBySubfield(
         ? container->type()->as<TypeKind::ROW>()
         : *parentType;
     auto childIdx = rowType.getChildIdx(nestedField->name());
-    auto child = rowVector->childAt(childIdx);
+    auto child = container->childAt(childIdx);
 
     if (i == path.size() - 1) {
       return child;
     }
     VELOX_CHECK(child->typeKind() == TypeKind::ROW);
     container = child->as<RowVector>();
-    parentType =
-        dynamic_cast<const RowType*>(parentType->childAt(childIdx).get());
+    parentType = dynamic_cast<const RowType*>(rowType.childAt(childIdx).get());
     VELOX_CHECK_NOT_NULL(
         parentType,
         "Expecting child to be row type",

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.h
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.h
@@ -314,10 +314,11 @@ class FilterGenerator {
   static std::string specsToString(const std::vector<FilterSpec>& specs);
   static SubfieldFilters cloneSubfieldFilters(const SubfieldFilters& src);
 
-  explicit FilterGenerator(std::shared_ptr<const RowType>& rowType)
-      : rowType_(rowType) {
-    reseedRng();
-  }
+  explicit FilterGenerator(
+      std::shared_ptr<const RowType>& rowType,
+      folly::Random::DefaultGenerator::result_type seed =
+          folly::Random::DefaultGenerator::default_seed)
+      : rowType_(rowType), seed_(seed), rng_(seed) {}
 
   SubfieldFilters makeSubfieldFilters(
       const std::vector<FilterSpec>& filterSpecs,
@@ -334,7 +335,7 @@ class FilterGenerator {
   }
 
   inline void reseedRng() {
-    rng_.seed(1);
+    rng_.seed(seed_);
   }
 
   inline const std::unordered_map<std::string, std::array<int32_t, 2>>&
@@ -352,8 +353,10 @@ class FilterGenerator {
   static void collectFilterableSubFields(
       const RowType* rowType,
       std::vector<std::string>& subFields);
-  folly::Random::DefaultGenerator rng_;
+
   std::shared_ptr<const RowType> rowType_;
+  folly::Random::DefaultGenerator::result_type seed_;
+  folly::Random::DefaultGenerator rng_;
   std::unordered_map<std::string, std::array<int32_t, 2>> filterCoverage_;
 };
 


### PR DESCRIPTION
Summary:
Today FilterGenerator's random generator is initialized with a hard coded seed.
Change it to take a seed in its constructor.

Differential Revision: D33852838

