### PR TITLE
Rename Timestamp member functions and update comments to avoid confusion

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -191,7 +191,7 @@ void CastExpr::applyCastWithTry(
         auto rawTimestamps = resultFlatVector->mutableRawValues();
 
         rows.applyToSelected(
-            [&](int row) { rawTimestamps[row].toTimezone(*timeZone); });
+            [&](int row) { rawTimestamps[row].toGMT(*timeZone); });
       }
     }
   }

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -40,7 +40,7 @@ struct ToUnixtimeFunction {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     const auto milliseconds = *timestampWithTimezone.template at<0>();
     Timestamp timestamp{milliseconds / kMillisecondsInSecond, 0UL};
-    timestamp.toTimezone(*timestampWithTimezone.template at<1>());
+    timestamp.toGMT(*timestampWithTimezone.template at<1>());
     result = toUnixtime(timestamp);
     return true;
   }
@@ -79,7 +79,7 @@ FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
 FOLLY_ALWAYS_INLINE int64_t
 getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
   if (timeZone != nullptr) {
-    timestamp.toTimezoneUTC(*timeZone);
+    timestamp.toTimezone(*timeZone);
     return timestamp.getSeconds();
   } else {
     return timestamp.getSeconds();
@@ -486,7 +486,7 @@ struct DateTruncFunction {
 
     result = Timestamp(timegm(&dateTime), 0);
     if (timeZone_ != nullptr) {
-      result.toTimezone(*timeZone_);
+      result.toGMT(*timeZone_);
     }
     return true;
   }
@@ -557,7 +557,7 @@ struct DateAddFunction {
       // sessionTimeZone not null means that the config
       // adjust_timestamp_to_timezone is on.
       Timestamp zonedTimestamp = timestamp;
-      zonedTimestamp.toTimezoneUTC(*sessionTimeZone_);
+      zonedTimestamp.toTimezone(*sessionTimeZone_);
 
       Timestamp resultTimestamp =
           addToTimestamp(zonedTimestamp, unit, (int32_t)value);
@@ -568,7 +568,7 @@ struct DateAddFunction {
         result = Timestamp(
             resultTimestamp.getSeconds() + offset, resultTimestamp.getNanos());
       } else {
-        resultTimestamp.toTimezone(*sessionTimeZone_);
+        resultTimestamp.toGMT(*sessionTimeZone_);
         result = resultTimestamp;
       }
     } else {
@@ -638,7 +638,7 @@ struct DateDiffFunction {
       // sessionTimeZone not null means that the config
       // adjust_timestamp_to_timezone is on.
       Timestamp fromZonedTimestamp = timestamp1;
-      fromZonedTimestamp.toTimezoneUTC(*sessionTimeZone_);
+      fromZonedTimestamp.toTimezone(*sessionTimeZone_);
 
       Timestamp toZonedTimestamp = timestamp2;
       if (isTimeUnit(unit)) {
@@ -648,7 +648,7 @@ struct DateDiffFunction {
             toZonedTimestamp.getSeconds() - offset,
             toZonedTimestamp.getNanos());
       } else {
-        toZonedTimestamp.toTimezoneUTC(*sessionTimeZone_);
+        toZonedTimestamp.toTimezone(*sessionTimeZone_);
       }
       result = diffTimestamp(unit, fromZonedTimestamp, toZonedTimestamp);
     } else {

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -61,7 +61,7 @@ class HourFunction : public exec::VectorFunction {
     if (timeZone != nullptr) {
       rows.applyToSelected([&](int row) {
         auto timestamp = timestamps[row];
-        timestamp.toTimezoneUTC(*timeZone);
+        timestamp.toTimezone(*timeZone);
         int64_t seconds = timestamp.getSeconds();
         std::tm dateTime;
         gmtime_r((const time_t*)&seconds, &dateTime);

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -44,7 +44,7 @@ inline int64_t getPrestoTZOffsetInSeconds(int16_t tzID) {
 
 } // namespace
 
-void Timestamp::toTimezone(const date::time_zone& zone) {
+void Timestamp::toGMT(const date::time_zone& zone) {
   // Magic number -2^39 + 24*3600. This number and any number lower than that
   // will cause time_zone::to_sys() to SIGABRT. We don't want that to happen.
   if (seconds_ <= (-1096193779200l + 86400l)) {
@@ -58,29 +58,29 @@ void Timestamp::toTimezone(const date::time_zone& zone) {
   seconds_ = sysTime.time_since_epoch().count();
 }
 
-void Timestamp::toTimezone(int16_t tzID) {
+void Timestamp::toGMT(int16_t tzID) {
   if (tzID == 0) {
     // No conversion required for time zone id 0, as it is '+00:00'.
   } else if (tzID <= 1680) {
     seconds_ -= getPrestoTZOffsetInSeconds(tzID);
   } else {
     // Other ids go this path.
-    toTimezone(*date::locate_zone(util::getTimeZoneName(tzID)));
+    toGMT(*date::locate_zone(util::getTimeZoneName(tzID)));
   }
 }
 
-void Timestamp::toTimezoneUTC(const date::time_zone& zone) {
+void Timestamp::toTimezone(const date::time_zone& zone) {
   seconds_ -= deltaWithTimezone(zone, seconds_);
 }
 
-void Timestamp::toTimezoneUTC(int16_t tzID) {
+void Timestamp::toTimezone(int16_t tzID) {
   if (tzID == 0) {
     // No conversion required for time zone id 0, as it is '+00:00'.
   } else if (tzID <= 1680) {
     seconds_ += getPrestoTZOffsetInSeconds(tzID);
   } else {
     // Other ids go this path.
-    toTimezoneUTC(*date::locate_zone(util::getTimeZoneName(tzID)));
+    toTimezone(*date::locate_zone(util::getTimeZoneName(tzID)));
   }
 }
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -59,29 +59,25 @@ struct Timestamp {
     return Timestamp(micros / 1'000'000, (micros % 1'000'000) * 1'000);
   }
 
-  // Converts the unix epoch represented by this object (assumes it's GMT)
-  // to the given timezone.
-  // For example, ts.toTimezone("Pacific/Apia") converts ts to represent
-  // the time in GMT when time zone Pacific/Apia reaches ts.
-  // Timestamp ts{0, 0};
-  // ts.Timezone("Pacific/Apia");
-  // ts.toString() returns January 1, 1970 11:00:00
+  // Assuming the timestamp represents a time at zone, converts it to the GMT
+  // time at the same moment.
+  // Example: Timestamp ts{0, 0};
+  // ts.Timezone("America/Los_Angeles");
+  // ts.toString() returns January 1, 1970 08:00:00
+  void toGMT(const date::time_zone& zone);
+
+  // Same as above, but accepts PrestoDB time zone ID.
+  void toGMT(int16_t tzID);
+
+  // Assuming the timestamp represents a GMT time, converts it to the time at
+  // the same moment at zone.
+  // Example: Timestamp ts{0, 0};
+  // ts.Timezone("America/Los_Angeles");
+  // ts.toString() returns December 31, 1969 16:00:00
   void toTimezone(const date::time_zone& zone);
 
   // Same as above, but accepts PrestoDB time zone ID.
   void toTimezone(int16_t tzID);
-
-  // Converts the unix epoch represented by this object to the time in
-  // in time zone `zone` when GMT reaches this timestamp.
-  // For example, ts.toTimezone("Pacific/Apia") converts ts to represent
-  // the time in Pacific/Apia when GMT reaches ts.
-  // Timestamp ts{0, 0};
-  // ts.Timezone("Pacific/Apia");
-  // ts.toString() returns December 31, 1969 13:00:00
-  void toTimezoneUTC(const date::time_zone& zone);
-
-  // Same as above, but accepts PrestoDB time zone ID.
-  void toTimezoneUTC(int16_t tzID);
 
   bool operator==(const Timestamp& b) const {
     return seconds_ == b.seconds_ && nanos_ == b.nanos_;


### PR DESCRIPTION
Summary: Before this change, the function names and comments of Timestamp::toTimezone() and Timestamp::toTimezoneUTC() were not clear and caused confusion among developers. This diff renames these functions and updates the comments to clarify the interface.

Differential Revision: D34983815

