### PR TITLE
Add callNullFree to Simple Function interface

### DIFF
--- a/velox/core/Metaprogramming.h
+++ b/velox/core/Metaprogramming.h
@@ -173,4 +173,21 @@ struct has_method {
     }                                                          \
   };
 
+// Calling Name::resolve<T>::type will return T::TypeName if T::TypeName
+// exists, and otherwise will return T::OtherTypeName (it's existence is not
+// checked)
+#define DECLARE_CONDITIONAL_TYPE_NAME(Name, TypeName, OtherTypeName) \
+  struct Name {                                                      \
+    template <typename __T, typename = void>                         \
+    struct resolve {                                                 \
+      using type = typename __T::OtherTypeName;                      \
+    };                                                               \
+                                                                     \
+    template <typename __T>                                          \
+    struct resolve<                                                  \
+        __T,                                                         \
+        std::void_t<decltype(sizeof(typename __T::TypeName))>> {     \
+      using type = typename __T::TypeName;                           \
+    };                                                               \
+  };
 } // namespace facebook::velox::util

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
+  SimpleFunctionCallNullFreeTest.cpp
   SimpleFunctionPresetNullsTest.cpp
   ArrayViewTest.cpp
   ArrayProxyTest.cpp

--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "velox/expression/Expr.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox {
+class SimpleFunctionCallNullFreeTest
+    : public functions::test::FunctionBaseTest {};
+
+// Test that function with default contains nulls behavior won't get called when
+// inputs are all null.
+template <typename T>
+struct DefaultContainsNullsBehaviorFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullFree(bool& out, const null_free_arg_type<Array<int32_t>>&) {
+    out = true;
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, defaultContainsNullsBehavior) {
+  registerFunction<DefaultContainsNullsBehaviorFunction, bool, Array<int32_t>>(
+      {"default_contains_nulls_behavior"});
+
+  // Make a vector with some null arrays, and some arrays containing nulls.
+  auto arrayVector = makeVectorWithNullArrays<int32_t>(
+      {std::nullopt, {{1, std::nullopt}}, {{std::nullopt, 2}}, {{1, 2, 3}}});
+
+  // Check that default contains nulls behavior functions don't get called on a
+  // null input.
+  auto result = evaluate<SimpleVector<bool>>(
+      "default_contains_nulls_behavior(c0)", makeRowVector({arrayVector}));
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt, std::nullopt, std::nullopt, true});
+  assertEqualVectors(expected, result);
+}
+
+constexpr int32_t kCallNullable = 0;
+constexpr int32_t kCallNullFree = 1;
+
+// Test that function with non-default contains nulls behavior.
+// Returns the original array prepended with 0 if callNullable
+// is invoked or 1 if callNullFree is invoked.
+template <typename T>
+struct NonDefaultBehaviorFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullable(
+      out_type<Array<int32_t>>& out,
+      const arg_type<Array<int32_t>>* input) {
+    out.append(kCallNullable);
+
+    if (input) {
+      for (auto i : *input) {
+        if (i.has_value()) {
+          out.append(i.value());
+        }
+      }
+    }
+
+    return true;
+  }
+
+  bool callNullFree(
+      out_type<Array<int32_t>>& out,
+      const null_free_arg_type<Array<int32_t>>& input) {
+    out.append(kCallNullFree);
+
+    for (auto i : input) {
+      out.append(i);
+    }
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, nonDefaultBehavior) {
+  registerFunction<NonDefaultBehaviorFunction, Array<int32_t>, Array<int32_t>>(
+      {"non_default_behavior"});
+
+  // Make a vector with a NULL.
+  auto arrayVectorWithNull = makeVectorWithNullArrays<int32_t>(
+      {std::nullopt, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
+  // Make a vector with an array that contains NULL.
+  auto arrayVectorContainsNull = makeVectorWithNullArrays<int32_t>(
+      {{{4, std::nullopt}}, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
+  // Make a vector that's NULL-free.
+  auto arrayVectorNullFree =
+      makeArrayVector<int32_t>({{4, 5}, {1, 2}, {3, 2}, {2, 2, 3}});
+
+  auto resultWithNull = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorWithNull}));
+  auto expectedWithNull = makeArrayVector<int32_t>(
+      {{kCallNullable},
+       {kCallNullable, 1, 2},
+       {kCallNullable, 3, 2},
+       {kCallNullable, 2, 2, 3}});
+  assertEqualVectors(expectedWithNull, resultWithNull);
+
+  auto resultContainsNull = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorContainsNull}));
+  auto expectedContainsNull = makeArrayVector<int32_t>(
+      {{kCallNullable, 4},
+       {kCallNullable, 1, 2},
+       {kCallNullable, 3, 2},
+       {kCallNullable, 2, 2, 3}});
+  assertEqualVectors(expectedContainsNull, resultContainsNull);
+
+  auto resultNullFree = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorNullFree}));
+  auto expectedNullFree = makeArrayVector<int32_t>(
+      {{kCallNullFree, 4, 5},
+       {kCallNullFree, 1, 2},
+       {kCallNullFree, 3, 2},
+       {kCallNullFree, 2, 2, 3}});
+  assertEqualVectors(expectedNullFree, resultNullFree);
+}
+
+template <typename T>
+struct DeeplyNestedInputTypeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullFree(
+      bool& out,
+      const null_free_arg_type<
+          Variadic<Row<Array<int32_t>, Map<int32_t, int32_t>>>>&) {
+    out = true;
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, deeplyNestedInputType) {
+  registerFunction<
+      DeeplyNestedInputTypeFunction,
+      bool,
+      Variadic<Row<Array<int32_t>, Map<int32_t, int32_t>>>>(
+      {"deeply_nested_input_type"});
+
+  vector_size_t size = 11;
+  auto arrayVector1 = makeArrayVector<int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      // First array is NULL.
+      [&](vector_size_t row) { return row == 0; },
+      // Second array contains NULL.
+      [&](vector_size_t idx) { return idx == 0; });
+  auto mapVector1 = makeMapVector<int32_t, int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      [&](vector_size_t idx) { return idx; },
+      // Third map is NULL.
+      [&](vector_size_t row) { return row == 2; },
+      // Fourth map has a NULL value.
+      [&](vector_size_t idx) { return idx == 2; });
+  auto rowVector1 = makeRowVector(
+      {"array", "map"},
+      {arrayVector1, mapVector1},
+      // Fifth row is NULL.
+      [&](vector_size_t row) { return row == 4; });
+  auto arrayVector2 = makeArrayVector<int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      // Sixth array is NULL.
+      [&](vector_size_t row) { return row == 5; },
+      // Seventh array contains NULL.
+      [&](vector_size_t idx) { return idx == 5; });
+  auto mapVector2 = makeMapVector<int32_t, int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      [&](vector_size_t idx) { return idx; },
+      // Eigth map is NULL.
+      [&](vector_size_t row) { return row == 7; },
+      // Ninth map has a NULL value.
+      [&](vector_size_t idx) { return idx == 7; });
+  auto rowVector2 = makeRowVector(
+      {"array", "map"},
+      {arrayVector2, mapVector2},
+      // Tenth row is NULL
+      [&](vector_size_t row) { return row == 9; });
+
+  auto result = evaluate<SimpleVector<bool>>(
+      "deeply_nested_input_type(c0, c1)",
+      makeRowVector({rowVector1, rowVector2}));
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       true});
+  assertEqualVectors(expected, result);
+}
+} // namespace facebook::velox

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "glog/logging.h"

--- a/velox/expression/tests/VectorReaderTest.cpp
+++ b/velox/expression/tests/VectorReaderTest.cpp
@@ -124,6 +124,7 @@ TEST_F(VectorReaderTest, mapContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Map<int32_t, float>> reader(
       decode(decoded, *vector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Map.
   ASSERT_FALSE(reader.containsNull(0));
@@ -183,6 +184,7 @@ TEST_F(VectorReaderTest, dictionaryEncodedMapContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Map<int32_t, float>> reader(
       decode(decoded, *mapVector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Map.
   ASSERT_FALSE(reader.containsNull(0));
@@ -230,6 +232,7 @@ TEST_F(VectorReaderTest, arrayContainsNull) {
       [](vector_size_t idx) { return idx % 6 == 0; });
   DecodedVector decoded;
   exec::VectorReader<Array<int32_t>> reader(decode(decoded, *vector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Array.
   ASSERT_FALSE(reader.containsNull(0));
@@ -288,6 +291,7 @@ TEST_F(VectorReaderTest, dictionaryEncodedArrayContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Array<int32_t>> reader(
       decode(decoded, *arrayVector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Array.
   ASSERT_FALSE(reader.containsNull(0));

--- a/velox/functions/Macros.h
+++ b/velox/functions/Macros.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/core/Metaprogramming.h"
 #include "velox/type/Type.h"
 
 #define VELOX_UDF_BEGIN(Name)                                                \
@@ -82,6 +83,13 @@
   template <typename TArgs>                                             \
   using opt_out_type = std::optional<                                   \
       typename __Velox_ExecParams::template resolver<TArgs>::out_type>; \
+                                                                        \
+  DECLARE_CONDITIONAL_TYPE_NAME(                                        \
+      null_free_in_type_resolver, null_free_in_type, in_type);          \
+  template <typename TArgs>                                             \
+  using null_free_arg_type =                                            \
+      typename null_free_in_type_resolver::template resolve<            \
+          typename __Velox_ExecParams::template resolver<TArgs>>::type; \
                                                                         \
   template <typename TKey, typename TVal>                               \
   using MapVal = arg_type<::facebook::velox::Map<TKey, TVal>>;          \


### PR DESCRIPTION
Summary:
# High Level Goal:
We've identified some use cases where they want UDFs to return NULL not only if any of the values of the arguments to a function are NULL, but also if any of those arguments are complex types containing NULLs.

In these cases these UDFs they want a variant of the call function which receive views that don't expose nullity (since there are guaranteed to be no NULLs).  E.g. for Array<int64_t> instead of getting an ArrayView that offers an interface similar to std::vector<std::optional<int64_t>, they want an ArrayView that offers an interface like std::vector<int64_t>.

I plan to augment the SimpleFunction interface to offer a callNullFree function, which is only called if the arguments are not NULL and do not contain NULLs.  This function exposes Views with the desired interface as described above.  If only callNullFree is implemented, SimpleFunctions will return NULL in the if callNullFree cannot be invoked, otherwise it acts like a fast path if we can quickly determine the inputs do not contain NULLs and otherwise we defer to call or callNullable.

# This Diff
Here I pull everything together adding the callNullFree function to the Simple Function interface which behaves as described in the High Level Goal.

I've tried to balance writing clean code with writing performant code, tradeoffs were generally made in favor of the latter.

Differential Revision: D33931112

