### PR TITLE
Fix LazyVector in dictionary

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -60,7 +60,8 @@ GroupingSet::GroupingSet(
       stringAllocator_(mappedMemory_),
       rows_(mappedMemory_),
       isAdaptive_(
-          operatorCtx->task()->queryCtx()->config().hashAdaptivityEnabled()) {
+          operatorCtx->task()->queryCtx()->config().hashAdaptivityEnabled()),
+      execCtx_(*operatorCtx->execCtx()) {
   for (auto& hasher : hashers_) {
     keyChannels_.push_back(hasher->channel());
   }
@@ -149,7 +150,7 @@ void GroupingSet::addInputForActiveRows(
   auto mode = table_->hashMode();
   if (ignoreNullKeys_) {
     // A null in any of the keys disables the row.
-    deselectRowsWithNulls(*input, keyChannels_, activeRows_);
+    deselectRowsWithNulls(*input, keyChannels_, activeRows_, execCtx_);
     for (int32_t i = 0; i < hashers.size(); ++i) {
       auto key = input->loadedChildAt(hashers[i]->channel());
       if (mode != BaseHashTable::HashMode::kHash) {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -123,6 +123,8 @@ class GroupingSet {
   AllocationPool rows_;
   const bool isAdaptive_;
 
+  core::ExecCtx& execCtx_;
+
   bool noMoreInput_{false};
 
   /// In case of partial streaming aggregation, the input vector passed to

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -110,9 +110,10 @@ HashAggregation::HashAggregation(
     const auto& expectedType = outputType_->childAt(numHashers + i);
     VELOX_CHECK(
         aggResultType->kindEquals(expectedType),
-        "Unexpected result type for an aggregation: {}, expected {}",
+        "Unexpected result type for an aggregation: {}, expected {}, step {}",
         aggResultType->toString(),
-        expectedType->toString());
+        expectedType->toString(),
+        static_cast<int32_t>(aggregationNode->step()));
   }
 
   if (isDistinct_) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -118,7 +118,8 @@ void HashBuild::addInput(RowVectorPtr input) {
   activeRows_.resize(input->size());
   activeRows_.setAll();
   if (!isRightJoin(joinType_)) {
-    deselectRowsWithNulls(*input, keyChannels_, activeRows_);
+    deselectRowsWithNulls(
+        *input, keyChannels_, activeRows_, *operatorCtx_->execCtx());
   }
 
   if (joinType_ == core::JoinType::kAnti) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -70,6 +70,8 @@ class HashProbe : public Operator {
   // 'rowNumberMapping_'. Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows);
 
+  void ensureLoadedIfNotAtEnd(ChannelIndex channel);
+
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const uint32_t outputBatchSize_;
 
@@ -234,6 +236,15 @@ class HashProbe : public Operator {
   SelectivityVector activeRows_;
 
   bool finished_{false};
+
+  // True if passingInputRows is up to date.
+  bool passingInputRowsInitialized_;
+
+  // Set of input rows for which there is at least one join hit. All
+  // set if right side optional. Used when loading lazy vectors for
+  // cases where there is more than one batch of output or join filter
+  // input.
+  SelectivityVector passingInputRows_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -72,11 +72,11 @@ class BaseHashTable {
     }
 
     bool atEnd() const {
-      return lastRowIndex == rows->size();
+      return !rows || lastRowIndex == rows->size();
     }
 
-    const raw_vector<vector_size_t>* rows;
-    const raw_vector<char*>* hits;
+    const raw_vector<vector_size_t>* rows{nullptr};
+    const raw_vector<char*>* hits{nullptr};
     char* nextHit{nullptr};
     vector_size_t lastRowIndex{0};
   };

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/OperatorUtils.h"
+#include "velox/expression/EvalCtx.h"
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -23,10 +24,13 @@ namespace facebook::velox::exec {
 void deselectRowsWithNulls(
     const RowVector& input,
     const std::vector<ChannelIndex>& channels,
-    SelectivityVector& rows) {
+    SelectivityVector& rows,
+    core::ExecCtx& execCtx) {
   bool anyChange = false;
   auto numRows = input.size();
+  EvalCtx evalCtx(&execCtx, nullptr, &input);
   for (auto channel : channels) {
+    evalCtx.ensureFieldLoaded(channel, rows);
     auto key = input.loadedChildAt(channel);
     if (key->mayHaveNulls()) {
       auto nulls = key->flatRawNulls(rows);

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -24,7 +24,8 @@ namespace facebook::velox::exec {
 void deselectRowsWithNulls(
     const RowVector& input,
     const std::vector<ChannelIndex>& channels,
-    SelectivityVector& rows);
+    SelectivityVector& rows,
+    core::ExecCtx& execCtx);
 
 // Reusable memory needed for processing filter results.
 struct FilterEvalCtx {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2447,3 +2447,35 @@ TEST_F(ExprTest, testEmptyVectors) {
   auto result = evaluate("c0 + c0", makeRowVector({a, a}));
   assertEqualVectors(a, result);
 }
+
+TEST_F(ExprTest, subsetOfDictOverLazy) {
+  // We have dictionaries over LazyVector. We load for some indices in
+  // the top dictionary. The intermediate dictionaries refer to
+  // non-loaded items in the base of the LazyVector, including indices
+  // past its end. We check that we end up with one level of
+  // dictionary and no dictionaries that are invalid by through
+  // referring to uninitialized/nonexistent positions.
+  auto base = makeFlatVector<int32_t>(100, [](auto row) { return row; });
+  auto lazy = std::make_shared<LazyVector>(
+      execCtx_->pool(),
+      INTEGER(),
+      1000,
+      std::make_unique<test::SimpleVectorLoader>(
+          [base](auto /*size*/) { return base; }));
+  auto row = makeRowVector({BaseVector::wrapInDictionary(
+      nullptr,
+      makeIndices(100, [](auto row) { return row; }),
+      100,
+
+      BaseVector::wrapInDictionary(
+          nullptr,
+          makeIndices(1000, [](auto row) { return row; }),
+          1000,
+          lazy))});
+
+  // We expect a single level of dictionary.
+  auto result = evaluate("c0", row);
+  EXPECT_EQ(result->encoding(), VectorEncoding::Simple::DICTIONARY);
+  EXPECT_EQ(result->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
+  assertEqualVectors(result, base);
+}


### PR DESCRIPTION
LazyVectors can b wrapped in dictionaries by joins and filters. Loading the LazyVector for the appropriate rows cannot be done by RowVector::loadedChild because the lazy vector is not the immediate child.


Fix hash join to load LazyVectors for the whole input when these are
operands of a join filter and the filter may be invoked multiple
times. Generally, inputs of joins where the input may be referenced in
more than one batch of output need to be loaded by the join. Otherwise
a downstream Operator could load the LazyVector for a subset of rows
and in the next batch would be missing values for other rows. Load
only for rows that pass the join or all rows for left/full join.


Fix EvalCtx::ensureFieldLoaded to collapse dictionaries inside
dictionaries into a single level of dictionary. Note that if we check
dictionary indices when building dictionary wrappers for selected
rows, inner dictionaries may reference base data rows that outer
dictionaries do not reference. Therefore, when loading a LazyVector
wrapped inside multiple dictionaries, we translate selected rows of
the outermost dictionary into distinct rows in the base data and then
load the base data for these rows. We then wrap the base data in one
level of dictionary.

This operation applies to loading data for expressions as well as
input vectors that Operators access. This does not apply to columns
operators pass through. Operators like PartitionedOutput that process
their whole input in one pass can use DecodedVector for loading
LazyVectors and do not need extra attention to this.