### PR TITLE
getdeps optionally can get hg info from env var (#1011)

### DIFF
--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -525,12 +525,15 @@ def get_fbsource_repo_data(build_options) -> FbsourceRepoData:
     if cached_data:
         return cached_data
 
-    cmd = ["hg", "log", "-r.", "-T{node}\n{date|hgdate}"]
-    env = Env()
-    env.set("HGPLAIN", "1")
-    log_data = subprocess.check_output(
-        cmd, cwd=build_options.fbsource_dir, env=dict(env.items())
-    ).decode("ascii")
+    if "GETDEPS_HG_REPO_DATA" in os.environ:
+        log_data = os.environ["GETDEPS_HG_REPO_DATA"]
+    else:
+        cmd = ["hg", "log", "-r.", "-T{node}\n{date|hgdate}"]
+        env = Env()
+        env.set("HGPLAIN", "1")
+        log_data = subprocess.check_output(
+            cmd, cwd=build_options.fbsource_dir, env=dict(env.items())
+        ).decode("ascii")
 
     (hash, datestr) = log_data.split("\n")
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/watchman/pull/1011

X-link: https://github.com/facebook/wangle/pull/205

X-link: https://github.com/facebook/proxygen/pull/401

X-link: https://github.com/facebook/openr/pull/129

X-link: https://github.com/facebook/fbzmq/pull/35

X-link: https://github.com/facebook/fb303/pull/26

X-link: https://github.com/facebook/bistro/pull/59

X-link: https://github.com/facebook/folly/pull/1734

X-link: https://github.com/facebook/fboss/pull/113

Adds an environment variable to getdeps to provide `hg` info to avoid calling `hg` directly.

When using `getdeps` inside a containerized environment (which we need to build Research Super Cluster tooling with the correct linker attributes), `getdeps` fails because of unregistered mercurial extensions in the `hgrc`.

This allows `getdeps` to be useable in an environment where the mercurial extensions used in a project aren't installed/available.

Reviewed By: vivekspai

Differential Revision: D34732506

