### PR TITLE
Fix hash mode selection

### DIFF
--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -23,7 +23,11 @@ inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
 }
 
-#if defined(__GNUC__)
+inline size_t count_leading_zeros(uint64_t x) {
+  return x == 0 ? 64 : __builtin_clzll(x);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
 #define INLINE_LAMBDA __attribute__((__always_inline__))
 #else
 #define INLINE_LAMBDA

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -581,6 +581,7 @@ void HashProbe::ensureLoadedIfNotAtEnd(ChannelIndex channel) {
   }
   EvalCtx evalCtx(operatorCtx_->execCtx(), nullptr, input_.get());
   if (!passingInputRowsInitialized_) {
+    passingInputRowsInitialized_ = true;
     passingInputRows_.resize(input_->size());
     if (isLeftJoin(joinType_)) {
       passingInputRows_.setAll();

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -357,6 +357,10 @@ class HashTable : public BaseHashTable {
       const std::vector<uint64_t>& rangeSizes,
       const std::vector<uint64_t>& distinctSizes);
 
+  // Clears all elements of 'useRange' except ones that correspond to boolean
+  // VectorHashers.
+  void clearUseRange(std::vector<bool>& useRange);
+
   void rehash();
   void initializeNewGroups(HashLookup& lookup);
   void storeKeys(HashLookup& lookup, vector_size_t row);

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -630,8 +630,25 @@ uint64_t VectorHasher::enableValueRange(uint64_t multiplier, int64_t reserve) {
   return result;
 }
 
+void VectorHasher::copyStatsFrom(const VectorHasher& other) {
+  hasRange_ = other.hasRange_;
+  rangeOverflow_ = other.rangeOverflow_;
+  distinctOverflow_ = other.distinctOverflow_;
+
+  min_ = other.min_;
+  max_ = other.max_;
+  uniqueValues_ = other.uniqueValues_;
+}
+
 void VectorHasher::merge(const VectorHasher& other) {
   if (typeKind_ == TypeKind::BOOLEAN) {
+    return;
+  }
+  if (other.empty()) {
+    return;
+  }
+  if (empty()) {
+    copyStatsFrom(other);
     return;
   }
   if (hasRange_ && other.hasRange_ && !rangeOverflow_ &&
@@ -655,6 +672,15 @@ void VectorHasher::merge(const VectorHasher& other) {
   } else {
     distinctOverflow_ = true;
   }
+}
+
+std::string VectorHasher::toString() const {
+  std::stringstream out;
+  out << "<VectorHasher type=" << type_->toString() << "  isRange_=" << isRange_
+      << " rangeSize= " << rangeSize_ << " min=" << min_ << " max=" << max_
+      << " multiplier=" << multiplier_
+      << " numDistinct=" << uniqueValues_.size() << ">";
+  return out.str();
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -271,6 +271,13 @@ class VectorHasher {
   // and distinct values are unioned.
   void merge(const VectorHasher& other);
 
+  // true if no values have been added.
+  bool empty() const {
+    return !hasRange_ && uniqueValues_.empty();
+  }
+
+  std::string toString() const;
+
  private:
   static constexpr uint32_t kStringASRangeMaxSize = 7;
   static constexpr uint32_t kStringBufferUnitSize = 1024;
@@ -290,6 +297,9 @@ class VectorHasher {
   inline int64_t toInt64(T value) const {
     return value;
   }
+
+  // Sets the data statistics from 'other'. Does not set the mapping mode.
+  void copyStatsFrom(const VectorHasher& other);
 
   template <TypeKind Kind>
   bool makeValueIds(const SelectivityVector& rows, uint64_t* result);
@@ -488,7 +498,7 @@ class VectorHasher {
   // Members for fast map to int domain for array/normalized key.
   // Maximum integer mapping. If distinct count exceeds this,
   // array/normalized key mapping fails.
-  uint32_t rangeSize_ = 0;
+  uint64_t rangeSize_ = 0;
 
   // Multiply int mapping by this before adding it to array index/normalized
   // key.

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -521,7 +521,12 @@ TEST_F(VectorHasherTest, merge) {
   VectorHasher otherHasher(BIGINT(), 0);
   otherHasher.computeValueIds(*otherVector, rows, hashes);
   // hasher has 0..99 and otherHasher has 0..49, 1050..1099.
-  hasher.merge(otherHasher);
+  VectorHasher emptyHasher(BIGINT(), 0);
+  VectorHasher otherEmptyHasher(BIGINT(), 0);
+  EXPECT_TRUE(emptyHasher.empty());
+  emptyHasher.merge(otherHasher);
+  hasher.merge(emptyHasher);
+  hasher.merge(otherEmptyHasher);
   uint64_t numRange;
   uint64_t numDistinct;
   hasher.cardinality(numRange, numDistinct);


### PR DESCRIPTION
Fix hash mode selection

Fixes hash mode selection in HashTable and Vectorhasher.

- Merging an empty VectorHasher with another would erroneously lead to
- kHash hash mode.

In choice of hash mode in decideHashMode:

Added calculation of rangesWithReserve for representing the
cardinality f all keys are mapped to ids via range.

A table where the best combination of range/distincts comes out under
kArray limit is always by array. Note that 'bestWithReserve' was
incorrectly calculated using range size even if distincts were chosen
for the hasher.

Table where the key cardinalities by range fit in uint64_t will always
be by normalized key.

The single key tables that would fit in kArray with distincts but are
not very small may go by kHash.

A boolean VectorHasher must always be by range or by hash, not by
distinct values. So, when clearing the useRange flag, do not do so for
booleans.

- Remove duplicate initialization in
  HashProbe::ensureLoadedIfNotAtEnd.
