### PR TITLE
Remove legacy PlanBuilder constructor

### DIFF
--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -58,10 +58,11 @@ TEST_F(CrossJoinTest, basic) {
   createDuckDbTable("u", {rightVectors});
 
   // All x 13. Join output vectors contains multiple probe rows each.
-  auto op = PlanBuilder(10)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .crossJoin(
-                    PlanBuilder(0)
+                    PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .filter("c0 < 13")
                         .project({"c0 AS u_c0"})
@@ -72,11 +73,12 @@ TEST_F(CrossJoinTest, basic) {
   assertQuery(op, "SELECT * FROM t, u WHERE u.c0 < 13");
 
   // 13 x all. Join output vectors contains single probe row each.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .filter("c0 < 13")
            .crossJoin(
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .project({"c0 AS u_c0"})
                    .planNode(),
@@ -86,10 +88,11 @@ TEST_F(CrossJoinTest, basic) {
   assertQuery(op, "SELECT * FROM t, u WHERE t.c0 < 13");
 
   // All x 13. No columns on the build side.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .crossJoin(
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({vectorMaker_.rowVector(ROW({}, {}), 13)})
                    .planNode(),
                {"c0"})
@@ -98,11 +101,12 @@ TEST_F(CrossJoinTest, basic) {
   assertQuery(op, "SELECT t.* FROM t, (SELECT * FROM u LIMIT 13) u");
 
   // 13 x All. No columns on the build side.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .filter("c0 < 13")
            .crossJoin(
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({vectorMaker_.rowVector(ROW({}, {}), 1121)})
                    .planNode(),
                {"c0"})
@@ -113,10 +117,11 @@ TEST_F(CrossJoinTest, basic) {
       "SELECT t.* FROM (SELECT * FROM t WHERE c0 < 13) t, (SELECT * FROM u LIMIT 1121) u");
 
   // Empty build side.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .crossJoin(
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .filter("c0 < 0")
                    .project({"c0 AS u_c0"})
@@ -127,13 +132,14 @@ TEST_F(CrossJoinTest, basic) {
   assertQueryReturnsEmptyResult(op);
 
   // Multi-threaded build side.
+  planNodeIdGenerator->reset();
   CursorParameters params;
   params.maxDrivers = 4;
   params.numResultDrivers = 1;
-  params.planNode = PlanBuilder(10)
+  params.planNode = PlanBuilder(planNodeIdGenerator)
                         .values({leftVectors})
                         .crossJoin(
-                            PlanBuilder(0, pool_.get())
+                            PlanBuilder(planNodeIdGenerator, pool_.get())
                                 .values({rightVectors}, true)
                                 .filter("c0 in (10, 17)")
                                 .project({"c0 AS u_c0"})
@@ -165,10 +171,11 @@ TEST_F(CrossJoinTest, lazyVectors) {
   createDuckDbTable("t", {makeRowVector({sequence<int32_t>(1117)})});
   createDuckDbTable("u", {makeRowVector({sequence<int32_t>(1121)})});
 
-  auto op = PlanBuilder(10)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .crossJoin(
-                    PlanBuilder(0)
+                    PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .project({"c0 AS u_c0"})
                         .planNode(),
@@ -196,22 +203,26 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
   createDuckDbTable("t", {leftVectors});
 
   // Build side has > 1 row.
-  auto op =
-      PlanBuilder(10)
-          .values({leftVectors})
-          .crossJoin(
-              PlanBuilder(0).values({rightVectors}).project({}).planNode(),
-              {"c0"})
-          .planNode();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
+                .values({leftVectors})
+                .crossJoin(
+                    PlanBuilder(planNodeIdGenerator)
+                        .values({rightVectors})
+                        .project({})
+                        .planNode(),
+                    {"c0"})
+                .planNode();
 
   assertQuery(
       op, "SELECT t.* FROM t, (SELECT * FROM UNNEST (ARRAY[0, 1, 2, 3, 4])) u");
 
   // Build side has exactly 1 row.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .crossJoin(
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .filter("c0 = 1")
                    .project({})
@@ -234,13 +245,15 @@ TEST_F(CrossJoinTest, parallelism) {
   auto left = {makeRowVector({sequence<int32_t>(2)})};
   auto right = {makeRowVector({"u_c0"}, {sequence<int32_t>(3)})};
 
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
   CursorParameters params;
   params.maxDrivers = 5;
   params.planNode =
-      PlanBuilder(10)
+      PlanBuilder(planNodeIdGenerator)
           .values({left}, true)
           .crossJoin(
-              PlanBuilder().values({right}, true).planNode(), {"c0", "u_c0"})
+              PlanBuilder(planNodeIdGenerator).values({right}, true).planNode(),
+              {"c0", "u_c0"})
           .partialAggregation({}, {"count(1)"})
           .planNode();
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -334,21 +334,27 @@ TEST_F(HashJoinTest, lazyVectors) {
   writeToFile(rightFile->path, kWriter, rightVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto op =
-      PlanBuilder(10)
-          .tableScan(ROW({"c0", "c1"}, {INTEGER(), BIGINT()}))
-          .hashJoin(
-              {"c0"},
-              {"c0"},
-              PlanBuilder(0).tableScan(ROW({"c0"}, {INTEGER()})).planNode(),
-              "",
-              {"c1"})
-          .project({"c1 + 1"})
-          .planNode();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId leftScanId;
+  core::PlanNodeId rightScanId;
+  auto op = PlanBuilder(planNodeIdGenerator)
+                .tableScan(ROW({"c0", "c1"}, {INTEGER(), BIGINT()}))
+                .capturePlanNodeId(leftScanId)
+                .hashJoin(
+                    {"c0"},
+                    {"c0"},
+                    PlanBuilder(planNodeIdGenerator)
+                        .tableScan(ROW({"c0"}, {INTEGER()}))
+                        .capturePlanNodeId(rightScanId)
+                        .planNode(),
+                    "",
+                    {"c1"})
+                .project({"c1 + 1"})
+                .planNode();
 
   assertQuery(
       op,
-      {{0, {rightFile}}, {10, {leftFile}}},
+      {{rightScanId, {rightFile}}, {leftScanId, {leftFile}}},
       "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
 }
 
@@ -389,16 +395,18 @@ TEST_F(HashJoinTest, arrayBasedLookup) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto op = PlanBuilder(10)
-                .values(leftVectors)
-                .hashJoin(
-                    {"c0"},
-                    {"c0"},
-                    PlanBuilder(0).values(rightVectors).planNode(),
-                    "",
-                    {"c1"})
-                .project({"c1 + 1"})
-                .planNode();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op =
+      PlanBuilder(planNodeIdGenerator)
+          .values(leftVectors)
+          .hashJoin(
+              {"c0"},
+              {"c0"},
+              PlanBuilder(planNodeIdGenerator).values(rightVectors).planNode(),
+              "",
+              {"c1"})
+          .project({"c1 + 1"})
+          .planNode();
 
   auto task = assertQuery(op, "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
   auto joinStats =
@@ -417,17 +425,20 @@ TEST_F(HashJoinTest, innerJoinWithEmptyBuild) {
   auto rightVectors = makeRowVector({makeFlatVector<int32_t>(
       123, [](auto row) { return row % 5; }, nullEvery(7))});
 
-  auto op =
-      PlanBuilder(10)
-          .values({leftVectors})
-          .hashJoin(
-              {"c0"},
-              {"c0"},
-              PlanBuilder(0).values({rightVectors}).filter("c0 < 0").planNode(),
-              "",
-              {"c1"},
-              core::JoinType::kInner)
-          .planNode();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
+                .values({leftVectors})
+                .hashJoin(
+                    {"c0"},
+                    {"c0"},
+                    PlanBuilder(planNodeIdGenerator)
+                        .values({rightVectors})
+                        .filter("c0 < 0")
+                        .planNode(),
+                    "",
+                    {"c1"},
+                    core::JoinType::kInner)
+                .planNode();
 
   assertQueryReturnsEmptyResult(op);
 }
@@ -447,12 +458,15 @@ TEST_F(HashJoinTest, semiJoin) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto op = PlanBuilder(10)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
                     {"c0"},
                     {"c0"},
-                    PlanBuilder(0).values({rightVectors}).planNode(),
+                    PlanBuilder(planNodeIdGenerator)
+                        .values({rightVectors})
+                        .planNode(),
                     "",
                     {"c1"},
                     core::JoinType::kSemi)
@@ -461,17 +475,20 @@ TEST_F(HashJoinTest, semiJoin) {
   assertQuery(op, "SELECT t.c1 FROM t WHERE t.c0 IN (SELECT c0 FROM u)");
 
   // Empty build side.
-  op =
-      PlanBuilder(10)
-          .values({leftVectors})
-          .hashJoin(
-              {"c0"},
-              {"c0"},
-              PlanBuilder(0).values({rightVectors}).filter("c0 < 0").planNode(),
-              "",
-              {"c1"},
-              core::JoinType::kSemi)
-          .planNode();
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
+           .values({leftVectors})
+           .hashJoin(
+               {"c0"},
+               {"c0"},
+               PlanBuilder(planNodeIdGenerator)
+                   .values({rightVectors})
+                   .filter("c0 < 0")
+                   .planNode(),
+               "",
+               {"c1"},
+               core::JoinType::kSemi)
+           .planNode();
 
   assertQuery(
       op, "SELECT t.c1 FROM t WHERE t.c0 IN (SELECT c0 FROM u WHERE c0 < 0)");
@@ -492,12 +509,13 @@ TEST_F(HashJoinTest, antiJoin) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto op = PlanBuilder(10)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
                     {"c0"},
                     {"c0"},
-                    PlanBuilder(0)
+                    PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .filter("c0 IS NOT NULL")
                         .planNode(),
@@ -511,29 +529,35 @@ TEST_F(HashJoinTest, antiJoin) {
       "SELECT t.c1 FROM t WHERE t.c0 NOT IN (SELECT c0 FROM u WHERE c0 IS NOT NULL)");
 
   // Empty build side.
-  op =
-      PlanBuilder(10)
-          .values({leftVectors})
-          .hashJoin(
-              {"c0"},
-              {"c0"},
-              PlanBuilder(0).values({rightVectors}).filter("c0 < 0").planNode(),
-              "",
-              {"c1"},
-              core::JoinType::kAnti)
-          .planNode();
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
+           .values({leftVectors})
+           .hashJoin(
+               {"c0"},
+               {"c0"},
+               PlanBuilder(planNodeIdGenerator)
+                   .values({rightVectors})
+                   .filter("c0 < 0")
+                   .planNode(),
+               "",
+               {"c1"},
+               core::JoinType::kAnti)
+           .planNode();
 
   assertQuery(
       op,
       "SELECT t.c1 FROM t WHERE t.c0 NOT IN (SELECT c0 FROM u WHERE c0 < 0)");
 
   // Build side with nulls. Anti join always returns nothing.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .hashJoin(
                {"c0"},
                {"c0"},
-               PlanBuilder(0).values({rightVectors}).planNode(),
+               PlanBuilder(planNodeIdGenerator)
+                   .values({rightVectors})
+                   .planNode(),
                "",
                {"c1"},
                core::JoinType::kAnti)
@@ -570,11 +594,13 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
 
-  auto buildSide = PlanBuilder(0)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+
+  auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values(rightVectors)
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
                        .planNode();
-  auto keyOnlyBuildSide = PlanBuilder(0)
+  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator)
                               .values({makeRowVector({rightKey})})
                               .project({"c0 AS u_c0"})
                               .planNode();
@@ -582,8 +608,10 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // Basic push-down.
   {
     // Inner join.
-    auto op = PlanBuilder(10)
+    core::PlanNodeId leftScanId;
+    auto op = PlanBuilder(planNodeIdGenerator)
                   .tableScan(probeType)
+                  .capturePlanNodeId(leftScanId)
                   .hashJoin(
                       {"c0"},
                       {"u_c0"},
@@ -596,7 +624,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -604,8 +632,9 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
 
     // Semi join.
-    op = PlanBuilder(10)
+    op = PlanBuilder(planNodeIdGenerator)
              .tableScan(probeType)
+             .capturePlanNodeId(leftScanId)
              .hashJoin(
                  {"c0"},
                  {"u_c0"},
@@ -618,7 +647,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c0, t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u)");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -634,19 +663,21 @@ TEST_F(HashJoinTest, dynamicFilters) {
     assignments["a"] = regularColumn("c0", INTEGER());
     assignments["b"] = regularColumn("c1", BIGINT());
 
+    core::PlanNodeId leftScanId;
     auto op =
-        PlanBuilder(10)
+        PlanBuilder(planNodeIdGenerator)
             .tableScan(
                 scanOutputType,
                 makeTableHandle(common::test::SubfieldFiltersBuilder().build()),
                 assignments)
+            .capturePlanNodeId(leftScanId)
             .hashJoin({"a"}, {"u_c0"}, buildSide, "", {"a", "b", "u_c1"})
             .project({"a", "b + 1", "b + u_c1"})
             .planNode();
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -658,18 +689,20 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     auto filters =
         common::test::singleSubfieldFilter("c0", common::test::lessThan(500));
-    auto op = PlanBuilder(10)
+    core::PlanNodeId leftScanId;
+    auto op = PlanBuilder(planNodeIdGenerator)
                   .tableScan(
                       probeType,
                       makeTableHandle(std::move(filters)),
                       allRegularColumns(probeType))
+                  .capturePlanNodeId(leftScanId)
                   .hashJoin({"c0"}, {"u_c0"}, buildSide, "", {"c1", "u_c1"})
                   .project({"c1 + u_c1"})
                   .planNode();
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -678,16 +711,18 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   // Push-down that turns join into a no-op.
   {
+    core::PlanNodeId leftScanId;
     auto op =
-        PlanBuilder(10)
+        PlanBuilder(planNodeIdGenerator)
             .tableScan(probeType)
+            .capturePlanNodeId(leftScanId)
             .hashJoin({"c0"}, {"u_c0"}, keyOnlyBuildSide, "", {"c0", "c1"})
             .project({"c0", "c1 + 1"})
             .planNode();
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c0, t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -699,18 +734,20 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     auto filters =
         common::test::singleSubfieldFilter("c0", common::test::lessThan(500));
-    auto op = PlanBuilder(10)
+    core::PlanNodeId leftScanId;
+    auto op = PlanBuilder(planNodeIdGenerator)
                   .tableScan(
                       probeType,
                       makeTableHandle(std::move(filters)),
                       allRegularColumns(probeType))
+                  .capturePlanNodeId(leftScanId)
                   .hashJoin({"c0"}, {"u_c0"}, keyOnlyBuildSide, "", {"c1"})
                   .project({"c1 + 1"})
                   .planNode();
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -723,10 +760,12 @@ TEST_F(HashJoinTest, dynamicFilters) {
     auto filters =
         common::test::singleSubfieldFilter("c0", common::test::lessThan(200));
     auto probeTableHandle = makeTableHandle(std::move(filters));
+    core::PlanNodeId leftScanId;
     auto op =
-        PlanBuilder(10)
+        PlanBuilder(planNodeIdGenerator)
             .tableScan(
                 probeType, probeTableHandle, allRegularColumns(probeType))
+            .capturePlanNodeId(leftScanId)
             .hashJoin(
                 {"c0"}, {"u_c0"}, buildSide, "", {"c1"}, core::JoinType::kInner)
             .project({"c1 + 1"})
@@ -734,16 +773,17 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 200");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
     EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
 
     // Semi join.
-    op = PlanBuilder(10)
+    op = PlanBuilder(planNodeIdGenerator)
              .tableScan(
                  probeType, probeTableHandle, allRegularColumns(probeType))
+             .capturePlanNodeId(leftScanId)
              .hashJoin(
                  {"c0"}, {"u_c0"}, buildSide, "", {"c1"}, core::JoinType::kSemi)
              .project({"c1 + 1"})
@@ -751,7 +791,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u) AND t.c0 < 200");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
@@ -760,7 +800,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   // Disable filter push-down by using values in place of scan.
   {
-    auto op = PlanBuilder(10)
+    auto op = PlanBuilder(planNodeIdGenerator)
                   .values(leftVectors)
                   .hashJoin({"c0"}, {"u_c0"}, buildSide, "", {"c1"})
                   .project({"c1 + 1"})
@@ -775,8 +815,10 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // Disable filter push-down by using an expression as the join key on the
   // probe side.
   {
-    auto op = PlanBuilder(10)
+    core::PlanNodeId leftScanId;
+    auto op = PlanBuilder(planNodeIdGenerator)
                   .tableScan(probeType)
+                  .capturePlanNodeId(leftScanId)
                   .project({"cast(c0 + 1 as integer) AS t_key", "c1"})
                   .hashJoin({"t_key"}, {"u_c0"}, buildSide, "", {"c1"})
                   .project({"c1 + 1"})
@@ -784,7 +826,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task = assertQuery(
         op,
-        {{10, leftFiles}},
+        {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t, u WHERE (t.c0 + 1) = u.c0");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
@@ -828,12 +870,13 @@ TEST_F(HashJoinTest, leftJoin) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto buildSide = PlanBuilder(0)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values({rightVectors})
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
                        .planNode();
 
-  auto op = PlanBuilder(10)
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values(leftVectors)
                 .hashJoin(
                     {"c0"},
@@ -850,13 +893,13 @@ TEST_F(HashJoinTest, leftJoin) {
       {0});
 
   // Empty build side.
-  auto emptyBuildSide = PlanBuilder(0)
+  auto emptyBuildSide = PlanBuilder(planNodeIdGenerator)
                             .values({rightVectors})
                             .filter("c0 < 0")
                             .project({"c0 AS u_c0", "c1 AS u_c1"})
                             .planNode();
 
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
@@ -873,7 +916,7 @@ TEST_F(HashJoinTest, leftJoin) {
       {0});
 
   // All left-side rows have a match on the build side.
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .filter("c0 < 5")
            .hashJoin(
@@ -892,7 +935,7 @@ TEST_F(HashJoinTest, leftJoin) {
       {0});
 
   // Additional filter.
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
@@ -909,7 +952,7 @@ TEST_F(HashJoinTest, leftJoin) {
       {0});
 
   // No rows pass the additional filter.
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
@@ -948,10 +991,14 @@ TEST_F(HashJoinTest, leftJoinWithNullableFilter) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", rightVectors);
 
-  auto buildSide =
-      PlanBuilder(0).values(rightVectors).project({"c0 AS u_c0"}).planNode();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
 
-  auto plan = PlanBuilder(10)
+  auto buildSide = PlanBuilder(planNodeIdGenerator)
+                       .values(rightVectors)
+                       .project({"c0 AS u_c0"})
+                       .planNode();
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
                   .values(leftVectors)
                   .hashJoin(
                       {"c0"},
@@ -992,12 +1039,14 @@ TEST_F(HashJoinTest, rightJoin) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto buildSide = PlanBuilder(0)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+
+  auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values({rightVectors})
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
                        .planNode();
 
-  auto op = PlanBuilder(10)
+  auto op = PlanBuilder(planNodeIdGenerator)
                 .values(leftVectors)
                 .hashJoin(
                     {"c0"},
@@ -1011,12 +1060,12 @@ TEST_F(HashJoinTest, rightJoin) {
   assertQuery(op, "SELECT t.c0, t.c1, u.c1 FROM t RIGHT JOIN u ON t.c0 = u.c0");
 
   // Empty build side.
-  auto emptyBuildSide = PlanBuilder(0)
+  auto emptyBuildSide = PlanBuilder(planNodeIdGenerator)
                             .values({rightVectors})
                             .filter("c0 > 100")
                             .project({"c0 AS u_c0", "c1 AS u_c1"})
                             .planNode();
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
@@ -1030,12 +1079,13 @@ TEST_F(HashJoinTest, rightJoin) {
   assertQueryReturnsEmptyResult(op);
 
   // All right-side rows have a match on the left side.
-  op = PlanBuilder(10)
+  planNodeIdGenerator->reset();
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
                {"u_c0"},
-               PlanBuilder(0)
+               PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .filter("c0 >= 0")
                    .project({"c0 AS u_c0", "c1 AS u_c1"})
@@ -1051,7 +1101,7 @@ TEST_F(HashJoinTest, rightJoin) {
       " RIGHT JOIN (SELECT * FROM u WHERE c0 >= 0) u ON t.c0 = u.c0");
 
   // Additional filter.
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},
@@ -1067,7 +1117,7 @@ TEST_F(HashJoinTest, rightJoin) {
       "SELECT t.c0, t.c1, u.c1 FROM t RIGHT JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 1");
 
   // No rows pass the additional filter.
-  op = PlanBuilder(10)
+  op = PlanBuilder(planNodeIdGenerator)
            .values(leftVectors)
            .hashJoin(
                {"c0"},

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -108,8 +108,9 @@ std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
 
 std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,
-    const std::unordered_map<int, std::vector<std::shared_ptr<TempFilePath>>>&
-        filePaths,
+    const std::unordered_map<
+        core::PlanNodeId,
+        std::vector<std::shared_ptr<TempFilePath>>>& filePaths,
     const std::string& duckDbSql) {
   bool noMoreSplits = false;
   return test::assertQuery(
@@ -117,7 +118,7 @@ std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
       [&](auto* task) {
         if (!noMoreSplits) {
           for (const auto& entry : filePaths) {
-            auto planNodeId = fmt::format("{}", entry.first);
+            auto planNodeId = entry.first;
             for (auto file : entry.second) {
               addSplit(task, planNodeId, makeHiveSplit(file->path));
             }

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -66,8 +66,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   std::shared_ptr<exec::Task> assertQuery(
       const std::shared_ptr<const core::PlanNode>& plan,
-      const std::unordered_map<int, std::vector<std::shared_ptr<TempFilePath>>>&
-          filePaths,
+      const std::unordered_map<
+          core::PlanNodeId,
+          std::vector<std::shared_ptr<TempFilePath>>>& filePaths,
       const std::string& duckDbSql);
 
   static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -36,6 +36,10 @@ class PlanNodeIdGenerator {
     return nextId_++;
   }
 
+  void reset(int startId = 0) {
+    nextId_ = startId;
+  }
+
  private:
   int nextId_;
 };
@@ -47,10 +51,8 @@ class PlanBuilder {
       memory::MemoryPool* pool = nullptr)
       : planNodeIdGenerator_{std::move(planNodeIdGenerator)}, pool_{pool} {}
 
-  explicit PlanBuilder(int planNodeId = 0, memory::MemoryPool* pool = nullptr)
-      : PlanBuilder(std::make_shared<PlanNodeIdGenerator>(planNodeId), pool) {}
-
-  explicit PlanBuilder(memory::MemoryPool* pool) : PlanBuilder(0, pool) {}
+  explicit PlanBuilder(memory::MemoryPool* pool = nullptr)
+      : PlanBuilder(std::make_shared<PlanNodeIdGenerator>(), pool) {}
 
   PlanBuilder& tableScan(const RowTypePtr& outputType);
 
@@ -310,6 +312,12 @@ class PlanBuilder {
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,
       const std::optional<std::string>& ordinalColumn = std::nullopt);
+
+  PlanBuilder& capturePlanNodeId(core::PlanNodeId& id) {
+    VELOX_CHECK_NOT_NULL(planNode_);
+    id = planNode_->id();
+    return *this;
+  }
 
   const std::shared_ptr<core::PlanNode>& planNode() const {
     return planNode_;


### PR DESCRIPTION
Remove constructor taking starting plan node ID in favor of the one taking
PlanNodeIdGenerator.

Add PlanBuilder::capturePlanNodeId to allow for capturing intermediate plan node
IDs without interrupting the flow of building the query plan. For example, this
allows to capture scan node IDs to use when adding splits.

```
  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
  core::PlanNodeId leftScanId;
  core::PlanNodeId rightScanId;
  auto op = PlanBuilder(planNodeIdGenerator)
                .tableScan(...)
                .capturePlanNodeId(leftScanId)
                .hashJoin(
                    {"c0"},
                    {"c0"},
                    PlanBuilder(planNodeIdGenerator)
                        .tableScan(...)
                        .capturePlanNodeId(rightScanId)
                        .planNode(),
                    ...)
                ...
                .planNode();

task->addSplit(leftScanId, ...);
task->addSplit(rightScanId, ...);
```