### PR TITLE
Enable unit test DriverTest.cancel

### DIFF
--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -337,7 +337,7 @@ TEST_F(DriverTest, error) {
   EXPECT_EQ(tasks_[0]->state(), TaskState::kFailed);
 }
 
-TEST_F(DriverTest, DISABLED_cancel) {
+TEST_F(DriverTest, cancel) {
   CursorParameters params;
   params.planNode = makeValuesFilterProject(
       rowType_,


### PR DESCRIPTION
Summary: Enable the previously disabled flaky unit test DriverTest.cancel since it has been fixed in D33993781 (https://github.com/facebookincubator/velox/commit/fafae58aa65f4e87e37a9014d834994f80124f31).

Differential Revision: D34044518

