### PR TITLE
Disallow calling setNull on ConstantVectors

### DIFF
--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -164,6 +164,10 @@ class ConstantVector final : public SimpleVector<T> {
     return isNull_ || (valueVector_ && valueVector_->mayHaveNullsRecursive());
   }
 
+  void setNull(vector_size_t /*idx*/, bool /*value*/) override {
+    VELOX_FAIL("setNull not supported on ConstantVector");
+  }
+
   const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
     VELOX_DCHECK(initialized_);
     if (isNull_) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1504,3 +1504,10 @@ TEST_F(VectorTest, clearAllNulls) {
   ASSERT_FALSE(vector->mayHaveNulls());
   ASSERT_FALSE(vector->isNullAt(50));
 }
+
+TEST_F(VectorTest, constantSetNull) {
+  auto vectorMaker = std::make_unique<test::VectorMaker>(pool_.get());
+  auto vector = vectorMaker->constantVector<int64_t>({{0}});
+
+  EXPECT_THROW(vector->setNull(0, true), VeloxRuntimeError);
+}


### PR DESCRIPTION
Summary:
Currently this defers to the implementation in BaseVector which has no effect on the value
in the ConstantVector.  It doesn't make sense to call it anyway, so throw an exception.

Differential Revision: D34489224

