### PR TITLE
Add documentation for callNullFree

### DIFF
--- a/velox/core/Metaprogramming.h
+++ b/velox/core/Metaprogramming.h
@@ -173,4 +173,21 @@ struct has_method {
     }                                                          \
   };
 
+// Calling Name::resolve<T>::type will return T::TypeName if T::TypeName
+// exists, and otherwise will return T::OtherTypeName (it's existence is not
+// checked)
+#define DECLARE_CONDITIONAL_TYPE_NAME(Name, TypeName, OtherTypeName) \
+  struct Name {                                                      \
+    template <typename __T, typename = void>                         \
+    struct resolve {                                                 \
+      using type = typename __T::OtherTypeName;                      \
+    };                                                               \
+                                                                     \
+    template <typename __T>                                          \
+    struct resolve<                                                  \
+        __T,                                                         \
+        std::void_t<decltype(sizeof(typename __T::TypeName))>> {     \
+      using type = typename __T::TypeName;                           \
+    };                                                               \
+  };
 } // namespace facebook::velox::util

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -104,6 +104,52 @@ an artificial example of a ceil function that returns 0 for null input:
 Notice that callNullable function takes arguments as raw pointers and not
 references to allow for specifying null values.
 
+Null-Free Fast Path
+*******************
+
+A "callNullFree" function may be implemented in place of or along side "call"
+and/or "callNullable" functions. When only the "callNullFree" function is
+implemented, evaluation of the function will be skipped and null will
+automatically be produced if any of the input arguments are null (like deafult
+null behavior) or if any of the input arguments are of a complex type and
+contain null anywhere in their value, e.g. an array that has a null element.
+If "callNullFree" is implemented alongside "call" and/or "callNullable", an
+efficient check is applied to the batch to see if any of the input arguments
+may be or contain null. Only if it can definitively be determined that that are
+no nulls will "callNullFree" be invoked.  In this case, "callNullFree" can act
+as a fast path by avoiding any per row null checks.
+
+Here is an example of an array_min function that returns the minimum value in
+an array:
+
+.. code-block:: c++
+
+  template <typename TExecParams>
+  struct ArrayMinFunction {
+    VELOX_DEFINE_FUNCTION_TYPES(TExecParams);
+
+    template <typename TInput>
+    FOLLY_ALWAYS_INLINE bool callNullFree(
+        TInput& out,
+        const null_free_arg_type<Array<TInput>>& array) {
+      out = INT32_MAX;
+      for (auto i = 0; i < array.size(); i++) {
+        if (array[i] < out) {
+          out = array[i]
+        }
+      }
+
+      return true;
+    }
+  };
+
+Notice that we can access the elements of "array" without checking their
+nullity in "callNullFree". Also notice that we wrap the input type in the
+null_free_arg_type<...> template instead of the arg_type<...> template. This is
+required as the input types for complex types are of a different type in
+"callNullFree" functions that do not wrap values in an std::optional-like
+interface upon access.
+
 Determinism
 ^^^^^^^^^^^
 

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -32,4 +32,5 @@ target_link_libraries(velox_expression velox_core velox_vector
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
+  add_subdirectory(benchmarks)
 endif()

--- a/velox/expression/benchmarks/CMakeLists.txt
+++ b/velox/expression/benchmarks/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(BENCHMARK_DEPENDENCIES
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_util
+    ${GTEST_BOTH_LIBRARIES}
+    ${gflags_LIBRARIES}
+    ${FOLLY_WITH_DEPENDENCIES}
+    ${FOLLY_BENCHMARK})
+
+add_executable(velox_benchmark_call_null_free_no_nulls
+               CallNullFreeBenchmark.cpp)
+target_link_libraries(velox_benchmark_call_null_free_no_nulls
+                      ${BENCHMARK_DEPENDENCIES})
+target_compile_definitions(
+  velox_benchmark_call_null_free_no_nulls PUBLIC WITH_NULL_ARRAYS=false
+                                                 WITH_NULL_ELEMENTS=false)
+
+add_executable(velox_benchmark_call_null_free_null_arrays
+               CallNullFreeBenchmark.cpp)
+target_link_libraries(velox_benchmark_call_null_free_null_arrays
+                      ${BENCHMARK_DEPENDENCIES})
+target_compile_definitions(
+  velox_benchmark_call_null_free_null_arrays PUBLIC WITH_NULL_ARRAYS=true
+                                                    WITH_NULL_ELEMENTS=false)
+
+add_executable(velox_benchmark_call_null_free_null_elements
+               CallNullFreeBenchmark.cpp)
+target_link_libraries(velox_benchmark_call_null_free_null_elements
+                      ${BENCHMARK_DEPENDENCIES})
+target_compile_definitions(
+  velox_benchmark_call_null_free_null_elements PUBLIC WITH_NULL_ARRAYS=false
+                                                      WITH_NULL_ELEMENTS=true)
+
+add_executable(velox_benchmark_call_null_free_null_arrays_and_null_elements
+               CallNullFreeBenchmark.cpp)
+target_link_libraries(
+  velox_benchmark_call_null_free_null_arrays_and_null_elements
+  ${BENCHMARK_DEPENDENCIES})
+target_compile_definitions(
+  velox_benchmark_call_null_free_null_arrays_and_null_elements
+  PUBLIC WITH_NULL_ARRAYS=true WITH_NULL_ELEMENTS=true)

--- a/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
+++ b/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h"
+
+// These macros should be set, defined in command line.
+// #define WITH_NULL_ARRAYS false
+// #define WITH_NULL_VALUES false
+
+// Benchmark a function that returns the minimum value in an array.
+// The function returns NULL if the array or any of its elements are NULL.
+
+namespace facebook::velox::functions {
+
+template <typename T>
+struct ArrayMinDefaultHasNullsBehaviorFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool callNullFree(
+      TInput& out,
+      const null_free_arg_type<Array<TInput>>& array) {
+    if (array.size() == 0) {
+      return false; // NULL
+    }
+
+    auto min = INT32_MAX;
+    for (auto i = 0; i < array.size(); i++) {
+      auto v = array[i];
+      if (v < min) {
+        min = v;
+      }
+    }
+    out = min;
+    return true;
+  }
+};
+
+template <typename T>
+struct ArrayMinNullFreeFastPathFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(
+      TInput& out,
+      const arg_type<Array<TInput>>& array) {
+    if (array.size() == 0) {
+      return false; // NULL
+    }
+
+    auto min = INT32_MAX;
+    if (array.mayHaveNulls()) {
+      for (auto i = 0; i < array.size(); i++) {
+        if (!array[i].has_value()) {
+          return false; // NULL
+        }
+        auto v = array[i].value();
+        if (v < min) {
+          min = v;
+        }
+      }
+    } else {
+      for (auto i = 0; i < array.size(); i++) {
+        auto v = array[i].value();
+        if (v < min) {
+          min = v;
+        }
+      }
+    }
+    out = min;
+    return true;
+  }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool callNullFree(
+      TInput& out,
+      const null_free_arg_type<Array<TInput>>& array) {
+    if (array.size() == 0) {
+      return false; // NULL
+    }
+
+    auto min = INT32_MAX;
+    for (auto i = 0; i < array.size(); i++) {
+      auto v = array[i];
+      if (v < min) {
+        min = v;
+      }
+    }
+    out = min;
+    return true;
+  }
+};
+
+void registerVectorFunctionFastPath() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_min, "vector_fast_path");
+}
+
+void registerSimpleFunctions() {
+  registerFunction<ArrayMinSimpleFunction, int32_t, Array<int32_t>>(
+      {"array_min_simple"});
+
+  registerFunction<
+      ArrayMinDefaultHasNullsBehaviorFunction,
+      int32_t,
+      Array<int32_t>>({"array_min_default_has_nulls_behavior"});
+
+  registerFunction<ArrayMinNullFreeFastPathFunction, int32_t, Array<int32_t>>(
+      {"array_min_null_free_fast_path"});
+}
+
+namespace {
+
+class CallNullFreeBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  CallNullFreeBenchmark() : FunctionBenchmarkBase() {
+    registerVectorFunctionFastPath();
+    registerSimpleFunctions();
+  }
+
+  RowVectorPtr makeData() {
+    std::function<bool(vector_size_t /*row */)> noNulls = nullptr;
+
+    const vector_size_t size = 1'000;
+    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
+        size,
+        [](auto row) { return row % 5; },
+        [](auto idx) { return idx % 23; },
+        WITH_NULL_ARRAYS ? [](auto row) { return row % 13 == 0; } : noNulls,
+        WITH_NULL_ELEMENTS ? [](auto idx) { return idx % 19 == 0; } : noNulls);
+
+    return vectorMaker_.rowVector({arrayVector});
+  }
+
+  size_t runInteger(const std::string& functionName) {
+    folly::BenchmarkSuspender suspender;
+    auto arrayVector = makeData()->childAt(0);
+    auto rowVector = vectorMaker_.rowVector({arrayVector});
+    auto exprSet = compileExpression(
+        fmt::format("{}(c0)", functionName), rowVector->type());
+    suspender.dismiss();
+
+    return doRun(exprSet, rowVector);
+  }
+
+  size_t doRun(exec::ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  bool hasSameResults(
+      exec::ExprSet& expr1,
+      exec::ExprSet& expr2,
+      const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void test() {
+    auto input = makeData();
+    auto exprSetRef = compileExpression("vector_fast_path(c0)", input->type());
+    std::vector<std::string> functions = {
+        "array_min_simple",
+        "array_min_default_has_nulls_behavior",
+        "array_min_null_free_fast_path",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        VELOX_UNREACHABLE(fmt::format("testing failed at function {}", name));
+      }
+    }
+  }
+};
+
+BENCHMARK_MULTI(vector) {
+  CallNullFreeBenchmark benchmark;
+  return benchmark.runInteger("vector_fast_path");
+}
+
+BENCHMARK_MULTI(simpleMinInteger) {
+  CallNullFreeBenchmark benchmark;
+  return benchmark.runInteger("array_min_simple");
+}
+
+BENCHMARK_MULTI(simpleMinIntegerDefaultHasNullsBehavior) {
+  CallNullFreeBenchmark benchmark;
+  return benchmark.runInteger("array_min_default_has_nulls_behavior");
+}
+
+BENCHMARK_MULTI(simpleMinIntegerNullFreeFastPath) {
+  CallNullFreeBenchmark benchmark;
+  return benchmark.runInteger("array_min_null_free_fast_path");
+}
+} // namespace
+} // namespace facebook::velox::functions
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::functions::CallNullFreeBenchmark benchmark;
+  benchmark.test();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
+  SimpleFunctionCallNullFreeTest.cpp
   SimpleFunctionPresetNullsTest.cpp
   ArrayViewTest.cpp
   ArrayProxyTest.cpp

--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "velox/expression/Expr.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox {
+class SimpleFunctionCallNullFreeTest
+    : public functions::test::FunctionBaseTest {};
+
+// Test that function with default contains nulls behavior won't get called when
+// inputs are all null.
+template <typename T>
+struct DefaultContainsNullsBehaviorFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullFree(bool& out, const null_free_arg_type<Array<int32_t>>&) {
+    out = true;
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, defaultContainsNullsBehavior) {
+  registerFunction<DefaultContainsNullsBehaviorFunction, bool, Array<int32_t>>(
+      {"default_contains_nulls_behavior"});
+
+  // Make a vector with some null arrays, and some arrays containing nulls.
+  auto arrayVector = makeVectorWithNullArrays<int32_t>(
+      {std::nullopt, {{1, std::nullopt}}, {{std::nullopt, 2}}, {{1, 2, 3}}});
+
+  // Check that default contains nulls behavior functions don't get called on a
+  // null input.
+  auto result = evaluate<SimpleVector<bool>>(
+      "default_contains_nulls_behavior(c0)", makeRowVector({arrayVector}));
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt, std::nullopt, std::nullopt, true});
+  assertEqualVectors(expected, result);
+}
+
+constexpr int32_t kCallNullable = 0;
+constexpr int32_t kCallNullFree = 1;
+
+// Test that function with non-default contains nulls behavior.
+// Returns the original array prepended with 0 if callNullable
+// is invoked or 1 if callNullFree is invoked.
+template <typename T>
+struct NonDefaultBehaviorFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullable(
+      out_type<Array<int32_t>>& out,
+      const arg_type<Array<int32_t>>* input) {
+    out.append(kCallNullable);
+
+    if (input) {
+      for (auto i : *input) {
+        if (i.has_value()) {
+          out.append(i.value());
+        }
+      }
+    }
+
+    return true;
+  }
+
+  bool callNullFree(
+      out_type<Array<int32_t>>& out,
+      const null_free_arg_type<Array<int32_t>>& input) {
+    out.append(kCallNullFree);
+
+    for (auto i : input) {
+      out.append(i);
+    }
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, nonDefaultBehavior) {
+  registerFunction<NonDefaultBehaviorFunction, Array<int32_t>, Array<int32_t>>(
+      {"non_default_behavior"});
+
+  // Make a vector with a NULL.
+  auto arrayVectorWithNull = makeVectorWithNullArrays<int32_t>(
+      {std::nullopt, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
+  // Make a vector with an array that contains NULL.
+  auto arrayVectorContainsNull = makeVectorWithNullArrays<int32_t>(
+      {{{4, std::nullopt}}, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
+  // Make a vector that's NULL-free.
+  auto arrayVectorNullFree =
+      makeArrayVector<int32_t>({{4, 5}, {1, 2}, {3, 2}, {2, 2, 3}});
+
+  auto resultWithNull = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorWithNull}));
+  auto expectedWithNull = makeArrayVector<int32_t>(
+      {{kCallNullable},
+       {kCallNullable, 1, 2},
+       {kCallNullable, 3, 2},
+       {kCallNullable, 2, 2, 3}});
+  assertEqualVectors(expectedWithNull, resultWithNull);
+
+  auto resultContainsNull = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorContainsNull}));
+  auto expectedContainsNull = makeArrayVector<int32_t>(
+      {{kCallNullable, 4},
+       {kCallNullable, 1, 2},
+       {kCallNullable, 3, 2},
+       {kCallNullable, 2, 2, 3}});
+  assertEqualVectors(expectedContainsNull, resultContainsNull);
+
+  auto resultNullFree = evaluate<ArrayVector>(
+      "non_default_behavior(c0)", makeRowVector({arrayVectorNullFree}));
+  auto expectedNullFree = makeArrayVector<int32_t>(
+      {{kCallNullFree, 4, 5},
+       {kCallNullFree, 1, 2},
+       {kCallNullFree, 3, 2},
+       {kCallNullFree, 2, 2, 3}});
+  assertEqualVectors(expectedNullFree, resultNullFree);
+}
+
+template <typename T>
+struct DeeplyNestedInputTypeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool callNullFree(
+      bool& out,
+      const null_free_arg_type<
+          Variadic<Row<Array<int32_t>, Map<int32_t, int32_t>>>>&) {
+    out = true;
+
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionCallNullFreeTest, deeplyNestedInputType) {
+  registerFunction<
+      DeeplyNestedInputTypeFunction,
+      bool,
+      Variadic<Row<Array<int32_t>, Map<int32_t, int32_t>>>>(
+      {"deeply_nested_input_type"});
+
+  vector_size_t size = 11;
+  auto arrayVector1 = makeArrayVector<int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      // First array is NULL.
+      [&](vector_size_t row) { return row == 0; },
+      // Second array contains NULL.
+      [&](vector_size_t idx) { return idx == 0; });
+  auto mapVector1 = makeMapVector<int32_t, int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      [&](vector_size_t idx) { return idx; },
+      // Third map is NULL.
+      [&](vector_size_t row) { return row == 2; },
+      // Fourth map has a NULL value.
+      [&](vector_size_t idx) { return idx == 2; });
+  auto rowVector1 = makeRowVector(
+      {"array", "map"},
+      {arrayVector1, mapVector1},
+      // Fifth row is NULL.
+      [&](vector_size_t row) { return row == 4; });
+  auto arrayVector2 = makeArrayVector<int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      // Sixth array is NULL.
+      [&](vector_size_t row) { return row == 5; },
+      // Seventh array contains NULL.
+      [&](vector_size_t idx) { return idx == 5; });
+  auto mapVector2 = makeMapVector<int32_t, int32_t>(
+      size,
+      [&](vector_size_t /* row */) { return 1; },
+      [&](vector_size_t idx) { return idx; },
+      [&](vector_size_t idx) { return idx; },
+      // Eigth map is NULL.
+      [&](vector_size_t row) { return row == 7; },
+      // Ninth map has a NULL value.
+      [&](vector_size_t idx) { return idx == 7; });
+  auto rowVector2 = makeRowVector(
+      {"array", "map"},
+      {arrayVector2, mapVector2},
+      // Tenth row is NULL
+      [&](vector_size_t row) { return row == 9; });
+
+  auto result = evaluate<SimpleVector<bool>>(
+      "deeply_nested_input_type(c0, c1)",
+      makeRowVector({rowVector1, rowVector2}));
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       true});
+  assertEqualVectors(expected, result);
+}
+} // namespace facebook::velox

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "glog/logging.h"

--- a/velox/expression/tests/VectorReaderTest.cpp
+++ b/velox/expression/tests/VectorReaderTest.cpp
@@ -124,6 +124,7 @@ TEST_F(VectorReaderTest, mapContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Map<int32_t, float>> reader(
       decode(decoded, *vector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Map.
   ASSERT_FALSE(reader.containsNull(0));
@@ -183,6 +184,7 @@ TEST_F(VectorReaderTest, dictionaryEncodedMapContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Map<int32_t, float>> reader(
       decode(decoded, *mapVector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Map.
   ASSERT_FALSE(reader.containsNull(0));
@@ -230,6 +232,7 @@ TEST_F(VectorReaderTest, arrayContainsNull) {
       [](vector_size_t idx) { return idx % 6 == 0; });
   DecodedVector decoded;
   exec::VectorReader<Array<int32_t>> reader(decode(decoded, *vector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Array.
   ASSERT_FALSE(reader.containsNull(0));
@@ -288,6 +291,7 @@ TEST_F(VectorReaderTest, dictionaryEncodedArrayContainsNull) {
   DecodedVector decoded;
   exec::VectorReader<Array<int32_t>> reader(
       decode(decoded, *arrayVector.get()));
+  reader.setChildrenMayHaveNulls();
 
   // Empty Array.
   ASSERT_FALSE(reader.containsNull(0));

--- a/velox/functions/Macros.h
+++ b/velox/functions/Macros.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/core/Metaprogramming.h"
 #include "velox/type/Type.h"
 
 #define VELOX_UDF_BEGIN(Name)                                                \
@@ -82,6 +83,13 @@
   template <typename TArgs>                                             \
   using opt_out_type = std::optional<                                   \
       typename __Velox_ExecParams::template resolver<TArgs>::out_type>; \
+                                                                        \
+  DECLARE_CONDITIONAL_TYPE_NAME(                                        \
+      null_free_in_type_resolver, null_free_in_type, in_type);          \
+  template <typename TArgs>                                             \
+  using null_free_arg_type =                                            \
+      typename null_free_in_type_resolver::template resolve<            \
+          typename __Velox_ExecParams::template resolver<TArgs>>::type; \
                                                                         \
   template <typename TKey, typename TVal>                               \
   using MapVal = arg_type<::facebook::velox::Map<TKey, TVal>>;          \


### PR DESCRIPTION
Summary: Adding documentation for the callNullFree function to the documentation for Scalar/Simple functions as a sub-section under "Null Behavior".

Differential Revision: D34048567

