### PR TITLE
Print query plan with runtime statistics

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
   OrderBy.cpp
   PartitionedOutput.cpp
   PartitionedOutputBufferManager.cpp
+  PlanNodeStats.cpp
   RowContainer.cpp
   StreamingAggregation.cpp
   TableScan.cpp

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/TaskStats.h"
+
+namespace facebook::velox::exec {
+
+void PlanNodeStats::add(const OperatorStats& stats) {
+  addTotals(stats);
+
+  auto it = operatorStats.find(stats.operatorType);
+  if (it != operatorStats.end()) {
+    it->second->addTotals(stats);
+  } else {
+    auto opStats = std::make_unique<PlanNodeStats>();
+    opStats->addTotals(stats);
+    operatorStats.emplace(stats.operatorType, std::move(opStats));
+  }
+}
+
+void PlanNodeStats::addTotals(const OperatorStats& stats) {
+  inputRows += stats.inputPositions;
+  inputBytes += stats.inputBytes;
+
+  outputRows += stats.outputPositions;
+  outputBytes += stats.outputBytes;
+
+  cpuWallTiming.add(stats.addInputTiming);
+  cpuWallTiming.add(stats.getOutputTiming);
+  cpuWallTiming.add(stats.finishTiming);
+
+  blockedWallNanos += stats.blockedWallNanos;
+
+  peakMemoryBytes += stats.memoryStats.peakTotalMemoryReservation;
+}
+
+std::string PlanNodeStats::toString(bool includeInputStats) const {
+  std::stringstream out;
+  if (includeInputStats) {
+    out << "Input: " << inputRows << " rows (" << inputBytes << " bytes"
+        << "), ";
+  }
+  out << "Output: " << outputRows << " rows (" << outputBytes << " bytes)"
+      << ", Cpu time: " << cpuWallTiming.cpuNanos << "ns"
+      << ", Blocked wall time: " << blockedWallNanos << "ns"
+      << ", Peak memory: " << peakMemoryBytes << " bytes";
+  return out.str();
+}
+
+std::unordered_map<core::PlanNodeId, PlanNodeStats> toPlanStats(
+    const TaskStats& taskStats) {
+  std::unordered_map<core::PlanNodeId, PlanNodeStats> planStats;
+
+  for (const auto& pipelineStats : taskStats.pipelineStats) {
+    for (const auto& opStats : pipelineStats.operatorStats) {
+      const auto& planNodeId = opStats.planNodeId;
+      auto it = planStats.find(planNodeId);
+      if (it != planStats.end()) {
+        it->second.add(opStats);
+      } else {
+        PlanNodeStats nodeStats;
+        nodeStats.add(opStats);
+        planStats.emplace(planNodeId, std::move(nodeStats));
+      }
+    }
+  }
+
+  return planStats;
+}
+
+std::string printPlanWithStats(
+    const core::PlanNode& plan,
+    const TaskStats& taskStats) {
+  auto planStats = toPlanStats(taskStats);
+  auto leafPlanNodes = plan.leafPlanNodeIds();
+
+  return plan.toString(
+      true,
+      true,
+      [&](const auto& planNodeId, const auto& indentation, auto& stream) {
+        const auto& stats = planStats[planNodeId];
+
+        // Print input rows and sizes only for leaf plan nodes. Including this
+        // information for other plan nodes is redundant as it is the same as
+        // output of the source nodes.
+        const bool includeInputStats = leafPlanNodes.count(planNodeId) > 0;
+        stream << stats.toString(includeInputStats);
+
+        // Include break down by operator type if there are more than one of
+        // these.
+        if (stats.operatorStats.size() > 1) {
+          int cnt = 0;
+          for (const auto& entry : stats.operatorStats) {
+            stream << std::endl;
+            stream << indentation << entry.first << ": "
+                   << entry.second->toString(includeInputStats);
+            ++cnt;
+          }
+        }
+      });
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/time/CpuWallTimer.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::exec {
+struct OperatorStats;
+struct TaskStats;
+} // namespace facebook::velox::exec
+
+namespace facebook::velox::exec {
+
+/// Aggregated runtime statistics per plan node.
+///
+/// Runtime statistics are collected on a per-operator instance basis. There can
+/// be multiple operator types and multiple instances of each operator type that
+/// correspond to a given plan node. For example, ProjectNode corresponds to
+/// a single operator type, FilterProject, but HashJoinNode corresponds to two
+/// operator types, HashProbe and HashBuild. Each operator type may have
+/// different runtime parallelism, e.g. there can be multiple instances of each
+/// operator type. Plan node statistics are calculated by adding up
+/// operator-level statistics for all corresponding operator instances.
+struct PlanNodeStats {
+  explicit PlanNodeStats() = default;
+
+  PlanNodeStats(const PlanNodeStats&) = delete;
+  PlanNodeStats& operator=(const PlanNodeStats&) = delete;
+
+  PlanNodeStats(PlanNodeStats&&) = default;
+  PlanNodeStats& operator=(PlanNodeStats&&) = default;
+
+  /// Sum of input rows for all corresponding operators. Useful primarily for
+  /// leaf plan nodes or plan nodes that correspond to a single operator type.
+  vector_size_t inputRows{0};
+
+  /// Sum of input bytes for all corresponding operators.
+  uint64_t inputBytes{0};
+
+  /// Sum of output rows for all corresponding operators. When
+  /// plan node corresponds to multiple operator types, operators of only one of
+  /// these types report non-zero output rows.
+  vector_size_t outputRows{0};
+
+  /// Sum of output bytes for all corresponding operators.
+  uint64_t outputBytes{0};
+
+  /// Sum of CPU, scheduled and wall times for all corresponding operators. For
+  /// each operator, timing of addInput, getOutput and finish calls are added
+  /// up.
+  CpuWallTiming cpuWallTiming;
+
+  /// Sum of blocked wall time for all corresponding operators.
+  uint64_t blockedWallNanos{0};
+
+  /// Max of peak memory usage for all corresponding operators. Assumes that all
+  /// operator instances were running concurrently.
+  uint64_t peakMemoryBytes{0};
+
+  /// Breakdown of stats by operator type.
+  std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
+
+  /// Add stats for a single operator instance.
+  void add(const OperatorStats& stats);
+
+  std::string toString(bool includeInputStats = false) const;
+
+ private:
+  void addTotals(const OperatorStats& stats);
+};
+
+std::unordered_map<core::PlanNodeId, PlanNodeStats> toPlanStats(
+    const TaskStats& taskStats);
+
+/// Returns human-friendly representation of the plan augmented with runtime
+/// statistics. The result has the same plan representation as in
+/// PlanNode::toString(true, true), but each plan node includes an additional
+/// line with runtime statistics. Plan nodes that correspond to multiple
+/// operator types, e.g. HashJoinNode, also include breakdown of runtime
+/// statistics per operator type.
+///
+/// Note that input row counts and sizes are printed only for leaf plan nodes.
+std::string printPlanWithStats(
+    const core::PlanNode& plan,
+    const TaskStats& taskStats);
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -20,6 +20,7 @@
 #include "velox/exec/LocalPartition.h"
 #include "velox/exec/MergeSource.h"
 #include "velox/exec/Split.h"
+#include "velox/exec/TaskStats.h"
 #include "velox/exec/TaskStructs.h"
 #include "velox/vector/ComplexVector.h"
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unordered_set>
+
+namespace facebook::velox::exec {
+
+struct OperatorStats;
+
+/// Stores execution stats per pipeline.
+struct PipelineStats {
+  // Cumulative OperatorStats for finished Drivers. The subscript is the
+  // operator id, which is the initial ordinal position of the
+  // operator in the DriverFactory.
+  std::vector<OperatorStats> operatorStats;
+
+  // True if contains the source node for the task.
+  bool inputPipeline;
+
+  // True if contains the sync node for the task.
+  bool outputPipeline;
+
+  PipelineStats(bool _inputPipeline, bool _outputPipeline)
+      : inputPipeline{_inputPipeline}, outputPipeline{_outputPipeline} {}
+};
+
+/// Stores execution stats per task.
+struct TaskStats {
+  int32_t numTotalSplits{0};
+  int32_t numFinishedSplits{0};
+  int32_t numRunningSplits{0};
+  int32_t numQueuedSplits{0};
+  std::unordered_set<int32_t> completedSplitGroups;
+
+  // The subscript is given by each Operator's
+  // DriverCtx::pipelineId. This is a sum total reflecting fully
+  // processed Splits for Drivers of this pipeline.
+  std::vector<PipelineStats> pipelineStats;
+
+  // Epoch time (ms) when task starts to run
+  uint64_t executionStartTimeMs{0};
+
+  // Epoch time (ms) when last split is processed. For some tasks there might be
+  // some additional time to send buffered results before the task finishes.
+  uint64_t executionEndTimeMs{0};
+
+  // Epoch time (ms) when first split is fetched from the task by an operator.
+  uint64_t firstSplitStartTimeMs{0};
+
+  // Epoch time (ms) when last split is fetched from the task by an operator.
+  uint64_t lastSplitStartTimeMs{0};
+
+  // Epoch time (ms) when the task completed, e.g. all splits were processed and
+  // results have been consumed.
+  uint64_t endTimeMs{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -27,54 +27,6 @@ class MergeSource;
 /// Corresponds to Presto TaskState, needed for reporting query completion.
 enum TaskState { kRunning, kFinished, kCanceled, kAborted, kFailed };
 
-/// Stores execution stats per pipeline.
-struct PipelineStats {
-  // Cumulative OperatorStats for finished Drivers. The subscript is the
-  // operator id, which is the initial ordinal position of the
-  // operator in the DriverFactory.
-  std::vector<OperatorStats> operatorStats;
-
-  // True if contains the source node for the task.
-  bool inputPipeline;
-
-  // True if contains the sync node for the task.
-  bool outputPipeline;
-
-  PipelineStats(bool _inputPipeline, bool _outputPipeline)
-      : inputPipeline{_inputPipeline}, outputPipeline{_outputPipeline} {}
-};
-
-/// Stores execution stats per task.
-struct TaskStats {
-  int32_t numTotalSplits{0};
-  int32_t numFinishedSplits{0};
-  int32_t numRunningSplits{0};
-  int32_t numQueuedSplits{0};
-  std::unordered_set<int32_t> completedSplitGroups;
-
-  // The subscript is given by each Operator's
-  // DriverCtx::pipelineId. This is a sum total reflecting fully
-  // processed Splits for Drivers of this pipeline.
-  std::vector<PipelineStats> pipelineStats;
-
-  // Epoch time (ms) when task starts to run
-  uint64_t executionStartTimeMs{0};
-
-  // Epoch time (ms) when last split is processed. For some tasks there might be
-  // some additional time to send buffered results before the task finishes.
-  uint64_t executionEndTimeMs{0};
-
-  // Epoch time (ms) when first split is fetched from the task by an operator.
-  uint64_t firstSplitStartTimeMs{0};
-
-  // Epoch time (ms) when last split is fetched from the task by an operator.
-  uint64_t lastSplitStartTimeMs{0};
-
-  // Epoch time (ms) when the task completed, e.g. all splits were processed and
-  // results have been consumed.
-  uint64_t endTimeMs{0};
-};
-
 struct BarrierState {
   int32_t numRequested;
   std::vector<std::shared_ptr<Driver>> drivers;


### PR DESCRIPTION
Add helper function to print query plan with runtime statistics.

The existing PlanNode::toString(true, true) method allows to print query plan with details about each plan node, e.g.

```
->hash join[FULL c0=u_c0]
  ->values[3456 rows in 2 vectors]
  ->project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:INTEGER, ROW["c1"]), ]
    ->values[123 rows in 1 vectors]
```

The new printPlanWithStats(PlanNode, TaskStats) function allows to print the query plan with runtime statistics about each plan node, e.g.

```
->hash join[FULL c0=u_c0]
  Output: 20626 rows (809384 bytes), Cpu time: 2318889ns, Blocked wall time: 425000ns, Peak memory: 2097152 bytes
  HashBuild: Output: 0 rows (0 bytes), Cpu time: 347279ns, Blocked wall time: 0ns, Peak memory: 1048576 bytes
  HashProbe: Output: 20626 rows (809384 bytes), Cpu time: 1971610ns, Blocked wall time: 425000ns, Peak memory: 1048576 bytes
  ->values[3456 rows in 2 vectors]
    Input: 0 rows (0 bytes), Output: 3456 rows (36928 bytes), Cpu time: 5268ns, Blocked wall time: 0ns, Peak memory: 0 bytes
  ->project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:INTEGER, ROW["c1"]), ]
    Output: 123 rows (1408 bytes), Cpu time: 117442ns, Blocked wall time: 0ns, Peak memory: 0 bytes
    ->values[123 rows in 1 vectors]
      Input: 0 rows (0 bytes), Output: 123 rows (1408 bytes), Cpu time: 17204ns, Blocked wall time: 0ns, Peak memory: 0 bytes
```