### PR TITLE
Add BaseVector::prepareForReuse method

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -66,6 +66,7 @@ void MemoryUsageTracker::incrementUsage(UsageType type, int64_t size) {
       size;
 
   ++usage(numAllocs_, type);
+  ++usage(numAllocs_, UsageType::kTotalMem);
   usage(cumulativeBytes_, type) += size;
 
   // We track the peak usage of total memory independent of user and

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -339,9 +339,18 @@ folly::Range<vector_size_t*> initializeRowNumberMapping(
 } // namespace
 
 void HashProbe::prepareOutput(vector_size_t size) {
-  // TODO Reuse output vector when possible.
-  output_ = std::static_pointer_cast<RowVector>(
-      BaseVector::create(outputType_, size, pool()));
+  // Try to re-use memory for the output vectors that contain build-side data.
+  // We expect output vectors containing probe-side data to be null (reset in
+  // clearIdentityProjectedOutput). BaseVector::prepareForReuse keeps null
+  // children unmodified and makes non-null (build side) children reusable.
+  if (output_) {
+    VectorPtr output = std::move(output_);
+    BaseVector::prepareForReuse(output, size);
+    output_ = std::static_pointer_cast<RowVector>(output);
+  } else {
+    output_ = std::static_pointer_cast<RowVector>(
+        BaseVector::create(outputType_, size, pool()));
+  }
 }
 
 void HashProbe::fillOutput(vector_size_t size) {

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -55,6 +55,15 @@ class AssignUniqueIdTest : public OperatorTestBase {
         0,
         [](vector_size_t sum, RowVectorPtr row) { return sum + row->size(); });
     ASSERT_EQ(totalInputSize * numThreads, ids.size());
+
+    auto task = result.first->task();
+
+    // Verify number of memory allocations. There should be exactly one
+    // allocation (per thread of execution) for the values buffer of the unique
+    // ID vector. Memory should be allocated when producing first batch of
+    // output and re-used for subsequent batches.
+    ASSERT_EQ(
+        numThreads, task->pool()->getMemoryUsageTracker()->getNumAllocs());
   }
 };
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1314,4 +1314,8 @@ TEST_F(HashJoinTest, memoryUsage) {
   auto planStats = toPlanStats(task->taskStats());
   auto outputBytes = planStats.at(joinNodeId).outputBytes;
   ASSERT_LT(outputBytes, 700 * 1024);
+
+  // Verify number of memory allocations. Should not be too high if hash join is
+  // able to re-use output vectors that contain build-side data.
+  ASSERT_GT(30, task->pool()->getMemoryUsageTracker()->getNumAllocs());
 }

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -311,6 +311,15 @@ uint64_t RowVector::estimateFlatSize() const {
   return total;
 }
 
+void RowVector::prepareForReuse() {
+  BaseVector::prepareForReuse();
+  for (auto& child : children_) {
+    if (child) {
+      BaseVector::prepareForReuse(child, 0);
+    }
+  }
+}
+
 bool ArrayVector::equalValueAt(
     const BaseVector* other,
     vector_size_t index,
@@ -592,6 +601,30 @@ void ArrayVector::ensureWritable(const SelectivityVector& rows) {
 uint64_t ArrayVector::estimateFlatSize() const {
   return BaseVector::retainedSize() + offsets_->capacity() +
       sizes_->capacity() + elements_->estimateFlatSize();
+}
+
+namespace {
+void zeroOutBuffer(BufferPtr buffer) {
+  memset(buffer->asMutable<char>(), 0, buffer->size());
+}
+} // namespace
+
+void ArrayVector::prepareForReuse() {
+  BaseVector::prepareForReuse();
+
+  if (!(offsets_->unique() && offsets_->isMutable())) {
+    offsets_ = nullptr;
+  } else {
+    zeroOutBuffer(offsets_);
+  }
+
+  if (!(sizes_->unique() && sizes_->isMutable())) {
+    sizes_ = nullptr;
+  } else {
+    zeroOutBuffer(sizes_);
+  }
+
+  BaseVector::prepareForReuse(elements_, 0);
 }
 
 bool MapVector::equalValueAt(
@@ -935,6 +968,25 @@ uint64_t MapVector::estimateFlatSize() const {
   return BaseVector::retainedSize() + offsets_->capacity() +
       sizes_->capacity() + keys_->estimateFlatSize() +
       values_->estimateFlatSize();
+}
+
+void MapVector::prepareForReuse() {
+  BaseVector::prepareForReuse();
+
+  if (!(offsets_->unique() && offsets_->isMutable())) {
+    offsets_ = nullptr;
+  } else {
+    zeroOutBuffer(offsets_);
+  }
+
+  if (!(sizes_->unique() && sizes_->isMutable())) {
+    sizes_ = nullptr;
+  } else {
+    zeroOutBuffer(sizes_);
+  }
+
+  BaseVector::prepareForReuse(keys_, 0);
+  BaseVector::prepareForReuse(values_, 0);
 }
 
 } // namespace velox

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -145,6 +145,10 @@ class RowVector : public BaseVector {
 
   void ensureWritable(const SelectivityVector& rows) override;
 
+  /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
+  /// needed, then calls BaseVector::prepareForReuse(child, 0) for all children.
+  void prepareForReuse() override;
+
   bool mayHaveNullsRecursive() const override {
     if (BaseVector::mayHaveNullsRecursive()) {
       return true;
@@ -373,6 +377,12 @@ class ArrayVector : public BaseVector {
 
   void ensureWritable(const SelectivityVector& rows) override;
 
+  /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
+  /// needed, checks and resets offsets and sizes buffers, zeros out offsets and
+  /// sizes if reusable, calls BaseVector::prepareForReuse(elements, 0) for the
+  /// elements vector.
+  void prepareForReuse() override;
+
   bool mayHaveNullsRecursive() const override {
     return BaseVector::mayHaveNullsRecursive() ||
         elements_->mayHaveNullsRecursive();
@@ -563,6 +573,12 @@ class MapVector : public BaseVector {
   std::vector<vector_size_t> sortedKeyIndices(vector_size_t index) const;
 
   void ensureWritable(const SelectivityVector& rows) override;
+
+  /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
+  /// needed, checks and resets offsets and sizes buffers, zeros out offsets and
+  /// sizes if reusable, calls BaseVector::prepareForReuse(keys|values, 0) for
+  /// the keys and values vectors.
+  void prepareForReuse() override;
 
   bool mayHaveNullsRecursive() const override {
     return BaseVector::mayHaveNullsRecursive() ||

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -335,5 +335,34 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
 
   BaseVector::ensureWritable(rows);
 }
+
+template <typename T>
+void FlatVector<T>::prepareForReuse() {
+  BaseVector::prepareForReuse();
+
+  // Check values buffer. Keep the buffer if singly-referenced and mutable.
+  // Reset otherwise.
+  if (values_ && !(values_->unique() && values_->isMutable())) {
+    values_ = nullptr;
+  }
+
+  // Check string buffers. Keep at most one singly-referenced buffer if it is
+  // not too large.
+  if (!stringBuffers_.empty()) {
+    auto& firstBuffer = stringBuffers_.front();
+    if (firstBuffer->unique() && firstBuffer->isMutable() &&
+        firstBuffer->capacity() <= kMaxStringSizeForReuse) {
+      firstBuffer->setSize(0);
+      stringBuffers_.resize(1);
+    } else {
+      stringBuffers_.clear();
+    }
+  }
+
+  // Clear ASCII-ness.
+  if constexpr (std::is_same_v<T, StringView>) {
+    SimpleVector<StringView>::invalidateIsAscii();
+  }
+}
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   VectorMakerTest.cpp
   VectorTest.cpp
   VectorEstimateFlatSizeTest.cpp
+  VectorPrepareForReuseTest.cpp
   DecodedVectorTest.cpp
   SelectivityVectorTest.cpp
   EnsureWritableVectorTest.cpp

--- a/velox/vector/tests/VectorPrepareForReuseTest.cpp
+++ b/velox/vector/tests/VectorPrepareForReuseTest.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+
+class VectorPrepareForReuseTest : public testing::Test,
+                                  public test::VectorTestBase {
+ protected:
+  VectorPrepareForReuseTest() {
+    pool()->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
+  }
+};
+
+class MemoryAllocationChecker {
+ public:
+  explicit MemoryAllocationChecker(memory::MemoryPool* pool)
+      : tracker_{pool->getMemoryUsageTracker().get()},
+        numAllocations_{tracker_->getNumAllocs()} {}
+
+  bool assertOne() {
+    bool ok = numAllocations_ + 1 == tracker_->getNumAllocs();
+    numAllocations_ = tracker_->getNumAllocs();
+    return ok;
+  }
+
+  bool assertAtLeastOne() {
+    bool ok = numAllocations_ < tracker_->getNumAllocs();
+    numAllocations_ = tracker_->getNumAllocs();
+    return ok;
+  }
+
+  ~MemoryAllocationChecker() {
+    EXPECT_EQ(numAllocations_, tracker_->getNumAllocs());
+  }
+
+ private:
+  memory::MemoryUsageTracker* tracker_;
+  int64_t numAllocations_;
+};
+
+TEST_F(VectorPrepareForReuseTest, strings) {
+  std::vector<std::string> largeStrings = {
+      std::string(20, '.'),
+      std::string(30, '-'),
+      std::string(40, '='),
+  };
+
+  auto stringAt = [&](auto row) {
+    return row % 3 == 0 ? StringView(largeStrings[(row / 3) % 3]) : ""_sv;
+  };
+
+  VectorPtr vector = makeFlatVector<StringView>(1'000, stringAt);
+  auto originalBytes = vector->retainedSize();
+  BaseVector* originalVector = vector.get();
+
+  // Verify that string buffers get reused rather than appended to.
+  {
+    MemoryAllocationChecker allocationChecker(pool());
+
+    BaseVector::prepareForReuse(vector, vector->size());
+    ASSERT_EQ(originalVector, vector.get());
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    for (auto i = 0; i < vector->size(); i++) {
+      vector->asFlatVector<StringView>()->set(i, stringAt(i));
+    }
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+  }
+
+  // Verify that string buffers get dropped if not singly referenced.
+  auto getStringBuffers = [](const VectorPtr& vector) {
+    return vector->asFlatVector<StringView>()->stringBuffers();
+  };
+
+  {
+    MemoryAllocationChecker allocationChecker(pool());
+
+    auto stringBuffers = getStringBuffers(vector);
+    ASSERT_FALSE(stringBuffers.empty());
+
+    BaseVector::prepareForReuse(vector, vector->size());
+    ASSERT_EQ(originalVector, vector.get());
+    ASSERT_GT(originalBytes, vector->retainedSize());
+    ASSERT_TRUE(getStringBuffers(vector).empty());
+
+    for (auto i = 0; i < vector->size(); i++) {
+      vector->asFlatVector<StringView>()->set(i, stringAt(i));
+    }
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    ASSERT_TRUE(allocationChecker.assertAtLeastOne());
+  }
+
+  // Verify that only one string buffer is kept for re-use.
+  {
+    std::vector<std::string> extraLargeStrings = {
+        std::string(200, '.'),
+        std::string(300, '-'),
+        std::string(400, '='),
+    };
+
+    VectorPtr extraLargeVector = makeFlatVector<StringView>(
+        1'000,
+        [&](auto row) { return StringView(extraLargeStrings[row % 3]); });
+    ASSERT_LT(1, getStringBuffers(extraLargeVector).size());
+
+    auto originalExtraLargeBytes = extraLargeVector->retainedSize();
+    BaseVector* originalExtraLargeVector = extraLargeVector.get();
+
+    MemoryAllocationChecker allocationChecker(pool());
+
+    BaseVector::prepareForReuse(extraLargeVector, extraLargeVector->size());
+    ASSERT_EQ(originalExtraLargeVector, extraLargeVector.get());
+    ASSERT_GT(originalExtraLargeBytes, extraLargeVector->retainedSize());
+    ASSERT_EQ(1, getStringBuffers(extraLargeVector).size());
+
+    for (auto i = 0; i < extraLargeVector->size(); i++) {
+      extraLargeVector->asFlatVector<StringView>()->set(i, stringAt(i));
+    }
+    ASSERT_EQ(originalBytes, extraLargeVector->retainedSize());
+  }
+}
+
+TEST_F(VectorPrepareForReuseTest, nulls) {
+  VectorPtr vector = makeFlatVector<int32_t>(
+      1'000, [](auto row) { return row; }, nullEvery(7));
+  auto originalBytes = vector->retainedSize();
+  BaseVector* originalVector = vector.get();
+
+  // Verify that nulls buffer is reused.
+  {
+    MemoryAllocationChecker allocationChecker(pool());
+
+    ASSERT_TRUE(vector->nulls() != nullptr);
+
+    BaseVector::prepareForReuse(vector, vector->size());
+    ASSERT_EQ(originalVector, vector.get());
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+  }
+
+  // Verify that nulls buffer is freed if there are no nulls.
+  {
+    MemoryAllocationChecker allocationChecker(pool());
+
+    for (auto i = 0; i < vector->size(); i++) {
+      vector->setNull(i, false);
+    }
+    ASSERT_TRUE(vector->nulls() != nullptr);
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    BaseVector::prepareForReuse(vector, vector->size());
+    ASSERT_EQ(originalVector, vector.get());
+    ASSERT_TRUE(vector->nulls() == nullptr);
+    ASSERT_GT(originalBytes, vector->retainedSize());
+
+    vector->setNull(12, true);
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    ASSERT_TRUE(allocationChecker.assertOne());
+  }
+
+  // Verify that nulls buffer is dropped if not singly-referenced.
+  {
+    MemoryAllocationChecker allocationChecker(pool());
+
+    ASSERT_TRUE(vector->nulls() != nullptr);
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    auto nulls = vector->nulls();
+    BaseVector::prepareForReuse(vector, vector->size());
+    ASSERT_EQ(originalVector, vector.get());
+    ASSERT_TRUE(vector->nulls() == nullptr);
+    ASSERT_GT(originalBytes, vector->retainedSize());
+
+    vector->setNull(12, true);
+    ASSERT_EQ(originalBytes, vector->retainedSize());
+
+    ASSERT_TRUE(allocationChecker.assertOne());
+  }
+}
+
+TEST_F(VectorPrepareForReuseTest, arrays) {
+  VectorPtr vector = makeArrayVector<int32_t>(
+      1'000,
+      [](auto row) { return 1; },
+      [](auto row, auto index) { return row + index; });
+  auto originalSize = vector->retainedSize();
+  BaseVector* originalVector = vector.get();
+
+  auto otherVector = makeArrayVector<int32_t>(
+      1'000,
+      [](auto row) { return 1; },
+      [](auto row, auto index) { return 2 * row + index; });
+
+  MemoryAllocationChecker allocationChecker(pool());
+  BaseVector::prepareForReuse(vector, vector->size());
+  ASSERT_EQ(originalVector, vector.get());
+  ASSERT_EQ(originalSize, vector->retainedSize());
+
+  for (auto i = 0; i < 1'000; i++) {
+    ASSERT_EQ(0, vector->as<ArrayVector>()->sizeAt(i));
+    ASSERT_EQ(0, vector->as<ArrayVector>()->offsetAt(i));
+  }
+
+  vector->copy(otherVector.get(), 0, 0, 1'000);
+  ASSERT_EQ(originalSize, vector->retainedSize());
+}


### PR DESCRIPTION
To safely reuse a vector one needs to (1) ensure that the vector as well
as all its buffers and child vectors are singly-referenced and mutable
(for buffers); (2) clear append-only string buffers and child vectors
(elements of arrays, keys and values of maps, fields of structs).

The new static BaseVector::prepareForReuse method is designed to enable safe
vector reuse without too much boiler plate. It takes a 'vector' and a new size
and returns possibly new flat vector of the specified size that is safe to
reuse. If input 'vector' is not singly-referenced or not flat, returns a new
vector of the same type and specified size. If some of the buffers cannot be
reused, these buffers are reset. Child vectors are updated by calling this
method recursively with size zero.


Here is an example of usage:


```
void HashProbe::prepareOutput(vector_size_t size) {
  if (output_) {
    VectorPtr output = std::move(output_);
    BaseVector::prepareForReuse(output, size)
    output_ = std::static_pointer_cast<RowVector>(output);
  } else {
    output_ = std::static_pointer_cast<RowVector>(
        BaseVector::create(outputType_, size, pool()));
  }
}
```

Note that the vector is moved into VectorPtr variable before calling
BaseVector::prepareForReuse. This is necessary if the type of the vector is not
VectorPtr, e.g. RowVectorPtr. Passing a reference to RowVectorPtr will
increment reference count and effectively disable reuse as vector.unique
() check inside the BaseVector::prepareForReuse method will return false.

Update HashProbe and AssignUniqueId operators to use the new method.