### PR TITLE
Remove extra copying in PartitionedOutput/Exchange

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -92,6 +92,10 @@ class QueryConfig {
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
   }
 
+  // Returns the target size for a Task's buffered output. The
+  // producer Drivers are blocked when the buffered size exceeds
+  // this. The Drivers are resumed when the buffered size goes below
+  // PartitionedOutputBufferManager::kContinuePct % of this.
   uint64_t maxPartitionedOutputBufferSize() const {
     static constexpr uint64_t kDefault = 32UL << 20;
     return get<uint64_t>(kMaxPartitionedOutputBufferSize, kDefault);

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -203,7 +203,7 @@ class MergeExchangeSource : public MergeSource {
     }
     if (!inputStream_) {
       inputStream_ = std::make_unique<ByteStream>();
-      mergeExchange_->stats().rawInputBytes += currentPage_->byteSize();
+      mergeExchange_->stats().rawInputBytes += currentPage_->size();
       currentPage_->prepareStreamForDeserialize(inputStream_.get());
     }
 

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -21,7 +21,7 @@ void DestinationBuffer::getData(
     uint64_t maxBytes,
     int64_t sequence,
     DataAvailableCallback notify,
-    std::vector<std::shared_ptr<VectorStreamGroup>>& result) {
+    std::vector<std::shared_ptr<SerializedPage>>& result) {
   VELOX_CHECK_GE(
       sequence, sequence_, "Get received for an already acknowledged item");
 
@@ -71,7 +71,7 @@ DataAvailable DestinationBuffer::getAndClearNotify() {
   return result;
 }
 
-std::vector<std::shared_ptr<VectorStreamGroup>> DestinationBuffer::acknowledge(
+std::vector<std::shared_ptr<SerializedPage>> DestinationBuffer::acknowledge(
     int64_t sequence,
     bool fromGetData) {
   int64_t numDeleted = sequence - sequence_;
@@ -94,7 +94,7 @@ std::vector<std::shared_ptr<VectorStreamGroup>> DestinationBuffer::acknowledge(
 
   VELOX_CHECK_LE(
       numDeleted, data_.size(), "Ack received for a not yet produced item");
-  std::vector<std::shared_ptr<VectorStreamGroup>> freed;
+  std::vector<std::shared_ptr<SerializedPage>> freed;
   for (auto i = 0; i < numDeleted; ++i) {
     if (!data_[i]) {
       VELOX_CHECK_EQ(i, data_.size() - 1, "null marker found in the middle");
@@ -107,9 +107,9 @@ std::vector<std::shared_ptr<VectorStreamGroup>> DestinationBuffer::acknowledge(
   return freed;
 }
 
-std::vector<std::shared_ptr<VectorStreamGroup>>
+std::vector<std::shared_ptr<SerializedPage>>
 DestinationBuffer::deleteResults() {
-  std::vector<std::shared_ptr<VectorStreamGroup>> freed;
+  std::vector<std::shared_ptr<SerializedPage>> freed;
   for (auto i = 0; i < data_.size(); ++i) {
     if (!data_[i]) {
       VELOX_CHECK_EQ(i, data_.size() - 1, "null marker found in the middle");
@@ -137,7 +137,7 @@ namespace {
 // that we do the expensive free outside and only then continue the
 // producers which will allocate more memory.
 void releaseAfterAcknowledge(
-    std::vector<std::shared_ptr<VectorStreamGroup>>& freed,
+    std::vector<std::shared_ptr<SerializedPage>>& freed,
     std::vector<VeloxPromise<bool>>& promises) {
   freed.clear();
   for (auto& promise : promises) {
@@ -145,6 +145,22 @@ void releaseAfterAcknowledge(
   }
 }
 } // namespace
+
+PartitionedOutputBuffer::PartitionedOutputBuffer(
+    std::shared_ptr<Task> task,
+    bool broadcast,
+    int numDestinations,
+    uint32_t numDrivers)
+    : task_(std::move(task)),
+      broadcast_(broadcast),
+      numDrivers_(numDrivers),
+      maxSize_(task_->queryCtx()->config().maxPartitionedOutputBufferSize()),
+      continueSize_((maxSize_ * kContinuePct) / 100) {
+  buffers_.reserve(numDestinations);
+  for (int i = 0; i < numDestinations; i++) {
+    buffers_.push_back(std::make_unique<DestinationBuffer>());
+  }
+}
 
 void PartitionedOutputBuffer::updateBroadcastOutputBuffers(
     int numBuffers,
@@ -202,7 +218,7 @@ void PartitionedOutputBuffer::addBroadcastOutputBuffersLocked(int numBuffers) {
 
 BlockingReason PartitionedOutputBuffer::enqueue(
     int destination,
-    std::unique_ptr<VectorStreamGroup> data,
+    std::shared_ptr<SerializedPage> data,
     ContinueFuture* future) {
   VELOX_CHECK(data);
   std::vector<DataAvailable> dataAvailableCallbacks;
@@ -215,14 +231,13 @@ BlockingReason PartitionedOutputBuffer::enqueue(
 
     totalSize_ += data->size();
     if (broadcast_) {
-      std::shared_ptr<VectorStreamGroup> shared = std::move(data);
       for (auto& buffer : buffers_) {
-        buffer->enqueue(shared);
+        buffer->enqueue(data);
         dataAvailableCallbacks.emplace_back(buffer->getAndClearNotify());
       }
 
       if (!noMoreBroadcastBuffers_) {
-        dataToBroadcast_.emplace_back(shared);
+        dataToBroadcast_.emplace_back(data);
       }
     } else {
       auto buffer = buffers_[destination].get();
@@ -300,7 +315,7 @@ bool PartitionedOutputBuffer::isFinishedLocked() {
 }
 
 void PartitionedOutputBuffer::acknowledge(int destination, int64_t sequence) {
-  std::vector<std::shared_ptr<VectorStreamGroup>> freed;
+  std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<VeloxPromise<bool>> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -318,7 +333,7 @@ void PartitionedOutputBuffer::acknowledge(int destination, int64_t sequence) {
 }
 
 void PartitionedOutputBuffer::updateAfterAcknowledgeLocked(
-    const std::vector<std::shared_ptr<VectorStreamGroup>>& freed,
+    const std::vector<std::shared_ptr<SerializedPage>>& freed,
     std::vector<VeloxPromise<bool>>& promises) {
   uint64_t totalFreed = 0;
   for (const auto& free : freed) {
@@ -343,7 +358,7 @@ void PartitionedOutputBuffer::updateAfterAcknowledgeLocked(
 }
 
 bool PartitionedOutputBuffer::deleteResults(int destination) {
-  std::vector<std::shared_ptr<VectorStreamGroup>> freed;
+  std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<VeloxPromise<bool>> promises;
   bool isFinished;
   {
@@ -376,8 +391,8 @@ void PartitionedOutputBuffer::getData(
     uint64_t maxBytes,
     int64_t sequence,
     DataAvailableCallback notify) {
-  std::vector<std::shared_ptr<VectorStreamGroup>> data;
-  std::vector<std::shared_ptr<VectorStreamGroup>> freed;
+  std::vector<std::shared_ptr<SerializedPage>> data;
+  std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<VeloxPromise<bool>> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -457,7 +472,7 @@ PartitionedOutputBufferManager::getBuffer(const std::string& taskId) {
 BlockingReason PartitionedOutputBufferManager::enqueue(
     const std::string& taskId,
     int destination,
-    std::unique_ptr<VectorStreamGroup> data,
+    std::shared_ptr<SerializedPage> data,
     ContinueFuture* future) {
   return getBuffer(taskId)->enqueue(destination, std::move(data), future);
 }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -224,8 +224,11 @@ void Task::start(
     }
 
     if (factory->needsExchangeClient()) {
-      self->exchangeClients_[pipeline] =
-          std::make_shared<ExchangeClient>(self->destination_);
+      // Low-water mark for filling the exchange queue is 1/2 of the per worker
+      // buffer size of the producers.
+      self->exchangeClients_[pipeline] = std::make_shared<ExchangeClient>(
+          self->destination_,
+          self->queryCtx()->config().maxPartitionedOutputBufferSize() / 2);
     }
   }
 


### PR DESCRIPTION
Writes the result of serialization into SerializedPage in
PartitionedOutput and makes SerializedPage the content type of
PartitionedOutputBufferManager. Uses folly::IOBuf as
the content type of SerializedPage, so that IOBufs received from
Proxygen in presto_cpp can be owned by the receiving ExchangeQueue without copy.

Since the serialization is finalized in PartitionedOutput, its CPU
time and transient memory are accounted for the Task, which is not
always the case if this is done in the presto_cpp TaskManager. The
serialization is done in MappedMemory and the ownership is handed to
the resulting IOBufs without copy.