### PR TITLE
Resolve simple functions based on generality.

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   HashJoinTest.cpp
   PlanNodeToStringTest.cpp
   FunctionSignatureBuilderTest.cpp
+  SimpleFunctionResolutionTest.cpp
   UnnestTest.cpp
   AssignUniqueIdTest.cpp)
 

--- a/velox/exec/tests/SimpleFunctionResolutionTest.cpp
+++ b/velox/exec/tests/SimpleFunctionResolutionTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+// This files contains e2e tests the simple functions resolution based on
+// priority which is determined based on the generality.
+namespace facebook::velox::exec {
+namespace {
+
+class SimpleFunctionResolutionTest : public functions::test::FunctionBaseTest {
+ protected:
+  void checkResults(const std::string& func, int32_t expected) {
+    auto results = evaluateOnce<int32_t, int32_t, int32_t>(
+        fmt::format("{}(c0, c1)", func), 1, 2);
+    ASSERT_EQ(results.value(), expected);
+  }
+};
+
+// Several `call` functions all that accepts two integers. With different
+// runtime representations.
+template <typename T>
+struct TestFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool call(int32_t& out, int32_t, int32_t) {
+    out = 1;
+    return true;
+  }
+
+  bool call(int32_t& out, const arg_type<Variadic<int32_t>>&) {
+    out = 2;
+    return true;
+  }
+
+  bool call(
+      int32_t& out,
+      const arg_type<Generic<T1>>&,
+      const arg_type<Generic<T1>>&) {
+    out = 3;
+    return true;
+  }
+
+  bool call(int32_t& out, const arg_type<Variadic<Generic<>>>&) {
+    out = 4;
+    return true;
+  }
+
+  bool
+  call(int32_t& out, const int32_t&, const arg_type<Variadic<Generic<>>>&) {
+    out = 5;
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionResolutionTest, rank1Picked) {
+  registerFunction<TestFunction, int32_t, int32_t, int32_t>({"f1"});
+  registerFunction<TestFunction, int32_t, Variadic<int32_t>>({"f1"});
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f1"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f1"});
+
+  checkResults("f1", 1);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank2Picked) {
+  registerFunction<TestFunction, int32_t, Variadic<int32_t>>({"f2"});
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f2"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f2"});
+  checkResults("f2", 2);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank3Picked) {
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f3"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f3"});
+  checkResults("f3", 3);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank4Picked) {
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f4"});
+  checkResults("f4", 4);
+}
+
+// Test when two functions have the same rank.
+TEST_F(SimpleFunctionResolutionTest, sameRank) {
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f5"});
+  registerFunction<TestFunction, int32_t, int32_t, Variadic<Generic<>>>({"f5"});
+  checkResults("f5", 5);
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -100,15 +100,22 @@ class FunctionRegistry {
   const FunctionEntry<Function, Metadata>* resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes) {
+    const FunctionEntry<Function, Metadata>* selectedCandidate = nullptr;
+
     if (auto signatureMap = getSignatureMap(name)) {
       for (const auto& [candidateSignature, functionEntry] : *signatureMap) {
         if (SignatureBinder(candidateSignature, argTypes).tryBind()) {
-          return functionEntry.get();
+          auto* currentCandidate = functionEntry.get();
+          if (!selectedCandidate ||
+              currentCandidate->getMetadata()->priority() <
+                  selectedCandidate->getMetadata()->priority()) {
+            selectedCandidate = currentCandidate;
+          }
         }
       }
     }
 
-    return nullptr;
+    return selectedCandidate;
   }
 
  private:


### PR DESCRIPTION
This diff completes the signature ranking work, and adds the e2e support 
to resolving simple functions based on their priority which is determined using 
the generality of the signature.

For example a function add(...) can be implemented as the following:

```
template<typename T>
struct AddFunc {

  bool call(int & out, int a , int b){
    out = a+b;
  }

  bool call(int & out, const arg_type<Variadic<int>>& inputs){
   out = 0; 
   for(auto v: inputs){
      out+=*v; 
   }
 }
};

registerFunction<AddFunc, int, int, int>({"add"});
registerFunction<AddFunc, int, Variadic<int>>{"add"};
```
In the case above we want to make sure that the first add is 
picked when the inputs are just two integers. since both registrations would work.

Priority is assigned as the following:
Lower priorities are picked first during function resolutions. The computation works as the
following, each signature get a rank out of 4. Those ranks form initial Lattice
ordering.

rank 1: generic free and variadic free.
     e.g: int, int, int -> int.

rank 2: has variadic but generic free.
     e.g: Variadic<int> -> int.

rank 3: has generic but no variadic of generic.
     e.g: Generic<>, Generic<>,Generic<>  -> int.

rank 4: has variadic of generic.
     e.g: Variadic<Generic<>> -> int.

If two functions have the same rank, then concreteCount is used to
to resolve the ordering which is the number of concrete types 
(other than variadic and generic) in the signature.

e.g: consider the two functions:
     1. int, Generic<>, Variadic<int> -> has rank 3. concreteCount =2
     2. int, Generic<>, Generic<>    -> has rank 3. concreteCount =1

in this case (2) is picked.
  e.g: (Generic<>, int) will be picked before (Generic<>, Generic<>)
  e.g: Variadic<Array<Generic<>>> is picked before Variadic<Generic<>>.

Differential Revision: D34233219

