### PR TITLE
Ensure we don't destroy Driver, which refers to a Task.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -532,6 +532,10 @@ void Driver::closeByTask() {
   task_ = nullptr;
 }
 
+void Driver::disconnectFromTask() {
+  task_ = nullptr;
+}
+
 bool Driver::mayPushdownAggregation(Operator* aggregation) const {
   for (auto i = 1; i < operators_.size(); ++i) {
     auto op = operators_[i].get();

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -251,6 +251,10 @@ class Driver {
   // closing non-running Drivers.
   void closeByTask();
 
+  // This is called if the creation of drivers failed and we want to disconnect
+  // driver from the task before driver's destruction.
+  void disconnectFromTask();
+
  private:
   void enqueueInternal();
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -135,6 +135,10 @@ RowVectorPtr OperatorTestBase::getResults(
     std::shared_ptr<const core::PlanNode> planNode) {
   CursorParameters params;
   params.planNode = std::move(planNode);
+  return getResults(params);
+}
+
+RowVectorPtr OperatorTestBase::getResults(const CursorParameters& params) {
   auto [cursor, results] = readCursor(params, [](auto) {});
 
   auto totalCount = 0;

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -95,6 +95,8 @@ class OperatorTestBase : public testing::Test,
 
   RowVectorPtr getResults(std::shared_ptr<const core::PlanNode> planNode);
 
+  RowVectorPtr getResults(const CursorParameters& params);
+
   static std::shared_ptr<const RowType> makeRowType(
       std::vector<std::shared_ptr<const Type>>&& types) {
     return velox::test::VectorMaker::rowType(


### PR DESCRIPTION
Summary:
During creation of Drivers in the Task we can have a situation when the code throws and all created Drivers so far are being destroyed before their reference to Task is removed.
That causes crash due to DLOLG(FATAL) in debug mode. In release mode it would be fine.
We wrap driver creation into the try/catch to ensure that does not happen.

Differential Revision: D34706093

