### PR TITLE
Disable reuse of output vectors in hash join

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -339,11 +339,9 @@ folly::Range<vector_size_t*> initializeRowNumberMapping(
 } // namespace
 
 void HashProbe::prepareOutput(vector_size_t size) {
-  VectorPtr outputAsBase = std::move(output_);
-  BaseVector::ensureWritable(
-      SelectivityVector::empty(), outputType_, pool(), &outputAsBase);
-  output_ = std::static_pointer_cast<RowVector>(outputAsBase);
-  output_->resize(size);
+  // TODO Reuse output vector when possible.
+  output_ = std::static_pointer_cast<RowVector>(
+      BaseVector::create(outputType_, size, pool()));
 }
 
 void HashProbe::fillOutput(vector_size_t size) {


### PR DESCRIPTION
Re-using variable-width vectors (strings, arrays and maps) causes unnecessary
large memory allocations as variable-width data is being appended on re-use.
This PR disables re-use of output vectors in hash join. A follow-up will
introduce a proper mechanism for re-use and apply in hash join and other
places.