### PR TITLE
Include constant value in ConstantExpr::toString() output

### DIFF
--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -66,6 +66,15 @@ void ConstantExpr::evalSpecialFormSimplified(
   }
 }
 
+std::string ConstantExpr::toString() const {
+  if (sharedSubexprValues_ == nullptr) {
+    return fmt::format("{}:{}", value_.toJson(), type()->toString());
+  } else {
+    return fmt::format(
+        "{}:{}", sharedSubexprValues_->toString(0), type()->toString());
+  }
+}
+
 void FieldReference::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,

--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -87,6 +87,8 @@ class ConstantExpr : public SpecialForm {
     return sharedSubexprValues_;
   }
 
+  std::string toString() const override;
+
  private:
   const variant value_;
   bool needToSetIsAscii_;


### PR DESCRIPTION
ConstantExpr::toString() used to return "literal", which is not very informative. Now it returns the value of constant.