### PR TITLE
Remove useless check

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -656,7 +656,7 @@ void Expr::evalWithNulls(
       }
     }
 
-    if (mayHaveNulls && !distinctFields_.empty()) {
+    if (mayHaveNulls) {
       LocalSelectivityVector nonNullHolder(context);
       if (removeSureNulls(rows, context, nonNullHolder)) {
         VarSetter noMoreNulls(context->mutableNullsPruned(), true);


### PR DESCRIPTION
In evalWithNulls, when mayHaveNulls is true, there is one distinct field at least. 
So only check mayHvaeNulls is enough