### PR TITLE
Add IOBufOutputStream

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -17,9 +17,44 @@
 #include "velox/common/memory/ByteStream.h"
 
 namespace facebook::velox {
+
+std::streampos ByteStream::tellp() const {
+  if (ranges_.empty()) {
+    return 0;
+  }
+  assert(current_);
+  int64_t size = 0;
+  for (auto& range : ranges_) {
+    if (&range == current_) {
+      return current_->position + size;
+    }
+    size += range.size;
+  }
+  VELOX_FAIL("ByteStream 'current_' is not in 'ranges_'.");
+}
+
+void ByteStream::seekp(std::streampos position) {
+  int64_t toSkip = position;
+  // Record how much was written pre-seek.
+  updateEnd();
+  if (ranges_.empty() && position == 0) {
+    return;
+  }
+  for (auto& range : ranges_) {
+    if (toSkip <= range.size) {
+      current_ = &range;
+      current_->position = toSkip;
+      return;
+    }
+    toSkip -= range.size;
+  }
+  VELOX_FAIL("Seeking past end of ByteStream: {}", position);
+}
+
 void ByteStream::flush(OutputStream* out) {
+  updateEnd();
   for (int32_t i = 0; i < ranges_.size(); ++i) {
-    int32_t count = ranges_[i].position;
+    int32_t count = i == ranges_.size() - 1 ? lastRangeEnd_ : ranges_[i].size;
     int32_t bytes = isBits_ ? bits::nbytes(count) : count;
     if (isBits_ && isReverseBitOrder_ && !isReversed_) {
       bits::reverseBits(ranges_[i].buffer, bytes);
@@ -29,6 +64,54 @@ void ByteStream::flush(OutputStream* out) {
   if (isBits_ && isReverseBitOrder_) {
     isReversed_ = true;
   }
+}
+
+void ByteStream::extend(int32_t bytes) {
+  // Check if rewriting existing content. If so, move to next range and start at
+  // 0.
+  if (current_ && current_ != &ranges_.back()) {
+    ++current_;
+    current_->position = 0;
+    return;
+  }
+  ranges_.emplace_back();
+  current_ = &ranges_.back();
+  arena_->newRange(bytes, current_);
+}
+
+namespace {
+void freeFunc(void* /*data*/, void* userData) {
+  auto ptr = reinterpret_cast<std::shared_ptr<StreamArena>*>(userData);
+  delete ptr;
+}
+} // namespace
+
+std::unique_ptr<folly::IOBuf> IOBufOutputStream::getIOBuf() {
+  // Make an IOBuf for each range. The IOBufs keep shared ownership of
+  // 'arena_'.
+  std::unique_ptr<folly::IOBuf> iobuf;
+  auto& ranges = out_->ranges();
+  for (auto& range : ranges) {
+    auto numValues =
+        &range == &ranges.back() ? out_->lastRangeEnd() : range.size;
+    auto userData = new std::shared_ptr<StreamArena>(arena_);
+    auto newBuf = folly::IOBuf::takeOwnership(
+        reinterpret_cast<char*>(range.buffer), numValues, freeFunc, userData);
+    if (iobuf) {
+      iobuf->prev()->appendChain(std::move(newBuf));
+    } else {
+      iobuf = std::move(newBuf);
+    }
+  }
+  return iobuf;
+}
+
+std::streampos IOBufOutputStream::tellp() const {
+  return out_->tellp();
+}
+
+void IOBufOutputStream::seekp(std::streampos pos) {
+  out_->seekp(pos);
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -18,17 +18,18 @@
 #include "velox/common/memory/StreamArena.h"
 #include "velox/type/Type.h"
 
+#include <folly/io/IOBuf.h>
+
 namespace facebook::velox {
 
 struct ByteRange {
- public:
-  template <typename T>
-  int32_t available() {
-    return (size - position) / sizeof(T);
-  }
-
+  // Start of buffer. Not owned.
   uint8_t* buffer;
+
+  // Number of bytes or bits  starting at 'buffer'.
   int32_t size;
+
+  // Index of next byte/bit to be read/written in 'buffer'.
   int32_t position;
 };
 
@@ -40,47 +41,58 @@ class OutputStreamListener {
 
 class OutputStream {
  public:
-  explicit OutputStream(
+  explicit OutputStream(OutputStreamListener* listener = nullptr)
+      : listener_(listener) {}
+
+  virtual ~OutputStream() = default;
+
+  virtual void write(const char* s, std::streamsize count) = 0;
+
+  virtual std::streampos tellp() const = 0;
+
+  virtual void seekp(std::streampos pos) = 0;
+
+  OutputStreamListener* listener() const {
+    return listener_;
+  }
+
+ protected:
+  OutputStreamListener* listener_;
+};
+
+class OStreamOutputStream : public OutputStream {
+ public:
+  explicit OStreamOutputStream(
       std::ostream* out,
       OutputStreamListener* listener = nullptr)
-      : out_(out), listener_(listener) {}
+      : OutputStream(listener), out_(out) {}
 
-  void write(const char* s, std::streamsize count) {
+  void write(const char* s, std::streamsize count) override {
     out_->write(s, count);
     if (listener_) {
       listener_->onWrite(s, count);
     }
   }
 
-  std::streampos tellp() const {
+  std::streampos tellp() const override {
     return out_->tellp();
   }
 
-  void seekp(std::streampos pos) {
+  void seekp(std::streampos pos) override {
     out_->seekp(pos);
-  }
-
-  OutputStreamListener* listener() const {
-    return listener_;
   }
 
  private:
   std::ostream* out_;
-  OutputStreamListener* listener_;
 };
-
-template <>
-inline int32_t ByteRange::available<bool>() {
-  return size * 8 - position;
-}
 
 // Stream over a chain of ByteRanges. Provides read, write and
 // comparison for equality between stream contents and memory. Used
 // for streams in repartitioning or for complex variable length data
-// in hash tables.
+// in hash tables. The stream is seekable and supports overwriting of
+// previous content, for example, writing a message body and then
+// seeking back to start to write a length header.
 class ByteStream {
-  using Position = std::tuple<ByteRange*, int32_t>;
-
  public:
   // For input.
   ByteStream() : isBits_(false), isReverseBitOrder_(false) {}
@@ -106,6 +118,7 @@ class ByteStream {
     ranges_.resize(1);
     ranges_[0] = range;
     current_ = ranges_.data();
+    lastRangeEnd_ = ranges_[0].size;
   }
 
   const std::vector<ByteRange>& ranges() const {
@@ -121,36 +134,40 @@ class ByteStream {
     current_->position = position;
   }
 
-  Position tellp() const {
-    return std::make_tuple(current_, current_->position);
-  }
+  std::streampos tellp() const;
 
-  void seekp(Position position) {
-    current_ = std::get<0>(position);
-    current_->position = std::get<1>(position);
-  }
+  void seekp(std::streampos position);
 
+  // Returns the size written into ranges_. This is the sum of the
+  // capacities of non-last ranges + the greatest write position of
+  // the last range.
   size_t size() const {
-    size_t total = 0;
-    for (auto& range : ranges_) {
-      total += range.position;
+    if (ranges_.empty()) {
+      return 0;
     }
-    return total;
+    size_t total = 0;
+    for (auto i = 0; i < ranges_.size() - 1; ++i) {
+      total += ranges_[i].size;
+    }
+    return total + std::max(ranges_.back().position, lastRangeEnd_);
   }
 
   // For input. Returns true if all input has been read.
   bool atEnd() const {
+    if (!current_) {
+      return false;
+    }
     if (current_->position < current_->size) {
       return false;
     }
 
-    size_t position = current_ - ranges_.data();
-    VELOX_CHECK(position >= 0 && position < ranges_.size());
-    if (position == ranges_.size() - 1) {
-      return true;
-    }
+    VELOX_CHECK(current_ >= ranges_.data() && current_ <= &ranges_.back());
+    return current_ == &ranges_.back();
+  }
 
-    return false;
+  int32_t lastRangeEnd() {
+    updateEnd();
+    return lastRangeEnd_;
   }
 
   // Sets 'current_' to point to the next range of input.  // The
@@ -332,10 +349,13 @@ class ByteStream {
   }
 
  private:
-  void extend(int32_t bytes = memory::MappedMemory::kPageSize) {
-    ranges_.emplace_back();
-    current_ = &ranges_.back();
-    arena_->newRange(bytes, current_);
+  void extend(int32_t bytes = memory::MappedMemory::kPageSize);
+
+  void updateEnd() {
+    if (!ranges_.empty() && current_ == &ranges_.back() &&
+        current_->position > lastRangeEnd_) {
+      lastRangeEnd_ = current_->position;
+    }
   }
 
   StreamArena* arena_;
@@ -348,6 +368,12 @@ class ByteStream {
   std::vector<ByteRange> ranges_;
   // Pointer to the current element of 'ranges_'.
   ByteRange* current_ = nullptr;
+
+  // Number of bits/bytes that have been written in the last element
+  // of 'ranges_'. In a write situation, all non-last ranges are full
+  // and the last may be partly full. The position in the last range
+  // is not necessarily the the end if there has been a seek.
+  int32_t lastRangeEnd_{0};
 };
 
 template <>
@@ -363,5 +389,35 @@ inline Date ByteStream::read<Date>() {
   readBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));
   return value;
 }
+
+class IOBufOutputStream : public OutputStream {
+ public:
+  explicit IOBufOutputStream(
+      memory::MappedMemory& mappedMemory,
+      OutputStreamListener* listener = nullptr,
+      int32_t initialSize = memory::MappedMemory::kPageSize)
+      : OutputStream(listener),
+        arena_(std::make_shared<StreamArena>(&mappedMemory)),
+        out_(std::make_unique<ByteStream>(arena_.get())) {
+    out_->startWrite(initialSize);
+  }
+
+  void write(const char* s, std::streamsize count) override {
+    out_->appendStringPiece(folly::StringPiece(s, count));
+    if (listener_) {
+      listener_->onWrite(s, count);
+    }
+  }
+
+  std::streampos tellp() const override;
+
+  void seekp(std::streampos pos) override;
+
+  std::unique_ptr<folly::IOBuf> getIOBuf();
+
+ private:
+  std::shared_ptr<StreamArena> arena_;
+  std::unique_ptr<ByteStream> out_;
+};
 
 } // namespace facebook::velox

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/ByteStream.h"
+#include "velox/common/base/test_utils/GTestUtils.h"
+#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MmapAllocator.h"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+class ByteStreamTest : public testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    constexpr uint64_t kMaxMappedMemory = 64 << 20;
+    MmapAllocatorOptions options = {kMaxMappedMemory};
+    mmapAllocator_ = std::make_unique<MmapAllocator>(options);
+    MappedMemory::setDefaultInstance(mmapAllocator_.get());
+  }
+
+  void TearDown() override {
+    MappedMemory::destroyTestOnly();
+    MappedMemory::setDefaultInstance(nullptr);
+  }
+
+  std::unique_ptr<MmapAllocator> mmapAllocator_;
+};
+
+TEST_F(ByteStreamTest, outputStream) {
+  auto out =
+      std::make_unique<IOBufOutputStream>(*mmapAllocator_, nullptr, 10000);
+  std::stringstream referenceSStream;
+  auto reference = std::make_unique<OStreamOutputStream>(&referenceSStream);
+  for (auto i = 0; i < 100; ++i) {
+    std::string data;
+    data.resize(10000);
+    std::fill(data.begin(), data.end(), i);
+    out->write(data.data(), data.size());
+    reference->write(data.data(), data.size());
+  }
+  EXPECT_EQ(reference->tellp(), out->tellp());
+  for (auto i = 0; i < 100; ++i) {
+    std::string data;
+    data.resize(6000);
+    std::fill(data.begin(), data.end(), i + 10);
+    out->seekp(i * 10000 + 5000);
+    reference->seekp(i * 10000 + 5000);
+    out->write(data.data(), data.size());
+    reference->write(data.data(), data.size());
+  }
+  auto str = referenceSStream.str();
+  auto numPages = mmapAllocator_->numAllocated();
+  EXPECT_LT(0, numPages);
+  auto iobuf = out->getIOBuf();
+  // We expect no new memory for the IOBufs, they take ownership of the buffers
+  // of 'out'.
+  EXPECT_EQ(numPages, mmapAllocator_->numAllocated());
+
+  // 'clone' holds a second reference to the data. 'clone' is
+  // destructively coalesced, dropping the second reference but the
+  // original reference in 'iobuf' keeps the data alive.
+  auto clone = iobuf->clone();
+  auto out1Data = clone->coalesce();
+  EXPECT_EQ(
+      str,
+      std::string(
+          reinterpret_cast<const char*>(out1Data.data()), out1Data.size()));
+  out = nullptr;
+  // The memory stays allocated since shared ownership in 'iobuf' chain.
+  EXPECT_EQ(numPages, mmapAllocator_->numAllocated());
+
+  iobuf = nullptr;
+  // We expect dropping the stream and the iobuf frees the backing memory.
+  EXPECT_EQ(0, mmapAllocator_->numAllocated());
+}

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 include(GoogleTest)
 add_executable(
   velox_memory_test
+  ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp
   MemoryHeaderTest.cpp

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -47,7 +47,7 @@ class SerializedPage {
       VectorStreamGroup* group) {
     std::stringstream out;
     OutputStreamListener listener;
-    OutputStream outputStream(&out, &listener);
+    OStreamOutputStream outputStream(&out, &listener);
     group->flush(&outputStream);
     return std::make_unique<SerializedPage>(
         &out, out.tellp(), group->mappedMemory());

--- a/velox/serializers/tests/PrestoOutputStreamListenerTest.cpp
+++ b/velox/serializers/tests/PrestoOutputStreamListenerTest.cpp
@@ -24,7 +24,7 @@ class PrestoOutputStreamListenerTest : public ::testing::Test {};
 TEST_F(PrestoOutputStreamListenerTest, basic) {
   std::stringstream out;
   serializer::presto::PrestoOutputStreamListener streamlListener;
-  auto os = std::make_unique<OutputStream>(&out, &streamlListener);
+  auto os = std::make_unique<OStreamOutputStream>(&out, &streamlListener);
 
   std::string str1 = "this";
   std::string str2 = "is";

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -61,7 +61,7 @@ class PrestoSerializerTest : public ::testing::Test {
 
     serializer->append(rowVector, folly::Range(rows.data(), numRows));
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
-    OutputStream out(output, &listener);
+    OStreamOutputStream out(output, &listener);
     serializer->flush(&out);
   }
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -697,8 +697,8 @@ class VectorTest : public testing::Test {
             oddIndices.size() - oddIndices.size() / 2));
     std::stringstream evenStream;
     std::stringstream oddStream;
-    OutputStream eventOutputStream(&evenStream);
-    OutputStream oddOutputStream(&oddStream);
+    OStreamOutputStream eventOutputStream(&evenStream);
+    OStreamOutputStream oddOutputStream(&oddStream);
     even.flush(&eventOutputStream);
     odd.flush(&oddOutputStream);
     ByteStream input;


### PR DESCRIPTION
Adds an OutputStream that allows retrieving the content as
folly::IOBufs. This is for use in partitioned output to get zero copy
message passing between Velox and the exchange server in presto_cpp.

Changes the Position type of ByteStream to a number so as to be
compatible with C++ streams.