### PR TITLE
Add 1st version of date_format Presto function

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -671,6 +671,56 @@ struct DateDiffFunction {
 };
 
 template <typename T>
+struct DateFormatFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr const std::size_t kYmdLength = 10;
+
+  const date::time_zone* sessionTimeZone_ = nullptr;
+  std::optional<StringView> format_ = std::nullopt;
+
+  FOLLY_ALWAYS_INLINE bool isValidFormat(const StringView& format) {
+    return format == "%Y-%m-%d";
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* formatString) {
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+
+    if (formatString != nullptr && isValidFormat(*formatString)) {
+      format_ = StringView(formatString->data(), formatString->size());
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<Varchar>& formatString) {
+    StringView format;
+    if (format_.has_value()) {
+      format = format_.value();
+    } else {
+      VELOX_USER_CHECK(
+          isValidFormat(formatString),
+          "Format {} is not implemented for TIMESTAMP yet",
+          formatString);
+      format = StringView(formatString.data(), formatString.size());
+    }
+
+    std::tm dateTime = getDateTime(timestamp, sessionTimeZone_);
+
+    char formattedDateTime[kYmdLength + 1];
+    std::strftime(
+        formattedDateTime, sizeof(formattedDateTime), format.data(), &dateTime);
+    result.resize(kYmdLength * sizeof(char));
+    std::memcpy(result.data(), formattedDateTime, kYmdLength * sizeof(char));
+    return true;
+  }
+};
+
+template <typename T>
 struct ParseDateTimeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -62,6 +62,8 @@ void registerSimpleFunctions() {
       {"date_diff"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
       {"date_diff"});
+  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
+      {"date_format"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1327,6 +1327,32 @@ TEST_F(DateTimeFunctionsTest, dateDiffTimestamp) {
           fromTimestampString("2018-02-28 10:00:00.500")));
 }
 
+TEST_F(DateTimeFunctionsTest, dateFormat) {
+  const auto dateFormat = [&](std::optional<Timestamp> timestamp,
+                              const std::string& formatString) {
+    return evaluateOnce<std::string>(
+        fmt::format("date_format(c0, '{}')", formatString), timestamp);
+  };
+
+  using util::fromTimestampString;
+
+  // Check null behaviors
+  EXPECT_EQ(std::nullopt, dateFormat(std::nullopt, "%Y"));
+
+  // Check invalid format
+  EXPECT_THROW(dateFormat(Timestamp(0, 0), "%Y"), VeloxUserError);
+
+  // Simple tests
+  EXPECT_EQ(
+      "2020-03-01",
+      dateFormat(fromTimestampString("2020-03-01 01:00:00.500"), "%Y-%m-%d"));
+
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(
+      "2020-02-29",
+      dateFormat(fromTimestampString("2020-03-01 01:00:00.500"), "%Y-%m-%d"));
+}
+
 TEST_F(DateTimeFunctionsTest, parseDatetime) {
   // Check null behavior.
   EXPECT_EQ(std::nullopt, parseDatetime("1970-01-01", std::nullopt));


### PR DESCRIPTION
This is the 1st hack of the date_format UDF that behaves the same as the corresponding Presto function but only supports the formatting of %Y-%m-%d, https://prestodb.io/docs/current/functions/datetime.html#mysql-date-functions


 