### PR TITLE
Fix LazyVector in MergeJoin

### DIFF
--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::exec {
 
@@ -30,6 +31,7 @@ class CallbackSink : public Operator {
         callback_{callback} {}
 
   void addInput(RowVectorPtr input) override {
+    loadColumns(input, *operatorCtx_->execCtx());
     blockingReason_ = callback_(input, &future_);
   }
 

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -69,4 +69,8 @@ wrapChild(vector_size_t size, BufferPtr mapping, const VectorPtr& child);
 // specified mapping. Returns vector as-is if mapping is null.
 RowVectorPtr
 wrap(vector_size_t size, BufferPtr mapping, const RowVectorPtr& vector);
+
+// Ensures that all LazyVectors reachable from 'input' are loaded for all rows.
+void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx);
+
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -252,6 +252,9 @@ class LocalSelectivityVector {
       : context_(context->execCtx()),
         vector_(context_->getSelectivityVector(size)) {}
 
+  explicit LocalSelectivityVector(core::ExecCtx* context)
+      : context_(context), vector_(nullptr) {}
+
   explicit LocalSelectivityVector(EvalCtx* context)
       : context_(context->execCtx()), vector_(nullptr) {}
 
@@ -321,6 +324,8 @@ class LocalSelectivityVector {
 
 class LocalDecodedVector {
  public:
+  explicit LocalDecodedVector(core::ExecCtx* context) : context_(context) {}
+
   explicit LocalDecodedVector(EvalCtx* context)
       : context_(context->execCtx()) {}
 

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/vector/LazyVector.h"
 #include <folly/ThreadLocal.h>
+#include "velox/common/base/RawVector.h"
 #include "velox/common/time/Timer.h"
 #include "velox/vector/DecodedVector.h"
 
@@ -80,6 +81,94 @@ void VectorLoader::loadInternal(
   int index = 0;
   rows.applyToSelected([&](vector_size_t row) { positions[index++] = row; });
   load(positions, hook, result);
+}
+
+//   static
+void LazyVector::ensureLoadedRows(
+    VectorPtr& vector,
+    const SelectivityVector& rows) {
+  if (isLazyNotLoaded(*vector)) {
+    DecodedVector decoded;
+    SelectivityVector baseRows;
+    ensureLoadedRows(vector, rows, decoded, baseRows);
+  } else {
+    // Even if LazyVectors have been loaded, via some other path, this
+    // is needed for initializing wrappers.
+    vector->loadedVector();
+  }
+}
+
+// static
+void LazyVector::ensureLoadedRows(
+    VectorPtr& vector,
+    const SelectivityVector& rows,
+    DecodedVector& decoded,
+    SelectivityVector& baseRows) {
+  decoded.decode(*vector, rows, false);
+  if (decoded.base()->encoding() != VectorEncoding::Simple::LAZY) {
+    return;
+  }
+  auto lazyVector = decoded.base()->asUnchecked<LazyVector>();
+  if (lazyVector->isLoaded()) {
+    vector->loadedVector();
+    return;
+  }
+  raw_vector<vector_size_t> rowNumbers;
+  RowSet rowSet;
+  if (decoded.isConstantMapping()) {
+    rowNumbers.push_back(decoded.index(rows.begin()));
+  } else if (decoded.isIdentityMapping()) {
+    if (rows.isAllSelected()) {
+      auto iota = velox::iota(rows.end(), rowNumbers);
+      rowSet = RowSet(iota, rows.end());
+    } else {
+      rowNumbers.resize(rows.end());
+      rowNumbers.resize(simd::indicesOfSetBits(
+          rows.asRange().bits(), 0, rows.end(), rowNumbers.data()));
+      rowSet = RowSet(rowNumbers);
+    }
+  } else {
+    baseRows.resize(0);
+    baseRows.resize(lazyVector->size()), false;
+    rows.applyToSelected([&](auto row) {
+      if (!decoded.isNullAt(row)) {
+        baseRows.setValid(decoded.index(row), true);
+      }
+    });
+    baseRows.updateBounds();
+
+    rowNumbers.resize(baseRows.end());
+    rowNumbers.resize(simd::indicesOfSetBits(
+        baseRows.asRange().bits(), 0, baseRows.end(), rowNumbers.data()));
+
+    rowSet = RowSet(rowNumbers);
+
+    // If we have a mapping that is not a single level of dictionary, we
+    // collapse this to a single level of dictionary. The reason is
+    // that the inner levels of dictionary will reference rows that
+    // are not loaded, since the load was done for only the rows that
+    // are reachable from 'vector'.
+    if (vector->encoding() != VectorEncoding::Simple::DICTIONARY ||
+        lazyVector != vector->valueVector().get()) {
+      lazyVector->load(rowSet, nullptr);
+      BufferPtr indices = allocateIndices(vector->size(), vector->pool());
+      std::memcpy(
+          indices->asMutable<vector_size_t>(),
+          decoded.indices(),
+          sizeof(vector_size_t) * vector->size());
+      vector = BaseVector::wrapInDictionary(
+          BufferPtr(nullptr),
+          std::move(indices),
+          vector->size(),
+          lazyVector->loadedVectorShared());
+      return;
+    }
+  }
+  lazyVector->load(rowSet, nullptr);
+  // An explicit call to loadedVector() is necessary to allow for proper
+  // initialization of dictionaries, sequences, etc. on top of lazy vector
+  // after it has been loaded, even if loaded via some other path.
+  vector->loadedVector();
 }
 
 } // namespace facebook::velox

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/vector/DecodedVector.h"
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox {
@@ -265,6 +266,23 @@ class LazyVector : public BaseVector {
   std::string toString(vector_size_t index) const override {
     return loadedVector()->toString(index);
   }
+
+  // Loads 'rows' of 'vector'. 'vector' may be an arbitrary wrapping
+  // of a LazyVector. 'rows' are translated through the wrappers. If
+  // there is no LazyVector inside 'vector', this has no
+  // effect. 'vector' may be replaced by a a new vector with 'rows'
+  // loaded and the rest as after default construction.
+  static void ensureLoadedRows(
+      VectorPtr& vector,
+      const SelectivityVector& rows);
+
+  // as ensureLoadedRows, above, but takes a scratch DecodedVector and
+  // SelectivityVector as arguments to enable reuse.
+  static void ensureLoadedRows(
+      VectorPtr& vector,
+      const SelectivityVector& rows,
+      DecodedVector& decoded,
+      SelectivityVector& baseRows);
 
  private:
   std::unique_ptr<VectorLoader> loader_;


### PR DESCRIPTION
Loads LazyVectors in CallbackSink. The load is scoped to the rows that
survive all filters. In general, this node passes data outside of the
pipeline, which means that after this point there is no guarantee for
the lifetime of the readers of the LazyVectors.

Loads all lazy vectors of inputs buffered by MergeJoin. The buffering
takes place when a left batch ends with a hit.

Adds a utility to load all LazyVectors reachable from a
RowVector. Note that even when a vector does not contain unloaded
LazyVectors, loadedVector() must be called to initialize wrappers
around LazyVectors that may have been loaded via some other path.
Separates out the logic for loading a selected set of top level rows
from LazyVectors that may be arbitrarily wrapped (ensureLoadedRows).