### PR TITLE
Include the expression in the CAST error message

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -40,6 +40,8 @@ class CastExpr : public SpecialForm {
       EvalCtx* context,
       VectorPtr* result) override;
 
+  std::string toString() const override;
+
  private:
   /// @tparam To The cast target type
   /// @tparam From The expression type

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1135,17 +1135,21 @@ void Expr::applySingleConstArgVectorFunction(
 std::string Expr::toString() const {
   std::stringstream out;
   out << name_;
+  appendInputs(out);
+  return out.str();
+}
+
+void Expr::appendInputs(std::stringstream& stream) const {
   if (!inputs_.empty()) {
-    out << "(";
+    stream << "(";
     for (auto i = 0; i < inputs_.size(); ++i) {
       if (i > 0) {
-        out << ", ";
+        stream << ", ";
       }
-      out << inputs_[i]->toString();
+      stream << inputs_[i]->toString();
     }
-    out << ")";
+    stream << ")";
   }
-  return out.str();
 }
 
 ExprSet::ExprSet(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -269,6 +269,8 @@ class Expr {
       VectorPtr* result);
 
  protected:
+  void appendInputs(std::stringstream& stream) const;
+
   const std::shared_ptr<const Type> type_;
   const std::vector<std::shared_ptr<Expr>> inputs_;
   const std::string name_;

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -624,3 +624,13 @@ TEST_F(CastExprTest, testNullOnFailure) {
   EXPECT_THROW(
       testComplexCast("c0", input, expected, false), std::invalid_argument);
 }
+
+TEST_F(CastExprTest, toString) {
+  auto input = std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "a");
+  exec::ExprSet exprSet(
+      {makeCastExpr(input, BIGINT(), false),
+       makeCastExpr(input, ARRAY(VARCHAR()), false)},
+      &execCtx_);
+  ASSERT_EQ("cast((a) as BIGINT)", exprSet.exprs()[0]->toString());
+  ASSERT_EQ("cast((a) as ARRAY<VARCHAR>)", exprSet.exprs()[1]->toString());
+}


### PR DESCRIPTION
Before: Failed to cast from VARCHAR to INTEGER: .

After: Failed to cast from VARCHAR to INTEGER: . Cast expression: cast((c0) as INTEGER).