### PR TITLE
Minor change to setup-ubuntu.sh

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -98,8 +98,11 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
+
+  # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev -B"${BINARY_DIR}" \
     -GNinja \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=17 \
     "${INSTALL_PREFIX+-DCMAKE_PREFIX_PATH=}${INSTALL_PREFIX-}" \
     "${INSTALL_PREFIX+-DCMAKE_INSTALL_PREFIX=}${INSTALL_PREFIX-}" \
@@ -121,8 +124,6 @@ function install_folly {
 
 function install_velox_deps {
   run_and_time install_fmt
-  sudo ln -s /usr/local/lib/libfmt.a /usr/lib/x86_64-linux-gnu/libfmt.a
-
   run_and_time install_folly
 }
 


### PR DESCRIPTION
1. Add back `CMAKE_POSITION_INDEPENDENT_CODE` when building dependent libraries.
Used to be there but get accidentally removed in c7373c1b911c4cce9aacd4ea8495c97bbea4467d

2. Remove the symbolic link for fmt -- tested not required  on a
fresh Ubuntu docker image.


Test built on a fresh Ubunt docker image.