### PR TITLE
Enable tests for selective timestamp column reader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -42,6 +42,35 @@ constexpr uint64_t BUFFER_SIZE = 1024;
 // case, we still need to make batch point to a valid address
 std::array<char, 1> EMPTY_DICT;
 
+namespace detail {
+
+void fillTimestamps(
+    Timestamp* timestamps,
+    const uint64_t* nullsPtr,
+    const int64_t* secondsPtr,
+    const uint64_t* nanosPtr,
+    vector_size_t numValues) {
+  for (vector_size_t i = 0; i < numValues; i++) {
+    if (!nullsPtr || !bits::isBitNull(nullsPtr, i)) {
+      auto nanos = nanosPtr[i];
+      uint64_t zeros = nanos & 0x7;
+      nanos >>= 3;
+      if (zeros != 0) {
+        for (uint64_t j = 0; j <= zeros; ++j) {
+          nanos *= 10;
+        }
+      }
+      auto seconds = secondsPtr[i] + EPOCH_OFFSET;
+      if (seconds < 0 && nanos != 0) {
+        seconds -= 1;
+      }
+      timestamps[i] = Timestamp(seconds, nanos);
+    }
+  }
+}
+
+} // namespace detail
+
 inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
   switch (static_cast<int64_t>(kind)) {
     case proto::ColumnEncoding_Kind_DIRECT:
@@ -57,7 +86,7 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
 
 template <typename T>
 FlatVector<T>* resetIfWrongFlatVectorType(VectorPtr& result) {
-  return resetIfWrongVectorType<FlatVector<T>>(result);
+  return detail::resetIfWrongVectorType<FlatVector<T>>(result);
 }
 
 BufferPtr ColumnReader::readNulls(
@@ -84,7 +113,7 @@ void ColumnReader::readNulls(
   auto numBytes = bits::nbytes(numValues);
   if (result && *result) {
     nulls = (*result)->mutableNulls(numValues + (simd::kPadding * 8));
-    resetIfNotWritable(*result, nulls);
+    detail::resetIfNotWritable(*result, nulls);
   }
   if (!nulls || nulls->capacity() < numBytes + simd::kPadding) {
     nulls =
@@ -225,7 +254,7 @@ void ByteRleColumnReader<DataType, RequestedType>::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<RequestedType>(numValues, &memoryPool_);
@@ -359,7 +388,7 @@ void IntegerDirectColumnReader<ReqT>::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<ReqT>(numValues, &memoryPool_);
@@ -499,7 +528,7 @@ void IntegerDictionaryColumnReader<ReqT>::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<ReqT>(numValues, &memoryPool_);
@@ -517,7 +546,7 @@ void IntegerDictionaryColumnReader<ReqT>::next(
   // is an offset or a literal value.
   const char* inDict = nullptr;
   if (inDictionaryReader) {
-    ensureCapacity<bool>(inDictionary, numValues, &memoryPool_);
+    detail::ensureCapacity<bool>(inDictionary, numValues, &memoryPool_);
     inDictionaryReader->next(
         inDictionary->asMutable<char>(), numValues, nullsPtr);
     inDict = inDictionary->as<char>();
@@ -606,7 +635,7 @@ void TimestampColumnReader::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<Timestamp>(numValues, &memoryPool_);
@@ -620,36 +649,15 @@ void TimestampColumnReader::next(
         &memoryPool_, nulls, nullCount, numValues, values);
   }
 
-  ensureCapacity<int64_t>(secondsBuffer_, numValues, &memoryPool_);
-  ensureCapacity<int64_t>(nanosBuffer_, numValues, &memoryPool_);
+  detail::ensureCapacity<int64_t>(secondsBuffer_, numValues, &memoryPool_);
+  detail::ensureCapacity<uint64_t>(nanosBuffer_, numValues, &memoryPool_);
   auto secondsData = secondsBuffer_->asMutable<int64_t>();
-  auto nanosData = nanosBuffer_->asMutable<int64_t>();
+  auto nanosData = nanosBuffer_->asMutable<uint64_t>();
   seconds->next(secondsData, numValues, nullsPtr);
-  nano->next(nanosData, numValues, nullsPtr);
-
-  // Construct the values
-  for (uint64_t i = 0; i < numValues; i++) {
-    if (!nulls || !bits::isBitNull(nullsPtr, i)) {
-      uint64_t zeros = nanosData[i] & 0x7;
-      nanosData[i] >>= 3;
-      if (zeros != 0) {
-        for (uint64_t j = 0; j <= zeros; ++j) {
-          nanosData[i] *= 10;
-        }
-      }
-      secondsData[i] += EPOCH_OFFSET;
-      if (secondsData[i] < 0 && nanosData[i] != 0) {
-        secondsData[i] -= 1;
-      }
-    }
-  }
-
+  nano->next(reinterpret_cast<int64_t*>(nanosData), numValues, nullsPtr);
   auto* valuesPtr = values->asMutable<Timestamp>();
-  for (uint64_t i = 0; i < numValues; i++) {
-    if (!nulls || !bits::isBitNull(nullsPtr, i)) {
-      valuesPtr[i] = Timestamp(secondsData[i], nanosData[i]);
-    }
-  }
+  detail::fillTimestamps(
+      valuesPtr, nullsPtr, secondsData, nanosData, numValues);
 }
 
 template <class T>
@@ -764,7 +772,7 @@ void FloatingPointColumnReader<DataT, ReqT>::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<ReqT>(numValues, &memoryPool_);
@@ -1003,7 +1011,7 @@ void StringDictionaryColumnReader::loadStrideDictionary() {
     strideDictStream->seekToRowGroup(pp);
     strideDictLengthDecoder->seekToRowGroup(pp);
 
-    ensureCapacity<int64_t>(
+    detail::ensureCapacity<int64_t>(
         strideDictOffset, strideDictCount + 1, &memoryPool_);
     strideDict = loadDictionary(
         strideDictCount,
@@ -1096,7 +1104,7 @@ void StringDictionaryColumnReader::readDictionaryVector(
     VectorPtr& result,
     const uint64_t* incomingNulls) {
   auto dictVector =
-      resetIfWrongVectorType<DictionaryVector<StringView>>(result);
+      detail::resetIfWrongVectorType<DictionaryVector<StringView>>(result);
   BufferPtr indices;
   if (dictVector) {
     indices = dictVector->mutableIndices(numValues);
@@ -1107,7 +1115,7 @@ void StringDictionaryColumnReader::readDictionaryVector(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (result) {
-    resetIfNotWritable(result, indices);
+    detail::resetIfNotWritable(result, indices);
   }
   if (!indices) {
     indices = AlignedBuffer::allocate<vector_size_t>(numValues, &memoryPool_);
@@ -1122,7 +1130,7 @@ void StringDictionaryColumnReader::readDictionaryVector(
   // load inDictionary
   const char* inDictPtr = nullptr;
   if (inDictionaryReader) {
-    ensureCapacity<bool>(inDict, numValues, &memoryPool_);
+    detail::ensureCapacity<bool>(inDict, numValues, &memoryPool_);
     inDictionaryReader->next(inDict->asMutable<char>(), numValues, nullsPtr);
     inDictPtr = inDict->as<char>();
   }
@@ -1239,7 +1247,7 @@ void StringDictionaryColumnReader::readFlatVector(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (result) {
-    resetIfNotWritable(result, data);
+    detail::resetIfNotWritable(result, data);
   }
   if (!data) {
     data = AlignedBuffer::allocate<StringView>(numValues, &memoryPool_);
@@ -1248,7 +1256,7 @@ void StringDictionaryColumnReader::readFlatVector(
   // load inDictionary
   const char* inDictPtr = nullptr;
   if (inDictionaryReader) {
-    ensureCapacity<bool>(inDict, numValues, &memoryPool_);
+    detail::ensureCapacity<bool>(inDict, numValues, &memoryPool_);
     inDictionaryReader->next(inDict->asMutable<char>(), numValues, nullsPtr);
     inDictPtr = inDict->as<char>();
   }
@@ -1329,7 +1337,8 @@ void StringDictionaryColumnReader::ensureInitialized() {
     return;
   }
 
-  ensureCapacity<int64_t>(dictionaryOffset, dictionaryCount + 1, &memoryPool_);
+  detail::ensureCapacity<int64_t>(
+      dictionaryOffset, dictionaryCount + 1, &memoryPool_);
   dictionaryBlob = loadDictionary(
       dictionaryCount, *blobStream, *lengthDecoder, dictionaryOffset);
   dictionaryValues_.reset();
@@ -1452,7 +1461,7 @@ void StringDirectColumnReader::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (flatVector) {
-    resetIfNotWritable(result, values);
+    detail::resetIfNotWritable(result, values);
   }
   if (!values) {
     values = AlignedBuffer::allocate<StringView>(numValues, &memoryPool_);
@@ -1583,7 +1592,7 @@ void StructColumnReader::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
-  auto rowVector = resetIfWrongVectorType<RowVector>(result);
+  auto rowVector = detail::resetIfWrongVectorType<RowVector>(result);
   std::vector<VectorPtr> childrenVectors;
   if (rowVector) {
     // Track children vectors in a local variable because readNulls may reset
@@ -1719,7 +1728,7 @@ void ListColumnReader::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
-  auto resultArray = resetIfWrongVectorType<ArrayVector>(result);
+  auto resultArray = detail::resetIfWrongVectorType<ArrayVector>(result);
   VectorPtr elements;
   BufferPtr offsets;
   BufferPtr lengths;
@@ -1734,7 +1743,7 @@ void ListColumnReader::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (resultArray) {
-    resetIfNotWritable(result, offsets, lengths);
+    detail::resetIfNotWritable(result, offsets, lengths);
   }
 
   if (!offsets) {
@@ -1879,7 +1888,7 @@ void MapColumnReader::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
-  auto resultMap = resetIfWrongVectorType<MapVector>(result);
+  auto resultMap = detail::resetIfWrongVectorType<MapVector>(result);
   VectorPtr keys;
   VectorPtr values;
   BufferPtr offsets;
@@ -1896,7 +1905,7 @@ void MapColumnReader::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (resultMap) {
-    resetIfNotWritable(result, offsets, lengths);
+    detail::resetIfNotWritable(result, offsets, lengths);
   }
 
   if (!offsets) {

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -129,6 +129,8 @@ class ColumnReaderFactory {
   static ColumnReaderFactory* baseFactory();
 };
 
+namespace detail {
+
 template <typename T>
 inline void ensureCapacity(
     BufferPtr& data,
@@ -169,4 +171,14 @@ inline void resetIfNotWritable(VectorPtr& result, T&... buffer) {
     result.reset();
   }
 }
+
+// Helper method to build timestamps based on nulls/seconds/nanos
+void fillTimestamps(
+    Timestamp* timestamps,
+    const uint64_t* nulls,
+    const int64_t* seconds,
+    const uint64_t* nanos,
+    vector_size_t numValues);
+
+} // namespace detail
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -322,7 +322,7 @@ void FlatMapColumnReader<T>::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
-  auto mapVector = resetIfWrongVectorType<MapVector>(result);
+  auto mapVector = detail::resetIfWrongVectorType<MapVector>(result);
   VectorPtr keysVector;
   VectorPtr valuesVector;
   BufferPtr offsets;
@@ -341,7 +341,7 @@ void FlatMapColumnReader<T>::next(
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
   if (mapVector) {
-    resetIfNotWritable(result, offsets, lengths);
+    detail::resetIfNotWritable(result, offsets, lengths);
   }
 
   if (!offsets) {
@@ -652,7 +652,7 @@ void FlatMapStructEncodingColumnReader<T>::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* FOLLY_NULLABLE incomingNulls) {
-  auto rowVector = resetIfWrongVectorType<RowVector>(result);
+  auto rowVector = detail::resetIfWrongVectorType<RowVector>(result);
   std::vector<VectorPtr> children;
   if (rowVector) {
     // Track children vectors in a local variable because readNulls may reset

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -81,7 +81,7 @@ void SelectiveIntegerDictionaryColumnReader::read(
     int32_t numFlags = (isBulk && nullsInReadRange_)
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
-    ensureCapacity<uint64_t>(
+    detail::ensureCapacity<uint64_t>(
         inDictionary_, bits::nwords(numFlags), &memoryPool_);
     inDictionaryReader_->next(
         inDictionary_->asMutable<char>(),

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -64,8 +64,8 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     // Reads the lengths, leaves an uninitialized gap for a null
     // map/list. Reading these checks the null nask.
     length_->next(allLengths_.data(), rows.back() + 1, nulls);
-    ensureCapacity<vector_size_t>(offsets_, rows.size(), &memoryPool_);
-    ensureCapacity<vector_size_t>(sizes_, rows.size(), &memoryPool_);
+    detail::ensureCapacity<vector_size_t>(offsets_, rows.size(), &memoryPool_);
+    detail::ensureCapacity<vector_size_t>(sizes_, rows.size(), &memoryPool_);
     auto rawOffsets = offsets_->asMutable<vector_size_t>();
     auto rawSizes = sizes_->asMutable<vector_size_t>();
     vector_size_t nestedLength = 0;

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -134,7 +134,7 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
     strideDictStream_->seekToRowGroup(pp);
     strideDictLengthDecoder_->seekToRowGroup(pp);
 
-    ensureCapacity<int64_t>(
+    detail::ensureCapacity<int64_t>(
         strideDictOffset_, strideDictCount_ + 1, &memoryPool_);
     strideDict_ = loadDictionary(
         strideDictCount_,
@@ -224,7 +224,8 @@ void SelectiveStringDictionaryColumnReader::read(
     int32_t numFlags = (isBulk && nullsInReadRange_)
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
-    ensureCapacity<uint64_t>(inDict_, bits::nwords(numFlags), &memoryPool_);
+    detail::ensureCapacity<uint64_t>(
+        inDict_, bits::nwords(numFlags), &memoryPool_);
     inDictionaryReader_->next(
         inDict_->asMutable<char>(), numFlags, isBulk ? nullptr : nullsPtr);
     loadStrideDictionary();
@@ -320,7 +321,7 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
 
   Timer timer;
 
-  ensureCapacity<int64_t>(
+  detail::ensureCapacity<int64_t>(
       dictionaryOffset_, dictionaryCount_ + 1, &memoryPool_);
   dictionaryBlob_ = loadDictionary(
       dictionaryCount_, *blobStream_, *lengthDecoder_, dictionaryOffset_);

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -46,7 +46,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
 
 uint64_t SelectiveStringDirectColumnReader::skip(uint64_t numValues) {
   numValues = ColumnReader::skip(numValues);
-  ensureCapacity<int64_t>(lengths_, numValues, &memoryPool_);
+  detail::ensureCapacity<int64_t>(lengths_, numValues, &memoryPool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), numValues);
   rawLengths_ = lengths_->as<uint32_t>();
   for (auto i = 0; i < numValues; ++i) {
@@ -412,7 +412,7 @@ void SelectiveStringDirectColumnReader::read(
   auto end = rows.back() + 1;
   auto numNulls =
       nullsInReadRange_ ? BaseVector::countNulls(nullsInReadRange_, 0, end) : 0;
-  ensureCapacity<int32_t>(lengths_, end - numNulls, &memoryPool_);
+  detail::ensureCapacity<int32_t>(lengths_, end - numNulls, &memoryPool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), end - numNulls);
   rawLengths_ = lengths_->as<uint32_t>();
   lengthIndex_ = 0;

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -3406,10 +3406,6 @@ TEST_P(TestColumnReader, testDoubleSkipWithNulls) {
 }
 
 TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
-  if (useSelectiveReader()) {
-    GTEST_SKIP() << "SelectiveColumnReader doesn't support timestamps yet";
-  }
-
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
@@ -3418,6 +3414,9 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 2 non-nulls, 2 nulls, 2 non-nulls, 2 nulls
@@ -3521,10 +3520,6 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
 }
 
 TEST_P(TestColumnReader, testTimestamp) {
-  if (useSelectiveReader()) {
-    GTEST_SKIP() << "SelectiveColumnReader doesn't support timestamps yet";
-  }
-
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
@@ -3533,6 +3528,9 @@ TEST_P(TestColumnReader, testTimestamp) {
 
   // set getStream
   EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {


### PR DESCRIPTION
Summary:
After implementing selective timestamp column reader, we can now enable the skipped unit tests.

Also minor refactory:
1. move utility methods to detail namespace.
2. create method for filling timestamp values from seconds and nanos

Differential Revision: D34705597

