### PR TITLE
Fix shift overflow

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -163,7 +163,7 @@ size_t MemoryPoolBase::getPreferredSize(size_t size) {
     return 8;
   }
   int32_t bits = 63 - bits::countLeadingZeros(size);
-  size_t lower = 1U << bits;
+  size_t lower = 1ULL << bits;
   // Size is a power of 2.
   if (lower == size) {
     return size;


### PR DESCRIPTION
Summary: It's rare but possible to allocate memory size close to 2g, shifting 1<<31 cause problem.

Reviewed By: Magoja, HuamengJiang

Differential Revision: D33858533

