### PR TITLE
Fix bug when reapplying peeled dictionary encoding when nulls have been removed

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2570,3 +2570,72 @@ TEST_F(ExprTest, constantToString) {
       "4 elements starting at 0 {1.2000000476837158, 3.4000000953674316, null, 5.599999904632568}:ARRAY<REAL>",
       exprSet.exprs()[2]->toString());
 }
+
+namespace {
+// A naive function that wraps the input in a dictionary vector resized to
+// rows.end() - 1.  It assumes all selected values are non-null.
+class TestingShrinkingDictionary : public exec::VectorFunction {
+ public:
+  bool isDefaultNullBehavior() const override {
+    return true;
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(rows.end(), context->pool());
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    rows.applyToSelected([&](int row) { rawIndices[row] = row; });
+
+    *result =
+        BaseVector::wrapInDictionary(nullptr, indices, rows.end() - 1, args[0]);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("bigint")
+                .argumentType("bigint")
+                .build()};
+  }
+};
+} // namespace
+
+TEST_F(ExprTest, specialFormPropagateNulls) {
+  exec::registerVectorFunction(
+      "test_shrinking_dictionary",
+      TestingShrinkingDictionary::signatures(),
+      std::make_unique<TestingShrinkingDictionary>());
+
+  // This test verifies an edge case where applyFunctionWithPeeling may produce
+  // a result vector which is dictionary encoded and has fewer values than
+  // are rows.
+  // This can happen when the last value in a column used in an expression is
+  // null which causes removeSureNulls to move the end of the SelectivityVector
+  // forward.  When we incorrectly use rows.end() as the size of the
+  // dictionary when rewrapping the results.
+  // Normally this is masked when this vector is used in a function call which
+  // produces a new output vector.  However, in SpecialForm expressions, we may
+  // return the output untouched, and when we try to add back in the nulls, we
+  // get an exception trying to resize the DictionaryVector.
+  // This is difficult to reproduce, so this test artificially triggers the
+  // issue by using a UDF that returns a dictionary one smaller than rows.end().
+
+  // Making the last row NULL, so we call addNulls in eval.
+  auto c0 = makeFlatVector<int64_t>(
+      5,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row == 4; });
+
+  auto rowVector = makeRowVector({c0});
+  auto evalResult = evaluate("test_shrinking_dictionary(\"c0\")", rowVector);
+
+  auto expectedResult = makeFlatVector<int64_t>(
+      5,
+      [](vector_size_t row) { return row; },
+      [](vector_size_t row) { return row == 4; });
+  assertEqualVectors(expectedResult, evalResult);
+}

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -345,13 +345,13 @@ VectorPtr BaseVector::create(
 }
 
 void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
-  VELOX_CHECK(mayAddNulls());
+  VELOX_CHECK(isNullsWritable());
   VELOX_CHECK(length_ >= rows.end());
   ensureNulls();
   auto target = nulls_->asMutable<uint64_t>();
   const uint64_t* selected = rows.asRange().bits();
   if (!bits) {
-    // A A 1 in rows makes a 0 in nulls.
+    // A 1 in rows makes a 0 in nulls.
     bits::andWithNegatedBits(target, selected, rows.begin(), rows.end());
     return;
   }
@@ -368,7 +368,7 @@ void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
 }
 
 void BaseVector::clearNulls(const SelectivityVector& rows) {
-  VELOX_CHECK(mayAddNulls());
+  VELOX_CHECK(isNullsWritable());
   if (!nulls_) {
     return;
   }
@@ -390,7 +390,7 @@ void BaseVector::clearNulls(const SelectivityVector& rows) {
 }
 
 void BaseVector::clearNulls(vector_size_t begin, vector_size_t end) {
-  VELOX_CHECK(mayAddNulls());
+  VELOX_CHECK(isNullsWritable());
   if (!nulls_) {
     return;
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -187,16 +187,26 @@ class BaseVector {
   }
 
   virtual BufferPtr mutableNulls(vector_size_t size) {
+    ensureNullsCapacity(size);
+    return nulls_;
+  }
+
+  /*
+   * Allocates or reallocates nulls_ with the given size if nulls_ hasn't
+   * been allocated yet or has been allocated with a smaller capacity.
+   */
+  void ensureNullsCapacity(vector_size_t size, bool setNotNull = false) {
     if (nulls_ && nulls_->capacity() >= bits::nbytes(size)) {
-      return nulls_;
+      return;
     }
     if (nulls_) {
-      AlignedBuffer::reallocate<bool>(&nulls_, size, false);
+      AlignedBuffer::reallocate<bool>(
+          &nulls_, size, setNotNull ? bits::kNotNull : bits::kNull);
     } else {
-      nulls_ = AlignedBuffer::allocate<bool>(size, pool_, false);
+      nulls_ = AlignedBuffer::allocate<bool>(
+          size, pool_, setNotNull ? bits::kNotNull : bits::kNull);
     }
     rawNulls_ = nulls_->as<uint64_t>();
-    return nulls_;
   }
 
   std::optional<vector_size_t> getDistinctValueCount() const {
@@ -342,7 +352,7 @@ class BaseVector {
     return countNulls(nulls, 0, size);
   }
 
-  virtual bool mayAddNulls() const {
+  virtual bool isNullsWritable() const {
     return true;
   }
 

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -159,7 +159,7 @@ class BiasVector : public SimpleVector<T> {
     return true;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -186,7 +186,7 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_->wrappedIndex(rawIndices_[index]);
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -290,7 +290,7 @@ class FlatVector final : public SimpleVector<T> {
     return size;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -164,7 +164,7 @@ class SimpleVector : public BaseVector {
     return elementSize_;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return false;
   }
 


### PR DESCRIPTION
Summary:
When we call setDictionaryWrap to peel dictionary encoding, and then setWrapped to
reapply the dictionary encoding the size of the DictionaryVector can change.  This is
because we do not use the original vector size, but rather rows.end() for the size of the new
unpeeled vector.

This causes problems when nulls are removed, as when we call addNulls, the
DictionaryVector may be smaller than the number of rows when there were nulls at the end
of the batch.  In this case, addNulls attempts to resize the DictionaryVector which is not
supported.

To fix this, I add logic to store the original size of the vector and use that when recreating
the DictionaryVector as I don't see any reason why peeling should change the size of a
vector (I'm not super familiar with this code so let me know if I missed anything).

Another approach I tried was to use rows.size() instead of rows.end() but this can break in
the case where setDictionaryWrapping was called and we entered the else block and
decoded.indices() is smaller than rows.size() (in which case the number of indices is less
than the size of the dictionary we're trying to create).

Differential Revision: D34176042

