### PR TITLE
Use smaller micro batch sizes in trabant writers

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -167,5 +167,5 @@ Config::Entry<bool> Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED(
 
 Config::Entry<uint64_t> Config::RAW_DATA_SIZE_PER_BATCH(
     "hive.exec.orc.raw.data.size.per.batch",
-    50 * 1000 * 1000);
+    50UL * 1024 * 1024);
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
Summary: Make writers use smaller micro batches to write to increase granularity of memory footprint increment.

Differential Revision: D34160643

