### PR TITLE
Fix aggregation pushdown

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "velox/common/serialization/Registry.h"
 #include "velox/core/PlanNode.h"
 #include "velox/vector/BaseVector.h"
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -198,7 +198,7 @@ void GroupingSet::addInputForActiveRows(
     // TODO(spershin): We disable the pushdown at the moment if selectivity
     // vector has changed after groups generation, we might want to revisit
     // this.
-    const bool canPushdown = (&rows != &activeRows_) && mayPushdown &&
+    const bool canPushdown = (&rows == &activeRows_) && mayPushdown &&
         mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
     populateTempVectors(i, input);
     if (isRawInput_) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1685,6 +1685,16 @@ TEST_P(TableScanTest, aggregationPushdown) {
            .planNode();
   assertQuery(
       op, {filePath}, "SELECT c5, min(c0), max(c0 + c1) FROM tmp GROUP BY 1");
+
+  op = PlanBuilder()
+           .tableScan(rowType_, tableHandle, assignments)
+           .project({"c5", "c0 + 1 as a", "c1 + 2 as b", "c2 + 3 as c"})
+           .singleAggregation({0}, {"min(a)", "max(b)", "sum(c)"})
+           .planNode();
+  assertQuery(
+      op,
+      {filePath},
+      "SELECT c5, min(c0 + 1), max(c1 + 2), sum(c2 + 3) FROM tmp GROUP BY 1");
 }
 
 TEST_P(TableScanTest, bitwiseAggregationPushdown) {

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -105,7 +105,8 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    if (mayPushdown && std::is_same<T, ResultType>::value) {
+    if (mayPushdown && args[0]->isLazy() &&
+        std::is_same<T, ResultType>::value) {
       BaseAggregate::template pushdown<MinMaxHook<T, false>>(
           groups, rows, args[0]);
       return;
@@ -179,7 +180,8 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    if (mayPushdown && std::is_same<T, ResultType>::value) {
+    if (mayPushdown && args[0]->isLazy() &&
+        std::is_same<T, ResultType>::value) {
       BaseAggregate::template pushdown<MinMaxHook<T, true>>(
           groups, rows, args[0]);
       return;

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -115,7 +115,7 @@ class SumAggregate
       bool mayPushdown) {
     const auto& arg = args[0];
 
-    if (mayPushdown) {
+    if (mayPushdown && arg->isLazy()) {
       BaseAggregate::template pushdown<SumHook<TInput, TData>>(
           groups, rows, arg);
       return;


### PR DESCRIPTION
Aggregations with selective masks over expressions were failing because

(1) pushdown was enabled only for aggregations with selective masks; 
(2) pushdown path didn't check if aggregation input is Lazy.