### PR TITLE
Optimize aggregation over partially clustered input

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -39,6 +39,7 @@ bool areAllLazyNotLoaded(const std::vector<VectorPtr>& vectors) {
 
 GroupingSet::GroupingSet(
     std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+    std::vector<ChannelIndex>&& preGroupedKeys,
     std::vector<std::unique_ptr<Aggregate>>&& aggregates,
     std::vector<std::optional<ChannelIndex>>&& aggrMaskChannels,
     std::vector<std::vector<ChannelIndex>>&& channelLists,
@@ -46,7 +47,8 @@ GroupingSet::GroupingSet(
     bool ignoreNullKeys,
     bool isRawInput,
     OperatorCtx* operatorCtx)
-    : hashers_(std::move(hashers)),
+    : preGroupedKeyChannels_(std::move(preGroupedKeys)),
+      hashers_(std::move(hashers)),
       isGlobal_(hashers_.empty()),
       isRawInput_(isRawInput),
       aggregates_(std::move(aggregates)),
@@ -73,6 +75,23 @@ GroupingSet::GroupingSet(
   }
 }
 
+namespace {
+bool equalKeys(
+    const std::vector<ChannelIndex>& keys,
+    const RowVectorPtr& vector,
+    vector_size_t index,
+    vector_size_t otherIndex) {
+  for (auto key : keys) {
+    const auto& child = vector->childAt(key);
+    if (!child->equalValueAt(child.get(), index, otherIndex)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+} // namespace
+
 void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
   if (isGlobal_) {
     addGlobalAggregationInput(input, mayPushdown);
@@ -80,16 +99,39 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
   }
 
   auto numRows = input->size();
+  if (!preGroupedKeyChannels_.empty()) {
+    // Look for the last group of pre-grouped keys.
+    remainingInput_.reset();
+    for (auto i = input->size() - 2; i >= 0; --i) {
+      if (!equalKeys(preGroupedKeyChannels_, input, i, i + 1)) {
+        // Process that many rows, flush the accumulators and the hash
+        // table, then add remaining rows.
+        numRows = i + 1;
+
+        remainingInput_ = input;
+        firstRemainingRow_ = numRows;
+        remainingMayPushdown_ = mayPushdown;
+        break;
+      }
+    }
+  }
+
   activeRows_.resize(numRows);
   activeRows_.setAll();
 
+  addInputForActiveRows(input, mayPushdown);
+}
+
+void GroupingSet::addInputForActiveRows(
+    const RowVectorPtr& input,
+    bool mayPushdown) {
   bool rehash = false;
   if (!table_) {
     rehash = true;
     createHashTable();
   }
   auto& hashers = lookup_->hashers;
-  lookup_->reset(numRows);
+  lookup_->reset(activeRows_.end());
   auto mode = table_->hashMode();
   if (ignoreNullKeys_) {
     // A null in any of the keys disables the row.
@@ -104,12 +146,6 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
         hashers[i]->hash(*key, activeRows_, i > 0, lookup_->hashes);
       }
     }
-    lookup_->rows.clear();
-    bits::forEachSetBit(
-        activeRows_.asRange().bits(),
-        0,
-        activeRows_.size(),
-        [&](vector_size_t row) { lookup_->rows.push_back(row); });
   } else {
     for (int32_t i = 0; i < hashers.size(); ++i) {
       auto key = input->loadedChildAt(hashers[i]->channel());
@@ -121,13 +157,23 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
         hashers[i]->hash(*key, activeRows_, i > 0, lookup_->hashes);
       }
     }
-    std::iota(lookup_->rows.begin(), lookup_->rows.end(), 0);
   }
+
+  if (activeRows_.isAllSelected()) {
+    std::iota(lookup_->rows.begin(), lookup_->rows.end(), 0);
+  } else {
+    lookup_->rows.clear();
+    bits::forEachSetBit(
+        activeRows_.asRange().bits(), 0, activeRows_.size(), [&](auto row) {
+          lookup_->rows.push_back(row);
+        });
+  }
+
   if (rehash) {
     if (table_->hashMode() != BaseHashTable::HashMode::kHash) {
       table_->decideHashMode(input->size());
     }
-    addInput(input, mayPushdown);
+    addInputForActiveRows(input, mayPushdown);
     return;
   }
   table_->groupProbe(*lookup_);
@@ -292,11 +338,32 @@ bool GroupingSet::getOutput(
     return getGlobalAggregationOutput(batchSize, isPartial, iterator, result);
   }
 
+  // We are ready to return results if received no-more-input message or running
+  // in partially streaming mode with non-empty pre-grouped keys and have full
+  // groups.
+  if (!(noMoreInput_ || (!preGroupedKeyChannels_.empty() && remainingInput_))) {
+    return false;
+  }
+
   // @lint-ignore CLANGTIDY
   char* groups[batchSize];
   int32_t numGroups =
       table_ ? table_->rows()->listRows(iterator, batchSize, groups) : 0;
   if (!numGroups) {
+    if (table_) {
+      table_->clear();
+    }
+    if (remainingInput_) {
+      // Call addInput for remaining rows.
+      activeRows_.clearAll();
+      activeRows_.resize(remainingInput_->size());
+      activeRows_.setValidRange(
+          firstRemainingRow_, remainingInput_->size(), true);
+      activeRows_.updateBounds();
+
+      addInputForActiveRows(remainingInput_, remainingMayPushdown_);
+      remainingInput_.reset();
+    }
     return false;
   }
   result->resize(numGroups);

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -38,10 +38,18 @@ class GroupingSet {
 
   void addInput(const RowVectorPtr& input, bool mayPushdown);
 
-  void noMoreInput() {
-    noMoreInput_ = true;
-  }
+  void noMoreInput();
 
+  /// Typically, the output is not available until all input has been added.
+  /// However, in case when input is clustered on some of the grouping keys, the
+  /// output becomes available every time one of these grouping keys changes
+  /// value. This method returns true if no-more-input message has been received
+  /// or if some groups are ready for output because pre-grouped keys values
+  /// have changed.
+  bool hasOutput();
+
+  /// Called if partial aggregation has reached memory limit or if hasOutput()
+  /// returns true.
   bool getOutput(
       int32_t batchSize,
       bool isPartial,
@@ -56,6 +64,8 @@ class GroupingSet {
 
  private:
   void addInputForActiveRows(const RowVectorPtr& input, bool mayPushdown);
+
+  void addRemainingInput();
 
   void initializeGlobalAggregation();
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -39,7 +39,8 @@ HashAggregation::HashAggregation(
               .maxPartialAggregationMemoryUsage()),
       isPartialOutput_(isPartialOutput(aggregationNode->step())),
       isDistinct_(aggregationNode->aggregates().empty()),
-      isGlobal_(aggregationNode->groupingKeys().empty()) {
+      isGlobal_(aggregationNode->groupingKeys().empty()),
+      hasPreGroupedKeys_(!aggregationNode->preGroupedKeys().empty()) {
   auto inputType = aggregationNode->sources()[0]->outputType();
 
   auto numHashers = aggregationNode->groupingKeys().size();
@@ -54,10 +55,17 @@ HashAggregation::HashAggregation(
     hashers.push_back(VectorHasher::create(key->type(), channel));
   }
 
+  std::vector<ChannelIndex> preGroupedChannels;
+  preGroupedChannels.reserve(aggregationNode->preGroupedKeys().size());
+  for (const auto& key : aggregationNode->preGroupedKeys()) {
+    auto channel = exprToChannel(key.get(), inputType);
+    preGroupedChannels.push_back(channel);
+  }
+
   auto numAggregates = aggregationNode->aggregates().size();
   std::vector<std::unique_ptr<Aggregate>> aggregates;
   aggregates.reserve(numAggregates);
-  std::vector<std::optional<uint32_t>> aggrMaskChannels;
+  std::vector<std::optional<ChannelIndex>> aggrMaskChannels;
   aggrMaskChannels.reserve(numAggregates);
   std::vector<std::vector<ChannelIndex>> args;
   std::vector<std::vector<VectorPtr>> constantLists;
@@ -115,6 +123,7 @@ HashAggregation::HashAggregation(
 
   groupingSet_ = std::make_unique<GroupingSet>(
       std::move(hashers),
+      std::move(preGroupedChannels),
       std::move(aggregates),
       std::move(aggrMaskChannels),
       std::move(args),
@@ -139,7 +148,9 @@ void HashAggregation::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr HashAggregation::getOutput() {
-  if (finished_ || (!noMoreInput_ && !partialFull_ && !newDistincts_)) {
+  if (finished_ ||
+      (!noMoreInput_ && !partialFull_ && !newDistincts_ &&
+       !hasPreGroupedKeys_)) {
     input_ = nullptr;
     return nullptr;
   }
@@ -181,13 +192,24 @@ RowVectorPtr HashAggregation::getOutput() {
       batchSize, isPartialOutput_, &resultIterator_, result);
   if (!hasData) {
     resultIterator_.reset();
-    if (isPartialOutput_) {
+
+    if (noMoreInput_ && hasPreGroupedKeys_) {
+      // Fetch the remaining data.
+      hasData = groupingSet_->getOutput(
+          batchSize, isPartialOutput_, &resultIterator_, result);
+      if (hasData) {
+        return result;
+      }
+
+      groupingSet_->resetPartial();
+    }
+
+    if (partialFull_) {
       partialFull_ = false;
       groupingSet_->resetPartial();
-      if (noMoreInput_) {
-        finished_ = true;
-      }
-    } else {
+    }
+
+    if (noMoreInput_) {
       finished_ = true;
     }
     return nullptr;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -35,6 +35,11 @@ class HashAggregation : public Operator {
     return !noMoreInput_ && !partialFull_;
   }
 
+  void noMoreInput() override {
+    groupingSet_->noMoreInput();
+    Operator::noMoreInput();
+  }
+
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {
     return BlockingReason::kNotBlocked;
   }
@@ -55,6 +60,7 @@ class HashAggregation : public Operator {
   const bool isPartialOutput_;
   const bool isDistinct_;
   const bool isGlobal_;
+  const bool hasPreGroupedKeys_;
 
   std::unique_ptr<GroupingSet> groupingSet_;
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -56,7 +56,7 @@ class StreamingAggregationTest : public OperatorTestBase {
                     .values(data)
                     .partialStreamingAggregation(
                         {0}, {"count(1)", "min(c1)", "max(c1)", "sum(c1)"})
-                    .finalStreamingAggregation()
+                    .finalAggregation()
                     .planNode();
 
     assertQuery(
@@ -72,7 +72,7 @@ class StreamingAggregationTest : public OperatorTestBase {
                    {0},
                    {"count(1)", "min(c1)", "max(c1)", "sum(c1)"},
                    {"", "m1", "m2", "m1"})
-               .finalStreamingAggregation()
+               .finalAggregation()
                .planNode();
 
     assertQuery(
@@ -136,7 +136,7 @@ class StreamingAggregationTest : public OperatorTestBase {
                         {},
                         core::AggregationNode::Step::kPartial,
                         false)
-                    .finalStreamingAggregation()
+                    .finalAggregation()
                     .planNode();
 
     // Generate a list of grouping keys to use in the query: c0, c1, c2,..

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -82,9 +82,7 @@ class StreamingAggregationTest : public OperatorTestBase {
         "FROM tmp GROUP BY 1");
   }
 
-  void testMultiKeyAggregation(
-      const std::vector<RowVectorPtr>& keys,
-      uint32_t outputBatchSize = 1'024) {
+  std::vector<RowVectorPtr> addPayload(const std::vector<RowVectorPtr>& keys) {
     auto numKeys = keys[0]->type()->size();
 
     std::vector<RowVectorPtr> data;
@@ -101,18 +99,45 @@ class StreamingAggregationTest : public OperatorTestBase {
       data.push_back(makeRowVector(children));
       totalSize += size;
     }
+    return data;
+  }
+
+  size_t numKeys(const std::vector<RowVectorPtr>& keys) {
+    return keys[0]->type()->size();
+  }
+
+  void testMultiKeyAggregation(
+      const std::vector<RowVectorPtr>& keys,
+      uint32_t outputBatchSize = 1'024) {
+    std::vector<ChannelIndex> preGroupedChannels(numKeys(keys));
+    std::iota(preGroupedChannels.begin(), preGroupedChannels.end(), 0);
+
+    testMultiKeyAggregation(keys, preGroupedChannels, outputBatchSize);
+  }
+
+  void testMultiKeyAggregation(
+      const std::vector<RowVectorPtr>& keys,
+      const std::vector<ChannelIndex>& preGroupedChannels,
+      uint32_t outputBatchSize = 1'024) {
+    auto data = addPayload(keys);
     createDuckDbTable(data);
+
+    auto numKeys = this->numKeys(keys);
 
     std::vector<ChannelIndex> keyChannels(numKeys);
     std::iota(keyChannels.begin(), keyChannels.end(), 0);
 
-    auto plan =
-        PlanBuilder()
-            .values(data)
-            .partialStreamingAggregation(
-                keyChannels, {"count(1)", "min(c1)", "max(c1)", "sum(c1)"})
-            .finalStreamingAggregation()
-            .planNode();
+    auto plan = PlanBuilder()
+                    .values(data)
+                    .aggregation(
+                        keyChannels,
+                        preGroupedChannels,
+                        {"count(1)", "min(c1)", "max(c1)", "sum(c1)"},
+                        {},
+                        core::AggregationNode::Step::kPartial,
+                        false)
+                    .finalStreamingAggregation()
+                    .planNode();
 
     // Generate a list of grouping keys to use in the query: c0, c1, c2,..
     std::ostringstream keySql;
@@ -202,4 +227,43 @@ TEST_F(StreamingAggregationTest, uniqueKeys) {
 
   // Cut output into small batches of size 100.
   testAggregation(keys, 100);
+}
+
+TEST_F(StreamingAggregationTest, partialStreaming) {
+  auto size = 1'024;
+
+  // Generate 2 key columns. First key is clustered / pre-grouped. Second key is
+  // not. Make one value of the clustered key last for exactly one batch,
+  // another value span two bathes.
+  auto keys = {
+      makeRowVector({
+          makeFlatVector<int32_t>({-10, -10, -5, -5, -5}),
+          makeFlatVector<int32_t>({0, 1, 2, 1, 4}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({-5, -5, -4, -3, -2}),
+          makeFlatVector<int32_t>({0, 1, 2, 1, 4}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({-1, -1, -1, -1, -1}),
+          makeFlatVector<int32_t>({0, 1, 2, 1, 4}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 0, 0, 0, 0}),
+          makeFlatVector<int32_t>({0, 4, 2, 3, 4}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>(size, [](auto row) { return row / 7; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>(
+              size, [&](auto row) { return (size + row) / 7; }),
+          makeFlatVector<int32_t>(
+              size, [&](auto row) { return (size + row) % 5; }),
+      }),
+  };
+
+  std::vector<ChannelIndex> preGroupedKeys = {0};
+  testMultiKeyAggregation(keys, preGroupedKeys);
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -235,8 +235,7 @@ class AggregateTypeResolver {
 std::shared_ptr<core::PlanNode>
 PlanBuilder::createIntermediateOrFinalAggregation(
     core::AggregationNode::Step step,
-    const core::AggregationNode* partialAggNode,
-    bool streaming) {
+    const core::AggregationNode* partialAggNode) {
   // Create intermediate or final aggregation using same grouping keys and same
   // aggregate function names.
   const auto& partialAggregates = partialAggNode->aggregates();
@@ -274,9 +273,7 @@ PlanBuilder::createIntermediateOrFinalAggregation(
       nextPlanNodeId(),
       step,
       groupingKeys,
-      streaming
-          ? groupingKeys
-          : std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>{},
+      partialAggNode->preGroupedKeys(),
       partialAggNode->aggregateNames(),
       aggregates,
       masks,
@@ -295,7 +292,7 @@ PlanBuilder& PlanBuilder::intermediateAggregation() {
 
   auto step = core::AggregationNode::Step::kIntermediate;
 
-  planNode_ = createIntermediateOrFinalAggregation(step, aggNode, false);
+  planNode_ = createIntermediateOrFinalAggregation(step, aggNode);
   return *this;
 }
 
@@ -320,7 +317,7 @@ PlanBuilder& PlanBuilder::finalAggregation() {
 
   auto step = core::AggregationNode::Step::kFinal;
 
-  planNode_ = createIntermediateOrFinalAggregation(step, aggNode, false);
+  planNode_ = createIntermediateOrFinalAggregation(step, aggNode);
   return *this;
 }
 
@@ -420,30 +417,6 @@ PlanBuilder& PlanBuilder::streamingAggregation(
       createAggregateMasks(numAggregates, masks),
       ignoreNullKeys,
       planNode_);
-  return *this;
-}
-
-PlanBuilder& PlanBuilder::finalStreamingAggregation() {
-  // Current plan node must be a partial or intermediate aggregation.
-  const auto* aggNode = dynamic_cast<core::AggregationNode*>(planNode_.get());
-  VELOX_CHECK_NOT_NULL(
-      aggNode,
-      "Current plan node must be a partial or intermediate aggregation.");
-
-  VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
-  if (!exec::isRawInput(aggNode->step())) {
-    // Check the source node.
-    aggNode =
-        dynamic_cast<const core::AggregationNode*>(aggNode->sources()[0].get());
-    VELOX_CHECK_NOT_NULL(
-        aggNode,
-        "Plan node before current plan node must be a partial aggregation.");
-    VELOX_CHECK(exec::isRawInput(aggNode->step()));
-    VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
-  }
-
-  planNode_ = createIntermediateOrFinalAggregation(
-      core::AggregationNode::Step::kFinal, aggNode, true);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -378,6 +378,7 @@ PlanBuilder::createAggregateMasks(
 
 PlanBuilder& PlanBuilder::aggregation(
     const std::vector<ChannelIndex>& groupingKeys,
+    const std::vector<ChannelIndex>& preGroupedKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
     core::AggregationNode::Step step,
@@ -390,7 +391,7 @@ PlanBuilder& PlanBuilder::aggregation(
       nextPlanNodeId(),
       step,
       fields(groupingKeys),
-      std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>{},
+      fields(preGroupedKeys),
       aggregatesAndNames.names,
       aggregatesAndNames.aggregates,
       createAggregateMasks(numAggregates, masks),

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -203,7 +203,6 @@ class PlanBuilder {
       core::AggregationNode::Step step,
       bool ignoreNullKeys,
       const std::vector<TypePtr>& resultTypes = {}) {
-    // TODO Introduce builder for the aggregation node.
     return aggregation(
         groupingKeys, {}, aggregates, masks, step, ignoreNullKeys, resultTypes);
   }
@@ -228,8 +227,6 @@ class PlanBuilder {
         core::AggregationNode::Step::kPartial,
         false);
   }
-
-  PlanBuilder& finalStreamingAggregation();
 
   PlanBuilder& finalStreamingAggregation(
       const std::vector<ChannelIndex>& groupingKeys,
@@ -380,8 +377,7 @@ class PlanBuilder {
 
   std::shared_ptr<core::PlanNode> createIntermediateOrFinalAggregation(
       core::AggregationNode::Step step,
-      const core::AggregationNode* partialAggNode,
-      bool streaming);
+      const core::AggregationNode* partialAggNode);
 
   std::shared_ptr<const core::ITypedExpr> inferTypes(
       const std::shared_ptr<const core::IExpr>& untypedExpr);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -135,6 +135,7 @@ class PlanBuilder {
       const std::vector<std::string>& masks = {}) {
     return aggregation(
         groupingKeys,
+        {},
         aggregates,
         masks,
         core::AggregationNode::Step::kPartial,
@@ -156,6 +157,7 @@ class PlanBuilder {
       const std::vector<TypePtr>& resultTypes) {
     return aggregation(
         groupingKeys,
+        {},
         aggregates,
         {},
         core::AggregationNode::Step::kFinal,
@@ -174,6 +176,7 @@ class PlanBuilder {
       const std::vector<TypePtr>& resultTypes) {
     return aggregation(
         groupingKeys,
+        {},
         aggregates,
         {},
         core::AggregationNode::Step::kIntermediate,
@@ -186,6 +189,7 @@ class PlanBuilder {
       const std::vector<std::string>& aggregates) {
     return aggregation(
         groupingKeys,
+        {},
         aggregates,
         {},
         core::AggregationNode::Step::kSingle,
@@ -194,6 +198,19 @@ class PlanBuilder {
 
   PlanBuilder& aggregation(
       const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      bool ignoreNullKeys,
+      const std::vector<TypePtr>& resultTypes = {}) {
+    // TODO Introduce builder for the aggregation node.
+    return aggregation(
+        groupingKeys, {}, aggregates, masks, step, ignoreNullKeys, resultTypes);
+  }
+
+  PlanBuilder& aggregation(
+      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<ChannelIndex>& preGroupedKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,


### PR DESCRIPTION
Optimize aggregation with multiple grouping keys for the case when input is
pre-grouped / clustered on a subset of these keys. In this case, there is no
need to accumulate all the input in memory before producing results. We can
produce results and flush memory every time a value of on the of pre-grouped
keys changes. This allows to reduce memory footprint of the aggregation.

A couple of straightforward optimizations can be added in follow up PRs.

First, we can add logic to avoid emitting very small batches of output by
waiting to accumulate at least N groups before producing output.

Second, we can optimize hashing of the high-cardinality pre-grouped keys by
mapping their values to small integers. We would iterate over the input vector
and assign repeated sequential numbers to each row. We would start with 0 and
increment the number every time one of the grouping keys change. This way, all
pre-grouped keys will map to a small integer domain and allow for array-based
aggregation if the other keys also have low cardinality.