### PR TITLE
fix bug in clearNulls

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -378,7 +378,7 @@ void BaseVector::clearNulls(const SelectivityVector& rows) {
   }
 
   auto rawNulls = nulls_->asMutable<uint64_t>();
-  bits::orWithNegatedBits(
+  bits::orBits(
       rawNulls,
       rows.asRange().bits(),
       std::min(length_, rows.begin()),

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -341,6 +341,7 @@ class BaseVector {
   // Sets null when 'nulls' has null value for a row in 'rows'
   virtual void addNulls(const uint64_t* bits, const SelectivityVector& rows);
 
+  // Clears null when 'nulls' has non-null value for a row in 'rows'
   virtual void clearNulls(const SelectivityVector& rows);
 
   virtual void clearNulls(vector_size_t begin, vector_size_t end);


### PR DESCRIPTION
Summary: The affected path was not call by any code, so probably when switching the bits meaning for nulls, we forgot to change it.

Differential Revision: D33892292

