### PR TITLE
Add S3 Read Benchmark

### DIFF
--- a/velox/common/file/benchmark/CMakeLists.txt
+++ b/velox/common/file/benchmark/CMakeLists.txt
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_read_benchmark ReadBenchmark.cpp ReadBenchmarkMain.cpp)
+add_library(velox_read_benchmark_lib ReadBenchmark.cpp)
 
-target_link_libraries(velox_read_benchmark velox_file velox_exception
-                      velox_exec_test_util ${FMT} ${FOLLY_WITH_DEPENDENCIES})
+add_executable(velox_read_benchmark ReadBenchmarkMain.cpp)
+
+target_link_libraries(
+  velox_read_benchmark
+  velox_read_benchmark_lib
+  velox_file
+  velox_exception
+  velox_exec_test_util
+  ${FMT}
+  ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/common/file/benchmark/ReadBenchmark.cpp
+++ b/velox/common/file/benchmark/ReadBenchmark.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/common/file/benchmark/ReadBenchmark.h"
 
-DEFINE_string(path, "unspecified", "Path of test file");
+DEFINE_string(path, "", "Path of test file");
 DEFINE_int64(
     file_size_gb,
     0,
@@ -42,6 +42,12 @@ DEFINE_int32(
     100 << 20,
     "Total reads per thread when throughput for a --bytes/--gap/--/gap/"
     "--num_in_run combination");
+
+static bool IsNonEmpty(const char* flagname, const std::string& value) {
+  return !value.empty();
+}
+
+DEFINE_validator(path, &IsNonEmpty);
 
 namespace facebook::velox {
 

--- a/velox/common/file/benchmark/ReadBenchmark.cpp
+++ b/velox/common/file/benchmark/ReadBenchmark.cpp
@@ -43,11 +43,13 @@ DEFINE_int32(
     "Total reads per thread when throughput for a --bytes/--gap/--/gap/"
     "--num_in_run combination");
 
-static bool IsNonEmpty(const char* flagname, const std::string& value) {
+namespace {
+static bool notEmpty(const char* /*flagName*/, const std::string& value) {
   return !value.empty();
 }
+} // namespace
 
-DEFINE_validator(path, &IsNonEmpty);
+DEFINE_validator(path, &notEmpty);
 
 namespace facebook::velox {
 

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -58,8 +58,6 @@ struct Scratch {
 
 class ReadBenchmark {
  public:
-  ReadBenchmark() {}
-
   virtual void initialize() {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -58,9 +58,9 @@ struct Scratch {
 
 class ReadBenchmark {
  public:
-  ReadBenchmark(bool initialize = true) {
-    if (!initialize)
-      return;
+  ReadBenchmark() {}
+
+  virtual void initialize() {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
     if (FLAGS_odirect) {

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -56,8 +56,11 @@ struct Scratch {
   std::string bufferCopy;
 };
 
+// This class implements functions that aid in measuring the throughput of a
+// FileSystem for various ReadFile APIs.
 class ReadBenchmark {
  public:
+  // Initialize a LocalReadFile instance for the specified 'path'.
   virtual void initialize() {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
@@ -126,6 +129,7 @@ class ReadBenchmark {
     return *scratch;
   }
 
+  // Measures the throughput for various ReadFile APIs(modes).
   void randomReads(
       int32_t size,
       int32_t gap,

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -58,7 +58,9 @@ struct Scratch {
 
 class ReadBenchmark {
  public:
-  ReadBenchmark() {
+  ReadBenchmark(bool initialize = true) {
+    if (!initialize)
+      return;
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
     if (FLAGS_odirect) {
@@ -287,7 +289,7 @@ class ReadBenchmark {
 
   void run();
 
- private:
+ protected:
   static constexpr int64_t kRegionSize = 64 << 20; // 64MB
   static constexpr int32_t kWrite = -10000;
   // 0 means no op, kWrite means being written, other numbers are reader counts.

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -56,6 +56,11 @@ struct Scratch {
   std::string bufferCopy;
 };
 
+// This benchmark measures the throughput of a Linux compatible FileSystem for
+// various ReadFile APIs. The output helps us understand the maximum possible
+// gains for queries. Example: If a single thread requires reading 1GB of data
+// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
+// data.
 class ReadBenchmark {
  public:
   virtual void initialize() {

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -60,6 +60,8 @@ struct Scratch {
 // FileSystem for various ReadFile APIs.
 class ReadBenchmark {
  public:
+  virtual ~ReadBenchmark() = default;
+
   // Initialize a LocalReadFile instance for the specified 'path'.
   virtual void initialize() {
     executor_ =

--- a/velox/common/file/benchmark/ReadBenchmark.h
+++ b/velox/common/file/benchmark/ReadBenchmark.h
@@ -56,11 +56,6 @@ struct Scratch {
   std::string bufferCopy;
 };
 
-// This benchmark measures the throughput of a Linux compatible FileSystem for
-// various ReadFile APIs. The output helps us understand the maximum possible
-// gains for queries. Example: If a single thread requires reading 1GB of data
-// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
-// data.
 class ReadBenchmark {
  public:
   virtual void initialize() {

--- a/velox/common/file/benchmark/ReadBenchmarkMain.cpp
+++ b/velox/common/file/benchmark/ReadBenchmarkMain.cpp
@@ -18,6 +18,11 @@
 
 using namespace facebook::velox;
 
+// This benchmark measures the throughput of a Linux compatible FileSystem for
+// various ReadFile APIs. The output helps us understand the maximum possible
+// gains for queries. Example: If a single thread requires reading 1GB of data
+// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
+// data.
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   ReadBenchmark bm;

--- a/velox/common/file/benchmark/ReadBenchmarkMain.cpp
+++ b/velox/common/file/benchmark/ReadBenchmarkMain.cpp
@@ -21,5 +21,6 @@ using namespace facebook::velox;
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   ReadBenchmark bm;
+  bm.initialize();
   bm.run();
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -223,7 +223,7 @@ class S3Config {
   }
 
  private:
-  const Config* config_;
+  const Config* FOLLY_NONNULL config_;
 };
 
 class S3FileSystem::Impl {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -378,7 +378,13 @@ static std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
       // Initialize on first access and reuse after that.
       static std::shared_ptr<FileSystem> s3fs;
       folly::call_once(S3FSInstantiationFlag, [&properties]() {
-        auto fs = std::make_shared<S3FileSystem>(properties);
+        std::shared_ptr<S3FileSystem> fs;
+        if (properties != nullptr) {
+          fs = std::make_shared<S3FileSystem>(properties);
+        } else {
+          fs = std::make_shared<S3FileSystem>(
+              std::make_shared<core::MemConfig>());
+        }
         fs->initializeClient();
         s3fs = fs;
       });

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -26,8 +26,7 @@ namespace facebook::velox::filesystems {
 // (register|generate)ReadFile and (register|generate)WriteFile functions.
 class S3FileSystem : public FileSystem {
  public:
-  S3FileSystem(std::shared_ptr<const Config> config);
-  ~S3FileSystem() {}
+  explicit S3FileSystem(std::shared_ptr<const Config> config);
 
   // Initialize the Aws::S3::S3Client from the input Config parameters.
   void initializeClient();

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -15,5 +15,11 @@
 add_executable(velox_s3read_benchmark S3ReadBenchmark.cpp
                                       S3ReadBenchmarkMain.cpp)
 
-target_link_libraries(velox_s3read_benchmark velox_s3fs velox_exception
-                      velox_exec_test_util ${FMT} ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(
+  velox_s3read_benchmark
+  velox_read_benchmark_lib
+  velox_s3fs
+  velox_exception
+  velox_exec_test_util
+  ${FMT}
+  ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# for generated headers
+add_executable(velox_s3read_benchmark S3ReadBenchmark.cpp
+                                      S3ReadBenchmarkMain.cpp)
 
-add_library(velox_s3fs S3FileSystem.cpp S3Util.cpp)
-target_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
-target_link_libraries(velox_s3fs ${AWSSDK_LIBRARIES})
-
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-  add_subdirectory(benchmark)
-endif()
+target_link_libraries(velox_s3read_benchmark velox_s3fs velox_exception
+                      velox_exec_test_util ${FMT} ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h"
+
+DEFINE_string(path, "", "Path of test file");
+DEFINE_int64(
+    file_size_gb,
+    0,
+    "Limits the test to the first --file_size_gb "
+    "of --path. 0 means use the whole file");
+DEFINE_int32(num_threads, 16, "Test paralelism");
+DEFINE_int32(seed, 0, "Random seed, 0 means no seed");
+
+DEFINE_int32(
+    bytes,
+    0,
+    "If 0, runs through a set of predefined read patterns. "
+    "If non-0, this is the size of a single read. The reads are "
+    "made in --num_in_run consecutive batches with --gap bytes between each read");
+DEFINE_int32(gap, 0, "Gap between consecutive reads if --bytes is non-0");
+DEFINE_int32(
+    num_in_run,
+    10,
+    "Number of consecutive reads of --bytes separated by --gap bytes");
+DEFINE_int32(
+    measurement_size,
+    100 << 20,
+    "Total reads per thread when throughput for a --bytes/--gap/--/gap/"
+    "--num_in_run combination");
+
+static bool IsNonEmpty(const char* flagname, const std::string& value) {
+  return !value.empty();
+}
+DEFINE_validator(path, &IsNonEmpty);
+
+namespace facebook::velox {
+
+void S3ReadBenchmark::run() {
+  if (FLAGS_bytes) {
+    modes(FLAGS_bytes, FLAGS_gap, FLAGS_num_in_run);
+    return;
+  }
+  modes(1100, 0, 10);
+  modes(1100, 1200, 10);
+  modes(16 * 1024, 0, 10);
+  modes(16 * 1024, 10000, 10);
+  modes(1000000, 0, 8);
+  modes(1000000, 100000, 8);
+}
+} // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
@@ -47,16 +47,4 @@ std::shared_ptr<Config> readConfig(const std::string& filePath) {
   return std::make_shared<facebook::velox::core::MemConfig>(properties);
 }
 
-void S3ReadBenchmark::run() {
-  if (FLAGS_bytes) {
-    modes(FLAGS_bytes, FLAGS_gap, FLAGS_num_in_run);
-    return;
-  }
-  modes(1100, 0, 10);
-  modes(1100, 1200, 10);
-  modes(16 * 1024, 0, 10);
-  modes(16 * 1024, 10000, 10);
-  modes(1000000, 0, 8);
-  modes(1000000, 100000, 8);
-}
 } // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.cpp
@@ -19,37 +19,7 @@
 
 #include <fstream>
 
-DEFINE_string(path, "", "Path of test file");
 DEFINE_string(s3_config, "", "Path of S3 config file");
-DEFINE_int64(
-    file_size_gb,
-    0,
-    "Limits the test to the first --file_size_gb "
-    "of --path. 0 means use the whole file");
-DEFINE_int32(num_threads, 16, "Test paralelism");
-DEFINE_int32(seed, 0, "Random seed, 0 means no seed");
-
-DEFINE_int32(
-    bytes,
-    0,
-    "If 0, runs through a set of predefined read patterns. "
-    "If non-0, this is the size of a single read. The reads are "
-    "made in --num_in_run consecutive batches with --gap bytes between each read");
-DEFINE_int32(gap, 0, "Gap between consecutive reads if --bytes is non-0");
-DEFINE_int32(
-    num_in_run,
-    10,
-    "Number of consecutive reads of --bytes separated by --gap bytes");
-DEFINE_int32(
-    measurement_size,
-    100 << 20,
-    "Total reads per thread when throughput for a --bytes/--gap/--/gap/"
-    "--num_in_run combination");
-
-static bool IsNonEmpty(const char* flagname, const std::string& value) {
-  return !value.empty();
-}
-DEFINE_validator(path, &IsNonEmpty);
 
 namespace facebook::velox {
 

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <folly/Random.h>
+#include <folly/Synchronized.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/QueuedImmediateExecutor.h>
+#include <folly/futures/Future.h>
+#include <folly/init/Init.h>
+#include <folly/portability/SysUio.h>
+#include <gflags/gflags.h>
+
+#include "velox/common/file/File.h"
+#include "velox/common/time/Timer.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+
+DECLARE_string(path);
+DECLARE_int64(file_size_gb);
+DECLARE_int32(num_threads);
+DECLARE_int32(seed);
+DECLARE_int32(bytes);
+DECLARE_int32(gap);
+DECLARE_int32(num_in_run);
+
+DECLARE_int32(measurement_size);
+
+namespace facebook::velox {
+
+enum class Mode { Pread = 0, Preadv = 1, Multiple = 2 };
+
+// Struct to read data into. If we read contiguous and then copy to
+// non-contiguous buffers, we read to 'buffer' and copy to
+// 'bufferCopy'.
+struct Scratch {
+  std::string buffer;
+  std::string bufferCopy;
+};
+
+class S3ReadBenchmark {
+ public:
+  S3ReadBenchmark() {
+    executor_ =
+        std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
+
+    filesystems::registerS3FileSystem();
+    auto s3fs = filesystems::getFileSystem(FLAGS_path, nullptr);
+    readFile_ = s3fs->openFileForRead(FLAGS_path);
+
+    fileSize_ = readFile_->size();
+    if (FLAGS_file_size_gb) {
+      fileSize_ = std::min<uint64_t>(FLAGS_file_size_gb << 30, fileSize_);
+    }
+
+    if (fileSize_ <= FLAGS_measurement_size) {
+      LOG(ERROR) << "File size " << fileSize_
+                 << " is <= then --measurement_size " << FLAGS_measurement_size;
+      exit(1);
+    }
+    if (FLAGS_seed) {
+      rng_.seed(FLAGS_seed);
+    }
+  }
+
+  void clearCache() {
+#ifdef linux
+    // system("echo 3 >/proc/sys/vm/drop_caches");
+    bool success = false;
+    auto fd = open("/proc//sys/vm/drop_caches", O_WRONLY);
+    if (fd > 0) {
+      success = write(fd, "3", 1) == 1;
+      close(fd);
+    }
+    if (!success) {
+      LOG(ERROR) << "Failed to clear OS disk cache: errno=" << errno;
+    }
+#endif
+  }
+
+  Scratch& getScratch(int32_t size) {
+    auto scratch = scratch_.withWLock([&](auto& table) {
+      auto& ptr = table[std::this_thread::get_id()];
+      if (!ptr) {
+        ptr = std::make_unique<Scratch>();
+      }
+      ptr->buffer.resize(size);
+      ptr->bufferCopy.resize(size);
+      return ptr.get();
+    });
+    return *scratch;
+  }
+
+  void randomReads(
+      int32_t size,
+      int32_t gap,
+      int32_t count,
+      int32_t repeats,
+      Mode mode,
+      bool parallel) {
+    clearCache();
+    std::vector<folly::Promise<bool>> promises;
+    std::vector<folly::SemiFuture<bool>> futures;
+    uint64_t usec = 0;
+    std::string label;
+    {
+      MicrosecondTimer timer(&usec);
+      int32_t rangeSize = size * count + gap * (count - 1);
+      auto& globalScratch = getScratch(rangeSize);
+      globalScratch.buffer.resize(rangeSize);
+      globalScratch.bufferCopy.resize(rangeSize);
+      for (auto repeat = 0; repeat < repeats; ++repeat) {
+        std::unique_ptr<folly::Promise<bool>> promise;
+        if (parallel) {
+          auto [tempPromise, future] = folly::makePromiseContract<bool>();
+          promise = std::make_unique<folly::Promise<bool>>();
+          *promise = std::move(tempPromise);
+          futures.push_back(std::move(future));
+        }
+        int64_t offset = folly::Random::rand64(rng_) % (fileSize_ - rangeSize);
+        switch (mode) {
+          case Mode::Pread:
+            label = "1 pread";
+            if (parallel) {
+              executor_->add([offset,
+                              gap,
+                              size,
+                              count,
+                              rangeSize,
+                              this,
+                              capturedPromise = std::move(promise)]() {
+                auto& scratch = getScratch(rangeSize);
+                readFile_->pread(offset, rangeSize, scratch.buffer.data());
+                for (auto i = 0; i < count; ++i) {
+                  memcpy(
+                      scratch.bufferCopy.data() + i * size,
+                      scratch.buffer.data() + i * (size + gap),
+                      size);
+                }
+                capturedPromise->setValue(true);
+              }
+
+              );
+            } else {
+              readFile_->pread(offset, rangeSize, globalScratch.buffer.data());
+              for (auto i = 0; i < count; ++i) {
+                memcpy(
+                    globalScratch.bufferCopy.data() + i * size,
+                    globalScratch.buffer.data() + i * (size + gap),
+                    size);
+              }
+            }
+            break;
+          case Mode::Preadv: {
+            label = "1 preadv";
+            if (parallel) {
+              executor_->add([offset,
+                              gap,
+                              size,
+                              rangeSize,
+                              this,
+                              capturedPromise = std::move(promise)]() {
+                auto& scratch = getScratch(rangeSize);
+                std::vector<folly::Range<char*>> ranges;
+                for (auto start = 0; start < rangeSize; start += size + gap) {
+                  ranges.push_back(
+                      folly::Range<char*>(scratch.buffer.data() + start, size));
+                  if (gap && start + gap < rangeSize) {
+                    ranges.push_back(folly::Range<char*>(nullptr, gap));
+                  }
+                }
+                readFile_->preadv(offset, ranges);
+                capturedPromise->setValue(true);
+              });
+            } else {
+              std::vector<folly::Range<char*>> ranges;
+              for (auto start = 0; start < rangeSize; start += size + gap) {
+                ranges.push_back(folly::Range<char*>(
+                    globalScratch.buffer.data() + start, size));
+                if (gap && start + gap < rangeSize) {
+                  ranges.push_back(folly::Range<char*>(nullptr, gap));
+                }
+              }
+              readFile_->preadv(offset, ranges);
+            }
+            break;
+          }
+          case Mode::Multiple: {
+            label = "multiple pread";
+            if (parallel) {
+              executor_->add([offset,
+                              gap,
+                              size,
+                              count,
+                              rangeSize,
+                              this,
+                              capturedPromise = std::move(promise)]() {
+                auto& scratch = getScratch(rangeSize);
+                for (auto counter = 0; counter < count; ++counter) {
+                  readFile_->pread(
+                      offset + counter * (size + gap),
+                      size,
+                      scratch.buffer.data() + counter * size);
+                }
+                capturedPromise->setValue(true);
+              });
+            } else {
+              for (auto counter = 0; counter < count; ++counter) {
+                readFile_->pread(
+                    offset + counter * (size + gap),
+                    size,
+                    globalScratch.buffer.data() + counter * size);
+              }
+            }
+            break;
+          }
+        }
+      }
+      if (parallel) {
+        auto& exec = folly::QueuedImmediateExecutor::instance();
+        for (int32_t i = futures.size() - 1; i >= 0; --i) {
+          std::move(futures[i]).via(&exec).wait();
+        }
+      }
+    }
+    std::cout << fmt::format(
+                     "{} MB/s {} {}",
+                     (static_cast<float>(count) * size * repeats) / usec,
+                     label,
+                     parallel ? "mt" : "")
+              << std::endl;
+  }
+
+  void modes(int32_t size, int32_t gap, int32_t count) {
+    int repeats =
+        std::max<int32_t>(3, (FLAGS_measurement_size) / (size * count));
+    std::cout << fmt::format(
+                     "Run: {} Gap: {} Count: {} Repeats: {}",
+                     size,
+                     gap,
+                     count,
+                     repeats)
+              << std::endl;
+    randomReads(size, gap, count, repeats, Mode::Pread, false);
+    randomReads(size, gap, count, repeats, Mode::Preadv, false);
+    randomReads(size, gap, count, repeats, Mode::Multiple, false);
+    randomReads(size, gap, count, repeats, Mode::Pread, true);
+    randomReads(size, gap, count, repeats, Mode::Preadv, true);
+    randomReads(size, gap, count, repeats, Mode::Multiple, true);
+  }
+
+  void run();
+
+ private:
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+  std::unique_ptr<ReadFile> readFile_;
+  folly::Random::DefaultGenerator rng_;
+  int64_t fileSize_;
+
+  folly::Synchronized<
+      std::unordered_map<std::thread::id, std::unique_ptr<Scratch>>>
+      scratch_;
+};
+
+} // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -25,9 +25,7 @@ std::shared_ptr<Config> readConfig(const std::string& filePath);
 
 class S3ReadBenchmark : public ReadBenchmark {
  public:
-  S3ReadBenchmark() {}
-
-  virtual void initialize() override {
+  void initialize() override {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
 

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -25,6 +25,7 @@ std::shared_ptr<Config> readConfig(const std::string& filePath);
 
 class S3ReadBenchmark : public ReadBenchmark {
  public:
+  // Initialize a S3ReadFile instance for the specified 'path'.
   void initialize() override {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -34,6 +34,7 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
 DECLARE_string(path);
+DECLARE_string(s3_config);
 DECLARE_int64(file_size_gb);
 DECLARE_int32(num_threads);
 DECLARE_int32(seed);
@@ -55,6 +56,8 @@ struct Scratch {
   std::string bufferCopy;
 };
 
+std::shared_ptr<Config> readConfig(const std::string& filePath);
+
 class S3ReadBenchmark {
  public:
   S3ReadBenchmark() {
@@ -62,7 +65,11 @@ class S3ReadBenchmark {
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
 
     filesystems::registerS3FileSystem();
-    auto s3fs = filesystems::getFileSystem(FLAGS_path, nullptr);
+    std::shared_ptr<Config> config;
+    if (!FLAGS_s3_config.empty()) {
+      config = readConfig(FLAGS_s3_config);
+    }
+    auto s3fs = filesystems::getFileSystem(FLAGS_path, config);
     readFile_ = s3fs->openFileForRead(FLAGS_path);
 
     fileSize_ = readFile_->size();

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -68,8 +68,6 @@ class S3ReadBenchmark : public ReadBenchmark {
       rng_.seed(FLAGS_seed);
     }
   }
-
-  void run();
 };
 
 } // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -23,6 +23,11 @@ namespace facebook::velox {
 
 std::shared_ptr<Config> readConfig(const std::string& filePath);
 
+// This benchmark measures the throughput of an S3 compatible FileSystem for
+// various ReadFile APIs. The output helps us understand the maximum possible
+// gains for queries. Example: If a single thread requires reading 1GB of data
+// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
+// data.
 class S3ReadBenchmark : public ReadBenchmark {
  public:
   void initialize() override {

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -14,24 +14,7 @@
  * limitations under the License.
  */
 
-#include <iostream>
-
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#include <folly/Random.h>
-#include <folly/Synchronized.h>
-#include <folly/executors/IOThreadPoolExecutor.h>
-#include <folly/executors/QueuedImmediateExecutor.h>
-#include <folly/futures/Future.h>
-#include <folly/init/Init.h>
-#include <folly/portability/SysUio.h>
-#include <gflags/gflags.h>
-
-#include "velox/common/file/File.h"
 #include "velox/common/file/benchmark/ReadBenchmark.h"
-#include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
 DECLARE_string(s3_config);

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -25,7 +25,9 @@ std::shared_ptr<Config> readConfig(const std::string& filePath);
 
 class S3ReadBenchmark : public ReadBenchmark {
  public:
-  S3ReadBenchmark() : ReadBenchmark(false) {
+  S3ReadBenchmark() {}
+
+  virtual void initialize() override {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
 

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -23,11 +23,6 @@ namespace facebook::velox {
 
 std::shared_ptr<Config> readConfig(const std::string& filePath);
 
-// This benchmark measures the throughput of an S3 compatible FileSystem for
-// various ReadFile APIs. The output helps us understand the maximum possible
-// gains for queries. Example: If a single thread requires reading 1GB of data
-// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
-// data.
 class S3ReadBenchmark : public ReadBenchmark {
  public:
   void initialize() override {

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -30,37 +30,19 @@
 #include <gflags/gflags.h>
 
 #include "velox/common/file/File.h"
+#include "velox/common/file/benchmark/ReadBenchmark.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
-DECLARE_string(path);
 DECLARE_string(s3_config);
-DECLARE_int64(file_size_gb);
-DECLARE_int32(num_threads);
-DECLARE_int32(seed);
-DECLARE_int32(bytes);
-DECLARE_int32(gap);
-DECLARE_int32(num_in_run);
-
-DECLARE_int32(measurement_size);
 
 namespace facebook::velox {
 
-enum class Mode { Pread = 0, Preadv = 1, Multiple = 2 };
-
-// Struct to read data into. If we read contiguous and then copy to
-// non-contiguous buffers, we read to 'buffer' and copy to
-// 'bufferCopy'.
-struct Scratch {
-  std::string buffer;
-  std::string bufferCopy;
-};
-
 std::shared_ptr<Config> readConfig(const std::string& filePath);
 
-class S3ReadBenchmark {
+class S3ReadBenchmark : public ReadBenchmark {
  public:
-  S3ReadBenchmark() {
+  S3ReadBenchmark() : ReadBenchmark(false) {
     executor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_threads);
 
@@ -87,203 +69,7 @@ class S3ReadBenchmark {
     }
   }
 
-  void clearCache() {
-#ifdef linux
-    // system("echo 3 >/proc/sys/vm/drop_caches");
-    bool success = false;
-    auto fd = open("/proc//sys/vm/drop_caches", O_WRONLY);
-    if (fd > 0) {
-      success = write(fd, "3", 1) == 1;
-      close(fd);
-    }
-    if (!success) {
-      LOG(ERROR) << "Failed to clear OS disk cache: errno=" << errno;
-    }
-#endif
-  }
-
-  Scratch& getScratch(int32_t size) {
-    auto scratch = scratch_.withWLock([&](auto& table) {
-      auto& ptr = table[std::this_thread::get_id()];
-      if (!ptr) {
-        ptr = std::make_unique<Scratch>();
-      }
-      ptr->buffer.resize(size);
-      ptr->bufferCopy.resize(size);
-      return ptr.get();
-    });
-    return *scratch;
-  }
-
-  void randomReads(
-      int32_t size,
-      int32_t gap,
-      int32_t count,
-      int32_t repeats,
-      Mode mode,
-      bool parallel) {
-    clearCache();
-    std::vector<folly::Promise<bool>> promises;
-    std::vector<folly::SemiFuture<bool>> futures;
-    uint64_t usec = 0;
-    std::string label;
-    {
-      MicrosecondTimer timer(&usec);
-      int32_t rangeSize = size * count + gap * (count - 1);
-      auto& globalScratch = getScratch(rangeSize);
-      globalScratch.buffer.resize(rangeSize);
-      globalScratch.bufferCopy.resize(rangeSize);
-      for (auto repeat = 0; repeat < repeats; ++repeat) {
-        std::unique_ptr<folly::Promise<bool>> promise;
-        if (parallel) {
-          auto [tempPromise, future] = folly::makePromiseContract<bool>();
-          promise = std::make_unique<folly::Promise<bool>>();
-          *promise = std::move(tempPromise);
-          futures.push_back(std::move(future));
-        }
-        int64_t offset = folly::Random::rand64(rng_) % (fileSize_ - rangeSize);
-        switch (mode) {
-          case Mode::Pread:
-            label = "1 pread";
-            if (parallel) {
-              executor_->add([offset,
-                              gap,
-                              size,
-                              count,
-                              rangeSize,
-                              this,
-                              capturedPromise = std::move(promise)]() {
-                auto& scratch = getScratch(rangeSize);
-                readFile_->pread(offset, rangeSize, scratch.buffer.data());
-                for (auto i = 0; i < count; ++i) {
-                  memcpy(
-                      scratch.bufferCopy.data() + i * size,
-                      scratch.buffer.data() + i * (size + gap),
-                      size);
-                }
-                capturedPromise->setValue(true);
-              }
-
-              );
-            } else {
-              readFile_->pread(offset, rangeSize, globalScratch.buffer.data());
-              for (auto i = 0; i < count; ++i) {
-                memcpy(
-                    globalScratch.bufferCopy.data() + i * size,
-                    globalScratch.buffer.data() + i * (size + gap),
-                    size);
-              }
-            }
-            break;
-          case Mode::Preadv: {
-            label = "1 preadv";
-            if (parallel) {
-              executor_->add([offset,
-                              gap,
-                              size,
-                              rangeSize,
-                              this,
-                              capturedPromise = std::move(promise)]() {
-                auto& scratch = getScratch(rangeSize);
-                std::vector<folly::Range<char*>> ranges;
-                for (auto start = 0; start < rangeSize; start += size + gap) {
-                  ranges.push_back(
-                      folly::Range<char*>(scratch.buffer.data() + start, size));
-                  if (gap && start + gap < rangeSize) {
-                    ranges.push_back(folly::Range<char*>(nullptr, gap));
-                  }
-                }
-                readFile_->preadv(offset, ranges);
-                capturedPromise->setValue(true);
-              });
-            } else {
-              std::vector<folly::Range<char*>> ranges;
-              for (auto start = 0; start < rangeSize; start += size + gap) {
-                ranges.push_back(folly::Range<char*>(
-                    globalScratch.buffer.data() + start, size));
-                if (gap && start + gap < rangeSize) {
-                  ranges.push_back(folly::Range<char*>(nullptr, gap));
-                }
-              }
-              readFile_->preadv(offset, ranges);
-            }
-            break;
-          }
-          case Mode::Multiple: {
-            label = "multiple pread";
-            if (parallel) {
-              executor_->add([offset,
-                              gap,
-                              size,
-                              count,
-                              rangeSize,
-                              this,
-                              capturedPromise = std::move(promise)]() {
-                auto& scratch = getScratch(rangeSize);
-                for (auto counter = 0; counter < count; ++counter) {
-                  readFile_->pread(
-                      offset + counter * (size + gap),
-                      size,
-                      scratch.buffer.data() + counter * size);
-                }
-                capturedPromise->setValue(true);
-              });
-            } else {
-              for (auto counter = 0; counter < count; ++counter) {
-                readFile_->pread(
-                    offset + counter * (size + gap),
-                    size,
-                    globalScratch.buffer.data() + counter * size);
-              }
-            }
-            break;
-          }
-        }
-      }
-      if (parallel) {
-        auto& exec = folly::QueuedImmediateExecutor::instance();
-        for (int32_t i = futures.size() - 1; i >= 0; --i) {
-          std::move(futures[i]).via(&exec).wait();
-        }
-      }
-    }
-    std::cout << fmt::format(
-                     "{} MB/s {} {}",
-                     (static_cast<float>(count) * size * repeats) / usec,
-                     label,
-                     parallel ? "mt" : "")
-              << std::endl;
-  }
-
-  void modes(int32_t size, int32_t gap, int32_t count) {
-    int repeats =
-        std::max<int32_t>(3, (FLAGS_measurement_size) / (size * count));
-    std::cout << fmt::format(
-                     "Run: {} Gap: {} Count: {} Repeats: {}",
-                     size,
-                     gap,
-                     count,
-                     repeats)
-              << std::endl;
-    randomReads(size, gap, count, repeats, Mode::Pread, false);
-    randomReads(size, gap, count, repeats, Mode::Preadv, false);
-    randomReads(size, gap, count, repeats, Mode::Multiple, false);
-    randomReads(size, gap, count, repeats, Mode::Pread, true);
-    randomReads(size, gap, count, repeats, Mode::Preadv, true);
-    randomReads(size, gap, count, repeats, Mode::Multiple, true);
-  }
-
   void run();
-
- private:
-  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
-  std::unique_ptr<ReadFile> readFile_;
-  folly::Random::DefaultGenerator rng_;
-  int64_t fileSize_;
-
-  folly::Synchronized<
-      std::unordered_map<std::thread::id, std::unique_ptr<Scratch>>>
-      scratch_;
 };
 
 } // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
@@ -21,5 +21,6 @@ using namespace facebook::velox;
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   S3ReadBenchmark bm;
+  bm.initialize();
   bm.run();
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
@@ -18,6 +18,11 @@
 
 using namespace facebook::velox;
 
+// This benchmark measures the throughput of an S3 compatible FileSystem for
+// various ReadFile APIs. The output helps us understand the maximum possible
+// gains for queries. Example: If a single thread requires reading 1GB of data
+// and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
+// data.
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   S3ReadBenchmark bm;

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h"
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv, false);
+  S3ReadBenchmark bm;
+  bm.run();
+}


### PR DESCRIPTION
This benchmark measures the throughput of an S3 compatible FileSystem for various ReadFile APIs.  The output helps us understand the maximum possible gains for queries.
Example: If a single thread requires reading 1GB of data and the IO throughput is 100 MBps, then it takes 10 seconds to just read the data.

AWS S3 does not need any config. Example usage on AWS EC2 instance
```
$ ./velox_s3read_benchmark --bytes 100000 --measurement_size 100000000 --path s3://sample-file
Run: 100000 Gap: 0 Count: 10 Repeats: 100
35.03296 MB/s 1 pread 
39.825024 MB/s 1 preadv 
5.3153095 MB/s multiple pread 
216.41368 MB/s 1 pread mt
324.83353 MB/s 1 preadv mt
45.15327 MB/s multiple pread mt
```

MinIO needs a config. Example usage on my laptop

```
> cat config.txt
hive.s3.aws-access-key=minioadmin
hive.s3.aws-secret-key=minioadmin
hive.s3.endpoint=http://127.0.0.1:9000
hive.s3.path-style-access=true
hive.s3.ssl.enabled=false

$ ./velox_s3read_benchmark --bytes 100000 --measurement_size 100000000 --s3-config config.txt --path s3://sample-file
Run: 100000 Gap: 0 Count: 10 Repeats: 100
250.32167 MB/s 1 pread 
268.4744 MB/s 1 preadv 
63.547096 MB/s multiple pread 
1215.0374 MB/s 1 pread mt
1268.6008 MB/s 1 preadv mt
224.98453 MB/s multiple pread mt
```