### PR TITLE
Add date_diff Presto function

### DIFF
--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -58,8 +58,12 @@ Unit            Description
 
 .. function:: date_add(unit, value, x) -> x
 
-    Adds an interval ``value`` of type ``unit`` to ``x``. The supported types for ``x`` are TIME and DATE.
+    Adds an interval ``value`` of type ``unit`` to ``x``. The supported types for ``x`` are TIMESTAMP and DATE.
     Subtraction can be performed by using a negative value.
+
+.. function:: date_diff(unit, x1, x2) -> bigint
+
+    Returns ``x2 - x1`` in terms of ``unit``. The supported types for ``x`` are TIMESTAMP and DATE.
 
 Java Date Functions
 -------------------

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -58,6 +58,10 @@ void registerSimpleFunctions() {
   registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>({"date_add"});
   registerFunction<DateAddFunction, Timestamp, Varchar, int64_t, Timestamp>(
       {"date_add"});
+  registerFunction<DateDiffFunction, int64_t, Varchar, Date, Date>(
+      {"date_diff"});
+  registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
+      {"date_diff"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -45,27 +45,6 @@
 
 namespace facebook::velox::util {
 
-constexpr const int32_t kHoursPerDay{24};
-constexpr const int32_t kMinsPerHour{60};
-constexpr const int32_t kSecsPerMinute{60};
-constexpr const int64_t kMsecsPerSec{1000};
-
-constexpr const int64_t kMicrosPerMsec{1000};
-constexpr const int64_t kMicrosPerSec{kMicrosPerMsec * kMsecsPerSec};
-constexpr const int64_t kMicrosPerMinute{kMicrosPerSec * kSecsPerMinute};
-constexpr const int64_t kMicrosPerHour{kMicrosPerMinute * kMinsPerHour};
-
-constexpr const int64_t kNanosPerMicro{1000};
-
-constexpr const int32_t kSecsPerHour{kSecsPerMinute * kMinsPerHour};
-constexpr const int32_t kSecsPerDay{kSecsPerHour * kHoursPerDay};
-
-constexpr static const int32_t kMinYear{-290307};
-constexpr static const int32_t kMaxYear{294247};
-
-constexpr static const int32_t kYearInterval{400};
-constexpr static const int32_t kDaysPerYearInterval{146097};
-
 constexpr int32_t kLeapDays[] =
     {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 constexpr int32_t kNormalDays[] =

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -20,6 +20,27 @@
 
 namespace facebook::velox::util {
 
+constexpr const int32_t kHoursPerDay{24};
+constexpr const int32_t kMinsPerHour{60};
+constexpr const int32_t kSecsPerMinute{60};
+constexpr const int64_t kMsecsPerSec{1000};
+
+constexpr const int64_t kMicrosPerMsec{1000};
+constexpr const int64_t kMicrosPerSec{kMicrosPerMsec * kMsecsPerSec};
+constexpr const int64_t kMicrosPerMinute{kMicrosPerSec * kSecsPerMinute};
+constexpr const int64_t kMicrosPerHour{kMicrosPerMinute * kMinsPerHour};
+
+constexpr const int64_t kNanosPerMicro{1000};
+
+constexpr const int32_t kSecsPerHour{kSecsPerMinute * kMinsPerHour};
+constexpr const int32_t kSecsPerDay{kSecsPerHour * kHoursPerDay};
+
+constexpr const int32_t kMinYear{-290307};
+constexpr const int32_t kMaxYear{294247};
+
+constexpr const int32_t kYearInterval{400};
+constexpr const int32_t kDaysPerYearInterval{146097};
+
 /// Date conversions.
 
 /// Returns the (signed) number of days since unix epoch (1970-01-01).


### PR DESCRIPTION
Add date_diff UDF that works the same as the corresponding Presto function, https://prestodb.io/docs/current/functions/datetime.html#interval-functions.

Supported types for date are TIMESTAMP and DATE.