### PR TITLE
Reader shim cleanup

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -29,6 +29,11 @@ std::unique_ptr<dwio::common::RowReader> DwrfReader::createRowReader(
   return std::make_unique<DwrfRowReader>(readerBase_, opts);
 }
 
+std::unique_ptr<DwrfRowReader> DwrfReader::createDwrfRowReader(
+    const RowReaderOptions& opts) const {
+  return std::make_unique<DwrfRowReader>(readerBase_, opts);
+}
+
 void DwrfRowReader::checkSkipStrides(
     const StatsContext& context,
     uint64_t strideSize) {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -102,6 +102,9 @@ class DwrfReader : public DwrfReaderShared {
   std::unique_ptr<dwio::common::RowReader> createRowReader(
       const dwio::common::RowReaderOptions& options = {}) const override;
 
+  std::unique_ptr<DwrfRowReader> createDwrfRowReader(
+      const dwio::common::RowReaderOptions& options = {}) const;
+
   /**
    * Create a reader to the for the dwrf file.
    * @param stream the stream to read


### PR DESCRIPTION
Summary:
The end goal is to make it very hard for customers to accidentally use the legacy readers. This diff
* Removed all usage of legacy dwio reader in dwio::api::DwrfReader, and make it a pure wrapper to implement the FileReader class.
* makes need of legacy reader in side table use an explicitly named legacy method from ReaderFactory.
* makes validation service stack depend on an explicitly named DwrfReaderShim class in a different namespace.

Some remaining steps for the future:
* remove DwrfReaderShim class by explicit branching in validation service stack.
* after solving side table merge problem, remove legacy method in ReaderFactory branching in SplitReader and api::Batch.

Reviewed By: Magoja

Differential Revision: D30587118

