### PR TITLE
Check unique plan node ids

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -757,9 +757,7 @@ PlanBuilder& PlanBuilder::unnest(
 }
 
 std::string PlanBuilder::nextPlanNodeId() {
-  auto id = fmt::format("{}", planNodeId_);
-  planNodeId_++;
-  return id;
+  return fmt::format("{}", planNodeIdGenerator_->next());
 }
 
 std::shared_ptr<const core::FieldAccessTypedExpr> PlanBuilder::field(

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -26,13 +26,31 @@ class IExpr;
 
 namespace facebook::velox::exec::test {
 
+/// Generates unique sequential plan node IDs starting with zero or specified
+/// value.
+class PlanNodeIdGenerator {
+ public:
+  explicit PlanNodeIdGenerator(int startId = 0) : nextId_{startId} {}
+
+  int next() {
+    return nextId_++;
+  }
+
+ private:
+  int nextId_;
+};
+
 class PlanBuilder {
  public:
-  explicit PlanBuilder(int planNodeId = 0, memory::MemoryPool* pool = nullptr)
-      : planNodeId_{planNodeId}, pool_{pool} {}
+  explicit PlanBuilder(
+      std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator,
+      memory::MemoryPool* pool = nullptr)
+      : planNodeIdGenerator_{std::move(planNodeIdGenerator)}, pool_{pool} {}
 
-  explicit PlanBuilder(memory::MemoryPool* pool)
-      : planNodeId_{0}, pool_{pool} {}
+  explicit PlanBuilder(int planNodeId = 0, memory::MemoryPool* pool = nullptr)
+      : PlanBuilder(std::make_shared<PlanNodeIdGenerator>(planNodeId), pool) {}
+
+  explicit PlanBuilder(memory::MemoryPool* pool) : PlanBuilder(0, pool) {}
 
   PlanBuilder& tableScan(const RowTypePtr& outputType);
 
@@ -358,7 +376,7 @@ class PlanBuilder {
       size_t numAggregates,
       const std::vector<std::string>& masks);
 
-  int planNodeId_;
+  std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator_;
   std::shared_ptr<core::PlanNode> planNode_;
   memory::MemoryPool* pool_;
 };

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -1087,6 +1087,7 @@ struct VectorWriter<std::shared_ptr<T>> {
 template <>
 struct VectorReader<Generic> {
   using exec_in_t = GenericView;
+  using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_(*decoded), base_(decoded->base()) {}
@@ -1102,6 +1103,10 @@ struct VectorReader<Generic> {
   exec_in_t operator[](size_t offset) const {
     auto index = decoded_.index(offset);
     return GenericView{base_, index};
+  }
+
+  exec_null_free_in_t readNullFree(vector_size_t offset) const {
+    return operator[](offset);
   }
 
   const DecodedVector& decoded_;


### PR DESCRIPTION
Plan node IDs must be unique. Add a check to detect duplicates and fail early at
task creation time to avoid difficult to troubleshoot runtime errors.

Enhance PlanBuilder to make it easy to ensure plan node IDs are unique. 

Introduce PlanNodeIdGenerator class that generates unique sequential node IDs
and modify PlanBuilder's constructor to take an instance of such generator.
When making non-linear plans using multiple instances of PlanBuilder just pass
the same instance of PlanNodeIdGenerator to each PlanBuilder to ensure all
nodes will have unique IDs.