### PR TITLE
Increase minimum size of a string buffer to 32 KB (from 8KB)

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1313,5 +1313,5 @@ TEST_F(HashJoinTest, memoryUsage) {
 
   auto planStats = toPlanStats(task->taskStats());
   auto outputBytes = planStats.at(joinNodeId).outputBytes;
-  ASSERT_LT(outputBytes, 512 * 1024);
+  ASSERT_LT(outputBytes, 700 * 1024);
 }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -40,8 +40,11 @@ class FlatVector final : public SimpleVector<T> {
        std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||
        std::is_same<T, bool>::value || std::is_same<T, size_t>::value);
 
+  // Minimum size of a string buffer. 32 KB value is chosen to ensure that a
+  // single buffer is sufficient for a "typical" vector: 1K rows, medium size
+  // strings.
   static constexpr vector_size_t kInitialStringSize =
-      (8 * 1024) - sizeof(AlignedBuffer);
+      (32 * 1024) - sizeof(AlignedBuffer);
 
   FlatVector(
       velox::memory::MemoryPool* pool,

--- a/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
+++ b/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
@@ -256,12 +256,12 @@ TEST_F(VectorEstimateFlatSizeTest, flatStrings) {
     return StringView(longStrings_[row % 3]);
   };
   flat = makeFlatVector<StringView>(1'000, longStringAt);
-  EXPECT_EQ(40672, flat->retainedSize());
-  EXPECT_EQ(40672, flat->estimateFlatSize());
+  EXPECT_EQ(65344, flat->retainedSize());
+  EXPECT_EQ(65343, flat->estimateFlatSize());
 
   flat = makeFlatVector<StringView>(1'000, longStringAt, nullEvery(5));
-  EXPECT_EQ(40832, flat->retainedSize());
-  EXPECT_EQ(40832, flat->estimateFlatSize());
+  EXPECT_EQ(65504, flat->retainedSize());
+  EXPECT_EQ(65504, flat->estimateFlatSize());
 }
 
 TEST_F(VectorEstimateFlatSizeTest, dictionaryShortStrings) {
@@ -298,24 +298,24 @@ TEST_F(VectorEstimateFlatSizeTest, dictionaryLongStrings) {
   };
 
   auto dict = makeDict(makeFlatVector<StringView>(1'000, longStringAt));
-  EXPECT_EQ(41088, dict->retainedSize());
-  EXPECT_EQ(4067, dict->estimateFlatSize());
+  EXPECT_EQ(65760, dict->retainedSize());
+  EXPECT_EQ(6534, dict->estimateFlatSize());
   // Flatten() method uses BaseVector::copy() which doesn't copy the strings,
   // but rather copies the shared pointer to the string buffers of the source
   // vector. Hence, the size of the "flattened" vector includes the size of the
   // original string buffers.
-  EXPECT_EQ(26336, flatten(dict)->retainedSize());
+  EXPECT_EQ(51008, flatten(dict)->retainedSize());
 
   // Non-inlined strings with nulls.
   dict =
       makeDict(makeFlatVector<StringView>(1'000, longStringAt, nullEvery(5)));
-  EXPECT_EQ(41248, dict->retainedSize());
-  EXPECT_EQ(4083, dict->estimateFlatSize());
+  EXPECT_EQ(65920, dict->retainedSize());
+  EXPECT_EQ(6550, dict->estimateFlatSize());
   // Flatten() method uses BaseVector::copy() which doesn't copy the strings,
   // but rather copies the shared pointer to the string buffers of the source
   // vector. Hence, the size of the "flattened" vector includes the size of the
   // original string buffers.
-  EXPECT_EQ(26368, flatten(dict)->retainedSize());
+  EXPECT_EQ(51040, flatten(dict)->retainedSize());
 }
 
 TEST_F(VectorEstimateFlatSizeTest, arrayOfInts) {
@@ -398,9 +398,9 @@ TEST_F(VectorEstimateFlatSizeTest, arrayOfLongStrings) {
 
   auto elements = array->elements();
 
-  EXPECT_EQ(40672, elements->retainedSize());
-  EXPECT_EQ(48672, array->retainedSize());
-  EXPECT_EQ(48672, array->estimateFlatSize());
+  EXPECT_EQ(65344, elements->retainedSize());
+  EXPECT_EQ(73344, array->retainedSize());
+  EXPECT_EQ(73343, array->estimateFlatSize());
 
   // Dictionary-encoded array.
   auto indices = makeIndices(100, [](auto row) { return row * 2; });
@@ -409,10 +409,10 @@ TEST_F(VectorEstimateFlatSizeTest, arrayOfLongStrings) {
     return wrapInDictionary(indices, 100, base);
   };
 
-  EXPECT_EQ(49088, makeDict(array)->retainedSize());
-  EXPECT_EQ(4867, makeDict(array)->estimateFlatSize());
+  EXPECT_EQ(73760, makeDict(array)->retainedSize());
+  EXPECT_EQ(7334, makeDict(array)->estimateFlatSize());
   // Flattened vector includes the original string buffers.
-  EXPECT_EQ(27168, flatten(makeDict(array))->estimateFlatSize());
+  EXPECT_EQ(51840, flatten(makeDict(array))->estimateFlatSize());
 
   // Flat array with dictionary encoded elements.
   auto offsets = makeIndices(100, [](auto row) { return row; });
@@ -420,10 +420,10 @@ TEST_F(VectorEstimateFlatSizeTest, arrayOfLongStrings) {
 
   array = makeArrayVector(
       ARRAY(VARCHAR()), 100, offsets, lengths, makeDict(elements));
-  EXPECT_EQ(41920, array->retainedSize());
-  EXPECT_EQ(4899, array->estimateFlatSize());
+  EXPECT_EQ(66592, array->retainedSize());
+  EXPECT_EQ(7366, array->estimateFlatSize());
   // Flattened vector includes the original string buffers.
-  EXPECT_EQ(27168, flatten(array)->estimateFlatSize());
+  EXPECT_EQ(51840, flatten(array)->estimateFlatSize());
 }
 
 TEST_F(VectorEstimateFlatSizeTest, mapOfInts) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -319,7 +319,6 @@ class VectorTest : public testing::Test {
   template <TypeKind KIND>
   void testFlat(TypePtr type, vector_size_t size, bool withNulls) {
     using T = typename TypeTraits<KIND>::NativeType;
-    BufferPtr buffer;
     VectorPtr base = BaseVector::create(type, size, pool_.get());
     auto flat = std::dynamic_pointer_cast<FlatVector<T>>(base);
     ASSERT_NE(flat.get(), nullptr);
@@ -338,6 +337,7 @@ class VectorTest : public testing::Test {
       EXPECT_TRUE(flat->isNullAt(size * 2 - 1));
     }
     // Test that the null is cleared.
+    BufferPtr buffer;
     flat->set(size * 2 - 1, testValue<T>(size, buffer));
     EXPECT_FALSE(flat->isNullAt(size * 2 - 1));
 
@@ -720,8 +720,7 @@ class VectorTest : public testing::Test {
         auto deserializedRetained = resultRow->retainedSize();
         EXPECT_LE(deserializedRetained, originalRetained)
             << "Deserializing half is larger than original";
-        EXPECT_GT(deserializedRetained, originalRetained / 8)
-            << "Deserialized half is less than 1/8 the of original size";
+        EXPECT_GT(deserializedRetained, 0);
         break;
       }
       default:


### PR DESCRIPTION
8KB is not sufficient to hold strings for a typical vector of 1K rows as it
allows only 8 bytes per string. 32KB buffer would fit 1K medium size (32 bytes)
strings.