### PR TITLE
RowWriter general interface.

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -268,6 +268,14 @@ struct TypeAnalysis<Row<T...>> {
   }
 };
 
+// TODO: remove once old writers deprecated.
+template <typename... T>
+struct TypeAnalysis<RowWriterT<T...>> {
+  void run(TypeAnalysisResults& results) {
+    TypeAnalysis<Row<T...>>().run(results);
+  }
+};
+
 // todo(youknowjack): need a better story for types for UDFs. Mapping
 //                    c++ types <-> Velox types is imprecise (e.g. string vs
 //                    binary) and difficult to change.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   HashJoinTest.cpp
   PlanNodeToStringTest.cpp
   FunctionSignatureBuilderTest.cpp
+  SimpleFunctionResolutionTest.cpp
   UnnestTest.cpp
   AssignUniqueIdTest.cpp)
 

--- a/velox/exec/tests/SimpleFunctionResolutionTest.cpp
+++ b/velox/exec/tests/SimpleFunctionResolutionTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+// This files contains e2e tests the simple functions resolution based on
+// priority which is determined based on the generality.
+namespace facebook::velox::exec {
+namespace {
+
+class SimpleFunctionResolutionTest : public functions::test::FunctionBaseTest {
+ protected:
+  void checkResults(const std::string& func, int32_t expected) {
+    auto results = evaluateOnce<int32_t, int32_t, int32_t>(
+        fmt::format("{}(c0, c1)", func), 1, 2);
+    ASSERT_EQ(results.value(), expected);
+  }
+};
+
+// Several `call` functions all that accepts two integers. With different
+// runtime representations.
+template <typename T>
+struct TestFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  bool call(int32_t& out, int32_t, int32_t) {
+    out = 1;
+    return true;
+  }
+
+  bool call(int32_t& out, const arg_type<Variadic<int32_t>>&) {
+    out = 2;
+    return true;
+  }
+
+  bool call(
+      int32_t& out,
+      const arg_type<Generic<T1>>&,
+      const arg_type<Generic<T1>>&) {
+    out = 3;
+    return true;
+  }
+
+  bool call(int32_t& out, const arg_type<Variadic<Generic<>>>&) {
+    out = 4;
+    return true;
+  }
+
+  bool
+  call(int32_t& out, const int32_t&, const arg_type<Variadic<Generic<>>>&) {
+    out = 5;
+    return true;
+  }
+};
+
+TEST_F(SimpleFunctionResolutionTest, rank1Picked) {
+  registerFunction<TestFunction, int32_t, int32_t, int32_t>({"f1"});
+  registerFunction<TestFunction, int32_t, Variadic<int32_t>>({"f1"});
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f1"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f1"});
+
+  checkResults("f1", 1);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank2Picked) {
+  registerFunction<TestFunction, int32_t, Variadic<int32_t>>({"f2"});
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f2"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f2"});
+  checkResults("f2", 2);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank3Picked) {
+  registerFunction<TestFunction, int32_t, Generic<T1>, Generic<T1>>({"f3"});
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f3"});
+  checkResults("f3", 3);
+}
+
+TEST_F(SimpleFunctionResolutionTest, rank4Picked) {
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f4"});
+  checkResults("f4", 4);
+}
+
+// Test when two functions have the same rank.
+TEST_F(SimpleFunctionResolutionTest, sameRank) {
+  registerFunction<TestFunction, int32_t, Variadic<Generic<>>>({"f5"});
+  registerFunction<TestFunction, int32_t, int32_t, Variadic<Generic<>>>({"f5"});
+  checkResults("f5", 5);
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -100,15 +100,22 @@ class FunctionRegistry {
   const FunctionEntry<Function, Metadata>* resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes) {
+    const FunctionEntry<Function, Metadata>* selectedCandidate = nullptr;
+
     if (auto signatureMap = getSignatureMap(name)) {
       for (const auto& [candidateSignature, functionEntry] : *signatureMap) {
         if (SignatureBinder(candidateSignature, argTypes).tryBind()) {
-          return functionEntry.get();
+          auto* currentCandidate = functionEntry.get();
+          if (!selectedCandidate ||
+              currentCandidate->getMetadata()->priority() <
+                  selectedCandidate->getMetadata()->priority()) {
+            selectedCandidate = currentCandidate;
+          }
         }
       }
     }
 
-    return nullptr;
+    return selectedCandidate;
   }
 
  private:

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -242,7 +242,7 @@ TEST_F(ArrayWriterTest, multipleRows) {
 }
 
 TEST_F(ArrayWriterTest, e2ePrimitives) {
-  testE2E<int8_t>("f_int6");
+  testE2E<int8_t>("f_int8");
   testE2E<int16_t>("f_int16");
   testE2E<int32_t>("f_int32");
   testE2E<int64_t>("f_int64");

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   CastExprTest.cpp
   MapWriterTest.cpp
   ArrayWriterTest.cpp
+  RowWriterTest.cpp
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -247,7 +247,7 @@ TEST_F(MapWriterTest, resizeAndSubscriptAccess) {
 }
 
 TEST_F(MapWriterTest, e2ePrimitives) {
-  testE2E<int8_t>("f_int6");
+  testE2E<int8_t>("f_int8");
   testE2E<int16_t>("f_int16");
   testE2E<int32_t>("f_int32");
   testE2E<int64_t>("f_int64");

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/core.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <optional>
+#include <tuple>
+
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/expression/VectorUdfTypeSystem.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/StringView.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+template <typename T>
+struct FuncPrimitivesTest {
+  template <typename TOut>
+  bool call(TOut& out, const int64_t& n) {
+    out.template set_null_at<0>();
+    out.template get_writer_at<1>() = n;
+    out.template get_writer_at<2>() = n * 2;
+    return true;
+  }
+};
+
+class RowWriterTest : public functions::test::FunctionBaseTest {
+ public:
+  VectorPtr prepareResult(const TypePtr& rowType, vector_size_t size = 1) {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(size), rowType, this->execCtx_.pool(), &result);
+    return result;
+  }
+
+  template <typename... T>
+  void testE2EPrimitive(const std::string& testFunctionName) {
+    auto functionName = "row_writer_test_" + testFunctionName;
+    registerFunction<FuncPrimitivesTest, RowWriterT<T...>, int64_t>(
+        {functionName});
+
+    auto result = evaluate(
+        fmt::format("{}(c0)", functionName),
+        makeRowVector(
+            {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+
+    using types = std::tuple<T...>;
+
+    // First row is always null.
+    auto vector1 = makeFlatVector<std::tuple_element_t<0, types>>(10);
+    for (auto i = 0; i < 10; i++) {
+      vector1->setNull(i, true);
+    }
+
+    // Second row is set to n.
+    auto vector2 = makeFlatVector<std::tuple_element_t<1, types>>(10);
+    for (auto i = 0; i < 10; i++) {
+      vector2->set(i, i + 1);
+    }
+
+    // Third row is set to n*2.
+    auto vector3 = makeFlatVector<std::tuple_element_t<2, types>>(10);
+    for (auto i = 0; i < 10; i++) {
+      vector3->set(i, (i + 1) * 2);
+    }
+
+    assertEqualVectors(makeRowVector({vector1, vector2, vector3}), result);
+  }
+
+  struct TestWriter {
+    VectorPtr result;
+    std::unique_ptr<VectorWriter<RowWriterT<int64_t, int64_t, int64_t>>>
+        writer = std::make_unique<
+            VectorWriter<RowWriterT<int64_t, int64_t, int64_t>>>();
+  };
+
+  TestWriter makeTestWriter() {
+    TestWriter writer;
+
+    writer.result = prepareResult(makeRowType({BIGINT(), BIGINT(), BIGINT()}));
+    writer.writer->init(*writer.result->as<RowVector>());
+    writer.writer->setOffset(0);
+    return writer;
+  }
+
+  VectorPtr nullEntry() {
+    return vectorMaker_.flatVectorNullable<int64_t>({std::nullopt});
+  }
+};
+
+TEST_F(RowWriterTest, setNullAt) {
+  auto [result, vectorWriter] = makeTestWriter();
+
+  auto& rowWriter = vectorWriter->current();
+
+  rowWriter.set_null_at<0>();
+  rowWriter.set_null_at<1>();
+  rowWriter.set_null_at<2>();
+
+  vectorWriter->commit();
+
+  auto expected = makeRowVector({nullEntry(), nullEntry(), nullEntry()});
+
+  assertEqualVectors(result, expected);
+}
+
+TEST_F(RowWriterTest, getWriterAt) {
+  auto [result, vectorWriter] = makeTestWriter();
+
+  auto& rowWriter = vectorWriter->current();
+
+  rowWriter.get_writer_at<0>() = 1;
+  rowWriter.set_null_at<1>();
+  rowWriter.get_writer_at<2>() = 3;
+
+  vectorWriter->commit();
+
+  auto expected = makeRowVector(
+      {vectorMaker_.flatVector<int64_t>({1}),
+       nullEntry(),
+       vectorMaker_.flatVector<int64_t>({3})},
+      [](auto row) { return row == 1; });
+
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(RowWriterTest, e2ePrimitives) {
+  testE2EPrimitive<int8_t, int8_t, int8_t>("f_int8");
+  testE2EPrimitive<int16_t, int16_t, int16_t>("f_int16");
+  testE2EPrimitive<int32_t, int32_t, int32_t>("f_int32");
+  testE2EPrimitive<int64_t, int64_t, int64_t>("f_int64");
+  testE2EPrimitive<float, float, float>("f_float");
+  testE2EPrimitive<double, double, double>("f_double");
+  testE2EPrimitive<bool, bool, bool>("f_bool");
+  testE2EPrimitive<double, float, bool>("f_mix1");
+  testE2EPrimitive<int32_t, int64_t, double>("f_mix2");
+}
+
+TEST_F(RowWriterTest, timeStamp) {
+  auto result = prepareResult(makeRowType({TIMESTAMP()}), 2);
+
+  VectorWriter<RowWriterT<Timestamp>> vectorWriter;
+  vectorWriter.init(*result->as<RowVector>());
+
+  {
+    vectorWriter.setOffset(0);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.get_writer_at<0>() = Timestamp::fromMillis(11);
+    vectorWriter.commit();
+  }
+
+  {
+    vectorWriter.setOffset(1);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.set_null_at<0>();
+    vectorWriter.commit();
+  }
+
+  auto expected = vectorMaker_.flatVectorNullable<Timestamp>(
+      {{Timestamp::fromMillis(11), std::nullopt}});
+  assertEqualVectors(result, makeRowVector({expected}));
+}
+
+TEST_F(RowWriterTest, varChar) {
+  auto result = prepareResult(makeRowType({VARCHAR()}), 2);
+
+  VectorWriter<RowWriterT<Varchar>> vectorWriter;
+  vectorWriter.init(*result->as<RowVector>());
+
+  {
+    vectorWriter.setOffset(0);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.get_writer_at<0>().append("hi");
+    vectorWriter.commit();
+  }
+
+  {
+    vectorWriter.setOffset(1);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.set_null_at<0>();
+    vectorWriter.commit();
+  }
+
+  auto expected =
+      vectorMaker_.flatVectorNullable<StringView>({{"hi"_sv, std::nullopt}});
+  assertEqualVectors(result, makeRowVector({expected}));
+}
+
+TEST_F(RowWriterTest, varBinary) {
+  auto result = prepareResult(makeRowType({VARBINARY()}), 2);
+
+  VectorWriter<RowWriterT<Varchar>> vectorWriter;
+  vectorWriter.init(*result->as<RowVector>());
+
+  {
+    vectorWriter.setOffset(0);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.get_writer_at<0>().append("hi");
+    vectorWriter.commit();
+  }
+
+  {
+    vectorWriter.setOffset(1);
+    auto& rowWriter = vectorWriter.current();
+    rowWriter.set_null_at<0>();
+    vectorWriter.commit();
+  }
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  VectorReader<Row<Varbinary>> reader(&decoded);
+  ASSERT_EQ(exec::get<0>(reader[0]), "hi"_sv);
+  ASSERT_EQ(exec::get<0>(reader[1]), std::nullopt);
+}
+
+TEST_F(RowWriterTest, nested) {
+  // Output is row(row(int, string), double).
+  auto result = prepareResult(
+      makeRowType({makeRowType({BIGINT(), VARCHAR()}), DOUBLE()}));
+
+  VectorWriter<RowWriterT<RowWriterT<int64_t, Varchar>, double>> vectorWriter;
+  vectorWriter.init(*result->as<RowVector>());
+
+  vectorWriter.setOffset(0);
+  auto& outerRowWriter = vectorWriter.current();
+
+  auto& innerRowWriter = outerRowWriter.get_writer_at<0>();
+  innerRowWriter.get_writer_at<0>() = 1;
+  innerRowWriter.get_writer_at<1>().append("hi");
+
+  outerRowWriter.get_writer_at<1>() = 1.1;
+  vectorWriter.commit();
+
+  auto expected1 = vectorMaker_.flatVectorNullable<int64_t>({{1}});
+  auto expected2 = vectorMaker_.flatVectorNullable<StringView>({{"hi"_sv}});
+  auto expected3 = vectorMaker_.flatVectorNullable<double>({{1.1}});
+  assertEqualVectors(
+      result,
+      makeRowVector({makeRowVector({expected1, expected2}), expected3}));
+}
+
+TEST_F(RowWriterTest, rowOfArray) {
+  auto result = prepareResult(makeRowType({ARRAY(BIGINT())}));
+
+  VectorWriter<RowWriterT<ArrayWriterT<int64_t>>> vectorWriter;
+  vectorWriter.init(*result->as<RowVector>());
+
+  vectorWriter.setOffset(0);
+
+  auto& rowWriter = vectorWriter.current();
+  auto& arrayWriter = rowWriter.get_writer_at<0>();
+  arrayWriter.push_back(1);
+  arrayWriter.push_back(2);
+  arrayWriter.push_back(3);
+
+  vectorWriter.commit();
+
+  auto expected = vectorMaker_.arrayVector<int64_t>({{1, 2, 3}});
+  assertEqualVectors(result, makeRowVector({expected}));
+}
+
+TEST_F(RowWriterTest, arrayOfRows) {
+  auto result = prepareResult(ARRAY(makeRowType({BIGINT(), BIGINT()})));
+
+  VectorWriter<ArrayWriterT<RowWriterT<int64_t, int64_t>>> vectorWriter;
+  vectorWriter.init(*result->as<ArrayVector>());
+
+  vectorWriter.setOffset(0);
+
+  auto& arrayWriter = vectorWriter.current();
+  {
+    auto& rowWriter = arrayWriter.add_item();
+    rowWriter.set_null_at<0>();
+    rowWriter.get_writer_at<1>() = 1;
+  }
+  arrayWriter.add_null();
+  {
+    auto& rowWriter = arrayWriter.add_item();
+    rowWriter.set_null_at<1>();
+    rowWriter.get_writer_at<0>() = 1;
+  }
+
+  vectorWriter.commit();
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  VectorReader<Array<Row<int64_t, int64_t>>> reader(&decoded);
+
+  auto arrayView = reader[0];
+  ASSERT_EQ(arrayView.size(), 3);
+
+  ASSERT_TRUE(arrayView[0].has_value());
+  ASSERT_FALSE(arrayView[1].has_value());
+  ASSERT_TRUE(arrayView[2].has_value());
+
+  auto row0 = arrayView[0].value();
+  ASSERT_FALSE(exec::get<0>(row0).has_value());
+  ASSERT_EQ(exec::get<1>(row0).value(), 1);
+
+  auto row2 = arrayView[2].value();
+  ASSERT_EQ(exec::get<0>(row2).value(), 1);
+  ASSERT_FALSE(exec::get<1>(row2).has_value());
+}
+
+TEST_F(RowWriterTest, commitNull) {
+  auto result = prepareResult(ARRAY(makeRowType({BIGINT(), BIGINT()})), 2);
+
+  VectorWriter<ArrayWriterT<RowWriterT<int64_t, int64_t>>> vectorWriter;
+  vectorWriter.init(*result->as<ArrayVector>());
+
+  {
+    vectorWriter.setOffset(0);
+
+    auto& arrayWriter = vectorWriter.current();
+    {
+      auto& rowWriter = arrayWriter.add_item();
+      rowWriter.set_null_at<0>();
+      rowWriter.get_writer_at<1>() = 1;
+    }
+
+    arrayWriter.add_null();
+
+    {
+      auto& rowWriter = arrayWriter.add_item();
+      rowWriter.set_null_at<1>();
+      rowWriter.get_writer_at<0>() = 1;
+    }
+
+    // The three items added to the array shall not be committed and shall be
+    // disregarded when writing the next row.
+    vectorWriter.commitNull();
+  }
+
+  {
+    vectorWriter.setOffset(1);
+    auto& arrayWriter = vectorWriter.current();
+    {
+      auto& rowWriter = arrayWriter.add_item();
+      rowWriter.set_null_at<0>();
+      rowWriter.get_writer_at<1>() = 1;
+    }
+    vectorWriter.commit();
+  }
+
+  // Test results.
+  DecodedVector decoded;
+  SelectivityVector rows(result->size());
+  decoded.decode(*result, rows);
+  VectorReader<Array<Row<int64_t, int64_t>>> reader(&decoded);
+
+  ASSERT_FALSE(reader.isSet(0));
+  ASSERT_TRUE(reader.isSet(1));
+  auto arrayView = reader[1];
+  ASSERT_EQ(arrayView.size(), 1);
+
+  ASSERT_TRUE(arrayView[0].has_value());
+  auto row0 = arrayView[0].value();
+
+  ASSERT_FALSE(exec::get<0>(row0).has_value());
+  ASSERT_EQ(exec::get<1>(row0).value(), 1);
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1377,6 +1377,18 @@ struct Row {
   Row() {}
 };
 
+template <typename... T>
+struct RowWriterT {
+  template <size_t idx>
+  using type_at = typename std::tuple_element<idx, std::tuple<T...>>::type;
+
+  static_assert(
+      std::conjunction<std::bool_constant<!isVariadicType<T>::value>...>::value,
+      "Struct fields cannot be Variadic");
+
+  RowWriterT() = delete;
+};
+
 struct DynamicRow {
  private:
   DynamicRow() {}
@@ -1507,6 +1519,13 @@ struct CppToType<ArrayWriterT<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
 
 template <typename... T>
 struct CppToType<Row<T...>> : public TypeTraits<TypeKind::ROW> {
+  static auto create() {
+    return ROW({CppToType<T>::create()...});
+  }
+};
+
+template <typename... T>
+struct CppToType<RowWriterT<T...>> : public TypeTraits<TypeKind::ROW> {
   static auto create() {
     return ROW({CppToType<T>::create()...});
   }


### PR DESCRIPTION
Summary:
This diff add RowWriter general interface,
the interface has two calls:

1. set_null_at<I>() : set the element at I to null.
2. get_writer_at<I>(): set the element at I to not null and return
reference to writer of the element.

Ex:
```
template <typename T>
struct FuncPrimitivesTest {
  template <typename TOut>
  bool call(TOut& out, const int64_t& n) {
    out.template set_null_at<0>();
    out.template get_writer_at<1>() = n;
    out.template get_writer_at<2>() = n * 2;
    return true;
  }
};
```

A following diff will add specialization for when the
row types are primitives.

The diff includes tests for all types and different nestings.

Differential Revision: D34538967

