### PR TITLE
Handle Velox Selectivce Reader Filter Generation with No Filterable Fields

### DIFF
--- a/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
@@ -252,6 +252,11 @@ std::vector<std::string> FilterGenerator::makeFilterables(
   std::vector<std::string> filterables;
   filterables.reserve(rowType_->size());
   collectFilterableSubFields(rowType_.get(), filterables);
+  if (filterables.empty()) {
+    // It could be empty if none of the columns is filterable, for example,
+    // there are only (or mix of) map, array columns.
+    return filterables;
+  }
   uint32_t countTotal = filterables.size();
   uint32_t countSelect = std::min(count, countTotal);
   if (countSelect == 0) {


### PR DESCRIPTION
Summary:
Handle Velox Selectivce Reader Filter Generation with No Filterable Fields.
Before the fix, when the random filter generation logic is used on data that doesn't have any filterable columns (e.g. only has map and/or list columns), it will cause failure.

Differential Revision: D34351444

