### PR TITLE
Added buffer reference count check to flatmap reader

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -23,7 +23,6 @@ namespace facebook::velox::dwrf {
 
 using dwio::common::TypeWithId;
 using memory::MemoryPool;
-using namespace flatmap_helper;
 
 StringKeyBuffer::StringKeyBuffer(
     MemoryPool& pool,
@@ -300,7 +299,7 @@ template <typename T>
 void FlatMapColumnReader<T>::initKeysVector(
     VectorPtr& vector,
     vector_size_t size) {
-  initializeFlatVector<T>(vector, memoryPool_, size, false);
+  flatmap_helper::initializeFlatVector<T>(vector, memoryPool_, size, false);
   vector->setSize(size);
 }
 
@@ -308,7 +307,7 @@ template <>
 void FlatMapColumnReader<StringView>::initKeysVector(
     VectorPtr& vector,
     vector_size_t size) {
-  initializeFlatVector<StringView>(
+  flatmap_helper::initializeFlatVector<StringView>(
       vector,
       memoryPool_,
       size,
@@ -387,7 +386,8 @@ void FlatMapColumnReader<T>::next(
     }
 
     initKeysVector(keysVector, totalChildren);
-    initializeVector(valuesVector, mapValueType, memoryPool_, nodeBatches);
+    flatmap_helper::initializeVector(
+        valuesVector, mapValueType, memoryPool_, nodeBatches);
 
     if (!returnFlatVector_) {
       for (auto batch : nodeBatches) {
@@ -417,7 +417,7 @@ void FlatMapColumnReader<T>::next(
         if (bulkInMapIter.hasValueAt(j)) {
           nodes[j]->fillKeysVector(keysVector, offset, stringKeyBuffer_.get());
           if (returnFlatVector_) {
-            copyOne(
+            flatmap_helper::copyOne(
                 mapValueType,
                 *valuesVector,
                 offset,

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -159,7 +159,7 @@ class StringKeyBuffer {
     callback(data, data_[ordinal + 1] - data);
   }
 
-  BufferPtr getBuffer() const {
+  const BufferPtr& getBuffer() const {
     return buffer_;
   }
 


### PR DESCRIPTION
Summary:
When working on D33756784 (https://github.com/facebookincubator/velox/commit/593f55475fd3c717c5c616be10a5abfb2b83c8ef), the flatmap "slow" path was missed. Adding similar logic here.

However, this "slow" path is ideally not triggered. Given that we know exactly what buffer maybe referenced by others, I'm taking a shortcut that only making the FlatVector logic handle the case that a buffer is multi-referenced. For all the other paths, added a check so we know if the assumption is changed.

Differential Revision: D34524998

