### PR TITLE
Upgrade to folly 2022.03.14.00 (from 2021.05.10.00)

### DIFF
--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -64,7 +64,7 @@ wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz 
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
 wget_and_untar https://github.com/google/googletest/archive/release-1.10.0.tar.gz googletest &
-wget_and_untar https://github.com/facebook/folly/archive/v2021.05.10.00.tar.gz folly &
+wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
 
 wait  # For cmake and source downloads to complete.

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -28,7 +28,7 @@
 set -e # Exit on error.
 set -x # Print commands that are executed.
 
-FB_OS_VERSION=v2021.05.10.00
+FB_OS_VERSION=v2022.03.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS="-mavx2 -mfma -mavx -mf16c -masm=intel -mlzcnt"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -19,7 +19,7 @@ set -eufx -o pipefail
 # Folly must be built with the same compiler flags so that some low level types
 # are the same size.
 export COMPILER_FLAGS="-mavx2 -mfma -mavx -mf16c -masm=intel -mlzcnt"
-FB_OS_VERSION=v2021.05.10.00
+FB_OS_VERSION=v2022.03.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -68,7 +68,7 @@ function wget_and_untar {
 
 
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz boost &
-wget_and_untar https://github.com/facebook/folly/archive/v2021.05.10.00.tar.gz folly &
+wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
 
 wait
 


### PR DESCRIPTION
- Upgrade to latest folly 2022.03.14.00 (from 2021.05.10.00).
- Upgrade fmt to 8.0 (from 7.1.3).
- Build folly in release mode.
- Set circleci docker image to velox-circleci:kpai-20220401  