### PR TITLE
Add support for LIKE operator to DuckParser

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -48,7 +48,7 @@ namespace {
 std::shared_ptr<const core::IExpr> parseExpr(ParsedExpression& expr);
 
 std::string normalizeFuncName(std::string input) {
-  static std::map<std::string, std::string> lookup{
+  static std::map<std::string, std::string> kLookup{
       {"+", "plus"},
       {"-", "minus"},
       {"*", "multiply"},
@@ -65,9 +65,11 @@ std::string normalizeFuncName(std::string input) {
       {"and", "and"},
       {"or", "or"},
       {"is", "is"},
+      {"~~", "like"},
+      {"like_escape", "like"},
   };
-  auto it = lookup.find(input);
-  return (it == lookup.end()) ? input : it->second;
+  auto it = kLookup.find(input);
+  return (it == kLookup.end()) ? input : it->second;
 }
 
 // Convert duckDB operator name to Velox function. Coalesce and subscript needs

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -255,3 +255,10 @@ TEST(DuckParserTest, alias) {
       parseExpr("cast(a AS DOUBLE) AS a_double")->toString());
   EXPECT_EQ("\"a\" AS b", parseExpr("a AS b")->toString());
 }
+
+TEST(DuckParserTest, like) {
+  EXPECT_EQ("like(\"name\",\"%b%\")", parseExpr("name LIKE '%b%'")->toString());
+  EXPECT_EQ(
+      "like(\"name\",\"%#_%\",\"#\")",
+      parseExpr("name LIKE '%#_%' ESCAPE '#'")->toString());
+}


### PR DESCRIPTION
Allow to use "name LIKE '%b%'" and "name LIKE '%#_%' ESCAPE '#'" syntax in test expressions.