### PR TITLE
Change PlanBuilder::orderBy to accept ORDER BY SQL clauses

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/common/base/Exceptions.h"
-#include "velox/core/Expressions.h"
+#include "velox/core/PlanNode.h"
 #include "velox/duckdb/conversion/DuckConversion.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/external/duckdb/duckdb.hpp"
@@ -403,6 +403,63 @@ std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString) {
   }
 
   return parseExpr(*parsedExpressions.front());
+}
+
+namespace {
+bool isAscending(::duckdb::OrderType orderType, const std::string& exprString) {
+  switch (orderType) {
+    case ::duckdb::OrderType::ASCENDING:
+      return true;
+    case ::duckdb::OrderType::DESCENDING:
+      return false;
+    case ::duckdb::OrderType::ORDER_DEFAULT:
+      // ASC is the default.
+      return true;
+    case ::duckdb::OrderType::INVALID:
+    default:
+      VELOX_FAIL("Cannot parse ORDER BY clause: {}", exprString)
+  }
+}
+
+bool isNullsFirst(
+    ::duckdb::OrderByNullType orderByNullType,
+    const std::string& exprString) {
+  switch (orderByNullType) {
+    case ::duckdb::OrderByNullType::NULLS_FIRST:
+      return true;
+    case ::duckdb::OrderByNullType::NULLS_LAST:
+      return false;
+    case ::duckdb::OrderByNullType::ORDER_DEFAULT:
+      // NULLS LAST is the default.
+      return false;
+    case ::duckdb::OrderByNullType::INVALID:
+    default:
+      VELOX_FAIL("Cannot parse ORDER BY clause: {}", exprString)
+  }
+
+  VELOX_UNREACHABLE();
+}
+} // namespace
+
+std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+    const std::string& exprString) {
+  ParserOptions options;
+  options.preserve_identifier_case = false;
+  auto orderByNodes = Parser::ParseOrderList(exprString, options);
+  if (orderByNodes.size() != 1) {
+    throw std::invalid_argument(folly::sformat(
+        "Expecting exactly one input expression, found {}.",
+        orderByNodes.size()));
+  }
+
+  const auto& orderByNode = orderByNodes[0];
+
+  const bool ascending = isAscending(orderByNode.type, exprString);
+  const bool nullsFirst = isNullsFirst(orderByNode.null_order, exprString);
+
+  return {
+      parseExpr(*orderByNode.expression),
+      core::SortOrder(ascending, nullsFirst)};
 }
 
 } // namespace facebook::velox::duckdb

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -20,6 +20,7 @@
 
 namespace facebook::velox::core {
 class IExpr;
+class SortOrder;
 } // namespace facebook::velox::core
 
 namespace facebook::velox::duckdb {
@@ -32,5 +33,11 @@ namespace facebook::velox::duckdb {
 // containing upper case letters (e.g: "concatRow" will be parsed as
 // "concatrow").
 std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString);
+
+// Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
+// converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC
+// NULLS LAST as the default sort order.
+std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+    const std::string& exprString);
 
 } // namespace facebook::velox::duckdb

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/duckdb/conversion/DuckParser.h"
 #include <gtest/gtest.h>
+#include "velox/core/PlanNode.h"
 #include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
@@ -295,4 +296,24 @@ TEST(DuckParserTest, like) {
   EXPECT_EQ(
       "like(\"name\",\"%#_%\",\"#\")",
       parseExpr("name LIKE '%#_%' ESCAPE '#'")->toString());
+}
+
+TEST(DuckParserTest, orderBy) {
+  auto parse = [](const auto& expr) {
+    auto orderBy = parseOrderByExpr(expr);
+    return fmt::format(
+        "{} {}", orderBy.first->toString(), orderBy.second.toString());
+  };
+
+  EXPECT_EQ("\"c1\" ASC NULLS LAST", parse("c1"));
+  EXPECT_EQ("\"c1\" ASC NULLS LAST", parse("c1 ASC"));
+  EXPECT_EQ("\"c1\" DESC NULLS LAST", parse("c1 DESC"));
+
+  EXPECT_EQ("\"c1\" ASC NULLS FIRST", parse("c1 NULLS FIRST"));
+  EXPECT_EQ("\"c1\" ASC NULLS LAST", parse("c1 NULLS LAST"));
+
+  EXPECT_EQ("\"c1\" ASC NULLS FIRST", parse("c1 ASC NULLS FIRST"));
+  EXPECT_EQ("\"c1\" ASC NULLS LAST", parse("c1 ASC NULLS LAST"));
+  EXPECT_EQ("\"c1\" DESC NULLS FIRST", parse("c1 DESC NULLS FIRST"));
+  EXPECT_EQ("\"c1\" DESC NULLS LAST", parse("c1 DESC NULLS LAST"));
 }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -307,7 +307,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
                                    {kAscNullsLast},
                                    {PlanBuilder(planNodeIdGenerator)
                                         .tableScan(rowType_)
-                                        .orderBy({0}, {kAscNullsLast}, true)
+                                        .orderBy({"c0"}, true)
                                         .planNode()})
                                .partitionedOutput({}, 1)
                                .planNode();

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -28,7 +28,7 @@ class OrderByTest : public OperatorTestBase {
     auto keyIndex = input[0]->type()->asRow().getChildIdx(key);
     auto plan = PlanBuilder()
                     .values(input)
-                    .orderBy({keyIndex}, {core::kAscNullsLast}, false)
+                    .orderBy({fmt::format("{} ASC NULLS LAST", key)}, false)
                     .planNode();
 
     assertQueryOrdered(
@@ -38,7 +38,7 @@ class OrderByTest : public OperatorTestBase {
 
     plan = PlanBuilder()
                .values(input)
-               .orderBy({keyIndex}, {core::kDescNullsFirst}, false)
+               .orderBy({fmt::format("{} DESC NULLS FIRST", key)}, false)
                .planNode();
 
     assertQueryOrdered(
@@ -55,7 +55,7 @@ class OrderByTest : public OperatorTestBase {
     auto plan = PlanBuilder()
                     .values(input)
                     .filter(filter)
-                    .orderBy({keyIndex}, {core::kAscNullsLast}, false)
+                    .orderBy({fmt::format("{} ASC NULLS LAST", key)}, false)
                     .planNode();
 
     assertQueryOrdered(
@@ -67,7 +67,7 @@ class OrderByTest : public OperatorTestBase {
     plan = PlanBuilder()
                .values(input)
                .filter(filter)
-               .orderBy({keyIndex}, {core::kDescNullsFirst}, false)
+               .orderBy({fmt::format("{} DESC NULLS FIRST", key)}, false)
                .planNode();
 
     assertQueryOrdered(
@@ -92,11 +92,13 @@ class OrderByTest : public OperatorTestBase {
 
     for (int i = 0; i < sortOrders.size(); i++) {
       for (int j = 0; j < sortOrders.size(); j++) {
-        auto plan =
-            PlanBuilder()
-                .values(input)
-                .orderBy(keyIndices, {sortOrders[i], sortOrders[j]}, false)
-                .planNode();
+        auto plan = PlanBuilder()
+                        .values(input)
+                        .orderBy(
+                            {fmt::format("{} {}", key1, sortOrderSqls[i]),
+                             fmt::format("{} {}", key2, sortOrderSqls[j])},
+                            false)
+                        .planNode();
 
         assertQueryOrdered(
             plan,
@@ -154,7 +156,7 @@ TEST_F(OrderByTest, singleKey) {
 
   auto plan = PlanBuilder()
                   .values(vectors)
-                  .orderBy({0}, {core::kDescNullsLast}, false)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
                   .planNode();
 
   assertQueryOrdered(
@@ -162,7 +164,7 @@ TEST_F(OrderByTest, singleKey) {
 
   plan = PlanBuilder()
              .values(vectors)
-             .orderBy({0}, {core::kAscNullsFirst}, false)
+             .orderBy({"c0 ASC NULLS FIRST"}, false)
              .planNode();
 
   assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST", {0});
@@ -185,20 +187,18 @@ TEST_F(OrderByTest, multipleKeys) {
 
   testTwoKeys(vectors, "c0", "c1");
 
-  auto plan =
-      PlanBuilder()
-          .values(vectors)
-          .orderBy({0, 1}, {core::kAscNullsFirst, core::kAscNullsLast}, false)
-          .planNode();
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, false)
+                  .planNode();
 
   assertQueryOrdered(
       plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST", {0, 1});
 
-  plan =
-      PlanBuilder()
-          .values(vectors)
-          .orderBy({0, 1}, {core::kDescNullsLast, core::kDescNullsFirst}, false)
-          .planNode();
+  plan = PlanBuilder()
+             .values(vectors)
+             .orderBy({"c0 DESC NULLS LAST", "c1 DESC NULLS FIRST"}, false)
+             .planNode();
 
   assertQueryOrdered(
       plan,
@@ -258,7 +258,7 @@ TEST_F(OrderByTest, unknown) {
 
   auto plan = PlanBuilder()
                   .values({vector})
-                  .orderBy({0}, {core::kDescNullsLast}, false)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
                   .planNode();
 
   assertQueryOrdered(

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -263,18 +263,17 @@ TEST_F(PlanNodeToStringTest, crossJoin) {
 TEST_F(PlanNodeToStringTest, orderBy) {
   auto plan = PlanBuilder()
                   .values({data_})
-                  .orderBy({1}, {core::kAscNullsFirst}, true)
+                  .orderBy({"c1 ASC NULLS FIRST"}, true)
                   .planNode();
 
   ASSERT_EQ("-> OrderBy\n", plan->toString());
   ASSERT_EQ(
       "-> OrderBy[PARTIAL c1 ASC NULLS FIRST]\n", plan->toString(true, false));
 
-  plan =
-      PlanBuilder()
-          .values({data_})
-          .orderBy({1, 0}, {core::kAscNullsFirst, core::kDescNullsLast}, false)
-          .planNode();
+  plan = PlanBuilder()
+             .values({data_})
+             .orderBy({"c1 ASC NULLS FIRST", "c0 DESC NULLS LAST"}, false)
+             .planNode();
 
   ASSERT_EQ("-> OrderBy\n", plan->toString());
   ASSERT_EQ(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -18,9 +18,9 @@
 #include <velox/exec/Aggregate.h>
 #include <velox/exec/HashPartitionFunction.h>
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/parse/Expressions.h"
-#include "velox/parse/ExpressionsParser.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
@@ -33,7 +33,7 @@ std::shared_ptr<const core::ITypedExpr> parseExpr(
     const std::string& text,
     RowTypePtr rowType,
     memory::MemoryPool* pool) {
-  auto untyped = parse::parseExpr(text);
+  auto untyped = duckdb::parseExpr(text);
   return core::Expressions::inferTypes(untyped, rowType, pool);
 }
 } // namespace
@@ -101,7 +101,7 @@ PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
   std::vector<std::shared_ptr<const core::ITypedExpr>> expressions;
   std::vector<std::string> projectNames;
   for (auto i = 0; i < projections.size(); ++i) {
-    auto untypedExpr = parse::parseExpr(projections[i]);
+    auto untypedExpr = duckdb::parseExpr(projections[i]);
     expressions.push_back(inferTypes(untypedExpr));
     if (untypedExpr->alias().has_value()) {
       projectNames.push_back(untypedExpr->alias().value());
@@ -337,7 +337,7 @@ PlanBuilder::createAggregateExpressionsAndNames(
       resolver.setResultType(resultTypes[i]);
     }
 
-    auto untypedExpr = parse::parseExpr(agg);
+    auto untypedExpr = duckdb::parseExpr(agg);
 
     auto expr = std::dynamic_pointer_cast<const core::CallTypedExpr>(
         inferTypes(untypedExpr));
@@ -441,15 +441,24 @@ PlanBuilder& PlanBuilder::localMerge(
 }
 
 PlanBuilder& PlanBuilder::orderBy(
-    const std::vector<ChannelIndex>& keyIndices,
-    const std::vector<core::SortOrder>& sortOrder,
+    const std::vector<std::string>& keys,
     bool isPartial) {
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> sortingKeys;
   std::vector<core::SortOrder> sortingOrders;
-  for (int i = 0; i < keyIndices.size(); i++) {
-    sortingKeys.emplace_back(field(keyIndices[i]));
-    sortingOrders.emplace_back(sortOrder[i]);
+  for (auto i = 0; i < keys.size(); ++i) {
+    auto [untypedExpr, sortOrder] = duckdb::parseOrderByExpr(keys[i]);
+    auto typedExpr = inferTypes(untypedExpr);
+
+    auto sortingKey =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(typedExpr);
+    VELOX_CHECK_NOT_NULL(
+        sortingKey,
+        "ORDER BY clause must use column names, not expressions: {}",
+        keys[i]);
+    sortingKeys.push_back(sortingKey);
+    sortingOrders.emplace_back(sortOrder);
   }
+
   planNode_ = std::make_shared<core::OrderByNode>(
       nextPlanNodeId(), sortingKeys, sortingOrders, isPartial, planNode_);
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -254,10 +254,15 @@ class PlanBuilder {
       const std::vector<core::SortOrder>& sortOrder,
       std::vector<std::shared_ptr<const core::PlanNode>> sources);
 
-  PlanBuilder& orderBy(
-      const std::vector<ChannelIndex>& keyIndices,
-      const std::vector<core::SortOrder>& sortOrder,
-      bool isPartial);
+  /// Adds an OrderByNode using specified ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .orderBy({"a", "b DESC", "c ASC NULLS FIRST"})
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+  PlanBuilder& orderBy(const std::vector<std::string>& keys, bool isPartial);
 
   PlanBuilder& topN(
       const std::vector<ChannelIndex>& keyIndices,

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -175,29 +175,28 @@ TpchPlan TpchQueryBuilder::getQ1Plan() const {
                "count(0)"})
           .planNode();
 
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .localPartition({}, {partialAggStage})
-          .finalAggregation(
-              {0, 1},
-              {"sum(a0)",
-               "sum(a1)",
-               "sum(a2)",
-               "sum(a3)",
-               "avg(a4)",
-               "avg(a5)",
-               "avg(a6)",
-               "count(a7)"},
-              {DOUBLE(),
-               DOUBLE(),
-               DOUBLE(),
-               DOUBLE(),
-               DOUBLE(),
-               DOUBLE(),
-               DOUBLE(),
-               BIGINT()})
-          .orderBy({0, 1}, {core::kAscNullsLast, core::kAscNullsLast}, false)
-          .planNode();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .localPartition({}, {partialAggStage})
+                  .finalAggregation(
+                      {0, 1},
+                      {"sum(a0)",
+                       "sum(a1)",
+                       "sum(a2)",
+                       "sum(a3)",
+                       "avg(a4)",
+                       "avg(a5)",
+                       "avg(a6)",
+                       "count(a7)"},
+                      {DOUBLE(),
+                       DOUBLE(),
+                       DOUBLE(),
+                       DOUBLE(),
+                       DOUBLE(),
+                       DOUBLE(),
+                       DOUBLE(),
+                       BIGINT()})
+                  .orderBy({"l_returnflag", "l_linestatus"}, false)
+                  .planNode();
 
   TpchPlan context;
   context.plan = std::move(plan);


### PR DESCRIPTION
PlanBuilder::orderBy used to require the caller to specify two lists:  indices
of sorting keys and corresponding sort orders. The new API takes a list of
ORDER BY SQL clauses making it easier to use when writing as well as 
reading code.

Before: `.orderBy({0, 1}, {core::kAscNullsLast, core::kAscNullsLast}, false)`

After: `.orderBy({"l_returnflag", "l_linestatus"}, false)`