### PR TITLE
Propagate CircleCI parquet-S3 run script failure

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -52,6 +52,8 @@ function install_aws-sdk-cpp {
 }
 
 cd "${DEPENDENCY_DIR}" || exit
+# aws-sdk-cpp missing dependencies
+yum install -y curl-devel
 
 install_aws-sdk-cpp
 _ret=$?

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Minimal setup for Ubuntu 20.04.
+set -eufx -o pipefail
+
 function install_aws-sdk-cpp {
   local NAME="aws-sdk-cpp"
   local AWS_SDK_VERSION="1.9.96"

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -52,9 +52,6 @@ function install_aws-sdk-cpp {
 }
 
 cd "${DEPENDENCY_DIR}" || exit
-# aws-sdk-cpp missing dependencies
-# TODO: Bake them into the docker image
-yum install -y curl-devel
 
 install_aws-sdk-cpp
 _ret=$?

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Minimal setup for Ubuntu 20.04.
+# Propagate errors and improve debugging.
 set -eufx -o pipefail
 
 function install_aws-sdk-cpp {


### PR DESCRIPTION
The `setup-adapters.sh` script does not report any errors and as a result the CircleCI step never fails if the script fails.
This is now fixed.