### PR TITLE
Re-use array deserialization optimizations in map deserializer

### DIFF
--- a/velox/row/UnsafeRow24Deserializer.h
+++ b/velox/row/UnsafeRow24Deserializer.h
@@ -31,9 +31,10 @@ class UnsafeRow24Deserializer {
 
   static std::unique_ptr<UnsafeRow24Deserializer> Create(RowTypePtr rowType);
 
+  // We are allowed to mutate `rows`.
   virtual RowVectorPtr DeserializeRows(
       memory::MemoryPool* pool,
-      const std::vector<std::string_view>& rows) = 0;
+      const std::vector<const char*>& rows) = 0;
 
  protected:
   UnsafeRow24Deserializer() = default;

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -51,13 +51,16 @@ struct UnsafeRowLegacyWrapper {
 
 struct UnsafeRow24Wrapper {
   static VectorPtr Deserialize(
-      const std::vector<std::string_view>& s,
+      const std::vector<std::string_view>& rows,
       TypePtr type,
       memory::MemoryPool* pool) {
     VELOX_CHECK(type->isRow());
+    std::vector<const char*> row_data;
+    for (std::string_view row : rows)
+      row_data.push_back(row.data());
     return UnsafeRow24Deserializer::Create(
                std::dynamic_pointer_cast<const RowType>(type))
-        ->DeserializeRows(pool, {s});
+        ->DeserializeRows(pool, row_data);
   }
 };
 


### PR DESCRIPTION
Summary:
This improves performance while reducing the amount of total code. We do end up
doing some redundant calculations for offsets+sizes, but it's probably not a
major issue. A future optimization for arrays of strings will now automatically
benefit maps.

Reviewed By: miaoever

Differential Revision: D34805537

