### PR TITLE
TPC-H query builder

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -15,41 +15,32 @@
  */
 
 #include "velox/common/file/FileSystems.h"
-#include "velox/dwio/dwrf/test/utils/DataFiles.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/exec/tests/utils/TpchQueryBuilder.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/type/tests/FilterBuilder.h"
-#include "velox/type/tests/SubfieldFiltersBuilder.h"
+#include "velox/parse/TypeResolver.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
-#if __has_include("filesystem")
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
+static const int kNumDrivers = 4;
 
 class ParquetTpchTest : public testing::Test {
  protected:
   // Setup a DuckDB instance for the entire suite and load TPC-H data with scale
   // factor 0.01.
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     if (duckDb_ == nullptr) {
       duckDb_ = std::make_shared<DuckDbQueryRunner>();
       constexpr double kTpchScaleFactor = 0.01;
       duckDb_->initializeTpch(kTpchScaleFactor);
     }
     functions::prestosql::registerAllScalarFunctions();
-  }
-
-  void SetUp() override {
+    parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
     parquet::registerParquetReaderFactory();
     auto hiveConnector =
@@ -58,209 +49,85 @@ class ParquetTpchTest : public testing::Test {
             ->newConnector(kHiveConnectorId, nullptr);
     connector::registerConnector(hiveConnector);
     tempDirectory_ = exec::test::TempDirectoryPath::create();
-    lineitemType_ =
-        ROW({"orderkey",
-             "partkey",
-             "suppkey",
-             "linenumber",
-             "quantity",
-             "extendedprice",
-             "discount",
-             "tax",
-             "returnflag",
-             "linestatus",
-             "shipdate",
-             "commitdate",
-             "receiptdate",
-             "shipinstruct",
-             "shipmode",
-             "comment"},
-            {BIGINT(),
-             BIGINT(),
-             BIGINT(),
-             BIGINT(),
-             DOUBLE(),
-             DOUBLE(),
-             DOUBLE(),
-             DOUBLE(),
-             VARCHAR(),
-             VARCHAR(),
-             DATE(),
-             DATE(),
-             DATE(),
-             VARCHAR(),
-             VARCHAR(),
-             VARCHAR()});
+    saveTpchTablesAsParquet();
+    tpchBuilder_.initialize(tempDirectory_->path);
   }
 
-  void TearDown() override {
+  /// Write TPC-H table as a Parquet file to temp directory in hive-style
+  /// partition
+  static void saveTpchTablesAsParquet() {
+    constexpr int kRowGroupSize = 10'000;
+    const auto tableNames = tpchBuilder_.getTableNames();
+    for (const auto& tableName : tableNames) {
+      auto tableDirectory =
+          fmt::format("{}/{}", tempDirectory_->path, tableName);
+      fs::create_directory(tableDirectory);
+      auto filePath = fmt::format("{}/file.parquet", tableDirectory);
+      auto query = fmt::format(
+          duckDbParquetWriteSQL_.at(tableName),
+          tableName,
+          filePath,
+          kRowGroupSize);
+      duckDb_->execute(query);
+    }
+  }
+
+  static void TearDownTestSuite() {
     connector::unregisterConnector(kHiveConnectorId);
     parquet::unregisterParquetReaderFactory();
   }
 
-  int64_t date(std::string_view stringDate) const {
-    Date date;
-    parseTo(stringDate, date);
-    return date.days();
-  }
-
-  // Split file at a given path 'filePath' into 'numSplits' splits.
-  std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> makeSplits(
-      const std::string& filePath,
-      int64_t numSplits = 10) const {
-    const int fileSize = fs::file_size(filePath);
-    // Take the upper bound.
-    const int splitSize = std::ceil(fileSize / numSplits);
-    std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;
-
-    // Add all the splits.
-    for (int i = 0; i < numSplits; i++) {
-      auto split = HiveConnectorTestBase::makeHiveConnectorSplit(
-          filePath, i * splitSize, splitSize);
-      split->fileFormat = dwio::common::FileFormat::PARQUET;
-      splits.push_back(std::move(split));
-    }
-    return splits;
-  }
-
-  // Write the DuckDB Lineitem TPC-H table to a Parquet file and return the file
-  // location.
-  std::string writeLineitemTableToParquet() const {
-    constexpr std::string_view tableName("lineitem");
-    constexpr int kRowGroupSize = 10'000;
-    const auto& filePath =
-        fmt::format("{}/{}.parquet", tempDirectory_->path, tableName);
-    // Convert decimal columns to double.
-    const auto& query = fmt::format(
-        "COPY (SELECT l_orderkey as orderkey, l_partkey as partkey, l_suppkey as suppkey, l_linenumber as linenumber, "
-        "l_quantity::DOUBLE as quantity, l_extendedprice::DOUBLE as extendedprice, l_discount::DOUBLE as discount, "
-        "l_tax::DOUBLE as tax, l_returnflag as returnflag, l_linestatus as linestatus, "
-        "l_shipdate as shipdate, l_receiptdate as receiptdate, "
-        "l_shipinstruct as shipinstruct, l_shipmode as shipmode, l_comment as comment "
-        "FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {})",
-        tableName,
-        filePath,
-        kRowGroupSize);
-    duckDb_->execute(query);
-    return filePath;
-  }
-
-  RowTypePtr getLineitemColumns(std::vector<std::string> names) const {
-    std::vector<TypePtr> types;
-    for (auto colName : names) {
-      types.push_back(lineitemType_->findChild(colName));
-    }
-    return ROW(std::move(names), std::move(types));
-  }
-
   std::shared_ptr<Task> assertQuery(
-      const CursorParameters& params,
-      const std::string& filePath,
-      const core::PlanNodeId& sourcePlanNodeId,
+      const TpchPlan& tpchPlan,
       const std::string& duckQuery) const {
     bool noMoreSplits = false;
-    return exec::test::assertQuery(
-        params,
-        [&](exec::Task* task) {
-          if (!noMoreSplits) {
-            auto const& splits = makeSplits(filePath);
+    constexpr int kNumSplits = 10;
+    auto addSplits = [&](exec::Task* task) {
+      if (!noMoreSplits) {
+        auto sources = tpchPlan.dataFiles;
+        for (const auto source : sources) {
+          const auto& filePaths = source.second;
+          for (const auto path : filePaths) {
+            auto const splits = HiveConnectorTestBase::makeHiveConnectorSplits(
+                path, kNumSplits, tpchPlan.dataFileFormat);
             for (const auto& split : splits) {
-              task->addSplit(sourcePlanNodeId, exec::Split(split));
+              task->addSplit(source.first, exec::Split(split));
             }
-            task->noMoreSplits(sourcePlanNodeId);
-            noMoreSplits = true;
           }
-        },
-        duckQuery,
-        *duckDb_);
+          task->noMoreSplits(source.first);
+        }
+      }
+      noMoreSplits = true;
+    };
+    CursorParameters params;
+    params.maxDrivers = kNumDrivers;
+    params.numResultDrivers = 1;
+    params.planNode = std::move(tpchPlan.plan);
+    return exec::test::assertQuery(params, addSplits, duckQuery, *duckDb_);
   }
 
   static std::shared_ptr<DuckDbQueryRunner> duckDb_;
-  std::shared_ptr<exec::test::TempDirectoryPath> tempDirectory_;
-  RowTypePtr lineitemType_;
+  static std::shared_ptr<exec::test::TempDirectoryPath> tempDirectory_;
+  static TpchQueryBuilder tpchBuilder_;
+  static std::unordered_map<std::string, std::string> duckDbParquetWriteSQL_;
 };
 
 std::shared_ptr<DuckDbQueryRunner> ParquetTpchTest::duckDb_ = nullptr;
+std::shared_ptr<exec::test::TempDirectoryPath> ParquetTpchTest::tempDirectory_ =
+    nullptr;
+TpchQueryBuilder ParquetTpchTest::tpchBuilder_(toFileFormat("parquet"));
+std::unordered_map<std::string, std::string>
+    ParquetTpchTest::duckDbParquetWriteSQL_ = {std::make_pair(
+        "lineitem",
+        R"(COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber,
+        l_quantity::DOUBLE as l_quantity, l_extendedprice::DOUBLE as l_extendedprice, l_discount::DOUBLE as l_discount,
+        l_tax::DOUBLE as l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate,
+        l_shipinstruct, l_shipmode, l_comment FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
 
 TEST_F(ParquetTpchTest, q1) {
-  const auto filePath = writeLineitemTableToParquet();
-
-  auto rowType = getLineitemColumns(
-      {"returnflag",
-       "linestatus",
-       "quantity",
-       "extendedprice",
-       "discount",
-       "tax",
-       "shipdate"});
-
-  // shipdate <= '1998-09-02'
-  auto filters =
-      common::test::SubfieldFiltersBuilder()
-          .add("shipdate", common::test::lessThanOrEqual(date("1998-09-02")))
-          .build();
-
-  CursorParameters params;
-  params.maxDrivers = 4;
-  params.numResultDrivers = 1;
-  static const core::SortOrder kAscNullsLast(true, false);
-
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-  core::PlanNodeId sourcePlanNodeId;
-
-  const auto stage1 =
-      PlanBuilder(planNodeIdGenerator)
-          .tableScan(
-              rowType,
-              HiveConnectorTestBase::makeTableHandle(std::move(filters)),
-              HiveConnectorTestBase::allRegularColumns(rowType))
-          .capturePlanNodeId(sourcePlanNodeId)
-          .project(
-              {"returnflag",
-               "linestatus",
-               "quantity",
-               "extendedprice",
-               "extendedprice * (1.0 - discount) AS sum_disc_price",
-               "extendedprice * (1.0 - discount) * (1.0 + tax) AS sum_charge",
-               "discount"})
-          .partialAggregation(
-              {0, 1},
-              {"sum(quantity)",
-               "sum(extendedprice)",
-               "sum(sum_disc_price)",
-               "sum(sum_charge)",
-               "avg(quantity)",
-               "avg(extendedprice)",
-               "avg(discount)",
-               "count(0)"})
-          .planNode();
-
-  auto plan = PlanBuilder(planNodeIdGenerator)
-                  .localPartition({}, {stage1})
-                  .finalAggregation(
-                      {0, 1},
-                      {"sum(a0)",
-                       "sum(a1)",
-                       "sum(a2)",
-                       "sum(a3)",
-                       "avg(a4)",
-                       "avg(a5)",
-                       "avg(a6)",
-                       "count(a7)"},
-                      {DOUBLE(),
-                       DOUBLE(),
-                       DOUBLE(),
-                       DOUBLE(),
-                       DOUBLE(),
-                       DOUBLE(),
-                       DOUBLE(),
-                       BIGINT()})
-                  .orderBy({0, 1}, {kAscNullsLast, kAscNullsLast}, false)
-                  .planNode();
-
-  params.planNode = std::move(plan);
+  auto tpchPlan = tpchBuilder_.getQueryPlan(1);
   auto duckDbSql = duckDb_->getTpchQuery(1);
-  auto task = assertQuery(params, filePath, sourcePlanNodeId, duckDbSql);
+  auto task = assertQuery(tpchPlan, duckDbSql);
 
   const auto& stats = task->taskStats();
   // There should be two pipelines.
@@ -270,47 +137,9 @@ TEST_F(ParquetTpchTest, q1) {
 }
 
 TEST_F(ParquetTpchTest, q6) {
-  const auto& filePath = writeLineitemTableToParquet();
-
-  auto rowType =
-      getLineitemColumns({"shipdate", "extendedprice", "quantity", "discount"});
-
-  auto filters =
-      common::test::SubfieldFiltersBuilder()
-          .add(
-              "shipdate",
-              common::test::between(date("1994-01-01"), date("1994-12-31")))
-          .add("discount", common::test::betweenDouble(0.05, 0.07))
-          .add("quantity", common::test::lessThanDouble(24.0))
-          .build();
-
-  CursorParameters params;
-  params.maxDrivers = 4;
-  params.numResultDrivers = 1;
-
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-  core::PlanNodeId sourcePlanNodeId;
-
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .localPartition(
-              {},
-              {PlanBuilder(planNodeIdGenerator)
-                   .tableScan(
-                       rowType,
-                       HiveConnectorTestBase::makeTableHandle(
-                           std::move(filters)),
-                       HiveConnectorTestBase::allRegularColumns(rowType))
-                   .capturePlanNodeId(sourcePlanNodeId)
-                   .project({"extendedprice * discount"})
-                   .partialAggregation({}, {"sum(p0)"})
-                   .planNode()})
-          .finalAggregation({}, {"sum(a0)"}, {DOUBLE()})
-          .planNode();
-
-  params.planNode = std::move(plan);
+  auto tpchPlan = tpchBuilder_.getQueryPlan(6);
   auto duckDbSql = duckDb_->getTpchQuery(6);
-  auto task = assertQuery(params, filePath, sourcePlanNodeId, duckDbSql);
+  auto task = assertQuery(tpchPlan, duckDbSql);
 
   const auto& stats = task->taskStats();
   // There should be two pipelines

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -53,7 +53,7 @@ class ParquetTpchTest : public testing::Test {
     tpchBuilder_.initialize(tempDirectory_->path);
   }
 
-  /// Write TPC-H table as a Parquet file to temp directory in hive-style
+  /// Write TPC-H tables as a Parquet file to temp directory in hive-style
   /// partition
   static void saveTpchTablesAsParquet() {
     constexpr int kRowGroupSize = 10'000;
@@ -84,17 +84,15 @@ class ParquetTpchTest : public testing::Test {
     constexpr int kNumSplits = 10;
     auto addSplits = [&](exec::Task* task) {
       if (!noMoreSplits) {
-        auto sources = tpchPlan.dataFiles;
-        for (const auto source : sources) {
-          const auto& filePaths = source.second;
-          for (const auto path : filePaths) {
+        for (const auto entry : tpchPlan.dataFiles) {
+          for (const auto path : entry.second) {
             auto const splits = HiveConnectorTestBase::makeHiveConnectorSplits(
                 path, kNumSplits, tpchPlan.dataFileFormat);
             for (const auto& split : splits) {
-              task->addSplit(source.first, exec::Split(split));
+              task->addSplit(entry.first, exec::Split(split));
             }
           }
-          task->noMoreSplits(source.first);
+          task->noMoreSplits(entry.first);
         }
       }
       noMoreSplits = true;

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -16,8 +16,10 @@ add_library(velox_temp_path TempFilePath.cpp TempDirectoryPath.cpp)
 
 target_link_libraries(velox_temp_path velox_exception)
 
-add_library(velox_exec_test_util PlanBuilder.cpp QueryAssertions.cpp Cursor.cpp
-                                 OperatorTestBase.cpp HiveConnectorTestBase.cpp)
+add_library(
+  velox_exec_test_util
+  Cursor.cpp HiveConnectorTestBase.cpp OperatorTestBase.cpp PlanBuilder.cpp
+  QueryAssertions.cpp TpchQueryBuilder.cpp)
 
 target_link_libraries(
   velox_exec_test_util

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -84,6 +84,13 @@ class HiveConnectorTestBase : public OperatorTestBase {
     return makeHiveConnectorSplit(filePath, {}, start, length);
   }
 
+  /// Split file at path 'filePath' into 'splitCount' splits.
+  static std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
+  makeHiveConnectorSplits(
+      const std::string& filePath,
+      uint32_t splitCount,
+      dwio::common::FileFormat format);
+
   static std::shared_ptr<connector::hive::HiveConnectorSplit>
   makeHiveConnectorSplit(
       const std::string& filePath,

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/TpchQueryBuilder.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/type/tests/FilterBuilder.h"
+#include "velox/type/tests/SubfieldFiltersBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+static int64_t toDate(std::string_view stringDate) {
+  Date date;
+  parseTo(stringDate, date);
+  return date.days();
+}
+
+void TpchQueryBuilder::initialize(const std::string& dataPath) {
+  for (const auto& [tableName, columns] : kTables_) {
+    const fs::path tablePath{dataPath + "/" + tableName};
+    for (auto const& dirEntry : fs::directory_iterator{tablePath}) {
+      if (!dirEntry.is_regular_file()) {
+        continue;
+      }
+      // Ignore hidden files.
+      if (dirEntry.path().filename().c_str()[0] == '.') {
+        continue;
+      }
+      if (tableMetadata_[tableName].dataFiles.empty()) {
+        dwio::common::ReaderOptions readerOptions;
+        readerOptions.setFileFormat(format_);
+        std::unique_ptr<dwio::common::Reader> reader =
+            dwio::common::getReaderFactory(readerOptions.getFileFormat())
+                ->createReader(
+                    std::make_unique<dwio::common::FileInputStream>(
+                        dirEntry.path()),
+                    readerOptions);
+        tableMetadata_[tableName].type = reader->rowType();
+        const auto aliases = reader->rowType()->names();
+        // There can be extra columns in the file towards the end.
+        VELOX_CHECK_GE(aliases.size(), columns.size());
+        std::unordered_map<std::string, std::string> aliasMap(columns.size());
+        std::transform(
+            columns.begin(),
+            columns.end(),
+            aliases.begin(),
+            std::inserter(aliasMap, aliasMap.begin()),
+            [](std::string a, std::string b) { return std::make_pair(a, b); });
+        tableMetadata_[tableName].columnAliases = std::move(aliasMap);
+      }
+      tableMetadata_[tableName].dataFiles.push_back(dirEntry.path());
+    }
+  }
+}
+
+const std::vector<std::string>& TpchQueryBuilder::getTableNames() {
+  return kTableNames_;
+}
+
+TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
+  switch (queryId) {
+    case 1:
+      return getQ1Plan();
+    case 6:
+      return getQ6Plan();
+    default:
+      VELOX_NYI();
+  }
+}
+
+namespace {
+using ColumnHandleMap =
+    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>;
+
+std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
+    common::test::SubfieldFilters subfieldFilters,
+    const std::shared_ptr<const core::ITypedExpr>& remainingFilter = nullptr) {
+  return std::make_shared<connector::hive::HiveTableHandle>(
+      true, std::move(subfieldFilters), remainingFilter);
+}
+
+std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
+    const std::string& name,
+    const TypePtr& type) {
+  return std::make_shared<connector::hive::HiveColumnHandle>(
+      name, connector::hive::HiveColumnHandle::ColumnType::kRegular, type);
+}
+
+ColumnHandleMap allRegularColumns(
+    const std::shared_ptr<const RowType>& rowType) {
+  ColumnHandleMap assignments;
+  assignments.reserve(rowType->size());
+  for (uint32_t i = 0; i < rowType->size(); ++i) {
+    const auto& name = rowType->nameOf(i);
+    assignments[name] = regularColumn(name, rowType->childAt(i));
+  }
+  return assignments;
+}
+} // namespace
+
+TpchPlan TpchQueryBuilder::getQ1Plan() const {
+  const std::string kTableName = "lineitem";
+  std::vector<std::string> selectedColumns = {
+      "l_returnflag",
+      "l_linestatus",
+      "l_quantity",
+      "l_extendedprice",
+      "l_discount",
+      "l_tax",
+      "l_shipdate"};
+
+  // Get the corresponding selected column names in the file.
+  const auto aliasSelectedColumns =
+      getColumnAliases(kTableName, selectedColumns);
+
+  auto columnSelector =
+      std::make_shared<facebook::velox::dwio::common::ColumnSelector>(
+          tableMetadata_.at(kTableName).type, aliasSelectedColumns);
+  auto selectedRowType = columnSelector->buildSelectedReordered();
+  // We need to add an extra project step to map file columns to standard
+  // column names.
+  const auto projectAlias =
+      getProjectColumnAliases(kTableName, selectedColumns);
+
+  // shipdate <= '1998-09-02'
+  auto shipDate = getColumnAlias(kTableName, "l_shipdate");
+  common::test::SubfieldFiltersBuilder filtersBuilder;
+  // DWRF does not support Date type. It uses Varchar instead.
+  if ((selectedRowType->findChild(shipDate))->isVarchar()) {
+    filtersBuilder.add(shipDate, common::test::lessThanOrEqual("1998-09-02"));
+  } else {
+    filtersBuilder.add(
+        shipDate, common::test::lessThanOrEqual(toDate("1998-09-02")));
+  }
+  auto filters = filtersBuilder.build();
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId lineitemPlanNodeId;
+
+  const auto stage1 =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              selectedRowType,
+              makeTableHandle(std::move(filters)),
+              allRegularColumns(selectedRowType))
+          .capturePlanNodeId(lineitemPlanNodeId)
+          .project(std::move(projectAlias))
+          .project(
+              {"l_returnflag",
+               "l_linestatus",
+               "l_quantity",
+               "l_extendedprice",
+               "l_extendedprice * (1.0 - l_discount) AS l_sum_disc_price",
+               "l_extendedprice * (1.0 - l_discount) * (1.0 + l_tax) AS l_sum_charge",
+               "l_discount"})
+          .partialAggregation(
+              {0, 1},
+              {"sum(l_quantity)",
+               "sum(l_extendedprice)",
+               "sum(l_sum_disc_price)",
+               "sum(l_sum_charge)",
+               "avg(l_quantity)",
+               "avg(l_extendedprice)",
+               "avg(l_discount)",
+               "count(0)"})
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localPartition({}, {stage1})
+          .finalAggregation(
+              {0, 1},
+              {"sum(a0)",
+               "sum(a1)",
+               "sum(a2)",
+               "sum(a3)",
+               "avg(a4)",
+               "avg(a5)",
+               "avg(a6)",
+               "count(a7)"},
+              {DOUBLE(),
+               DOUBLE(),
+               DOUBLE(),
+               DOUBLE(),
+               DOUBLE(),
+               DOUBLE(),
+               DOUBLE(),
+               BIGINT()})
+          .orderBy({0, 1}, {core::kAscNullsLast, core::kAscNullsLast}, false)
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[lineitemPlanNodeId] = getTableFilePaths(kTableName);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ6Plan() const {
+  const std::string kTableName = "lineitem";
+  std::vector<std::string> selectedColumns = {
+      "l_shipdate", "l_extendedprice", "l_quantity", "l_discount"};
+
+  // Get the corresponding selected column names in the file.
+  const auto aliasSelectedColumns =
+      getColumnAliases(kTableName, selectedColumns);
+
+  auto columnSelector =
+      std::make_shared<facebook::velox::dwio::common::ColumnSelector>(
+          tableMetadata_.at(kTableName).type, aliasSelectedColumns);
+  auto selectedRowType = columnSelector->buildSelectedReordered();
+  // We need to add an extra project step to map file columns to standard
+  // column names.
+  const auto projectAlias =
+      getProjectColumnAliases(kTableName, selectedColumns);
+
+  auto shipDate = getColumnAlias(kTableName, "l_shipdate");
+  common::test::SubfieldFiltersBuilder filtersBuilder;
+  // DWRF does not support Date type. It uses Varchar instead.
+  if ((selectedRowType->findChild(shipDate))->isVarchar()) {
+    filtersBuilder.add(
+        shipDate, common::test::between("1994-01-01", "1994-12-31"));
+  } else {
+    filtersBuilder.add(
+        shipDate,
+        common::test::between(toDate("1994-01-01"), toDate("1994-12-31")));
+  }
+  auto filters = filtersBuilder
+                     .add(
+                         getColumnAlias(kTableName, "l_discount"),
+                         common::test::betweenDouble(0.05, 0.07))
+                     .add(
+                         getColumnAlias(kTableName, "l_quantity"),
+                         common::test::lessThanDouble(24.0))
+                     .build();
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId lineitemPlanNodeId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .localPartition(
+                      {},
+                      {PlanBuilder(planNodeIdGenerator)
+                           .tableScan(
+                               selectedRowType,
+                               makeTableHandle(std::move(filters)),
+                               allRegularColumns(selectedRowType))
+                           .capturePlanNodeId(lineitemPlanNodeId)
+                           .project(std::move(projectAlias))
+                           .project({"l_extendedprice * l_discount"})
+                           .partialAggregation({}, {"sum(p0)"})
+                           .planNode()})
+                  .finalAggregation({}, {"sum(a0)"}, {DOUBLE()})
+                  .planNode();
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[lineitemPlanNodeId] = getTableFilePaths(kTableName);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+const std::vector<std::string> TpchQueryBuilder::kTableNames_ = {"lineitem"};
+
+const std::unordered_map<std::string, std::vector<std::string>>
+    TpchQueryBuilder::kTables_ = {std::make_pair(
+        "lineitem",
+        std::vector<std::string>{
+            "l_orderkey",
+            "l_partkey",
+            "l_suppkey",
+            "l_linenumber",
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_returnflag",
+            "l_linestatus",
+            "l_shipdate",
+            "l_commitdate",
+            "l_receiptdate",
+            "l_shipinstruct",
+            "l_shipmode",
+            "l_comment"})};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -136,8 +136,8 @@ TpchPlan TpchQueryBuilder::getQ1Plan() const {
   // shipdate <= '1998-09-02'
   auto shipDate = getColumnAlias(kTableName, "l_shipdate");
   common::test::SubfieldFiltersBuilder filtersBuilder;
-  // DWRF does not support Date type. It uses Varchar instead.
-  if ((selectedRowType->findChild(shipDate))->isVarchar()) {
+  // DWRF does not support Date type. Use Varchar instead.
+  if (selectedRowType->findChild(shipDate)->isVarchar()) {
     filtersBuilder.add(shipDate, common::test::lessThanOrEqual("1998-09-02"));
   } else {
     filtersBuilder.add(
@@ -226,7 +226,7 @@ TpchPlan TpchQueryBuilder::getQ6Plan() const {
 
   auto shipDate = getColumnAlias(kTableName, "l_shipdate");
   common::test::SubfieldFiltersBuilder filtersBuilder;
-  // DWRF does not support Date type. Uses Varchar instead.
+  // DWRF does not support Date type. Use Varchar instead.
   if (selectedRowType->findChild(shipDate)->isVarchar()) {
     filtersBuilder.add(
         shipDate, common::test::between("1994-01-01", "1994-12-31"));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -97,7 +97,7 @@ class TpchQueryBuilder {
 
   std::vector<std::string> getColumnAliases(
       const std::string& tableName,
-      std::vector<std::string> columnNames) const {
+      const std::vector<std::string>& columnNames) const {
     std::vector<std::string> aliases;
     for (const auto& name : columnNames) {
       aliases.push_back(getColumnAlias(tableName, name));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/dwio/common/Options.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#if __has_include("filesystem")
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+using namespace facebook::velox::dwio::common;
+
+namespace facebook::velox::exec::test {
+
+/// Contains the query plan and input data files keyed on source plan node ID.
+/// All data files use the same file format specified in 'dataFileFormat'.
+struct TpchPlan {
+  std::shared_ptr<core::PlanNode> plan;
+  std::unordered_map<core::PlanNodeId, std::vector<std::string>> dataFiles;
+  FileFormat dataFileFormat;
+};
+
+/// Contains type information, data files, and column aliases for a table.
+/// This information is inferred from the input data files.
+struct TableMetadata {
+  RowTypePtr type;
+  std::vector<std::string> dataFiles;
+  std::unordered_map<std::string, std::string> columnAliases;
+};
+
+/// Builds TPC-H queries using TPC-H data files located in the specified
+/// directory. Each table data must be placed in hive-style partitioning. That
+/// is, the top-level directory is expected to contain a sub-directory per table
+/// name and the name of the sub-directory must match the table name. Example:
+/// ls -R data/
+///  customer   lineitem
+///
+///  data/customer:
+///  customer1.parquet  customer2.parquet
+///
+///  data/lineitem:
+///  lineitem1.parquet  lineitem2.parquet  lineitem3.parquet
+
+/// The column names can vary. Additional columns may exist towards the end.
+/// The class uses standard names (example: l_returnflag) to build TPC-H plans.
+/// Since the column names in the file can vary, they are mapped to the standard
+/// names. Therefore, the order of the columns in the file is important and
+/// should be in the same order as in the TPC-H standard.
+class TpchQueryBuilder {
+ public:
+  TpchQueryBuilder(const dwio::common::FileFormat format) : format_(format) {}
+
+  /// Read each data file and initialize row types and determine data paths for
+  /// each table.
+  /// @param dataPath path to the data files
+  /// @param format file format
+  void initialize(const std::string& dataPath);
+
+  /// Get the query plan for a given TPC-H query number.
+  /// @param queryId TPC-H query number
+  TpchPlan getQueryPlan(int queryId) const;
+
+  /// Get the TPC-H table names present.
+  static const std::vector<std::string>& getTableNames();
+
+ private:
+  TpchPlan getQ1Plan() const;
+  TpchPlan getQ6Plan() const;
+
+  const std::vector<std::string>& getTableFilePaths(
+      const std::string& tableName) const {
+    return tableMetadata_.at(tableName).dataFiles;
+  }
+
+  const std::string& getColumnAlias(
+      const std::string& tableName,
+      const std::string& columnName) const {
+    return tableMetadata_.at(tableName).columnAliases.at(columnName);
+  }
+
+  std::vector<std::string> getColumnAliases(
+      const std::string& tableName,
+      std::vector<std::string> columnNames) const {
+    std::vector<std::string> aliases;
+    for (const auto& name : columnNames) {
+      aliases.push_back(getColumnAlias(tableName, name));
+    }
+    return aliases;
+  }
+
+  std::vector<std::string> getProjectColumnAliases(
+      std::string tableName,
+      std::vector<std::string> columnNames) const {
+    std::vector<std::string> aliases;
+    for (const auto& name : columnNames) {
+      aliases.push_back(getColumnAlias(tableName, name) + " AS " + name);
+    }
+    return aliases;
+  }
+
+  std::unordered_map<std::string, TableMetadata> tableMetadata_;
+  const dwio::common::FileFormat format_;
+  static const std::unordered_map<std::string, std::vector<std::string>>
+      kTables_;
+  static const std::vector<std::string> kTableNames_;
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -40,7 +40,7 @@ struct TpchPlan {
 
 /// Contains type information, data files, and column aliases for a table.
 /// This information is inferred from the input data files.
-struct TableMetadata {
+struct TpchTableMetadata {
   RowTypePtr type;
   std::vector<std::string> dataFiles;
   std::unordered_map<std::string, std::string> columnAliases;
@@ -66,12 +66,11 @@ struct TableMetadata {
 /// should be in the same order as in the TPC-H standard.
 class TpchQueryBuilder {
  public:
-  TpchQueryBuilder(const dwio::common::FileFormat format) : format_(format) {}
+  TpchQueryBuilder(dwio::common::FileFormat format) : format_(format) {}
 
-  /// Read each data file and initialize row types and determine data paths for
+  /// Read each data file, initialize row types, and determine data paths for
   /// each table.
   /// @param dataPath path to the data files
-  /// @param format file format
   void initialize(const std::string& dataPath);
 
   /// Get the query plan for a given TPC-H query number.
@@ -107,8 +106,8 @@ class TpchQueryBuilder {
   }
 
   std::vector<std::string> getProjectColumnAliases(
-      std::string tableName,
-      std::vector<std::string> columnNames) const {
+      const std::string& tableName,
+      const std::vector<std::string>& columnNames) const {
     std::vector<std::string> aliases;
     for (const auto& name : columnNames) {
       aliases.push_back(getColumnAlias(tableName, name) + " AS " + name);
@@ -116,7 +115,7 @@ class TpchQueryBuilder {
     return aliases;
   }
 
-  std::unordered_map<std::string, TableMetadata> tableMetadata_;
+  std::unordered_map<std::string, TpchTableMetadata> tableMetadata_;
   const dwio::common::FileFormat format_;
   static const std::unordered_map<std::string, std::vector<std::string>>
       kTables_;


### PR DESCRIPTION
Refactor ParquetTpchTest to extract TpchQueryBuilder utility for building query
plans for TPC-H queries. At the moment, only q1 and q6 are supported.