### PR TITLE
Add release linux build to periodic circleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ workflows:
                 - main
     jobs:
       - linux-build
+      - linux-build-release
       - linux-build-options
       - linux-parquet-s3-build
       - macos-build
@@ -157,6 +158,40 @@ jobs:
          command: |
            _build/debug/velox/examples/velox_example_expression_eval
            _build/debug/velox/examples/velox_example_opaque_type
+
+  linux-build-release:
+    executor: build
+    steps:
+      - checkout
+      - run:
+          name: "Calculate merge-base date for CCache"
+          command: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
+      - restore_cache:
+          name: "Restore CCache cache"
+          keys:
+            - velox-ccache-release-{{ arch }}-{{ checksum "merge-base-date" }}
+      - run:
+          name: Build
+          command: |
+            mkdir -p .ccache
+            export CCACHE_DIR=$(realpath .ccache)
+            ccache -sz -M 5Gi
+            source /opt/rh/gcc-toolset-9/enable
+            make release NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            ccache -s
+          no_output_timeout: 1h
+      - store_artifacts:
+          path: '_build/release/.ninja_log'
+      - save_cache:
+          name: "Save CCache cache"
+          key: velox-ccache-release-{{ arch }}-{{ checksum "merge-base-date" }}
+          paths:
+            - .ccache/
+      - run:
+          name: "Run Unit Tests"
+          command: |
+            cd _build/release && ctest -j 16 -VV --output-on-failure
+          no_output_timeout: 1h
 
   linux-benchmarks:
     executor: build


### PR DESCRIPTION
Other than having a release job outside of the parquet and S3 builds, this will help ensure caches are warm for new PR-time benchmark builds. 