### PR TITLE
Use consistent SimpleFunction resolution in FunctionRegistry

### DIFF
--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -93,13 +93,11 @@ std::shared_ptr<const Type> resolveFunction(
 std::shared_ptr<const Type> resolveSimpleFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
-  auto simpleFunctionSignatures =
-      exec::SimpleFunctions().getFunctionSignatures(functionName);
-  for (const auto* signature : simpleFunctionSignatures) {
-    exec::SignatureBinder binder(*signature, argTypes);
-    if (binder.tryBind()) {
-      return binder.tryResolveReturnType();
-    }
+  auto resolvedFunction =
+      exec::SimpleFunctions().resolveFunction(functionName, argTypes);
+
+  if (resolvedFunction) {
+    return resolvedFunction->getMetadata()->returnType();
   }
 
   return nullptr;


### PR DESCRIPTION
Summary:
In velox/functions/FunctionRegistry.cpp we have custom resolution logic for
SimpleFunctions, distinct from that used in velox/expression/FunctionRegistry.h.  This has
a couple issues:

1) it's not picking up the new logic to resolve functions based on priority (generality)
2) It uses slightly different logic for generating the return type (from the FunctionSignature
instead of the SimpleFunctionMetadata)

Since external users primarily use the functions/FunctionRegistry and velox internally
primarily uses expression/FunctionRegistry, this means that users are seeing inconsistent
behavior, and we're frequently missing issues when testing.

I updated functions/FunctionRegistry.cpp to defer to the implementation for
SimpleFunction resolution in expression/FunctionRegistry.h to ensure it's consistent.

The same should probably also be done for VectorFunctions, but at this point, the
resolution for VectorFunctions hasn't been consolidated into a single point yet even
internally, so it's not as straightforward (and also not as urgent as that logic is much
simpler and appears to be correct).

AFAICT functions/FunctionRegistry is used to abstract away the fact there are
SimpleFunctions and VectorFunctions from the user so they see a single unified interface,
so it shouldn't have any significant logic.  (It is also due for renaming)

Differential Revision: D34759410

