### PR TITLE
Add missing dependency for velox_temp_path

### DIFF
--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 add_library(velox_temp_path TempFilePath.cpp TempDirectoryPath.cpp)
 
+target_link_libraries(velox_temp_path velox_exception)
+
 add_library(
   velox_exec_test_util
   FunctionUtils.cpp PlanBuilder.cpp QueryAssertions.cpp Cursor.cpp


### PR DESCRIPTION
This is needed when installing to a non-default location in presto_cpp.