### PR TITLE
Add missing types to TypeAnalysis

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -181,6 +181,10 @@ struct TypeAnalysisResults {
 template <typename T>
 struct TypeAnalysis {
   void run(TypeAnalysisResults& results) {
+    // This should only handle primitives and OPAQUE.
+    static_assert(
+        CppToType<T>::isPrimitiveType ||
+        CppToType<T>::typeKind == TypeKind::OPAQUE);
     results.stats.concreteCount++;
     results.out << boost::algorithm::to_lower_copy(
         std::string(CppToType<T>::name));
@@ -207,7 +211,7 @@ struct TypeAnalysis<Map<K, V>> {
     results.stats.concreteCount++;
     results.out << "map(";
     TypeAnalysis<K>().run(results);
-    results.out << ",";
+    results.out << ", ";
     TypeAnalysis<V>().run(results);
     results.out << ")";
   }
@@ -269,6 +273,20 @@ struct TypeAnalysis<Row<T...>> {
 };
 
 // TODO: remove once old writers deprecated.
+template <typename V>
+struct TypeAnalysis<ArrayWriterT<V>> {
+  void run(TypeAnalysisResults& results) {
+    TypeAnalysis<Array<V>>().run(results);
+  }
+};
+
+template <typename K, typename V>
+struct TypeAnalysis<MapWriterT<K, V>> {
+  void run(TypeAnalysisResults& results) {
+    TypeAnalysis<Map<K, V>>().run(results);
+  }
+};
+
 template <typename... T>
 struct TypeAnalysis<RowWriterT<T...>> {
   void run(TypeAnalysisResults& results) {

--- a/velox/core/tests/TestTypeAnalysis.cpp
+++ b/velox/core/tests/TestTypeAnalysis.cpp
@@ -167,7 +167,7 @@ TEST_F(TypeAnalysisTest, testStringType) {
   testStringType<float>({"real"});
 
   testStringType<Array<int32_t>>({"array(integer)"});
-  testStringType<Map<Generic<>, int32_t>>({"map(any,integer)"});
+  testStringType<Map<Generic<>, int32_t>>({"map(any, integer)"});
   testStringType<Row<int32_t, int32_t>>({"row(integer, integer)"});
 
   testStringType<Generic<>>({"any"});
@@ -178,8 +178,13 @@ TEST_F(TypeAnalysisTest, testStringType) {
   testStringType<int32_t, int64_t, Map<Array<int32_t>, Generic<T2>>>({
       "integer",
       "bigint",
-      "map(array(integer),__user_T2)",
+      "map(array(integer), __user_T2)",
   });
+
+  testStringType<ArrayWriterT<int32_t>>({"array(integer)"});
+  testStringType<MapWriterT<int64_t, double>>({"map(bigint, double)"});
+  testStringType<RowWriterT<Generic<>, double, Generic<T1>>>(
+      {"row(any, double, __user_T1)"});
 }
 
 TEST_F(TypeAnalysisTest, testVariables) {

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -290,7 +290,8 @@ struct NestedArrayF {
 };
 
 TEST_F(NullableArrayViewTest, nestedArray) {
-  registerFunction<NestedArrayF, int64_t, Array<Array<int64_t>>>({"func"});
+  registerFunction<NestedArrayF, int64_t, Array<Array<int64_t>>>(
+      {"nested_array_func"});
   std::vector<std::vector<int64_t>> arrayData = {
       {0, 1, 2, 4},
       {99, 98},
@@ -301,7 +302,8 @@ TEST_F(NullableArrayViewTest, nestedArray) {
   size_t rows = arrayData.size();
   auto arrayVector = makeArrayVector(arrayData);
   auto result = evaluate<FlatVector<int64_t>>(
-      "func(array_constructor(c0, c0))", makeRowVector({arrayVector}));
+      "nested_array_func(array_constructor(c0, c0))",
+      makeRowVector({arrayVector}));
 
   auto expected = makeFlatVector<int64_t>(rows, [&](auto row) {
     return 2 * std::accumulate(arrayData[row].begin(), arrayData[row].end(), 0);

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -242,13 +242,13 @@ TEST_F(ArrayWriterTest, multipleRows) {
 }
 
 TEST_F(ArrayWriterTest, e2ePrimitives) {
-  testE2E<int8_t>("f_int8");
-  testE2E<int16_t>("f_int16");
-  testE2E<int32_t>("f_int32");
-  testE2E<int64_t>("f_int64");
-  testE2E<float>("f_float");
-  testE2E<double>("f_double");
-  testE2E<bool>("f_bool");
+  testE2E<int8_t>("array_writer_f_int8");
+  testE2E<int16_t>("array_writer_f_int16");
+  testE2E<int32_t>("array_writer_f_int32");
+  testE2E<int64_t>("array_writer_f_int64");
+  testE2E<float>("array_writer_f_float");
+  testE2E<double>("array_writer_f_double");
+  testE2E<bool>("array_writer_f_bool");
 }
 
 TEST_F(ArrayWriterTest, testTimeStamp) {
@@ -433,10 +433,10 @@ TEST_F(ArrayWriterTest, nestedArrayE2E) {
   registerFunction<
       MakeMatrixFunc,
       ArrayWriterT<ArrayWriterT<int64_t>>,
-      int64_t>({"func"});
+      int64_t>({"make_matrix"});
 
   auto result = evaluate(
-      "func(c0)",
+      "make_matrix(c0)",
       makeRowVector(
           {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
 
@@ -565,9 +565,10 @@ struct CopyFromFunc {
 
 TEST_F(ArrayWriterTest, copyFromE2EMapArray) {
   registerFunction<CopyFromFunc, ArrayWriterT<MapWriterT<int64_t, int64_t>>>(
-      {"func"});
+      {"copy_from"});
 
-  auto result = evaluate("func()", makeRowVector({makeFlatVector<int64_t>(1)}));
+  auto result =
+      evaluate("copy_from()", makeRowVector({makeFlatVector<int64_t>(1)}));
 
   // Test results.
   DecodedVector decoded;

--- a/velox/expression/tests/GenericViewTest.cpp
+++ b/velox/expression/tests/GenericViewTest.cpp
@@ -264,14 +264,15 @@ struct HashAllArgs {
 };
 
 TEST_F(GenericViewTest, e2eHashVariadicSameType) {
-  registerFunction<HashAllArgs, int64_t, Variadic<Generic<T1>>>({"func"});
+  registerFunction<HashAllArgs, int64_t, Variadic<Generic<T1>>>(
+      {"hash_all_args"});
 
   auto vectorInt1 = vectorMaker_.flatVector<int64_t>({1, 2, 3});
   auto vectorInt2 = vectorMaker_.flatVector<int64_t>({1, 2, 3});
   auto vectorDouble = vectorMaker_.flatVector<double>({4, 5, 6});
 
   auto result1 = evaluate<FlatVector<int64_t>>(
-      "func(c0, c1)", makeRowVector({vectorInt1, vectorInt2}));
+      "hash_all_args(c0, c1)", makeRowVector({vectorInt1, vectorInt2}));
 
   for (auto i = 0; i < 3; i++) {
     ASSERT_EQ(
@@ -282,7 +283,7 @@ TEST_F(GenericViewTest, e2eHashVariadicSameType) {
   // All arguments expected to be of the same type.
   ASSERT_THROW(
       evaluate<FlatVector<int64_t>>(
-          "func(c0, c1, c2)",
+          "hash_all_args(c0, c1, c2)",
           makeRowVector({vectorInt1, vectorInt2, vectorDouble})),
       std::invalid_argument);
 }

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -450,7 +450,7 @@ struct MapComplexKeyF {
 
 TEST_F(NullableMapViewTest, mapCoplexKey) {
   registerFunction<MapComplexKeyF, double, Map<Array<double>, double>>(
-      {"func"});
+      {"map_complex_key"});
 
   const vector_size_t size = 10;
   auto values1 = makeArrayVector<double>(
@@ -464,7 +464,7 @@ TEST_F(NullableMapViewTest, mapCoplexKey) {
       [](auto /*row*/, auto index) { return 1.2 * index; });
 
   auto result = evaluate<FlatVector<double>>(
-      "func(map(array_constructor(c0), c1))",
+      "map_complex_key(map(array_constructor(c0), c1))",
       makeRowVector({values1, values2}));
 
   auto expected =

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -247,13 +247,13 @@ TEST_F(MapWriterTest, resizeAndSubscriptAccess) {
 }
 
 TEST_F(MapWriterTest, e2ePrimitives) {
-  testE2E<int8_t>("f_int8");
-  testE2E<int16_t>("f_int16");
-  testE2E<int32_t>("f_int32");
-  testE2E<int64_t>("f_int64");
-  testE2E<float>("f_float");
-  testE2E<double>("f_double");
-  testE2E<bool>("f_bool");
+  testE2E<int8_t>("map_writer_f_int8");
+  testE2E<int16_t>("map_writer_f_int16");
+  testE2E<int32_t>("map_writer_f_int32");
+  testE2E<int64_t>("map_writer_f_int64");
+  testE2E<float>("map_writer_f_float");
+  testE2E<double>("map_writer_f_double");
+  testE2E<bool>("map_writer_f_bool");
 }
 
 TEST_F(MapWriterTest, testTimeStamp) {

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -146,15 +146,15 @@ TEST_F(RowWriterTest, getWriterAt) {
 }
 
 TEST_F(RowWriterTest, e2ePrimitives) {
-  testE2EPrimitive<int8_t, int8_t, int8_t>("f_int8");
-  testE2EPrimitive<int16_t, int16_t, int16_t>("f_int16");
-  testE2EPrimitive<int32_t, int32_t, int32_t>("f_int32");
-  testE2EPrimitive<int64_t, int64_t, int64_t>("f_int64");
-  testE2EPrimitive<float, float, float>("f_float");
-  testE2EPrimitive<double, double, double>("f_double");
-  testE2EPrimitive<bool, bool, bool>("f_bool");
-  testE2EPrimitive<double, float, bool>("f_mix1");
-  testE2EPrimitive<int32_t, int64_t, double>("f_mix2");
+  testE2EPrimitive<int8_t, int8_t, int8_t>("row_writer_f_int8");
+  testE2EPrimitive<int16_t, int16_t, int16_t>("row_writer_f_int16");
+  testE2EPrimitive<int32_t, int32_t, int32_t>("row_writer_f_int32");
+  testE2EPrimitive<int64_t, int64_t, int64_t>("row_writer_f_int64");
+  testE2EPrimitive<float, float, float>("row_writer_f_float");
+  testE2EPrimitive<double, double, double>("row_writer_f_double");
+  testE2EPrimitive<bool, bool, bool>("row_writer_f_bool");
+  testE2EPrimitive<double, float, bool>("row_writer_f_mix1");
+  testE2EPrimitive<int32_t, int64_t, double>("row_writer_f_mix2");
 }
 
 TEST_F(RowWriterTest, timeStamp) {

--- a/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
+++ b/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
@@ -56,7 +56,7 @@ class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
     };
 
     static void registerUdf() {
-      registerFunction<udf, T, T>({"func"});
+      registerFunction<udf, T, T>({"preset_nulls_test_func"});
     }
   };
 
@@ -112,8 +112,9 @@ class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
 
     auto input = createInput<T>(size);
     auto result = createResults<T>(size);
-    evaluate<SimpleVector<T>>("func(c0)", input, rows, result);
-    auto expectedResult = evaluate("func(c0)", input);
+    evaluate<SimpleVector<T>>(
+        "preset_nulls_test_func(c0)", input, rows, result);
+    auto expectedResult = evaluate("preset_nulls_test_func(c0)", input);
 
     assertEqualVectors(result, expectedResult);
   }


### PR DESCRIPTION
Summary:
ArrayWriterT and MapWriterT were missing template specializations, so their types in the
type signature were missing their children

I also added a static check that no complex types (other than Opaque) use the default
template function.

Differential Revision: D34761501

