### PR TITLE
Add suport for COMPARE_NOT_IN operator

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -234,7 +234,9 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(ParsedExpression& expr) {
         variant::array(arrayElements), getAlias(expr));
   }
 
-  if (expr.GetExpressionType() == ExpressionType::COMPARE_IN) {
+  // Check if the operator is "IN" or "NOT IN".
+  if (expr.GetExpressionType() == ExpressionType::COMPARE_IN ||
+      expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN) {
     auto numValues = operExpr.children.size() - 1;
 
     std::vector<variant> values;
@@ -252,7 +254,11 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(ParsedExpression& expr) {
     params.emplace_back(parseExpr(*operExpr.children[0]));
     params.emplace_back(std::make_shared<const core::ConstantExpr>(
         variant::array(values), std::nullopt));
-    return callExpr("in", std::move(params), getAlias(expr));
+    auto inExpr = callExpr("in", std::move(params), getAlias(expr));
+    // Translate COMPARE_NOT_IN into NOT(IN()).
+    return (expr.GetExpressionType() == ExpressionType::COMPARE_IN)
+        ? inExpr
+        : callExpr("not", inExpr, std::nullopt);
   }
 
   std::vector<std::shared_ptr<const core::IExpr>> params;

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -107,6 +107,40 @@ TEST(DuckParserTest, in) {
       parseExpr("col1 in ('a', null, 'b', 'c')")->toString());
 }
 
+TEST(DuckParserTest, notin) {
+  EXPECT_EQ(
+      "not(in(\"col1\",[1,2,3]))",
+      parseExpr("col1 not in (1, 2, 3)")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[1,2,3]))",
+      parseExpr("not(col1 in (1, 2, 3))")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[1,2,null,3]))",
+      parseExpr("col1 not in (1, 2, null, 3)")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[1,2,null,3]))",
+      parseExpr("not(col1 in (1, 2, null, 3))")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[\"a\",\"b\",\"c\"]))",
+      parseExpr("col1 not in ('a', 'b', 'c')")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[\"a\",\"b\",\"c\"]))",
+      parseExpr("not(col1 in ('a', 'b', 'c'))")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[\"a\",null,\"b\",\"c\"]))",
+      parseExpr("col1 not in ('a', null, 'b', 'c')")->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",[\"a\",null,\"b\",\"c\"]))",
+      parseExpr("not(col1 in ('a', null, 'b', 'c'))")->toString());
+}
+
 TEST(DuckParserTest, expressions) {
   // Comparisons.
   EXPECT_EQ("eq(1,0)", parseExpr("1 = 0")->toString());


### PR DESCRIPTION
Summary: This diff adds support to parse "NOT(column IN ())" and "column NOT IN ()" expressions using DuckDb parser in Velox.

Reviewed By: pedroerp

Differential Revision: D34247298

