### PR TITLE
Add handling for null free to VectorReader<Generic>

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -1087,6 +1087,7 @@ struct VectorWriter<std::shared_ptr<T>> {
 template <>
 struct VectorReader<Generic> {
   using exec_in_t = GenericView;
+  using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_(*decoded), base_(decoded->base()) {}
@@ -1102,6 +1103,10 @@ struct VectorReader<Generic> {
   exec_in_t operator[](size_t offset) const {
     auto index = decoded_.index(offset);
     return GenericView{base_, index};
+  }
+
+  exec_null_free_in_t readNullFree(vector_size_t offset) const {
+    return operator[](offset);
   }
 
   const DecodedVector& decoded_;


### PR DESCRIPTION
Summary:
PR926 which added support for null free Views landed around the same time as PR957 which added GenericViews, so Generics were missing the necessary changes.

Since GenericView doesn't expose the underlying values there's no need  for changes beyond adding exec_null_free_in_t and readNullFree to VectorReader<Generic> which behave the same as the existing exec_in_t and [] operator respectively.

Reviewed By: pedroerp

Differential Revision: D33946492

