### PR TITLE
Support `CAST(... AS JSON)` from complex types with JSON elements

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -456,6 +456,12 @@ void applyCustomTypeCast(
     const TypePtr& otherType,
     exec::EvalCtx* context,
     VectorPtr* result) {
+  VELOX_CHECK_NE(
+      thisType,
+      otherType,
+      "Attempting to cast from {} to itself.",
+      thisType->toString());
+
   LocalDecodedVector inputDecoded(context, *input, allRows);
 
   exec::LocalSelectivityVector baseRows(

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -307,13 +307,14 @@ class VectorTestBase {
   //   EXPECT_EQ(3, arrayVector->size());
   template <typename T>
   ArrayVectorPtr makeNullableArrayVector(
-      const std::vector<std::vector<std::optional<T>>>& data) {
+      const std::vector<std::vector<std::optional<T>>>& data,
+      const TypePtr& type = ARRAY(CppToType<T>::create())) {
     std::vector<std::optional<std::vector<std::optional<T>>>> convData;
     convData.reserve(data.size());
     for (auto& array : data) {
       convData.push_back(array);
     }
-    return vectorMaker_.arrayVectorNullable<T>(convData);
+    return vectorMaker_.arrayVectorNullable<T>(convData, type);
   }
 
   template <typename T>
@@ -369,16 +370,20 @@ class VectorTestBase {
       std::function<TKey(vector_size_t /* idx */)> keyAt,
       std::function<TValue(vector_size_t /* idx */)> valueAt,
       std::function<bool(vector_size_t /*row */)> isNullAt = nullptr,
-      std::function<bool(vector_size_t /*row */)> valueIsNullAt = nullptr) {
+      std::function<bool(vector_size_t /*row */)> valueIsNullAt = nullptr,
+      const TypePtr& type =
+          MAP(CppToType<TKey>::create(), CppToType<TValue>::create())) {
     return vectorMaker_.mapVector<TKey, TValue>(
-        size, sizeAt, keyAt, valueAt, isNullAt, valueIsNullAt);
+        size, sizeAt, keyAt, valueAt, isNullAt, valueIsNullAt, type);
   }
 
   // Create map vector from nested std::vector representation.
   template <typename TKey, typename TValue>
   MapVectorPtr makeMapVector(
       const std::vector<std::vector<std::pair<TKey, std::optional<TValue>>>>&
-          maps) {
+          maps,
+      const TypePtr& type =
+          MAP(CppToType<TKey>::create(), CppToType<TValue>::create())) {
     std::vector<vector_size_t> lengths;
     std::vector<TKey> keys;
     std::vector<TValue> values;
@@ -400,7 +405,8 @@ class VectorTestBase {
         [&](vector_size_t idx) { return keys[idx]; },
         [&](vector_size_t idx) { return values[idx]; },
         nullptr,
-        [&](vector_size_t idx) { return nullValues[idx]; });
+        [&](vector_size_t idx) { return nullValues[idx]; },
+        type);
   }
 
   template <typename T>


### PR DESCRIPTION
Summary: When the element type of a complex-type vector is Json, the generation of the element json strings is a no-op. VectorMaker and VectorTestBase are extended to allow indicating the vector type for tests. (Without this extension, they create vector of Varchar instead of Json type.)

Differential Revision: D34810304

