### PR TITLE
Add unit test for grouped/bucketed execution.

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -211,8 +211,7 @@ BlockingReason PartitionedOutputBuffer::enqueue(
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK_LT(destination, buffers_.size());
     VELOX_CHECK(
-        task_->state() == kRunning,
-        "Task is terminated, cannot add data to output.");
+        task_->isRunning(), "Task is terminated, cannot add data to output.");
 
     totalSize_ += data->size();
     if (broadcast_) {
@@ -406,7 +405,7 @@ void PartitionedOutputBuffer::getData(
 
 void PartitionedOutputBuffer::terminate() {
   std::lock_guard<std::mutex> l(mutex_);
-  VELOX_CHECK(task_->state() != kRunning);
+  VELOX_CHECK(not task_->isRunning());
   for (auto& promise : promises_) {
     promise.setValue(true);
   }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -131,6 +131,12 @@ class Task : public std::enable_shared_from_this<Task> {
 
   bool isUngroupedExecution() const;
 
+  /// Returns true if state is 'running'.
+  bool isRunning() const;
+
+  /// Returns true if state is 'finished'.
+  bool isFinished() const;
+
   void createLocalMergeSources(
       uint32_t splitGroupId,
       unsigned numSources,
@@ -370,6 +376,12 @@ class Task : public std::enable_shared_from_this<Task> {
   }
 
  private:
+  /// Returns true if state is 'running'.
+  bool isRunningLocked() const;
+
+  /// Returns true if state is 'finished'.
+  bool isFinishedLocked() const;
+
   template <class TBridgeType>
   std::shared_ptr<TBridgeType> getJoinBridgeInternal(
       uint32_t splitGroupId,
@@ -507,7 +519,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// queued split groups.
   std::queue<uint32_t> queuedSplitGroups_;
 
-  TaskState state_ = kRunning;
+  TaskState state_ = TaskState::kRunning;
 
   /// Stores separate splits state for each plan node.
   std::unordered_map<core::PlanNodeId, SplitsState> splitsStates_;

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -185,7 +185,7 @@ class DriverTest : public OperatorTestBase {
         } else if (operation == ResultOperation::kCancel) {
           cursor->task()->requestTerminate();
         } else if (operation == ResultOperation::kTerminate) {
-          cursor->task()->terminate(kAborted);
+          cursor->task()->terminate(TaskState::kAborted);
         } else if (operation == ResultOperation::kYield) {
           cursor->task()->requestYield();
         } else if (operation == ResultOperation::kPause) {
@@ -334,7 +334,7 @@ TEST_F(DriverTest, error) {
   EXPECT_TRUE(stateFutures_.at(0).isReady());
   // Realized immediately since task not running.
   EXPECT_TRUE(tasks_[0]->stateChangeFuture(1'000'000).isReady());
-  EXPECT_EQ(tasks_[0]->state(), kFailed);
+  EXPECT_EQ(tasks_[0]->state(), TaskState::kFailed);
 }
 
 TEST_F(DriverTest, DISABLED_cancel) {
@@ -380,7 +380,7 @@ TEST_F(DriverTest, terminate) {
   }
   EXPECT_GE(numRead, 1'000'000);
   EXPECT_TRUE(stateFutures_.at(0).isReady());
-  EXPECT_EQ(tasks_[0]->state(), kAborted);
+  EXPECT_EQ(tasks_[0]->state(), TaskState::kAborted);
 }
 
 TEST_F(DriverTest, slow) {
@@ -435,7 +435,7 @@ TEST_F(DriverTest, pause) {
   auto& executor = folly::QueuedImmediateExecutor::instance();
   auto state = std::move(stateFuture).via(&executor);
   state.wait();
-  EXPECT_EQ(state.value(), TaskState::kFinished);
+  EXPECT_TRUE(tasks_[0]->isFinished());
   EXPECT_EQ(tasks_[0]->numRunningDrivers(), 0);
   const auto taskStats = tasks_[0]->taskStats();
   ASSERT_EQ(taskStats.pipelineStats.size(), 1);

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -280,11 +280,11 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   for (int destination = 0; destination < 3; destination++) {
     fetchEndMarker(taskId, destination, 2);
   }
-  EXPECT_EQ(task->state(), kRunning);
+  EXPECT_TRUE(task->isRunning());
   deleteResults(taskId, 3);
   fetchEndMarker(taskId, 4, 2);
 
-  EXPECT_EQ(task->state(), kFinished);
+  EXPECT_TRUE(task->isFinished());
 }
 
 TEST_F(PartitionedOutputBufferManagerTest, maxBytes) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1802,6 +1802,95 @@ TEST_P(TableScanTest, structInArrayOrMap) {
   assertQuery(op, {filePath}, "select c0, c0 from tmp");
 }
 
+// Here we test various aspects of grouped/bucketed execution.
+TEST_P(TableScanTest, groupedExecution) {
+  // Create source file - we will read from it in 6 splits.
+  const size_t numSplits{6};
+  auto vectors = makeVectors(10, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, vectors);
+
+  CursorParameters params;
+  params.planNode = tableScanNode(ROW({}, {}));
+  params.maxDrivers = 2;
+  params.concurrentSplitGroups = 2;
+  // We will have 10 split groups 'in total', but our task will only handle
+  // three of them: 1, 5 and 8.
+  // Split 0 is from split group 1.
+  // Splits 1 and 2 are from split group 5.
+  // Splits 3, 4 and 5 are from split group 8.
+  params.executionStrategy = core::ExecutionStrategy::kGrouped;
+  params.numSplitGroups = 10;
+  // We'll only run 3 split groups, 2 drivers each.
+  params.numResultDrivers = 3 * 2;
+
+  // Create the cursor with the task underneath. It is not started yet.
+  auto cursor = std::make_unique<TaskCursor>(params);
+  auto* pTask = cursor->task().get();
+
+  // Add one splits before start to ensure we can handle such cases.
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 8));
+
+  // Start task now.
+  cursor->start();
+
+  // Only one split group should be in the processing mode, so 2 drivers.
+  EXPECT_EQ(2, pTask->numRunningDrivers());
+
+  // Add the rest of splits
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 1));
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 5));
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 8));
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 5));
+  pTask->addSplit("0", makeHiveSplitWithGroup(filePath->path, 8));
+
+  // Only two split groups should be in the processing mode, so 4 drivers.
+  EXPECT_EQ(4, pTask->numRunningDrivers());
+
+  // Finalize one split group (8) and wait until 2 drivers are finished.
+  pTask->noMoreSplitsForGroup("0", 8);
+  while (pTask->numFinishedDrivers() != 2) {
+    /* sleep override */
+    usleep(100'000); // 0.1 second.
+  }
+  // As one split group is finished, another one should kick in, so 4 drivers.
+  EXPECT_EQ(4, pTask->numRunningDrivers());
+
+  // Finalize the second split group (5) and wait until 4 drivers are finished.
+  pTask->noMoreSplitsForGroup("0", 5);
+  while (pTask->numFinishedDrivers() != 4) {
+    /* sleep override */
+    usleep(100'000); // 0.1 second.
+  }
+  // As the second split group is finished, only one is left, so 2 drivers.
+  EXPECT_EQ(2, pTask->numRunningDrivers());
+
+  // Finalize the third split group (1) and wait until 6 drivers are finished.
+  pTask->noMoreSplitsForGroup("0", 1);
+  while (pTask->numFinishedDrivers() != 6) {
+    /* sleep override */
+    usleep(100'000); // 0.1 second.
+  }
+  // No split groups should be processed at the moment, so 0 drivers.
+  EXPECT_EQ(0, pTask->numRunningDrivers());
+
+  // Flag that we would have no more split groups.
+  pTask->noMoreSplits("0");
+
+  // Make sure we've got the right number of rows.
+  int32_t numRead = 0;
+  while (cursor->moveNext()) {
+    auto vector = cursor->current();
+    EXPECT_EQ(vector->childrenSize(), 0);
+    numRead += vector->size();
+  }
+
+  // Task must be finished at this stage.
+  EXPECT_EQ(TaskState::kFinished, pTask->state());
+
+  EXPECT_EQ(numRead, numSplits * 10'000);
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     TableScanTests,
     TableScanTest,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -180,6 +180,14 @@ exec::Split HiveConnectorTestBase::makeHiveSplit(
       length));
 }
 
+exec::Split HiveConnectorTestBase::makeHiveSplitWithGroup(
+    const std::string& filePath,
+    int32_t groupId) {
+  auto split = HiveConnectorTestBase::makeHiveSplit(filePath);
+  split.groupId = groupId;
+  return split;
+}
+
 std::shared_ptr<connector::hive::HiveColumnHandle>
 HiveConnectorTestBase::regularColumn(
     const std::string& name,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -97,6 +97,10 @@ class HiveConnectorTestBase : public OperatorTestBase {
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max());
 
+  static exec::Split makeHiveSplitWithGroup(
+      const std::string& filePath,
+      int32_t groupId);
+
   static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
       common::test::SubfieldFilters subfieldFilters,
       const std::shared_ptr<const core::ITypedExpr>& remainingFilter =


### PR DESCRIPTION
Summary:
Adding the unist test to test out-of-sync addition of splits and split groups, also for partial split groups and for adding splits before the Task start.
Added a new Task state (kNone) to reflect that we haven't started yet.
Updated exec task utils classes to be able to work with split groups.

Differential Revision: D34088826

