### PR TITLE
Support random_access_iterator requirements in ArrayView::Iterator

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -49,20 +49,52 @@ class PointerWrapper {
   T t_;
 };
 
-// Base class for ArrayView::Iterator and MapView::Iterator. The missing parts
-// to be implemented by deriving classes are: operator*() and operator->().
-template <typename T, typename TIndex>
+// Base class for ArrayView::Iterator, MapView::Iterator, and
+// VariadicView::Iterator.
+// TElementAccessor is a class that supplies the following:
+// index_t: the type to use for indexes into the container. It should be signed
+// to allow, for example, loops to iterate backwards and end at a point before
+// the beginning of the container.
+// element_t: the type returned when the iterator is dereferenced.
+// element_t operator()(index_t index): returns the element at the provided
+// index in the container being iterated over.
+template <typename TElementAccessor>
 class IndexBasedIterator {
  public:
-  using Iterator = IndexBasedIterator<T, TIndex>;
-  using iterator_category = std::input_iterator_tag;
-  using value_type = T;
-  using difference_type = int;
-  using pointer = PointerWrapper<value_type>;
-  using reference = T;
+  using Iterator = IndexBasedIterator<TElementAccessor>;
+  using index_t = typename TElementAccessor::index_t;
+  using element_t = typename TElementAccessor::element_t;
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = element_t;
+  using difference_type = index_t;
+  using pointer = PointerWrapper<element_t>;
+  using reference = element_t;
 
-  explicit IndexBasedIterator<value_type, TIndex>(int64_t index)
-      : index_(index) {}
+  explicit IndexBasedIterator(
+      index_t index,
+      index_t containerStartIndex,
+      index_t containerEndIndex,
+      const TElementAccessor& elementAccessor)
+      : index_(index),
+        containerStartIndex_(containerStartIndex),
+        containerEndIndex_(containerEndIndex),
+        elementAccessor_(elementAccessor) {}
+
+  PointerWrapper<element_t> operator->() const {
+    validateBounds(index_);
+
+    return PointerWrapper(elementAccessor_(index_));
+  }
+
+  element_t operator*() const {
+    validateBounds(index_);
+
+    return elementAccessor_(index_);
+  }
+
+  element_t operator[](difference_type n) const {
+    return elementAccessor_(index_ + n);
+  }
 
   bool operator!=(const Iterator& rhs) const {
     return index_ != rhs.index_;
@@ -101,8 +133,85 @@ class IndexBasedIterator {
     return *this;
   }
 
+  // Implement post decrement.
+  Iterator operator--(int) {
+    Iterator old = *this;
+    --*this;
+    return old;
+  }
+
+  // Implement pre decrement.
+  Iterator& operator--() {
+    index_--;
+    return *this;
+  }
+
+  Iterator& operator+=(const difference_type& rhs) {
+    index_ += rhs;
+    return *this;
+  }
+
+  Iterator& operator-=(const difference_type& rhs) {
+    index_ -= rhs;
+    return *this;
+  }
+
+  // Iterators +/- ints.
+  Iterator operator+(difference_type rhs) const {
+    return Iterator(
+        this->index_ + rhs,
+        containerStartIndex_,
+        containerEndIndex_,
+        elementAccessor_);
+  }
+
+  Iterator operator-(difference_type rhs) const {
+    return Iterator(
+        this->index_ - rhs,
+        containerStartIndex_,
+        containerEndIndex_,
+        elementAccessor_);
+  }
+
+  // Subtract iterators.
+  difference_type operator-(const Iterator& rhs) const {
+    return this->index_ - rhs.index_;
+  }
+
+  friend Iterator operator+(
+      typename Iterator::difference_type lhs,
+      const Iterator& rhs) {
+    return rhs + lhs;
+  }
+
  protected:
-  TIndex index_;
+  index_t index_;
+
+  // Every instance of Iterator for the same container should have the same
+  // values for these two fields.
+  // The first index in the container. When begin() is called on a container
+  // the returned iterator should have index_ == containerStartIndex_.
+  index_t containerStartIndex_;
+
+  // Last index in the container + 1. When end() is called on a
+  // container the returned iterator should have index_ == containerEndIndex_.
+  index_t containerEndIndex_;
+  TElementAccessor elementAccessor_;
+
+  inline void validateBounds(index_t index) const {
+    VELOX_DCHECK_LT(
+        index,
+        containerEndIndex_,
+        "Iterator has index {} beyond the length of the container {}.",
+        index,
+        containerEndIndex_);
+    VELOX_DCHECK_GE(
+        index,
+        containerStartIndex_,
+        "Iterator has index {} before the start of the container {}.",
+        index,
+        containerStartIndex_);
+  }
 };
 
 // Implements an iterator for values that skips nulls and provides direct access
@@ -115,6 +224,10 @@ class IndexBasedIterator {
 template <typename BaseIterator>
 class SkipNullsIterator {
   using Iterator = SkipNullsIterator<BaseIterator>;
+
+  // SkipNullsIterator cannot meet the requirements of
+  // random_access_iterator_tag as moving between elements is a linear time
+  // operation.
   using iterator_category = std::input_iterator_tag;
   using value_type = typename std::result_of<decltype (&BaseIterator::value)(
       BaseIterator)>::type;
@@ -412,69 +525,88 @@ class ArrayView {
       VectorOptionalValueAccessor<reader_t>,
       element_t>::type;
 
-  class Iterator : public IndexBasedIterator<Element, vector_size_t> {
+  class ElementAccessor {
    public:
-    Iterator(const reader_t* reader, vector_size_t index)
-        : IndexBasedIterator<Element, vector_size_t>(index), reader_(reader) {}
+    using element_t = Element;
+    using index_t = vector_size_t;
 
-    PointerWrapper<Element> operator->() const {
+    explicit ElementAccessor(const reader_t* reader) : reader_(reader) {}
+
+    Element operator()(vector_size_t index) const {
       if constexpr (returnsOptionalValues) {
-        return PointerWrapper(Element{reader_, this->index_});
+        return Element{reader_, index};
       } else {
-        return PointerWrapper(reader_->readNullFree(this->index_));
+        return reader_->readNullFree(index);
       }
     }
 
-    Element operator*() const {
-      if constexpr (returnsOptionalValues) {
-        return Element{reader_, this->index_};
-      } else {
-        return reader_->readNullFree(this->index_);
-      }
-    }
-
-   protected:
+   private:
     const reader_t* reader_;
   };
 
+  using Iterator = IndexBasedIterator<ElementAccessor>;
+
   Iterator begin() const {
-    return Iterator{reader_, offset_};
+    return Iterator{
+        offset_, offset_, offset_ + size_, ElementAccessor(reader_)};
   }
 
   Iterator end() const {
-    return Iterator{reader_, offset_ + size_};
+    return Iterator{
+        offset_ + size_, offset_, offset_ + size_, ElementAccessor(reader_)};
   }
 
   struct SkipNullsContainer {
     class SkipNullsBaseIterator : public Iterator {
      public:
-      SkipNullsBaseIterator(const reader_t* reader, vector_size_t index)
-          : Iterator(reader, index) {}
+      SkipNullsBaseIterator(
+          const reader_t* reader,
+          vector_size_t index,
+          vector_size_t startIndex,
+          vector_size_t endIndex)
+          : Iterator(index, startIndex, endIndex, ElementAccessor(reader)),
+            reader_(reader) {}
 
       bool hasValue() const {
-        return this->reader_->isSet(this->index_);
+        return reader_->isSet(this->index_);
       }
 
       element_t value() const {
-        return (*this->reader_)[this->index_];
+        return (*reader_)[this->index_];
       }
+
+     private:
+      const reader_t* reader_;
     };
 
     explicit SkipNullsContainer(const ArrayView* array_) : array_(array_) {}
 
     SkipNullsIterator<SkipNullsBaseIterator> begin() {
       return SkipNullsIterator<SkipNullsBaseIterator>::initialize(
-          SkipNullsBaseIterator{array_->reader_, array_->offset_},
           SkipNullsBaseIterator{
-              array_->reader_, array_->offset_ + array_->size_});
+              array_->reader_,
+              array_->offset_,
+              array_->offset_,
+              array_->offset_ + array_->size_},
+          SkipNullsBaseIterator{
+              array_->reader_,
+              array_->offset_ + array_->size_,
+              array_->offset_,
+              array_->offset_ + array_->size_});
     }
 
     SkipNullsIterator<SkipNullsBaseIterator> end() {
       return SkipNullsIterator<SkipNullsBaseIterator>{
           SkipNullsBaseIterator{
-              array_->reader_, array_->offset_ + array_->size_},
+              array_->reader_,
+              array_->offset_ + array_->size_,
+              array_->offset_,
+              array_->offset_ + array_->size_},
           SkipNullsBaseIterator{
-              array_->reader_, array_->offset_ + array_->size_}};
+              array_->reader_,
+              array_->offset_ + array_->size_,
+              array_->offset_,
+              array_->offset_ + array_->size_}};
     }
 
    private:
@@ -625,22 +757,18 @@ class MapView {
     }
   };
 
-  class Iterator : public IndexBasedIterator<Element, vector_size_t> {
+  class ElementAccessor {
    public:
-    Iterator(
+    using element_t = Element;
+    using index_t = vector_size_t;
+
+    ElementAccessor(
         const key_reader_t* keyReader,
-        const value_reader_t* valueReader,
-        vector_size_t index)
-        : IndexBasedIterator<Element, vector_size_t>(index),
-          keyReader_(keyReader),
-          valueReader_(valueReader) {}
+        const value_reader_t* valueReader)
+        : keyReader_(keyReader), valueReader_(valueReader) {}
 
-    PointerWrapper<Element> operator->() const {
-      return PointerWrapper(Element{keyReader_, valueReader_, this->index_});
-    }
-
-    Element operator*() const {
-      return Element{keyReader_, valueReader_, this->index_};
+    Element operator()(vector_size_t index) const {
+      return Element{keyReader_, valueReader_, index};
     }
 
    private:
@@ -648,12 +776,22 @@ class MapView {
     const value_reader_t* valueReader_;
   };
 
+  using Iterator = IndexBasedIterator<ElementAccessor>;
+
   Iterator begin() const {
-    return Iterator{keyReader_, valueReader_, offset_};
+    return Iterator{
+        offset_,
+        offset_,
+        offset_ + size_,
+        ElementAccessor(keyReader_, valueReader_)};
   }
 
   Iterator end() const {
-    return Iterator{keyReader_, valueReader_, size_ + offset_};
+    return Iterator{
+        offset_ + size_,
+        offset_,
+        offset_ + size_,
+        ElementAccessor(keyReader_, valueReader_)};
   }
 
   // Index-based access for the map elements.

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include "glog/logging.h"
 #include "gtest/gtest.h"
+#include "velox/common/base/VeloxException.h"
 #include "velox/expression/VectorUdfTypeSystem.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
@@ -106,6 +107,30 @@ class ArrayViewTest : public functions::test::FunctionBaseTest {
         j++;
       }
       ASSERT_EQ(j, arrayDataBigInt[i].size());
+
+      // Test loop iteration in reverse with post decrement
+      j = arrayDataBigInt[i].size() - 1;
+      for (it = arrayView.end() - 1; it >= arrayView.begin(); it--) {
+        testItem(i, j, *it);
+        j--;
+      }
+      // This is unintuitive but because we decrement after accessing each
+      // element, since j starts as one less than the size of the array, it
+      // should finish at -1.
+      ASSERT_EQ(j, -1);
+
+      // Test iterate with pre decrement
+      it = arrayView.end() - 1;
+      j = arrayDataBigInt[i].size() - 1;
+      while (it >= arrayView.begin()) {
+        testItem(i, j, *it);
+        j--;
+        --it;
+      }
+      // This is unintuitive but because we decrement after accessing each
+      // element, since j starts as one less than the size of the array, it
+      // should finish at -1.
+      ASSERT_EQ(j, -1);
     }
   }
 
@@ -132,6 +157,106 @@ class ArrayViewTest : public functions::test::FunctionBaseTest {
 
     ASSERT_EQ(read(reader, 0).size(), 2);
     ASSERT_EQ(read(reader, 1).size(), 1);
+  }
+
+  void iteratorDifferenceTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k <= j; k++) {
+          ASSERT_EQ(it - it2, j - k);
+          ASSERT_EQ(it2 - it, k - j);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorAdditionTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(it, it2 + (j - k));
+          ASSERT_EQ(it, (j - k) + it2);
+          auto it3 = it2;
+          it3 += j - k;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubtractionTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(it, it2 - (k - j));
+          auto it3 = it2;
+          it3 -= k - j;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubscriptTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(*it, it2[j - k]);
+          it2++;
+        }
+        it++;
+      }
+    }
   }
 };
 
@@ -314,6 +439,22 @@ TEST_F(NullableArrayViewTest, nestedArray) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(NullableArrayViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorSubscript) {
+  iteratorSubscriptTest();
+}
+
 TEST_F(NullFreeArrayViewTest, intArray) {
   auto testItem = [&](int i, int j, auto item) {
     ASSERT_TRUE(item == arrayDataBigInt[i][j]);
@@ -395,4 +536,19 @@ TEST_F(NullableArrayViewTest, materializeArrayWithOpaque) {
   ASSERT_FALSE(array[1].has_value());
 }
 
+TEST_F(NullFreeArrayViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorSubscript) {
+  iteratorSubscriptTest();
+}
 } // namespace

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -137,6 +137,161 @@ class MapViewTest : public functions::test::FunctionBaseTest {
     }
   }
 
+  void iteratorDecrementTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      // Test using post decrement on the iterator.
+      auto j = mapView.size() - 1;
+      for (auto it = mapView.end() - 1; it >= mapView.begin(); it--) {
+        ASSERT_EQ(it->first, map[i][j].first);
+        ASSERT_EQ(it->second, map[i][j].second);
+        j--;
+      }
+      ASSERT_EQ(j, -1);
+
+      // Test using pre decrement on the iterator.
+      j = mapView.size() - 1;
+      for (auto it = mapView.end() - 1; it >= mapView.begin(); --it) {
+        ASSERT_EQ(it->first, map[i][j].first);
+        ASSERT_EQ(it->second, map[i][j].second);
+        j--;
+      }
+      ASSERT_EQ(j, -1);
+    }
+  }
+
+  void iteratorDifferenceTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k <= j; k++) {
+          ASSERT_EQ(it - it2, j - k);
+          ASSERT_EQ(it2 - it, k - j);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorAdditionTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(it, it2 + (j - k));
+          ASSERT_EQ(it, (j - k) + it2);
+          auto it3 = it2;
+          it3 += j - k;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubtractionTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(it, it2 - (k - j));
+          auto it3 = it2;
+          it3 -= k - j;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubscriptTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(*it, it2[j - k]);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
   void encodedTest() {
     VectorPtr mapVector = createTestMapVector();
     // Wrap in dictionary.
@@ -501,6 +656,26 @@ TEST_F(NullableMapViewTest, testSubscript) {
   ASSERT_EQ(read(reader, 1)[1], 4);
 }
 
+TEST_F(NullableMapViewTest, iteratorDecrement) {
+  iteratorDecrementTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorSubscript) {
+  iteratorSubscriptTest();
+}
+
 TEST_F(NullFreeMapViewTest, testReadingRangeLoop) {
   readingRangeLoopTest();
 }
@@ -592,4 +767,23 @@ TEST_F(NullableMapViewTest, materializeNested) {
   ASSERT_EQ(reader[0].materialize(), expected);
 }
 
+TEST_F(NullFreeMapViewTest, iteratorDecrement) {
+  iteratorDecrementTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorSubscript) {
+  iteratorSubscriptTest();
+}
 } // namespace


### PR DESCRIPTION
Summary:
As the title suggests, this diff makes it so that ArrayView::Iterator meets the requirements
of a random_access_iterator.  This lets std algorithms on instances of the iterator like
distance know that they can use constant time implementations rather than linear time.

The new functions include:
In the IndexBasedIterator:
* pre-decrement
* post-decrement
* +=
* -=
In the ArrayView::Iterator
* iterator + int
* int + iterator
* iterator - int
* iterator - iterator
* [n] to access the value at iterator + n

In addition I added a validateBounds() function to IndexBasedIterator to ensure we don't
accidentally dereference values off the end of the current collection (I'll add calls to this to
MapView::Iterator and VariadicView::Iterator in subsequent diffs).

I also added a static check to the Iterator to ensure it's properly declaring its
iterator_category (Iterators don't inherit this from the parent, which it seems like the code
was assuming before).

Differential Revision: D34899195

