### PR TITLE
Simplify SIMD Comparison

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -89,11 +89,11 @@ inline T roundUp(T value, U factor) {
   return (value + (factor - 1)) / factor * factor;
 }
 
-inline uint64_t lowMask(int32_t bits) {
+constexpr inline uint64_t lowMask(int32_t bits) {
   return (1UL << bits) - 1;
 }
 
-inline uint64_t highMask(int32_t bits) {
+constexpr inline uint64_t highMask(int32_t bits) {
   return lowMask(bits) << (64 - bits);
 }
 

--- a/velox/common/tests/SimdUtilTest.cpp
+++ b/velox/common/tests/SimdUtilTest.cpp
@@ -129,8 +129,7 @@ TEST_F(SimdUtilTest, gather32) {
   EXPECT_EQ(result6[6], -1);
   EXPECT_EQ(result6[7], -1);
 
-  auto bits =
-      V32::compareBitMask(V32::compareResult(V32::compareEq(result8, result6)));
+  auto bits = V32::compareBitMask(V32::compareEq(result8, result6));
   // Low 6 lanes are the same.
   EXPECT_EQ(63, bits);
 }
@@ -155,8 +154,7 @@ TEST_F(SimdUtilTest, gather64) {
     EXPECT_EQ(resultPtr[i], data4[indices4[i]]);
   }
   EXPECT_EQ(result3[3], -1);
-  auto bits =
-      V64::compareBitMask(V32::compareResult(V64::compareEq(result4, result3)));
+  auto bits = V64::compareBitMask(V64::compareEq(result4, result3));
   // Low 3 lanes are the same.
   EXPECT_EQ(7, bits);
 }
@@ -194,8 +192,7 @@ TEST_F(SimdUtilTest, permute32) {
   // Find elements that satisfy a condition and pack them to the left.
   __m256si data = {12345, 23456, 111, 32000, 14123, 20000, 25000};
   __m256si result;
-  auto bits = V32::compareBitMask(
-      V32::compareResult(V32::compareGt(data, V32::setAll(15000))));
+  auto bits = V32::compareBitMask(V32::compareGt(data, V32::setAll(15000)));
   simd::storePermute(&result, data, V32::load(&simd::byteSetBits()[bits]));
   int32_t j = 0;
   for (auto i = 0; i < 8; ++i) {
@@ -212,8 +209,7 @@ TEST_F(SimdUtilTest, permute64) {
   // Find elements that satisfy a condition and pack them to the left.
   __m256i data = {12345, 23456, 111, 32000};
   __m256i result;
-  auto bits = V64::compareBitMask(
-      V64::compareResult(V64::compareGt(data, V64::setAll(15000))));
+  auto bits = V64::compareBitMask(V64::compareGt(data, V64::setAll(15000)));
   simd::storePermute(
       &result,
       reinterpret_cast<__m256si>(data),
@@ -249,8 +245,7 @@ TEST_F(SimdUtilTest, permute16) {
       22000,
       12,
   };
-  auto bits = V16::compareBitMask(
-      V16::compareResult(V16::compareGt(data, V16::setAll(15000))));
+  auto bits = V16::compareBitMask(V16::compareGt(data, V16::setAll(15000)));
   uint8_t first8 = bits & 0xff;
   uint8_t second8 = bits >> 8;
   int16_t result[16];
@@ -277,8 +272,7 @@ TEST_F(SimdUtilTest, permuteFloat) {
   // Find elements that satisfy a condition and pack them to the left.
   __m256 data = {std::nanf("nan"), 23456, 111, 32000, 14123, 20000, 25000};
   __m256si result;
-  auto bits = VF::compareBitMask(
-      VF::compareResult(VF::compareGt(data, VF::setAll(15000))));
+  auto bits = VF::compareBitMask(VF::compareGt(data, VF::setAll(15000)));
   simd::storePermute(
       &result,
       reinterpret_cast<__m256si>(data),
@@ -298,8 +292,7 @@ TEST_F(SimdUtilTest, permuteDouble) {
   // Find elements that satisfy a condition and pack them to the left.
   __m256d data = {std::nan("nan"), 23456, 111, 32000};
   __m256i result;
-  auto bits = VD::compareBitMask(
-      VD::compareResult(VD::compareGt(data, VD::setAll(15000))));
+  auto bits = VD::compareBitMask(VD::compareGt(data, VD::setAll(15000)));
   simd::storePermute(
       &result,
       reinterpret_cast<__m256si>(data),
@@ -335,11 +328,11 @@ TEST_F(SimdUtilTest, misc) {
 
   // Masks
   for (auto i = 0; i < V32::VSize; ++i) {
-    auto compare = V32::compareResult(
+    auto compare = V32::compareBitMask(
         V32::compareEq(V32::leadingMask(i), V32::mask((1 << i) - 1)));
     EXPECT_EQ(V32::kAllTrue, compare);
     if (i < V64::VSize) {
-      compare = V64::compareResult(
+      compare = V64::compareBitMask(
           V64::compareEq(V64::leadingMask(i), V64::mask((1 << i) - 1)));
       EXPECT_EQ(V64::kAllTrue, compare);
     }

--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -105,7 +105,7 @@ inline void processFixedFilter(
   using V32 = simd::Vectors<int32_t>;
   using TV = simd::Vectors<T>;
   constexpr bool is16 = sizeof(T) == 2;
-  auto word = TV::compareResult(
+  auto word = TV::compareBitMask(
       reinterpret_cast<typename TV::CompareType>(testSimd<T>(filter, values)));
   if (!word) {
     ; /* no values passed, no action*/
@@ -121,8 +121,7 @@ inline void processFixedFilter(
     }
     numValues += width;
   } else {
-    auto allBits =
-        simd::Vectors<T>::compareBitMask(word) & bits::lowMask(width);
+    auto allBits = word & bits::lowMask(width);
     auto bits = is16 ? allBits & 0xff : allBits;
     auto setBits = simd::Vectors<T>::compareSetBits(bits);
     auto numBits = __builtin_popcount(bits);

--- a/velox/dwio/dwrf/reader/ColumnVisitors.h
+++ b/velox/dwio/dwrf/reader/ColumnVisitors.h
@@ -742,12 +742,12 @@ class DictionaryColumnVisitor
       // loading less than 8.
       V32::TV cache = V32::maskGather32<1>(
           V32::setAll(0), dictMask, filterCache_ - 3, indices);
-      auto unknowns = V32::compareResult((cache & (kUnknown << 24)) << 1);
-      auto passed = V32::compareBitMask(V32::compareResult(cache));
+      auto unknowns = V32::compareBitMask((cache & (kUnknown << 24)) << 1);
+      auto passed = V32::compareBitMask(cache);
       if (UNLIKELY(unknowns)) {
+        uint16_t bits = unknowns;
         // Ranges only over inputs that are in dictionary, the not in dictionary
         // were masked off in 'dictMask'.
-        uint16_t bits = V32::compareBitMask(unknowns);
         while (bits) {
           int index = bits::getAndClearLastSetBit(bits);
           auto value = input[i + index];
@@ -761,9 +761,9 @@ class DictionaryColumnVisitor
       }
       // Were there values not in dictionary?
       if (inDict_) {
-        auto mask = V32::compareResult(dictMask);
+        auto mask = V32::compareBitMask(dictMask);
         if (mask != V32::kAllTrue) {
-          uint16_t bits = (~V32::compareBitMask(mask)) & bits::lowMask(kWidth);
+          uint16_t bits = (V32::kAllTrue ^ mask) & bits::lowMask(kWidth);
           while (bits) {
             auto index = bits::getAndClearLastSetBit(bits);
             if (i + index >= numInput) {
@@ -1089,10 +1089,10 @@ class StringDictionaryColumnVisitor
       } else {
         cache = V32::gather32<1>(DictSuper::filterCache_ - 3, indices);
       }
-      auto unknowns = V32::compareResult((cache & (kUnknown << 24)) << 1);
-      auto passed = V32::compareBitMask(V32::compareResult(cache));
+      auto unknowns = V32::compareBitMask((cache & (kUnknown << 24)) << 1);
+      auto passed = V32::compareBitMask(cache);
       if (UNLIKELY(unknowns)) {
-        uint16_t bits = V32::compareBitMask(unknowns);
+        uint16_t bits = unknowns;
         while (bits) {
           int index = bits::getAndClearLastSetBit(bits);
           int32_t value = input[i + index];

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -228,8 +228,8 @@ void SelectiveColumnReader::getFlatValues<int8_t, bool>(
   auto rawBytes = values_->as<int8_t>();
   auto zero = V8::setAll(0);
   for (auto i = 0; i < numValues_; i += kWidth) {
-    rawBits[i / kWidth] = ~V8::compareBitMask(
-        V8::compareResult(V8::compareEq(zero, V8::load(rawBytes + i))));
+    rawBits[i / kWidth] =
+        ~V8::compareBitMask(V8::compareEq(zero, V8::load(rawBytes + i)));
   }
   BufferPtr nulls = anyNulls_
       ? (returnReaderNulls_ ? nullsInReadRange_ : resultNulls_)

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -427,7 +427,7 @@ void HashTable<ignoreNullKeys>::arrayGroupProbe(HashLookup& lookup) {
       auto loaded = simd::Vectors<int64_t>::gather64(
           table_, simd::Vectors<int64_t>::load(hashes + i));
       *simd::Vectors<int64_t>::pointer(groups + i) = loaded;
-      auto misses = simd::Vectors<int64_t>::compareResult(
+      auto misses = simd::Vectors<int64_t>::compareBitMask(
           simd::Vectors<int64_t>::compareEq(loaded, allZero));
       if (LIKELY(!misses)) {
         continue;

--- a/velox/type/tests/FilterBenchmark.cpp
+++ b/velox/type/tests/FilterBenchmark.cpp
@@ -47,7 +47,7 @@ int32_t run4x64(const std::vector<int64_t>& data) {
   assert(data.size() % 4 == 0);
   for (auto i = 0; i < data.size(); i += 4) {
     auto result = filter->test4x64(V64::load(data.data() + i));
-    count += TV::compareBitMask(TV::compareResult(result));
+    count += V64::compareBitMask(result);
   }
   return count;
 }

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -49,16 +49,16 @@ TEST(FilterTest, alwaysTrue) {
   EXPECT_TRUE(alwaysTrue.testNonNull());
   EXPECT_TRUE(alwaysTrue.testNull());
   __m256i int64s = {};
-  EXPECT_EQ(V64::kAllTrue, V64::compareResult(alwaysTrue.test4x64(int64s)));
+  EXPECT_EQ(V64::kAllTrue, V64::compareBitMask(alwaysTrue.test4x64(int64s)));
   __m256si int32s = {};
   EXPECT_EQ(
       V32::kAllTrue,
-      V32::compareResult(
+      V32::compareBitMask(
           alwaysTrue.test8x32(reinterpret_cast<__m256i>(int32s))));
   __m256si int16s = {};
   EXPECT_EQ(
       V16::kAllTrue,
-      V16::compareResult(
+      V16::compareBitMask(
           alwaysTrue.test16x16(reinterpret_cast<__m256i>(int16s))));
 
   EXPECT_EQ(
@@ -109,8 +109,7 @@ void checkSimd(
     default:
       FAIL() << "Bad type width " << sizeof(T);
   }
-  auto bits =
-      simd::Vectors<T>::compareBitMask(simd::Vectors<T>::compareResult(result));
+  auto bits = simd::Vectors<T>::compareBitMask(result);
   for (auto i = 0; i < simd::Vectors<T>::VSize; ++i) {
     T lane = reinterpret_cast<const T*>(vector)[i];
     EXPECT_EQ(scalarTest(lane), bits::isBitSet(&bits, i)) << "Lane " << i;
@@ -501,9 +500,7 @@ TEST(FilterTest, bytesRange) {
     EXPECT_TRUE(filter->testLength(3));
     __m256si length8 = {0, 1, 3, 0, 4, 10, 11, 12};
     // The bit for lane 2 should be set.
-    EXPECT_EQ(
-        4,
-        V32::compareBitMask(V32::compareResult(filter->test8xLength(length8))));
+    EXPECT_EQ(4, V32::compareBitMask(filter->test8xLength(length8)));
 
     EXPECT_FALSE(filter->testNull());
     EXPECT_FALSE(filter->testBytes("apple", 5));


### PR DESCRIPTION
Removes the concept of compareResult', an intermediate formm between a
SIMD vector from a comparison and the corresponding bit mask. Removes
the use of pext + movemask_epi8 and uses the direct movemask_pd and
movemask_ps instead. There is no movemask_epi16, so for a 16x16 vector
we still use movemask_epi8 + pext but this is not frequent.