### PR TITLE
Restrict number and size of build jobs in linux-benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make benchmarks-dump
+            make benchmarks-dump NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - store_artifacts:


### PR DESCRIPTION
Summary:
Restricting number and size of build jobs in linux-benchmarks (like we
do in regular linux builds) to prevent build processes from OOMing.

Differential Revision: D34246432

