### PR TITLE
Return ConstantVector column values with the right size

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -207,17 +207,18 @@ void EvalCtx::setErrors(
   rows.applyToSelected([&](auto row) { setError(row, exceptionPtr); });
 }
 
-VectorPtr EvalCtx::getField(int32_t index) const {
-  VectorPtr field;
+const VectorPtr& EvalCtx::getField(int32_t index) const {
+  const VectorPtr* field;
   if (!peeledFields_.empty()) {
-    field = peeledFields_[index];
+    field = &peeledFields_[index];
   } else {
-    field = row_->childAt(index);
+    field = &row_->childAt(index);
   }
-  if (field->isLazy() && field->asUnchecked<LazyVector>()->isLoaded()) {
-    return BaseVector::loadedVectorShared(field);
+  if ((*field)->isLazy() && (*field)->asUnchecked<LazyVector>()->isLoaded()) {
+    auto lazy = (*field)->asUnchecked<LazyVector>();
+    return lazy->loadedVectorShared();
   }
-  return field;
+  return *field;
 }
 
 BaseVector* EvalCtx::getRawField(int32_t index) const {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -44,7 +44,7 @@ class EvalCtx {
   // Returns the index-th column of the base row. If we have peeled off
   // wrappers like dictionaries, then this provides access only to the
   // peeled off fields.
-  VectorPtr getField(int32_t index) const;
+  const VectorPtr& getField(int32_t index) const;
 
   BaseVector* getRawField(int32_t index) const;
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1458,3 +1458,35 @@ TEST_F(VectorTest, clearNulls) {
   vector->clearNulls(selection);
   ASSERT_TRUE(vector->isNullAt(70));
 }
+
+TEST_F(VectorTest, setStringToNull) {
+  constexpr int32_t kSize = 100;
+  auto vectorMaker = std::make_unique<test::VectorMaker>(pool_.get());
+  auto target = vectorMaker->flatVector<StringView>(kSize, [](auto row) {
+    return StringView(fmt::format("Non-inlined string {}", row));
+  });
+  target->setNull(kSize - 1, true);
+  auto unknownNull = std::make_shared<ConstantVector<UnknownValue>>(
+      pool_.get(), kSize, true, UNKNOWN(), UnknownValue());
+
+  auto stringNull = BaseVector::wrapInConstant(kSize, kSize - 1, target);
+  SelectivityVector rows(kSize, false);
+  rows.setValid(2, true);
+  rows.updateBounds();
+  target->copy(unknownNull.get(), rows, nullptr);
+  EXPECT_TRUE(target->isNullAt(2));
+
+  rows.setValid(4, true);
+  rows.updateBounds();
+  target->copy(stringNull.get(), rows, nullptr);
+  EXPECT_TRUE(target->isNullAt(4));
+  auto nulls = AlignedBuffer::allocate<uint64_t>(
+      bits::nwords(kSize), pool_.get(), bits::kNull64);
+  auto flatNulls = std::make_shared<FlatVector<UnknownValue>>(
+      pool_.get(), nulls, kSize, BufferPtr(nullptr), std::vector<BufferPtr>());
+  rows.setValid(6, true);
+  rows.updateBounds();
+  target->copy(flatNulls.get(), rows, nullptr);
+  EXPECT_TRUE(target->isNullAt(6));
+  EXPECT_EQ(4, bits::countNulls(target->rawNulls(), 0, kSize));
+}


### PR DESCRIPTION
ConstantVector has a size that is set to what is appropriate for the
use context. The constant itself is dimensionless but the vector that
represents an instance of it has a dimension so as to be consistent
with other vectors.

When a column with a constant encoded value is projected out, the
constant is not wrapped in a dictionary but is just copied to a
constant of a different size. Then, when the constant is combined with
a dictionary wrapped column in an expression, the values of the
dictionary and the constant have a different size. This leads to
incorrect results and access of uninitialized, i.e. crash for strings,
when the constant is made writable (flattened) for the wrong number of
elements.

select count(if (c > x, ds, null)) from table where z + 1 > 2;

ds is a partitioning column, hence represented by a constant
vector. The other columns are flat. After the filter, c and x are
wrapped in a dictionary. ds is an unwrapped constant with the size
matching the count of passed rows from z + 1 > 2. The condition in if
is true for some and false for others. We get a constant vector of ds
which is then flattened and set to null for the rows where c > x was
false. This is done in the peeled domain, where vectors are at the
size they had before the filter. But ds is at the size after the
filter and we have therefore uninitialized positions at the end of
flattened ds, unless we return ds at the cardinality in the peeled
(pre-filter) domain.

To effect this change, we make FieldReference resize ConstantVectors
it returns. We do the resize in place for singly referenced and make a
copy otherwise. In order to distinguish singly referenced from
multiply referenced, we make EvalCtx::getField return const VectorPtr&
instead of VectorPtr. Like this the return does not affect reference
count and is also a little faster.

We fix assignment of all-null data to string vectors. The all-null
source vector could be of unknown type and hence would not have string
buffers.