### PR TITLE
Use ContiguousAllocation for hashTable

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -247,6 +247,10 @@ class HashStringAllocator : public StreamArena {
     pool_.clear();
   }
 
+  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
+    return pool_.mappedMemory();
+  }
+
   // Checks the free space accounting and consistency of
   // Headers. Throws when detects corruption.
   void checkConsistency() const;

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -285,7 +285,7 @@ int64_t MappedMemoryImpl::free(Allocation& allocation) {
   return numFreed * kPageSize;
 }
 void MappedMemoryImpl::freeContiguous(ContiguousAllocation& allocation) {
-  if (allocation.data()) {
+  if (allocation.data() && allocation.size()) {
     if (munmap(allocation.data(), allocation.size()) < 0) {
       LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
                  << ", " << allocation.size();

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -195,7 +195,7 @@ bool MmapAllocator::allocateContiguous(
 }
 
 void MmapAllocator::freeContiguous(ContiguousAllocation& allocation) {
-  if (allocation.data()) {
+  if (allocation.data() && allocation.size()) {
     if (munmap(allocation.data(), allocation.size()) < 0) {
       LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
                  << ", " << allocation.size();

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -268,9 +268,7 @@ class HashTable : public BaseHashTable {
         memory);
   }
 
-  virtual ~HashTable() override {
-    allocateTables(0);
-  }
+  virtual ~HashTable() override = default;
 
   void groupProbe(HashLookup& lookup) override;
 
@@ -433,6 +431,7 @@ class HashTable : public BaseHashTable {
   int32_t nextOffset_;
   uint8_t* tags_ = nullptr;
   char** table_ = nullptr;
+  memory::MappedMemory::ContiguousAllocation tableAllocation_;
   int64_t size_ = 0;
   int64_t sizeMask_ = 0;
   int64_t numDistinct_ = 0;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -348,6 +348,10 @@ class RowContainer {
     }
   }
 
+  memory::MappedMemory* mappedMemory() const {
+    return stringAllocator_.mappedMemory();
+  }
+
   // Checks that row and free row counts match and that free list
   // membership is consistent with free flag.
   void checkConsistency();


### PR DESCRIPTION
Uses MappedMemory::ContiguousAllocation for the potentially large
contiguous arrays for HashTable. This replaces bare malloc which was
not accounted for in any tracking. Now the HashTable is accounted for
in the MappedMemory of its RowContainer. This removes fragmentation
and prevents increase of RSS from making large arrays.