### PR TITLE
De-flake LocalFile::viaRegistry test

### DIFF
--- a/velox/common/file/FileTest.cpp
+++ b/velox/common/file/FileTest.cpp
@@ -94,7 +94,8 @@ TEST(LocalFile, writeAndRead) {
 
 TEST(LocalFile, viaRegistry) {
   filesystems::registerLocalFileSystem();
-  const char filename[] = "/tmp/test";
+  auto tempFile = ::exec::test::TempFilePath::create();
+  const auto& filename = tempFile->path.c_str();
   remove(filename);
   auto lfs = filesystems::getFileSystem(filename, nullptr);
   {


### PR DESCRIPTION
Use unique file path in each test run to avoid collisions when multiple
instances of the test run concurrently.