### PR TITLE
Improve CAST error message

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -86,6 +86,17 @@ void populateNestedRows(
   nestedRows.updateBounds();
 }
 
+std::string makeErrorMessage(
+    const DecodedVector& input,
+    vector_size_t row,
+    const TypePtr& toType) {
+  return fmt::format(
+      "Failed to cast from {} to {}: {}",
+      input.base()->type()->toString(),
+      toType->toString(),
+      input.base()->toString(input.index(row)));
+}
+
 } // namespace
 
 template <typename To, typename From>
@@ -109,13 +120,13 @@ void CastExpr::applyCastWithTry(
             context->setError(
                 row,
                 std::make_exception_ptr(std::invalid_argument(
-                    "Cast error for input #" + std::to_string(row))));
+                    makeErrorMessage(input, row, resultFlatVector->type()))));
           }
         } catch (const std::exception& e) {
           context->setError(
               row,
               std::make_exception_ptr(std::invalid_argument(
-                  "Cast error for input #" + std::to_string(row))));
+                  makeErrorMessage(input, row, resultFlatVector->type()))));
         }
       });
     } else {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -193,9 +193,10 @@ class CastExprTest : public functions::test::FunctionBaseTest {
     auto rowVector = makeRowVector({inputVector});
     std::string castFunction = tryCast ? "try_cast" : "cast";
     if (expectFailure) {
-      EXPECT_ANY_THROW(
+      EXPECT_THROW(
           evaluate<FlatVector<typename CppToType<TTo>::NativeType>>(
-              castFunction + "(c0 as " + typeString + ")", rowVector));
+              castFunction + "(c0 as " + typeString + ")", rowVector),
+          std::invalid_argument);
       return;
     }
     // run try cast and get the result vector
@@ -389,7 +390,7 @@ TEST_F(CastExprTest, truncateVsRound) {
   EXPECT_THROW(
       (testCast<int32_t, int8_t>(
           "tinyint", {1111111, 2, 3, 1000, -100101}, {71, 2, 3, -24, -5})),
-      std::exception);
+      std::invalid_argument);
 }
 
 TEST_F(CastExprTest, nullInputs) {
@@ -620,5 +621,6 @@ TEST_F(CastExprTest, testNullOnFailure) {
   testComplexCast("c0", input, expected, true);
 
   // nullOnFailure is false, so we should throw.
-  EXPECT_THROW(testComplexCast("c0", input, expected, false), std::exception);
+  EXPECT_THROW(
+      testComplexCast("c0", input, expected, false), std::invalid_argument);
 }


### PR DESCRIPTION
CAST failures didn't provide much information to help troubleshooting. This
change is to include the to and from types of the CAST as well as a value that
failed the cast.

Before: Cast error for input #0 

After: Failed to cast from VARCHAR to BIGINT: a