### PR TITLE
Updating ArrowArray n_buffers' default value when converting from VeloxVector to ArrowArray

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -330,7 +330,7 @@ void exportToArrow(
   arrowArray.buffers = bridgeHolder->getArrowBuffers();
   arrowArray.release = bridgeRelease;
   arrowArray.length = vector->size();
-  arrowArray.n_buffers = 0;
+  arrowArray.n_buffers = 1;
   arrowArray.n_children = 0;
   arrowArray.children = nullptr;
 
@@ -340,7 +340,6 @@ void exportToArrow(
   // Setting up buffer pointers. First one is always nulls.
   if (vector->nulls()) {
     bridgeHolder->setBuffer(0, vector->nulls());
-    arrowArray.n_buffers = 1;
 
     // getNullCount() returns a std::optional. -1 means we don't have the count
     // available yet (and we don't want to count it here).

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -324,7 +324,7 @@ TEST_F(ArrowBridgeArrayExportTest, rowVector) {
   EXPECT_EQ(col1.size(), arrowArray.length);
   EXPECT_EQ(0, arrowArray.null_count);
   EXPECT_EQ(0, arrowArray.offset);
-  EXPECT_EQ(0, arrowArray.n_buffers);
+  EXPECT_EQ(1, arrowArray.n_buffers);
   EXPECT_EQ(vector->childrenSize(), arrowArray.n_children);
 
   EXPECT_NE(nullptr, arrowArray.children);
@@ -386,7 +386,7 @@ TEST_F(ArrowBridgeArrayExportTest, rowVectorEmpty) {
   ArrowArray arrowArray;
   exportToArrow(vectorMaker_.rowVector({}), arrowArray, pool_.get());
   EXPECT_EQ(0, arrowArray.n_children);
-  EXPECT_EQ(0, arrowArray.n_buffers);
+  EXPECT_EQ(1, arrowArray.n_buffers);
   EXPECT_EQ(nullptr, arrowArray.children);
 
   arrowArray.release(&arrowArray);


### PR DESCRIPTION
Summary:
As per discussion in
https://fb.workplace.com/groups/466548188255217/permalink/488813672695335/

Following the incoming fix described in the below Jira, we set ArrowArray's variable "n_buffers"'s default value to be 1:
https://issues.apache.org/jira/browse/ARROW-15846

Differential Revision: D34617591

