### PR TITLE
MapWriter benchmark

### DIFF
--- a/velox/expression/ComplexProxyTypes.h
+++ b/velox/expression/ComplexProxyTypes.h
@@ -441,6 +441,9 @@ class MapWriter {
     keysVector_ = &keysWriter_->vector();
     valuesVector_ = &valuesWriter_->vector();
 
+    // Keys can never be null.
+    keysVector_->resetNulls();
+
     keysWriter_->ensureSize(1);
     valuesWriter_->ensureSize(1);
 
@@ -454,7 +457,6 @@ class MapWriter {
     auto index = indexOfLast();
     if constexpr (!requires_commit<K>) {
       VELOX_DCHECK(provide_std_interface<K>);
-      keysVector_->setNull(index, false);
       return keysWriter_->data_[index];
     } else {
       keyNeedsCommit_ = true;

--- a/velox/expression/VectorUdfTypeSystem.h
+++ b/velox/expression/VectorUdfTypeSystem.h
@@ -596,19 +596,19 @@ struct VectorWriter<ArrayProxyT<V>> {
   void init(vector_t& vector) {
     arrayVector_ = &vector;
     childWriter_.init(static_cast<child_vector_t&>(*vector.elements().get()));
-    proxy_.initialize(this);
+    writer_.initialize(this);
   }
 
   // This should be called once all rows are processed.
   void finish() {
-    proxy_.elementsVector_->resize(proxy_.valuesOffset_);
+    writer_.elementsVector_->resize(writer_.valuesOffset_);
     arrayVector_ = nullptr;
   }
 
   VectorWriter() = default;
 
   exec_out_t& current() {
-    return proxy_;
+    return writer_;
   }
 
   vector_t& vector() {
@@ -626,15 +626,15 @@ struct VectorWriter<ArrayProxyT<V>> {
   // Commit a not null value.
   void commit() {
     arrayVector_->setOffsetAndSize(
-        offset_, proxy_.valuesOffset_, proxy_.length_);
+        offset_, writer_.valuesOffset_, writer_.length_);
     arrayVector_->setNull(offset_, false);
-    // Will reset length to 0 and prepare proxy_ for the next item.
-    proxy_.finalize();
+    // Will reset length to 0 and prepare elementWriter_ for the next item.
+    writer_.finalize();
   }
 
   // Commit a null value.
   void commitNull() {
-    proxy_.finalizeNull();
+    writer_.finalizeNull();
     arrayVector_->setNull(offset_, true);
   }
 
@@ -652,12 +652,12 @@ struct VectorWriter<ArrayProxyT<V>> {
   }
 
   void reset() {
-    proxy_.valuesOffset_ = 0;
+    writer_.valuesOffset_ = 0;
   }
 
   vector_t* arrayVector_ = nullptr;
 
-  exec_out_t proxy_;
+  exec_out_t writer_;
 
   VectorWriter<V> childWriter_;
 
@@ -678,21 +678,21 @@ struct VectorWriter<MapWriterT<K, V>> {
     mapVector_ = &vector;
     keyWriter_.init(static_cast<key_vector_t&>(*vector.mapKeys()));
     valWriter_.init(static_cast<val_vector_t&>(*vector.mapValues()));
-    elementWriter_.initialize(this);
+    writer_.initialize(this);
   }
 
   // This should be called once all rows are processed.
   void finish() {
     // Downsize to actual used size.
-    elementWriter_.keysVector_->resize(elementWriter_.innerOffset_);
-    elementWriter_.valuesVector_->resize(elementWriter_.innerOffset_);
+    writer_.keysVector_->resize(writer_.innerOffset_);
+    writer_.valuesVector_->resize(writer_.innerOffset_);
     mapVector_ = nullptr;
   }
 
   VectorWriter() = default;
 
   exec_out_t& current() {
-    return elementWriter_;
+    return writer_;
   }
 
   vector_t& vector() {
@@ -709,16 +709,16 @@ struct VectorWriter<MapWriterT<K, V>> {
   // Commit a not null value.
   void commit() {
     mapVector_->setOffsetAndSize(
-        offset_, elementWriter_.innerOffset_, elementWriter_.length_);
+        offset_, writer_.innerOffset_, writer_.length_);
     mapVector_->setNull(offset_, false);
     // Will reset length to 0 and prepare proxy_.valuesOffset_ for the next
     // item.
-    elementWriter_.finalize();
+    writer_.finalize();
   }
 
   // Commit a null value.
   void commitNull() {
-    elementWriter_.finalizeNull();
+    writer_.finalizeNull();
     mapVector_->setNull(offset_, true);
   }
 
@@ -736,10 +736,10 @@ struct VectorWriter<MapWriterT<K, V>> {
   }
 
   void reset() {
-    elementWriter_.innerOffset_ = 0;
+    writer_.innerOffset_ = 0;
   }
 
-  exec_out_t elementWriter_;
+  exec_out_t writer_;
 
   vector_t* mapVector_;
   VectorWriter<K> keyWriter_;

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -106,3 +106,15 @@ target_compile_definitions(velox_benchmark_nested_array_proxy_with_nulls
                            PUBLIC WITH_NULLS=true)
 target_link_libraries(velox_benchmark_nested_array_proxy_with_nulls
                       ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+
+add_executable(velox_benchmark_map_writer_with_nulls MapWriterBenchmarks.cpp)
+target_compile_definitions(velox_benchmark_map_writer_with_nulls
+                           PUBLIC WITH_NULLS=true)
+target_link_libraries(velox_benchmark_map_writer_with_nulls
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+
+add_executable(velox_benchmark_map_writer_no_nulls MapWriterBenchmarks.cpp)
+target_link_libraries(velox_benchmark_map_writer_no_nulls
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+target_compile_definitions(velox_benchmark_map_writer_no_nulls
+                           PUBLIC WITH_NULLS=false)

--- a/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+
+// This macro should be set, defined in command line.
+// #define WITH_NULLS false
+
+// This file includes benchmarks that evaluate performance of map writer.
+// It benchmark a function that constructs map<int, int> (i-> i*2).
+
+namespace facebook::velox::exec {
+
+namespace {
+
+template <bool oneResize = false>
+class VectorFunctionImpl : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
+
+    // Prepare results.
+    BaseVector::ensureWritable(
+        rows, MAP(BIGINT(), BIGINT()), context->pool(), result);
+
+    auto flatResult = (*result)->as<MapVector>();
+    auto currentOffset = 0;
+    auto keysFlat = flatResult->mapKeys()->asFlatVector<int64_t>();
+    auto valuesFlat = flatResult->mapValues()->asFlatVector<int64_t>();
+
+    auto totalSize = 0;
+
+    if constexpr (oneResize) {
+      rows.applyToSelected([&](vector_size_t row) {
+        totalSize += decoded_->valueAt<int64_t>(row);
+      });
+
+      keysFlat->resize(totalSize, false);
+      valuesFlat->resize(totalSize, false);
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto length = decoded_->valueAt<int64_t>(row);
+
+      flatResult->setNull(row, false);
+      flatResult->setOffsetAndSize(row, currentOffset, length);
+
+      if constexpr (!oneResize) {
+        totalSize += length;
+        keysFlat->resize(totalSize, false);
+        valuesFlat->resize(totalSize, false);
+      }
+
+      for (auto i = 0; i < length; i++) {
+        keysFlat->set(currentOffset + i, i);
+        if (WITH_NULLS && i % 5) {
+          valuesFlat->setNull(currentOffset + i, true);
+        } else {
+          valuesFlat->set(currentOffset + i, i * 2);
+        }
+      }
+
+      currentOffset += length;
+    });
+  }
+};
+
+template <typename T>
+struct SimpleGeneral {
+  template <typename OutT>
+  bool call(OutT& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.add_null() = i;
+      } else {
+        out.add_item() = std::make_tuple(i, i * 2);
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleEmplace {
+  template <typename OutT>
+  bool call(OutT& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.emplace(i, std::nullopt);
+      } else {
+        out.emplace(i, i * 2);
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleResizeSubscript {
+  template <typename OutT>
+  bool call(OutT& out, const int64_t& n) {
+    out.resize(n);
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out[i] = std::make_tuple(i, std::nullopt);
+      } else {
+        out[i] = std::make_tuple(i, i * 2);
+      }
+    }
+    return true;
+  }
+};
+
+template <typename T>
+struct SimpleOld {
+  template <typename OutT>
+  bool call(OutT& out, const int64_t& n) {
+    for (int i = 0; i < n; i++) {
+      if (WITH_NULLS && i % 5) {
+        out.appendNullable(i) = std::nullopt;
+      } else {
+        out.append(i) = i * 2;
+      }
+    }
+    return true;
+  }
+};
+
+class MapWriterBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  MapWriterBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<
+        SimpleResizeSubscript,
+        MapWriterT<int64_t, int64_t>,
+        int64_t>({"simple_resize_subscript"});
+    registerFunction<SimpleGeneral, MapWriterT<int64_t, int64_t>, int64_t>(
+        {"simple_general"});
+    registerFunction<SimpleEmplace, MapWriterT<int64_t, int64_t>, int64_t>(
+        {"simple_emplace"});
+
+    registerFunction<SimpleOld, Map<int64_t, int64_t>, int64_t>({"simple_old"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_resize_per_row",
+        {exec::FunctionSignatureBuilder()
+             .returnType("map(bigint, bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<false>>());
+
+    facebook::velox::exec::registerVectorFunction(
+        "vector_one_resize",
+        {exec::FunctionSignatureBuilder()
+             .returnType("map(bigint, bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl<true>>());
+  }
+
+  vector_size_t size = 1'000;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  void run(const std::string& functionName, size_t n) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+
+    doRun(exprSet, input, n);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t n) {
+    int cnt = 0;
+    for (auto i = 0; i < n; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+
+  bool
+  hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void test() {
+    auto input = makeInput();
+    auto exprSetRef =
+        compileExpression("vector_resize_per_row(c0)", input->type());
+    std::vector<std::string> functions = {
+        "simple_resize_subscript",
+        "simple_general",
+        "simple_old",
+        "simple_emplace",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        VELOX_UNREACHABLE(fmt::format("testing failed at function {}", name));
+      }
+    }
+  }
+};
+
+BENCHMARK(vector_one_resize, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("vector_one_resize", n);
+}
+
+BENCHMARK(vector_resize_per_row, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("vector_resize_per_row", n);
+}
+
+BENCHMARK(simple_resize_subscript, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("simple_resize_subscript", n);
+}
+
+BENCHMARK(simple_emplace, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("simple_emplace", n);
+}
+
+BENCHMARK(simple_general, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("simple_general", n);
+}
+
+BENCHMARK(simple_old, n) {
+  MapWriterBenchmark benchmark;
+  return benchmark.run("simple_old", n);
+}
+
+} // namespace
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::MapWriterBenchmark benchmark;
+  benchmark.test();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
**TLDR:**
- The new map writer interface is 6X-8X faster than the old one.
- Simple functions performance is comparable and very close to vector implementation
that does resize per row.
- The resize + subscript is not that much faster than general and emplace, unlike
in the array writer. I will look into this if i could not make it better, I will just remove those
functions from the interface.

**Details:**
The benchmarks runs a functions with that constructs a map with no other
work to focus at map construction time. Having additional work will reduce the gap
between vector and simple.

Two vector implementations are added:
- `vector_one_resize `: does one resize for all the rows. This is not possible to do in the simple
function right now, and it's not  always possible to do even in vector function.

- `vector_resize_per_row`: resize keys and value for every processed rows.

The following simple function implementations are added:
- `simple_old` : old writer.
- `simple_general`: the general interface ( addNull and addItem).
- `simple_emplace`
- `simple_resize_subscript`

**Results:**

with nulls:
```
-bm_min_usec 1000000
============================================================================
vector_one_resize                                            1.98ms   505.57
vector_resize_per_row                                        2.49ms   402.03
simple_resize_subscript                                      2.28ms   438.92
simple_emplace                                               2.38ms   420.98
simple_general                                               2.41ms   414.58
simple_old                                                  12.78ms    78.25
============================================================================
```

no nulls:
```
 -bm_min_usec 1000000
============================================================================
vector_one_resize                                            1.08ms   925.35
vector_resize_per_row                                        1.67ms   598.42
simple_resize_subscript                                      1.56ms   640.77
simple_emplace                                               1.47ms   680.28
simple_general                                               1.46ms   685.25
simple_old                                                  11.70ms    85.44

============================================================================

 -bm_min_usec 100000000 (10^8).

============================================================================

vector_one_resize                                            1.11ms   901.87
vector_resize_per_row                                        1.56ms   639.08
simple_resize_subscript                                      1.69ms   590.73
simple_emplace                                               1.66ms   602.88
simple_general                                               1.65ms   607.12
simple_old                                                  11.30ms    88.47
============================================================================
```

**Next steps:**
- try to cache data* when key is primitive and see if that gives speedups.
- benchmark nested .i.e: Array<Map> or nested map. I am positive numbers
will be closer for those since there would be more work in general.

Differential Revision: D34289772

