### PR TITLE
Remove BaseVector::clear() method

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -90,8 +90,8 @@ void FilterProject::addInput(RowVectorPtr input) {
 
   for (int32_t i = 0; i < firstProjected; ++i) {
     if (results_[i]) {
-      if (results_[i]->encoding() == VectorEncoding::Simple::FLAT) {
-        results_[i]->clear();
+      if (BaseVector::isReusableFlatVector(results_[i])) {
+        results_[i]->resize(0);
       } else {
         results_[i] = nullptr;
       }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -144,7 +144,7 @@ VectorPtr Operator::getResultVector(ChannelIndex index) {
   }
 
   if (BaseVector::isReusableFlatVector(vector)) {
-    vector->clear();
+    vector->resize(0);
     return std::move(vector);
   }
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -88,9 +88,8 @@ class Expr {
     if (sharedSubexprRows_) {
       sharedSubexprRows_->clearAll();
     }
-    if (sharedSubexprValues_.unique() &&
-        sharedSubexprValues_->encoding() == VectorEncoding::Simple::FLAT) {
-      sharedSubexprValues_->clear();
+    if (BaseVector::isReusableFlatVector(sharedSubexprValues_)) {
+      sharedSubexprValues_->resize(0);
     } else {
       sharedSubexprValues_ = nullptr;
     }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -350,10 +350,6 @@ class BaseVector {
     clearNulls(0, size());
   }
 
-  virtual void clear() {
-    resize(0);
-  }
-
   // Sets the size to 'size' and ensures there is space for the
   // indicated number of nulls and top level values.
   // 'setNotNull' indicates if nulls in range [oldSize, newSize) should be set


### PR DESCRIPTION
BaseVector::clear() was defined as resize(0). This works for flat vectors of
simple types, but doesn't work for flat vectors of complex types (arrays, maps
and structs) as resize(0) doesn't resize nested vectors. A follow-up PR will
introduce BaseVector::prepareForReuse() method for preparing a vector for
reuse. The new method will (1) check nested buffers and vectors and allocate
news ones if these are not singly-references; (2) clear string buffers except
for one; (3) clear nulls buffer if there are no nulls; (4) call prepareForReuse
recursively for child vectors.

The new BaseVector::prepareForReuse() will replace existing calls to 
BaseVector::isReusableFlatVector + resize(0).