### PR TITLE
Fix DecodedVector for case of no values() )all null)

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -349,7 +349,8 @@ void DecodedVector::setBaseData(
     case VectorEncoding::Simple::LAZY:
       break;
     case VectorEncoding::Simple::FLAT: {
-      data_ = vector.values()->as<void>();
+      // values() may be nullptr if 'vector' is all nulls.
+      data_ = vector.values() ? vector.values()->as<void>() : nullptr;
       setFlatNulls(vector, rows);
       break;
     }

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -573,4 +573,23 @@ TEST_F(DecodedVectorTest, wrapOnConstantEncoding) {
   }
 }
 
+TEST_F(DecodedVectorTest, noValues) {
+  // Tests decoding a flat vector that consists of all nulls and has
+  // no values() buffer.
+  constexpr vector_size_t kSize = 100;
+  auto nulls = AlignedBuffer::allocate<uint64_t>(
+      bits::nwords(kSize), pool_.get(), bits::kNull64);
+  auto vector = std::make_shared<FlatVector<int32_t>>(
+      pool_.get(),
+      std::move(nulls),
+      kSize,
+      BufferPtr(nullptr),
+      std::vector<BufferPtr>{});
+  SelectivityVector rows(kSize);
+  DecodedVector decoded;
+  decoded.decode(*vector, rows);
+  EXPECT_EQ(nullptr, decoded.data<int32_t>());
+  EXPECT_TRUE(decoded.isNullAt(kSize - 1));
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
DecodedVector::decode crashes for flag vectors that have no values
buffer. This is a legitimate situation for a vector with all nulls.