### PR TITLE
Move execCtx from Driver to Operator

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -158,9 +158,6 @@ class BlockingState {
 };
 
 struct DriverCtx {
-  std::shared_ptr<Task> task;
-  std::unique_ptr<core::ExecCtx> execCtx;
-  std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator;
   const int driverId;
   const int pipelineId;
   /// Id of the split group this driver should process in case of grouped
@@ -169,6 +166,9 @@ struct DriverCtx {
   /// Id of the partition to use by this driver. For local exchange, for
   /// instance.
   const uint32_t partitionId;
+
+  std::shared_ptr<Task> task;
+  memory::MemoryPool* FOLLY_NONNULL pool;
   Driver* FOLLY_NONNULL driver;
 
   explicit DriverCtx(
@@ -181,13 +181,6 @@ struct DriverCtx {
   const core::QueryConfig& queryConfig() const;
 
   velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool();
-
-  // Makes an extract of QueryCtx for use in a connector. 'planNodeId'
-  // is the id of the calling TableScan. This and the task id identify
-  // the scan for column access tracking.
-  std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
-      const std::string& connectorId,
-      const std::string& planNodeId) const;
 };
 
 class Driver {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -152,21 +152,11 @@ class OperatorCtx {
  public:
   explicit OperatorCtx(DriverCtx* driverCtx);
 
-  velox::memory::MemoryPool* pool() const {
-    return pool_;
-  }
-
-  memory::MappedMemory* mappedMemory() const;
-
   const std::shared_ptr<Task>& task() const {
     return driverCtx_->task;
   }
 
   const std::string& taskId() const;
-
-  core::ExecCtx* execCtx() const {
-    return driverCtx_->execCtx.get();
-  }
 
   Driver* driver() const {
     return driverCtx_->driver;
@@ -176,12 +166,29 @@ class OperatorCtx {
     return driverCtx_;
   }
 
+  velox::memory::MemoryPool* pool() const {
+    return pool_;
+  }
+
+  memory::MappedMemory* mappedMemory() const;
+
+  core::ExecCtx* execCtx() const;
+
+  // Makes an extract of QueryCtx for use in a connector. 'planNodeId'
+  // is the id of the calling TableScan. This and the task id identify
+  // the scan for column access tracking.
+  std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
+      const std::string& connectorId,
+      const std::string& planNodeId) const;
+
  private:
   DriverCtx* driverCtx_;
   velox::memory::MemoryPool* pool_;
 
   // These members are created on demand.
   mutable memory::MappedMemory* mappedMemory_{nullptr};
+  mutable std::unique_ptr<core::ExecCtx> execCtx_;
+  mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };
 
 // Query operator

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -68,7 +68,7 @@ RowVectorPtr TableScan::getOutput() {
 
       if (!connector_) {
         connector_ = connector::getConnector(connectorSplit->connectorId);
-        connectorQueryCtx_ = driverCtx_->createConnectorQueryCtx(
+        connectorQueryCtx_ = operatorCtx_->createConnectorQueryCtx(
             connectorSplit->connectorId, planNodeId_);
         dataSource_ = connector_->createDataSource(
             outputType_,

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -42,7 +42,7 @@ TableWriter::TableWriter(
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
   connector_ = connector::getConnector(connectorId);
   connectorQueryCtx_ =
-      driverCtx_->createConnectorQueryCtx(connectorId, stats_.planNodeId);
+      operatorCtx_->createConnectorQueryCtx(connectorId, stats_.planNodeId);
 
   auto names = tableWriteNode->columnNames();
   auto types = tableWriteNode->columns()->children();


### PR DESCRIPTION
FilterProject operator uses ExecCtx from the Driver for expression evaluation.
This means that memory usage that happens during expression evaluation is
tracked in the Driver's memory pool and is not being attributed to the
operator. To fix this, we move ExecCtx to the Operator and use operator's 
memory pool to create it.