### PR TITLE
Add DuckDB QueryAssertions logic for MAP columns

### DIFF
--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -20,10 +20,13 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec::test;
 
 class LimitTest : public OperatorTestBase {
-protected:
- void basicLimitTests(const std::vector<RowVectorPtr>& vectors) {
+ protected:
+  void basicLimitTests(const std::vector<RowVectorPtr>& vectors) {
     auto makePlan = [&](int32_t offset, int32_t limit) {
-        return PlanBuilder().values(vectors).limit(offset, limit, true).planNode();
+      return PlanBuilder()
+          .values(vectors)
+          .limit(offset, limit, true)
+          .planNode();
     };
 
     assertQuery(makePlan(0, 10), "SELECT * FROM tmp LIMIT 10");
@@ -35,20 +38,22 @@ protected:
     assertQuery(makePlan(17, 1'000), "SELECT * FROM tmp OFFSET 17 LIMIT 1000");
     assertQuery(makePlan(17, 2'000), "SELECT * FROM tmp OFFSET 17 LIMIT 2000");
 
-    assertQuery(makePlan(1'000, 145), "SELECT * FROM tmp OFFSET 1000 LIMIT 145");
     assertQuery(
-            makePlan(1'000, 1'000), "SELECT * FROM tmp OFFSET 1000 LIMIT 1000");
+        makePlan(1'000, 145), "SELECT * FROM tmp OFFSET 1000 LIMIT 145");
     assertQuery(
-            makePlan(1'000, 1'234), "SELECT * FROM tmp OFFSET 1000 LIMIT 1234");
+        makePlan(1'000, 1'000), "SELECT * FROM tmp OFFSET 1000 LIMIT 1000");
+    assertQuery(
+        makePlan(1'000, 1'234), "SELECT * FROM tmp OFFSET 1000 LIMIT 1234");
 
     assertQuery(makePlan(1'234, 10), "SELECT * FROM tmp OFFSET 1234 LIMIT 10");
-    assertQuery(makePlan(1'234, 983), "SELECT * FROM tmp OFFSET 1234 LIMIT 983");
     assertQuery(
-            makePlan(1'234, 1'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 1000");
+        makePlan(1'234, 983), "SELECT * FROM tmp OFFSET 1234 LIMIT 983");
     assertQuery(
-            makePlan(1'234, 2'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 2000");
+        makePlan(1'234, 1'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 1000");
+    assertQuery(
+        makePlan(1'234, 2'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 2000");
     assertQueryReturnsEmptyResult(makePlan(12'345, 10));
-}
+  }
 };
 
 TEST_F(LimitTest, basic) {

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -63,3 +63,43 @@ TEST_F(LimitTest, basic) {
 
   assertQueryReturnsEmptyResult(makePlan(12'345, 10));
 }
+
+TEST_F(LimitTest, basicMap) {
+  vector_size_t batchSize = 1'000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 3; ++i) {
+    vectors.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(batchSize, [](auto row) { return row; }),
+         makeMapVector<int64_t, int64_t>(
+             batchSize,
+             [](auto row) { return 2; },
+             [](auto row) { return row % 2; },
+             [](auto row) { return row % 2 + 1; })}));
+  }
+  createDuckDbTable(vectors);
+  auto makePlan = [&](int32_t offset, int32_t limit) {
+    return PlanBuilder().values(vectors).limit(offset, limit, false).planNode();
+  };
+
+  assertQuery(makePlan(0, 10), "SELECT * FROM tmp LIMIT 10");
+  assertQuery(makePlan(0, 1'000), "SELECT * FROM tmp LIMIT 1000");
+  assertQuery(makePlan(0, 1'234), "SELECT * FROM tmp LIMIT 1234");
+
+  assertQuery(makePlan(17, 10), "SELECT * FROM tmp OFFSET 17 LIMIT 10");
+  assertQuery(makePlan(17, 983), "SELECT * FROM tmp OFFSET 17 LIMIT 983");
+  assertQuery(makePlan(17, 1'000), "SELECT * FROM tmp OFFSET 17 LIMIT 1000");
+  assertQuery(makePlan(17, 2'000), "SELECT * FROM tmp OFFSET 17 LIMIT 2000");
+
+  assertQuery(makePlan(1'000, 145), "SELECT * FROM tmp OFFSET 1000 LIMIT 145");
+  assertQuery(
+      makePlan(1'000, 1'000), "SELECT * FROM tmp OFFSET 1000 LIMIT 1000");
+  assertQuery(
+      makePlan(1'000, 1'234), "SELECT * FROM tmp OFFSET 1000 LIMIT 1234");
+
+  assertQuery(makePlan(1'234, 10), "SELECT * FROM tmp OFFSET 1234 LIMIT 10");
+  assertQuery(makePlan(1'234, 983), "SELECT * FROM tmp OFFSET 1234 LIMIT 983");
+  assertQuery(
+      makePlan(1'234, 1'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 1000");
+  assertQuery(
+      makePlan(1'234, 2'000), "SELECT * FROM tmp OFFSET 1234 LIMIT 2000");
+}

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -333,7 +333,7 @@ TEST_P(TableScanTest, constDictLazy) {
        makeFlatVector<int64_t>(size, [](auto row) { return row; }),
        makeMapVector<int64_t, double>(
            size,
-           [](auto row) { return row % 3 + 1; },
+           [](auto row) { return row % 3; },
            [](auto row) { return row; },
            [](auto row) { return row * 0.1; })});
 
@@ -364,7 +364,7 @@ TEST_P(TableScanTest, constDictLazy) {
            .project({"cardinality(c2)"})
            .planNode();
 
-  assertQuery(op, {filePath}, "SELECT 1 FROM tmp WHERE c0 = 5");
+  assertQuery(op, {filePath}, "SELECT 0 FROM tmp WHERE c0 = 5");
 
   tableHandle =
       makeTableHandle(SubfieldFilters{}, parseExpr("c0 = 2", rowType));
@@ -373,7 +373,7 @@ TEST_P(TableScanTest, constDictLazy) {
            .project({"cardinality(c2)"})
            .planNode();
 
-  assertQuery(op, {filePath}, "SELECT 3 FROM tmp WHERE c0 = 5");
+  assertQuery(op, {filePath}, "SELECT 2 FROM tmp WHERE c0 = 5");
 }
 
 TEST_P(TableScanTest, count) {

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -118,9 +118,10 @@ template <>
   auto offset = mapVector->offsetAt(row);
   auto size = mapVector->sizeAt(row);
   if (size == 0) {
-      return ::duckdb::Value::MAP(
-              ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(mapKeys->typeKind())),
-              ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(mapValues->typeKind())));
+    return ::duckdb::Value::MAP(
+        ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(mapKeys->typeKind())),
+        ::duckdb::Value::EMPTYLIST(
+            duckdb::fromVeloxType(mapValues->typeKind())));
   }
 
   std::vector<::duckdb::Value> duckKeysVector;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -126,7 +126,7 @@ template <>
     auto innerRow = offset + i;
     duckKeysVector.emplace_back(VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
         duckValueAt, mapKeys->typeKind(), mapKeys, innerRow));
-    if (!mapValues->isNullAt(innerRow)) {
+    if (mapValues->isNullAt(innerRow)) {
       duckValuesVector.emplace_back(::duckdb::Value(nullptr));
     } else {
       duckValuesVector.emplace_back(VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -117,6 +117,11 @@ template <>
   const auto& mapValues = mapVector->mapValues();
   auto offset = mapVector->offsetAt(row);
   auto size = mapVector->sizeAt(row);
+  if (size == 0) {
+      return ::duckdb::Value::MAP(
+              ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(mapKeys->typeKind())),
+              ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(mapValues->typeKind())));
+  }
 
   std::vector<::duckdb::Value> duckKeysVector;
   std::vector<::duckdb::Value> duckValuesVector;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -113,8 +113,8 @@ template <>
     const VectorPtr& vector,
     int32_t row) {
   auto mapVector = vector->as<MapVector>();
-  auto& mapKeys = mapVector->mapKeys();
-  auto& mapValues = mapVector->mapValues();
+  const auto& mapKeys = mapVector->mapKeys();
+  const auto& mapValues = mapVector->mapValues();
   auto offset = mapVector->offsetAt(row);
   auto size = mapVector->sizeAt(row);
 
@@ -189,7 +189,7 @@ velox::variant variantAt(const ::duckdb::Value& value) {
 
 velox::variant rowVariantAt(
     const ::duckdb::Value& vector,
-    const std::shared_ptr<const Type>& rowType) {
+    const TypePtr& rowType) {
   std::vector<velox::variant> values;
   const auto& structValue = ::duckdb::StructValue::GetChildren(vector);
   for (size_t i = 0; i < structValue.size(); ++i) {
@@ -210,18 +210,18 @@ velox::variant rowVariantAt(
 
 velox::variant mapVariantAt(
     const ::duckdb::Value& vector,
-    const std::shared_ptr<const Type>& mapType) {
+    const TypePtr& mapType) {
   std::map<variant, variant> map;
 
   const auto& mapValue = ::duckdb::StructValue::GetChildren(vector);
-  VELOX_CHECK(mapValue.size() == 2);
+  VELOX_CHECK_EQ(mapValue.size(), 2);
 
   auto mapTypePtr = dynamic_cast<const MapType*>(mapType.get());
   auto keyType = mapTypePtr->keyType()->kind();
   auto valueType = mapTypePtr->valueType()->kind();
   const auto& keyList = ::duckdb::ListValue::GetChildren(mapValue[0]);
   const auto& valueList = ::duckdb::ListValue::GetChildren(mapValue[1]);
-  VELOX_CHECK(keyList.size() == valueList.size());
+  VELOX_CHECK_EQ(keyList.size(), valueList.size());
   for (int i = 0; i < keyList.size(); i++) {
     auto variantKey =
         VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(variantAt, keyType, keyList[i]);

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -233,37 +233,37 @@ velox::variant mapVariantAt(
 }
 
 std::vector<MaterializedRow> materialize(
-        ::duckdb::DataChunk* dataChunk,
-        const std::shared_ptr<const RowType>& rowType) {
-    EXPECT_EQ(rowType->size(), dataChunk->GetTypes().size())
-                        << "Wrong number of columns";
+    ::duckdb::DataChunk* dataChunk,
+    const std::shared_ptr<const RowType>& rowType) {
+  EXPECT_EQ(rowType->size(), dataChunk->GetTypes().size())
+      << "Wrong number of columns";
 
-    auto size = dataChunk->size();
-    std::vector<MaterializedRow> rows;
-    rows.reserve(size);
+  auto size = dataChunk->size();
+  std::vector<MaterializedRow> rows;
+  rows.reserve(size);
 
-    for (size_t i = 0; i < size; ++i) {
-        MaterializedRow row;
-        row.reserve(rowType->size());
-        for (size_t j = 0; j < rowType->size(); ++j) {
-            auto typeKind = rowType->childAt(j)->kind();
-            if (dataChunk->GetValue(j, i).IsNull()) {
-                row.push_back(variant(typeKind));
-            } else if (typeKind == TypeKind::MAP) {
-                row.push_back(
-                        mapVariantAt(dataChunk->GetValue(j, i), rowType->childAt(j)));
-            } else if (typeKind == TypeKind::ROW) {
-                row.push_back(
-                        rowVariantAt(dataChunk->GetValue(j, i), rowType->childAt(j)));
-            } else {
-                auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-                        variantAt, typeKind, dataChunk, i, j);
-                row.push_back(value);
-            }
-        }
-        rows.push_back(row);
+  for (size_t i = 0; i < size; ++i) {
+    MaterializedRow row;
+    row.reserve(rowType->size());
+    for (size_t j = 0; j < rowType->size(); ++j) {
+      auto typeKind = rowType->childAt(j)->kind();
+      if (dataChunk->GetValue(j, i).IsNull()) {
+        row.push_back(variant(typeKind));
+      } else if (typeKind == TypeKind::MAP) {
+        row.push_back(
+            mapVariantAt(dataChunk->GetValue(j, i), rowType->childAt(j)));
+      } else if (typeKind == TypeKind::ROW) {
+        row.push_back(
+            rowVariantAt(dataChunk->GetValue(j, i), rowType->childAt(j)));
+      } else {
+        auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            variantAt, typeKind, dataChunk, i, j);
+        row.push_back(value);
+      }
     }
-    return rows;
+    rows.push_back(row);
+  }
+  return rows;
 }
 
 template <TypeKind kind>


### PR DESCRIPTION
This allows us to write tests for MAP columns in Velox Operator
testing.