### PR TITLE
Fix HashTable::allocatedBytes

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -249,6 +249,7 @@ void HashBuild::addRuntimeStats() {
       stats_.addRuntimeStat(fmt::format("distinctKey{}", i), asDistinct);
     }
   }
+  stats_.addRuntimeStat("buildBytes", table_->allocatedBytes());
 }
 
 BlockingReason HashBuild::isBlocked(ContinueFuture* future) {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -558,6 +558,15 @@ void HashTable<ignoreNullKeys>::clear() {
 }
 
 template <bool ignoreNullKeys>
+int64_t HashTable<ignoreNullKeys>::allocatedBytes() const {
+  int64_t size = tableAllocation_.size() + rows_->allocatedBytes();
+  for (auto& other : otherTables_) {
+    size += other->allocatedBytes();
+  }
+  return size;
+}
+
+template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::checkSize(int32_t numNew) {
   if (!table_ || !size_) {
     // Initial guess of cardinality is double the first input batch or at

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -288,11 +288,7 @@ class HashTable : public BaseHashTable {
 
   void clear() override;
 
-  int64_t allocatedBytes() const override {
-    // for each row: 1 byte per tag + sizeof(Entry) per table entry + memory
-    // allocated with MappedMemory for fixed-width rows and strings.
-    return (1 + sizeof(char*)) * size_ + rows_->allocatedBytes();
-  }
+  int64_t allocatedBytes() const override;
 
   HashStringAllocator* stringAllocator() override {
     return &rows_->stringAllocator();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -459,6 +459,10 @@ TEST_F(HashJoinTest, arrayBasedLookup) {
       task->taskStats().pipelineStats.back().operatorStats.back().runtimeStats;
   EXPECT_EQ(101, joinStats["distinctKey0"].sum);
   EXPECT_EQ(200, joinStats["rangeKey0"].sum);
+  // The size is between 64 and 72K because the allocation of the
+  // payload rounds up to next 64K and the table itself to the next 4K.
+  EXPECT_LT(64 * 1024, joinStats["buildBytes"].sum);
+  EXPECT_GT(72 * 1024, joinStats["buildBytes"].sum);
 }
 
 TEST_F(HashJoinTest, innerJoinWithEmptyBuild) {


### PR DESCRIPTION
Fix HashTable::allocatedBytes

Fix allocatedBytes in HashTable. Count the ContiguousAllocation for
the tables and the memory owned by all the RowContainers.
