### PR TITLE
Fix Clang compiler warning 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make release EXTRA_CMAKE_FLAGS=" -DTREAT_WARNINGS_AS_ERRORS=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_S3=ON " AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make release EXTRA_CMAKE_FLAGS=" -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_S3=ON " AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make release EXTRA_CMAKE_FLAGS=" -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_S3=ON " AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make release EXTRA_CMAKE_FLAGS=" -DTREAT_WARNINGS_AS_ERRORS=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_S3=ON " AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - store_artifacts:

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -42,16 +42,17 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
 
   static const int64_t kMax = std::numeric_limits<int64_t>::max();
   static const int64_t kMin = std::numeric_limits<int64_t>::min();
-  static const uint64_t kSignedMax = (1ull << 63);
 
   static const Timestamp kMaxTimestamp(
       kMax / 1000, kMax % 1000 * kNanosecondsInMillisecond);
   static const Timestamp kMinTimestamp(
       kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMillisecond);
 
-  // We use kSignedMax because on some compilers if we cast kMax to a double, we
-  // get a number larger than kMax, which overflows.
-  if (UNLIKELY(kSignedMax - unixtime <= 1)) {
+  // On some compilers if we cast kMax to a double, we can get a number larger
+  // than kMax. This will allow 'unixtime' values > kMax. The workaround here is
+  // to use uint64_t to represent (kMax + 1), which can be represented exactly
+  // as double. We then check if the difference with unixtime <= 1
+  if (UNLIKELY((static_cast<uint64_t>(kMax) + 1) - unixtime <= 1)) {
     return kMaxTimestamp;
   }
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -42,17 +42,20 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
 
   static const int64_t kMax = std::numeric_limits<int64_t>::max();
   static const int64_t kMin = std::numeric_limits<int64_t>::min();
+  static const uint64_t kSignedMax = (1ull << 63);
 
   static const Timestamp kMaxTimestamp(
       kMax / 1000, kMax % 1000 * kNanosecondsInMillisecond);
   static const Timestamp kMinTimestamp(
       kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMillisecond);
 
-  if (UNLIKELY(unixtime >= static_cast<double>(kMax))) {
+  // We use kSignedMax because on some compilers if we cast kMax to a double, we
+  // get a number larger than kMax, which overflows.
+  if (UNLIKELY(kSignedMax - unixtime <= 1)) {
     return kMaxTimestamp;
   }
 
-  if (UNLIKELY(unixtime <= static_cast<double>(kMin))) {
+  if (UNLIKELY(unixtime <= kMin)) {
     return kMinTimestamp;
   }
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -49,9 +49,9 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
       kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMillisecond);
 
   // On some compilers if we cast kMax to a double, we can get a number larger
-  // than kMax. This will allow 'unixtime' values > kMax. The workaround here is
-  // to use uint64_t to represent (kMax + 1), which can be represented exactly
-  // as double. We then check if the difference with unixtime <= 1
+  // than 'kMax'. This will allow 'unixtime' values > 'kMax'. The workaround
+  // here is to use uint64_t to represent ('kMax' + 1), which can be represented
+  // exactly as double. We then check if the difference with 'unixtime' <= 1.
   if (UNLIKELY((static_cast<uint64_t>(kMax) + 1) - unixtime <= 1)) {
     return kMaxTimestamp;
   }

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -48,11 +48,11 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
   static const Timestamp kMinTimestamp(
       kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMillisecond);
 
-  if (UNLIKELY(unixtime >= kMax)) {
+  if (UNLIKELY(unixtime >= static_cast<double>(kMax))) {
     return kMaxTimestamp;
   }
 
-  if (UNLIKELY(unixtime <= kMin)) {
+  if (UNLIKELY(unixtime <= static_cast<double>(kMin))) {
     return kMinTimestamp;
   }
 


### PR DESCRIPTION
This seems to occur only in Clang version >= 12.0.
Resolves https://github.com/facebookincubator/velox/issues/1089