### PR TITLE
Enable more aggregation pushdown into scan

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -26,7 +26,10 @@ bool checkAddIdentityProjection(
     std::vector<IdentityProjection>& identityProjections) {
   if (auto field = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
           projection)) {
-    if (field->inputs().empty()) {
+    const auto& inputs = field->inputs();
+    if (inputs.empty() ||
+        (inputs.size() == 1 &&
+         dynamic_cast<const core::InputTypedExpr*>(inputs[0].get()))) {
       const auto inputChannel = inputType->getChildIdx(field->name());
       identityProjections.emplace_back(inputChannel, outputChannel);
       return true;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -195,12 +195,12 @@ void GroupingSet::addInputForActiveRows(
   masks_.addInput(input, activeRows_);
   for (auto i = 0; i < aggregates_.size(); ++i) {
     const auto& rows = getSelectivityVector(i);
+    populateTempVectors(i, input);
     // TODO(spershin): We disable the pushdown at the moment if selectivity
     // vector has changed after groups generation, we might want to revisit
     // this.
     const bool canPushdown = (&rows == &activeRows_) && mayPushdown &&
         mayPushdown_[i] && areAllLazyNotLoaded(tempVectors_);
-    populateTempVectors(i, input);
     if (isRawInput_) {
       aggregates_[i]->addRawInput(
           lookup_->hits.data(), rows, tempVectors_, canPushdown);

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -41,6 +41,15 @@ void VectorLoader::load(RowSet rows, ValueHook* hook, VectorPtr* result) {
   const auto ioTimeStartMicros = getCurrentTimeMicro();
   loadInternal(rows, hook, result);
   writeIOWallTimeStat(ioTimeStartMicros);
+
+  if (hook) {
+    // Record number of rows loaded directly into ValueHook bypassing
+    // materialization into vector. This counter can be used to understand
+    // whether aggregation pushdown is happening or not.
+    if (auto* pWriter = sRunTimeStatWriters.get()) {
+      pWriter->addRuntimeStat("loadedToValueHook", rows.size());
+    }
+  }
 }
 
 void VectorLoader::load(


### PR DESCRIPTION
Add runtime statistic "loadedToValueHook" to track number of values processed
via aggregation pushdown into scan. This value contains total number of values,
not rows, e.g. if we have 2 aggregates using pushdown for 10 rows each,
loadedToValueHook will be 10 + 10 = 29. This statistics is reported by the
LazyVector::load() method when it is called with non-null ValueHook.

Use the new statistic to verify pushdown in TableScanTest.aggregationPushdown.
These checks showed that aggregation pushdown is not enabled when it should be.
Hence, a couple more fixes.

Fix check for identity projections in FilterProject operator to identify these
more reliably. This allows pushdown for queries like SELECT f(a), sum(b) FROM t
GROUP BY 1.

Fix can-pushdown check in GroupingSet to use the correct set of aggregation
inputs. This check was consistently producing 'false' for non-first aggregates.
This allows pushdown for all aggregates in queries like SELECT a, sum(b), sum
(c), min(d) FROM t GROUP BY 1.

Remaining TODOs for follow-up PRs:

- Enable pushdown for global aggregations.
- Fix runtime statistics reporting in LazyVector. As of now, aggregation
  pushdown statistics reported by LazyVector are added to the first operator
  upstream of aggregation. In some queries it is TableScan, while in others it
  is FilterProject. 