### PR TITLE
Add copy_from to writers

### DIFF
--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -1108,7 +1108,17 @@ class StringProxy<FlatVector<StringView>, false /*reuseInput*/>
     finalized_ = true;
   }
 
-  void append(const StringView& input) {
+  template <typename T>
+  void operator+=(const T& input) {
+    append(input);
+  }
+
+  void operator+=(const char* input) {
+    append(std::string_view(input));
+  }
+
+  template <typename T>
+  void append(const T& input) {
     DCHECK(!finalized_);
     auto oldSize = size();
     resize(this->size() + input.size());
@@ -1119,23 +1129,18 @@ class StringProxy<FlatVector<StringView>, false /*reuseInput*/>
     }
   }
 
-  void operator+=(const StringView& input) {
+  void append(const char* input) {
+    append(std::string_view(input));
+  }
+
+  template <typename T>
+  void copy_from(const T& input) {
+    VELOX_DCHECK(initialized());
     append(input);
   }
 
-  void append(const std::string_view input) {
-    DCHECK(!finalized_);
-    auto oldSize = size();
-    resize(this->size() + input.size());
-    if (input.size() != 0) {
-      DCHECK(data());
-      DCHECK(input.data());
-      std::memcpy(data() + oldSize, input.data(), input.size());
-    }
-  }
-
-  void operator+=(const std::string_view input) {
-    append(input);
+  void copy_from(const char* input) {
+    append(std::string_view(input));
   }
 
  private:

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   SimpleFunctionPresetNullsTest.cpp
   ArrayViewTest.cpp
   ArrayProxyTest.cpp
+  StringProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
   VariadicViewTest.cpp

--- a/velox/expression/tests/StringProxyTest.cpp
+++ b/velox/expression/tests/StringProxyTest.cpp
@@ -24,7 +24,7 @@ namespace facebook::velox::expressions::test {
 
 class StringProxyTest : public functions::test::FunctionBaseTest {};
 
-TEST_F(StringProxyTest, testAppend) {
+TEST_F(StringProxyTest, append) {
   auto vector = makeFlatVector<StringView>(2);
   auto proxy = exec::StringProxy<FlatVector<StringView>, /*reuse input*/ false>(
       vector.get(), 0);
@@ -39,7 +39,7 @@ TEST_F(StringProxyTest, testAppend) {
   ASSERT_EQ(vector->valueAt(0), StringView("1 2 3 4 5 "));
 }
 
-TEST_F(StringProxyTest, testPlusOperator) {
+TEST_F(StringProxyTest, plusOperator) {
   auto vector = makeFlatVector<StringView>(1);
   auto proxy = exec::StringProxy<FlatVector<StringView>, /*reuse input*/ false>(
       vector.get(), 0);
@@ -54,4 +54,33 @@ TEST_F(StringProxyTest, testPlusOperator) {
   ASSERT_EQ(vector->valueAt(0), StringView("1 2 3 4 5 "));
 }
 
+TEST_F(StringProxyTest, copyFromStringView) {
+  auto vector = makeFlatVector<StringView>(4);
+  auto proxy = exec::StringProxy<FlatVector<StringView>, /*reuse input*/ false>(
+      vector.get(), 0);
+  proxy.copy_from("1 2 3 4 5 "_sv);
+  proxy.finalize();
+
+  ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
+}
+
+TEST_F(StringProxyTest, copyFromStdString) {
+  auto vector = makeFlatVector<StringView>(4);
+  auto proxy = exec::StringProxy<FlatVector<StringView>, /*reuse input*/ false>(
+      vector.get(), 0);
+  proxy.copy_from(std::string("1 2 3 4 5 "));
+  proxy.finalize();
+
+  ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
+}
+
+TEST_F(StringProxyTest, copyFromCString) {
+  auto vector = makeFlatVector<StringView>(4);
+  auto proxy = exec::StringProxy<FlatVector<StringView>, /*reuse input*/ false>(
+      vector.get(), 0);
+  proxy.copy_from("1 2 3 4 5 ");
+  proxy.finalize();
+
+  ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
+}
 } // namespace facebook::velox::expressions::test


### PR DESCRIPTION
Summary:
Add function copy_from to array, map, and string writers.
The function copies data into velox vector from a container
composed of the type with std like interface.

Differential Revision: D34162874

