### PR TITLE
Move aggregate function registry API to velox/exec

### DIFF
--- a/velox/exec/AggregateFunctionRegistry.cpp
+++ b/velox/exec/AggregateFunctionRegistry.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/AggregateFunctionRegistry.h"
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+std::pair<TypePtr, TypePtr> resolveAggregateFunction(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes) {
+  if (auto aggregateFunctionSignatures =
+          getAggregateFunctionSignatures(functionName)) {
+    for (const auto& signature : aggregateFunctionSignatures.value()) {
+      SignatureBinder binder(*signature, argTypes);
+      if (binder.tryBind()) {
+        return std::make_pair(
+            binder.tryResolveReturnType(),
+            binder.tryResolveType(signature->intermediateType()));
+      }
+    }
+  }
+
+  return std::make_pair(nullptr, nullptr);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/AggregateFunctionRegistry.h
+++ b/velox/exec/AggregateFunctionRegistry.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+/// Given a name of aggregate function and argument types, returns a pair of the
+/// return type and intermediate type if the function exists. Returns a pair of
+/// nullptr otherwise.
+std::pair<TypePtr, TypePtr> resolveAggregateFunction(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
+} // namespace facebook::velox::exec

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_library(
   velox_exec
   Aggregate.cpp
+  AggregateFunctionRegistry.cpp
   AggregationMasks.cpp
   ContainerRowSerde.cpp
   CrossJoinBuild.cpp

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/functions/Registerer.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+class AggregateFunc : public Aggregate {
+ public:
+  explicit AggregateFunc(TypePtr resultType) : Aggregate(resultType) {}
+
+  void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return 0;
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
+
+  void addRawInput(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addIntermediateResults(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupRawInput(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupIntermediateResults(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void extractValues(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+
+  void extractAccumulators(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+};
+
+bool registerAggregateFunc(const std::string& name) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .intermediateType("array(T)")
+          .argumentType("T")
+          .argumentType("T")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("date")
+          .intermediateType("date")
+          .build(),
+  };
+
+  registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [&](core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        if (isPartialOutput(step)) {
+          if (argTypes.empty()) {
+            return std::make_unique<AggregateFunc>(resultType);
+          }
+          return std::make_unique<AggregateFunc>(ARRAY(resultType));
+        }
+        return std::make_unique<AggregateFunc>(resultType);
+      });
+
+  return true;
+}
+
+} // namespace
+
+class FunctionRegistryTest : public testing::Test {
+ public:
+  FunctionRegistryTest() {
+    registerAggregateFunc("aggregate_func");
+  }
+
+  void checkEqual(const TypePtr& actual, const TypePtr& expected) {
+    if (expected) {
+      EXPECT_EQ(*actual, *expected);
+    } else {
+      EXPECT_EQ(actual, nullptr);
+    }
+  }
+
+  void testResolveAggregateFunction(
+      const std::string& functionName,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& expectedReturn,
+      const TypePtr& expectedIntermediate) {
+    auto result = resolveAggregateFunction(functionName, argTypes);
+    checkEqual(result.first, expectedReturn);
+    checkEqual(result.second, expectedIntermediate);
+  }
+};
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignature) {
+  testResolveAggregateFunction(
+      "aggregate_func", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
+  testResolveAggregateFunction(
+      "aggregate_func", {DOUBLE(), DOUBLE()}, DOUBLE(), ARRAY(DOUBLE()));
+  testResolveAggregateFunction(
+      "aggregate_func",
+      {ARRAY(BOOLEAN()), ARRAY(BOOLEAN())},
+      ARRAY(BOOLEAN()),
+      ARRAY(ARRAY(BOOLEAN())));
+  testResolveAggregateFunction("aggregate_func", {}, DATE(), DATE());
+}
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongFunctionName) {
+  testResolveAggregateFunction(
+      "aggregate_func_nonexist", {BIGINT(), BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction("aggregate_func_nonexist", {}, nullptr, nullptr);
+}
+
+TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongArgType) {
+  testResolveAggregateFunction(
+      "aggregate_func", {DOUBLE(), BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction("aggregate_func", {BIGINT()}, nullptr, nullptr);
+  testResolveAggregateFunction(
+      "aggregate_func", {BIGINT(), BIGINT(), BIGINT()}, nullptr, nullptr);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   TableScanTest.cpp
   TaskTest.cpp
   AggregationTest.cpp
+  AggregateFunctionRegistryTest.cpp
   RowContainerTest.cpp
   HashTableTest.cpp
   TreeOfLosersTest.cpp

--- a/velox/functions/CMakeLists.txt
+++ b/velox/functions/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_library(velox_function_registry FunctionRegistry.cpp)
 
 target_link_libraries(velox_function_registry velox_expression velox_type
-                      velox_core velox_exception velox_exec)
+                      velox_core velox_exception)
 
 add_subdirectory(lib)
 if(${VELOX_ENABLE_PRESTO_FUNCTIONS})

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -22,7 +22,6 @@
 #include <sstream>
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/SimpleFunctionMetadata.h"
-#include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
@@ -118,24 +117,6 @@ std::shared_ptr<const Type> resolveVectorFunction(
   }
 
   return nullptr;
-}
-
-std::pair<TypePtr, TypePtr> resolveAggregateFunction(
-    const std::string& functionName,
-    const std::vector<TypePtr>& argTypes) {
-  if (auto aggregateFunctionSignatures =
-          exec::getAggregateFunctionSignatures(functionName)) {
-    for (const auto& signature : aggregateFunctionSignatures.value()) {
-      exec::SignatureBinder binder(*signature, argTypes);
-      if (binder.tryBind()) {
-        return std::make_pair(
-            binder.tryResolveReturnType(),
-            binder.tryResolveType(signature->intermediateType()));
-      }
-    }
-  }
-
-  return std::make_pair(nullptr, nullptr);
 }
 
 } // namespace facebook::velox

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -48,11 +48,4 @@ std::shared_ptr<const Type> resolveVectorFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
-/// Given name of aggregate function and argument types, returns a pair of the
-/// return type and intermediate type if function exists otherwise returns a
-/// pair of nullptr
-std::pair<TypePtr, TypePtr> resolveAggregateFunction(
-    const std::string& functionName,
-    const std::vector<TypePtr>& argTypes);
-
 } // namespace facebook::velox

--- a/velox/functions/tests/CMakeLists.txt
+++ b/velox/functions/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable(velox_function_registry_test FunctionRegistryTest.cpp)
 add_test(NAME velox_function_registry_test COMMAND velox_function_registry_test)
 
 target_link_libraries(velox_function_registry_test velox_function_registry
-                      velox_exec ${GMock} ${GTEST_BOTH_LIBRARIES})
+                      ${GMock} ${GTEST_BOTH_LIBRARIES})

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -17,7 +17,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "velox/exec/Aggregate.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/VectorFunction.h"
@@ -198,94 +197,6 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     VectorFuncFour::signatures(),
     std::make_unique<VectorFuncFour>());
 
-class AggregateFunc : public velox::exec::Aggregate {
- public:
-  explicit AggregateFunc(TypePtr resultType) : Aggregate(resultType) {}
-
-  void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
-
-  int32_t accumulatorFixedWidthSize() const override {
-    return 0;
-  }
-
-  void initializeNewGroups(
-      char** /*groups*/,
-      folly::Range<const vector_size_t*> /*indices*/) override {}
-
-  void addRawInput(
-      char** /*groups*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void addIntermediateResults(
-      char** /*groups*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void addSingleGroupRawInput(
-      char* /*group*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void addSingleGroupIntermediateResults(
-      char* /*group*/,
-      const SelectivityVector& /*rows*/,
-      const std::vector<VectorPtr>& /*args*/,
-      bool /*mayPushdown*/) override {}
-
-  void extractValues(
-      char** /*groups*/,
-      int32_t /*numGroups*/,
-      VectorPtr* /*result*/) override {}
-
-  void extractAccumulators(
-      char** /*groups*/,
-      int32_t /*numGroups*/,
-      VectorPtr* /*result*/) override {}
-};
-
-bool registerAggregateFunc(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
-      exec::AggregateFunctionSignatureBuilder()
-          .returnType("bigint")
-          .intermediateType("array(bigint)")
-          .argumentType("bigint")
-          .argumentType("double")
-          .build(),
-      exec::AggregateFunctionSignatureBuilder()
-          .typeVariable("T")
-          .returnType("T")
-          .intermediateType("array(T)")
-          .argumentType("T")
-          .argumentType("T")
-          .build(),
-      exec::AggregateFunctionSignatureBuilder()
-          .returnType("date")
-          .intermediateType("date")
-          .build(),
-  };
-
-  exec::registerAggregateFunction(
-      name,
-      std::move(signatures),
-      [&](core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
-        if (exec::isPartialOutput(step)) {
-          if (argTypes.empty()) {
-            return std::make_unique<AggregateFunc>(resultType);
-          }
-          return std::make_unique<AggregateFunc>(ARRAY(resultType));
-        }
-        return std::make_unique<AggregateFunc>(resultType);
-      });
-
-  return true;
-}
-
 inline void registerTestFunctions() {
   // If no alias is specified, ensure it will fallback to the struct name.
   registerFunction<FuncOne, Varchar, Varchar>({"func_one"});
@@ -308,8 +219,6 @@ inline void registerTestFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_two, "vector_func_two");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_three, "vector_func_three");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_four, "vector_func_four");
-
-  registerAggregateFunc("aggregate_func");
 }
 } // namespace
 
@@ -333,16 +242,6 @@ class FunctionRegistryTest : public ::testing::Test {
     } else {
       EXPECT_EQ(actual, nullptr);
     }
-  }
-
-  void testResolveAggregateFunction(
-      const std::string& functionName,
-      const std::vector<TypePtr>& argTypes,
-      const TypePtr& expectedReturn,
-      const TypePtr& expectedIntermediate) {
-    auto result = velox::resolveAggregateFunction(functionName, argTypes);
-    checkEqual(result.first, expectedReturn);
-    checkEqual(result.second, expectedIntermediate);
   }
 };
 
@@ -603,33 +502,6 @@ TEST_F(FunctionRegistryTest, resolveFunctionsBasedOnPriority) {
 
   auto result5 = resolveFunction(func, {INTEGER(), INTEGER()});
   ASSERT_EQ(*result5, *REAL());
-}
-
-TEST_F(FunctionRegistryTest, hasAggregateFunctionSignature) {
-  testResolveAggregateFunction(
-      "aggregate_func", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
-  testResolveAggregateFunction(
-      "aggregate_func", {DOUBLE(), DOUBLE()}, DOUBLE(), ARRAY(DOUBLE()));
-  testResolveAggregateFunction(
-      "aggregate_func",
-      {ARRAY(BOOLEAN()), ARRAY(BOOLEAN())},
-      ARRAY(BOOLEAN()),
-      ARRAY(ARRAY(BOOLEAN())));
-  testResolveAggregateFunction("aggregate_func", {}, DATE(), DATE());
-}
-
-TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongFunctionName) {
-  testResolveAggregateFunction(
-      "aggregate_func_nonexist", {BIGINT(), BIGINT()}, nullptr, nullptr);
-  testResolveAggregateFunction("aggregate_func_nonexist", {}, nullptr, nullptr);
-}
-
-TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongArgType) {
-  testResolveAggregateFunction(
-      "aggregate_func", {DOUBLE(), BIGINT()}, nullptr, nullptr);
-  testResolveAggregateFunction("aggregate_func", {BIGINT()}, nullptr, nullptr);
-  testResolveAggregateFunction(
-      "aggregate_func", {BIGINT(), BIGINT(), BIGINT()}, nullptr, nullptr);
 }
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: `resolveAggregateFunction()` used to be in velox/functions/FunctionRegistry.h, which makes velox_function_registry depend on velox_exec. This is not desired for users who do not need `resolveAggregateFunction()`. This diff moves `resolveAggregateFunction()` to velox/exec/AggregateFunctionRegistry.h to address this problem.

Differential Revision: D34870813

