### PR TITLE
Remove wrong check.

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -137,11 +137,6 @@ void Task::start(
     std::shared_ptr<Task> self,
     uint32_t maxDrivers,
     uint32_t concurrentSplitGroups) {
-  if (concurrentSplitGroups > 1) {
-    VELOX_CHECK(
-        self->isGroupedExecution(),
-        "concurrentSplitGroups parameter applies only to grouped execution");
-  }
   VELOX_CHECK_GE(
       maxDrivers, 1, "maxDrivers parameter must be greater then or equal to 1");
   VELOX_CHECK_GE(


### PR DESCRIPTION
Summary:
In a query we can have multiple tasks and some of them won't have grouped execution.
So, it is incorrect to perform this check.

Differential Revision: D34865123

