### PR TITLE
Fix coalesce function to avoid calling BaseVector::copy on empty rows

### DIFF
--- a/velox/functions/prestosql/Coalesce.cpp
+++ b/velox/functions/prestosql/Coalesce.cpp
@@ -54,11 +54,14 @@ class CoalesceFunction : public exec::VectorFunction {
       } else {
         *copyRows = *activeRows;
         copyRows->deselectNulls(rawNulls, 0, activeRows->end());
-        (*result)->copy(arg.get(), *copyRows, nullptr);
+        if (copyRows->hasSelections()) {
+          (*result)->copy(arg.get(), *copyRows, nullptr);
+        } else {
+          continue;
+        }
       }
 
       activeRows->deselectNonNulls(rawNulls, 0, activeRows->end());
-      activeRows->updateBounds();
       if (!activeRows->hasSelections()) {
         // no nulls left
         return;

--- a/velox/functions/prestosql/tests/CoalesceTest.cpp
+++ b/velox/functions/prestosql/tests/CoalesceTest.cpp
@@ -56,3 +56,20 @@ TEST_F(CoalesceTest, basic) {
     }
   }
 }
+
+TEST_F(CoalesceTest, strings) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<StringView>(
+          {"a", std::nullopt, std::nullopt, "d", std::nullopt}),
+      makeNullableFlatVector<StringView>(
+          {"aa", std::nullopt, std::nullopt, "dd", std::nullopt}),
+      makeNullableFlatVector<StringView>(
+          {"aaa", "bbb", std::nullopt, "ddd", "eee"}),
+  });
+
+  auto expectedResult = makeNullableFlatVector<StringView>(
+      {"a", "bbb", std::nullopt, "d", "eee"});
+
+  auto result = evaluate<FlatVector<StringView>>("coalesce(c0, c1, c2)", input);
+  assertEqualVectors(expectedResult, result);
+}


### PR DESCRIPTION
Coalesce function sometimes called BaseVector::copy with an empty SelectivityVector. 
This caused VELOX_CHECK(rows.hasSelections()) failure in SimpleVector::isAscii.

Also, remove redundant call activeRows->updateBounds(). SelectivityVector::deselectNonNulls() 
already includes a call to updateBounds.