### PR TITLE
Add mechanism to provide context to exceptions

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -21,6 +21,11 @@
 namespace facebook {
 namespace velox {
 
+ExceptionContext& getExceptionContext() {
+  thread_local ExceptionContext context;
+  return context;
+}
+
 VeloxException::VeloxException(
     const char* file,
     size_t line,
@@ -40,6 +45,7 @@ VeloxException::VeloxException(
         state.message = message;
         state.errorSource = errorSource;
         state.errorCode = errorCode;
+        state.context = getExceptionContext().message();
         state.isRetriable = isRetriable;
       })) {}
 
@@ -134,6 +140,10 @@ void VeloxException::State::finalize() const {
     elaborateMessage += "Expression: ";
     elaborateMessage += failingExpression;
     elaborateMessage += '\n';
+  }
+
+  if (!context.empty()) {
+    elaborateMessage += "Context: " + context + "\n";
   }
 
   if (function) {

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -34,6 +34,47 @@ DECLARE_int32(velox_exception_stacktrace_rate_limit_ms);
 namespace facebook {
 namespace velox {
 
+/// Holds a pointer to a function that provides addition context to be
+/// added to the detailed error message in case of an exception.
+struct ExceptionContext {
+  using MessageFunction = std::string (*)(void* arg);
+
+  /// Function to call in case of an exception to get additional context.
+  MessageFunction messageFunc{nullptr};
+
+  /// Value to pass to `messageFunc`. Can be null.
+  void* arg{nullptr};
+
+  /// Calls `messageFunc(arg)` and returns the result. Returns empty string if
+  /// `messageFunc` is null.
+  std::string message() {
+    return messageFunc ? messageFunc(arg) : "";
+  }
+};
+
+/// Returns a reference to thread_local variable that holds a function that can
+/// be used to get addition context to be added to the detailed error message in
+/// case an exception occurs. This is to used in cases when stack trace would
+/// not provide enough information, e.g. in case of hierarchical processing like
+/// expression evaluation.
+ExceptionContext& getExceptionContext();
+
+/// RAII class to set and restore context for exceptions.
+class ExceptionContextSetter {
+ public:
+  explicit ExceptionContextSetter(ExceptionContext value)
+      : prev_{getExceptionContext()} {
+    getExceptionContext() = std::move(value);
+  }
+
+  ~ExceptionContextSetter() {
+    getExceptionContext() = std::move(prev_);
+  }
+
+ private:
+  ExceptionContext prev_;
+};
+
 namespace error_source {
 using namespace folly::string_literals;
 
@@ -151,6 +192,10 @@ class VeloxException : public std::exception {
     return state_->errorSource == error_source::kErrorSourceUser;
   }
 
+  const std::string& context() const {
+    return state_->context;
+  }
+
  private:
   struct State {
     std::unique_ptr<process::StackTrace> stackTrace;
@@ -162,6 +207,7 @@ class VeloxException : public std::exception {
     std::string message;
     std::string errorSource;
     std::string errorCode;
+    std::string context;
     bool isRetriable;
 
     mutable folly::once_flag once;

--- a/velox/common/tests/ExceptionTests.cpp
+++ b/velox/common/tests/ExceptionTests.cpp
@@ -436,3 +436,69 @@ TEST(ExceptionTests, ExceptionWithErrorCode) {
           "False",
           "operator()"));
 }
+
+TEST(ExceptionTests, context) {
+  // No context.
+  verifyVeloxException(
+      [&]() { VELOX_CHECK_EQ(1, 3); },
+      "Exception: VeloxRuntimeError"
+      "\nError Source: RUNTIME"
+      "\nError Code: INVALID_STATE"
+      "\nReason: (1 vs. 3)"
+      "\nRetriable: False"
+      "\nExpression: 1 == 3"
+      "\nFunction: operator()"
+      "\nFile: ");
+
+  // With context.
+  {
+    std::string troubleshootingAid = "Troubleshooting aid.";
+    facebook::velox::ExceptionContextSetter context(
+        {[](auto* arg) { return std::string(static_cast<char*>(arg)); },
+         troubleshootingAid.data()});
+
+    verifyVeloxException(
+        [&]() { VELOX_CHECK_EQ(1, 3); },
+        "Exception: VeloxRuntimeError"
+        "\nError Source: RUNTIME"
+        "\nError Code: INVALID_STATE"
+        "\nReason: (1 vs. 3)"
+        "\nRetriable: False"
+        "\nExpression: 1 == 3"
+        "\nContext: Troubleshooting aid."
+        "\nFunction: operator()"
+        "\nFile: ");
+  }
+
+  // Different context.
+  {
+    std::string debuggingInfo = "Debugging info.";
+    facebook::velox::ExceptionContextSetter context(
+        {[](auto* arg) { return std::string(static_cast<char*>(arg)); },
+         debuggingInfo.data()});
+
+    verifyVeloxException(
+        [&]() { VELOX_CHECK_EQ(1, 3); },
+        "Exception: VeloxRuntimeError"
+        "\nError Source: RUNTIME"
+        "\nError Code: INVALID_STATE"
+        "\nReason: (1 vs. 3)"
+        "\nRetriable: False"
+        "\nExpression: 1 == 3"
+        "\nContext: Debugging info."
+        "\nFunction: operator()"
+        "\nFile: ");
+  }
+
+  // No context.
+  verifyVeloxException(
+      [&]() { VELOX_CHECK_EQ(1, 3); },
+      "Exception: VeloxRuntimeError"
+      "\nError Source: RUNTIME"
+      "\nError Code: INVALID_STATE"
+      "\nReason: (1 vs. 3)"
+      "\nRetriable: False"
+      "\nExpression: 1 == 3"
+      "\nFunction: operator()"
+      "\nFile: ");
+}

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -220,6 +220,11 @@ void Expr::eval(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  // Make sure to include current expression in the error message in case of an
+  // exception.
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
     *result = BaseVector::createNullConstant(type(), 0, context->pool());


### PR DESCRIPTION
Errors happening during expression evaluation are hard to troubleshoot because
it is not clear which sub-expression triggered the error. This PR adds a
mechanism to specify context for exceptions via a thread_local variable and
uses it to specify the expression being evaluated and add it to the exception.

Here are some examples of the new "context" information being added to the
exceptions:

(c0 + c1) % 0 -> Context: mod(cast(plus(c0, c1)), literal)
c0 + (c1 % 0) -> Context: mod(cast(c1), literal)

