### PR TITLE
Add GenericView, and VectorReader<Generic>

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -199,7 +199,7 @@ class ArrayProxy {
 
   void initialize(VectorWriter<ArrayProxyT<V>, void>* writer) {
     childWriter_ = &writer->childWriter_;
-    elementsVector_ = childWriter_->vector_;
+    elementsVector_ = &childWriter_->vector();
     childWriter_->ensureSize(1);
     elementsVectorCapacity_ = elementsVector_->size();
   }

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -20,11 +20,16 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/DecodedVector.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::exec {
+
 template <typename T>
 struct VectorReader;
+
 // Pointer wrapper used to convert r-values to valid return type for operator->.
 template <typename T>
 class PointerWrapper {
@@ -611,4 +616,32 @@ auto get(const RowView<Types...>& row) {
   return row.template at<I>();
 }
 
+class GenericView {
+ public:
+  GenericView(const BaseVector* baseVector, vector_size_t index)
+      : baseVector_(baseVector), index_(index) {}
+
+  uint64_t hash() const {
+    return baseVector_->hashValueAt(index_);
+  }
+
+  bool operator==(const GenericView& other) const {
+    return baseVector_->compare(other.baseVector_, index_, other.index_) == 0;
+  }
+
+ private:
+  // Represent the decoded vector of the represented element.
+  const BaseVector* baseVector_;
+  vector_size_t index_;
+};
+
 } // namespace facebook::velox::exec
+
+namespace std {
+template <>
+struct hash<facebook::velox::exec::GenericView> {
+  size_t operator()(const facebook::velox::exec::GenericView& x) const {
+    return x.hash();
+  }
+};
+} // namespace std

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -882,7 +882,7 @@ struct VectorWriter<
     std::enable_if_t<
         std::is_same_v<T, Varchar> | std::is_same_v<T, Varbinary>>> {
   using vector_t = typename TypeToFlatVector<T>::type;
-  using proxy_t = StringProxy<FlatVector<StringView>, false>;
+  using exec_out_t = StringProxy<FlatVector<StringView>, false>;
 
   void init(vector_t& vector) {
     vector_ = &vector;
@@ -896,12 +896,12 @@ struct VectorWriter<
 
   VectorWriter() {}
 
-  proxy_t& current() {
-    proxy_ = proxy_t(vector_, offset_);
+  exec_out_t& current() {
+    proxy_ = exec_out_t(vector_, offset_);
     return proxy_;
   }
 
-  void copyCommit(const proxy_t& data) {
+  void copyCommit(const exec_out_t& data) {
     // If not initialized for zero-copy writes, copy the value into the vector.
     if (!proxy_.initialized()) {
       vector_->set(offset_, StringView(data.value()));
@@ -932,7 +932,7 @@ struct VectorWriter<
     return *vector_;
   }
 
-  proxy_t proxy_;
+  exec_out_t proxy_;
   vector_t* vector_;
   size_t offset_ = 0;
 };

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -465,7 +465,7 @@ struct VectorWriter<ArrayProxyT<V>> {
     if (size > arrayVector_->size()) {
       arrayVector_->resize(size);
       childWriter_.init(
-          static_cast<child_vector_t&>(arrayVector_->elements().get()));
+          static_cast<child_vector_t&>(*arrayVector_->elements().get()));
     }
   }
 

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <optional>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+namespace {
+DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
+  SelectivityVector rows(vector.size());
+  decoder.decode(vector, rows);
+  return &decoder;
+}
+
+class GenericViewTest : public functions::test::FunctionBaseTest {
+ protected:
+  using array_data_t =
+      std::vector<std::optional<std::vector<std::optional<int64_t>>>>;
+
+  array_data_t arrayData1 = {
+      {{}},
+      {{std::nullopt}},
+      {{std::nullopt, 1}},
+      {{std::nullopt, std::nullopt, std::nullopt}},
+      {{0, 1, 2, 4}},
+      {{99, 98}},
+      {{101, std::nullopt}},
+      {{10001, 12345676, std::nullopt}}, // after this index different
+      {{std::nullopt, 1}},
+      {{std::nullopt, 2}},
+      {{std::nullopt, 3, std::nullopt}},
+      {{0, 1, 2, 4}},
+      {{99, 100}},
+      {{101, std::nullopt, 22}},
+      {{10001, 12345676, std::nullopt, 101}},
+  };
+
+  array_data_t arrayData2 = {
+      {{}},
+      {{std::nullopt}},
+      {{std::nullopt, 1}},
+      {{std::nullopt, std::nullopt, std::nullopt}},
+      {{0, 1, 2, 4}},
+      {{99, 98}},
+      {{101, std::nullopt}},
+      {{10001, 12345676, std::nullopt, 1}}, // after this index different
+      {{2, 1}},
+      {{std::nullopt, 3}},
+      {{std::nullopt, 3, std::nullopt, 1}},
+      {{0, 1, 2, 4}},
+      {{99, 100, 12}},
+      {{1011, std::nullopt, 22}},
+      {{10001, 1, std::nullopt, 101}},
+  };
+
+  template <typename DataT>
+  void testEqual(
+      const VectorPtr& vector1,
+      const VectorPtr& vector2,
+      const DataT& data1,
+      const DataT& data2) {
+    DecodedVector decoded1;
+    DecodedVector decoded2;
+    exec::VectorReader<Generic> reader1(decode(decoded1, *vector1));
+    exec::VectorReader<Generic> reader2(decode(decoded2, *vector2));
+
+    for (auto i = 0; i < vector1->size(); i++) {
+      ASSERT_EQ(data1[i].has_value(), reader1.isSet(i));
+      ASSERT_EQ(data2[i].has_value(), reader2.isSet(i));
+      if (data1[i].has_value() && data2[i].has_value()) {
+        ASSERT_EQ(
+            data1[i].value() == data2[i].value(), reader1[i] == reader2[i]);
+      }
+    }
+  }
+
+  void testHash(const VectorPtr& vector) {
+    DecodedVector decoded;
+    exec::VectorReader<Generic> reader(decode(decoded, *vector));
+    for (auto i = 0; i < vector->size(); i++) {
+      if (reader.isSet(i)) {
+        ASSERT_EQ(
+            std::hash<exec::GenericView>{}(reader[i]), vector->hashValueAt(i));
+        ASSERT_EQ(reader[i].hash(), vector->hashValueAt(i));
+      }
+    }
+  }
+};
+
+TEST_F(GenericViewTest, testInt) {
+  std::vector<std::optional<int64_t>> data1 = {
+      1, 2, std::nullopt, 1, std::nullopt, 5, 6};
+  std::vector<std::optional<int64_t>> data2 = {
+      2, 2, 1, std::nullopt, std::nullopt, 5, 7};
+
+  auto vector1 = vectorMaker_.flatVectorNullable<int64_t>(data1);
+  auto vector2 = vectorMaker_.flatVectorNullable<int64_t>(data2);
+  testEqual(vector1, vector2, data1, data2);
+  testHash(vector1);
+}
+
+// Test reader<Generic> where generic elements are arrays<ints>
+TEST_F(GenericViewTest, testArrayOfInt) {
+  auto vector1 = vectorMaker_.arrayVectorNullable(arrayData1);
+  auto vector2 = vectorMaker_.arrayVectorNullable(arrayData2);
+  testEqual(vector1, vector2, arrayData1, arrayData2);
+  testHash(vector1);
+}
+
+// Test reader<Array<Generic>> where generic elements are ints.
+TEST_F(GenericViewTest, testArrayOfGeneric) {
+  auto vector1 = vectorMaker_.arrayVectorNullable(arrayData1);
+  auto vector2 = vectorMaker_.arrayVectorNullable(arrayData2);
+
+  DecodedVector decoded1;
+  DecodedVector decoded2;
+  exec::VectorReader<Array<Generic>> reader1(decode(decoded1, *vector1));
+  exec::VectorReader<Array<Generic>> reader2(decode(decoded2, *vector2));
+
+  // Reader will return std::vector<std::optional<Generic>> like object.
+  for (auto i = 0; i < vector1->size(); i++) {
+    auto arrayView1 = reader1[i];
+    auto arrayView2 = reader2[i];
+
+    // Test comparing generics nested in ArrayView.
+    for (auto j = 0; j < arrayView1.size(); j++) {
+      auto generic1 = arrayView1[j];
+
+      for (auto k = 0; k < arrayView2.size(); k++) {
+        auto generic2 = arrayView2[k];
+
+        ASSERT_EQ(
+            generic1 == generic2,
+            arrayData1[i].value()[j] == arrayData2[i].value()[k]);
+      }
+    }
+  }
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -94,3 +94,7 @@ target_compile_definitions(velox_benchmark_array_proxy_with_nulls
 
 target_compile_definitions(velox_benchmark_array_proxy_no_nulls
                            PUBLIC WITH_NULLS=false)
+
+add_executable(velox_benchmark_nested_array_proxy NestedArrayProxyBenchmark.cpp)
+target_link_libraries(velox_benchmark_nested_array_proxy
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})

--- a/velox/functions/prestosql/benchmarks/NestedArrayProxyBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NestedArrayProxyBenchmark.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+
+#define WITH_NULLS false
+
+// Benchmark a function that creates a matrix of size n*n with numbers 1 to
+// n^2-1 for every input n, it set nulls in the diagonal when WITH_NULLS is
+// true.
+
+namespace facebook::velox::exec {
+namespace {
+class VectorFunctionImpl : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    LocalDecodedVector decoded_(context, *args[0], rows);
+
+    // Prepare results
+    auto elementType =
+        ArrayType(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+    BaseVector::ensureWritable(
+        rows,
+        std::make_shared<ArrayType>(elementType),
+        context->pool(),
+        result);
+
+    auto arrayVectorOuter = (*result)->as<ArrayVector>();
+    auto arrayVectorInner = arrayVectorOuter->elements()->as<ArrayVector>();
+    auto flatElements = arrayVectorInner->elements()->as<FlatVector<int64_t>>();
+
+    auto offsetOuter = 0;
+    auto offsetInner = 0;
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto n = decoded_->valueAt<int64_t>(row);
+      arrayVectorOuter->setOffsetAndSize(row, offsetOuter, n);
+      auto count = 0;
+
+      arrayVectorInner->resize(arrayVectorInner->size() + n);
+      // This is an optimization that we can not do in the simple function
+      // interface.
+      flatElements->resize(flatElements->size() + n * n, false);
+      for (auto i = 0; i < n; i++) {
+        // Create n arrays of size n.
+        arrayVectorInner->setOffsetAndSize(offsetOuter + i, offsetInner, n);
+        for (auto j = 0; j < n; j++) {
+          if (WITH_NULLS && i == j) {
+            flatElements->setNull(offsetInner + j, true);
+          } else {
+            flatElements->set(offsetInner + j, count);
+          }
+          count++;
+        }
+        offsetInner += n;
+      }
+      offsetOuter += n;
+    });
+  }
+};
+
+template <typename T>
+struct SimpleFunctionImpl {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    int count = 0;
+    for (auto i = 0; i < n; i++) {
+      auto& matrixRow = out.add_item();
+      matrixRow.resize(n);
+      for (auto j = 0; j < n; j++) {
+        if (WITH_NULLS && i == j) {
+          matrixRow[j] = std::nullopt;
+        } else {
+          matrixRow[j] = count;
+        }
+        count++;
+      }
+    }
+    VELOX_DCHECK(count == n * n);
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleFunctionOldImpl {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    int count = 0;
+    for (auto i = 0; i < n; i++) {
+      core::ArrayValWriter<int64_t> matrixRow;
+      for (auto j = 0; j < n; j++) {
+        if (WITH_NULLS && i == j) {
+          matrixRow.appendNullable();
+        } else {
+          matrixRow.append(count);
+        }
+        count++;
+      }
+      out.append(std::move(matrixRow));
+    }
+    VELOX_DCHECK(count == n * n);
+    return true;
+  }
+};
+
+class NestedArrayProxyBenchmark
+    : public functions::test::FunctionBenchmarkBase {
+ public:
+  NestedArrayProxyBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<
+        SimpleFunctionImpl,
+        ArrayProxyT<ArrayProxyT<int64_t>>,
+        int64_t>({"array_proxy"});
+
+    registerFunction<SimpleFunctionOldImpl, Array<Array<int64_t>>, int64_t>(
+        {"simple_old"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector",
+        {exec::FunctionSignatureBuilder()
+             .returnType("array(array(bigint))")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl>());
+  }
+
+  vector_size_t size = 200;
+  size_t totalItemsCount = size * size - 1;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  size_t run(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+
+    doRun(exprSet, input);
+    return totalItemsCount;
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool
+  hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool test() {
+    auto input = makeInput();
+    auto exprSetRef = compileExpression("vector(c0)", input->type());
+    std::vector<std::string> functions = {
+        "array_proxy",
+        "simple_old",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
+BENCHMARK_MULTI(VectorBasic) {
+  NestedArrayProxyBenchmark benchmark;
+  return benchmark.run("vector");
+}
+
+BENCHMARK_MULTI(simpleArrayProxy) {
+  NestedArrayProxyBenchmark benchmark;
+  return benchmark.run("array_proxy");
+}
+
+BENCHMARK_MULTI(simpleArrayOld) {
+  NestedArrayProxyBenchmark benchmark;
+  return benchmark.run("simple_old");
+}
+
+} // namespace
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::NestedArrayProxyBenchmark benchmark;
+  if (benchmark.test()) {
+    folly::runBenchmarks();
+  } else {
+    VELOX_UNREACHABLE("testing failed!")
+  }
+  return 0;
+}

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1262,8 +1262,12 @@ template <typename UNDERLYING_TYPE>
 struct Variadic {
   using underlying_type = UNDERLYING_TYPE;
 
- private:
-  Variadic() {}
+  Variadic() = delete;
+};
+
+// A type that can be used in simple function to represent any type.
+struct Generic {
+  Generic() = delete;
 };
 
 template <typename>


### PR DESCRIPTION
Summary:
This diff adds the Generic static type, and GenericView
which represents that type when reading from VectorReader<Generic>
which was also added in this diff.

- GenericView support two operations (compare and hash), in the future I
am planning to add casting to other types(unchecked and dynamic safe)
 and ability to access the type.
- While this is not plugged into the simple function interface yet. It
can be used in the vector functions to simplify implementations
of functions such as array_union and array_position.

- The diff tests VectorReader<Generic> with int, and array<int> .
(The generic is int, or array<int>)
- The diff also tests a VectorReader<ArrayView<Generic>>
with an array<int>. (generics are ints).

- Next, I will add more testing to test different possible types,
although the logic is the same and not dependent on the type.

- Also it might be useful to add compare and hash functionality to
ArrayView and MapView.

- Finally, I will have to plug this in the simple function interface and its
registration system.

**Note on possible optimization:**
I was thinking that if we allow multiple functions to be registered with
same name but different type signatures and carefully do the resolution of function
by prioritizing non-generic signatures first we can register generic functions with an enabled fast path for non-generic

for example, a function compare is simple
```
template<A,B>
Call (){out = a==b};
```

can be registered for all primitives and for generic.
```
register<cmp, bool , int, int>();
register<cmp, bool , Generic, Generic>();
```
during resolutions two functions will be available for an int
input, but the first should be picked for that . And the one
with Generic would be the last option to pick as a the
general path of nested complex types. or complex types in
general.

Reviewed By: funrollloops

Differential Revision: D33809195

