### PR TITLE
Add generic date time formatter

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -14,8 +14,14 @@
 find_library(RE2 re2 REQUIRED)
 
 add_library(
-  velox_functions_lib IsNull.cpp LambdaFunctionUtil.cpp Re2Functions.cpp
-                      StringEncodingUtils.cpp JodaDateTime.cpp)
+  velox_functions_lib
+  DateTimeFormatter.cpp
+  DateTimeFormatterBuilder.cpp
+  IsNull.cpp
+  JodaDateTime.cpp
+  LambdaFunctionUtil.cpp
+  Re2Functions.cpp
+  StringEncodingUtils.cpp)
 
 target_link_libraries(velox_functions_lib velox_vector ${RE2})
 

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/external/date/date.h"
+#include "velox/external/date/tz.h"
+#include "velox/functions/lib/DateTimeFormatterBuilder.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+constexpr std::string_view weekdaysFull[] = {
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"};
+constexpr std::string_view weekdaysShort[] =
+    {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+constexpr std::string_view monthsFull[] = {
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+};
+constexpr std::string_view monthsShort[] = {
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+};
+
+/// Pads the content with desired padding characters. E.g. if we need to pad 999
+/// with three 0s in front, the result will be '000999'
+/// \param content the content that is going to be padded.
+/// \param padding the padding that is going to be used to pad the content.
+/// \param totalDigits the total number of digits the padded result is desired
+/// to be. If totalDigits is already smaller than content length, the original
+/// content will be returned with no padding
+/// \param padFront if the padding is in front of the content or back of the
+/// content.
+template <typename T>
+std::string padContent(
+    const T& content,
+    char padding,
+    size_t totalDigits,
+    bool padFront = true) {
+  std::string strContent = folly::to<std::string>(content);
+  auto contentLength = strContent.size();
+  if (contentLength == 0) {
+    return std::string(totalDigits, padding);
+  }
+
+  bool isNegative = strContent[0] == '-';
+  auto digitLength = contentLength - (isNegative ? 1 : 0);
+  if (digitLength >= totalDigits) {
+    return strContent;
+  }
+  std::string paddingStr(totalDigits - digitLength, padding);
+  if (padFront) {
+    return strContent.insert((isNegative ? 1 : 0), paddingStr);
+  } else {
+    return strContent.append(paddingStr);
+  }
+}
+
+void validateTimePoint(const std::chrono::time_point<
+                       std::chrono::system_clock,
+                       std::chrono::milliseconds>& timePoint) {
+  // Due to the limit of std::chrono we can only represent time in
+  // [-32767-01-01, 32767-12-31] date range
+  const auto minTimePoint = date::sys_days{
+      date::year_month_day(date::year::min(), date::month(1), date::day(1))};
+  const auto maxTimePoint = date::sys_days{
+      date::year_month_day(date::year::max(), date::month(12), date::day(31))};
+  if (timePoint < minTimePoint || timePoint > maxTimePoint) {
+    VELOX_USER_FAIL(
+        "Cannot format time out of range of [{}-{}-{}, {}-{}-{}]",
+        (int)date::year::min(),
+        "01",
+        "01",
+        (int)date::year::max(),
+        "12",
+        "31");
+  }
+}
+
+size_t countOccurence(const std::string_view& base, const std::string& target) {
+  int occurrences = 0;
+  std::string::size_type pos = 0;
+  while ((pos = base.find(target, pos)) != std::string::npos) {
+    ++occurrences;
+    pos += target.length();
+  }
+  return occurrences;
+}
+
+} // namespace
+
+std::string DateTimeFormatter::format(
+    const Timestamp& timestamp,
+    const date::time_zone* timezone) const {
+  const std::chrono::
+      time_point<std::chrono::system_clock, std::chrono::milliseconds>
+          timePoint(std::chrono::milliseconds(timestamp.toMillis()));
+  validateTimePoint(timePoint);
+  const auto daysTimePoint = date::floor<date::days>(timePoint);
+
+  const auto durationInTheDay = date::make_time(timePoint - daysTimePoint);
+  const date::year_month_day calDate(daysTimePoint);
+  const date::weekday weekday(daysTimePoint);
+
+  std::string result;
+  for (auto& token : tokens_) {
+    if (token.type == DateTimeToken::Type::kLiteral) {
+      result += token.literal;
+    } else {
+      switch (token.pattern.specifier) {
+        case DateTimeFormatSpecifier::ERA:
+          result += static_cast<signed>(calDate.year()) >= 0 ? "AD" : "BC";
+          break;
+
+        case DateTimeFormatSpecifier::CENTURY_OF_ERA: {
+          auto year = static_cast<signed>(calDate.year());
+          if (year < 0) {
+            VELOX_USER_FAIL(
+                "With century of era in format, year should be greater than 0.")
+          } else {
+            auto century = year / 100;
+            result +=
+                padContent(century, '0', token.pattern.minRepresentDigits);
+          }
+        } break;
+
+        case DateTimeFormatSpecifier::YEAR_OF_ERA:
+          result += padContent(
+              std::abs(static_cast<signed>(calDate.year())),
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED:
+        case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED: {
+          auto weekdayNum = weekday.c_encoding();
+          if (weekdayNum == 0 &&
+              token.pattern.specifier ==
+                  DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED) {
+            weekdayNum = 7;
+          }
+          result +=
+              padContent(weekdayNum, '0', token.pattern.minRepresentDigits);
+        } break;
+
+        case DateTimeFormatSpecifier::DAY_OF_WEEK_TEXT: {
+          auto weekdayNum = weekday.c_encoding();
+          if (token.pattern.minRepresentDigits <= 3) {
+            result += weekdaysShort[weekdayNum];
+          } else {
+            result += weekdaysFull[weekdayNum];
+          }
+        } break;
+
+        case DateTimeFormatSpecifier::YEAR:
+          result += padContent(
+              static_cast<signed>(calDate.year()),
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::DAY_OF_YEAR: {
+          auto firstDayOfTheYear = date::year_month_day(
+              calDate.year(), date::month(1), date::day(1));
+          auto delta =
+              (date::sys_days{calDate} - date::sys_days{firstDayOfTheYear})
+                  .count();
+          delta += 1;
+          result += padContent(delta, '0', token.pattern.minRepresentDigits);
+        } break;
+
+        case DateTimeFormatSpecifier::MONTH_OF_YEAR:
+          result += padContent(
+              static_cast<unsigned>(calDate.month()),
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::MONTH_OF_YEAR_TEXT:
+          if (token.pattern.minRepresentDigits <= 3) {
+            result += monthsShort[static_cast<unsigned>(calDate.month()) - 1];
+          } else {
+            result += monthsFull[static_cast<unsigned>(calDate.month()) - 1];
+          }
+          break;
+
+        case DateTimeFormatSpecifier::DAY_OF_MONTH:
+          result += padContent(
+              static_cast<unsigned>(calDate.day()),
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::HALFDAY_OF_DAY:
+          result += durationInTheDay.hours().count() < 12 ? "AM" : "PM";
+          break;
+
+        case DateTimeFormatSpecifier::HOUR_OF_HALFDAY:
+        case DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY:
+        case DateTimeFormatSpecifier::HOUR_OF_DAY:
+        case DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY: {
+          auto hourNum = durationInTheDay.hours().count();
+          if (token.pattern.specifier ==
+              DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY) {
+            hourNum = (hourNum + 11) % 12 + 1;
+          } else if (
+              token.pattern.specifier ==
+              DateTimeFormatSpecifier::HOUR_OF_HALFDAY) {
+            hourNum = hourNum % 12;
+          } else if (
+              token.pattern.specifier ==
+              DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY) {
+            hourNum = (hourNum + 23) % 24 + 1;
+          }
+          result += padContent(hourNum, '0', token.pattern.minRepresentDigits);
+        } break;
+
+        case DateTimeFormatSpecifier::MINUTE_OF_HOUR:
+          result += padContent(
+              durationInTheDay.minutes().count() % 60,
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::SECOND_OF_MINUTE:
+          result += padContent(
+              durationInTheDay.seconds().count() % 60,
+              '0',
+              token.pattern.minRepresentDigits);
+          break;
+
+        case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
+          result += padContent(
+                        durationInTheDay.subseconds().count(),
+                        '0',
+                        token.pattern.minRepresentDigits,
+                        false)
+                        .substr(0, token.pattern.minRepresentDigits);
+          break;
+        case DateTimeFormatSpecifier::TIMEZONE:
+          // TODO: implement short name time zone, need a map from full name to
+          // short name
+          if (token.pattern.minRepresentDigits <= 3) {
+            VELOX_UNSUPPORTED("short name time zone is not yet supported")
+          }
+          if (timezone == nullptr) {
+            VELOX_USER_FAIL("Timezone unknown")
+          }
+          result += timezone->name();
+          break;
+
+        case DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID:
+          // TODO: implement timezone offset id formatting, need a map from full
+          // name to offset time
+        case DateTimeFormatSpecifier::WEEK_YEAR:
+        case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
+        default:
+          VELOX_UNSUPPORTED(
+              "format is not supported for specifier {}",
+              token.pattern.specifier);
+      }
+    }
+  }
+  return result;
+}
+
+std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
+    const std::string_view& format) {
+  // For %r we should reserve 1 extra space because it has 3 literals ':' ':'
+  // and ' '
+  DateTimeFormatterBuilder builder(
+      format.size() + countOccurence(format, "%r"));
+
+  const char* cur = format.data();
+  const char* end = cur + format.size();
+  while (cur < end) {
+    auto tokenEnd = cur;
+    if (*tokenEnd == '%') { // pattern
+      ++tokenEnd;
+      if (tokenEnd == end) {
+        break;
+      }
+      switch (*tokenEnd) {
+        case 'a':
+          builder.appendDayOfWeekText(3);
+          break;
+        case 'b':
+          builder.appendMonthOfYearText(3);
+          break;
+        case 'c':
+          builder.appendMonthOfYear(1);
+          break;
+        case 'd':
+          builder.appendDayOfMonth(2);
+          break;
+        case 'e':
+          builder.appendDayOfMonth(1);
+          break;
+        case 'f':
+          builder.appendFractionOfSecond(6);
+          break;
+        case 'H':
+          builder.appendHourOfDay(2);
+          break;
+        case 'h':
+        case 'I':
+          builder.appendClockHourOfHalfDay(2);
+          break;
+        case 'i':
+          builder.appendMinuteOfHour(2);
+          break;
+        case 'j':
+          builder.appendDayOfYear(3);
+          break;
+        case 'k':
+          builder.appendHourOfDay(1);
+          break;
+        case 'l':
+          builder.appendClockHourOfHalfDay(1);
+          break;
+        case 'M':
+          builder.appendMonthOfYearText(4);
+          break;
+        case 'm':
+          builder.appendMonthOfYear(2);
+          break;
+        case 'p':
+          builder.appendHalfDayOfDay();
+          break;
+        case 'r':
+          builder.appendClockHourOfHalfDay(2);
+          builder.appendLiteral(":");
+          builder.appendMinuteOfHour(2);
+          builder.appendLiteral(":");
+          builder.appendSecondOfMinute(2);
+          builder.appendLiteral(" ");
+          builder.appendHalfDayOfDay();
+          break;
+        case 'S':
+        case 's':
+          builder.appendSecondOfMinute(2);
+          break;
+        case 'T':
+          builder.appendHourOfDay(2);
+          builder.appendLiteral(":");
+          builder.appendMinuteOfHour(2);
+          builder.appendLiteral(":");
+          builder.appendSecondOfMinute(2);
+          break;
+        case 'v':
+          builder.appendWeekOfWeekYear(2);
+          break;
+        case 'W':
+          builder.appendDayOfWeekText(4);
+          break;
+        case 'x':
+          builder.appendWeekYear(4);
+          break;
+        case 'Y':
+          builder.appendYear(4);
+          break;
+        case 'y':
+          builder.appendYear(2);
+          break;
+        case '%':
+          builder.appendLiteral("%");
+          break;
+        case 'D':
+        case 'U':
+        case 'u':
+        case 'V':
+        case 'w':
+        case 'X':
+          VELOX_UNSUPPORTED("Specifier {} is not supported.", *tokenEnd)
+        default:
+          builder.appendLiteral(tokenEnd, 1);
+          break;
+      }
+      ++tokenEnd;
+    } else {
+      while (tokenEnd < end && *tokenEnd != '%') {
+        ++tokenEnd;
+      }
+      builder.appendLiteral(cur, tokenEnd - cur);
+    }
+    cur = tokenEnd;
+  }
+  return builder.build();
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/Timestamp.h"
+
+namespace facebook::velox::functions {
+
+enum class DateTimeFormatSpecifier : uint8_t {
+  // Era, e.g: "AD"
+  ERA = 0,
+
+  // Century of era (>=0), e.g: 20
+  CENTURY_OF_ERA = 1,
+
+  // Year of era (>=0), e.g: 1996
+  YEAR_OF_ERA = 2,
+
+  // Week year based on ISO week date, e.g: 1996
+  WEEK_YEAR = 3,
+
+  // Week of week year based on ISO week date, e.g: 27
+  WEEK_OF_WEEK_YEAR = 4,
+
+  // Day of week, 0 ~ 6 with 0 representing Sunday
+  DAY_OF_WEEK_0_BASED = 5,
+
+  // Day of week, 1 ~ 7
+  DAY_OF_WEEK_1_BASED = 6,
+
+  // Day of week, e.g: "Tuesday" or "Tue", depending on number of times provided
+  // formatter character repeats
+  DAY_OF_WEEK_TEXT = 7,
+
+  // Year, can be negative e.g: 1996, -2000
+  YEAR = 8,
+
+  // Day of year, 1 ~ 366 e.g: 189
+  DAY_OF_YEAR = 9,
+
+  // Month of year, e.g: 07, or 7 depending on number of times provided
+  // formatter character repeats
+  MONTH_OF_YEAR = 10,
+
+  // Month of year, e.g. Dec, December depending on number of times provided
+  // formatter character repeats
+  MONTH_OF_YEAR_TEXT = 11,
+
+  // Day of month, e.g: 10, 01, 001, with/without padding 0s depending on number
+  // of times provided formatter character repeats
+  DAY_OF_MONTH = 12,
+
+  // Halfday of day, e.g: "PM"
+  HALFDAY_OF_DAY = 13,
+
+  // Hour of halfday (0~11)
+  HOUR_OF_HALFDAY = 14,
+
+  // Clockhour of halfday (1~12)
+  CLOCK_HOUR_OF_HALFDAY = 15,
+
+  // Hour of day (0~23)
+  HOUR_OF_DAY = 16,
+
+  // Clockhour of day (1~24)
+  CLOCK_HOUR_OF_DAY = 17,
+
+  // Minute of hour, e.g: 30
+  MINUTE_OF_HOUR = 18,
+
+  // Second of minute, e.g: 55
+  SECOND_OF_MINUTE = 19,
+
+  // Decimal fraction of a second, e.g: The fraction of 00:00:01.987 is 987
+  FRACTION_OF_SECOND = 20,
+
+  // Timezone, e.g: "Pacific Standard Time" or "PST"
+  TIMEZONE = 21,
+
+  // Timezone offset/id, e.g: "-0800", "-08:00" or "America/Los_Angeles"
+  TIMEZONE_OFFSET_ID = 22,
+
+  // A literal % character
+  LITERAL_PERCENT = 23
+};
+
+struct FormatPattern {
+  DateTimeFormatSpecifier specifier;
+
+  // The minimum number of digits the formatter is going to use to represent a
+  // field. The formatter is assumed to use as few digits as possible for the
+  // representation. E.g: For text representation of March, with
+  // minRepresentDigits being 2 or 3 it will be 'Mar'. And with
+  // minRepresentDigits being 4 or 5 it will be 'March'.
+  size_t minRepresentDigits;
+};
+
+struct DateTimeToken {
+  enum class Type { kPattern, kLiteral } type;
+  union {
+    FormatPattern pattern;
+    std::string_view literal;
+  };
+
+  explicit DateTimeToken(const FormatPattern& pattern)
+      : type(Type::kPattern), pattern(pattern) {}
+
+  explicit DateTimeToken(const std::string_view& literal)
+      : type(Type::kLiteral), literal(literal) {}
+
+  bool operator==(const DateTimeToken& right) const {
+    if (type == right.type) {
+      if (type == Type::kLiteral) {
+        return literal == right.literal;
+      } else {
+        return pattern.specifier == right.pattern.specifier &&
+            pattern.minRepresentDigits == right.pattern.minRepresentDigits;
+      }
+    }
+    return false;
+  }
+};
+
+struct DateTimeResult {
+  Timestamp timestamp;
+  int64_t timezoneId{-1};
+};
+
+/// A user defined formatter that formats/parses time to/from user provided
+/// format. User can use DateTimeFormatterBuilder to build desired formatter.
+/// E.g. In MySQL standard a formatter will have '%Y' '%d' and etc. as its
+/// specifiers. But in Joda standard a formatter will have 'YYYY' 'dd' and etc.
+/// as its specifiers. Both standards can be configured using this formatter.
+class DateTimeFormatter {
+ public:
+  explicit DateTimeFormatter(
+      std::unique_ptr<char[]>&& literalBuf,
+      size_t bufSize,
+      std::vector<DateTimeToken>&& tokens)
+      : literalBuf_(std::move(literalBuf)),
+        bufSize_(bufSize),
+        tokens_(std::move(tokens)) {}
+
+  const std::unique_ptr<char[]>& literalBuf() const {
+    return literalBuf_;
+  }
+
+  size_t bufSize() const {
+    return bufSize_;
+  }
+
+  const std::vector<DateTimeToken>& tokens() const {
+    return tokens_;
+  }
+
+  Timestamp parse(const std::string_view& /* input */) const {
+    VELOX_NYI("date time parsing not implemented yet");
+  }
+
+  std::string format(
+      const Timestamp& timestamp,
+      const date::time_zone* timezone) const;
+
+ private:
+  std::unique_ptr<char[]> literalBuf_;
+  size_t bufSize_;
+  std::vector<DateTimeToken> tokens_;
+};
+
+std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
+    const std::string_view& format);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/DateTimeFormatterBuilder.cpp
+++ b/velox/functions/lib/DateTimeFormatterBuilder.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/DateTimeFormatterBuilder.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
+
+namespace facebook::velox::functions {
+
+DateTimeFormatterBuilder::DateTimeFormatterBuilder(size_t literalBufSize) {
+  literalBuf_ = std::unique_ptr<char[]>(new char[literalBufSize]);
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendEra() {
+  tokens_.emplace_back(FormatPattern{DateTimeFormatSpecifier::ERA, 2});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendCenturyOfEra(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::CENTURY_OF_ERA, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendYearOfEra(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::YEAR_OF_ERA, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekYear(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::WEEK_YEAR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendWeekOfWeekYear(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfWeek0Based(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfWeek1Based(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfWeekText(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_TEXT, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendYear(
+    size_t minDigits) {
+  tokens_.emplace_back(FormatPattern{DateTimeFormatSpecifier::YEAR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfYear(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::DAY_OF_YEAR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendMonthOfYear(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::MONTH_OF_YEAR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendMonthOfYearText(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::MONTH_OF_YEAR_TEXT, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendDayOfMonth(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::DAY_OF_MONTH, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendHalfDayOfDay() {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendHourOfHalfDay(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::HOUR_OF_HALFDAY, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendClockHourOfHalfDay(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendHourOfDay(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::HOUR_OF_DAY, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendClockHourOfDay(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendMinuteOfHour(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::MINUTE_OF_HOUR, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendSecondOfMinute(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::SECOND_OF_MINUTE, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendFractionOfSecond(
+    size_t digits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::FRACTION_OF_SECOND, digits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendTimeZone(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::TIMEZONE, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendTimeZoneOffsetId(
+    size_t minDigits) {
+  tokens_.emplace_back(
+      FormatPattern{DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID, minDigits});
+  return *this;
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendLiteral(
+    const std::string_view& literal) {
+  return appendLiteral(literal.data(), literal.size());
+}
+
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendLiteral(
+    const char* literalStart,
+    size_t literalSize) {
+  std::strncpy(literalBuf_.get() + bufEnd_, literalStart, literalSize);
+  bufEnd_ += literalSize;
+  if (!tokens_.empty() &&
+      tokens_.back().type == DateTimeToken::Type::kLiteral) {
+    // Extend the previous literal string view.
+    auto& prev = tokens_.back().literal;
+    tokens_.back().literal =
+        std::string_view(prev.data(), prev.size() + literalSize);
+  } else {
+    tokens_.emplace_back(std::string_view(
+        literalBuf_.get() + bufEnd_ - literalSize, literalSize));
+  }
+  return *this;
+}
+
+std::shared_ptr<DateTimeFormatter> DateTimeFormatterBuilder::build() {
+  return std::make_shared<DateTimeFormatter>(
+      std::move(literalBuf_), bufEnd_, std::move(tokens_));
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/DateTimeFormatterBuilder.h
+++ b/velox/functions/lib/DateTimeFormatterBuilder.h
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::functions {
+
+class DateTimeFormatter;
+struct DateTimeToken;
+
+/// Builder class that builds DateTimeFormatter object. For example, let's
+/// assume MySQL date time standard is used. To build a formatter of the form
+/// '%Y-%m-%d' you do:
+/// DateTimeFormatterBuilder(8)     // Length of format
+///     .appendYear(4)              // Year of 4 digits
+///     .appendLiteral("-")
+///     .appendMonthOfYear(2)       // Month of 2 digits
+///     .appendLiteral("-")
+///     .appendDayOfMonth(2)        // Day of 2 digits
+///     .build();
+class DateTimeFormatterBuilder {
+ public:
+  explicit DateTimeFormatterBuilder(size_t literalBufSize);
+
+  /// Appends era to formatter builder, e.g: "AD"
+  DateTimeFormatterBuilder& appendEra();
+
+  /// Appends century of era (>=0) to formatter builder, e.g: 20
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent century of era. The format by default is going use
+  /// as few digits as possible but greater than or equal to minDigits to
+  /// represent century of era. e.g. year 999, with min digit being 1 the
+  /// formatted result will be 9 , with min digit being 2 the formatted result
+  /// will be 09
+  DateTimeFormatterBuilder& appendCenturyOfEra(size_t minDigits);
+
+  /// Appends year of era (>=0) to formatter builder, e.g: 1999
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent year of era. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent
+  /// year of era. e.g. year 1999, with min digit being 1 the formatted result
+  /// will be 99 (year of century), with min digit being 2 the formatted result
+  /// will be 99 (year of century), with min digit being 3 the formatted result
+  /// will be 1999, with min digit being 4 the formatted result will be 1999,
+  /// and with min digit being 5 the formatted result will be 01999
+  DateTimeFormatterBuilder& appendYearOfEra(size_t minDigits);
+
+  /// Appends week year to formatter builder, e.g: 1999
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent week year. The format by default is going use as few
+  /// digits as possible greater than or equal to minDigits to represent
+  /// week year. e.g. 1999-01-01, with min digit being 1 the formatted result
+  /// will be 98 (year of century), with min digit being 2 the formatted result
+  /// will be 98 (year of century), with min digit being 3 the formatted result
+  /// will be 1998, with min digit being 4 the formatted result will be 1998,
+  /// and with min digit being 5 the formatted result will be 01998
+  DateTimeFormatterBuilder& appendWeekYear(size_t minDigits);
+
+  /// Appends week of week year to formatter builder, e.g: 2
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent week of week year. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent week of week year. e.g. 1999-01-08, with min digit being 1 the
+  /// formatted result will be 1, with min digit being 2 the formatted result
+  /// will be 01 (year of century), with min digit being 3 the formatted result
+  /// will be 001
+  DateTimeFormatterBuilder& appendWeekOfWeekYear(size_t minDigits);
+
+  /// Appends day of week to formatter builder. The number is 0 based with 0 ~ 6
+  /// representing Sunday to Saturday respectively
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent day of week. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent day
+  /// of week. e.g. 1999-01-01, with min digit being 1 the formatted result will
+  /// be 5, with min digit being 2 the formatted result will be 05
+  DateTimeFormatterBuilder& appendDayOfWeek0Based(size_t minDigits);
+
+  /// Appends day of week to formatter builder. The number is 1 based with 1 ~ 7
+  /// representing Monday to Sunday respectively
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent day of week. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent day
+  /// of week. e.g. 1999-01-01, with min digit being 1 the formatted result will
+  /// be 5, with min digit being 2 the formatted result will be 05
+  DateTimeFormatterBuilder& appendDayOfWeek1Based(size_t minDigits);
+
+  /// Appends day of week text to formatter builder, e.g: 'Tue' or 'Tuesday'
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent day of week in text. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent day of week. e.g. 1999-01-01, with min digit being 1 the
+  /// formatted result will be 'Fri', with min digit being 4 the formatted
+  /// result will be 'Friday'
+  DateTimeFormatterBuilder& appendDayOfWeekText(size_t minDigits);
+
+  /// Appends year to formatter builder, e.g: 1999
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent year. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent
+  /// year. e.g. year 1999, with min digit being 1 the formatted result will be
+  /// 99 (year of century), with min digit being 2 the formatted result will be
+  /// 99 (year of century), with min digit being 3 the formatted result will be
+  /// 1999, with min digit being 4 the formatted result will be 1999, and with
+  /// min digit being 5 the formatted result will be 01999
+  DateTimeFormatterBuilder& appendYear(size_t minDigits);
+
+  /// Appends day of year to formatter builder, e.g: 365
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent day of year. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent day
+  /// of year. e.g. 1999-01-01, with min digit being 1 the formatted result will
+  /// be 1, with min digit being 4 the formatted result will be 0001
+  DateTimeFormatterBuilder& appendDayOfYear(size_t minDigits);
+
+  /// Appends month of year to formatter builder, e.g: 12
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent month of year. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent
+  /// month of year. e.g. 1999-01-01, with min digit being 1 the formatted
+  /// result will be 1, with min digit being 4 the formatted result will be 0001
+  DateTimeFormatterBuilder& appendMonthOfYear(size_t minDigits);
+
+  /// Appends month of year in text to formatter builder, e.g: Jan, Feb
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent month of year in text. The format by default is
+  /// going use as few digits as possible greater than or equal to minDigits to
+  /// represent month of year. e.g. 1999-01-01, with min digit being 1 the
+  /// formatted result will be Jan, with min digit being 4 the formatted result
+  /// will be January
+  DateTimeFormatterBuilder& appendMonthOfYearText(size_t minDigits);
+
+  /// Appends day of month to formatter builder, e.g: 30
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent day of month. The format by default is going use as
+  /// few digits as possible greater than or equal to minDigits to represent day
+  /// of month. e.g. 1999-01-01, with min digit being 1 the formatted result
+  /// will be 1, with min digit being 4 the formatted result will be 0001
+  DateTimeFormatterBuilder& appendDayOfMonth(size_t minDigits);
+
+  /// Appends half day of day to formatter builder, e.g: 'AM' or 'PM'
+  DateTimeFormatterBuilder& appendHalfDayOfDay();
+
+  /// Appends hour of half day to formatter builder, e.g: 11
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent hour of half day. The format by default is going use
+  /// as few digits as possible greater than or equal to minDigits to represent
+  /// hour of half day. e.g. 1999-01-01 01:00:00, with min digit being 1 the
+  /// formatted result will be 1, with min digit being 4 the formatted result
+  /// will be 0001
+  DateTimeFormatterBuilder& appendHourOfHalfDay(size_t minDigits);
+
+  /// Appends clock hour of half day to formatter builder, e.g: 12
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent clock hour of half day. The format by default is
+  /// going use as few digits as possible greater than or equal to minDigits to
+  /// represent clock hour of half day. e.g. 1999-01-01 00:00:00, with min digit
+  /// being 1 the formatted result will be 12, with min digit being 4 the
+  /// formatted result will be 0012
+  DateTimeFormatterBuilder& appendClockHourOfHalfDay(size_t minDigits);
+
+  /// Appends hour of day to formatter builder, e.g: 23
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent hour of day. The format by default is going use
+  /// as few digits as possible greater than or equal to minDigits to represent
+  /// hour of day. e.g. 1999-01-01 01:00:00, with min digit being 1 the
+  /// formatted result will be 1, with min digit being 4 the formatted result
+  /// will be 0001
+  DateTimeFormatterBuilder& appendHourOfDay(size_t minDigits);
+
+  /// Appends clock hour of day to formatter builder, e.g: 24
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent clock hour of day. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent clock hour of day. e.g. 1999-01-01 01:00:00, with min digit
+  /// being 1 the formatted result will be 1, with min digit being 4 the
+  /// formatted result will be 0001
+  DateTimeFormatterBuilder& appendClockHourOfDay(size_t minDigits);
+
+  /// Appends minute of hour to formatter builder, e.g: 59
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent minute of hour. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent minute of hour. e.g. 1999-01-01 01:59:00, with min digit
+  /// being 1 the formatted result will be 59, with min digit being 4 the
+  /// formatted result will be 0059
+  DateTimeFormatterBuilder& appendMinuteOfHour(size_t minDigits);
+
+  /// Appends second of minute to formatter builder, e.g: 59
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent second of minute. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent second of minute. e.g. 1999-01-01 01:59:00, with min digit
+  /// being 1 the formatted result will be 59, with min digit being 4 the
+  /// formatted result will be 0059
+  DateTimeFormatterBuilder& appendSecondOfMinute(size_t minDigits);
+
+  /// Appends fraction of second to formatter builder, e.g: 998
+  ///
+  /// \param digits describes the number of digits this format uses to represent
+  /// fraction of second. e.g. 1999-01-01 01:59:00.987, with digit being 1 the
+  /// formatted result will be 9, with digit being 4 the formatted result will
+  /// be 9870, with digit being 6 the formatted result will be 987000
+  DateTimeFormatterBuilder& appendFractionOfSecond(size_t digits);
+
+  /// Appends time zone to formatter builder, e.g: 'Pacific Standard Time' or
+  /// 'PST'
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent time zone. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent time zone.
+  DateTimeFormatterBuilder& appendTimeZone(size_t minDigits);
+
+  /// Appends time zone offset id to formatter builder, e.g: '-0800' or '-08:00'
+  /// or 'America/Los_Angeles'
+  ///
+  /// \param minDigits describes the minimum number of digits this format is
+  /// required to represent time zone offset id. The format by default is going
+  /// use as few digits as possible greater than or equal to minDigits to
+  /// represent time zone offset id.
+  DateTimeFormatterBuilder& appendTimeZoneOffsetId(size_t minDigits);
+
+  DateTimeFormatterBuilder& appendLiteral(const std::string_view& literal);
+
+  DateTimeFormatterBuilder& appendLiteral(
+      const char* literalStart,
+      size_t literalSize);
+
+  std::shared_ptr<DateTimeFormatter> build();
+
+ private:
+  std::unique_ptr<char[]> literalBuf_;
+  size_t bufEnd_{0};
+  std::vector<DateTimeToken> tokens_;
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 add_executable(
   velox_functions_lib_test
-  IsNullTest.cpp IsNotNullTest.cpp JodaDateTimeTest.cpp Re2FunctionsTest.cpp
-  ArrayBuilderTest.cpp)
+  ArrayBuilderTest.cpp DateTimeFormatterTest.cpp IsNullTest.cpp
+  IsNotNullTest.cpp JodaDateTimeTest.cpp Re2FunctionsTest.cpp)
 
 add_test(velox_functions_lib_test velox_functions_lib_test)
 

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/external/date/tz.h"
+#include "velox/functions/lib/DateTimeFormatterBuilder.h"
+#include "velox/type/TimestampConversion.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+namespace facebook::velox::functions {
+
+class DateTimeFormatterTest : public testing::Test {};
+
+TEST_F(DateTimeFormatterTest, fixedLengthTokenBuilder) {
+  DateTimeFormatterBuilder builder(100);
+  std::string expectedLiterals;
+  std::vector<DateTimeToken> expectedTokens;
+
+  // Test fixed length tokens
+  builder.appendEra();
+  builder.appendLiteral("-");
+  auto formatter = builder.appendHalfDayOfDay().build();
+
+  expectedLiterals = "-";
+  std::string_view actualLiterals(
+      formatter->literalBuf().get(), formatter->bufSize());
+  EXPECT_EQ(actualLiterals, expectedLiterals);
+  expectedTokens = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::ERA, 2}),
+      DateTimeToken("-"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
+  EXPECT_EQ(formatter->tokens(), expectedTokens);
+}
+
+TEST_F(DateTimeFormatterTest, variableLengthTokenBuilder) {
+  // Test variable length tokens
+  DateTimeFormatterBuilder builder(100);
+  std::string expectedLiterals;
+  std::vector<DateTimeToken> expectedTokens;
+
+  auto formatter = builder.appendCenturyOfEra(3)
+                       .appendLiteral("-")
+                       .appendYearOfEra(4)
+                       .appendLiteral("/")
+                       .appendWeekYear(3)
+                       .appendLiteral("//")
+                       .appendWeekOfWeekYear(3)
+                       .appendLiteral("-00-")
+                       .appendDayOfWeek0Based(3)
+                       .appendDayOfWeek1Based(4)
+                       .appendLiteral("--")
+                       .appendDayOfWeekText(6)
+                       .appendLiteral("---")
+                       .appendYear(5)
+                       .appendLiteral("///")
+                       .appendDayOfYear(4)
+                       .appendMonthOfYear(2)
+                       .appendMonthOfYearText(4)
+                       .appendDayOfMonth(4)
+                       .appendHourOfHalfDay(2)
+                       .appendClockHourOfHalfDay(3)
+                       .appendClockHourOfDay(2)
+                       .appendHourOfDay(2)
+                       .appendMinuteOfHour(2)
+                       .appendSecondOfMinute(1)
+                       .appendFractionOfSecond(6)
+                       .appendTimeZone(3)
+                       .appendTimeZoneOffsetId(3)
+                       .build();
+
+  expectedLiterals = "-///-00------///";
+  auto actualLiterals =
+      std::string_view(formatter->literalBuf().get(), formatter->bufSize());
+  EXPECT_EQ(actualLiterals, expectedLiterals);
+  expectedTokens = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::CENTURY_OF_ERA, 3}),
+      DateTimeToken("-"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR_OF_ERA, 4}),
+      DateTimeToken("/"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::WEEK_YEAR, 3}),
+      DateTimeToken("//"),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR, 3}),
+      DateTimeToken("-00-"),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED, 3}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED, 4}),
+      DateTimeToken("--"),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::DAY_OF_WEEK_TEXT, 6}),
+      DateTimeToken("---"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 5}),
+      DateTimeToken("///"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::DAY_OF_YEAR, 4}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::MONTH_OF_YEAR, 2}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::MONTH_OF_YEAR_TEXT, 4}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::DAY_OF_MONTH, 4}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HOUR_OF_HALFDAY, 2}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY, 3}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY, 2}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HOUR_OF_DAY, 2}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::MINUTE_OF_HOUR, 2}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::SECOND_OF_MINUTE, 1}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::FRACTION_OF_SECOND, 6}),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::TIMEZONE, 3}),
+      DateTimeToken(
+          FormatPattern{DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID, 3})};
+  EXPECT_EQ(formatter->tokens(), expectedTokens);
+}
+
+class MysqlDateTimeTest : public DateTimeFormatterTest {};
+
+TEST_F(MysqlDateTimeTest, validBuild) {
+  std::vector<DateTimeToken> expected;
+
+  expected = {DateTimeToken(" ")};
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter(" ")->tokens());
+
+  expected = {
+      DateTimeToken(" "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter(" %Y")->tokens());
+
+  expected = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 2}),
+      DateTimeToken(" "),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("%y ")->tokens());
+
+  expected = {DateTimeToken(" 132&2618*673 *--+= }{[]\\:")};
+  EXPECT_EQ(
+      expected,
+      buildMysqlDateTimeFormatter(" 132&2618*673 *--+= }{[]\\:")->tokens());
+
+  expected = {
+      DateTimeToken("   "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+      DateTimeToken(" &^  "),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("   %Y &^  ")->tokens());
+
+  expected = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 2}),
+      DateTimeToken("   & "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+      DateTimeToken(" "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("%y  % & %Y %Y%")->tokens());
+
+  expected = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+      DateTimeToken(" 'T'"),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("%Y 'T'")->tokens());
+
+  expected = {DateTimeToken("1''2")};
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("1''2")->tokens());
+
+  expected = {
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 4}),
+      DateTimeToken("-"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::MONTH_OF_YEAR, 2}),
+      DateTimeToken("-"),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::DAY_OF_MONTH, 2}),
+      DateTimeToken(" "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::MINUTE_OF_HOUR, 2}),
+      DateTimeToken(" "),
+      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::YEAR, 2}),
+  };
+  EXPECT_EQ(expected, buildMysqlDateTimeFormatter("%Y-%m-%d %i %y")->tokens());
+}
+
+TEST_F(MysqlDateTimeTest, invalidBuild) {
+  // Unsupported specifiers
+  EXPECT_THROW(buildMysqlDateTimeFormatter("%D"), VeloxUserError);
+  EXPECT_THROW(buildMysqlDateTimeFormatter("%U"), VeloxUserError);
+  EXPECT_THROW(buildMysqlDateTimeFormatter("%u"), VeloxUserError);
+  EXPECT_THROW(buildMysqlDateTimeFormatter("%V"), VeloxUserError);
+  EXPECT_THROW(buildMysqlDateTimeFormatter("%w"), VeloxUserError);
+}
+
+TEST_F(MysqlDateTimeTest, formatYear) {
+  auto* timezone = date::locate_zone("GMT");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("0-01-01"), timezone),
+      "0000");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("1-01-01"), timezone),
+      "0001");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("199-01-01"), timezone),
+      "0199");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("9999-01-01"), timezone),
+      "9999");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("-1-01-01"), timezone),
+      "-0001");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("19999-01-01"), timezone),
+      "19999");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("-19999-01-01"), timezone),
+      "-19999");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("-1-01-01"), timezone),
+      "-0001");
+  EXPECT_THROW(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("-99999-01-01"), timezone),
+      VeloxUserError);
+  EXPECT_THROW(
+      buildMysqlDateTimeFormatter("%Y")->format(
+          util::fromTimestampString("99999-01-01"), timezone),
+      VeloxUserError);
+}
+
+TEST_F(MysqlDateTimeTest, formatMonthDay) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("0-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("1-10-24"), timezone),
+      "10~24");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("199-09-30"), timezone),
+      "09~30");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("9999-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("-1-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("19999-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("-19999-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("-1-01-01"), timezone),
+      "01~01");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("2000-02-29"), timezone),
+      "02~29");
+  EXPECT_THROW(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("-1-13-01"), timezone),
+      VeloxUserError);
+  EXPECT_THROW(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("1999-02-50"), timezone),
+      VeloxUserError);
+  EXPECT_THROW(
+      buildMysqlDateTimeFormatter("%m~%d")->format(
+          util::fromTimestampString("1999-02-29"), timezone),
+      VeloxUserError);
+}
+
+TEST_F(MysqlDateTimeTest, formatWeekday) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-04"), timezone),
+      "Mon..->Monday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-05"), timezone),
+      "Tue..->Tuesday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-06"), timezone),
+      "Wed..->Wednesday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-07"), timezone),
+      "Thu..->Thursday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-08"), timezone),
+      "Fri..->Friday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-09"), timezone),
+      "Sat..->Saturday");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%a..->%W")
+          ->format(util::fromTimestampString("1999-01-10"), timezone),
+      "Sun..->Sunday");
+}
+
+TEST_F(MysqlDateTimeTest, formatMonth) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-01-04"), timezone),
+      "1-01-January");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-02-04"), timezone),
+      "2-02-February");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-03-04"), timezone),
+      "3-03-March");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-04-04"), timezone),
+      "4-04-April");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-05-04"), timezone),
+      "5-05-May");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-06-04"), timezone),
+      "6-06-June");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-07-04"), timezone),
+      "7-07-July");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-08-04"), timezone),
+      "8-08-August");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-09-04"), timezone),
+      "9-09-September");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-10-04"), timezone),
+      "10-10-October");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-11-04"), timezone),
+      "11-11-November");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%c-%m-%M")
+          ->format(util::fromTimestampString("1999-12-04"), timezone),
+      "12-12-December");
+}
+
+TEST_F(MysqlDateTimeTest, formatDayOfMonth) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%d-%e")->format(
+          util::fromTimestampString("2000-02-01"), timezone),
+      "01-1");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%d-%e")->format(
+          util::fromTimestampString("2000-02-29"), timezone),
+      "29-29");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%d-%e")->format(
+          util::fromTimestampString("2000-12-31"), timezone),
+      "31-31");
+}
+
+TEST_F(MysqlDateTimeTest, formatFractionOfSecond) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.987"), timezone),
+      "987000");
+
+  // As our current precision is 3 decimal places.
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.987654"), timezone),
+      "987000");
+}
+
+TEST_F(MysqlDateTimeTest, formatHour) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%h--%H--%I--%k--%l")
+          ->format(util::fromTimestampString("2000-02-01 00:00:00"), timezone),
+      "12--00--12--0--12");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%h--%H--%I--%k--%l")
+          ->format(util::fromTimestampString("2000-02-01 12:12:01"), timezone),
+      "12--12--12--12--12");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%h--%H--%I--%k--%l")
+          ->format(util::fromTimestampString("2000-02-01 23:23:01"), timezone),
+      "11--23--11--23--11");
+}
+
+TEST_F(MysqlDateTimeTest, formatMinute) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%i")->format(
+          util::fromTimestampString("2000-02-01 00:00:00"), timezone),
+      "00");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%i")->format(
+          util::fromTimestampString("2000-02-01 00:09:00"), timezone),
+      "09");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%i")->format(
+          util::fromTimestampString("2000-02-01 00:31:00"), timezone),
+      "31");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%i")->format(
+          util::fromTimestampString("2000-02-01 00:59:00"), timezone),
+      "59");
+}
+
+TEST_F(MysqlDateTimeTest, formatDayOfYear) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%j")->format(
+          util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+      "001");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%j")->format(
+          util::fromTimestampString("2000-12-31 00:09:00"), timezone),
+      "366");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%j")->format(
+          util::fromTimestampString("1999-12-31 00:31:00"), timezone),
+      "365");
+}
+
+TEST_F(MysqlDateTimeTest, formatAmPm) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%p")->format(
+          util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+      "AM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%p")->format(
+          util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+      "AM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%p")->format(
+          util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+      "PM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%p")->format(
+          util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+      "PM");
+}
+
+TEST_F(MysqlDateTimeTest, formatSecond) {
+  auto* timezone = date::locate_zone("GMT");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%s-%S")->format(
+          util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+      "00-00");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%s-%S")->format(
+          util::fromTimestampString("2000-01-01 00:00:30"), timezone),
+      "30-30");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%s-%S")->format(
+          util::fromTimestampString("2000-01-01 00:00:59"), timezone),
+      "59-59");
+}
+
+TEST_F(MysqlDateTimeTest, formatCompositeTime) {
+  auto* timezone = date::locate_zone("GMT");
+
+  // 12 hour %r
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%r")->format(
+          util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+      "12:00:00 AM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%r")->format(
+          util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+      "11:59:59 AM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%r")->format(
+          util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+      "12:00:00 PM");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%r")->format(
+          util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+      "11:59:59 PM");
+
+  // 24 hour %T
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%T")->format(
+          util::fromTimestampString("2000-01-01 00:00:00"), timezone),
+      "00:00:00");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%T")->format(
+          util::fromTimestampString("2000-01-01 11:59:59"), timezone),
+      "11:59:59");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%T")->format(
+          util::fromTimestampString("2000-01-01 12:00:00"), timezone),
+      "12:00:00");
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%T")->format(
+          util::fromTimestampString("2000-01-01 23:59:59"), timezone),
+      "23:59:59");
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -16,6 +16,7 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/Macros.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/JodaDateTime.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -674,23 +675,19 @@ template <typename T>
 struct DateFormatFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  static constexpr const std::size_t kYmdLength = 10;
-
   const date::time_zone* sessionTimeZone_ = nullptr;
-  std::optional<StringView> format_ = std::nullopt;
-
-  FOLLY_ALWAYS_INLINE bool isValidFormat(const StringView& format) {
-    return format == "%Y-%m-%d";
-  }
+  std::shared_ptr<DateTimeFormatter> mysqlDateTime_;
+  bool isConstFormat_ = false;
 
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
       const arg_type<Timestamp>* /*timestamp*/,
       const arg_type<Varchar>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
-
-    if (formatString != nullptr && isValidFormat(*formatString)) {
-      format_ = StringView(formatString->data(), formatString->size());
+    if (formatString != nullptr) {
+      mysqlDateTime_ = buildMysqlDateTimeFormatter(
+          std::string_view(formatString->data(), formatString->size()));
+      isConstFormat_ = true;
     }
   }
 
@@ -698,24 +695,17 @@ struct DateFormatFunction {
       out_type<Varchar>& result,
       const arg_type<Timestamp>& timestamp,
       const arg_type<Varchar>& formatString) {
-    StringView format;
-    if (format_.has_value()) {
-      format = format_.value();
-    } else {
-      VELOX_USER_CHECK(
-          isValidFormat(formatString),
-          "Format {} is not implemented for TIMESTAMP yet",
-          formatString);
-      format = StringView(formatString.data(), formatString.size());
+    if (!isConstFormat_) {
+      mysqlDateTime_ = buildMysqlDateTimeFormatter(
+          std::string_view(formatString.data(), formatString.size()));
     }
 
-    std::tm dateTime = getDateTime(timestamp, sessionTimeZone_);
-
-    char formattedDateTime[kYmdLength + 1];
-    std::strftime(
-        formattedDateTime, sizeof(formattedDateTime), format.data(), &dateTime);
-    result.resize(kYmdLength * sizeof(char));
-    std::memcpy(result.data(), formattedDateTime, kYmdLength * sizeof(char));
+    auto formattedResult = mysqlDateTime_->format(timestamp, sessionTimeZone_);
+    auto resultSize = formattedResult.size();
+    result.resize(resultSize);
+    if (resultSize != 0) {
+      std::memcpy(result.data(), formattedResult.data(), resultSize);
+    }
     return true;
   }
 };

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -69,6 +69,8 @@ void registerSimpleFunctions() {
       TimestampWithTimezone,
       Varchar,
       Varchar>({"parse_datetime"});
+  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
+      {"date_format"});
 }
 } // namespace
 


### PR DESCRIPTION
Add date time formatter builder for generic date time formatting.

In Velox we need to support joda time standard as well as mysql time standard. The series of commits will be working on abstracting time parser/formatter to be flexibly applied to different time format systems.

Based on different format systems, developers use DateTimeFormatterBuilder to build costumed formatter and then apply that formatter to format/parse timestamp/string. The implementation of formatter will come in later commits.

New classes will be added first. When fully implemented, it will be changed to replace existing formatter.