### PR TITLE
Move registerTypeResolver() to parser library

### DIFF
--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(
   velox_type
   velox_vector
   velox_expression
-  velox_exec_test_util
   velox_expression_fuzzer
   velox_parse_parser
   velox_serialization

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -16,10 +16,8 @@ add_library(velox_temp_path TempFilePath.cpp TempDirectoryPath.cpp)
 
 target_link_libraries(velox_temp_path velox_exception)
 
-add_library(
-  velox_exec_test_util
-  FunctionUtils.cpp PlanBuilder.cpp QueryAssertions.cpp Cursor.cpp
-  OperatorTestBase.cpp HiveConnectorTestBase.cpp)
+add_library(velox_exec_test_util PlanBuilder.cpp QueryAssertions.cpp Cursor.cpp
+                                 OperatorTestBase.cpp HiveConnectorTestBase.cpp)
 
 target_link_libraries(
   velox_exec_test_util

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -15,14 +15,14 @@
  */
 
 #include "velox/exec/tests/utils/OperatorTestBase.h"
-#include <velox/parse/Expressions.h>
-#include <velox/parse/ExpressionsParser.h>
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/dwio/common/DataSink.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 namespace facebook::velox::exec::test {
@@ -36,7 +36,7 @@ OperatorTestBase::OperatorTestBase() {
   if (!isRegisteredVectorSerde()) {
     velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
   }
-  registerTypeResolver();
+  parse::registerTypeResolver();
 }
 
 OperatorTestBase::~OperatorTestBase() {

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 #pragma once
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <sstream>
 #include <stdexcept>
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/experimental/codegen/ast/CodegenUtils.h"
 #include "velox/experimental/codegen/code_generator/ExprCodeGenerator.h"
 #include "velox/experimental/codegen/compiler_utils/CodeManager.h"
@@ -30,6 +30,7 @@
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ConstantVector.h"
@@ -502,7 +503,7 @@ class ExpressionCodegenTestBase : public testing::Test {
     functions::prestosql::registerArithmeticFunctions();
 
     // Register type resolver with the SQL parser.
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
   }
 
  protected:

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -21,13 +21,13 @@
 #include <memory>
 #include "velox/core/PlanNode.h"
 #include "velox/dwio_move/dwrf/test/utils/BatchMaker.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/experimental/codegen/CodegenCompiledExpressionTransform.h"
 #include "velox/experimental/codegen/CompiledExpressionAnalysis.h"
 #include "velox/experimental/codegen/tests/CodegenTestBase.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::codegen;

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -24,7 +24,6 @@
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/tests/utils/Cursor.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/codegen/CodegenCompiledExpressionTransform.h"
 #include "velox/experimental/codegen/CodegenLogger.h"
@@ -33,6 +32,7 @@
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::codegen {
@@ -106,7 +106,7 @@ class CodegenTestCore {
     queryCtx_ = core::QueryCtx::createForTest();
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
     functions::prestosql::registerAllScalarFunctions();
   }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -17,14 +17,14 @@
 #include <folly/Benchmark.h>
 #include "glog/logging.h"
 #include "gtest/gtest.h"
+
 #include "velox/dwio/common/DataSink.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/expression/ControlExpr.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorEncoding.h"
 #include "velox/vector/tests/VectorMaker.h"
 
@@ -105,7 +105,7 @@ class ExprTest : public testing::Test {
  protected:
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
 
     testDataType_ =
         ROW({"tinyint1",

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -15,10 +15,10 @@
  */
 #pragma once
 
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/expression/Expr.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/VectorMaker.h"
 
 namespace facebook::velox::functions::test {
@@ -26,7 +26,7 @@ namespace facebook::velox::functions::test {
 class FunctionBenchmarkBase {
  public:
   FunctionBenchmarkBase() {
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
   }
 
   exec::ExprSet compileExpression(

--- a/velox/functions/lib/tests/IsNotNullTest.cpp
+++ b/velox/functions/lib/tests/IsNotNullTest.cpp
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/tests/utils/FunctionUtils.h"
+
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions {
+
 void registerIsNotNull() {
-  facebook::velox::exec::test::registerTypeResolver();
+  parse::registerTypeResolver();
   VELOX_REGISTER_VECTOR_FUNCTION(udf_is_not_null, "isnotnull");
 }
+
 }; // namespace facebook::velox::functions
 
 using namespace facebook::velox;

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -22,8 +22,8 @@
 #include <string>
 
 #include "velox/common/base/VeloxException.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/type/StringView.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
@@ -40,7 +40,7 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
 class Re2FunctionsTest : public test::FunctionBaseTest {
  public:
   static void SetUpTestCase() {
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
     exec::registerStatefulVectorFunction(
         "re2_match", re2MatchSignatures(), makeRe2Match);
     exec::registerStatefulVectorFunction(

--- a/velox/functions/prestosql/tests/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.cpp
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions::test {
+
 void FunctionBaseTest::SetUpTestCase() {
-  exec::test::registerTypeResolver();
+  parse::registerTypeResolver();
   functions::prestosql::registerAllScalarFunctions();
 }
+
 } // namespace facebook::velox::functions::test

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -18,7 +18,6 @@
 #include <limits>
 #include <optional>
 
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/functions/sparksql/Register.h"
 #include "velox/functions/sparksql/tests/ArraySortTestData.h"

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -18,7 +18,6 @@
 #include <limits>
 #include <optional>
 
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/functions/sparksql/Register.h"
 #include "velox/functions/sparksql/tests/ArraySortTestData.h"

--- a/velox/functions/sparksql/tests/SparkFunctionBaseTest.h
+++ b/velox/functions/sparksql/tests/SparkFunctionBaseTest.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include "velox/exec/tests/utils/FunctionUtils.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/functions/sparksql/Register.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions::sparksql::test {
 
@@ -28,7 +28,7 @@ class SparkFunctionBaseTest : public FunctionBaseTest {
   // Ensure Spark functions are registered; don't register the "common"
   // (CoreSQL) functions.
   static void SetUpTestCase() {
-    exec::test::registerTypeResolver();
+    parse::registerTypeResolver();
     sparksql::registerFunctions("");
   }
 };

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(velox_parse_parser ExpressionsParser.cpp)
 target_link_libraries(velox_parse_parser velox_parse_expression velox_type
                       velox_duckdb_parser)
 
-add_library(velox_parse_utils VariantToVector.cpp)
+add_library(velox_parse_utils TypeResolver.cpp VariantToVector.cpp)
 target_link_libraries(velox_parse_utils velox_buffer velox_type velox_vector)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/tests/utils/FunctionUtils.h"
+
+#include "velox/parse/TypeResolver.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/SignatureBinder.h"
@@ -21,7 +22,7 @@
 #include "velox/parse/Expressions.h"
 #include "velox/type/Type.h"
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::parse {
 namespace {
 
 std::shared_ptr<const Type> resolveType(
@@ -74,7 +75,7 @@ std::shared_ptr<const Type> resolveType(
     }
 
     for (const auto& signature : signatures.value()) {
-      SignatureBinder binder(*signature, inputTypes);
+      exec::SignatureBinder binder(*signature, inputTypes);
       if (binder.tryBind()) {
         return binder.tryResolveReturnType();
       }
@@ -83,9 +84,11 @@ std::shared_ptr<const Type> resolveType(
 
   return nullptr;
 }
+
 } // namespace
 
 void registerTypeResolver() {
   core::Expressions::setTypeResolverHook(&resolveType);
 }
-} // namespace facebook::velox::exec::test
+
+} // namespace facebook::velox::parse

--- a/velox/parse/TypeResolver.h
+++ b/velox/parse/TypeResolver.h
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
-namespace facebook::velox::memory {
-class MemoryPool;
-}
+namespace facebook::velox::parse {
 
-namespace facebook::velox::exec::test {
 // Registers type resolver with the parser to resolve return types of special
 // forms (if, switch, and, or, etc.) and vector functions.
 void registerTypeResolver();
-} // namespace facebook::velox::exec::test
+
+} // namespace facebook::velox::parse


### PR DESCRIPTION
Moving this function out of exec/test/utils so we can better organize dependencies, since it only has to do with parsing. 