### PR TITLE
Fix TaskManagerTest.outOfQueryUserMemory

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -121,7 +121,8 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Sets the (so far) max split sequence id, so all splits with sequence id
   // equal or below that, will be ignored in the 'addSplitWithSequence' call.
-  // Note, that 'addSplitWithSequence' does not update max split sequence id.
+  // Note, that 'addSplitWithSequence' does not update max split sequence id
+  // and the operation is silently ignored if Task is not running.
   void setMaxSplitSequenceId(
       const core::PlanNodeId& planNodeId,
       long maxSequenceId);
@@ -133,6 +134,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // duplicate.
   // Note, that this method does NOT update max split sequence id.
   // Returns true if split was added, false if it was ignored.
+  // Note that, the operation is silently ignored if Task is not running.
   bool addSplitWithSequence(
       const core::PlanNodeId& planNodeId,
       exec::Split&& split,
@@ -140,6 +142,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Adds split for a source operator corresponding to plan node with
   // specified ID. Does not require sequential id.
+  // Note that, the operation is silently ignored if Task is not running.
   void addSplit(const core::PlanNodeId& planNodeId, exec::Split&& split);
 
   // We mark that for the given group there would be no more splits coming.

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1970,6 +1970,38 @@ TEST_P(TableScanTest, groupedExecution) {
   EXPECT_EQ(numRead, numSplits * 10'000);
 }
 
+TEST_P(TableScanTest, addSplitsToFailedTask) {
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(12'000, [](auto row) { return row % 5; })});
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, kTableScanTest, {data});
+
+  core::PlanNodeId scanNodeId;
+  exec::test::CursorParameters params;
+  params.planNode = exec::test::PlanBuilder()
+                        .tableScan(ROW({"c0"}, {INTEGER()}))
+                        .capturePlanNodeId(scanNodeId)
+                        .project({"5 / c0"})
+                        .planNode();
+
+  auto cursor = std::make_unique<exec::test::TaskCursor>(params);
+  cursor->task()->addSplit(scanNodeId, makeHiveSplit(filePath->path));
+
+  EXPECT_THROW(
+      while (cursor->moveNext()) {
+        std::cout << cursor->current()->toString(0) << std::endl;
+      },
+      VeloxUserError);
+
+  // Verify that splits can be added to the task ever after task has failed.
+  // In this case these splits will be ignored.
+  cursor->task()->addSplit(scanNodeId, makeHiveSplit(filePath->path));
+  cursor->task()->addSplitWithSequence(
+      scanNodeId, makeHiveSplit(filePath->path), 20L);
+  cursor->task()->setMaxSplitSequenceId(scanNodeId, 20L);
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     TableScanTests,
     TableScanTest,


### PR DESCRIPTION
Summary:
`setMaxSplitSequenceId`  and `addSplitWithSequence` methods are called after calling start method on the task. That means by the time we call these methods, task might already fail due to errors (e.g. out of memory here)

Example:

Here is the place where its called from:
https://www.internalfb.com/code/fbsource/fbcode/presto_cpp/main/TaskManager.cpp?lines=280

Note that, task execution already starts at here

https://www.internalfb.com/code/fbsource//fbcode/presto_cpp/main/TaskManager.cpp?lines=235

Which means by the time we call `setMaxSplitSequenceId`, it can already be failed.  This does not happen always, however its possible to reproduce with stress runs. To reproduce, I ran stress ran the test and see error like P485197923

```
E0307 22:47:20.305493 197748 Exceptions.h:68] velox/common/memory/MemoryUsageTracker.cpp84incrementUsageExceeded memory cap of 1 MBRUNTIMEMEM_CAP_EXCEEDED
E0307 22:47:20.307257 196392 Exceptions.h:68] velox/exec/Task.cpp445setMaxSplitSequenceIdisRunningLocked()RUNTIMEINVALID_STATE
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Retriable: False
Expression: isRunningLocked()
Function: setMaxSplitSequenceId
File: velox/exec/Task.cpp
Line: 445
Stack trace:
```
Which tells task already failed due to memory capacity and when we call set maxsplit sequence, Velox check throws.

Differential Revision: D34711822

