### PR TITLE
Zeng old commits

### DIFF
--- a/velox/experimental/codegen/ast/ConstantExpressions.h
+++ b/velox/experimental/codegen/ast/ConstantExpressions.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,12 +14,12 @@
 #pragma once
 #include <string>
 
-#include "velox/experimental/codegen/CodegenExceptions.h"
-#include "velox/experimental/codegen/ast/ASTNode.h"
-#include "velox/experimental/codegen/ast/CodegenUtils.h"
+#include "f4d/experimental/codegen/CodegenExceptions.h"
+#include "f4d/experimental/codegen/ast/ASTNode.h"
+#include "f4d/experimental/codegen/ast/CodegenUtils.h"
 
 namespace facebook {
-namespace velox {
+namespace f4d {
 namespace codegen {
 
 namespace {
@@ -105,8 +103,7 @@ class ConstantExpression final : public ASTNode {
 
     auto constantValue =
         isNull() ? "std::nullopt" : codegenValue<T>(value_.value());
-    auto code = codegenUtils::codegenAssignment(
-        codegenUtils::codegenOptionalAccess(outputVarName), constantValue);
+    auto code = codegenUtils::codegenAssignment(outputVarName, constantValue);
     return CodeSnippet(outputVarName, code);
   }
 
@@ -165,5 +162,5 @@ CodeSnippet ConstantExpression<std::string>::generateCode(
     const std::string& outputVarName) const;
 
 } // namespace codegen
-} // namespace velox
+} // namespace f4d
 } // namespace facebook

--- a/velox/experimental/codegen/vector_function/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,7 +10,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+add_subdirectory(tests)
 add_library(velox_codegen_vector_function INTERFACE)

--- a/velox/experimental/codegen/vector_function/Perf.h
+++ b/velox/experimental/codegen/vector_function/Perf.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +17,7 @@
 #include <iostream>
 
 #if !defined(CODEGEN_PERF) || !defined(__linux__)
-namespace facebook::velox::codegen {
+namespace facebook::f4d::codegen {
 class Perf {
  public:
   Perf() {}
@@ -34,7 +32,7 @@ class Perf {
   void report() const {}
   void report(std::ostream&) const {}
 };
-} // namespace facebook::velox::codegen
+} // namespace facebook::f4d::codegen
 #else
 
 #include <linux/perf_event.h>
@@ -125,7 +123,7 @@ inline std::ostream& operator<<(std::ostream& os, const PerfEvent& e) {
 }
 
 namespace facebook {
-namespace velox {
+namespace f4d {
 namespace codegen {
 
 class Perf {
@@ -215,7 +213,7 @@ class Perf {
 };
 
 } // namespace codegen
-} // namespace velox
+} // namespace f4d
 } // namespace facebook
 
 #endif // !defined(CODEGEN_PERF) || !defined(__linux__)

--- a/velox/experimental/codegen/vector_function/StringTypes.h
+++ b/velox/experimental/codegen/vector_function/StringTypes.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,12 +19,12 @@
 #include <string>
 #include <unordered_set>
 #include <variant>
-#include "velox/buffer/Buffer.h"
-#include "velox/common/base/Exceptions.h"
-#include "velox/type/StringView.h"
+#include "f4d/buffer/Buffer.h"
+#include "f4d/common/base/Exceptions.h"
+#include "f4d/type/StringView.h"
 #pragma once
 
-namespace facebook::velox {
+namespace facebook::f4d {
 namespace codegen {
 
 struct TempBuffer {
@@ -293,4 +291,4 @@ struct ConcatOutputString {};
 // TODO:// coming have some thoughts
 
 } // namespace codegen
-} // namespace facebook::velox
+} // namespace facebook::f4d

--- a/velox/experimental/codegen/vector_function/VectorFunctionLoadUtils.h
+++ b/velox/experimental/codegen/vector_function/VectorFunctionLoadUtils.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,5 +13,5 @@
  */
 #pragma once
 
-#include "velox/experimental/codegen/library_loader/FunctionTable.h"
-#include "velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h"
+#include "f4d/experimental/codegen/library_loader/FunctionTable.h"
+#include "f4d/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h"

--- a/velox/experimental/codegen/vector_function/VectorReader-inl.h
+++ b/velox/experimental/codegen/vector_function/VectorReader-inl.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,14 +13,14 @@
  */
 #pragma once
 
-#include "velox/buffer/Buffer.h"
-#include "velox/common/base/Nulls.h"
-#include "velox/experimental/codegen/vector_function/StringTypes.h"
-#include "velox/type/Type.h"
-#include "velox/vector/FlatVector.h"
+#include "f4d/buffer/Buffer.h"
+#include "f4d/common/base/Nulls.h"
+#include "f4d/experimental/codegen/vector_function/StringTypes.h"
+#include "f4d/type/Type.h"
+#include "f4d/vector/FlatVector.h"
 
 namespace facebook {
-namespace velox {
+namespace f4d {
 namespace codegen {
 
 // Expected members of the vector reader config.
@@ -35,7 +33,7 @@ namespace codegen {
 //   // true means set to null, false means not null
 //   static constexpr bool intializedWithNullSet_
 //
-//   // when true, the reader will never receive a null value to write
+//   // when true, the reader will never reveive a null value to write
 //   static constexpr bool mayWriteNull_
 //
 //
@@ -80,13 +78,17 @@ struct VectorReader {
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
-      mutableRawValues_ = flatVector->mutableRawValues();
     } else {
       if constexpr (Config::mayReadNull_) {
         // TODO when read only vector does not have nulls we dont need to
         // allocate nulls
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
+    }
+
+    if constexpr (Config::isWriter_) {
+      mutableRawValues_ = flatVector->mutableRawValues();
+    } else {
       mutableRawValues_ = const_cast<NativeType*>(flatVector->rawValues());
     }
   }
@@ -181,13 +183,17 @@ struct VectorReader<
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
-      mutableRawValues_ = flatVector->template mutableRawValues<uint64_t>();
     } else {
       // TODO when read only vector does not have nulls we dont need to allocate
       // nulls
       if constexpr (Config::mayReadNull_) {
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
+    }
+
+    if constexpr (Config::isWriter_) {
+      mutableRawValues_ = flatVector->template mutableRawValues<uint64_t>();
+    } else {
       mutableRawValues_ =
           const_cast<uint64_t*>(flatVector->template rawValues<uint64_t>());
     }
@@ -305,13 +311,17 @@ struct VectorReader<
 
     if constexpr (Config::isWriter_) {
       mutableRawNulls_ = flatVector->mutableRawNulls();
-      mutableRawValues_ = flatVector->template mutableRawValues<StringView>();
     } else {
       // TODO when read only vector does not have nulls we dont need to allocate
       // nulls
       if constexpr (Config::mayReadNull_) {
         mutableRawNulls_ = flatVector->mutableRawNulls();
       }
+    }
+
+    if constexpr (Config::isWriter_) {
+      mutableRawValues_ = flatVector->template mutableRawValues<StringView>();
+    } else {
       mutableRawValues_ =
           const_cast<StringView*>(flatVector->template rawValues<StringView>());
     }
@@ -585,5 +595,5 @@ struct VectorReader<
 };
 
 } // namespace codegen
-} // namespace velox
+} // namespace f4d
 } // namespace facebook

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,22 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-  velox_codegen_vector_function_test CodegenVectorFunctionTest.cpp
-                                     TempStringTest.cpp VectorReaderTest.cpp)
+add_executable(velox_codegen_vector_function_test
+               veloxCodegenVectorFunctionTest.cpp, TempStringTest.cpp)
 add_test(velox_codegen_vector_function_test velox_codegen_vector_function_test)
 
 target_link_libraries(
   velox_codegen_vector_function_test
   velox_codegen_ast
   velox_codegen_external_process
+  velox_exec_test_lib
   velox_exec
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
   velox_dwio_common
   velox_aggregates
   velox_functions_lib
-  velox_functions_prestosql
+  velox_functions_common
   velox_hive_connector
   velox_core
   velox_type
@@ -37,10 +35,9 @@ target_link_libraries(
   velox_vector
   velox_memory
   velox_dwio_type_fbhive
-  velox_dwio_common_exception
   velox_dwrf_test_utils
   velox_presto_serializer
-  velox_transform_utils
+  velox_transform
   ${ANTLR4_RUNTIME}
   ${Boost_ATOMIC_LIBRARIES}
   ${Boost_CONTEXT_LIBRARIES}
@@ -55,6 +52,6 @@ target_link_libraries(
   ${FOLLY_WITH_DEPENDENCIES}
   ${DOUBLE_CONVERSION}
   ${GFLAGS_LIBRARIES}
-  glog::glog
+  ${GLOG}
   ${FMT}
   dl)

--- a/velox/experimental/codegen/vector_function/tests/TempStringTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/TempStringTest.cpp
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,8 +15,8 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <iostream>
-#include "velox/experimental/codegen/vector_function/StringTypes.h"
-namespace facebook::velox::codegen {
+#include "f4d/experimental/codegen/vector_function/StringTypes.h"
+namespace facebook::f4d::codegen {
 class TempAllocatorTest : public testing::Test {};
 
 TEST_F(TempAllocatorTest, construction) {
@@ -84,4 +82,4 @@ TEST_F(TempAllocatorTest, Assignment) {
   std::memcpy((*string1).data(), refString.data(), refString.size());
   checkValue(string1);
 }
-} // namespace facebook::velox::codegen
+} // namespace facebook::f4d::codegen

--- a/velox/experimental/codegen/vector_function/tests/veloxCodegenPerfTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/veloxCodegenPerfTest.cpp
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,11 +13,11 @@
  */
 
 #include <gtest/gtest.h>
-#include "velox/experimental/codegen/vector_function/Perf.h"
+#include "f4d/experimental/codegen/vector_function/Perf.h"
 
 using namespace ::testing;
 
-namespace facebook::velox::codegen {
+namespace facebook::f4d::codegen {
 /*@mode/dev-sand
 branch instructions: 3012
 branch misses: 7
@@ -39,4 +37,4 @@ TEST(PerfTest, TestLoop) {
     /// this whole thing disappears
   }
 }
-} // namespace facebook::velox::codegen
+} // namespace facebook::f4d::codegen


### PR DESCRIPTION
    Let filter+projection can apply default null optimization on projection as well (#1345)

    Summary:
    Pull Request resolved: https://github.com/facebookexternal/f4d/pull/1345

    1. Separate filter and projection default null and apply default null optimization to both filter and projection now and added a benchmark to reflect this where the filter isn't default null but projection is.
    2. Changed assorted classes from having individual flags to just take one single flag reference. This makes adding flags requires less change.
    3. Fixed a bug in code generator for constant expression. We don't need to dereference(*) a std::optional to assign it value, it's properly overloaded. However, when the variable we are assigning to is an output cell, meaning it's PointerType, then dereferencing it turns it into a ReferenceType and mess up the behavior.