### PR TITLE
Fixing support for grouped execution.

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -294,8 +294,9 @@ struct DriverFactory {
   OperatorSupplier consumerSupplier;
   /// Maximum number of drivers that can be run concurrently in this pipeline.
   uint32_t maxDrivers;
-  /// Number of drivers that will be run concurrently in this pipeline. It is
-  /// also the number of drivers per split group in case of grouped execution.
+  /// Number of drivers that will be run concurrently in this pipeline for one
+  /// split group (during grouped execution) or for the whole task (ungrouped
+  /// execution).
   uint32_t numDrivers;
   /// Total number of drivers in this pipeline we expect to be run. In case of
   /// grouped execution it is 'numDrivers' * 'numSplitGroups', otherwise it is

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -63,10 +63,6 @@ std::unordered_set<core::PlanNodeId> collectSourcePlanNodeIds(
 
 } // namespace
 
-// The number of splits groups we run concurrently.
-// TODO(spershin): We need to expose this as some kind of setting/parameter.
-static constexpr uint32_t kNumConcurrentSplitGroups = 1;
-
 Task::Task(
     const std::string& taskId,
     core::PlanFragment planFragment,
@@ -130,8 +126,12 @@ Task::addOperatorPool(velox::memory::MemoryPool* FOLLY_NONNULL driverPool) {
   return childPools_.back().get();
 }
 
-void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
+void Task::start(
+    std::shared_ptr<Task> self,
+    uint32_t maxDrivers,
+    uint32_t concurrentSplitGroups) {
   VELOX_CHECK(self->drivers_.empty());
+  self->concurrentSplitGroups_ = concurrentSplitGroups;
   {
     std::lock_guard<std::mutex> l(self->mutex_);
     self->taskStats_.executionStartTimeMs = getCurrentTimeMs();
@@ -164,11 +164,10 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
   const auto numPipelines = self->driverFactories_.size();
   self->exchangeClients_.resize(numPipelines);
 
-  // For grouped execution we need one split group state per split group,
-  // otherwise just one.
+  // For ungrouped execution we reuse some of the structures used grouped
+  // execution and assume we have "1 split".
   const uint32_t numSplitGroups =
       std::max(1, self->planFragment_.numSplitGroups);
-  self->splitGroupStates_.resize(numSplitGroups);
 
   // For each pipeline we have a corresponding driver factory.
   // Here we count how many drivers in total we need and we also create create
@@ -192,13 +191,14 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
       "Unable to initialize task. "
       "PartitionedOutputBufferManager was already destructed");
 
-  // In this loop we prepare the pipelines: buffer manager, exchange clients,
-  // local exchanges and join bridges.
+  // In this loop we prepare the global state of pipelines: partitioned output
+  // buffer and exchange client(s).
   for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
     auto& factory = self->driverFactories_[pipeline];
 
     auto partitionedOutputNode = factory->needsPartitionedOutput();
     if (partitionedOutputNode) {
+      self->numDriversInPartitionedOutput_ = factory->numDrivers;
       VELOX_CHECK(
           !self->hasPartitionedOutput_,
           "Only one output pipeline per task is supported");
@@ -207,63 +207,52 @@ void Task::start(std::shared_ptr<Task> self, uint32_t maxDrivers) {
           self,
           partitionedOutputNode->isBroadcast(),
           partitionedOutputNode->numPartitions(),
-          factory->numTotalDrivers);
+          self->numDriversInPartitionedOutput_ * numSplitGroups);
     }
 
     if (factory->needsExchangeClient()) {
       self->exchangeClients_[pipeline] =
           std::make_shared<ExchangeClient>(self->destination_);
     }
+  }
 
-    auto exchangeId = factory->needsLocalExchangeSource();
-    if (exchangeId.has_value()) {
-      self->createLocalExchangeSources(exchangeId.value(), factory->numDrivers);
+  // For grouped execution we postpone driver creation up until the splits start
+  // arriving, as we don't know what split groups we are going to get.
+  // Here we create Drivers only for ungrouped (normal) execution.
+  if (self->isUngroupedExecution()) {
+    std::unique_lock<std::mutex> l(self->mutex_);
+    // Create the drivers we are going to run for this task.
+    std::vector<std::shared_ptr<Driver>> drivers;
+    drivers.reserve(self->numDriversPerSplitGroup_);
+    self->createSplitGroupStateLocked(self, 0);
+    self->createDriversLocked(self, 0, drivers);
+
+    // Set and start all Drivers together inside 'mutex_' so that cancellations
+    // and pauses have well defined timing. For example, do not pause and
+    // restart a task while it is still adding Drivers.
+    // If the given executor is folly::InlineLikeExecutor (or it's child), since
+    // the drivers will be executed synchronously on the same thread as the
+    // current task, so we need release the lock to avoid the deadlock.
+    self->drivers_ = std::move(drivers);
+    if (dynamic_cast<const folly::InlineLikeExecutor*>(
+            self->queryCtx()->executor())) {
+      l.unlock();
     }
-
-    self->addHashJoinBridges(factory->needsHashJoinBridges());
-    self->addCrossJoinBridges(factory->needsCrossJoinBridges());
-  }
-
-  // In this loop we create the drivers we are going to run for this task.
-  // Note, that for grouped execution (when we have split groups) we will create
-  // only a portion of drivers here to tackle first N split groups. As drivers
-  // finish, we'll create more of them to tackle the remaining split groups,
-  // until we have worked through all split groups.
-  const uint32_t initialSplitGroups =
-      std::min(numSplitGroups, kNumConcurrentSplitGroups);
-  std::vector<std::shared_ptr<Driver>> drivers;
-  drivers.reserve(self->numDriversPerSplitGroup_ * initialSplitGroups);
-  for (size_t i = 0; i < initialSplitGroups; ++i) {
-    self->createDrivers(drivers, self);
-  }
-
-  // Initialize operator stats using the 1st driver of each operator.
-  size_t driverIndex{0};
-  for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
-    auto& factory = self->driverFactories_[pipeline];
-    drivers[driverIndex]->initializeOperatorStats(
-        self->taskStats_.pipelineStats[pipeline].operatorStats);
-    driverIndex += factory->numDrivers;
-  }
-
-  // Set and start all Drivers together inside 'mutex_' so that
-  // cancellations and pauses have well
-  // defined timing. For example, do not pause and restart a task
-  // while it is still adding Drivers.
-  // If the given executor is folly::InlineLikeExecutor (or it's child), since
-  // the drivers will be executed synchronously on the same thread as the
-  // current task, so we need release the lock to avoid the deadlock.
-  std::unique_lock<std::mutex> l(self->mutex_);
-  self->drivers_ = std::move(drivers);
-  if (dynamic_cast<const folly::InlineLikeExecutor*>(
-          self->queryCtx()->executor())) {
-    l.unlock();
-  }
-  for (auto& driver : self->drivers_) {
-    if (driver) {
-      ++self->numRunningDrivers_;
-      Driver::enqueue(driver);
+    for (auto& driver : self->drivers_) {
+      if (driver) {
+        ++self->numRunningDrivers_;
+        Driver::enqueue(driver);
+      }
     }
+  } else {
+    // Preallocate a bunch of slots for max concurrent drivers during grouped
+    // execution.
+    self->drivers_.resize(
+        self->numDriversPerSplitGroup_ * self->concurrentSplitGroups_);
+
+    // As some splits could have been added before the task start, ensure we
+    // start running drivers for them.
+    self->ensureSplitGroupsAreBeingProcessedLocked(self);
   }
 }
 
@@ -297,14 +286,37 @@ void Task::resume(std::shared_ptr<Task> self) {
   }
 }
 
-void Task::createDrivers(
-    std::vector<std::shared_ptr<Driver>>& out,
-    std::shared_ptr<Task>& self) {
-  auto& splitGroupState = self->splitGroupStates_[nextSplitGroupId_];
+void Task::createSplitGroupStateLocked(
+    std::shared_ptr<Task>& self,
+    uint32_t splitGroupId) {
+  // In this loop we prepare per split group pipelines structures:
+  // local exchanges and join bridges.
+  const auto numPipelines = self->driverFactories_.size();
+  for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
+    auto& factory = self->driverFactories_[pipeline];
+
+    auto exchangeId = factory->needsLocalExchangeSource();
+    if (exchangeId.has_value()) {
+      self->createLocalExchangeSourcesLocked(
+          splitGroupId, exchangeId.value(), factory->numDrivers);
+    }
+
+    self->addHashJoinBridgesLocked(
+        splitGroupId, factory->needsHashJoinBridges());
+    self->addCrossJoinBridgesLocked(
+        splitGroupId, factory->needsCrossJoinBridges());
+  }
+}
+
+void Task::createDriversLocked(
+    std::shared_ptr<Task>& self,
+    uint32_t splitGroupId,
+    std::vector<std::shared_ptr<Driver>>& out) {
+  auto& splitGroupState = self->splitGroupStates_[splitGroupId];
   const auto numPipelines = driverFactories_.size();
   for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
     auto& factory = driverFactories_[pipeline];
-    const uint32_t driverIdOffset = factory->numDrivers * nextSplitGroupId_;
+    const uint32_t driverIdOffset = factory->numDrivers * splitGroupId;
     for (uint32_t partitionId = 0; partitionId < factory->numDrivers;
          ++partitionId) {
       out.emplace_back(factory->createDriver(
@@ -312,7 +324,7 @@ void Task::createDrivers(
               self,
               driverIdOffset + partitionId,
               pipeline,
-              nextSplitGroupId_,
+              splitGroupId,
               partitionId),
           self->exchangeClients_[pipeline],
           [self](size_t i) {
@@ -323,8 +335,20 @@ void Task::createDrivers(
       ++splitGroupState.activeDrivers;
     }
   }
-  noMoreLocalExchangeProducers(nextSplitGroupId_);
-  ++self->nextSplitGroupId_;
+  noMoreLocalExchangeProducers(splitGroupId);
+  ++numRunningSplitGroups_;
+
+  // Initialize operator stats using the 1st driver of each operator.
+  if (not initializedOpStats_) {
+    initializedOpStats_ = true;
+    size_t driverIndex{0};
+    for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
+      auto& factory = self->driverFactories_[pipeline];
+      out[driverIndex]->initializeOperatorStats(
+          self->taskStats_.pipelineStats[pipeline].operatorStats);
+      driverIndex += factory->numDrivers;
+    }
+  }
 }
 
 // static
@@ -348,36 +372,49 @@ void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
     if (self->isGroupedExecution()) {
       // Check if a split group is finished.
       if (splitGroupState.activeDrivers == 0) {
+        --self->numRunningSplitGroups_;
         splitGroupState.clear();
-
-        // Create a bunch of drivers for the next split, if there is one.
-        if (self->state_ == TaskState::kRunning &&
-            self->nextSplitGroupId_ < self->planFragment_.numSplitGroups) {
-          std::vector<std::shared_ptr<Driver>> drivers;
-          drivers.reserve(self->numDriversPerSplitGroup_);
-          self->createDrivers(drivers, self);
-          // Move created drivers into the vacant spots in 'drivers_' and
-          // enqueue them.
-          size_t i = 0;
-          for (auto& newDriverPtr : drivers) {
-            while (self->drivers_[i] != nullptr) {
-              VELOX_CHECK_LT(i, self->drivers_.size());
-              ++i;
-            }
-            auto& targetPtr = self->drivers_[i];
-            targetPtr = std::move(newDriverPtr);
-            if (targetPtr) {
-              ++self->numRunningDrivers_;
-              Driver::enqueue(targetPtr);
-            }
-          }
-        }
+        self->ensureSplitGroupsAreBeingProcessedLocked(self);
       }
     }
-
     return;
   }
   LOG(WARNING) << "Trying to remove a Driver twice from its Task";
+}
+
+void Task::ensureSplitGroupsAreBeingProcessedLocked(
+    std::shared_ptr<Task>& self) {
+  // Only try creating more drivers if we are running.
+  if (state_ != TaskState::kRunning) {
+    return;
+  }
+
+  while (numRunningSplitGroups_ < concurrentSplitGroups_ and
+         not queuedSplitGroups_.empty()) {
+    const uint32_t splitGroupId = queuedSplitGroups_.front();
+    queuedSplitGroups_.pop();
+
+    std::vector<std::shared_ptr<Driver>> drivers;
+    drivers.reserve(numDriversPerSplitGroup_);
+    createSplitGroupStateLocked(self, splitGroupId);
+    createDriversLocked(self, splitGroupId, drivers);
+    // Move created drivers into the vacant spots in 'drivers_' and enqueue
+    // them. We have vacant spots, because we initially allocate enough items in
+    // the vector and keep null pointers for completed drivers.
+    size_t i = 0;
+    for (auto& newDriverPtr : drivers) {
+      while (drivers_[i] != nullptr) {
+        VELOX_CHECK_LT(i, drivers_.size());
+        ++i;
+      }
+      auto& targetPtr = drivers_[i];
+      targetPtr = std::move(newDriverPtr);
+      if (targetPtr) {
+        ++numRunningDrivers_;
+        Driver::enqueue(targetPtr);
+      }
+    }
+  }
 }
 
 void Task::setMaxSplitSequenceId(
@@ -448,15 +485,25 @@ std::unique_ptr<ContinuePromise> Task::addSplitLocked(
   ++taskStats_.numTotalSplits;
   ++taskStats_.numQueuedSplits;
 
-  if (not isGroupedExecution()) {
+  if (isUngroupedExecution()) {
     VELOX_DCHECK(
         not split.hasGroup(), "Got split group for ungrouped execution!");
-    return addSplitToStoreLocked(splitsState.splitsStore, std::move(split));
+    return addSplitToStoreLocked(
+        splitsState.groupSplitsStores[0], std::move(split));
   } else {
     VELOX_CHECK(split.hasGroup(), "Missing split group for grouped execution!");
     const auto splitGroupId = split.groupId; // Avoid eval order c++ warning.
+    // If this is the 1st split from this group, add the split group to queue.
+    // Also add that split group to the set of 'seen' split groups.
+    if (seenSplitGroups_.find(splitGroupId) == seenSplitGroups_.end()) {
+      seenSplitGroups_.emplace(splitGroupId);
+      queuedSplitGroups_.push(splitGroupId);
+      auto self = shared_from_this();
+      // We might have some free driver slots to process this split group.
+      ensureSplitGroupsAreBeingProcessedLocked(self);
+    }
     return addSplitToStoreLocked(
-        groupSplitsStoreSafe(splitsState, splitGroupId), std::move(split));
+        splitsState.groupSplitsStores[splitGroupId], std::move(split));
   }
 }
 
@@ -482,7 +529,7 @@ void Task::noMoreSplitsForGroup(
     std::lock_guard<std::mutex> l(mutex_);
 
     auto& splitsState = splitsStates_[planNodeId];
-    auto& splitsStore = groupSplitsStoreSafe(splitsState, splitGroupId);
+    auto& splitsStore = splitsState.groupSplitsStores[splitGroupId];
     splitsStore.noMoreSplits = true;
     checkGroupSplitsCompleteLocked(splitGroupId, splitsStore);
     promises = std::move(splitsStore.splitPromises);
@@ -498,19 +545,62 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
   {
     std::lock_guard<std::mutex> l(mutex_);
 
-    auto& splitsStore = splitsStates_[planNodeId].splitsStore;
-    splitsStore.noMoreSplits = true;
-    promises = std::move(splitsStore.splitPromises);
+    // Global 'no more splits' for a plan node comes in case of ungrouped
+    // execution when no more splits will arrive. For grouped execution it
+    // comes when no more split groups will arrive for that plan node.
+    auto& splitsState = splitsStates_[planNodeId];
+    splitsState.noMoreSplits = true;
+    if (not splitsState.groupSplitsStores.empty()) {
+      // Mark all split stores as 'no more splits'.
+      for (auto& it : splitsState.groupSplitsStores) {
+        it.second.noMoreSplits = true;
+        promises = std::move(it.second.splitPromises);
+      }
+    } else if (isUngroupedExecution()) {
+      // During ungrouped execution, in the unlikely case there are no split
+      // stores (this means there were no splits at all), we create one.
+      splitsState.groupSplitsStores.emplace(0, SplitsStore{{}, true, {}});
+    }
+
+    checkNoMoreSplitGroupsLocked();
   }
   for (auto& promise : promises) {
     promise.setValue(false);
   }
 }
 
+void Task::checkNoMoreSplitGroupsLocked() {
+  if (isUngroupedExecution()) {
+    return;
+  }
+
+  // For grouped execution, when all plan nodes have 'no more splits' coming,
+  // we should review the total number of drivers, which initially is set to
+  // process all split groups, but in reality workers share split groups and
+  // each worker processes only a part of them, meaning much less than all.
+  bool noMoreSplitGroups = true;
+  for (auto& it : splitsStates_) {
+    if (not it.second.noMoreSplits) {
+      noMoreSplitGroups = false;
+      break;
+    }
+  }
+  if (noMoreSplitGroups) {
+    numTotalDrivers_ = seenSplitGroups_.size() * numDriversPerSplitGroup_;
+    {
+      auto bufferManager = bufferManager_.lock();
+      bufferManager->updateNumDrivers(
+          taskId(), numDriversInPartitionedOutput_ * seenSplitGroups_.size());
+    }
+
+    checkIfFinishedLocked();
+  }
+}
+
 bool Task::isAllSplitsFinishedLocked() {
   if (taskStats_.numFinishedSplits == taskStats_.numTotalSplits) {
     for (const auto& it : splitsStates_) {
-      if (not it.second.splitsStore.noMoreSplits) {
+      if (not it.second.noMoreSplits) {
         return false;
       }
     }
@@ -528,12 +618,12 @@ BlockingReason Task::getSplitOrFuture(
 
   auto& splitsState = splitsStates_[planNodeId];
 
-  if (not isGroupedExecution()) {
-    return getSplitOrFutureLocked(splitsState.splitsStore, split, future);
-  } else {
-    // Driver id allows a single driver to only access splits of a single group.
+  if (isUngroupedExecution()) {
     return getSplitOrFutureLocked(
-        groupSplitsStoreSafe(splitsState, splitGroupId), split, future);
+        splitsState.groupSplitsStores[0], split, future);
+  } else {
+    return getSplitOrFutureLocked(
+        splitsState.groupSplitsStores[splitGroupId], split, future);
   }
 }
 
@@ -575,19 +665,18 @@ void Task::splitFinished(
     taskStats_.executionEndTimeMs = getCurrentTimeMs();
   }
 
-  if (not isGroupedExecution()) {
+  if (isUngroupedExecution()) {
     VELOX_DCHECK(
         splitGroupId == -1, "Got split group for ungrouped execution!");
   } else {
     VELOX_CHECK(
         splitGroupId >= 0, "Missing split group for grouped execution!");
     auto& splitsState = splitsStates_[planNodeId];
-    VELOX_DCHECK_LT(
-        splitGroupId,
-        splitsState.groupSplitsStores(planFragment_.numSplitGroups).size(),
-        "Split group id is greater than number of split groups!");
-    checkGroupSplitsCompleteLocked(
-        splitGroupId, groupSplitsStoreSafe(splitsState, splitGroupId));
+    auto it = splitsState.groupSplitsStores.find(splitGroupId);
+    VELOX_DCHECK(
+        it != splitsState.groupSplitsStores.end(),
+        "Split group split store is missing!");
+    checkGroupSplitsCompleteLocked(splitGroupId, it->second);
   }
 }
 
@@ -609,6 +698,10 @@ bool Task::isGroupedExecution() const {
   return planFragment_.isGroupedExecution();
 }
 
+bool Task::isUngroupedExecution() const {
+  return not isGroupedExecution();
+}
+
 void Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
@@ -623,11 +716,7 @@ void Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
 void Task::setAllOutputConsumed() {
   std::lock_guard<std::mutex> l(mutex_);
   partitionedOutputConsumed_ = true;
-  if ((numFinishedDrivers_ == numTotalDrivers_) && state_ == kRunning) {
-    state_ = kFinished;
-    taskStats_.endTimeMs = getCurrentTimeMs();
-    stateChangedLocked();
-  }
+  checkIfFinishedLocked();
 }
 
 void Task::driverClosedLocked() {
@@ -635,6 +724,10 @@ void Task::driverClosedLocked() {
     --numRunningDrivers_;
   }
   ++numFinishedDrivers_;
+  checkIfFinishedLocked();
+}
+
+void Task::checkIfFinishedLocked() {
   if ((numFinishedDrivers_ == numTotalDrivers_) && (state_ == kRunning)) {
     if (taskStats_.executionEndTimeMs == 0) {
       // In case we haven't set executionEndTimeMs due to all splits depleted,
@@ -643,6 +736,7 @@ void Task::driverClosedLocked() {
       taskStats_.executionEndTimeMs = getCurrentTimeMs();
     }
     if (!hasPartitionedOutput_ || partitionedOutputConsumed_) {
+      taskStats_.endTimeMs = getCurrentTimeMs();
       state_ = kFinished;
       stateChangedLocked();
     }
@@ -685,25 +779,23 @@ bool Task::allPeersFinished(
   return false;
 }
 
-void Task::addHashJoinBridges(
+void Task::addHashJoinBridgesLocked(
+    uint32_t splitGroupId,
     const std::vector<core::PlanNodeId>& planNodeIds) {
-  std::lock_guard<std::mutex> l(mutex_);
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
   for (const auto& planNodeId : planNodeIds) {
-    for (auto& splitGroupState : splitGroupStates_) {
-      splitGroupState.bridges.emplace(
-          planNodeId, std::make_shared<HashJoinBridge>());
-    }
+    splitGroupState.bridges.emplace(
+        planNodeId, std::make_shared<HashJoinBridge>());
   }
 }
 
-void Task::addCrossJoinBridges(
+void Task::addCrossJoinBridgesLocked(
+    uint32_t splitGroupId,
     const std::vector<core::PlanNodeId>& planNodeIds) {
-  std::lock_guard<std::mutex> l(mutex_);
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
   for (const auto& planNodeId : planNodeIds) {
-    for (auto& splitGroupState : splitGroupStates_) {
-      splitGroupState.bridges.emplace(
-          planNodeId, std::make_shared<CrossJoinBridge>());
-    }
+    splitGroupState.bridges.emplace(
+        planNodeId, std::make_shared<CrossJoinBridge>());
   }
 }
 
@@ -724,7 +816,6 @@ std::shared_ptr<TBridgeType> Task::getJoinBridgeInternal(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
   std::lock_guard<std::mutex> l(mutex_);
-  checkSplitGroupIndex(splitGroupId, "Get join bridge");
   const auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   auto it = splitGroupState.bridges.find(planNodeId);
@@ -819,18 +910,16 @@ void Task::terminate(TaskState terminalState) {
 
     // Collect all the join bridges to clear them.
     for (auto& splitGroupState : splitGroupStates_) {
-      for (auto& pair : splitGroupState.bridges) {
+      for (auto& pair : splitGroupState.second.bridges) {
         oldBridges.emplace_back(std::move(pair.second));
       }
-      splitGroupState.bridges.clear();
+      splitGroupState.second.bridges.clear();
     }
 
     // Collect all outstanding split promises from all splits state structures.
     for (auto& pair : splitsStates_) {
-      movePromisesOut(pair.second.splitsStore.splitPromises, promises);
-      for (auto& groupSplitsStore :
-           pair.second.groupSplitsStores(planFragment_.numSplitGroups)) {
-        movePromisesOut(groupSplitsStore.splitPromises, promises);
+      for (auto& it : pair.second.groupSplitsStores) {
+        movePromisesOut(it.second.splitPromises, promises);
       }
     }
   }
@@ -918,30 +1007,6 @@ std::string Task::toString() {
     }
   }
 
-  for (const auto& pair : splitsStates_) {
-    const auto& splitStore = pair.second.splitsStore;
-    out << "Plan Node: " << pair.first << ": " << std::endl;
-
-    out << splitStore.splits.size() << " splits: ";
-    int32_t counter = 0;
-    for (const auto& split : splitStore.splits) {
-      out << split.toString() << " ";
-      if (++counter > 4) {
-        out << "...";
-        break;
-      }
-    }
-    out << std::endl;
-
-    if (splitStore.noMoreSplits) {
-      out << "No more splits" << std::endl;
-    }
-
-    if (not splitStore.splitPromises.empty()) {
-      out << splitStore.splitPromises.size() << " split promises" << std::endl;
-    }
-  }
-
   return out.str();
 }
 
@@ -950,7 +1015,6 @@ void Task::createLocalMergeSources(
     unsigned numSources,
     const std::shared_ptr<const RowType>& rowType,
     memory::MappedMemory* mappedMemory) {
-  checkSplitGroupIndex(splitGroupId, "Create local merge sources");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   VELOX_CHECK(
@@ -966,7 +1030,6 @@ void Task::createLocalMergeSources(
 std::shared_ptr<MergeSource> Task::getLocalMergeSource(
     uint32_t splitGroupId,
     int sourceId) {
-  checkSplitGroupIndex(splitGroupId, "Get local merge source");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   VELOX_CHECK_LT(
@@ -979,7 +1042,6 @@ std::shared_ptr<MergeSource> Task::getLocalMergeSource(
 void Task::createMergeJoinSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
-  checkSplitGroupIndex(splitGroupId, "Create merge join source");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   VELOX_CHECK(
@@ -995,7 +1057,6 @@ void Task::createMergeJoinSource(
 std::shared_ptr<MergeJoinSource> Task::getMergeJoinSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
-  checkSplitGroupIndex(splitGroupId, "Get merge join source");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   auto it = splitGroupState.mergeJoinSources.find(planNodeId);
@@ -1006,34 +1067,33 @@ std::shared_ptr<MergeJoinSource> Task::getMergeJoinSource(
   return it->second;
 }
 
-void Task::createLocalExchangeSources(
+void Task::createLocalExchangeSourcesLocked(
+    uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId,
     int numPartitions) {
-  for (auto& splitGroupState : splitGroupStates_) {
-    VELOX_CHECK(
-        splitGroupState.localExchanges.find(planNodeId) ==
-            splitGroupState.localExchanges.end(),
-        "Local exchange already exists: {}",
-        planNodeId);
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
+  VELOX_CHECK(
+      splitGroupState.localExchanges.find(planNodeId) ==
+          splitGroupState.localExchanges.end(),
+      "Local exchange already exists: {}",
+      planNodeId);
 
-    // TODO(spershin): Should we have one memory manager for all local exchanges
-    //  in all split groups?
-    LocalExchange exchange;
-    exchange.memoryManager = std::make_unique<LocalExchangeMemoryManager>(
-        queryCtx_->config().maxLocalExchangeBufferSize());
+  // TODO(spershin): Should we have one memory manager for all local exchanges
+  //  in all split groups?
+  LocalExchange exchange;
+  exchange.memoryManager = std::make_unique<LocalExchangeMemoryManager>(
+      queryCtx_->config().maxLocalExchangeBufferSize());
 
-    exchange.sources.reserve(numPartitions);
-    for (auto i = 0; i < numPartitions; ++i) {
-      exchange.sources.emplace_back(std::make_shared<LocalExchangeSource>(
-          exchange.memoryManager.get(), i));
-    }
-
-    splitGroupState.localExchanges.insert({planNodeId, std::move(exchange)});
+  exchange.sources.reserve(numPartitions);
+  for (auto i = 0; i < numPartitions; ++i) {
+    exchange.sources.emplace_back(
+        std::make_shared<LocalExchangeSource>(exchange.memoryManager.get(), i));
   }
+
+  splitGroupState.localExchanges.insert({planNodeId, std::move(exchange)});
 }
 
 void Task::noMoreLocalExchangeProducers(uint32_t splitGroupId) {
-  checkSplitGroupIndex(splitGroupId, "No more local exchange producers");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   for (auto& exchange : splitGroupState.localExchanges) {
@@ -1060,7 +1120,6 @@ const std::vector<std::shared_ptr<LocalExchangeSource>>&
 Task::getLocalExchangeSources(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
-  checkSplitGroupIndex(splitGroupId, "No more local exchange producers");
   auto& splitGroupState = splitGroupStates_[splitGroupId];
 
   auto it = splitGroupState.localExchanges.find(planNodeId);
@@ -1263,15 +1322,6 @@ StopReason Task::shouldStopLocked() {
     return StopReason::kYield;
   }
   return StopReason::kNone;
-}
-
-void Task::checkSplitGroupIndex(uint32_t splitGroupId, const char* context) {
-  VELOX_DCHECK_LT(
-      splitGroupId,
-      splitGroupStates_.size(),
-      "Invalid split group {} while executing {}",
-      splitGroupId,
-      context);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -91,36 +91,21 @@ struct SplitsStore {
   std::vector<VeloxPromise<bool>> splitPromises;
 };
 
-/// Structure contains the current info on splits.
+/// Structure contains the current info on splits for a particular plan node.
 struct SplitsState {
-  /// For ungrouped (usual) execution, we store splits here.
-  /// Also, we use 'noMoreSplits' member here in grouped execution as well.
-  SplitsStore splitsStore;
+  /// Plan node-wide 'no more splits'.
+  bool noMoreSplits{false};
 
   /// Keep the max added split's sequence id to deduplicate incoming splits.
   long maxSequenceId{std::numeric_limits<long>::min()};
 
-  /// Ensure we always have allocated entries when accessing group stores.
-  std::vector<SplitsStore>& groupSplitsStores(uint32_t numGroups) {
-    if (groupSplitsStores_.size() == numGroups) {
-      return groupSplitsStores_;
-    }
-    // This member will be called only once and resize from 0 to 'numGroups'.
-    // Use swap, as promises are not copyable and 'resize' wouldn't compile.
-    std::vector<SplitsStore> tmp{numGroups};
-    groupSplitsStores_.swap(tmp);
-    return groupSplitsStores_;
-  }
+  /// Map split group id -> split store.
+  std::unordered_map<uint32_t, SplitsStore> groupSplitsStores;
 
   /// We need these due to having promises in the structure.
   SplitsState() = default;
   SplitsState(SplitsState const&) = delete;
   SplitsState& operator=(SplitsState const&) = delete;
-
- private:
-  /// For grouped execution we store splits in this vector, separately for
-  /// each group.
-  std::vector<SplitsStore> groupSplitsStores_;
 };
 
 /// Stores local exchange sources with the memory manager.

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -103,6 +103,28 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
   VELOX_ASSERT_THROW(task.noMoreSplitsForGroup("12", 5), errorMessage)
 }
 
+// Dummy node class to construct a node we don't need.
+class DummyNode : public core::PlanNode {
+ public:
+  explicit DummyNode(const core::PlanNodeId& id) : PlanNode(id) {}
+
+  const std::shared_ptr<const RowType>& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return id();
+  }
+
+ private:
+  std::vector<std::shared_ptr<const core::PlanNode>> sources_;
+  std::shared_ptr<const RowType> outputType_;
+};
+
 // Test if the Task correctly handles split groups.
 TEST_F(TaskTest, splitGroup) {
   // Create single hive connector split and the task.
@@ -112,57 +134,58 @@ TEST_F(TaskTest, splitGroup) {
       facebook::velox::dwio::common::FileFormat::ORC,
       0,
       100);
-  auto plan = exec::test::PlanBuilder()
-                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
-                  .planNode();
   core::PlanNodeId planNodeId{"0"};
-  core::PlanFragment planFragment{plan, core::ExecutionStrategy::kGrouped, 3};
-  exec::Task task(
-      "0", std::move(planFragment), 0, core::QueryCtx::createForTest());
+  auto queryCtx = core::QueryCtx::createForTest();
+  core::PlanFragment planFragment{
+      std::make_shared<DummyNode>(planNodeId),
+      core::ExecutionStrategy::kGrouped,
+      3};
+  auto task = std::make_shared<exec::Task>(
+      "0", std::move(planFragment), 0, std::move(queryCtx));
 
   // This is the set of completed groups we expect.
   std::unordered_set<int32_t> completedSplitGroups;
 
   // Add and complete 3 splits for group 0.
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
-  useOneSplit(task, 0, planNodeId);
-  useOneSplit(task, 0, planNodeId);
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
-  useOneSplit(task, 0, planNodeId);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
+  useOneSplit(*task, 0, planNodeId);
+  useOneSplit(*task, 0, planNodeId);
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 0));
+  useOneSplit(*task, 0, planNodeId);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 
   // Declare 'no more splits' for group 0.
-  task.noMoreSplitsForGroup(planNodeId, 0);
+  task->noMoreSplitsForGroup(planNodeId, 0);
   completedSplitGroups.insert(0);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 
   // Add 3 splits for group 1, declare 'no more splits' for group 1, finish 2
   // splits from group 1.
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
-  task.noMoreSplitsForGroup(planNodeId, 1);
-  useOneSplit(task, 1, planNodeId);
-  useOneSplit(task, 1, planNodeId);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 1));
+  task->noMoreSplitsForGroup(planNodeId, 1);
+  useOneSplit(*task, 1, planNodeId);
+  useOneSplit(*task, 1, planNodeId);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 
   // Add 2 splits for group 2, declare 'no more splits' for group 2.
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 2));
-  task.addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 2));
-  task.noMoreSplitsForGroup(planNodeId, 2);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 2));
+  task->addSplit(planNodeId, exec::Split(folly::copy(connectorSplit), 2));
+  task->noMoreSplitsForGroup(planNodeId, 2);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 
   // Finish the last split for group 1
-  useOneSplit(task, 1, planNodeId);
+  useOneSplit(*task, 1, planNodeId);
   completedSplitGroups.insert(1);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 
   // Finish the 2 split for group 2
-  useOneSplit(task, 2, planNodeId);
-  useOneSplit(task, 2, planNodeId);
+  useOneSplit(*task, 2, planNodeId);
+  useOneSplit(*task, 2, planNodeId);
   completedSplitGroups.insert(2);
-  EXPECT_EQ(completedSplitGroups, task.taskStats().completedSplitGroups);
+  EXPECT_EQ(completedSplitGroups, task->taskStats().completedSplitGroups);
 }
 
 TEST_F(TaskTest, duplicatePlanNodeIds) {


### PR DESCRIPTION
Summary:
Change grouped execution logic:
  - We can have any subset of the all the split groups and in any order.
  - We store split stores in a map keyed by split group id, instead of having a vector of them.
  - We store split states in a map keyed by split group id, instead of having a vector of them. We create split states right before processing another slpit group.
  - After another bunch of splits arrived, we double-check that Task is running Driers necessary to process splits arrived so far.
  - Track Task completion by comparing total drivers with finished drivers (as before).
  - Track the moment when all plan nodes that were expecting split groups have 'no more splits' event arrived, at which point we go into 'no more split groups' state. At that instance we recalculate how many drivers we are supposed to have in total and check for the Task completion.
  - Create Local Exchange Sources and Join Bridges for a split group right before we create Drivers for that split group.
  - Keep track of additional stats in the Task: the number of split groups being currently processed, split groups we've received from coordinator and split groups that needs to start being processed.
  - PartitionedOutputBuffer now allows changing the number of producing Drivers - we use that when we understand the actual number of split groups we have during grouped execution.

I will, of course, remove all debug logging before landing.

Differential Revision: D33934506

