### PR TITLE
De-flake ParquetTableScanTest

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/init/Init.h>
 #include "velox/dwio/dwrf/test/utils/DataFiles.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -222,4 +223,10 @@ TEST_F(ParquetTableScanTest, countStar) {
                   .planNode();
 
   assertQuery(plan, {split}, "SELECT 20");
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
ParquetTableScanTest fails intermittently with

```
F0316 20:16:56.515322  9132 Singleton.cpp:145] Singleton folly::ThreadWheelTimekeeper requested before registrationComplete() call.
This usually means that either main() never called folly::init, or singleton was requested before main() (which is not allowed).
```

The fix is the same as in https://github.com/facebookincubator/velox/issues/1209