### PR TITLE
Realize stateChangeFuture at state change, not at termination of activity

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -911,6 +911,7 @@ void Task::terminate(TaskState terminalState) {
     // is cleared here so that this is 0 right after terminate as
     // tests expect.
     numRunningDrivers_ = 0;
+    stateChangedLocked();
     for (auto& driver : drivers_) {
       if (driver) {
         if (enterForTerminateLocked(driver->state()) ==
@@ -967,8 +968,6 @@ void Task::terminate(TaskState terminalState) {
   for (auto& bridge : oldBridges) {
     bridge->cancel();
   }
-  std::lock_guard<std::mutex> l(mutex_);
-  stateChangedLocked();
 }
 
 void Task::addOperatorStats(OperatorStats& stats) {


### PR DESCRIPTION
In Task::terminate, status reporting clients should see the state
change as it happens, instead of after all threads have
finished. Otherwise tests in DriverTest.cpp may see a race where
threads are finished (finishFuture realized) but the stateChange is
not yet realized.