### PR TITLE
Fix code in the test that waits for Task to finish.

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -684,13 +684,14 @@ std::shared_ptr<Task> assertQuery(
   }
   auto task = cursor->task();
 
-  if (!task->isFinished()) {
+  if (not task->isFinished()) {
     // The Task can return results before the Driver is finished executing.
     // Wait for the Task to finish before returning it to ensure it's stable
     // e.g. the Driver isn't updating it anymore.
     auto& executor = folly::QueuedImmediateExecutor::instance();
-    auto future = task->finishFuture().via(&executor);
+    auto future = task->stateChangeFuture(1'000'000).via(&executor);
     future.wait();
+    EXPECT_TRUE(task->isFinished());
   }
 
   return task;


### PR DESCRIPTION
Summary:
Fix code in the test that waits for Task to finish.
Before that the existing wait for Task to finish was not exactly what we wanted.

Differential Revision: D34804719

