### PR TITLE
Check plan node IDs associated with splits

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -415,11 +415,19 @@ class Task {
       uint32_t splitGroupId,
       const char* FOLLY_NONNULL context);
 
- private:
+  /// Checks that specified plan node ID refers to a source plan node. Throws if
+  /// that's not the case.
+  void checkPlanNodeIdForSplit(const core::PlanNodeId& id) const;
+
   const std::string taskId_;
   core::PlanFragment planFragment_;
   const int destination_;
   std::shared_ptr<core::QueryCtx> queryCtx_;
+
+  /// A set of source plan node IDs. Used to check plan node IDs specified in
+  /// split management methods.
+  const std::unordered_set<core::PlanNodeId> sourcePlanNodeIds_;
+
   // True if produces output via PartitionedOutputBufferManager.
   bool hasPartitionedOutput_ = false;
   // Set to true by PartitionedOutputBufferManager when all output is

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox;
@@ -38,13 +39,17 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
 
   std::shared_ptr<Task> initializeTask(
       const std::string& taskId,
+      const RowTypePtr& rowType,
       int numDestinations,
       int numDrivers) {
-    auto queryCtx = core::QueryCtx::createForTest();
     bufferManager_->removeTask(taskId);
-    core::PlanFragment emptyPlanFragment;
+
+    auto planFragment = exec::test::PlanBuilder()
+                            .values({std::dynamic_pointer_cast<RowVector>(
+                                BatchMaker::createBatch(rowType, 100, *pool_))})
+                            .planFragment();
     auto task = std::make_shared<Task>(
-        taskId, std::move(emptyPlanFragment), 0, std::move(queryCtx));
+        taskId, std::move(planFragment), 0, core::QueryCtx::createForTest());
 
     bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
     return task;
@@ -224,7 +229,7 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  auto task = initializeTask(taskId, 5, 1);
+  auto task = initializeTask(taskId, rowType, 5, 1);
 
   // - enqueue one group per destination
   // - fetch and ask one group per destination
@@ -289,7 +294,7 @@ TEST_F(PartitionedOutputBufferManagerTest, maxBytes) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  initializeTask(taskId, 5, 1);
+  initializeTask(taskId, rowType, 5, 1);
 
   enqueue(taskId, 0, rowType, size);
   enqueue(taskId, 1, rowType, size);
@@ -320,7 +325,7 @@ TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  auto task = initializeTask(taskId, 5, 1);
+  auto task = initializeTask(taskId, rowType, 5, 1);
 
   enqueue(taskId, 0, rowType, size);
   for (int i = 0; i < 10; i++) {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -16,11 +16,26 @@
 #include "velox/exec/Task.h"
 #include <gtest/gtest.h>
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+#define VELOX_ASSERT_THROW(expression, errorMessage)                  \
+  try {                                                               \
+    (expression);                                                     \
+    VELOX_FAIL("Expected an exception");                              \
+  } catch (const VeloxException& e) {                                 \
+    ASSERT_TRUE(e.isUserError());                                     \
+    ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos); \
+  }
 
 using namespace facebook::velox;
 
 class TaskTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    functions::prestosql::registerAllFunctions();
+  }
+
   void useOneSplit(
       exec::Task& task,
       uint32_t splitGroupId,
@@ -32,6 +47,62 @@ class TaskTest : public testing::Test {
   }
 };
 
+TEST_F(TaskTest, wrongPlanNodeForSplit) {
+  auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
+      "test",
+      "file:/tmp/abc",
+      facebook::velox::dwio::common::FileFormat::ORC,
+      0,
+      100);
+
+  auto plan = exec::test::PlanBuilder()
+                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
+                  .project({"a * a", "b + b"})
+                  .planFragment();
+
+  exec::Task task(
+      "task-1", std::move(plan), 0, core::QueryCtx::createForTest());
+
+  // Add split for the source node.
+  task.addSplit("0", exec::Split(folly::copy(connectorSplit)));
+
+  // Try to add split for a non-source node.
+  auto errorMessage =
+      "Splits can be associated only with source plan nodes. Plan node ID 1 doesn't refer to a source node.";
+  VELOX_ASSERT_THROW(
+      task.addSplit("1", exec::Split(folly::copy(connectorSplit))),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(
+      task.addSplitWithSequence(
+          "1", exec::Split(folly::copy(connectorSplit)), 3),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(task.setMaxSplitSequenceId("1", 9), errorMessage)
+
+  VELOX_ASSERT_THROW(task.noMoreSplits("1"), errorMessage)
+
+  VELOX_ASSERT_THROW(task.noMoreSplitsForGroup("1", 5), errorMessage)
+
+  // Try to add split for non-existent node.
+  errorMessage =
+      "Splits can be associated only with source plan nodes. Plan node ID 12 doesn't refer to a source node.";
+  VELOX_ASSERT_THROW(
+      task.addSplit("12", exec::Split(folly::copy(connectorSplit))),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(
+      task.addSplitWithSequence(
+          "12", exec::Split(folly::copy(connectorSplit)), 3),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(task.setMaxSplitSequenceId("12", 9), errorMessage)
+
+  VELOX_ASSERT_THROW(task.noMoreSplits("12"), errorMessage)
+
+  VELOX_ASSERT_THROW(task.noMoreSplitsForGroup("12", 5), errorMessage)
+}
+
 // Test if the Task correctly handles split groups.
 TEST_F(TaskTest, splitGroup) {
   // Create single hive connector split and the task.
@@ -41,11 +112,13 @@ TEST_F(TaskTest, splitGroup) {
       facebook::velox::dwio::common::FileFormat::ORC,
       0,
       100);
+  auto plan = exec::test::PlanBuilder()
+                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
+                  .planNode();
   core::PlanNodeId planNodeId{"0"};
-  auto queryCtx = core::QueryCtx::createForTest();
-  core::PlanFragment planFragment{
-      nullptr, core::ExecutionStrategy::kGrouped, 3};
-  exec::Task task("0", std::move(planFragment), 0, std::move(queryCtx));
+  core::PlanFragment planFragment{plan, core::ExecutionStrategy::kGrouped, 3};
+  exec::Task task(
+      "0", std::move(planFragment), 0, core::QueryCtx::createForTest());
 
   // This is the set of completed groups we expect.
   std::unordered_set<int32_t> completedSplitGroups;


### PR DESCRIPTION
Update Task::addSplit, addSplitWithSequence, noMoreSplits, noMoreSplitsForGroup
and setMaxSplitSequenceId methods to check and throw if specified plan node ID
does not refer to a source plan node. This should help prevent a class of
difficult to debug hangs.