### PR TITLE
Add custom operator stats to printPlanWithStats

### DIFF
--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -16,10 +16,9 @@
 #pragma once
 
 #include "velox/common/time/CpuWallTimer.h"
-#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {
-struct OperatorStats;
 struct TaskStats;
 } // namespace facebook::velox::exec
 
@@ -79,6 +78,9 @@ struct PlanNodeStats {
   /// operator instances were running concurrently.
   uint64_t peakMemoryBytes{0};
 
+  /// Operator-specific counters.
+  std::unordered_map<std::string, RuntimeMetric> customStats;
+
   /// Breakdown of stats by operator type.
   std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
 
@@ -102,7 +104,10 @@ std::unordered_map<core::PlanNodeId, PlanNodeStats> toPlanStats(
 /// statistics per operator type.
 ///
 /// Note that input row counts and sizes are printed only for leaf plan nodes.
+///
+/// @param includeCustomStats If true, prints operator-specific counters.
 std::string printPlanWithStats(
     const core::PlanNode& plan,
-    const TaskStats& taskStats);
+    const TaskStats& taskStats,
+    bool includeCustomStats = false);
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Without custom stats: `std::cout << printPlanWithStats(*op, task->taskStats()) << std::endl;`

```
-> Project[expressions: (c0:INTEGER, ROW["c0"]), (p1:BIGINT, plus(ROW["c1"],1)), (p2:BIGINT, plus(ROW["c1"],ROW["u_c1"])), ]
   Output: 2000 rows (104120 bytes), Cpu time: 2503330ns, Blocked wall time: 0ns, Peak memory: 1048576 bytes
  -> HashJoin[INNER c0=u_c0]
     Output: 2000 rows (85580 bytes), Cpu time: 2701516ns, Blocked wall time: 331000ns, Peak memory: 2097152 bytes
     HashBuild: Output: 0 rows (0 bytes), Cpu time: 338118ns, Blocked wall time: 0ns, Peak memory: 1048576 bytes
     HashProbe: Output: 2000 rows (85580 bytes), Cpu time: 2363398ns, Blocked wall time: 331000ns, Peak memory: 1048576 bytes
    -> TableScan[]
       Input: 11240 rows (60480 bytes), Raw Input: 20480 rows (74041 bytes), Output: 11240 rows (60480 bytes), Cpu time: 10910117ns, Blocked wall time: 9000ns, Peak memory: 1048576 bytes
    -> Project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:BIGINT, ROW["c1"]), ]
       Output: 100 rows (1343 bytes), Cpu time: 62045ns, Blocked wall time: 0ns, Peak memory: 0 bytes
      -> Values[100 rows in 1 vectors]
         Input: 0 rows (0 bytes), Output: 100 rows (1343 bytes), Cpu time: 5015ns, Blocked wall time: 0ns, Peak memory: 0 bytes
```

with custom stats: `std::cout << printPlanWithStats(*op, task->taskStats(), true) << std::endl;`
```
    std::cout << printPlanWithStats(*op, task->taskStats(), true) << std::endl;

-> Project[expressions: (c0:INTEGER, ROW["c0"]), (p1:BIGINT, plus(ROW["c1"],1)), (p2:BIGINT, plus(ROW["c1"],ROW["u_c1"])), ]
   Output: 2000 rows (104120 bytes), Cpu time: 2503330ns, Blocked wall time: 0ns, Peak memory: 1048576 bytes
      dataSourceLazyWallNanos    sum: 706000, count: 20, min: 28000, max: 68000
  -> HashJoin[INNER c0=u_c0]
     Output: 2000 rows (85580 bytes), Cpu time: 2701516ns, Blocked wall time: 331000ns, Peak memory: 2097152 bytes
     HashBuild: Output: 0 rows (0 bytes), Cpu time: 338118ns, Blocked wall time: 0ns, Peak memory: 1048576 bytes
        queuedWallNanos    sum: 166000, count: 1, min: 166000, max: 166000
        rangeKey0          sum: 200, count: 1, min: 200, max: 200
        distinctKey0       sum: 101, count: 1, min: 101, max: 101
     HashProbe: Output: 2000 rows (85580 bytes), Cpu time: 2363398ns, Blocked wall time: 331000ns, Peak memory: 1048576 bytes
        queuedWallNanos           sum: 53000, count: 1, min: 53000, max: 53000
        dynamicFiltersProduced    sum: 1, count: 1, min: 1, max: 1
    -> TableScan[]
       Input: 11240 rows (60480 bytes), Raw Input: 20480 rows (74041 bytes), Output: 11240 rows (60480 bytes), Cpu time: 10910117ns, Blocked wall time: 9000ns, Peak memory: 1048576 bytes
          queuedWallNanos            sum: 30000, count: 1, min: 30000, max: 30000
          ramReadBytes               sum: 0, count: 1, min: 0, max: 0
          dataSourceLazyWallNanos    sum: 866000, count: 10, min: 56000, max: 156000
          skippedStrides             sum: 0, count: 1, min: 0, max: 0
          dynamicFiltersAccepted     sum: 1, count: 1, min: 1, max: 1
          localReadBytes             sum: 0, count: 1, min: 0, max: 0
          numRamRead                 sum: 0, count: 1, min: 0, max: 0
          numPrefetch                sum: 26, count: 1, min: 26, max: 26
          prefetchBytes              sum: 21881, count: 1, min: 21881, max: 21881
          skippedSplits              sum: 0, count: 1, min: 0, max: 0
          storageReadBytes           sum: 153855, count: 1, min: 153855, max: 153855
          dataSourceWallNanos        sum: 4187000, count: 40, min: 29000, max: 286000
          numStorageRead             sum: 140, count: 1, min: 140, max: 140
          skippedSplitBytes          sum: 0, count: 1, min: 0, max: 0
          numLocalRead               sum: 0, count: 1, min: 0, max: 0
    -> Project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:BIGINT, ROW["c1"]), ]
       Output: 100 rows (1343 bytes), Cpu time: 62045ns, Blocked wall time: 0ns, Peak memory: 0 bytes
      -> Values[100 rows in 1 vectors]
         Input: 0 rows (0 bytes), Output: 100 rows (1343 bytes), Cpu time: 5015ns, Blocked wall time: 0ns, Peak memory: 0 bytes
```