### PR TITLE
Support 'Generic' types in simple functions e2e.

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -103,8 +103,8 @@ struct resolver<Variadic<T>> {
   // Variadic cannot be used as an out_type
 };
 
-template <>
-struct resolver<Generic> {
+template <typename T>
+struct resolver<Generic<T>> {
   using in_type = GenericView;
   using out_type = void; // Not supported as output type yet.
 };
@@ -716,7 +716,6 @@ struct VectorWriter<Row<T...>> {
 
 template <typename T>
 struct VectorReader<Variadic<T>> {
-  using in_vector_t = typename TypeToFlatVector<T>::type;
   using exec_in_t = typename VectorExec::resolver<Variadic<T>>::in_type;
   using exec_null_free_in_t =
       typename VectorExec::template resolver<Variadic<T>>::null_free_in_type;
@@ -1089,17 +1088,17 @@ struct VectorWriter<std::shared_ptr<T>> {
   size_t offset_ = 0;
 };
 
-template <>
-struct VectorReader<Generic> {
+template <typename T>
+struct VectorReader<Generic<T>> {
   using exec_in_t = GenericView;
   using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded)
       : decoded_(*decoded), base_(decoded->base()) {}
 
-  explicit VectorReader(const VectorReader<Generic>&) = delete;
+  explicit VectorReader(const VectorReader<Generic<T>>&) = delete;
 
-  VectorReader<Generic>& operator=(const VectorReader<Generic>&) = delete;
+  VectorReader<Generic<T>>& operator=(const VectorReader<Generic<T>>&) = delete;
 
   bool isSet(size_t offset) const {
     return !decoded_.isNullAt(offset);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <folly/Format.h>
 #include <folly/Range.h>
@@ -22,13 +23,16 @@
 #include <folly/json.h>
 #include <time.h>
 #include <cstdint>
+#include <cstring>
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <typeindex>
 #include <vector>
+
 #include "folly/CPortability.h"
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
@@ -463,6 +467,7 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
   VELOX_FLUENT_CAST(Map, MAP)
   VELOX_FLUENT_CAST(Row, ROW)
   VELOX_FLUENT_CAST(Opaque, OPAQUE)
+  VELOX_FLUENT_CAST(UnKnown, UNKNOWN)
 
   bool containsUnknown() const;
 
@@ -1266,6 +1271,26 @@ struct Variadic {
 };
 
 // A type that can be used in simple function to represent any type.
+// Two Generics with the same type variables should bound to the same type.
+template <size_t id>
+struct TypeVariable {
+  static size_t getId() {
+    return id;
+  }
+};
+
+using T1 = TypeVariable<1>;
+using T2 = TypeVariable<2>;
+using T3 = TypeVariable<3>;
+using T4 = TypeVariable<4>;
+using T5 = TypeVariable<5>;
+using T6 = TypeVariable<6>;
+using T7 = TypeVariable<7>;
+using T8 = TypeVariable<8>;
+
+struct AnyType {};
+
+template <typename T = AnyType>
 struct Generic {
   Generic() = delete;
 };


### PR DESCRIPTION
Summary:
This diff adds the e2e support for Generic types in the simple
function interface.
After this diff, someone for example can write a function
that hashes all the inputs as the following:
```
// Add hash(arg1) + hash(arg2) + hash(arg3)... etc.
template <typename T>
struct HashAllArgs {
 VELOX_DEFINE_FUNCTION_TYPES(T);

 FOLLY_ALWAYS_INLINE bool call(int64_t& out, const arg_type<Variadic<Generic<AnyType>>>& args) {
 out = 0;
 for (auto arg : args) {
 out += arg.value().hash();
 }
 return true;
 }
};
```

**Notes:**
- Generic is now templated on TypeVariable
i.e.
```
Generic<T1>
Generic<T2>
...
```
- Two generics with the same type variable should be bound to the same type.
(see unit test for examples).

- ``Generic<AnyType>`` can be used to define a type that can be bound to any type. ``Generic<>`` is an alias to that also.

**Next:**
- Next we want to introduce a more precise function
resolution that ranks signatures based on how general they
are and pick the less general.
- Add more functionality to GenericView, such as cast to otherView types (asArrayView, asMapView ...etc) and
access to the type.

Reviewed By: kevinwilfong

Differential Revision: D33962703

