### PR TITLE
Add date_add Presto function

### DIFF
--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -38,6 +38,28 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
     Returns ``x`` truncated to ``unit``. The supported types for ``x`` are TIMESTAMP and DATE.
 
+Interval Functions
+------------------
+
+The functions in this section support the following interval units:
+
+=============== =======================
+Unit            Description
+=============== =======================
+``millisecond`` ``Milliseconds``
+``second``      ``Seconds``
+``minute``      ``Minutes``
+``hour``        ``Hours``
+``day``         ``Days``
+``month``       ``Months``
+``quarter``     ``Quarters of a year``
+``year``        ``Years``
+=============== =======================
+
+.. function:: date_add(unit, value, x) -> x
+
+    Adds an interval ``value`` of type ``unit`` to ``x``. The supported types for ``x`` are TIME and DATE.
+    Subtraction can be performed by using a negative value.
 
 Java Date Functions
 -------------------

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -15,7 +15,10 @@
  */
 #pragma once
 
+#include <chrono>
 #include <optional>
+#include "velox/external/date/date.h"
+#include "velox/type/Date.h"
 #include "velox/type/Timestamp.h"
 
 namespace facebook::velox::functions {
@@ -59,5 +62,129 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
   auto seconds = std::floor(unixtime);
   auto nanos = unixtime - seconds;
   return Timestamp(seconds, nanos * kNanosecondsInSecond);
+}
+
+namespace {
+enum class DateTimeUnit {
+  kMillisecond,
+  kSecond,
+  kMinute,
+  kHour,
+  kDay,
+  kMonth,
+  kQuarter,
+  kYear
+};
+} // namespace
+
+// Year, quarter or month are not uniformly incremented. Months have different
+// total days, and leap years have more days than the rest. If the new year,
+// quarter or month has less total days than the given one, it will be coerced
+// to use the valid last day of the new month. This could result in weird
+// arithmetic behavior. For example,
+//
+// 2022-01-30 + (1 month) = 2022-02-28
+// 2022-02-28 - (1 month) = 2022-01-28
+//
+// 2022-08-31 + (1 quarter) = 2022-11-30
+// 2022-11-30 - (1 quarter) = 2022-08-30
+//
+// 2020-02-29 + (1 year) = 2021-02-28
+// 2021-02-28 - (1 year) = 2020-02-28
+FOLLY_ALWAYS_INLINE
+Date addToDate(
+    const Date& date,
+    const DateTimeUnit& unit,
+    const int32_t value) {
+  // TODO(gaoge): Handle overflow and underflow with 64-bit representation
+  if (value == 0) {
+    return date;
+  }
+
+  const std::chrono::time_point<std::chrono::system_clock, date::days> inDate(
+      date::days(date.days()));
+  std::chrono::time_point<std::chrono::system_clock, date::days> outDate;
+
+  if (unit == DateTimeUnit::kDay) {
+    outDate = inDate + date::days(value);
+  } else {
+    const date::year_month_day inCalDate(inDate);
+    date::year_month_day outCalDate;
+
+    if (unit == DateTimeUnit::kMonth) {
+      outCalDate = inCalDate + date::months(value);
+    } else if (unit == DateTimeUnit::kQuarter) {
+      outCalDate = inCalDate + date::months(3 * value);
+    } else if (unit == DateTimeUnit::kYear) {
+      outCalDate = inCalDate + date::years(value);
+    } else {
+      VELOX_UNREACHABLE();
+    }
+
+    if (!outCalDate.ok()) {
+      outCalDate = outCalDate.year() / outCalDate.month() / date::last;
+    }
+    outDate = date::sys_days{outCalDate};
+  }
+
+  return Date(outDate.time_since_epoch().count());
+}
+
+FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
+    const Timestamp& timestamp,
+    const DateTimeUnit& unit,
+    const int32_t value) {
+  // TODO(gaoge): Handle overflow and underflow with 64-bit representation
+  if (value == 0) {
+    return timestamp;
+  }
+
+  const std::chrono::
+      time_point<std::chrono::system_clock, std::chrono::milliseconds>
+          inTimestamp(std::chrono::milliseconds(timestamp.toMillis()));
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
+      outTimestamp;
+
+  switch (unit) {
+    // Year, quarter or month are not uniformly incremented in terms of number
+    // of days. So we treat them differently.
+    case DateTimeUnit::kYear:
+    case DateTimeUnit::kQuarter:
+    case DateTimeUnit::kMonth:
+    case DateTimeUnit::kDay: {
+      const Date inDate(
+          std::chrono::duration_cast<date::days>(inTimestamp.time_since_epoch())
+              .count());
+      const Date outDate = addToDate(inDate, unit, value);
+
+      outTimestamp = inTimestamp + date::days(outDate.days() - inDate.days());
+      break;
+    }
+    case DateTimeUnit::kHour: {
+      outTimestamp = inTimestamp + std::chrono::hours(value);
+      break;
+    }
+    case DateTimeUnit::kMinute: {
+      outTimestamp = inTimestamp + std::chrono::minutes(value);
+      break;
+    }
+    case DateTimeUnit::kSecond: {
+      outTimestamp = inTimestamp + std::chrono::seconds(value);
+      break;
+    }
+    case DateTimeUnit::kMillisecond: {
+      outTimestamp = inTimestamp + std::chrono::milliseconds(value);
+      break;
+    }
+    default:
+      VELOX_UNREACHABLE();
+  }
+
+  Timestamp milliTimestamp =
+      Timestamp::fromMillis(outTimestamp.time_since_epoch().count());
+  return Timestamp(
+      milliTimestamp.getSeconds(),
+      milliTimestamp.getNanos() +
+          timestamp.getNanos() % kNanosecondsInMillisecond);
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -55,6 +55,9 @@ void registerSimpleFunctions() {
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {"date_trunc"});
   registerFunction<DateTruncFunction, Date, Varchar, Date>({"date_trunc"});
+  registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>({"date_add"});
+  registerFunction<DateAddFunction, Timestamp, Varchar, int64_t, Timestamp>(
+      {"date_add"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -31,6 +31,12 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     });
   }
 
+  void disableAdjustTimestampToTimezone() {
+    queryCtx_->setConfigOverridesUnsafe({
+        {core::QueryConfig::kAdjustTimestampToTimezone, "false"},
+    });
+  }
+
  public:
   struct TimestampWithTimezone {
     TimestampWithTimezone(int64_t milliSeconds, int16_t timezoneId)
@@ -671,6 +677,345 @@ TEST_F(DateTimeFunctionsTest, dateTruncDate) {
   EXPECT_THROW(dateTrunc("second", Date(-18297)), VeloxUserError);
   EXPECT_THROW(dateTrunc("minute", Date(-18297)), VeloxUserError);
   EXPECT_THROW(dateTrunc("hour", Date(-18297)), VeloxUserError);
+}
+
+TEST_F(DateTimeFunctionsTest, dateAddDate) {
+  const auto dateAdd = [&](const std::string& unit,
+                           std::optional<int32_t> value,
+                           std::optional<Date> date) {
+    return evaluateOnce<Date>(
+        fmt::format("date_add('{}', c0, c1)", unit), value, date);
+  };
+
+  const auto parseDate = [&](const std::string& strDate) -> Date {
+    Date result;
+    parseTo(strDate, result);
+    return result;
+  };
+
+  // Check null behaviors
+  EXPECT_EQ(std::nullopt, dateAdd("day", 1, std::nullopt));
+  EXPECT_EQ(std::nullopt, dateAdd("month", std::nullopt, Date(0)));
+
+  // Check invalid units
+  EXPECT_THROW(dateAdd("millisecond", 1, Date(0)), VeloxUserError);
+  EXPECT_THROW(dateAdd("second", 1, Date(0)), VeloxUserError);
+  EXPECT_THROW(dateAdd("minute", 1, Date(0)), VeloxUserError);
+  EXPECT_THROW(dateAdd("hour", 1, Date(0)), VeloxUserError);
+  EXPECT_THROW(dateAdd("invalid_unit", 1, Date(0)), VeloxUserError);
+
+  // Simple tests
+  EXPECT_EQ(
+      parseDate("2019-03-01"), dateAdd("day", 1, parseDate("2019-02-28")));
+  EXPECT_EQ(
+      parseDate("2020-03-28"), dateAdd("month", 13, parseDate("2019-02-28")));
+  EXPECT_EQ(
+      parseDate("2020-02-28"), dateAdd("quarter", 4, parseDate("2019-02-28")));
+  EXPECT_EQ(
+      parseDate("2020-02-28"), dateAdd("year", 1, parseDate("2019-02-28")));
+
+  // Account for the last day of a year-month
+  EXPECT_EQ(
+      parseDate("2020-02-29"), dateAdd("day", 395, parseDate("2019-01-30")));
+  EXPECT_EQ(
+      parseDate("2020-02-29"), dateAdd("month", 13, parseDate("2019-01-30")));
+  EXPECT_EQ(
+      parseDate("2020-02-29"), dateAdd("quarter", 1, parseDate("2019-11-30")));
+  EXPECT_EQ(
+      parseDate("2030-02-28"), dateAdd("year", 10, parseDate("2020-02-29")));
+
+  // Check for negative intervals
+  EXPECT_EQ(
+      parseDate("2019-02-28"), dateAdd("day", -366, parseDate("2020-02-29")));
+  EXPECT_EQ(
+      parseDate("2019-02-28"), dateAdd("month", -12, parseDate("2020-02-29")));
+  EXPECT_EQ(
+      parseDate("2019-02-28"), dateAdd("quarter", -4, parseDate("2020-02-29")));
+  EXPECT_EQ(
+      parseDate("2018-02-28"), dateAdd("year", -2, parseDate("2020-02-29")));
+}
+
+TEST_F(DateTimeFunctionsTest, dateAddTimestamp) {
+  const auto dateAdd = [&](const std::string& unit,
+                           std::optional<int32_t> value,
+                           std::optional<Timestamp> timestamp) {
+    return evaluateOnce<Timestamp>(
+        fmt::format("date_add('{}', c0, c1)", unit), value, timestamp);
+  };
+
+  // Check null behaviors
+  EXPECT_EQ(std::nullopt, dateAdd("second", 1, std::nullopt));
+  EXPECT_EQ(std::nullopt, dateAdd("month", std::nullopt, Timestamp(0, 0)));
+
+  // Check invalid units
+  EXPECT_THROW(dateAdd("invalid_unit", 1, Timestamp(0, 0)), VeloxUserError);
+
+  // Simple tests
+  EXPECT_EQ(
+      Timestamp(1551348061, 999'999) /*2019-02-28 10:01:01.000*/,
+      dateAdd(
+          "millisecond",
+          60 * 1000 + 500,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999) /*2019-03-01 10:00:00.500*/,
+      dateAdd(
+          "second",
+          60 * 60 * 24,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999) /*2019-03-01 10:00:00.500*/,
+      dateAdd(
+          "minute",
+          60 * 24,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999) /*2019-03-01 10:00:00.500*/,
+      dateAdd(
+          "hour",
+          24,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999) /*2019-03-01 10:00:00.500*/,
+      dateAdd(
+          "day",
+          1,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1585389600, 500'999'999) /*2020-03-28 10:00:00.500*/,
+      dateAdd(
+          "month",
+          12 + 1,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582884000, 500'999'999) /*2020-02-28 10:00:00.500*/,
+      dateAdd(
+          "quarter",
+          4,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582884000, 500'999'999) /*2020-02-28 10:00:00.500*/,
+      dateAdd(
+          "year",
+          1,
+          Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+
+  // Test for daylight saving. Daylight saving in US starts at 2021-03-14
+  // 02:00:00 PST.
+  // When adjust_timestamp_to_timezone is off, no Daylight saving occurs
+  EXPECT_EQ(
+      Timestamp(
+          1615770000, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500' UTC*/,
+      dateAdd(
+          "millisecond",
+          1000 * 60 * 60 * 24,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500 UTC'*/));
+  EXPECT_EQ(
+      Timestamp(
+          1615770000, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500 UTC'*/,
+      dateAdd(
+          "second",
+          60 * 60 * 24,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500 UTC'*/));
+  EXPECT_EQ(
+      Timestamp(
+          1615770000, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500' UTC*/,
+      dateAdd(
+          "minute",
+          60 * 24,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+  EXPECT_EQ(
+      Timestamp(
+          1615770000, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500' UTC*/,
+      dateAdd(
+          "hour",
+          24,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+  EXPECT_EQ(
+      Timestamp(
+          1615770000, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500' UTC*/,
+      dateAdd(
+          "day",
+          1,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+  EXPECT_EQ(
+      Timestamp(
+          1618362000, 500'999'999) /*TIMESTAMP '2021-04-14 01:00:00.500' UTC*/,
+      dateAdd(
+          "month",
+          1,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+  EXPECT_EQ(
+      Timestamp(
+          1623632400, 500'999'999) /*TIMESTAMP '2021-06-14 01:00:00.500' UTC*/,
+      dateAdd(
+          "quarter",
+          1,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+  EXPECT_EQ(
+      Timestamp(
+          1647219600, 500'999'999) /*TIMESTAMP '2022-03-14 01:00:00.500' UTC*/,
+      dateAdd(
+          "year",
+          1,
+          Timestamp(
+              1615683600,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' UTC*/));
+
+  // When adjust_timestamp_to_timezone is off, respect Daylight saving in the
+  // session time zone
+  setQueryTimeZone("America/Los_Angeles");
+
+  EXPECT_EQ(
+      Timestamp(1615798800, 0) /*TIMESTAMP '2021-03-15 02:00:00' PST*/,
+      dateAdd(
+          "millisecond",
+          1000 * 60 * 60 * 24,
+          Timestamp(1615712400, 0) /*TIMESTAMP '2021-03-14 01:00:00' PST*/));
+  EXPECT_EQ(
+      Timestamp(1615798800, 0) /*TIMESTAMP '2021-03-15 02:00:00' PST*/,
+      dateAdd(
+          "second",
+          60 * 60 * 24,
+          Timestamp(1615712400, 0) /*TIMESTAMP '2021-03-14 01:00:00' PST*/));
+  EXPECT_EQ(
+      Timestamp(1615798800, 0) /*TIMESTAMP '2021-03-15 02:00:00' PST*/,
+      dateAdd(
+          "minute",
+          60 * 24,
+          Timestamp(1615712400, 0) /*TIMESTAMP '2021-03-14 01:00:00' PST*/));
+  EXPECT_EQ(
+      Timestamp(1615798800, 0) /*TIMESTAMP '2021-03-15 02:00:00' PST*/,
+      dateAdd(
+          "hour",
+          24,
+          Timestamp(1615712400, 0) /*TIMESTAMP '2021-03-14 01:00:00' PST*/));
+  EXPECT_EQ(
+      Timestamp(
+          1615795200, 500'999'999) /*TIMESTAMP '2021-03-15 01:00:00.500' PST*/,
+      dateAdd(
+          "day",
+          1,
+          Timestamp(
+              1615712400,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' PST*/));
+  EXPECT_EQ(
+      Timestamp(
+          1618387200, 500'999'999) /*TIMESTAMP '2021-04-14 01:00:00.500' PST*/,
+      dateAdd(
+          "month",
+          1,
+          Timestamp(
+              1615712400,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' PST*/));
+  EXPECT_EQ(
+      Timestamp(
+          1623657600, 500'999'999) /*TIMESTAMP '2021-06-14 01:00:00.500' PST*/,
+      dateAdd(
+          "quarter",
+          1,
+          Timestamp(
+              1615712400,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' PST*/));
+  EXPECT_EQ(
+      Timestamp(
+          1647244800, 500'999'999) /*TIMESTAMP '2022-03-14 01:00:00.500' PST*/,
+      dateAdd(
+          "year",
+          1,
+          Timestamp(
+              1615712400,
+              500'999'999) /*TIMESTAMP '2021-03-14 01:00:00.500' PST*/));
+
+  // Test for coercing to the last day of a year-month
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      dateAdd(
+          "day",
+          365 + 30,
+          Timestamp(1548842400, 500'999'999) /*2019-01-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      dateAdd(
+          "month",
+          12 + 1,
+          Timestamp(1548842400, 500'999'999) /*2019-01-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      dateAdd(
+          "quarter",
+          1,
+          Timestamp(1575108000, 500'999'999) /*2019-11-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1898503200, 500'999'999) /*2030-02-28 10:00:00.500*/,
+      dateAdd(
+          "year",
+          10,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
+
+  // Test for negative intervals
+  EXPECT_EQ(
+      Timestamp(1582934400, 999'999) /*2020-02-29 00:00:00.000*/,
+      dateAdd(
+          "millisecond",
+          -60 * 60 * 24 * 1000 - 500,
+          Timestamp(1583020800, 500'999'999) /*2020-03-01 00:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582934400, 500'999'999) /*2020-02-29 00:00:00.500*/,
+      dateAdd(
+          "second",
+          -60 * 60 * 24,
+          Timestamp(1583020800, 500'999'999) /*2020-03-01 00:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582934400, 500'999'999) /*2020-02-29 00:00:00.500*/,
+      dateAdd(
+          "minute",
+          -60 * 24,
+          Timestamp(1583020800, 500'999'999) /*2020-03-01 00:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582934400, 500'999'999) /*2020-02-29 00:00:00.500*/,
+      dateAdd(
+          "hour",
+          -24,
+          Timestamp(1583020800, 500'999'999) /*2020-03-01 00:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/,
+      dateAdd(
+          "day",
+          -366,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/,
+      dateAdd(
+          "month",
+          -12,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/,
+      dateAdd(
+          "quarter",
+          -4,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1519812000, 500'999'999) /*2019-02-28 10:00:00.500*/,
+      dateAdd(
+          "year",
+          -2,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
 }
 
 TEST_F(DateTimeFunctionsTest, parseDatetime) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -44,7 +44,11 @@ inline int64_t getPrestoTZOffsetInSeconds(int16_t tzID) {
 } // namespace
 
 void Timestamp::toTimezone(const date::time_zone& zone) {
-  seconds_ += deltaWithTimezone(zone, seconds_);
+  date::local_time<std::chrono::seconds> localTime{
+      std::chrono::seconds(seconds_)};
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>
+      sysTime = zone.to_sys(localTime, date::choose::latest);
+  seconds_ = sysTime.time_since_epoch().count();
 }
 
 void Timestamp::toTimezone(int16_t tzID) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -216,9 +216,9 @@ TEST(DateTimeUtilTest, toTimezone) {
   EXPECT_EQ(ts, fromTimestampString("2021-03-14 08:00:00"));
 
   // After it starts, 7h offset:
-  ts = fromTimestampString("2021-03-15 00:00:00");
+  ts = fromTimestampString("2021-03-14 08:00:00");
   ts.toTimezone(*laZone);
-  EXPECT_EQ(ts, fromTimestampString("2021-03-15 07:00:00"));
+  EXPECT_EQ(ts, fromTimestampString("2021-03-14 15:00:00"));
 }
 
 TEST(DateTimeUtilTest, toTimezoneUTC) {


### PR DESCRIPTION
Add date_add UDF that works the same as the corresponding Presto function, https://prestodb.io/docs/current/functions/datetime.html#interval-functions.

Supported types for date are TIMESTAMP and DATE. Interval can be negative to perform subtraction.

Fix a bug in Timestamp::toTimezone(const date::time_zone& zone) that incorrectly takes local instant as UTC instant to calculate the delta between local timezone and UTC.
