### PR TITLE
Fix a typo in docker image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ executors:
       - image : prestocpp/velox-check:mikesh-20210609
   doc-gen:
     docker:
-      - image : prestocpp/velox-circleci:sagarm-2022013
+      - image : prestocpp/velox-circleci:sagarm-20220131
 
 jobs:
   macos-build:


### PR DESCRIPTION
prestocpp/velox-circleci:sagarm-2022013 does not exist, missing a trailing '1' from the correct one "prestocpp/velox-circleci:sagarm-20220131"