### PR TITLE
Remove `virtual` from some BaseVector functions

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -181,15 +181,15 @@ class BaseVector {
    * vector. May hold nullptr if there are no nulls. Not const because
    * some vectors may generate this on first access.
    */
-  virtual const BufferPtr& nulls() const {
+  const BufferPtr& nulls() const {
     return nulls_;
   }
 
-  virtual const uint64_t* rawNulls() const {
+  const uint64_t* rawNulls() const {
     return rawNulls_;
   }
 
-  virtual uint64_t* mutableRawNulls() {
+  uint64_t* mutableRawNulls() {
     ensureNulls();
     return const_cast<uint64_t*>(rawNulls_);
   }


### PR DESCRIPTION
Summary:
pedroerp noticed that GCC does not inline mutableRawNulls().
The only reason I can think of is that it is marked virtual.
However, then it does not need to since they are never overridden.
This diff removes the virtual from three functions in BaseVector.h

Differential Revision: D34218519

