### PR TITLE
Change PlanBuilder::localMerge to accept ORDER BY SQL clauses

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -303,8 +303,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
     auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
     auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
                                .localMerge(
-                                   {0},
-                                   {kAscNullsLast},
+                                   {"c0"},
                                    {PlanBuilder(planNodeIdGenerator)
                                         .tableScan(rowType_)
                                         .orderBy({"c0"}, true)

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -380,20 +380,18 @@ TEST_F(PlanNodeToStringTest, partitionedOutput) {
 }
 
 TEST_F(PlanNodeToStringTest, localMerge) {
-  auto plan = PlanBuilder()
-                  .localMerge(
-                      {1},
-                      {core::kAscNullsFirst},
-                      {PlanBuilder().values({data_}).planNode()})
-                  .planNode();
+  auto plan =
+      PlanBuilder()
+          .localMerge(
+              {"c1 NULLS FIRST"}, {PlanBuilder().values({data_}).planNode()})
+          .planNode();
 
   ASSERT_EQ("-> LocalMerge\n", plan->toString());
   ASSERT_EQ("-> LocalMerge[c1 ASC NULLS FIRST]\n", plan->toString(true, false));
 
   plan = PlanBuilder()
              .localMerge(
-                 {1, 0},
-                 {core::kAscNullsFirst, core::kDescNullsLast},
+                 {"c1 NULLS FIRST", "c0 DESC"},
                  {PlanBuilder().values({data_}).planNode()})
              .planNode();
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -249,9 +249,16 @@ class PlanBuilder {
       bool ignoreNullKeys,
       const std::vector<TypePtr>& resultTypes = {});
 
+  /// Adds a LocalMergeNode using specified ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .localMerge({"a", "b DESC", "c ASC NULLS FIRST"})
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
   PlanBuilder& localMerge(
-      const std::vector<ChannelIndex>& keyIndices,
-      const std::vector<core::SortOrder>& sortOrder,
+      const std::vector<std::string>& keys,
       std::vector<std::shared_ptr<const core::PlanNode>> sources);
 
   /// Adds an OrderByNode using specified ORDER BY clauses.


### PR DESCRIPTION
PlanBuilder::localMerge used to require the caller to specify two lists:  indices
of sorting keys and corresponding sort orders. The new API takes a list of
ORDER BY SQL clauses making it easier to use when writing as well as
reading code.

Before: `.localMerge({0, 1}, {core::kAscNullsLast, core::kAscNullsLast}, false)`

After: `.localMerge({"l_returnflag", "l_linestatus"}, false)`

See #1201 for similar change to PlanBuilder::orderBy.