### PR TITLE
Add raw input stats to PlanNodeStats

### DIFF
--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -36,6 +36,9 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   inputRows += stats.inputPositions;
   inputBytes += stats.inputBytes;
 
+  rawInputRows += stats.rawInputPositions;
+  rawInputBytes += stats.rawInputBytes;
+
   outputRows += stats.outputPositions;
   outputBytes += stats.outputBytes;
 
@@ -51,8 +54,11 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
 std::string PlanNodeStats::toString(bool includeInputStats) const {
   std::stringstream out;
   if (includeInputStats) {
-    out << "Input: " << inputRows << " rows (" << inputBytes << " bytes"
-        << "), ";
+    out << "Input: " << inputRows << " rows (" << inputBytes << " bytes), ";
+    if (rawInputRows != inputRows) {
+      out << "Raw Input: " << rawInputRows << " rows (" << rawInputBytes
+          << " bytes), ";
+    }
   }
   out << "Output: " << outputRows << " rows (" << outputBytes << " bytes)"
       << ", Cpu time: " << cpuWallTiming.cpuNanos << "ns"

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -51,6 +51,14 @@ struct PlanNodeStats {
   /// Sum of input bytes for all corresponding operators.
   uint64_t inputBytes{0};
 
+  /// Sum of raw input rows for all corresponding operators. Applies primarily
+  /// to TableScan operator which reports rows before pushed down filter as raw
+  /// input.
+  vector_size_t rawInputRows{0};
+
+  /// Sum of raw input bytes for all corresponding operators.
+  uint64_t rawInputBytes{0};
+
   /// Sum of output rows for all corresponding operators. When
   /// plan node corresponds to multiple operator types, operators of only one of
   /// these types report non-zero output rows.


### PR DESCRIPTION
Raw input rows and bytes for TableScan operator reports number of rows before
pushed down filter. Add these stats to PlanNodeStats and use them in
TableScanTest. 

The new output of printPlanWithStats:

```
-> TableScan[]
   Input: 2370 rows (41280 bytes), Raw Input: 10000 rows (99210 bytes), Output: 2370 rows (41280 bytes), Cpu time: 10598826ns, Blocked wall time: 72000ns, Peak memory: 1048576 bytes
```