### PR TITLE
Reduce usage of DriverCtx::execCtx

### DIFF
--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -28,8 +28,7 @@ CrossJoinProbe::CrossJoinProbe(
           operatorId,
           joinNode->id(),
           "CrossJoinProbe"),
-      outputBatchSize_{
-          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()} {
+      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()} {
   bool isIdentityProjection = true;
 
   auto probeType = joinNode->sources()[0]->outputType();

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -74,6 +74,10 @@ DriverCtx::DriverCtx(
       splitGroupId(_splitGroupId),
       partitionId(_partitionId) {}
 
+const core::QueryConfig& DriverCtx::queryConfig() const {
+  return task->queryCtx()->config();
+}
+
 velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
   return task->addOperatorPool(execCtx->pool());
 }

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -178,6 +178,8 @@ struct DriverCtx {
       uint32_t _splitGroupId,
       uint32_t _partitionId);
 
+  const core::QueryConfig& queryConfig() const;
+
   velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool();
 
   // Makes an extract of QueryCtx for use in a connector. 'planNodeId'

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -31,12 +31,9 @@ HashAggregation::HashAggregation(
           aggregationNode->step() == core::AggregationNode::Step::kPartial
               ? "PartialAggregation"
               : "Aggregation"),
-      outputBatchSize_{
-          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()},
+      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
       maxPartialAggregationMemoryUsage_(
-          driverCtx->execCtx->queryCtx()
-              ->config()
-              .maxPartialAggregationMemoryUsage()),
+          driverCtx->queryConfig().maxPartialAggregationMemoryUsage()),
       isPartialOutput_(isPartialOutput(aggregationNode->step())),
       isDistinct_(aggregationNode->aggregates().empty()),
       isGlobal_(aggregationNode->groupingKeys().empty()),

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -60,8 +60,7 @@ HashProbe::HashProbe(
           operatorId,
           joinNode->id(),
           "HashProbe"),
-      outputBatchSize_{
-          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()},
+      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
       joinType_{joinNode->joinType()},
       filterResult_(1),
       outputRows_(outputBatchSize_) {

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -30,8 +30,7 @@ MergeJoin::MergeJoin(
           operatorId,
           joinNode->id(),
           "MergeJoin"),
-      outputBatchSize_{
-          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()},
+      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
       joinType_{joinNode->joinType()},
       numKeys_{joinNode->leftKeys().size()} {
   VELOX_USER_CHECK(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -168,10 +168,6 @@ class OperatorCtx {
     return driverCtx_->execCtx.get();
   }
 
-  core::QueryCtx* queryCtx() const {
-    return driverCtx_->execCtx->queryCtx();
-  }
-
   Driver* driver() const {
     return driverCtx_->driver;
   }

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -31,8 +31,7 @@ StreamingAggregation::StreamingAggregation(
           aggregationNode->step() == core::AggregationNode::Step::kPartial
               ? "PartialAggregation"
               : "Aggregation"),
-      outputBatchSize_{
-          driverCtx->execCtx->queryCtx()->config().preferredOutputBatchSize()},
+      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
       step_{aggregationNode->step()} {
   auto numKeys = aggregationNode->groupingKeys().size();
   decodedKeys_.resize(numKeys);


### PR DESCRIPTION
FilterProject operator uses ExecCtx from the Driver for expression evaluation.
This means that memory usage that happens during expression evaluation is
tracked in the Driver's memory pool and is not being attributed to the
operator. To fix this, we'll remove ExecCtx from the Driver and have each
operator create its own using operator's memory pool. This is a preparation
step to reduce usage of DriverCtx::execCtx.

Introduce DriverCtx::queryConfig and replace driverCtx->execCtx->queryCtx
()->config() calls with driverCtx->queryConfig().