### PR TITLE
Add containsNulls functions to VectorReaders

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -23,6 +23,7 @@
 #include <string_view>
 #include <type_traits>
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/ComplexProxyTypes.h"
 #include "velox/expression/ComplexViewTypes.h"
@@ -203,6 +204,26 @@ struct VectorReader {
     return decoded_.mayHaveNulls();
   }
 
+  // These functions can be used to check if any elements in a given row are
+  // NULL. They are not especially fast, so they should only be used when
+  // necessary, and other options, e.g. calling mayHaveNullsRecursive() on the
+  // vector, have already been exhausted.
+  inline bool containsNull(vector_size_t index) const {
+    return decoded_.isNullAt(index);
+  }
+
+  bool containsNull(vector_size_t startIndex, vector_size_t endIndex) const {
+    // Note: This can be optimized for the special case where the underlying
+    // vector is flat using bit operations on the nulls buffer.
+    for (auto index = startIndex; index < endIndex; ++index) {
+      if (containsNull(index)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   const DecodedVector& decoded_;
 };
 
@@ -337,6 +358,30 @@ struct VectorReader<Map<K, V>> {
     return !decoded_.isNullAt(offset);
   }
 
+  bool containsNull(vector_size_t index) const {
+    auto decodedIndex = decoded_.index(index);
+
+    return decoded_.isNullAt(index) ||
+        (decodedKeys_.mayHaveNullsRecursive() &&
+         keyReader_.containsNull(
+             offsets_[decodedIndex],
+             offsets_[decodedIndex] + lengths_[decodedIndex])) ||
+        (decodedVals_.mayHaveNullsRecursive() &&
+         valReader_.containsNull(
+             offsets_[decodedIndex],
+             offsets_[decodedIndex] + lengths_[decodedIndex]));
+  }
+
+  bool containsNull(vector_size_t startIndex, vector_size_t endIndex) const {
+    for (auto index = startIndex; index < endIndex; ++index) {
+      if (containsNull(index)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   const DecodedVector& decoded_;
   const MapVector& vector_;
   DecodedVector decodedKeys_;
@@ -379,6 +424,26 @@ struct VectorReader<Array<V>> {
   exec_null_free_in_t readNullFree(size_t offset) const {
     auto index = decoded_.index(offset);
     return {&childReader_, offsets_[index], lengths_[index]};
+  }
+
+  inline bool containsNull(vector_size_t index) const {
+    auto decodedIndex = decoded_.index(index);
+
+    return decoded_.isNullAt(index) ||
+        (arrayValuesDecoder_.mayHaveNullsRecursive() &&
+         childReader_.containsNull(
+             offsets_[decodedIndex],
+             offsets_[decodedIndex] + lengths_[decodedIndex]));
+  }
+
+  bool containsNull(vector_size_t startIndex, vector_size_t endIndex) const {
+    for (auto index = startIndex; index < endIndex; ++index) {
+      if (containsNull(index)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   DecodedVector arrayValuesDecoder_;
@@ -575,6 +640,32 @@ struct VectorReader<Row<T...>> {
     return !decoded_.isNullAt(offset);
   }
 
+  bool containsNull(vector_size_t index) const {
+    if (decoded_.isNullAt(index)) {
+      return true;
+    }
+
+    bool fieldsContainNull = false;
+    auto decodedIndex = decoded_.index(index);
+    std::apply(
+        [&](const auto&... reader) {
+          fieldsContainNull |= (reader->containsNull(decodedIndex) || ...);
+        },
+        childReaders_);
+
+    return fieldsContainNull;
+  }
+
+  bool containsNull(vector_size_t startIndex, vector_size_t endIndex) const {
+    for (auto index = startIndex; index < endIndex; ++index) {
+      if (containsNull(index)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
  private:
   template <size_t... I>
   std::tuple<std::unique_ptr<VectorReader<T>>...> prepareChildReaders(
@@ -735,6 +826,26 @@ struct VectorReader<Variadic<T>> {
     // The Variadic itself can never be null, only the values of the underlying
     // Types
     return true;
+  }
+
+  bool containsNull(vector_size_t index) const {
+    for (const auto& childReader : childReaders_) {
+      if (childReader->containsNull(index)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool containsNull(vector_size_t startIndex, vector_size_t endIndex) const {
+    for (const auto& childReader : childReaders_) {
+      if (childReader->containsNull(startIndex, endIndex)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
  private:
@@ -1111,6 +1222,22 @@ struct VectorReader<Generic<T>> {
 
   exec_null_free_in_t readNullFree(vector_size_t offset) const {
     return operator[](offset);
+  }
+
+  inline bool containsNull(vector_size_t /* index */) const {
+    // This function is only called if callNullFree is defined.
+    // TODO (kevinwilfong): Add support for Generics in callNullFree.
+    VELOX_UNSUPPORTED(
+        "Calling callNullFree with Generic arguments is not yet supported.");
+  }
+
+  bool containsNull(
+      vector_size_t /* startIndex */,
+      vector_size_t /* endIndex */) const {
+    // This function is only called if callNullFree is defined.
+    // TODO (kevinwilfong): Add support for Generics in callNullFree.
+    VELOX_UNSUPPORTED(
+        "Calling callNullFree with Generic arguments is not yet supported.");
   }
 
   const DecodedVector& decoded_;

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ add_executable(
   ArrayProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
-  VariadicViewTest.cpp)
+  VariadicViewTest.cpp
+  VectorReaderTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/VectorReaderTest.cpp
+++ b/velox/expression/tests/VectorReaderTest.cpp
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+
+DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
+  SelectivityVector rows(vector.size());
+  decoder.decode(vector, rows);
+  return &decoder;
+}
+
+class VectorReaderTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(VectorReaderTest, scalarContainsNull) {
+  // Vector is:
+  // [NULL, 1, 2, 3, 4, NULL, 6, 7, 8, 9]
+  auto vector = makeFlatVector<int32_t>(
+      10,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  DecodedVector decoded;
+  exec::VectorReader<int32_t> reader(decode(decoded, *vector.get()));
+
+  ASSERT_FALSE(reader.containsNull(1));
+  ASSERT_FALSE(reader.containsNull(2));
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_TRUE(reader.containsNull(0));
+  ASSERT_TRUE(reader.containsNull(5));
+
+  // Value before is NULL.
+  ASSERT_FALSE(reader.containsNull(1, 2));
+  // Value after is NULL.
+  ASSERT_FALSE(reader.containsNull(2, 5));
+  // Up to the last value.
+  ASSERT_FALSE(reader.containsNull(7, 10));
+  // First value is NULL.
+  ASSERT_TRUE(reader.containsNull(0, 3));
+  // NULL value in middle of range.
+  ASSERT_TRUE(reader.containsNull(4, 7));
+  // Last value is NULL.
+  ASSERT_TRUE(reader.containsNull(1, 6));
+}
+
+TEST_F(VectorReaderTest, dictionaryEncodedScalarContainsNull) {
+  // Vector is:
+  // [NULL, 3, 6, 9, 2, 5, NULL, 1, NULL, 7]
+  vector_size_t size = 10;
+  auto baseVector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 4 == 0; });
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < size; ++i) {
+    // 13 and 10 are coprime so this shuffles the indices.
+    rawIndices[i] = (i * 13) % size;
+  }
+  auto scalarVector = wrapInDictionary(indices, size, baseVector);
+
+  DecodedVector decoded;
+  exec::VectorReader<int32_t> reader(decode(decoded, *scalarVector.get()));
+
+  ASSERT_FALSE(reader.containsNull(1));
+  ASSERT_FALSE(reader.containsNull(2));
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_TRUE(reader.containsNull(0));
+  ASSERT_TRUE(reader.containsNull(6));
+
+  // Value before is NULL.
+  ASSERT_FALSE(reader.containsNull(1, 6));
+  // Value after is NULL.
+  ASSERT_FALSE(reader.containsNull(7, 8));
+  // Up to the last value.
+  ASSERT_FALSE(reader.containsNull(9, 10));
+  // First value is NULL.
+  ASSERT_TRUE(reader.containsNull(0, 3));
+  // NULL value in middle of range.
+  ASSERT_TRUE(reader.containsNull(4, 8));
+  // Last value is NULL.
+  ASSERT_TRUE(reader.containsNull(7, 9));
+}
+
+TEST_F(VectorReaderTest, mapContainsNull) {
+  // Vector is:
+  // [
+  //   {},
+  //   NULL,
+  //   {0: 0, 1: NULL},
+  //   {2: 2, 3: 3, 4: 4},
+  //   {},
+  //   {5: NULL},
+  //   NULL,
+  //   {6: 6, 7: 7, 8: 8},
+  //   {},
+  //   {9: NULL}
+  // ]
+  auto vector = makeMapVector<int32_t, float>(
+      10,
+      [](vector_size_t row) { return row % 4; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t row) { return row % 5 == 1; },
+      [](vector_size_t idx) { return idx % 4 == 1; });
+  DecodedVector decoded;
+  exec::VectorReader<Map<int32_t, float>> reader(
+      decode(decoded, *vector.get()));
+
+  // Empty Map.
+  ASSERT_FALSE(reader.containsNull(0));
+  // Non-empty maps without NULLs.
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_FALSE(reader.containsNull(7));
+  // Map is NULL.
+  ASSERT_TRUE(reader.containsNull(1));
+  // Map contains NULL value.
+  ASSERT_TRUE(reader.containsNull(2));
+
+  // Next map is NULL.
+  ASSERT_FALSE(reader.containsNull(0, 1));
+  // Previous map is NULL.
+  ASSERT_FALSE(reader.containsNull(7, 9));
+  // Surrounded by NULL and map containing NULL.
+  ASSERT_FALSE(reader.containsNull(3, 5));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(0, 4));
+  // First map contains NULL.
+  ASSERT_TRUE(reader.containsNull(2, 5));
+  // Last map contains NULL.
+  ASSERT_TRUE(reader.containsNull(7, 10));
+}
+
+TEST_F(VectorReaderTest, dictionaryEncodedMapContainsNull) {
+  // Vector is:
+  // [
+  //   {},
+  //   {2: 2, 3: 3, 4: 4},
+  //   NULL,
+  //   {9: NULL}
+  //   {0: 0, 1: NULL},
+  //   {5: NULL},
+  //   {},
+  //   NULL,
+  //   {},
+  //   {6: 6, 7: 7, 8: 8},
+  // ]
+  vector_size_t size = 10;
+  auto baseVector = makeMapVector<int32_t, float>(
+      size,
+      [](vector_size_t row) { return row % 4; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t row) { return row % 5 == 1; },
+      [](vector_size_t idx) { return idx % 4 == 1; });
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < size; ++i) {
+    // 13 and 10 are coprime so this shuffles the indices.
+    rawIndices[i] = (i * 13) % size;
+  }
+  auto mapVector = wrapInDictionary(indices, size, baseVector);
+
+  DecodedVector decoded;
+  exec::VectorReader<Map<int32_t, float>> reader(
+      decode(decoded, *mapVector.get()));
+
+  // Empty Map.
+  ASSERT_FALSE(reader.containsNull(0));
+  // Non-empty maps without NULLs.
+  ASSERT_FALSE(reader.containsNull(1));
+  ASSERT_FALSE(reader.containsNull(9));
+  // Map is NULL.
+  ASSERT_TRUE(reader.containsNull(7));
+  // Map contains NULL value.
+  ASSERT_TRUE(reader.containsNull(4));
+
+  // Next map is NULL.
+  ASSERT_FALSE(reader.containsNull(0, 2));
+  // Previous map is NULL.
+  ASSERT_FALSE(reader.containsNull(8, 10));
+  // Surrounded by NULL and map containing NULL.
+  ASSERT_FALSE(reader.containsNull(6, 7));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(6, 10));
+  // First map contains NULL.
+  ASSERT_TRUE(reader.containsNull(5, 7));
+  // Last map is NULL.
+  ASSERT_TRUE(reader.containsNull(0, 3));
+}
+
+TEST_F(VectorReaderTest, arrayContainsNull) {
+  // Vector is:
+  // [
+  //   [],
+  //   [NULL],
+  //   NULL,
+  //   [1, 2, 3],
+  //   [4, 5, NULL, 7],
+  //   [],
+  //   [8],
+  //   NULL,
+  //   [9, 10, 11],
+  //   [NULL, 13, 14, 15]
+  // ]
+  auto vector = makeArrayVector<int32_t>(
+      10,
+      [](vector_size_t row) { return row % 5; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t row) { return row % 5 == 2; },
+      [](vector_size_t idx) { return idx % 6 == 0; });
+  DecodedVector decoded;
+  exec::VectorReader<Array<int32_t>> reader(decode(decoded, *vector.get()));
+
+  // Empty Array.
+  ASSERT_FALSE(reader.containsNull(0));
+  // Non-empty arrays without NULLs.
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_FALSE(reader.containsNull(8));
+  // Array is NULL.
+  ASSERT_TRUE(reader.containsNull(2));
+  // Array contains NULL value.
+  ASSERT_TRUE(reader.containsNull(4));
+
+  // Next array is NULL.
+  ASSERT_FALSE(reader.containsNull(5, 7));
+  // Previous array is NULL.
+  ASSERT_FALSE(reader.containsNull(3, 4));
+  // Surrounded by NULL and array containing NULL.
+  ASSERT_FALSE(reader.containsNull(8, 9));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(0, 4));
+  // First array contains NULL.
+  ASSERT_TRUE(reader.containsNull(4, 7));
+  // Last array contains NULL.
+  ASSERT_TRUE(reader.containsNull(8, 10));
+}
+
+TEST_F(VectorReaderTest, dictionaryEncodedArrayContainsNull) {
+  // Vector is:
+  // [
+  //   [],
+  //   [1, 2, 3],
+  //   [8],
+  //   [NULL, 13, 14, 15]
+  //   NULL,
+  //   [],
+  //   [9, 10, 11],
+  //   [NULL],
+  //   [4, 5, NULL, 7],
+  //   NULL,
+  // ]
+  vector_size_t size = 10;
+  auto baseVector = makeArrayVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row % 5; },
+      [](vector_size_t idx) { return idx; },
+      [](vector_size_t row) { return row % 5 == 2; },
+      [](vector_size_t idx) { return idx % 6 == 0; });
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < size; ++i) {
+    // 13 and 10 are coprime so this shuffles the indices.
+    rawIndices[i] = (i * 13) % size;
+  }
+  auto arrayVector = wrapInDictionary(indices, size, baseVector);
+
+  DecodedVector decoded;
+  exec::VectorReader<Array<int32_t>> reader(
+      decode(decoded, *arrayVector.get()));
+
+  // Empty Array.
+  ASSERT_FALSE(reader.containsNull(0));
+  // Non-empty arrays without NULLs.
+  ASSERT_FALSE(reader.containsNull(1));
+  ASSERT_FALSE(reader.containsNull(6));
+  // Array is NULL.
+  ASSERT_TRUE(reader.containsNull(4));
+  // Array contains NULL value.
+  ASSERT_TRUE(reader.containsNull(8));
+
+  // Next contains NULL.
+  ASSERT_FALSE(reader.containsNull(6, 7));
+  // Previous array is NULL.
+  ASSERT_FALSE(reader.containsNull(5, 6));
+  // Surrounded by NULL and array containing NULL.
+  ASSERT_FALSE(reader.containsNull(5, 7));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(2, 6));
+  // First array is NULL.
+  ASSERT_TRUE(reader.containsNull(4, 7));
+  // Last array contains NULL.
+  ASSERT_TRUE(reader.containsNull(5, 8));
+}
+
+TEST_F(VectorReaderTest, rowContainsNull) {
+  // Vector is:
+  // [
+  //   {field1: NULL, field2: 0},
+  //   {field1: 1, field2: NULL},
+  //   {field1: 2, field2: 2},
+  //   NULL,
+  //   {field1: 4, field2: 4},
+  //   {field1: NULL, field2: 5},
+  //   {field1: 6, field2: NULL},
+  //   {field1: 7, field2: 7},
+  //   NULL,
+  //   {field1: 9, field2: 9},
+  // ]
+  vector_size_t size = 10;
+  auto field1Vector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  auto field2Vector = makeFlatVector<float>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 1; });
+  auto vector = makeRowVector(
+      {field1Vector, field2Vector},
+      [](vector_size_t idx) { return idx % 5 == 3; });
+  DecodedVector decoded;
+  exec::VectorReader<Row<int32_t, float>> reader(
+      decode(decoded, *vector.get()));
+
+  // Row without NULLs.
+  ASSERT_FALSE(reader.containsNull(4));
+  ASSERT_FALSE(reader.containsNull(7));
+  // Row is NULL.
+  ASSERT_TRUE(reader.containsNull(3));
+  // Row contains NULL field.
+  ASSERT_TRUE(reader.containsNull(1));
+
+  // Next row is NULL.
+  ASSERT_FALSE(reader.containsNull(2, 3));
+  // Previous row contains NULL.
+  ASSERT_FALSE(reader.containsNull(7, 8));
+  // Surrounded by NULL and row containing NULL.
+  ASSERT_FALSE(reader.containsNull(4, 5));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(7, 10));
+  // First row contains NULL.
+  ASSERT_TRUE(reader.containsNull(1, 3));
+  // Last row contains NULL.
+  ASSERT_TRUE(reader.containsNull(4, 6));
+}
+
+TEST_F(VectorReaderTest, dictionaryEncodedRowContainsNull) {
+  // Vector is:
+  // [
+  //   {field1: NULL, field2: 0},
+  //   NULL,
+  //   {field1: 6, field2: NULL},
+  //   {field1: 9, field2: 9},
+  //   {field1: 2, field2: 2},
+  //   {field1: NULL, field2: 5},
+  //   NULL,
+  //   {field1: 1, field2: NULL},
+  //   {field1: 4, field2: 4},
+  //   {field1: 7, field2: 7},
+  // ]
+  vector_size_t size = 10;
+  auto field1Vector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  auto field2Vector = makeFlatVector<float>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 1; });
+  auto baseVector = makeRowVector(
+      {field1Vector, field2Vector},
+      [](vector_size_t idx) { return idx % 5 == 3; });
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < size; ++i) {
+    // 13 and 10 are coprime so this shuffles the indices.
+    rawIndices[i] = (i * 13) % size;
+  }
+  auto rowVector = wrapInDictionary(indices, size, baseVector);
+
+  DecodedVector decoded;
+  exec::VectorReader<Row<int32_t, float>> reader(
+      decode(decoded, *rowVector.get()));
+
+  // Row without NULLs.
+  ASSERT_FALSE(reader.containsNull(4));
+  ASSERT_FALSE(reader.containsNull(8));
+  // Row is NULL.
+  ASSERT_TRUE(reader.containsNull(1));
+  // Row contains NULL field.
+  ASSERT_TRUE(reader.containsNull(2));
+
+  // Next row contains NULL.
+  ASSERT_FALSE(reader.containsNull(4, 5));
+  // Previous row contains NULL.
+  ASSERT_FALSE(reader.containsNull(8, 10));
+  // Surrounded by rows containing NULL.
+  ASSERT_FALSE(reader.containsNull(3, 5));
+  // NULL in middle of range.
+  ASSERT_TRUE(reader.containsNull(4, 9));
+  // First row contains NULL.
+  ASSERT_TRUE(reader.containsNull(7, 10));
+  // Last row contains NULL.
+  ASSERT_TRUE(reader.containsNull(3, 6));
+}
+
+TEST_F(VectorReaderTest, variadicContainsNull) {
+  // Vector is:
+  // [
+  //   [NULL, 0, 0],
+  //   [1, NULL, 1],
+  //   [2, 2, NULL],
+  //   [3, 3, 3],
+  //   [4, 4, 4],
+  //   [NULL, 5, 5],
+  //   [6, NULL, 6],
+  //   [7, 7, NULL],
+  //   [8, 8, 8],
+  //   [9, 9, 9],
+  // ]
+  vector_size_t size = 10;
+  auto field1Vector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  auto field2Vector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 1; });
+  auto field3Vector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 2; });
+  SelectivityVector rows(10);
+  exec::EvalCtx ctx(&execCtx_, nullptr, nullptr);
+  exec::DecodedArgs args(
+      rows, {field1Vector, field2Vector, field3Vector}, &ctx);
+  exec::VectorReader<Variadic<int32_t>> reader(args, 0);
+
+  // Row without NULLs.
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_FALSE(reader.containsNull(9));
+  // Row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(1));
+
+  // Next row contains NULL arg.
+  ASSERT_FALSE(reader.containsNull(4, 5));
+  // Previous row contains NULL arg.
+  ASSERT_FALSE(reader.containsNull(8, 10));
+  // Surrounded by rows containing NULL arg.
+  ASSERT_FALSE(reader.containsNull(3, 5));
+  // Row containing NULL arg in middle of range.
+  ASSERT_TRUE(reader.containsNull(4, 9));
+  // First row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(2, 5));
+  // Last row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(3, 6));
+}
+
+TEST_F(VectorReaderTest, dictionaryEncodedVariadicContainsNull) {
+  // Vector is:
+  // [
+  //   [NULL, 0, 0],
+  //   [9, 3, 7],
+  //   [8, NULL, 4],
+  //   [7, 9, 1],
+  //   [6, 2, NULL],
+  //   [NULL, 5, 5],
+  //   [4, 8, 2],
+  //   [3, NULL, 9],
+  //   [2, 4, 6],
+  //   [1, 7, NULL],
+  // ]
+  vector_size_t size = 10;
+  auto field1BaseVector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  auto field2BaseVector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 1; });
+  auto field3BaseVector = makeFlatVector<int32_t>(
+      size,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 3; });
+  BufferPtr field1indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  BufferPtr field2indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  BufferPtr field3indices =
+      AlignedBuffer::allocate<vector_size_t>(size, execCtx_.pool());
+  auto field1RawIndices = field1indices->asMutable<vector_size_t>();
+  auto field2RawIndices = field2indices->asMutable<vector_size_t>();
+  auto field3RawIndices = field3indices->asMutable<vector_size_t>();
+  for (auto i = 0; i < size; ++i) {
+    // 19, 13, 17 and 10 are coprime so this shuffles the indices.
+    field1RawIndices[i] = (i * 19) % size;
+    field2RawIndices[i] = (i * 13) % size;
+    field3RawIndices[i] = (i * 17) % size;
+  }
+  auto field1Vector = wrapInDictionary(field1indices, size, field1BaseVector);
+  auto field2Vector = wrapInDictionary(field2indices, size, field2BaseVector);
+  auto field3Vector = wrapInDictionary(field3indices, size, field3BaseVector);
+
+  SelectivityVector rows(10);
+  exec::EvalCtx ctx(&execCtx_, nullptr, nullptr);
+  exec::DecodedArgs args(
+      rows, {field1Vector, field2Vector, field3Vector}, &ctx);
+  exec::VectorReader<Variadic<int32_t>> reader(args, 0);
+
+  // Row without NULLs.
+  ASSERT_FALSE(reader.containsNull(3));
+  ASSERT_FALSE(reader.containsNull(8));
+  // Row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(2));
+
+  // Next row contains NULL arg.
+  ASSERT_FALSE(reader.containsNull(1, 2));
+  // Previous row contains NULL arg.
+  ASSERT_FALSE(reader.containsNull(3, 4));
+  // Surrounded by rows containing NULL arg.
+  ASSERT_FALSE(reader.containsNull(6, 7));
+  // Row containing NULL arg in middle of range.
+  ASSERT_TRUE(reader.containsNull(6, 9));
+  // First row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(2, 4));
+  // Last row contains NULL arg.
+  ASSERT_TRUE(reader.containsNull(3, 5));
+}
+
+TEST_F(VectorReaderTest, genericContainsNull) {
+  // Vector is:
+  // [NULL, 1, 2, 3, 4, NULL, 6, 7, 8, 9]
+  auto vector = makeFlatVector<int32_t>(
+      10,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row % 5 == 0; });
+  DecodedVector decoded;
+  exec::VectorReader<Generic<>> reader(decode(decoded, *vector.get()));
+
+  ASSERT_THROW(reader.containsNull(1), VeloxUserError);
+  // TODO (kevinwilfong): Add these back once generics are supported, and add
+  // test for generics that are containers.
+  // ASSERT_FALSE(reader.containsNull(1));
+  // ASSERT_FALSE(reader.containsNull(2));
+  // ASSERT_FALSE(reader.containsNull(3));
+  // ASSERT_TRUE(reader.containsNull(0));
+  // ASSERT_TRUE(reader.containsNull(5));
+
+  // // Value before is NULL.
+  // ASSERT_FALSE(reader.containsNull(1, 2));
+  // // Value after is NULL.
+  // ASSERT_FALSE(reader.containsNull(2, 5));
+  // // Up to the last value.
+  // ASSERT_FALSE(reader.containsNull(7, 10));
+  // // First value is NULL.
+  // ASSERT_TRUE(reader.containsNull(0, 3));
+  // // NULL value in middle of range.
+  // ASSERT_TRUE(reader.containsNull(4, 7));
+  // // Last value is NULL.
+  // ASSERT_TRUE(reader.containsNull(1, 6));
+}
+} // namespace facebook::velox

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -126,6 +126,10 @@ class DecodedVector {
     return mayHaveNulls_;
   }
 
+  bool mayHaveNullsRecursive() const {
+    return mayHaveNulls_ || baseVector_->mayHaveNullsRecursive();
+  }
+
   bool isNullAt(vector_size_t idx) const {
     if (!nulls_) {
       return false;

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -324,8 +324,10 @@ class VectorTestBase {
       vector_size_t size,
       std::function<vector_size_t(vector_size_t /* row */)> sizeAt,
       std::function<T(vector_size_t /* idx */)> valueAt,
-      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
-    return vectorMaker_.arrayVector<T>(size, sizeAt, valueAt, isNullAt);
+      std::function<bool(vector_size_t /* row */)> isNullAt = nullptr,
+      std::function<bool(vector_size_t /* idx */)> valueIsNullAt = nullptr) {
+    return vectorMaker_.arrayVector<T>(
+        size, sizeAt, valueAt, isNullAt, valueIsNullAt);
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
# High Level Goal:
We've identified some use cases where they want UDFs to return NULL not only if any of the values of the arguments to a function are NULL, but also if any of those arguments are complex types containing NULLs.

In these cases these UDFs they want a variant of the call function which receive views that don't expose nullity (since there are guaranteed to be no NULLs).  E.g. for Array<int64_t> instead of getting an ArrayView that offers an interface similar to std::vector<std::optional<int64_t>, they want an ArrayView that offers an interface like std::vector<int64_t>.

I plan to augment the SimpleFunction interface to offer a callNullFree function, which is only called if the arguments are not NULL and do not contain NULLs.  This function exposes Views with the desired interface as described above.  If only callNullFree is implemented, SimpleFunctions will return NULL in the if callNullFree cannot be invoked, otherwise it acts like a fast path if we can quickly determine the inputs do not contain NULLs and otherwise we defer to call or callNullable.

# This Diff
I add a function containsNulls to the VectorReaders, which allows us to inspect the value at a specific index to see if it is NULL or any of its children (e.g. the elements in an array) contain NULL.

I add two variants of the function, one that takes a single index, and one that takes a range of indices, to make evaluating the check for container types easier.

Note in VectorReaders for containers mayHaveNullsRecursive is called on the child vectors on each call to containsNulls.  This is only temporary, and I plan to compute the value only once in the next diff because it was difficult to do that in this diff in a way that allowed me to split the diffs.  (I only want to initialize it when we're going to call containsNulls, and that context is only available in the next diff).

Differential Revision: D33921847

