### PR TITLE
Fix flaky IO count

### DIFF
--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -587,12 +587,6 @@ TEST_F(CacheTest, ssdThreads) {
     // All threads access the same amount. Where the data comes from varies.
     EXPECT_EQ(stats[0]->rawBytesRead(), stats[i]->rawBytesRead());
 
-    // What is accessed is <= what is hit from RAM + read from storage + read
-    // from SSD.
-    EXPECT_LE(
-        stats[i]->rawBytesRead(),
-        stats[i]->ramHit().bytes() + stats[i]->ssdRead().bytes() +
-            stats[i]->read().bytes());
     EXPECT_GE(stats[i]->rawBytesRead(), stats[i]->ramHit().bytes());
 
     // Prefetch is <= read from storage + read from SSD.


### PR DESCRIPTION
The assertion that total bytes accessed <= hits from RAM + read from
SSD + read from storage is not always true at the level of the
thread. It is possibl that both the read and the hit get counted on
the same thread if another thread accesses an entry prefetched on
another thread. Then the thread that hits the entry after the prefetch
but before the prefetcher initiating thread does not count the
hit. This is a marginal edge case that will not significantly alter
stats.