### PR TITLE
Nested TRYs catch the same errors over and over

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -115,6 +115,10 @@ class EvalCtx {
     return errors_.get();
   }
 
+  ErrorVectorPtr* errorsPtr() {
+    return &errors_;
+  }
+
   void swapErrors(ErrorVectorPtr* other) {
     std::swap(errors_, *other);
   }


### PR DESCRIPTION
Summary:
TRY expressions don't reset the errors in the EvalCtx, so if a nested TRY "catches" an error
and NULLs out the row, the upstream TRY will catch the same error again and NULL it out
again (even if there was a coalesce or some other expression that converts the NULL to
some non-NULL value).

Differential Revision: D34403320

