### PR TITLE
Allow calling FlatVector<StringView>::copy for no rows

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -285,6 +285,10 @@ void FlatVector<StringView>::copy(
     const BaseVector* source,
     const SelectivityVector& rows,
     const vector_size_t* toSourceRow) {
+  if (!rows.hasSelections()) {
+    return;
+  }
+
   auto leaf = source->wrappedVector()->asUnchecked<SimpleVector<StringView>>();
   VELOX_CHECK(leaf, "Assigning non-string to string");
   if (pool_ == leaf->pool()) {

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -233,6 +233,9 @@ class FlatVector final : public SimpleVector<T> {
       const BaseVector* source,
       const SelectivityVector& rows,
       const vector_size_t* toSourceRow) override {
+    if (!rows.hasSelections()) {
+      return;
+    }
     copyValuesAndNulls(source, rows, toSourceRow);
   }
 

--- a/velox/vector/SimpleVector.cpp
+++ b/velox/vector/SimpleVector.cpp
@@ -16,9 +16,6 @@
 
 #include "velox/vector/SimpleVector.h"
 #include "velox/common/base/Exceptions.h"
-#include "velox/vector/ConstantVector.h"
-#include "velox/vector/DictionaryVector.h"
-#include "velox/vector/FlatVector.h"
 
 namespace facebook {
 namespace velox {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1062,6 +1062,23 @@ TEST_F(VectorTest, resizeStringAsciiness) {
   ASSERT_FALSE(stringVector->isAscii(rows));
 }
 
+TEST_F(VectorTest, copyNoRows) {
+  auto maker = std::make_unique<test::VectorMaker>(pool_.get());
+  {
+    auto source = maker->flatVectorNullable<int32_t>({1, 2, 3});
+    auto target = BaseVector::create(INTEGER(), 10, pool_.get());
+    SelectivityVector rows(3, false);
+    target->copy(source.get(), rows, nullptr);
+  }
+
+  {
+    auto source = maker->flatVectorNullable<StringView>({"a", "b", "c"});
+    auto target = BaseVector::create(VARCHAR(), 10, pool_.get());
+    SelectivityVector rows(3, false);
+    target->copy(source.get(), rows, nullptr);
+  }
+}
+
 TEST_F(VectorTest, copyAscii) {
   auto maker = std::make_unique<test::VectorMaker>(pool_.get());
   std::vector<std::string> stringData = {"a", "b", "c"};


### PR DESCRIPTION
FlatVector<StringView>::copy used to fail when called with empty SelectivityVector. 
This change allows such calls to succeed.