### PR TITLE
Rename registerAllFunctions for clarity

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -46,7 +46,7 @@ class ParquetTpchTest : public testing::Test {
       constexpr double kTpchScaleFactor = 0.01;
       duckDb_->initializeTpch(kTpchScaleFactor);
     }
-    functions::prestosql::registerAllFunctions();
+    functions::prestosql::registerAllScalarFunctions();
   }
 
   void SetUp() override {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -33,7 +33,7 @@ using namespace facebook::velox;
 class TaskTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    functions::prestosql::registerAllFunctions();
+    functions::prestosql::registerAllScalarFunctions();
   }
 
   void useOneSplit(

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -62,7 +62,7 @@ void OperatorTestBase::SetUp() {
 }
 
 void OperatorTestBase::SetUpTestCase() {
-  functions::prestosql::registerAllFunctions();
+  functions::prestosql::registerAllScalarFunctions();
 }
 
 std::shared_ptr<Task> OperatorTestBase::assertQuery(

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -107,7 +107,7 @@ class CodegenTestCore {
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
     exec::test::registerTypeResolver();
-    functions::prestosql::registerAllFunctions();
+    functions::prestosql::registerAllScalarFunctions();
   }
 
   /// Creates a plan node given filter and a list of projection

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -103,7 +103,7 @@ struct TestData {
 class ExprTest : public testing::Test {
  protected:
   void SetUp() override {
-    functions::prestosql::registerAllFunctions();
+    functions::prestosql::registerAllScalarFunctions();
     exec::test::registerTypeResolver();
 
     testDataType_ =

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
   // experience, and initialize glog and gflags.
   folly::init(&argc, &argv);
 
-  functions::prestosql::registerAllFunctions();
+  functions::prestosql::registerAllScalarFunctions();
 
   test::expressionFuzzer(
       filterSignatures(getFunctionSignatures(), FLAGS_only),

--- a/velox/functions/prestosql/coverage/Coverage.cpp
+++ b/velox/functions/prestosql/coverage/Coverage.cpp
@@ -404,7 +404,7 @@ int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   // Register all simple and vector scalar functions.
-  functions::prestosql::registerAllFunctions();
+  functions::prestosql::registerAllScalarFunctions();
 
   if (FLAGS_all) {
     printCoverageMapForAll();

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -81,7 +81,7 @@ void registerBitwiseFunctions() {
   functions::registerBitwiseFunctions();
 }
 
-void registerAllFunctions() {
+void registerAllScalarFunctions() {
   registerArithmeticFunctions();
   registerCheckedArithmeticFunctions();
   registerComparisonFunctions();

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -41,7 +41,7 @@ void registerStringFunctions();
 
 void registerBitwiseFunctions();
 
-void registerAllFunctions();
+void registerAllScalarFunctions();
 
 void registerMapAllowingDuplicates(const std::string& name);
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/tests/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.cpp
@@ -20,6 +20,6 @@
 namespace facebook::velox::functions::test {
 void FunctionBaseTest::SetUpTestCase() {
   exec::test::registerTypeResolver();
-  functions::prestosql::registerAllFunctions();
+  functions::prestosql::registerAllScalarFunctions();
 }
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
Rename prestosql::registerAllFunctions to prestosql::registerAllScalarFunctions
to clarify that this function registers only scalar functions and doesn't
register aggregate functions. Some users assumed this function registers both
scalar and aggregate functions and were surprised to receive
aggregation-function-no-registered errors.