### PR TITLE
Fix presto_cpp e2e test TestHiveAggregationQueries.testApproxDistinct

### DIFF
--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   ComparisonsTest.cpp
   DateTimeFunctionsTest.cpp
   ElementAtTest.cpp
+  HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
   JsonCastTest.cpp

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/core/ITypedExpr.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/vector/tests/TestingDictionaryFunction.h"
+
+namespace facebook::velox::functions::test {
+
+class CastBaseTest : public FunctionBaseTest {
+ protected:
+  CastBaseTest() {
+    exec::registerVectorFunction(
+        "testing_dictionary",
+        ::facebook::velox::test::TestingDictionaryFunction::signatures(),
+        std::make_unique<::facebook::velox::test::TestingDictionaryFunction>());
+  }
+
+  template <typename TTo>
+  void evaluateCast(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      const RowVectorPtr& input,
+      const VectorPtr& expected,
+      bool tryCast = false) {
+    std::shared_ptr<const core::ITypedExpr> inputField =
+        std::make_shared<const core::FieldAccessTypedExpr>(fromType, "c0");
+    std::shared_ptr<const core::ITypedExpr> castExpr =
+        std::make_shared<const core::CastTypedExpr>(
+            toType,
+            std::vector<std::shared_ptr<const core::ITypedExpr>>{inputField},
+            tryCast);
+
+    auto result = evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename TTo>
+  void evaluateCastDictEncoding(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      const RowVectorPtr& input,
+      const VectorPtr& expected,
+      bool tryCast = false) {
+    std::shared_ptr<const core::ITypedExpr> inputField =
+        std::make_shared<const core::FieldAccessTypedExpr>(fromType, "c0");
+    std::shared_ptr<const core::ITypedExpr> callExpr =
+        std::make_shared<const core::CallTypedExpr>(
+            fromType,
+            std::vector<std::shared_ptr<const core::ITypedExpr>>{inputField},
+            "testing_dictionary");
+    std::shared_ptr<const core::ITypedExpr> castExpr =
+        std::make_shared<const core::CastTypedExpr>(
+            toType,
+            std::vector<std::shared_ptr<const core::ITypedExpr>>{callExpr},
+            tryCast);
+
+    auto indices =
+        ::facebook::velox::test::makeIndicesInReverse(input->size(), pool());
+
+    auto result = evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    assertEqualVectors(
+        wrapInDictionary(indices, input->size(), expected), result);
+  }
+
+  template <typename TTo>
+  void testCast(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      const VectorPtr& input,
+      const VectorPtr& expected) {
+    // Test with flat encoding.
+    evaluateCast<TTo>(fromType, toType, makeRowVector({input}), expected);
+    evaluateCast<TTo>(fromType, toType, makeRowVector({input}), expected, true);
+
+    // Test with constant encoding that repeats the first element five times.
+    auto constInput = BaseVector::wrapInConstant(5, 0, input);
+    auto constExpected = BaseVector::wrapInConstant(5, 0, expected);
+
+    evaluateCast<TTo>(
+        fromType, toType, makeRowVector({constInput}), constExpected);
+    evaluateCast<TTo>(
+        fromType, toType, makeRowVector({constInput}), constExpected, true);
+
+    // Test with dictionary encoding that reverses the indices.
+    evaluateCastDictEncoding<TTo>(
+        fromType, toType, makeRowVector({input}), expected);
+    evaluateCastDictEncoding<TTo>(
+        fromType, toType, makeRowVector({input}), expected, true);
+  }
+
+  template <typename TFrom, typename TTo>
+  void testCast(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      std::vector<std::optional<TFrom>> input,
+      std::vector<std::optional<TTo>> expected) {
+    auto inputVector = makeNullableFlatVector<TFrom>(input);
+    auto expectedVector = makeNullableFlatVector<TTo>(expected);
+
+    testCast<TTo>(fromType, toType, inputVector, expectedVector);
+  }
+};
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/tests/HyperLogLogCastTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogCastTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+
+using namespace facebook::velox;
+
+class HyperLogLogCastTest : public functions::test::CastBaseTest {};
+
+TEST_F(HyperLogLogCastTest, toHyperLogLog) {
+  testCast<StringView, StringView>(
+      VARBINARY(),
+      HYPERLOGLOG(),
+      {"aaa"_sv, ""_sv, std::nullopt},
+      {"aaa"_sv, ""_sv, std::nullopt});
+  testCast<StringView, StringView>(
+      VARBINARY(),
+      HYPERLOGLOG(),
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+}
+
+TEST_F(HyperLogLogCastTest, fromHyperLogLog) {
+  testCast<StringView, StringView>(
+      HYPERLOGLOG(),
+      VARBINARY(),
+      {"aaa"_sv, ""_sv, std::nullopt},
+      {"aaa"_sv, ""_sv, std::nullopt});
+  testCast<StringView, StringView>(
+      HYPERLOGLOG(),
+      VARBINARY(),
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+}

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -56,9 +56,9 @@ class HyperLogLogTypeFactories : public CustomTypeFactories {
     return HYPERLOGLOG();
   }
 
+  // HyperLogLog should be treated as Varbinary during type castings.
   exec::CastOperatorPtr getCastOperator() const override {
-    VELOX_NYI(
-        "Casting of {} is not implemented yet.", HYPERLOGLOG()->toString());
+    return nullptr;
   }
 };
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -60,6 +60,7 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
     return TIMESTAMP_WITH_TIME_ZONE();
   }
 
+  // Type casting from and to TimestampWithTimezone is not supported yet.
   exec::CastOperatorPtr getCastOperator() const override {
     VELOX_NYI(
         "Casting of {} is not implemented yet.",

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1591,8 +1591,10 @@ class CustomTypeFactories {
   /// types.
   virtual TypePtr getType(std::vector<TypePtr> childTypes) const = 0;
 
-  /// Returns a shared pointer to the custom cast operator. If no cast operator
-  /// supports the custom type, this function throws an exception.
+  /// Returns a shared pointer to the custom cast operator. If a custom type
+  /// should be treated as its underlying native type during type castings,
+  /// return a nullptr. If a custom type does not support castings, throw an
+  /// exception.
   virtual exec::CastOperatorPtr getCastOperator() const = 0;
 };
 
@@ -1609,7 +1611,8 @@ bool typeExists(const std::string& name);
 TypePtr getType(const std::string& name, std::vector<TypePtr> childTypes);
 
 /// Returns the custom cast operator for the custom type with the specified
-/// name. Returns nullptr if a type with the specified name does not exist.
+/// name. Returns nullptr if a type with the specified name does not exist or
+/// does not have a dedicated custom cast operator.
 exec::CastOperatorPtr getCastOperator(const std::string& name);
 
 // Allows us to transparently use folly::toAppend(), folly::join(), etc.


### PR DESCRIPTION
Summary: Casting to HyperLogLog failed after introducing a new logic in CastExpr that calls custom cast operators when the from-type or to-type is a custom type. HyperLogLog is a custom type but does not implement its own cast operator. Instead, it reused the cast logic for Varbinary. This diff makes HyperLogLogTypeFactories::getCastOperator() return a nullptr so that CastExpr falls through to use the cast logic of Varbinary as it did before.

Differential Revision: D34594007

