### PR TITLE
Extend lifetime of MappedMemory instance to lifetime of the Task

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -95,9 +95,7 @@ class LocalMergeSource : public MergeSource {
         const std::shared_ptr<const RowType>& rowType,
         memory::MappedMemory* mappedMemory,
         int queueSize)
-        : rowType_(rowType),
-          mappedMemory_(mappedMemory->sharedPtr()),
-          data_(queueSize) {
+        : rowType_(rowType), mappedMemory_(mappedMemory), data_(queueSize) {
       VELOX_CHECK(mappedMemory_);
     }
 
@@ -134,7 +132,7 @@ class LocalMergeSource : public MergeSource {
         return BlockingReason::kNotBlocked;
       }
       VELOX_CHECK(!data_.full(), "LocalMergeSourceQueue is full");
-      data_.push_back(MergeSourceData(rowType_, mappedMemory_.get(), input));
+      data_.push_back(MergeSourceData(rowType_, mappedMemory_, input));
       notifyConsumers();
 
       if (data_.full()) {
@@ -147,10 +145,7 @@ class LocalMergeSource : public MergeSource {
 
    private:
     const std::shared_ptr<const RowType> rowType_;
-    // Since LocalMergeSource's lifetime is same as Tasks, keep mappedMemory's
-    // shared pointer to prevent prematurely when the LocalMerge operator is
-    // destroyed.
-    std::shared_ptr<memory::MappedMemory> mappedMemory_;
+    memory::MappedMemory* mappedMemory_;
 
     bool atEnd_ = false;
     boost::circular_buffer<MergeSourceData> data_;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -64,10 +64,10 @@ std::optional<uint32_t> Operator::maxDrivers(
 
 memory::MappedMemory* OperatorCtx::mappedMemory() const {
   if (!mappedMemory_) {
-    auto parent = driverCtx_->task->queryCtx()->mappedMemory();
-    mappedMemory_ = parent->addChild(pool_->getMemoryUsageTracker());
+    mappedMemory_ =
+        driverCtx_->task->addOperatorMemory(pool_->getMemoryUsageTracker());
   }
-  return mappedMemory_.get();
+  return mappedMemory_;
 }
 
 const std::string& OperatorCtx::taskId() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -185,7 +185,7 @@ class OperatorCtx {
   velox::memory::MemoryPool* pool_;
 
   // These members are created on demand.
-  mutable std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  mutable memory::MappedMemory* mappedMemory_{nullptr};
 };
 
 // Query operator

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -104,10 +104,10 @@ void PartitionedOutput::initializeInput(RowVectorPtr input) {
 
 void PartitionedOutput::initializeDestinations() {
   if (destinations_.empty()) {
-    auto memory = operatorCtx_->mappedMemory();
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
-      destinations_.push_back(std::make_unique<Destination>(taskId, i, memory));
+      destinations_.push_back(
+          std::make_unique<Destination>(taskId, i, mappedMemory_));
     }
   }
 }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -126,6 +126,13 @@ Task::addOperatorPool(velox::memory::MemoryPool* FOLLY_NONNULL driverPool) {
   return childPools_.back().get();
 }
 
+memory::MappedMemory* FOLLY_NONNULL Task::addOperatorMemory(
+    const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
+  auto mappedMemory = queryCtx_->mappedMemory()->addChild(tracker);
+  childMappedMemories_.emplace_back(mappedMemory);
+  return mappedMemory.get();
+}
+
 void Task::start(
     std::shared_ptr<Task> self,
     uint32_t maxDrivers,

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -56,10 +56,19 @@ class Task : public std::enable_shared_from_this<Task> {
     return taskId_;
   }
 
-  velox::memory::MemoryPool* FOLLY_NONNULL addDriverPool();
+  memory::MemoryPool* FOLLY_NONNULL addDriverPool();
 
-  velox::memory::MemoryPool* FOLLY_NONNULL
-  addOperatorPool(velox::memory::MemoryPool* FOLLY_NONNULL driverPool);
+  /// Creates new instance of MemoryPool, stores it in the task to ensure
+  /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
+  /// from the Operator's constructor.
+  memory::MemoryPool* FOLLY_NONNULL
+  addOperatorPool(memory::MemoryPool* FOLLY_NONNULL driverPool);
+
+  /// Creates new instance of MappedMemory, stores it in the task to ensure
+  /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
+  /// from the Operator's constructor.
+  memory::MappedMemory* FOLLY_NONNULL
+  addOperatorMemory(const std::shared_ptr<memory::MemoryUsageTracker>& tracker);
 
   static void start(
       std::shared_ptr<Task> self,
@@ -301,7 +310,7 @@ class Task : public std::enable_shared_from_this<Task> {
     return numFinishedDrivers_;
   }
 
-  velox::memory::MemoryPool* FOLLY_NONNULL pool() const {
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
     return pool_.get();
   }
 
@@ -530,11 +539,15 @@ class Task : public std::enable_shared_from_this<Task> {
   std::vector<VeloxPromise<bool>> stateChangePromises_;
 
   TaskStats taskStats_;
-  std::unique_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<memory::MemoryPool> pool_;
 
   // Keep driver and operator memory pools alive for the duration of the task to
   // allow for sharing vectors across drivers without copy.
-  std::vector<std::unique_ptr<velox::memory::MemoryPool>> childPools_;
+  std::vector<std::unique_ptr<memory::MemoryPool>> childPools_;
+
+  // Keep operator MappedMemory instances alive for the duration of the task to
+  // allow for sharing data without copy.
+  std::vector<std::shared_ptr<memory::MappedMemory>> childMappedMemories_;
 
   /// Stores inter-operator state (exchange, bridges) per split group.
   /// During ungrouped execution we use the [0] entry in this vector.


### PR DESCRIPTION
Earlier change extended lifetime of MemoryPool instances used in operators to
the lifetime of the Task to allow for sharing data between drivers without a
copy. This change extends lifetime of MappedMemory instances in the same way.

Included in this change:
- Remove MappedMemory::sharedPtr method.
- Remove shared_ptr<MappedMemory> from Allocation.