### PR TITLE
Optimize deserialization of arrays of fixed-width elements

### DIFF
--- a/velox/row/UnsafeRow24Deserializer.h
+++ b/velox/row/UnsafeRow24Deserializer.h
@@ -31,9 +31,10 @@ class UnsafeRow24Deserializer {
 
   static std::unique_ptr<UnsafeRow24Deserializer> Create(RowTypePtr rowType);
 
+  // We are allowed to mutate `rows`.
   virtual RowVectorPtr DeserializeRows(
       memory::MemoryPool* pool,
-      const std::vector<std::string_view>& rows) = 0;
+      const std::vector<const char*>& rows) = 0;
 
  protected:
   UnsafeRow24Deserializer() = default;

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -51,13 +51,16 @@ struct UnsafeRowLegacyWrapper {
 
 struct UnsafeRow24Wrapper {
   static VectorPtr Deserialize(
-      const std::vector<std::string_view>& s,
+      const std::vector<std::string_view>& rows,
       TypePtr type,
       memory::MemoryPool* pool) {
     VELOX_CHECK(type->isRow());
+    std::vector<const char*> row_data;
+    for (std::string_view row : rows)
+      row_data.push_back(row.data());
     return UnsafeRow24Deserializer::Create(
                std::dynamic_pointer_cast<const RowType>(type))
-        ->DeserializeRows(pool, {s});
+        ->DeserializeRows(pool, row_data);
   }
 };
 


### PR DESCRIPTION
Summary:
This diff adds fast-paths for arrays of fixed-width types (`DeserializeFixedWidthArrayElements`). `DeserializeArray` now has a type switch that dispatches to this function. `arrayElementStride` is kept for now because it is used by `DeserializeMap`, but the next diff rewrites `DeserializeMap` by re-using `DeserializeArray`.

The logic in `DeserializeFixedWidthArrayElements` to calculate the pointer to the next element would be drastically simpler if it could be written in coroutine style. Unfortunately that is not possible.

DeserializeArray is getting a little long at ~60 lines, but it's within reason.

Reviewed By: miaoever

Differential Revision: D34804831

