### PR TITLE
Add preGroupedKeys field to Aggregation plan node

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -397,8 +397,6 @@ class TableWriteNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
-// TODO Split into AbstractAggregationNode and HashAggregation. Move Step one
-// level up.
 class AggregationNode : public PlanNode {
  public:
   enum class Step {
@@ -413,6 +411,10 @@ class AggregationNode : public PlanNode {
   };
 
   /**
+   * @param preGroupedKeys A subset of the 'groupingKeys' on which the input is
+   * clustered, e.g. identical sets of values for these keys always appear next
+   * to each other. Can be empty. If contains all the 'groupingKeys', the
+   * aggregation will run in streaming mode.
    * @param ignoreNullKeys True if rows with at least one null key should be
    * ignored. Used when group by is a source of a join build side and grouping
    * keys are join keys.
@@ -422,6 +424,8 @@ class AggregationNode : public PlanNode {
       Step step,
       const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
           groupingKeys,
+      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
+          preGroupedKeys,
       const std::vector<std::string>& aggregateNames,
       const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
       const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
@@ -444,6 +448,11 @@ class AggregationNode : public PlanNode {
   const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& groupingKeys()
       const {
     return groupingKeys_;
+  }
+
+  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
+  preGroupedKeys() const {
+    return preGroupedKeys_;
   }
 
   const std::vector<std::string>& aggregateNames() const {
@@ -470,6 +479,8 @@ class AggregationNode : public PlanNode {
  private:
   const Step step_;
   const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> groupingKeys_;
+  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
+      preGroupedKeys_;
   const std::vector<std::string> aggregateNames_;
   const std::vector<std::shared_ptr<const CallTypedExpr>> aggregates_;
   // Keeps mask/'no mask' for every aggregation. Mask, if given, is a reference
@@ -502,32 +513,6 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
   ss << step;
   return ss.str();
 }
-
-/// Represents streaming aggregation that assumes that input is already grouped
-/// on the grouping keys.
-class StreamingAggregationNode : public AggregationNode {
- public:
-  StreamingAggregationNode(
-      const PlanNodeId& id,
-      Step step,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          groupingKeys,
-      const std::vector<std::string>& aggregateNames,
-      const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          aggregateMasks,
-      bool ignoreNullKeys,
-      std::shared_ptr<const PlanNode> source)
-      : AggregationNode(
-            id,
-            step,
-            groupingKeys,
-            aggregateNames,
-            aggregates,
-            aggregateMasks,
-            ignoreNullKeys,
-            std::move(source)) {}
-};
 
 class ExchangeNode : public PlanNode {
  public:

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -323,15 +323,16 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
           std::make_unique<CrossJoinProbe>(id, ctx.get(), joinNode));
     } else if (
         auto aggregationNode =
-            std::dynamic_pointer_cast<const core::StreamingAggregationNode>(
-                planNode)) {
-      operators.push_back(std::make_unique<StreamingAggregation>(
-          id, ctx.get(), aggregationNode));
-    } else if (
-        auto aggregationNode =
             std::dynamic_pointer_cast<const core::AggregationNode>(planNode)) {
-      operators.push_back(
-          std::make_unique<HashAggregation>(id, ctx.get(), aggregationNode));
+      if (!aggregationNode->preGroupedKeys().empty() &&
+          aggregationNode->preGroupedKeys().size() ==
+              aggregationNode->groupingKeys().size()) {
+        operators.push_back(std::make_unique<StreamingAggregation>(
+            id, ctx.get(), aggregationNode));
+      } else {
+        operators.push_back(
+            std::make_unique<HashAggregation>(id, ctx.get(), aggregationNode));
+      }
     } else if (
         auto topNNode =
             std::dynamic_pointer_cast<const core::TopNNode>(planNode)) {

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -22,8 +22,7 @@ namespace facebook::velox::exec {
 StreamingAggregation::StreamingAggregation(
     int32_t operatorId,
     DriverCtx* driverCtx,
-    const std::shared_ptr<const core::StreamingAggregationNode>&
-        aggregationNode)
+    const std::shared_ptr<const core::AggregationNode>& aggregationNode)
     : Operator(
           driverCtx,
           aggregationNode->outputType(),

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -28,8 +28,7 @@ class StreamingAggregation : public Operator {
   StreamingAggregation(
       int32_t operatorId,
       DriverCtx* driverCtx,
-      const std::shared_ptr<const core::StreamingAggregationNode>&
-          aggregationNode);
+      const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
   void addInput(RowVectorPtr input) override;
 


### PR DESCRIPTION
Remove StreamingAggregationNode and add preGroupedKeys field to AggregationNode
instead. Update LocalPlanner to use StreamingAggregation operator if input if
pre-grouped / clustered on all grouping keys. A follow-up PR will introduce an
optimization in HashAggregation operator for the case when input is clustered
on some, but not all grouping keys. In this case, we can reduce memory
footprint of the aggregation by flushing accumulators and the hash table every
time one of the pre-grouped keys value changes. 

We can also optimize hashing of the high-cardinality pre-grouped keys by mapping
their values to a small integer. We would iterate over the input vector and
assign repeated sequential numbers to each row. We would start with 0 and
increment the number every time one of the grouping keys change. This way, all
pre-grouped keys will map to a small integer domain and allow for array-based
aggregation if the other keys also have low cardinality.