### PR TITLE
Fix buffer indexing for String Array

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -194,13 +194,13 @@ void exportFlatStringVector(
   }
 
   // Allocate raw string buffer.
-  bridgeHolder.setBuffer(1, AlignedBuffer::allocate<char>(bufferSize, pool));
-  char* rawBuffer = bridgeHolder.getBufferAs<char>(1);
+  bridgeHolder.setBuffer(2, AlignedBuffer::allocate<char>(bufferSize, pool));
+  char* rawBuffer = bridgeHolder.getBufferAs<char>(2);
 
   // Allocate offset buffer.
   bridgeHolder.setBuffer(
-      2, AlignedBuffer::allocate<TOffset>(vector->size() + 1, pool));
-  TOffset* rawOffsets = bridgeHolder.getBufferAs<TOffset>(2);
+      1, AlignedBuffer::allocate<TOffset>(vector->size() + 1, pool));
+  TOffset* rawOffsets = bridgeHolder.getBufferAs<TOffset>(1);
   *rawOffsets = 0;
 
   // Second pass to actually copy the string data and set offsets.
@@ -734,8 +734,8 @@ VectorPtr importFromArrowImpl(
         type,
         nulls,
         arrowArray.length,
-        static_cast<const int32_t*>(arrowArray.buffers[2]), // offsets
-        static_cast<const char*>(arrowArray.buffers[1]), // values
+        static_cast<const int32_t*>(arrowArray.buffers[1]), // offsets
+        static_cast<const char*>(arrowArray.buffers[2]), // values
         arrowArray.null_count,
         wrapInBufferView);
   }

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -104,8 +104,8 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     ASSERT_EQ(3, arrowArray.n_buffers); // null, values, and offsets buffers.
 
     const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
-    const char* values = static_cast<const char*>(arrowArray.buffers[1]);
-    const int32_t* offsets = static_cast<const int32_t*>(arrowArray.buffers[2]);
+    const char* values = static_cast<const char*>(arrowArray.buffers[2]);
+    const int32_t* offsets = static_cast<const int32_t*>(arrowArray.buffers[1]);
 
     if (arrowArray.null_count == 0) {
       EXPECT_EQ(nulls, nullptr);
@@ -501,8 +501,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     auto rawValues = holder.values->asMutable<char>();
     *rawOffsets = 0;
 
-    holder.buffers[1] = (length == 0) ? nullptr : (const void*)rawValues;
-    holder.buffers[2] = (length == 0) ? nullptr : (const void*)rawOffsets;
+    holder.buffers[2] = (length == 0) ? nullptr : (const void*)rawValues;
+    holder.buffers[1] = (length == 0) ? nullptr : (const void*)rawOffsets;
 
     for (size_t i = 0; i < length; ++i) {
       if (inputValues[i] == std::nullopt) {


### PR DESCRIPTION
Summary: Arrow's string arrays use buffers[2] for offsets and buffers[1] for values, but not the other way around (see Hanqi's comment for an example from the official documet).

Differential Revision: D34733418

