### PR TITLE
Expand function registry for resolving aggregate functions

### DIFF
--- a/velox/functions/CMakeLists.txt
+++ b/velox/functions/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_library(velox_function_registry FunctionRegistry.cpp)
 
 target_link_libraries(velox_function_registry velox_expression velox_type
-                      velox_core velox_exception)
+                      velox_core velox_exception velox_exec)
 
 add_subdirectory(lib)
 if(${VELOX_ENABLE_PRESTO_FUNCTIONS})

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -48,4 +48,11 @@ std::shared_ptr<const Type> resolveVectorFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Given name of aggregate function and argument types, returns a pair of the
+/// return type and intermediate type if function exists otherwise returns a
+/// pair of nullptr
+std::pair<TypePtr, TypePtr> resolveAggregateFunction(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
 } // namespace facebook::velox

--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable(velox_function_registry_test FunctionRegistryTest.cpp)
 add_test(NAME velox_function_registry_test COMMAND velox_function_registry_test)
 
 target_link_libraries(velox_function_registry_test velox_function_registry
-                      ${GMock} ${GTEST_BOTH_LIBRARIES})
+                      velox_exec ${GMock} ${GTEST_BOTH_LIBRARIES})

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/exec/Aggregate.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/VectorFunction.h"
@@ -197,6 +198,94 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     VectorFuncFour::signatures(),
     std::make_unique<VectorFuncFour>());
 
+class AggregateFunc : public velox::exec::Aggregate {
+ public:
+  explicit AggregateFunc(TypePtr resultType) : Aggregate(resultType) {}
+
+  void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return 0;
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
+
+  void addRawInput(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addIntermediateResults(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupRawInput(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupIntermediateResults(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void extractValues(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+
+  void extractAccumulators(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+};
+
+bool registerAggregateFunc(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("double")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .intermediateType("array(T)")
+          .argumentType("T")
+          .argumentType("T")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("date")
+          .intermediateType("date")
+          .build(),
+  };
+
+  exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [&](core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        if (exec::isPartialOutput(step)) {
+          if (argTypes.empty()) {
+            return std::make_unique<AggregateFunc>(resultType);
+          }
+          return std::make_unique<AggregateFunc>(ARRAY(resultType));
+        }
+        return std::make_unique<AggregateFunc>(resultType);
+      });
+
+  return true;
+}
+
 inline void registerTestFunctions() {
   // If no alias is specified, ensure it will fallback to the struct name.
   registerFunction<FuncOne, Varchar, Varchar>({"func_one"});
@@ -219,6 +308,8 @@ inline void registerTestFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_two, "vector_func_two");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_three, "vector_func_three");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_four, "vector_func_four");
+
+  registerAggregateFunc("aggregate_func");
 }
 } // namespace
 
@@ -242,6 +333,16 @@ class FunctionRegistryTest : public ::testing::Test {
     } else {
       EXPECT_EQ(actual, nullptr);
     }
+  }
+
+  void testResolveAggregateFunction(
+      const std::string& functionName,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& expectedReturn,
+      const TypePtr& expectedIntermediate) {
+    auto result = velox::resolveAggregateFunction(functionName, argTypes);
+    checkEqual(result.first, expectedReturn);
+    checkEqual(result.second, expectedIntermediate);
   }
 };
 
@@ -502,6 +603,33 @@ TEST_F(FunctionRegistryTest, resolveFunctionsBasedOnPriority) {
 
   auto result5 = resolveFunction(func, {INTEGER(), INTEGER()});
   ASSERT_EQ(*result5, *REAL());
+}
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignature) {
+  testResolveAggregateFunction(
+      "aggregate_func", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
+  testResolveAggregateFunction(
+      "aggregate_func", {DOUBLE(), DOUBLE()}, DOUBLE(), ARRAY(DOUBLE()));
+  testResolveAggregateFunction(
+      "aggregate_func",
+      {ARRAY(BOOLEAN()), ARRAY(BOOLEAN())},
+      ARRAY(BOOLEAN()),
+      ARRAY(ARRAY(BOOLEAN())));
+  testResolveAggregateFunction("aggregate_func", {}, DATE(), DATE());
+}
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongFunctionName) {
+  testResolveAggregateFunction(
+      "aggregate_func_nonexist", {BIGINT(), BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction("aggregate_func_nonexist", {}, nullptr, nullptr);
+}
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongArgType) {
+  testResolveAggregateFunction(
+      "aggregate_func", {DOUBLE(), BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction("aggregate_func", {BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction(
+      "aggregate_func", {BIGINT(), BIGINT(), BIGINT()}, nullptr, nullptr);
 }
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: Add resolveAggregateFunction() for looking up registered aggregate functions by the function name and argument types.

Differential Revision: D34743430

