### PR TITLE
Optimize BitUtils::forEachBit

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -337,6 +337,7 @@ void forEachBit(
     int32_t end,
     bool isSet,
     Callable func) {
+  static const uint64_t kAllSet = -1ULL;
   forEachWord(
       begin,
       end,
@@ -355,9 +356,17 @@ void forEachBit(
         if (!word) {
           return;
         }
-        while (word) {
-          func(idx * 64 + __builtin_ctzll(word));
-          word &= word - 1;
+        if (kAllSet == word) {
+          const size_t start = idx * 64;
+          const size_t end = (idx + 1) * 64;
+          for (size_t row = start; row < end; ++row) {
+            func(row);
+          }
+        } else {
+          while (word) {
+            func(idx * 64 + __builtin_ctzll(word));
+            word &= word - 1;
+          }
         }
       });
 }

--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -337,7 +337,7 @@ void forEachBit(
     int32_t end,
     bool isSet,
     Callable func) {
-  static const uint64_t kAllSet = -1ULL;
+  static constexpr uint64_t kAllSet = -1ULL;
   forEachWord(
       begin,
       end,
@@ -353,9 +353,6 @@ void forEachBit(
       },
       [isSet, bits, func](int32_t idx) {
         auto word = (isSet ? bits[idx] : ~bits[idx]);
-        if (!word) {
-          return;
-        }
         if (kAllSet == word) {
           const size_t start = idx * 64;
           const size_t end = (idx + 1) * 64;

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -27,6 +27,6 @@ add_library(velox_common_base BitUtil.cpp RawVector.cpp SimdUtil.cpp)
 target_link_libraries(velox_common_base velox_exception velox_process)
 
 add_subdirectory(test_utils)
-if(${VELOX_ENABLE_TESTING})
+if(${VELOX_BUILD_TESTING})
   add_subdirectory(benchmarks)
 endif()

--- a/velox/common/base/benchmarks/BitUtilBenchmark.cpp
+++ b/velox/common/base/benchmarks/BitUtilBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <boost/preprocessor/repetition/repeat.hpp>
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
@@ -164,30 +165,25 @@ void BM_forEachBit(
 }
 
 namespace {
-const static auto kNumRuns = 1000;
-}
-void BM_ForEachBitAllTrue(uint32_t iterations, size_t numBits) {
-  for (int i = 0; i < kNumRuns; i++) {
-    BM_forEachBit(iterations, numBits);
-  }
+constexpr static auto kNumRuns = 1000;
+constexpr static auto numBits = 10000;
+} // namespace
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(forEachBitAllTrue) {
+  BM_forEachBit(kNumRuns, numBits);
+  return kNumRuns;
 }
 
-void BM_ForEachBitLastBitFalse(uint32_t iterations, size_t numBits) {
-  for (int i = 0; i < kNumRuns; i++) {
-    BM_forEachBit(iterations, numBits, numBits - 1);
-  }
+BENCHMARK_RELATIVE_MULTI(forEachBitLastBitFalse) {
+  BM_forEachBit(kNumRuns, numBits, numBits - 1);
+  return kNumRuns;
 }
 
-void BM_ForEachBitFirstBitFalse(uint32_t iterations, size_t numBits) {
-  for (int i = 0; i < kNumRuns; i++) {
-    BM_forEachBit(iterations, numBits, 1);
-  }
+BENCHMARK_RELATIVE_MULTI(forEachBitFirstBitFalse) {
+  BM_forEachBit(kNumRuns, numBits, 1);
+  return kNumRuns;
 }
-BENCHMARK_DRAW_LINE();
-BENCHMARK_PARAM(BM_ForEachBitAllTrue, 10000);
-BENCHMARK_RELATIVE_PARAM(BM_ForEachBitLastBitFalse, 10000);
-BENCHMARK_RELATIVE_PARAM(BM_ForEachBitFirstBitFalse, 10000);
-BENCHMARK_DRAW_LINE();
 
 } // namespace test
 } // namespace velox

--- a/velox/common/tests/BitUtilTest.cpp
+++ b/velox/common/tests/BitUtilTest.cpp
@@ -416,6 +416,43 @@ TEST_F(BitUtilTest, forEachBit) {
   expectedIndex = 3;
   forEachUnsetBit(data, 2, totalBits - 3, calledOnEveryOther);
   EXPECT_EQ(totalBits - 3, expectedIndex);
+
+  totalBits = 100;
+  std::vector<uint64_t> bits(bits::nwords(totalBits));
+  uint64_t* rawBits = bits.data();
+
+  // Test all bits set.
+  bits::fillBits(rawBits, 0, totalBits, true);
+  int count = 0;
+  auto countEach = [&](auto row) {
+    ASSERT_EQ(row, count);
+    count++;
+  };
+
+  bits::forEachBit(rawBits, 0, totalBits, true, countEach);
+  ASSERT_EQ(totalBits, count);
+
+  // Test all bits unset.
+  bits::fillBits(rawBits, 0, totalBits, false);
+
+  count = 0;
+  bits::forEachBit(rawBits, 0, totalBits, false, countEach);
+  ASSERT_EQ(totalBits, count);
+
+  // Test all but one bit set.
+  bits::fillBits(rawBits, 0, totalBits, true);
+  bits::setBit(rawBits, 50, false);
+  count = 0;
+  auto incrementCount = [&](auto row) { count++; };
+  bits::forEachBit(rawBits, 0, totalBits, true, incrementCount);
+  ASSERT_EQ(totalBits - 1, count);
+
+  // Test all but one bit unset.
+  bits::fillBits(rawBits, 0, totalBits, false);
+  bits::setBit(rawBits, 50, true);
+  count = 0;
+  bits::forEachBit(rawBits, 0, totalBits, false, incrementCount);
+  ASSERT_EQ(totalBits - 1, count);
 }
 
 TEST_F(BitUtilTest, hash) {

--- a/velox/common/tests/BitUtilTest.cpp
+++ b/velox/common/tests/BitUtilTest.cpp
@@ -443,7 +443,7 @@ TEST_F(BitUtilTest, forEachBit) {
   bits::fillBits(rawBits, 0, totalBits, true);
   bits::setBit(rawBits, 50, false);
   count = 0;
-  auto incrementCount = [&](auto row) { count++; };
+  auto incrementCount = [&](auto _) { count++; };
   bits::forEachBit(rawBits, 0, totalBits, true, incrementCount);
   ASSERT_EQ(totalBits - 1, count);
 


### PR DESCRIPTION
Currently large SelectivityVectors, say with 1k+ rows (e.g element vector of an array vector) are slower when they have any one row not selected vs all rows selected. This is because even if one row is not selected we default to slowest way of iterating through the vector. Typically this results in the iteration being 100% slower. With this fix to forEachBit, applyToSelected() runs faster but also more consistent. This will also gracefully degrade to slowest way of iterating through vector based on number of unset bits. 


```
----------------------------------------------------------------------------
BM_isAllSelectedTrue(1000)                                 315.71us    3.17K
BM_isAllSelectedFalseLastBit(1000)                58.82%   536.78us    1.86K
BM_isAllSelectedFalseFirstBit(1000)               58.79%   537.06us    1.86K
----------------------------------------------------------------------------
============================================================================
```
Heres new :
```
----------------------------------------------------------------------------
BM_isAllSelectedTrue(1000)                                 316.38us    3.16K
BM_isAllSelectedFalseLastBit(1000)                92.80%   340.91us    2.93K
BM_isAllSelectedFalseFirstBit(1000)               89.65%   352.89us    2.83K
----------------------------------------------------------------------------
============================================================================
```

**How it works:**
* We take one word at a time
* Check if all bits are set, if true : Then run func() over set bits using for loop . (fastest)
* Else if any one bit is unset, use while loop to individually run func() over selected bits. (slowest)
* ForEachWord, takes a partial word function, and a full word function which implement the above . 

