### PR TITLE
Fix FINAL type for Presto's AVG aggregation function.

### DIFF
--- a/velox/docs/functions/aggregate.rst
+++ b/velox/docs/functions/aggregate.rst
@@ -25,9 +25,11 @@ General Aggregate Functions
 
     Returns an array created from the input ``x`` elements.
 
-.. function:: avg(x) -> double
+.. function:: avg(x) -> double|real
 
     Returns the average (arithmetic mean) of all input values.
+    When x is of type REAL, the result type is REAL.
+    For all other input types, the result type is DOUBLE.
 
 .. function:: bool_and(boolean) -> boolean
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -231,7 +231,8 @@ TEST_F(AverageAggregationTest, avg) {
             .planNode();
     assertQuery(
         agg,
-        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), avg(c4), avg(c5) FROM tmp GROUP BY 1");
+        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), "
+        "avg(c4), avg(c5) FROM tmp GROUP BY 1");
 
     agg = PlanBuilder()
               .values(vectors)
@@ -241,7 +242,8 @@ TEST_F(AverageAggregationTest, avg) {
               .planNode();
     assertQuery(
         agg,
-        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), avg(c4), avg(c5) FROM tmp GROUP BY 1");
+        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), "
+        "avg(c4), avg(c5) FROM tmp GROUP BY 1");
 
     agg = PlanBuilder()
               .values(vectors)
@@ -253,7 +255,8 @@ TEST_F(AverageAggregationTest, avg) {
               .planNode();
     assertQuery(
         agg,
-        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), avg(c4), avg(c5) FROM tmp GROUP BY 1");
+        "SELECT c0 % 10, avg(c1), avg(c2), avg(c3::DOUBLE), "
+        "avg(c4), avg(c5) FROM tmp GROUP BY 1");
   }
 
   // group by; no input


### PR DESCRIPTION
Summary:
Real input type in Presto has special case and returns REAL, not DOUBLE.
So, we are being compatible with Presto here.

Reviewed By: mbasmanova

Differential Revision: D34630335

