### PR TITLE
Add TPC-H query 18 to ParquetTpchTest

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -122,25 +122,28 @@ class ParquetTpchTest : public testing::TestWithParam<QueryParams> {
 };
 
 std::shared_ptr<DuckDbQueryRunner> ParquetTpchTest::duckDb_ = nullptr;
-std::shared_ptr<exec::test::TempDirectoryPath> ParquetTpchTest::tempDirectory_ = nullptr;
-TpchQueryBuilder ParquetTpchTest::tpchBuilder_(    dwio::common::FileFormat::PARQUET);
+std::shared_ptr<exec::test::TempDirectoryPath> ParquetTpchTest::tempDirectory_ =
+    nullptr;
+TpchQueryBuilder ParquetTpchTest::tpchBuilder_(
+    dwio::common::FileFormat::PARQUET);
 
-std::unordered_map<std::string, std::string> ParquetTpchTest::duckDbParquetWriteSQL_ = {
-std::make_pair(
-        "lineitem",
-        R"(COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber,
+std::unordered_map<std::string, std::string>
+    ParquetTpchTest::duckDbParquetWriteSQL_ = {
+        std::make_pair(
+            "lineitem",
+            R"(COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber,
         l_quantity::DOUBLE as l_quantity, l_extendedprice::DOUBLE as l_extendedprice, l_discount::DOUBLE as l_discount,
         l_tax::DOUBLE as l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate,
         l_shipinstruct, l_shipmode, l_comment FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-    std::make_pair(
-      "orders",
-      R"(COPY (SELECT o_orderkey, o_custkey, o_orderstatus,
+        std::make_pair(
+            "orders",
+            R"(COPY (SELECT o_orderkey, o_custkey, o_orderstatus,
         o_totalprice::DOUBLE as o_totalprice,
         o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
         FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
         std::make_pair(
-      "customer",
-      R"(COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone,
+            "customer",
+            R"(COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone,
         c_acctbal::DOUBLE as c_acctbal, c_mktsegment, c_comment
         FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
 };

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -34,9 +34,9 @@ using namespace facebook::velox::exec::test;
 static const int kNumDrivers = 4;
 
 struct QueryParams {
-  int queryId;
-  int queryPipelineCount;
-  int queryFinishedSplits;
+  int id;
+  int pipelineCount;
+  int finishedSplits;
 };
 
 class ParquetTpchTest : public testing::TestWithParam<QueryParams> {
@@ -149,19 +149,19 @@ std::unordered_map<std::string, std::string>
 };
 
 std::ostream& operator<<(std::ostream& os, const QueryParams& params) {
-  os << "QueryId_" << params.queryId;
+  os << "QueryId_" << params.id;
   return os;
 }
 
 TEST_P(ParquetTpchTest, CompareWithDuckDB) {
   auto queryParams = GetParam();
-  auto tpchPlan = tpchBuilder_.getQueryPlan(queryParams.queryId);
-  auto duckDbSql = duckDb_->getTpchQuery(queryParams.queryId);
+  auto tpchPlan = tpchBuilder_.getQueryPlan(queryParams.id);
+  auto duckDbSql = duckDb_->getTpchQuery(queryParams.id);
   auto task = assertQuery(tpchPlan, duckDbSql);
 
   const auto& stats = task->taskStats();
-  ASSERT_EQ(queryParams.queryPipelineCount, stats.pipelineStats.size());
-  ASSERT_EQ(queryParams.queryFinishedSplits, stats.numFinishedSplits);
+  ASSERT_EQ(queryParams.pipelineCount, stats.pipelineStats.size());
+  ASSERT_EQ(queryParams.finishedSplits, stats.numFinishedSplits);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -260,15 +260,14 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
   static const std::string kLineitem = "lineitem";
   static const std::string kOrders = "orders";
   static const std::string kCustomer = "customer";
-  std::vector<std::string> lineitemSelectedColumns = {
-      "l_orderkey", "l_quantity"};
-  std::vector<std::string> ordersSelectedColumns = {
+  std::vector<std::string> lineitemColumns = {"l_orderkey", "l_quantity"};
+  std::vector<std::string> ordersColumns = {
       "o_orderkey", "o_custkey", "o_orderdate", "o_totalprice"};
-  std::vector<std::string> customerSelectedColumns = {"c_name", "c_custkey"};
+  std::vector<std::string> customerColumns = {"c_name", "c_custkey"};
 
-  auto lineitemSelectedRowType = getRowType(kLineitem, lineitemSelectedColumns);
-  auto ordersSelectedRowType = getRowType(kOrders, ordersSelectedColumns);
-  auto customerSelectedRowType = getRowType(kCustomer, customerSelectedColumns);
+  auto lineitemSelectedRowType = getRowType(kLineitem, lineitemColumns);
+  auto ordersSelectedRowType = getRowType(kOrders, ordersColumns);
+  auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
 
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -384,8 +384,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
 const std::vector<std::string> TpchQueryBuilder::kTableNames_ = {
     "lineitem",
     "orders",
-    "customer"
-};
+    "customer"};
 
 const std::unordered_map<std::string, std::vector<std::string>>
     TpchQueryBuilder::kTables_ = {

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -105,6 +105,15 @@ class TpchQueryBuilder {
     return aliases;
   }
 
+  std::shared_ptr<const RowType> getRowType(
+      const std::string& tableName,
+      const std::vector<std::string>& columnNames) const {
+    const auto aliases = getColumnAliases(tableName, columnNames);
+    auto columnSelector = std::make_shared<dwio::common::ColumnSelector>(
+        tableMetadata_.at(tableName).type, aliases);
+    return columnSelector->buildSelectedReordered();
+  }
+
   std::vector<std::string> getProjectColumnAliases(
       const std::string& tableName,
       const std::vector<std::string>& columnNames) const {

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -82,6 +82,7 @@ class TpchQueryBuilder {
  private:
   TpchPlan getQ1Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ18Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(
       const std::string& tableName) const {


### PR DESCRIPTION
I have modified the existing TPC-H queries 1 and 6 slightly to accommodate adding more queries easily.

I would like add more TPC-H queries, but I first wanted to get the framework changes in place a thumbs up before adding more queries.