### PR TITLE
Support CAST(... as JSON) from maps of boolean, integral, and floating-point keys

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -518,9 +518,7 @@ void CastExpr::apply(
   if ((castOperator = getCastOperator(toType->toString()))) {
     if (!castOperator->isSupportedType(fromType)) {
       VELOX_FAIL(
-          "Casting from {} to {} is not supported.",
-          fromType->toString(),
-          toType->toString());
+          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
     }
 
     applyCustomTypeCast<true>(
@@ -535,9 +533,7 @@ void CastExpr::apply(
   } else if ((castOperator = getCastOperator(fromType->toString()))) {
     if (!castOperator->isSupportedType(toType)) {
       VELOX_FAIL(
-          "Casting from {} to {} is not supported.",
-          fromType->toString(),
-          toType->toString());
+          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
     }
 
     applyCustomTypeCast<false>(

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -123,22 +123,26 @@ class CastOperator {
   /// @param input The flat or constant input vector
   /// @param context The context
   /// @param rows Non-null rows of input
+  /// @param nullOnFailure Whether this is a cast or try_cast operation
   /// @param result The writable output vector of the custom type
   virtual void castTo(
       const BaseVector& input,
       exec::EvalCtx* context,
       const SelectivityVector& rows,
+      bool nullOnFailure,
       BaseVector& result) const = 0;
 
   /// Casts a vector of the custom type to another type.
   /// @param input The flat or constant input vector
   /// @param context The context
   /// @param rows Non-null rows of input
+  /// @param nullOnFailure Whether this is a cast or try_cast operation
   /// @param result The writable output vector of the destination type
   virtual void castFrom(
       const BaseVector& input,
       exec::EvalCtx* context,
       const SelectivityVector& rows,
+      bool nullOnFailure,
       BaseVector& result) const = 0;
 };
 

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -34,11 +34,10 @@ class CastBaseTest : public FunctionBaseTest {
   }
 
   template <typename TTo>
-  void evaluateCast(
+  VectorPtr evaluateCast(
       const TypePtr& fromType,
       const TypePtr& toType,
       const RowVectorPtr& input,
-      const VectorPtr& expected,
       bool tryCast = false) {
     std::shared_ptr<const core::ITypedExpr> inputField =
         std::make_shared<const core::FieldAccessTypedExpr>(fromType, "c0");
@@ -48,13 +47,22 @@ class CastBaseTest : public FunctionBaseTest {
             std::vector<std::shared_ptr<const core::ITypedExpr>>{inputField},
             tryCast);
 
-    auto result = evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    return evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+  }
 
+  template <typename TTo>
+  void evaluateAndVerify(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      const RowVectorPtr& input,
+      const VectorPtr& expected,
+      bool tryCast = false) {
+    auto result = evaluateCast<TTo>(fromType, toType, input, tryCast);
     assertEqualVectors(expected, result);
   }
 
   template <typename TTo>
-  void evaluateCastDictEncoding(
+  void evaluateAndVerifyDictEncoding(
       const TypePtr& fromType,
       const TypePtr& toType,
       const RowVectorPtr& input,
@@ -88,22 +96,23 @@ class CastBaseTest : public FunctionBaseTest {
       const VectorPtr& input,
       const VectorPtr& expected) {
     // Test with flat encoding.
-    evaluateCast<TTo>(fromType, toType, makeRowVector({input}), expected);
-    evaluateCast<TTo>(fromType, toType, makeRowVector({input}), expected, true);
+    evaluateAndVerify<TTo>(fromType, toType, makeRowVector({input}), expected);
+    evaluateAndVerify<TTo>(
+        fromType, toType, makeRowVector({input}), expected, true);
 
     // Test with constant encoding that repeats the first element five times.
     auto constInput = BaseVector::wrapInConstant(5, 0, input);
     auto constExpected = BaseVector::wrapInConstant(5, 0, expected);
 
-    evaluateCast<TTo>(
+    evaluateAndVerify<TTo>(
         fromType, toType, makeRowVector({constInput}), constExpected);
-    evaluateCast<TTo>(
+    evaluateAndVerify<TTo>(
         fromType, toType, makeRowVector({constInput}), constExpected, true);
 
     // Test with dictionary encoding that reverses the indices.
-    evaluateCastDictEncoding<TTo>(
+    evaluateAndVerifyDictEncoding<TTo>(
         fromType, toType, makeRowVector({input}), expected);
-    evaluateCastDictEncoding<TTo>(
+    evaluateAndVerifyDictEncoding<TTo>(
         fromType, toType, makeRowVector({input}), expected, true);
   }
 

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -36,12 +36,14 @@ class JsonCastOperator : public exec::CastOperator {
       const BaseVector& input,
       exec::EvalCtx* context,
       const SelectivityVector& rows,
+      bool nullOnFailure,
       BaseVector& result) const override;
 
   void castFrom(
       const BaseVector& /*input*/,
       exec::EvalCtx* /*context*/,
       const SelectivityVector& /*rows*/,
+      bool /*nullOnFailure*/,
       BaseVector& /*result*/) const override {
     VELOX_NYI("Casting from JSON is not implemented yet.");
   }


### PR DESCRIPTION
Summary: Besides maps with varchar keys, Presto also supports CAST(... as JSON) from maps with boolean, integral, and floating-point keys (https://github.com/prestodb/presto/blob/f85a1c2bf1bcda217655c24220059bc5377d6b76/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java#L200). These map keys are treated as if they were first converted to varchar implicitely. This diff adds support for these map key types and the corresponding tests in Velox.

Differential Revision: D34529948

This PR is based on PR #1055. The first commit inside this PR is a duplicate of the commit in PR #1055.