### PR TITLE
Export mapped memory stats

### DIFF
--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -241,8 +241,9 @@ class MmapAllocator : public MappedMemory {
   // increment of this by the desired amount is <= 'capacity_'.
   std::atomic<MachinePageCount> numAllocated_;
 
-  //  Number of machine pages backed by memory in the
-  // address ranges in 'sizeClasses_'
+  // Number of machine pages backed by memory in the address ranges in
+  // 'sizeClasses_'. It includes pages that are already freed. Hence it should
+  // be larger than numAllocated_
   std::atomic<MachinePageCount> numMapped_;
 
   // Number of pages allocated and explicitly mmap'd by the


### PR DESCRIPTION
Summary: Exports 2 critical memory stats from MappedMemory to reflect system memory usage. Currently it only reflects the amount of memory used by async caches. Later MemoryPool will be migrated to use MappedMemory instead of JEMALLOC so the stats will reflect pretty much all large application wise memory usage.

Differential Revision: D34695186

