### PR TITLE
Make allocation counters atomic

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -67,8 +67,6 @@ void MemoryUsageTracker::incrementUsage(UsageType type, int64_t size) {
 
   ++usage(numAllocs_, type);
   usage(cumulativeBytes_, type) += size;
-  ++usage(numAllocs_, type);
-  usage(cumulativeBytes_, type) += size;
 
   // We track the peak usage of total memory independent of user and
   // system memory since freed user memory can be reallocated as system

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -370,8 +370,8 @@ class MemoryUsageTracker
   std::array<std::atomic<int64_t>, 2> currentUsageInBytes_{};
   std::array<std::atomic<int64_t>, 3> peakUsageInBytes_{};
   std::array<int64_t, 3> maxMemory_;
-  std::array<int64_t, 3> numAllocs_{};
-  std::array<int64_t, 3> cumulativeBytes_{};
+  std::array<std::atomic<int64_t>, 3> numAllocs_{};
+  std::array<std::atomic<int64_t>, 3> cumulativeBytes_{};
 
   int64_t reservation_{0};
 


### PR DESCRIPTION
Makes the numAllocs_ and cumulativeBytes_ counter arrays in
MemoryUsageTrackers atomic. This is to get rid of thread sanitizer
errors. The counters by themselves do not have to be exact since these
are for tracking approximate volume only.