### PR TITLE
Skip execution of rows that have already thrown exceptions

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -901,6 +901,25 @@ void Expr::evalAll(
     }
   }
 
+  // If any errors occurred evaluating the arguments, it's possible (even
+  // likely) that the values for those arguments were not defined which could
+  // lead to undefined behavior if we try to evaluate the current function on
+  // them.  It's safe to skip evaluating them since the value for this branch
+  // of the expression tree will be NULL for those rows anyway.
+  if (context->errors()) {
+    if (remainingRows == &rows) {
+      nonNulls.allocate(rows.end());
+      *nonNulls.get() = rows;
+      remainingRows = nonNulls.get();
+    }
+    deselectErrors(context, *nonNulls.get());
+    if (!remainingRows->hasSelections()) {
+      inputValues_.clear();
+      setAllNulls(rows, context, result);
+      return;
+    }
+  }
+
   if (!tryPeelArgs ||
       !applyFunctionWithPeeling(rows, *remainingRows, context, result)) {
     applyFunction(*remainingRows, context, result);

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   StringProxyTest.cpp
   MapViewTest.cpp
   RowViewTest.cpp
+  TryExprTest.cpp
   VariadicViewTest.cpp
   VectorReaderTest.cpp)
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1923,27 +1923,6 @@ TEST_F(ExprTest, ifWithConstant) {
   EXPECT_EQ(true, result->as<ConstantVector<bool>>()->valueAt(0));
 }
 
-TEST_F(ExprTest, tryExpr) {
-  auto a = makeFlatVector<int32_t>({10, 20, 30, 20, 50, 30});
-  auto b = makeFlatVector<int32_t>({1, 0, 3, 4, 0, 6});
-  {
-    auto result = evaluate("try(c0 / c1)", makeRowVector({a, b}));
-
-    auto expectedResult = vectorMaker_->flatVectorNullable<int32_t>(
-        {10, std::nullopt, 10, 5, std::nullopt, 5});
-    assertEqualVectors(expectedResult, result);
-  }
-
-  auto c =
-      vectorMaker_->flatVectorNullable<StringView>({"1", "2x", "3", "4", "5y"});
-  {
-    auto result = evaluate("try(cast(c0 as integer))", makeRowVector({c}));
-    auto expectedResult = vectorMaker_->flatVectorNullable<int32_t>(
-        {1, std::nullopt, 3, 4, std::nullopt});
-    assertEqualVectors(expectedResult, result);
-  }
-}
-
 namespace {
 // Testing functions for generating intermediate results in different
 // encodings. The test case passes vectors to these and these

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+namespace facebook::velox {
+class TryExprTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(TryExprTest, tryExpr) {
+  auto a = makeFlatVector<int32_t>({10, 20, 30, 20, 50, 30});
+  auto b = makeFlatVector<int32_t>({1, 0, 3, 4, 0, 6});
+  {
+    auto result = evaluate("try(c0 / c1)", makeRowVector({a, b}));
+
+    auto expectedResult = makeNullableFlatVector<int32_t>(
+        {10, std::nullopt, 10, 5, std::nullopt, 5});
+    assertEqualVectors(expectedResult, result);
+  }
+
+  auto c = makeNullableFlatVector<StringView>({"1", "2x", "3", "4", "5y"});
+  {
+    auto result = evaluate("try(cast(c0 as integer))", makeRowVector({c}));
+    auto expectedResult =
+        makeNullableFlatVector<int32_t>({1, std::nullopt, 3, 4, std::nullopt});
+    assertEqualVectors(expectedResult, result);
+  }
+}
+
+// Returns the number of times this function has been called so far.
+template <typename T>
+struct CountCallsFunction {
+  int64_t numCalls = 0;
+
+  bool callNullable(int64_t& out, const int64_t*) {
+    out = numCalls++;
+
+    return true;
+  }
+};
+
+TEST_F(TryExprTest, skipExecution) {
+  registerFunction<CountCallsFunction, int64_t, int64_t>(
+      {"count_calls"}, BIGINT());
+
+  std::vector<std::optional<int64_t>> expected{
+      0, std::nullopt, 1, std::nullopt, 2};
+  auto flatVector = makeFlatVector<StringView>(expected.size(), [&](auto row) {
+    return expected[row].has_value() ? "1" : "a";
+  });
+  auto result = evaluate<FlatVector<int64_t>>(
+      "try(count_calls(cast(c0 as integer)))", makeRowVector({flatVector}));
+
+  assertEqualVectors(makeNullableFlatVector(expected), result);
+}
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
Today, when we wrap an expression in a TRY we still evaluate expressions on rows that have already thrown an exception.

E.g. try(url_extract_path(to_base(4042309829,"c0"))) if to_base throws an exception, we'll still evaluate url_extract_path on that row

This can cause the system to crash with an SIGSEG for example because the argument passed in could have a null pointer as it was never initialized.

To address this I've updated evalAll to unselect any rows that have thrown exceptions (the TRY will turn the values in these rows to NULL later on anyway).

Differential Revision: D34358383

