### PR TITLE
Add floor_divide

### DIFF
--- a/velox/docs/functions/math.rst
+++ b/velox/docs/functions/math.rst
@@ -31,6 +31,14 @@ Mathematical Functions
     zero returns positive infinity if x is greater than zero, negative infinity if
     x if less than zero and NaN if x is equal to zero.
 
+.. function:: floor_divide(x, y) -> [same as x]
+
+    Returns the floor of dividing x by y. The types of x and y must be the same.
+    The result of dividing by zero depends on the input types. For integral types,
+    division by zero results in an error. For floating point types,  division by
+    zero returns positive infinity if x is greater than zero, negative infinity if
+    x if less than zero and NaN if x is equal to zero.
+
 .. function:: exp(x) -> double
 
     Returns Euler's number raised to the power of ``x``.

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -86,6 +86,23 @@ struct DivideFunction {
 };
 
 template <typename T>
+struct FloorDivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b)
+// depend on compiler have correct behaviour for divide by zero
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("float-divide-by-zero")))
+#endif
+#endif
+  {
+    result = std::floor(a / b);
+    return true;
+  }
+};
+
+template <typename T>
 struct ModulusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool

--- a/velox/functions/prestosql/CheckedArithmetic.h
+++ b/velox/functions/prestosql/CheckedArithmetic.h
@@ -64,6 +64,16 @@ struct CheckedDivideFunction {
 };
 
 template <typename T>
+struct CheckedFloorDivideFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = checkedFloorDivide(a, b);
+    return true;
+  }
+};
+
+template <typename T>
 struct CheckedModulusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool

--- a/velox/functions/prestosql/CheckedArithmeticImpl.h
+++ b/velox/functions/prestosql/CheckedArithmeticImpl.h
@@ -60,6 +60,16 @@ T checkedDivide(const T& a, const T& b) {
 }
 
 template <typename T>
+T checkedFloorDivide(const T& a, const T& b) {
+  if (b == 0) {
+    VELOX_ARITHMETIC_ERROR("division by zero");
+  }
+  // promote to float type to correctly compute floor divide for negative
+  // integers. e.g: -3 / 2 is -1, but floor(float(-3) / 2) is -2.
+  return std::floor(float(a) / b);
+}
+
+template <typename T>
 T checkedModulus(const T& a, const T& b) {
   if (UNLIKELY(b == 0)) {
     VELOX_ARITHMETIC_ERROR("Cannot divide by 0");

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -27,6 +27,7 @@ void registerSimpleFunctions() {
   registerBinaryFloatingPoint<MinusFunction>({"minus"});
   registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
   registerBinaryFloatingPoint<DivideFunction>({"divide"});
+  registerBinaryFloatingPoint<FloorDivideFunction>({"floor_divide"});
   registerBinaryFloatingPoint<ModulusFunction>({"mod"});
   registerUnaryNumeric<CeilFunction>({"ceil", "ceiling"});
   registerUnaryNumeric<FloorFunction>({"floor"});

--- a/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
+++ b/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
@@ -25,6 +25,7 @@ void registerCheckedArithmeticFunctions() {
   registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
   registerBinaryIntegral<CheckedModulusFunction>({"mod"});
   registerBinaryIntegral<CheckedDivideFunction>({"divide"});
+  registerBinaryIntegral<CheckedFloorDivideFunction>({"floor_divide"});
   registerUnaryIntegral<CheckedNegateFunction>({"negate"});
 }
 

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -93,6 +93,33 @@ __attribute__((__no_sanitize__("float-divide-by-zero")))
       "c0 / c1", {10.5, 9.2, 0.0}, {2, 0, 0}, {5.25, kInf, kNan});
 }
 
+TEST_F(ArithmeticTest, floor_divide)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+__attribute__((__no_sanitize__("float-divide-by-zero")))
+#endif
+#endif
+{
+  assertExpression<int32_t>(
+      "floor_divide(c0, c1)", {10, 11, -34}, {2, 2, 10}, {5, 5, -4});
+  assertExpression<int64_t>(
+      "floor_divide(c0, c1)", {10, 11, -34}, {2, 2, 10}, {5, 5, -4});
+
+  assertError<int32_t>("floor_divide(c0, c1)", {10}, {0}, "division by zero");
+  assertError<int32_t>("floor_divide(c0, c1)", {0}, {0}, "division by zero");
+
+  assertExpression<float>(
+      "floor_divide(c0, c1)",
+      {10.5, -3.0, 1.0, 0.0},
+      {2, 2, 0, 0},
+      {5.0, -2.0, kInfF, kNanF});
+  assertExpression<double>(
+      "floor_divide(c0, c1)",
+      {10.5, -3.0, 1.0, 0.0},
+      {2, 2, 0, 0},
+      {5.0, -2.0, kInf, kNan});
+}
+
 TEST_F(ArithmeticTest, mod) {
   std::vector<double> numerDouble = {0, 6, 0, -7, -1, -9, 9, 10.1};
   std::vector<double> denomDouble = {1, 2, -1, 3, -1, -3, -3, -99.9};


### PR DESCRIPTION
Summary: Add a new arithmetic funtion `floor_divide(a,b)`, which is "floor of a / b". The behavior is same as Python operator `//`.

Reviewed By: Tianshu-Bao

Differential Revision: D33884936

