### PR TITLE
ExpressionFuzzer expects TRY to catch exceptions in query compilation

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -496,13 +496,17 @@ class ExpressionFuzzer {
       exec::ExprSet exprSetCommon({plan}, &execCtx_);
       exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
 
-      exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
-    } catch (...) {
-      if (!canThrow) {
-        LOG(ERROR)
-            << "Common eval wasn't supposed to throw, but it did. Aborting.";
-        throw;
+      try {
+        exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
+      } catch (...) {
+        if (!canThrow) {
+          LOG(ERROR)
+              << "Common eval wasn't supposed to throw, but it did. Aborting.";
+          throw;
+        }
+        exceptionCommonPtr = std::current_exception();
       }
+    } catch (...) {
       exceptionCommonPtr = std::current_exception();
     }
 
@@ -514,13 +518,17 @@ class ExpressionFuzzer {
       exec::EvalCtx evalCtxSimplified(
           &execCtx_, &exprSetSimplified, rowVector.get());
 
-      exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
-    } catch (...) {
-      if (!canThrow) {
-        LOG(ERROR)
-            << "Simplified eval wasn't supposed to throw, but it did. Aborting.";
-        throw;
+      try {
+        exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
+      } catch (...) {
+        if (!canThrow) {
+          LOG(ERROR)
+              << "Simplified eval wasn't supposed to throw, but it did. Aborting.";
+          throw;
+        }
+        exceptionSimplifiedPtr = std::current_exception();
       }
+    } catch (...) {
       exceptionSimplifiedPtr = std::current_exception();
     }
 


### PR DESCRIPTION
Summary:
Currently when the ExpressionFuzzer is run with the --retry-with-try option, it fails if after
wrapping the expression in a TRY query compilation or execution fails.

It's not possible for TRY to catch exceptions in query compilation, only execution.

Here I add a separate try catch around query compilation, that sets exception<X>Ptr  if
query compilation fails regardless of whether or not the --retry-with-try is set.

This way if the expression is wrapped in TRY we still verify that the exception is
consistent in the common and simplified paths.

(We could avoid re-executing the query with TRY if query compilation fails in the original
run, but I didn't implement that in the interest of keeping the code simple)

Differential Revision: D34355097

