### PR TITLE
Fix deadlock in Task::removeDriver

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -194,9 +194,7 @@ class Driver {
       std::unique_ptr<DriverCtx> driverCtx,
       std::vector<std::unique_ptr<Operator>>&& operators);
 
-  ~Driver() {
-    close();
-  }
+  ~Driver();
 
   static void run(std::shared_ptr<Driver> self);
 
@@ -215,13 +213,6 @@ class Driver {
   ThreadState& state() {
     return state_;
   }
-
-  // Frees the resources associated with this if this is
-  // off-thread. Returns true if resources are freed. If this is on
-  // thread, returns false. In this case the Driver's thread will see
-  // that the Task is set to terminate and will free the
-  // resources on the thread.
-  bool terminate();
 
   void initializeOperatorStats(std::vector<OperatorStats>& stats);
 
@@ -253,6 +244,10 @@ class Driver {
   std::shared_ptr<Task> task() const {
     return task_;
   }
+
+  // Updates the stats in 'task_' and frees resources. Only called by Task for
+  // closing non-running Drivers.
+  void closeByTask();
 
  private:
   void enqueueInternal();

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -300,7 +300,7 @@ class Task {
   // Driver was not on thread. When this happens, the Driver is on the
   // caller thread wit isTerminated set and the caller is responsible
   // for freeing resources.
-  StopReason enterForTerminate(ThreadState& state);
+  StopReason enterForTerminateLocked(ThreadState& state);
 
   // Marks that the Driver is not on thread. If no more Drivers in the
   // CancelPool are on thread, this realizes any finishFutures. The


### PR DESCRIPTION
Fix deadlocks in Driver/Task termination


A task can be terminated anytime by a Driver inside it or any other thread.

Drivers are created as part of a Task. Before they can be destroyed,
they have to be unhooked from the Task. Otherwise the Task has a
shared_ptr to the Driver and the Driver to the Task and both are live
indefinitely.

Destruction of a Driver should not reference the Task. This is a
liability for deadlock if the last reference is dropped inside
Task::mutex_.


The Task termination is split into off-thread Drivers and on-thread
Drivers. The off-thread Drivers are unhooked from the Task inside
Task::mutex_. The on-thread ones will unhook themselves when they
notice the Task's terminateRequested_ flag, at latest when they go off
thread.

Updates and fixes some comments.
