### PR TITLE
New map writer, the general interface.

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -60,6 +60,11 @@ struct resolver<Map<K, V>> {
       typename resolver<V>::out_type>;
 };
 
+template <typename K, typename V>
+struct resolver<MapWriterT<K, V>> {
+  using out_type = MapWriter<K, V>;
+};
+
 template <typename... T>
 struct resolver<Row<T...>> {
   using in_type = RowView<true, T...>;
@@ -531,8 +536,8 @@ struct VectorWriter<Array<V>> {
   size_t offset_ = 0;
 };
 
-// A new temporary writer, to be used when the user wants a proxy interface for
-// the array output. Will eventually replace VectorWriter<Array>>.
+// A new temporary VectorWriter for the new array writer interface.
+// Will eventually replace VectorWriter<Array>>.
 template <typename V>
 struct VectorWriter<ArrayProxyT<V>> {
   using vector_t = typename TypeToFlatVector<Array<V>>::type;
@@ -545,7 +550,7 @@ struct VectorWriter<ArrayProxyT<V>> {
     proxy_.initialize(this);
   }
 
-  // This should be called once all rows are proccessed.
+  // This should be called once all rows are processed.
   void finish() {
     proxy_.elementsVector_->resize(proxy_.valuesOffset_);
     arrayVector_ = nullptr;
@@ -574,13 +579,13 @@ struct VectorWriter<ArrayProxyT<V>> {
     arrayVector_->setOffsetAndSize(
         offset_, proxy_.valuesOffset_, proxy_.length_);
     arrayVector_->setNull(offset_, false);
-    // Will reset length to 0 and prepare proxy_.valuesOffset_ for the next
-    // item.
+    // Will reset length to 0 and prepare proxy_ for the next item.
     proxy_.finalize();
   }
 
   // Commit a null value.
   void commitNull() {
+    proxy_.finalizeNull();
     arrayVector_->setNull(offset_, true);
   }
 
@@ -609,6 +614,88 @@ struct VectorWriter<ArrayProxyT<V>> {
 
   // The index being written in the array vector.
   vector_size_t offset_ = 0;
+};
+
+// A new temporary vector writer, to be used when the user wants a writer
+// interface for the map output. Will eventually replace VectorWriter<Map>>.
+template <typename K, typename V>
+struct VectorWriter<MapWriterT<K, V>> {
+  using vector_t = typename TypeToFlatVector<Map<K, V>>::type;
+  using key_vector_t = typename TypeToFlatVector<K>::type;
+  using val_vector_t = typename TypeToFlatVector<V>::type;
+  using exec_out_t = MapWriter<K, V>;
+
+  void init(vector_t& vector) {
+    mapVector_ = &vector;
+    keyWriter_.init(static_cast<key_vector_t&>(*vector.mapKeys()));
+    valWriter_.init(static_cast<val_vector_t&>(*vector.mapValues()));
+    elementWriter_.initialize(this);
+  }
+
+  // This should be called once all rows are processed.
+  void finish() {
+    // Downsize to actual used size.
+    elementWriter_.keysVector_->resize(elementWriter_.innerOffset_);
+    elementWriter_.valuesVector_->resize(elementWriter_.innerOffset_);
+    mapVector_ = nullptr;
+  }
+
+  VectorWriter() = default;
+
+  exec_out_t& current() {
+    return elementWriter_;
+  }
+
+  vector_t& vector() {
+    return *mapVector_;
+  }
+
+  void ensureSize(size_t size) {
+    if (size > mapVector_->size()) {
+      mapVector_->resize(size);
+      init(vector());
+    }
+  }
+
+  // Commit a not null value.
+  void commit() {
+    mapVector_->setOffsetAndSize(
+        offset_, elementWriter_.innerOffset_, elementWriter_.length_);
+    mapVector_->setNull(offset_, false);
+    // Will reset length to 0 and prepare proxy_.valuesOffset_ for the next
+    // item.
+    elementWriter_.finalize();
+  }
+
+  // Commit a null value.
+  void commitNull() {
+    elementWriter_.finalizeNull();
+    mapVector_->setNull(offset_, true);
+  }
+
+  void commit(bool isSet) {
+    if (LIKELY(isSet)) {
+      commit();
+    } else {
+      commitNull();
+    }
+  }
+
+  // Set the index being written.
+  void setOffset(vector_size_t offset) {
+    offset_ = offset;
+  }
+
+  void reset() {
+    elementWriter_.innerOffset_ = 0;
+  }
+
+  exec_out_t elementWriter_;
+
+  vector_t* mapVector_;
+  VectorWriter<K> keyWriter_;
+  VectorWriter<V> valWriter_;
+  size_t offset_ = 0;
 };
 
 template <typename... T>

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(
   velox_expression_test
   ExprTest.cpp
   CastExprTest.cpp
+  MapWriterTest.cpp
+  ArrayProxyTest.cpp
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <fmt/core.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <optional>
+
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/StringView.h"
+namespace facebook::velox {
+namespace {
+
+// Function that creates a map with elements i->i*2+1 if i is odd.
+// and i->null if i is even. For every i = [0..n).
+template <typename T>
+struct Func {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      switch (i % 2) {
+        case 0: {
+          auto [keyWriter, valueWriter] = out.add_item();
+          keyWriter = i;
+          valueWriter = i * 2 + 1;
+          break;
+        }
+        case 1:
+          out.add_null() = i;
+          break;
+      }
+    }
+    return true;
+  }
+};
+
+class MapWriterTest : public functions::test::FunctionBaseTest {
+ public:
+  template <typename K, typename V>
+  using map_pairs_t = std::vector<std::pair<K, std::optional<V>>>;
+
+  VectorPtr prepareResult(const TypePtr& mapType, vector_size_t size = 1) {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(size), mapType, this->execCtx_.pool(), &result);
+    return result;
+  }
+
+  template <typename T>
+  void testE2E(const std::string& testFunctionName) {
+    registerFunction<Func, MapWriterT<T, T>, int64_t>({testFunctionName});
+
+    auto result = evaluate(
+        fmt::format("{}(c0)", testFunctionName),
+        makeRowVector(
+            {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+
+    std::vector<map_pairs_t<T, T>> expected;
+    for (auto i = 1; i <= 10; i++) {
+      expected.push_back({});
+      auto& currentExpected = expected[expected.size() - 1];
+      for (auto j = 0; j < i; j++) {
+        switch (j % 2) {
+          case 0:
+            currentExpected.push_back({j, {j * 2 + 1}});
+            break;
+          case 1:
+            currentExpected.push_back({j, std::nullopt});
+            break;
+        }
+      }
+    }
+    assertEqualVectors(result, makeMapVector<T, T>(expected));
+  }
+
+  struct TestWriter {
+    VectorPtr result;
+    std::unique_ptr<exec::VectorWriter<MapWriterT<int64_t, int64_t>>> writer =
+        std::make_unique<exec::VectorWriter<MapWriterT<int64_t, int64_t>>>();
+  };
+
+  TestWriter makeTestWriter() {
+    TestWriter writer;
+
+    writer.result =
+        prepareResult(std::make_shared<MapType>(MapType(BIGINT(), BIGINT())));
+    writer.writer->init(*writer.result->as<MapVector>());
+    writer.writer->setOffset(0);
+    return writer;
+  }
+};
+
+TEST_F(MapWriterTest, addNull) {
+  auto [result, vectorWriter] = makeTestWriter();
+
+  auto& mapWriter = vectorWriter->current();
+  mapWriter.add_null() = 1;
+  mapWriter.add_null() = 2;
+  vectorWriter->commit();
+
+  vectorWriter->finish();
+  map_pairs_t<int64_t, int64_t> expected = {
+      {1, std::nullopt}, {2, std::nullopt}};
+  assertEqualVectors(result, makeMapVector<int64_t, int64_t>({expected}));
+}
+
+TEST_F(MapWriterTest, writeThenCommitNull) {
+  auto [result, vectorWriter] = makeTestWriter();
+  vectorWriter->ensureSize(2);
+
+  {
+    vectorWriter->setOffset(0);
+    auto& mapWriter = vectorWriter->current();
+    mapWriter.add_null() = 1;
+    mapWriter.add_null() = 2;
+    mapWriter.add_item() = std::make_tuple(100, 100);
+    vectorWriter->commitNull();
+  }
+
+  {
+    vectorWriter->setOffset(1);
+    auto& mapWriter = vectorWriter->current();
+    mapWriter.add_item() = std::make_tuple(200, 200);
+    mapWriter.add_null() = 1;
+    vectorWriter->commit();
+  }
+  vectorWriter->finish();
+
+  map_pairs_t<int64_t, int64_t> expected = {{200, 200}, {1, std::nullopt}};
+  auto expexctedVector = makeMapVector<int64_t, int64_t>({{}, expected});
+  expexctedVector->setNull(0, true);
+  assertEqualVectors(result, expexctedVector);
+}
+
+TEST_F(MapWriterTest, addItem) {
+  auto [result, vectorWriter] = makeTestWriter();
+
+  auto& mapWriter = vectorWriter->current();
+  // Item 1.
+  auto [key, value] = mapWriter.add_item();
+  key = 1;
+  value = 1;
+
+  // Item 2.
+  mapWriter.add_item() = std::make_tuple(1, 3);
+
+  // Item 3.
+  auto writers = mapWriter.add_item();
+  std::get<0>(writers) = 11;
+  std::get<1>(writers) = 12;
+
+  vectorWriter->commit();
+  vectorWriter->finish();
+
+  map_pairs_t<int64_t, int64_t> expected = {{1, 1}, {1, 3}, {11, 12}};
+  assertEqualVectors(result, makeMapVector<int64_t, int64_t>({expected}));
+}
+
+TEST_F(MapWriterTest, e2ePrimitives) {
+  testE2E<int8_t>("f_int6");
+  testE2E<int16_t>("f_int16");
+  testE2E<int32_t>("f_int32");
+  testE2E<int64_t>("f_int64");
+  testE2E<float>("f_float");
+  testE2E<double>("f_double");
+  testE2E<bool>("f_bool");
+}
+
+TEST_F(MapWriterTest, testTimeStamp) {
+  auto result =
+      prepareResult(std::make_shared<MapType>(MapType(BIGINT(), TIMESTAMP())));
+
+  exec::VectorWriter<MapWriterT<int64_t, Timestamp>> writer;
+  writer.init(*result->as<MapVector>());
+  writer.setOffset(0);
+  auto& mapWriter = writer.current();
+  // General interface.
+  mapWriter.add_item() = std::make_tuple(1, Timestamp::fromMillis(1));
+  mapWriter.add_null() = 2;
+  writer.commit();
+  writer.finish();
+  map_pairs_t<int64_t, Timestamp> expected = {
+      {1, Timestamp::fromMillis(1)}, {2, std::nullopt}};
+  assertEqualVectors(result, makeMapVector<int64_t, Timestamp>({expected}));
+}
+
+TEST_F(MapWriterTest, testVarChar) {
+  auto result =
+      prepareResult(std::make_shared<MapType>(MapType(VARCHAR(), VARCHAR())));
+
+  exec::VectorWriter<MapWriterT<Varchar, Varchar>> writer;
+  writer.init(*result->as<MapVector>());
+  writer.setOffset(0);
+  auto& mapWriter = writer.current();
+  {
+    auto [keyWriter, valueWriter] = mapWriter.add_item();
+    keyWriter.resize(2);
+    keyWriter.data()[0] = 'h';
+    keyWriter.data()[1] = 'i';
+
+    valueWriter += "welcome"_sv;
+  }
+
+  {
+    auto& keyWriter = mapWriter.add_null();
+    keyWriter += "null"_sv;
+  }
+
+  writer.commit();
+  writer.finish();
+
+  map_pairs_t<StringView, StringView> expected = {
+      {"hi"_sv, "welcome"_sv}, {"null"_sv, std::nullopt}};
+  assertEqualVectors(result, makeMapVector<StringView, StringView>({expected}));
+}
+
+TEST_F(MapWriterTest, testVarBinary) {
+  auto result = prepareResult(
+      std::make_shared<MapType>(MapType(VARBINARY(), VARBINARY())));
+
+  exec::VectorWriter<MapWriterT<Varbinary, Varbinary>> writer;
+  writer.init(*result->as<MapVector>());
+  writer.setOffset(0);
+
+  auto& mapWriter = writer.current();
+  {
+    auto [keyWriter, valueWriter] = mapWriter.add_item();
+    keyWriter.resize(2);
+    keyWriter.data()[0] = 'h';
+    keyWriter.data()[1] = 'i';
+
+    valueWriter += "welcome"_sv;
+  }
+
+  {
+    auto& keyWriter = mapWriter.add_null();
+    keyWriter += "null"_sv;
+  }
+
+  writer.commit();
+  writer.finish();
+
+  map_pairs_t<StringView, StringView> expected = {
+      {"hi"_sv, "welcome"_sv}, {"null"_sv, std::nullopt}};
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  exec::VectorReader<Map<Varbinary, Varbinary>> reader(&decoded);
+  auto mapView = reader[0];
+
+  ASSERT_EQ(mapView.size(), expected.size());
+
+  auto i = 0;
+  for (auto [key, value] : mapView) {
+    ASSERT_EQ(key, expected[i].first);
+    ASSERT_EQ(value, expected[i].second);
+    i++;
+  }
+}
+
+// A function that returns map<array<int>, map<int, int>> as output.
+template <typename T>
+struct MakeComplexMapFunction {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    auto [arrayWriter, mapWriter] = out.add_item();
+    arrayWriter.resize(n);
+    for (auto i = 0; i < n; i++) {
+      arrayWriter[i] = i;
+    }
+    for (auto i = 0; i < n; i++) {
+      mapWriter.add_item() = std::make_tuple(i, i + 1);
+    }
+    return true;
+  }
+};
+
+// Test a function that writes out map<array, map<>>.
+TEST_F(MapWriterTest, nestedMap) {
+  using out_t = MapWriterT<ArrayProxyT<int64_t>, MapWriterT<int64_t, int64_t>>;
+  registerFunction<MakeComplexMapFunction, out_t, int64_t>({"complex_map"});
+
+  auto result = evaluate(
+      "complex_map(c0)",
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9})}));
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  exec::VectorReader<Map<Array<int64_t>, Map<int64_t, int64_t>>> reader(
+      &decoded);
+  for (auto i = 0; i < rows.size(); i++) {
+    auto outerMap = reader[i];
+    for (const auto& [array, innerMap] : outerMap) {
+      ASSERT_EQ(array.size(), i);
+      // Check key.
+      for (auto j = 0; j < i; j++) {
+        ASSERT_EQ(array[j].value(), j);
+      }
+
+      // Check value.
+      auto j = 0;
+      for (const auto& [key, val] : innerMap.value()) {
+        ASSERT_EQ(key, j);
+        ASSERT_EQ(*val, j + 1);
+        j++;
+      }
+    }
+  }
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1345,6 +1345,25 @@ struct ArrayProxyT {
   ArrayProxyT() {}
 };
 
+// This is a temporary type to be used when the fast MapWriter is requested by
+// the user to represent a map output type in the simple function interface.
+// Eventually this will be removed and joined with Map once all writers
+// types are implemented.
+template <typename K, typename V>
+struct MapWriterT {
+  using key_type = K;
+  using value_type = V;
+
+  static_assert(
+      !isVariadicType<key_type>::value,
+      "Map keys cannot be Variadic");
+  static_assert(
+      !isVariadicType<value_type>::value,
+      "Map values cannot be Variadic");
+
+  MapWriterT() = delete;
+};
+
 template <typename... T>
 struct Row {
   template <size_t idx>
@@ -1460,6 +1479,13 @@ struct CppToType<std::shared_ptr<T>> : public CppToTypeBase<TypeKind::OPAQUE> {
 
 template <typename KEY, typename VAL>
 struct CppToType<Map<KEY, VAL>> : public TypeTraits<TypeKind::MAP> {
+  static auto create() {
+    return MAP(CppToType<KEY>::create(), CppToType<VAL>::create());
+  }
+};
+
+template <typename KEY, typename VAL>
+struct CppToType<MapWriterT<KEY, VAL>> : public TypeTraits<TypeKind::MAP> {
   static auto create() {
     return MAP(CppToType<KEY>::create(), CppToType<VAL>::create());
   }


### PR DESCRIPTION
Add the implementation of the new map writer. It's pretty similar to the array writer, but 
extended for two underlying vectors. 

This diff adds the general interface, (not the primitive specialized one). The diff includes tests 
for all types and nested complex types.

The map writer interface is as the following:

 **General Interface**
  - add_item()  : return references to key and value writers as tuple.
  - add_null()  :  return key writer, set value to null.
   - size()      : return the size of the map.
// The interface does not guarantee that duplicates not written.

examples of functions written with the new interface. 
1) Function that creates a map with elements i->i*2+1 if i is odd and i->null if i is even. 
For every i in [0..n).
```
template <typename T>
struct Func {
  template <typename TOut>
  bool call(TOut& out, const int64_t& n) {
    for (int i = 0; i < n; i++) {
      switch (i % 2) {
        case 0: {
          auto [keyWriter, valueWriter] = out.add_item();
          keyWriter = i;
          valueWriter = i * 2 + 1;
          break;
        }
        case 1:
          out.add_null() = i;
          break;
      }
    }
    return true;
  }
};
```
2) A function that returns map<array<int>, map<int, int>> as output.

```
template <typename T>
struct MakeComplexMapFunction {
  template <typename TOut>
  bool call(TOut& out, const int64_t& n) {
    auto [arrayWriter, mapWriter] = out.add_item();
    arrayWriter.resize(n);
    for (auto i = 0; i < n; i++) {
      arrayWriter[i] = i;
    }
    for (auto i = 0; i < n; i++) {
      mapWriter.add_item() = std::make_tuple(i, i + 1);
    }
    return true;
  }
};
```
