### PR TITLE
Support random_access_iterator requirements in MapView::Iterator

### DIFF
--- a/velox/expression/VariadicView.h
+++ b/velox/expression/VariadicView.h
@@ -48,7 +48,7 @@ class VariadicView {
         const std::vector<std::unique_ptr<reader_t>>* readers,
         size_t readerIndex,
         vector_size_t offset)
-        : IndexBasedIterator<Element, int>(readerIndex),
+        : IndexBasedIterator<Element, int>(readerIndex, 0, readers->size()),
           readers_(readers),
           offset_(offset) {}
 

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <iterator>
 #include "glog/logging.h"
 #include "gtest/gtest.h"
+#include "velox/common/base/VeloxException.h"
 #include "velox/expression/VectorUdfTypeSystem.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
@@ -104,6 +106,30 @@ class ArrayViewTest : public functions::test::FunctionBaseTest {
         j++;
       }
       ASSERT_EQ(j, arrayDataBigInt[i].size());
+
+      // Test loop iteration in reverse with post decrement
+      j = arrayDataBigInt[i].size() - 1;
+      for (it = arrayView.end() - 1; it >= arrayView.begin(); it--) {
+        testItem(i, j, *it);
+        j--;
+      }
+      // This is unintuitive but because we decrement after accessing each
+      // element, since j starts as one less than the size of the array, it
+      // should finish at -1.
+      ASSERT_EQ(j, -1);
+
+      // Test iterate with pre decrement
+      it = arrayView.end() - 1;
+      j = arrayDataBigInt[i].size() - 1;
+      while (it >= arrayView.begin()) {
+        testItem(i, j, *it);
+        j--;
+        --it;
+      }
+      // This is unintuitive but because we decrement after accessing each
+      // element, since j starts as one less than the size of the array, it
+      // should finish at -1.
+      ASSERT_EQ(j, -1);
     }
   }
 
@@ -130,6 +156,106 @@ class ArrayViewTest : public functions::test::FunctionBaseTest {
 
     ASSERT_EQ(read(reader, 0).size(), 2);
     ASSERT_EQ(read(reader, 1).size(), 1);
+  }
+
+  void iteratorDifferenceTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k <= j; k++) {
+          ASSERT_EQ(it - it2, j - k);
+          ASSERT_EQ(it2 - it, k - j);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorAdditionTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(it, it2 + (j - k));
+          ASSERT_EQ(it, (j - k) + it2);
+          auto it3 = it2;
+          it3 += j - k;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubtractionTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(it, it2 - (k - j));
+          auto it3 = it2;
+          it3 -= k - j;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSquareBracketsTest() {
+    std::vector<std::vector<std::optional<int32_t>>> intArray{
+        {1}, {2, 3}, {4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+    auto arrayVector = makeNullableArrayVector(intArray);
+    DecodedVector decoded;
+    exec::VectorReader<Array<int32_t>> reader(
+        decode(decoded, *arrayVector.get()));
+
+    for (auto i = 0; i < arrayVector->size(); i++) {
+      auto arrayView = read(reader, i);
+      auto it = arrayView.begin();
+
+      for (int j = 0; j < arrayView.size(); j++) {
+        auto it2 = arrayView.begin();
+        for (int k = 0; k < arrayView.size(); k++) {
+          ASSERT_EQ(*it, it2[j - k]);
+          it2++;
+        }
+        it++;
+      }
+    }
   }
 };
 
@@ -312,6 +438,22 @@ TEST_F(NullableArrayViewTest, nestedArray) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(NullableArrayViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullableArrayViewTest, iteratorSquareBrackets) {
+  iteratorSquareBracketsTest();
+}
+
 TEST_F(NullFreeArrayViewTest, intArray) {
   auto testItem = [&](int i, int j, auto item) {
     ASSERT_TRUE(item == arrayDataBigInt[i][j]);
@@ -324,4 +466,19 @@ TEST_F(NullFreeArrayViewTest, encoded) {
   encodedTest();
 }
 
+TEST_F(NullFreeArrayViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullFreeArrayViewTest, iteratorSquareBrackets) {
+  iteratorSquareBracketsTest();
+}
 } // namespace

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -136,6 +136,161 @@ class MapViewTest : public functions::test::FunctionBaseTest {
     }
   }
 
+  void iteratorDecrementTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      // Test using post decrement on the iterator.
+      auto j = mapView.size() - 1;
+      for (auto it = mapView.end() - 1; it >= mapView.begin(); it--) {
+        ASSERT_EQ(it->first, map[i][j].first);
+        ASSERT_EQ(it->second, map[i][j].second);
+        j--;
+      }
+      ASSERT_EQ(j, -1);
+
+      // Test using pre decrement on the iterator.
+      j = mapView.size() - 1;
+      for (auto it = mapView.end() - 1; it >= mapView.begin(); --it) {
+        ASSERT_EQ(it->first, map[i][j].first);
+        ASSERT_EQ(it->second, map[i][j].second);
+        j--;
+      }
+      ASSERT_EQ(j, -1);
+    }
+  }
+
+  void iteratorDifferenceTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k <= j; k++) {
+          ASSERT_EQ(it - it2, j - k);
+          ASSERT_EQ(it2 - it, k - j);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorAdditionTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(it, it2 + (j - k));
+          ASSERT_EQ(it, (j - k) + it2);
+          auto it3 = it2;
+          it3 += j - k;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSubtractionTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(it, it2 - (k - j));
+          auto it3 = it2;
+          it3 -= k - j;
+          ASSERT_EQ(it, it3);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
+  void iteratorSquareBracketsTest() {
+    std::vector<std::vector<std::pair<int64_t, std::optional<int64_t>>>> map{
+        {{1, 101}},
+        {{2, 102}, {3, 103}},
+        {{4, 104}, {5, 105}, {6, 106}},
+        {{7, 107}, {8, 108}, {9, 109}, {10, 110}},
+        {{11, 111}, {12, 112}, {13, 113}, {14, 114}, {15, 115}}};
+    auto mapVector = makeMapVector(map);
+
+    DecodedVector decoded;
+    exec::VectorReader<Map<int64_t, int64_t>> reader(
+        decode(decoded, *mapVector.get()));
+
+    for (auto i = 0; i < map.size(); i++) {
+      auto mapView = read(reader, i);
+      auto it = mapView.begin();
+
+      for (int j = 0; j < mapView.size(); j++) {
+        auto it2 = mapView.begin();
+        for (int k = 0; k < mapView.size(); k++) {
+          ASSERT_EQ(*it, it2[j - k]);
+          it2++;
+        }
+        it++;
+      }
+    }
+  }
+
   void encodedTest() {
     VectorPtr mapVector = createTestMapVector();
     // Wrap in dictionary.
@@ -500,6 +655,26 @@ TEST_F(NullableMapViewTest, testSubscript) {
   ASSERT_EQ(read(reader, 1)[1], 4);
 }
 
+TEST_F(NullableMapViewTest, iteratorDecrement) {
+  iteratorDecrementTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullableMapViewTest, iteratorSquareBrackets) {
+  iteratorSquareBracketsTest();
+}
+
 TEST_F(NullFreeMapViewTest, testReadingRangeLoop) {
   readingRangeLoopTest();
 }
@@ -548,6 +723,26 @@ TEST_F(NullFreeMapViewTest, testSubscript) {
 
   ASSERT_THROW(read(reader, 1)[5], VeloxException);
   ASSERT_EQ(read(reader, 1)[3], 3);
+}
+
+TEST_F(NullFreeMapViewTest, iteratorDecrement) {
+  iteratorDecrementTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorDifference) {
+  iteratorDifferenceTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorAddition) {
+  iteratorAdditionTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorSubtraction) {
+  iteratorSubtractionTest();
+}
+
+TEST_F(NullFreeMapViewTest, iteratorSquareBrackets) {
+  iteratorSquareBracketsTest();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
As the title suggests, this diff makes it so that MapView::Iterator meets the requirements
of a random_access_iterator.  This lets std algorithms on instances of the iterator like
distance know that they can use constant time implementations rather than linear time.

The new functions include:
In the IndexBasedIterator:
pre-decrement
post-decrement
+=
-=
In the MapView::Iterator
iterator + int
int + iterator
iterator - int
iterator - iterator
[n] to access the value at iterator + n

In addition I added calls to the validateBounds() function in IndexBasedIterator when
dereferencing the iterator to ensure we don't accidentally dereference values off the end
of the current collection.

I also added a static check to the Iterator to ensure it's properly declaring its
iterator_category (Iterators don't inherit this from the parent, which it seems like the code
was assuming before).

Differential Revision: D34911295

