### PR TITLE
Make format calls compatible with older versions of fmt

### DIFF
--- a/velox/experimental/codegen/CodegenCompiledExpressionTransform.h
+++ b/velox/experimental/codegen/CodegenCompiledExpressionTransform.h
@@ -475,17 +475,17 @@ class CompiledExpressionTransformVisitor {
     for (const auto& includePath : includeSet) {
       includes << fmt::format("#include {}\n", includePath);
     };
-    const std::string fileString = fmt::format(
+    const std::string fileString = fmt::vformat(
         fileFormat(),
-        fmt::arg("includes", includes.str()),
-        fmt::arg("GeneratedCode", genCode),
-        fmt::arg("GeneratedCodeClass", "FilterExpr"),
-        fmt::arg(
-            "isDefaultNull", isDefaultNull(filter.id()) ? "true" : "false"),
-        fmt::arg(
-            "isDefaultNullStrict",
-            isDefaultNullStrict(filter.id()) ? "true" : "false"));
-
+        fmt::make_format_args(
+            fmt::arg("includes", includes.str()),
+            fmt::arg("GeneratedCode", genCode),
+            fmt::arg("GeneratedCodeClass", "FilterExpr"),
+            fmt::arg(
+                "isDefaultNull", isDefaultNull(filter.id()) ? "true" : "false"),
+            fmt::arg(
+                "isDefaultNullStrict",
+                isDefaultNullStrict(filter.id()) ? "true" : "false")));
     auto compiledObject = codeManager_.compiler().compileString({}, fileString);
     auto dynamicObject = codeManager_.compiler().link({}, {compiledObject});
 
@@ -574,14 +574,16 @@ class CompiledExpressionTransformVisitor {
       isDefaultNullStrict = this->isDefaultNullStrict(projection.id());
     }
 
-    const std::string fileString = fmt::format(
+    const std::string fileString = fmt::vformat(
         fileFormat(),
-        fmt::arg("includes", includes.str()),
-        fmt::arg("GeneratedCode", genCode),
-        fmt::arg("GeneratedCodeClass", "ProjectExpr"),
-        fmt::arg("isDefaultNull", isDefaultNull ? "true" : "false"),
-        fmt::arg(
-            "isDefaultNullStrict", isDefaultNullStrict ? "true" : "false"));
+        fmt::make_format_args(
+            fmt::arg("includes", includes.str()),
+            fmt::arg("GeneratedCode", genCode),
+            fmt::arg("GeneratedCodeClass", "ProjectExpr"),
+            fmt::arg("isDefaultNull", isDefaultNull ? "true" : "false"),
+            fmt::arg(
+                "isDefaultNullStrict",
+                isDefaultNullStrict ? "true" : "false")));
 
     auto compiledObject = codeManager_.compiler().compileString({}, fileString);
     auto dynamicObject = codeManager_.compiler().link({}, {compiledObject});

--- a/velox/experimental/codegen/external_process/Filesystem.h
+++ b/velox/experimental/codegen/external_process/Filesystem.h
@@ -40,11 +40,11 @@ class PathGenerator {
       const std::string& extension) {
     fmt::memory_buffer stringBuffer;
 
-    fmt::format_to(
-        stringBuffer,
+    fmt::vformat_to(
+        std::back_insert_iterator(stringBuffer),
         (rootDir / fileNameFormat).string(),
-        fmt::arg("prefix", prefix),
-        fmt::arg("ext", extension));
+        fmt::make_format_args(
+            fmt::arg("prefix", prefix), fmt::arg("ext", extension)));
 
     // mkstemps expects a null terminated string.
     stringBuffer.push_back('\0');


### PR DESCRIPTION
Summary: CircleCI macOS build uses an older version of fmt which doesn't have `fmt::runtime` so change formatting function calls with runtime format strings to not use this function.

Reviewed By: spershin

Differential Revision: D33863063

