### PR TITLE
Add SelectiveTimestampColumnReader

### DIFF
--- a/velox/dwio/dwrf/common/DecoderUtil.cpp
+++ b/velox/dwio/dwrf/common/DecoderUtil.cpp
@@ -180,29 +180,54 @@ template bool nonNullRowsFromSparse<false, false>(
     int32_t& tailSkip);
 
 template <typename T>
-void scatterNonNulls(int32_t numRows, const int32_t* target, T* data) {
-  for (auto index = numRows - 1; index >= 0; --index) {
-    auto destination = target[index];
-    if (destination == index) {
+void scatterNonNulls(
+    int32_t targetBegin,
+    int32_t numValues,
+    int32_t sourceBegin,
+    const int32_t* target,
+    T* data) {
+  for (auto index = numValues - 1; index >= 0; --index) {
+    auto destination = target[targetBegin + index];
+    if (destination == sourceBegin + index) {
       break;
     }
-    data[destination] = data[index];
+    data[destination] = data[sourceBegin + index];
   }
 }
 
-template void
-scatterNonNulls(int32_t numRows, const int32_t* target, int64_t* data);
+template void scatterNonNulls(
+    int32_t rowIndex,
+    int32_t numRows,
+    int32_t numValues,
+    const int32_t* target,
+    int64_t* data);
 
-template void
-scatterNonNulls(int32_t numRows, const int32_t* target, int32_t* data);
+template void scatterNonNulls(
+    int32_t rowIndex,
+    int32_t numRows,
+    int32_t numValues,
+    const int32_t* target,
+    int32_t* data);
 
-template void
-scatterNonNulls(int32_t numRows, const int32_t* target, int16_t* data);
+template void scatterNonNulls(
+    int32_t rowIndex,
+    int32_t numRows,
+    int32_t numValues,
+    const int32_t* target,
+    int16_t* data);
 
-template void
-scatterNonNulls(int32_t numRows, const int32_t* target, float* data);
+template void scatterNonNulls(
+    int32_t rowIndex,
+    int32_t numRows,
+    int32_t numValues,
+    const int32_t* target,
+    float* data);
 
-template void
-scatterNonNulls(int32_t numRows, const int32_t* target, double* data);
+template void scatterNonNulls(
+    int32_t rowIndex,
+    int32_t numRows,
+    int32_t numValues,
+    const int32_t* target,
+    double* data);
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -429,10 +429,25 @@ bool useFastPath(Visitor& visitor) {
        Visitor::HookType::kSkipNulls);
 }
 
+// Scatters 'numValues' elements of 'data' starting at data[sourceBegin] to
+// indices given starting with target[targetBegin]. The scatter is done from
+// last to first so as not to overwrite source data when copying from lower to
+// higher indices. data[target[targetBegin + numValues - 1] = data[sourceBegin +
+// numValues - 1] is the first copy in execution order and
+// data[target[targetBegin]] = data[sourceBegin] is the last copy.
 template <typename T>
-void scatterNonNulls(int32_t numRows, const int32_t* target, T* data);
+void scatterNonNulls(
+    int32_t targetBegin,
+    int32_t numValues,
+    int32_t sourceBegin,
+    const int32_t* target,
+    T* data);
 
-// Processes a run of contiguous Ts in 'values'. If hook, call it on
+// Processes a run of contiguous Ts in 'values'. 'values', starting at
+// 'numValues' have been decoded from consecutive (dense case) or
+// non-consecutive places in the encoding. The row number in the
+// non-null space for values[numValues + i] is rows[rowIndex +i ].
+// If hook, call it on
 // all.  If no filter and no hook and no nulls, do nothing since the
 // values are already in place. If no filter and nulls, scatter the
 // values so that there is a gap for the nulls.
@@ -440,6 +455,10 @@ void scatterNonNulls(int32_t numRows, const int32_t* target, T* data);
 // If filter, filter the values and shift them down so that there are
 // no gaps. Produce the passing row numbers in 'filterHits'. If there
 // are nulls, scatter the passing row numbers.
+//
+// 'numInput' is the number of new values to process. The first of these is in
+// values[numValues]. 'rowIndex' is the index of the corresponding value in
+// 'scatterRows'
 template <
     typename T,
     bool filterOnly,
@@ -449,6 +468,8 @@ template <
     typename THook>
 void processFixedWidthRun(
     folly::Range<const int32_t*> rows,
+    int32_t rowIndex,
+    int32_t numInput,
     const int32_t* scatterRows,
     T* values,
     int32_t* filterHits,
@@ -460,42 +481,47 @@ void processFixedWidthRun(
   constexpr bool hasHook = !std::is_same<THook, NoHook>::value;
   if (!hasFilter) {
     if (hasHook) {
-      hook.addValues(scatterRows, values, rows.size(), sizeof(T));
+      hook.addValues(scatterRows + rowIndex, values, rows.size(), sizeof(T));
     } else if (scatter) {
-      scatterNonNulls(rows.size(), scatterRows, values);
-      numValues = scatterRows[rows.size() - 1] + 1;
+      scatterNonNulls(rowIndex, numInput, numValues, scatterRows, values);
+      numValues = scatterRows[rowIndex + numInput - 1] + 1;
+    } else {
+      // The values are already in place.
+      numValues += numInput;
     }
     return;
   }
-  auto numInput = rows.size();
   auto end = numInput & ~(kWidth - 1);
   int32_t row = 0;
+  int32_t valuesBegin = numValues;
   // Process full vectors
   for (; row < end; row += kWidth) {
-    auto valueVector = simd::Vectors<T>::load(values + row);
+    auto valueVector = simd::Vectors<T>::load(values + valuesBegin + row);
     processFixedFilter<T, filterOnly, scatter, dense>(
         reinterpret_cast<__m256i>(valueVector),
         kWidth,
-        rows[row],
+        rows[rowIndex + row],
         filter,
         [&](int32_t offset) {
           return simd::Vectors<T>::loadGather32Indices(
-              (scatter ? scatterRows : rows.data()) + row + offset * 8);
+              (scatter ? scatterRows : rows.data()) + rowIndex + row +
+              offset * 8);
         },
         values,
         filterHits,
         numValues);
   }
   if (numInput > end) {
-    auto valueVector = simd::Vectors<T>::load(values + row);
+    auto valueVector = simd::Vectors<T>::load(values + valuesBegin + row);
     processFixedFilter<T, filterOnly, scatter, dense>(
         reinterpret_cast<__m256i>(valueVector),
         numInput - end,
-        rows[row],
+        rows[rowIndex + row],
         filter,
         [&](int32_t offset) {
           return simd::Vectors<T>::loadGather32Indices(
-              (scatter ? scatterRows : rows.data()) + row + offset * 8);
+              (scatter ? scatterRows : rows.data()) + row + rowIndex +
+              offset * 8);
         },
         values,
         filterHits,

--- a/velox/dwio/dwrf/common/DirectDecoder.h
+++ b/velox/dwio/dwrf/common/DirectDecoder.h
@@ -148,11 +148,13 @@ class DirectDecoder : public IntDecoder<isSigned> {
           super::bulkReadRows(*innerVector, data);
         }
         skip<false>(tailSkip, 0, nullptr);
+        auto dataRows = innerVector
+            ? folly::Range<const int*>(innerVector->data(), innerVector->size())
+            : folly::Range<const int32_t*>(rows, outerVector->size());
         processFixedWidthRun<T, filterOnly, true, Visitor::dense>(
-            innerVector
-                ? folly::Range<const int*>(
-                      innerVector->data(), innerVector->size())
-                : folly::Range<const int32_t*>(rows, outerVector->size()),
+            dataRows,
+            0,
+            dataRows.size(),
             outerVector->data(),
             data,
             hasFilter ? visitor.outputRows(numRows) : nullptr,
@@ -186,6 +188,8 @@ class DirectDecoder : public IntDecoder<isSigned> {
         }
         processFixedWidthRun<T, filterOnly, false, Visitor::dense>(
             rowsAsRange,
+            0,
+            rowsAsRange.size(),
             hasHook ? velox::iota(numRows, visitor.innerNonNullRows())
                     : nullptr,
             visitor.rawValues(numRows),

--- a/velox/dwio/dwrf/test/DecoderUtilTest.cpp
+++ b/velox/dwio/dwrf/test/DecoderUtilTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include <folly/Random.h>
 #include "velox/common/base/Nulls.h"
+#include "velox/type/Filter.h"
 
 #include <gtest/gtest.h>
 
@@ -161,6 +162,80 @@ TEST_F(DecoderUtilTest, nonNullsFromSparse) {
         rows.push_back(1234);
       }
       testNonNullFromSparseCases(nulls.data(), rows);
+    }
+  }
+}
+
+namespace facebook::velox::dwrf {
+// Excerpt from LazyVector.h.
+struct NoHook {
+  void addValues(
+      const int32_t* /*rows*/,
+      const void* /*values*/,
+      int32_t /*size*/,
+      uint8_t /*valueWidth*/) {}
+};
+
+} // namespace facebook::velox::dwrf
+
+TEST_F(DecoderUtilTest, processFixedWithRun) {
+  // Tests processing consecutive batches of integers with processFixedWidthRun.
+  constexpr int kSize = 100;
+  constexpr int32_t kStep = 17;
+  raw_vector<int32_t> data;
+  raw_vector<int32_t> scatter;
+  data.reserve(kSize);
+  scatter.reserve(kSize);
+  // Data is 0, 100,  2, 98 ... 98, 2.
+  // scatter is 0, 2, 4,6 ... 196, 198.
+  for (auto i = 0; i < kSize; i += 2) {
+    data.push_back(i / 2);
+    data.push_back(kSize - i);
+    scatter.push_back(i * 2);
+    scatter.push_back((i + 1) * 2);
+  }
+
+  // the row numbers that pass the filter come here, translated via scatter.
+  raw_vector<int32_t> hits(kSize);
+  // Each valid index in 'data'
+  raw_vector<int32_t> rows(kSize);
+  auto filter = std::make_unique<common::BigintRange>(40, 1000, false);
+  std::iota(rows.begin(), rows.end(), 0);
+  // The passing values are gathered here. Before each call to
+  // processFixedWidthRun, the candidate values are appended here and
+  // processFixedWidthRun overwrites them with the passing values and sets
+  // numValues to be the first unused index after the passing values.
+  raw_vector<int32_t> results;
+  int32_t numValues = 0;
+  for (auto rowIndex = 0; rowIndex < kSize; rowIndex += kStep) {
+    int32_t numInput = std::min<int32_t>(kStep, kSize - rowIndex);
+    results.resize(numValues + numInput);
+    std::memcpy(
+        results.data() + numValues,
+        data.data() + rowIndex,
+        numInput * sizeof(results[0]));
+
+    NoHook noHook;
+    processFixedWidthRun<int32_t, false, true, false>(
+        rows,
+        rowIndex,
+        numInput,
+        scatter.data(),
+        results.data(),
+        hits.data(),
+        numValues,
+        *filter,
+        noHook);
+  }
+  // Check that each value that passes the filter is in 'results' and that   its
+  // index times 2 is in 'data' is in 'hits'. The 2x is because the scatter maps
+  // each row to 2x the row number.
+  int32_t passedCount = 0;
+  for (auto i = 0; i < kSize; ++i) {
+    if (data[i] >= 40) {
+      EXPECT_EQ(data[i], results[passedCount]);
+      EXPECT_EQ(i * 2, hits[passedCount]);
+      ++passedCount;
     }
   }
 }


### PR DESCRIPTION
Adds a timestamp reader and test in E2EFilterTest. There are no
Filters for the timestamp type.

Adds a ColumnVisitor for non-dictionary uses of RLE encoding, which first occurs with the timestamp encoding.

Enhances processFixedWidthRun in DecoderUtil.h to to apply to parts of
the run to decode instead of processing the whole range given at the
top level. This is needed for use in DirectRLEColumnVisitor where this
is called multiple times for repeatied/literal runs.

Adds a test for processFixedRun processing  a column filter in multiple
installments. This covers the changed lines in processFixedWidthRun.