### PR TITLE
Add Kll sketch implementation.

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -19,11 +19,15 @@ add_library(
   DateTimeFormatterBuilder.cpp
   IsNull.cpp
   JodaDateTime.cpp
+  KllSketch.cpp
+  KllSketch.h
+  KllSketch-inl.h
   LambdaFunctionUtil.cpp
   Re2Functions.cpp
   StringEncodingUtils.cpp)
 
-target_link_libraries(velox_functions_lib velox_vector ${RE2})
+target_link_libraries(velox_functions_lib velox_vector ${RE2}
+                      ${FOLLY_WITH_DEPENDENCIES})
 
 add_subdirectory(string)
 if(${VELOX_BUILD_TESTING})

--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <queue>
+#include <type_traits>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions::kll {
+
+namespace detail {
+
+uint32_t computeTotalCapacity(uint16_t k, uint8_t numLevels);
+
+uint16_t levelCapacity(uint16_t k, uint8_t numLevels, uint8_t height);
+
+// Collect elements in odd or even positions to first half of buf.
+template <typename T, typename RandomBit>
+void randomlyHalveDown(
+    T* buf,
+    uint32_t start,
+    uint32_t length,
+    RandomBit& randomBit) {
+  VELOX_DCHECK_EQ(length & 1, 0);
+  const uint32_t halfLength = length / 2;
+  const uint32_t offset = randomBit();
+  uint32_t j = start + offset;
+  for (uint32_t i = start; i < start + halfLength; i++) {
+    buf[i] = buf[j];
+    j += 2;
+  }
+}
+
+// Collect elements in odd or even positions to second half of buf.
+template <typename T, typename RandomBit>
+void randomlyHalveUp(
+    T* buf,
+    uint32_t start,
+    uint32_t length,
+    RandomBit& randomBit) {
+  VELOX_DCHECK_EQ(length & 1, 0);
+  const uint32_t halfLength = length / 2;
+  const uint32_t offset = randomBit();
+  uint32_t j = (start + length) - 1 - offset;
+  for (uint32_t i = (start + length) - 1; i >= (start + halfLength); i--) {
+    buf[i] = buf[j];
+    j -= 2;
+  }
+}
+
+// Merge 2 sorted ranges:
+//   buf[startA] to buf[startA + lenA]
+//   buf[startB] to buf[startB + lenB]
+//
+// The target range starting buf[startC] could overlap with range B,
+// so we cannot use std::merge here.
+template <typename T, typename C>
+void mergeOverlap(
+    T* buf,
+    uint32_t startA,
+    uint32_t lenA,
+    uint32_t startB,
+    uint32_t lenB,
+    uint32_t startC,
+    C compare) {
+  const uint32_t limA = startA + lenA;
+  const uint32_t limB = startB + lenB;
+  VELOX_DCHECK_LE(limA, startC);
+  VELOX_DCHECK_LE(startC + lenA, startB);
+  uint32_t a = startA;
+  uint32_t b = startB;
+  uint32_t c = startC;
+  while (a < limA && b < limB) {
+    if (compare(buf[a], buf[b])) {
+      buf[c++] = buf[a++];
+    } else {
+      buf[c++] = buf[b++];
+    }
+  }
+  while (a < limA) {
+    buf[c++] = buf[a++];
+  }
+  while (b < limB) {
+    buf[c++] = buf[b++];
+  }
+}
+
+// Return floor(log2(p/q)).
+uint8_t floorLog2(uint64_t p, uint64_t q);
+
+struct CompressResult {
+  uint8_t finalNumLevels;
+  uint32_t finalCapacity;
+  uint32_t finalNumItems;
+};
+
+/*
+ * Here is what we do for each level:
+ * If it does not need to be compacted, then simply copy it over.
+ *
+ * Otherwise, it does need to be compacted, so...
+ *   Copy zero or one guy over.
+ *   If the level above is empty, halve up.
+ *   Else the level above is nonempty, so...
+ *        halve down, then merge up.
+ *   Adjust the boundaries of the level above.
+ *
+ * It can be proved that generalCompress returns a sketch that satisfies the
+ * space constraints no matter how much data is passed in.
+ * All levels except for level zero must be sorted before calling this, and will
+ * still be sorted afterwards.
+ * Level zero is not required to be sorted before, and may not be sorted
+ * afterwards.
+ */
+template <typename T, typename C, typename RandomBit>
+CompressResult generalCompress(
+    uint16_t k,
+    uint8_t numLevelsIn,
+    T* items,
+    uint32_t* inLevels,
+    uint32_t* outLevels,
+    bool isLevelZeroSorted,
+    RandomBit& randomBit) {
+  VELOX_DCHECK_GT(numLevelsIn, 0);
+  uint8_t currentNumLevels = numLevelsIn;
+  // `currentItemCount` decreases with each compaction.
+  uint32_t currentItemCount = inLevels[numLevelsIn] - inLevels[0];
+  // Increases if we add levels.
+  uint32_t targetItemCount = computeTotalCapacity(k, currentNumLevels);
+  outLevels[0] = 0;
+  for (uint8_t level = 0; level < currentNumLevels; ++level) {
+    // If we are at the current top level, add an empty level above it
+    // for convenience, but do not increment currentNumLevels until later.
+    if (level == (currentNumLevels - 1)) {
+      inLevels[level + 2] = inLevels[level + 1];
+    }
+    const auto rawBeg = inLevels[level];
+    const auto rawLim = inLevels[level + 1];
+    const auto rawPop = rawLim - rawBeg;
+    if ((currentItemCount < targetItemCount) ||
+        (rawPop < levelCapacity(k, currentNumLevels, level))) {
+      // Move level over as is.
+      // Make sure we are not moving data upwards.
+      VELOX_DCHECK_GE(rawBeg, outLevels[level]);
+      std::move(&items[rawBeg], &items[rawLim], &items[outLevels[level]]);
+      outLevels[level + 1] = outLevels[level] + rawPop;
+    } else {
+      // The sketch is too full AND this level is too full, so we compact it.
+      // Note: this can add a level and thus change the sketches capacities.
+      const auto popAbove = inLevels[level + 2] - rawLim;
+      const bool oddPop = rawPop & 1;
+      const auto adjBeg = rawBeg + oddPop;
+      const auto adjPop = rawPop - oddPop;
+      const auto halfAdjPop = adjPop / 2;
+
+      if (oddPop) { // Move one guy over.
+        items[outLevels[level]] = std::move(items[rawBeg]);
+        outLevels[level + 1] = outLevels[level] + 1;
+      } else { // Even number of items in this level.
+        outLevels[level + 1] = outLevels[level];
+      }
+
+      // Level zero might not be sorted, so we must sort it if we wish
+      // to compact it.
+      if ((level == 0) && !isLevelZeroSorted) {
+        std::sort(&items[adjBeg], &items[adjBeg + adjPop], C());
+      }
+
+      if (popAbove == 0) { // Level above is empty, so halve up.
+        randomlyHalveUp(items, adjBeg, adjPop, randomBit);
+      } else { // Level above is nonempty, so halve down, then merge up.
+        randomlyHalveDown(items, adjBeg, adjPop, randomBit);
+        mergeOverlap(
+            items,
+            adjBeg,
+            halfAdjPop,
+            rawLim,
+            popAbove,
+            adjBeg + halfAdjPop,
+            C());
+      }
+
+      // Track the fact that we just eliminated some data.
+      currentItemCount -= halfAdjPop;
+
+      // Adjust the boundaries of the level above.
+      inLevels[level + 1] = inLevels[level + 1] - halfAdjPop;
+
+      // Increment num levels if we just compacted the old top level
+      // this creates some more capacity (the size of the new bottom
+      // level).
+      if (level == (currentNumLevels - 1)) {
+        ++currentNumLevels;
+        targetItemCount += levelCapacity(k, currentNumLevels, 0);
+      }
+    }
+  }
+  VELOX_DCHECK_EQ(outLevels[currentNumLevels] - outLevels[0], currentItemCount);
+  return {currentNumLevels, targetItemCount, currentItemCount};
+}
+
+uint64_t sumSampleWeights(uint8_t numLevels, const uint32_t* levels);
+
+} // namespace detail
+
+template <typename T, typename A, typename C>
+KllSketch<T, A, C>::KllSketch(uint16_t k, const A& allocator, uint32_t seed)
+    : k_(k),
+      allocator_(allocator),
+      randomBit_(seed),
+      n_(0),
+      items_(k, allocator),
+      levels_(2, k, allocator),
+      isLevelZeroSorted_(false) {}
+
+template <typename T, typename A, typename C>
+void KllSketch<T, A, C>::insert(T value) {
+  if (n_ == 0) {
+    minValue_ = maxValue_ = value;
+  } else {
+    minValue_ = std::min(minValue_, value, C());
+    maxValue_ = std::max(maxValue_, value, C());
+  }
+  items_[insertPosition()] = value;
+}
+
+template <typename T, typename A, typename C>
+uint32_t KllSketch<T, A, C>::insertPosition() {
+  if (levels_[0] == 0) {
+    const uint8_t level = findLevelToCompact();
+
+    // It is important to add the new top level right here. Be aware
+    // that this operation grows the buffer and shifts the data and
+    // also the boundaries of the data and grows the levels array.
+    if (level == numLevels() - 1) {
+      addEmptyTopLevelToCompletelyFullSketch();
+    }
+
+    const uint32_t rawBeg = levels_[level];
+    const uint32_t rawLim = levels_[level + 1];
+    // +2 is OK because we already added a new top level if necessary.
+    const uint32_t popAbove = levels_[level + 2] - rawLim;
+    const uint32_t rawPop = rawLim - rawBeg;
+    const bool oddPop = rawPop & 1;
+    const uint32_t adjBeg = rawBeg + oddPop;
+    const uint32_t adjPop = rawPop - oddPop;
+    const uint32_t halfAdjPop = adjPop / 2;
+
+    // Level zero might not be sorted, so we must sort it if we wish
+    // to compact it.
+    if (level == 0 && !isLevelZeroSorted_) {
+      std::sort(&items_[adjBeg], &items_[adjBeg + adjPop], C());
+    }
+    if (popAbove == 0) {
+      detail::randomlyHalveUp(&items_[0], adjBeg, adjPop, randomBit_);
+    } else {
+      detail::randomlyHalveDown(&items_[0], adjBeg, adjPop, randomBit_);
+      detail::mergeOverlap(
+          &items_[0],
+          adjBeg,
+          halfAdjPop,
+          rawLim,
+          popAbove,
+          adjBeg + halfAdjPop,
+          C());
+    }
+    levels_[level + 1] -= halfAdjPop; // Adjust boundaries of the level above.
+    if (oddPop) {
+      // The current level now contains one item.
+      levels_[level] = levels_[level + 1] - 1;
+      if (levels_[level] != rawBeg) {
+        // Namely this leftover guy.
+        items_[levels_[level]] = std::move(items_[rawBeg]);
+      }
+    } else {
+      levels_[level] = levels_[level + 1]; // The current level is now empty.
+    }
+
+    // Verify that we freed up halfAdjPop array slots just below the
+    // current level.
+    VELOX_DCHECK_EQ(levels_[level], rawBeg + halfAdjPop);
+
+    // Finally, we need to shift up the data in the levels below
+    // so that the freed-up space can be used by level zero.
+    if (level > 0) {
+      const uint32_t amount = rawBeg - levels_[0];
+      std::move_backward(
+          &items_[levels_[0]],
+          &items_[levels_[0] + amount],
+          &items_[levels_[0] + halfAdjPop + amount]);
+      for (uint8_t lvl = 0; lvl < level; lvl++) {
+        levels_[lvl] += halfAdjPop;
+      }
+    }
+  }
+  ++n_;
+  isLevelZeroSorted_ = false;
+  return --levels_[0];
+}
+
+template <typename T, typename A, typename C>
+int KllSketch<T, A, C>::findLevelToCompact() const {
+  for (int level = 0;; ++level) {
+    VELOX_DCHECK_LT(level + 1, levels_.size());
+    const uint32_t pop = levels_[level + 1] - levels_[level];
+    const uint32_t cap = detail::levelCapacity(k_, numLevels(), level);
+    if (pop >= cap) {
+      return level;
+    }
+  }
+}
+
+template <typename T, typename A, typename C>
+void KllSketch<T, A, C>::addEmptyTopLevelToCompletelyFullSketch() {
+  const uint32_t curTotalCap = levels_.back();
+
+  // Make sure that we are following a certain growth scheme.
+  VELOX_DCHECK_EQ(levels_[0], 0);
+  VELOX_DCHECK_EQ(items_.size(), curTotalCap);
+
+  const uint32_t deltaCap = detail::levelCapacity(k_, numLevels() + 1, 0);
+  const uint32_t newTotalCap = curTotalCap + deltaCap;
+  items_.resize(newTotalCap);
+  std::move_backward(
+      items_.begin(), items_.begin() + curTotalCap, items_.end());
+
+  // This loop includes the old "extra" index at the top.
+  for (auto& lvl : levels_) {
+    lvl += deltaCap;
+  }
+  VELOX_DCHECK_EQ(levels_.back(), newTotalCap);
+  levels_.push_back(newTotalCap);
+}
+
+template <typename T, typename A, typename C>
+T KllSketch<T, A, C>::estimateQuantile(double fraction) {
+  T ans;
+  estimateQuantiles(folly::Range(&fraction, 1), &ans);
+  return ans;
+}
+
+template <typename T, typename A, typename C>
+template <typename Iter>
+std::vector<T, A> KllSketch<T, A, C>::estimateQuantiles(
+    const folly::Range<Iter>& fractions) {
+  std::vector<T, A> ans(fractions.size(), T{}, allocator_);
+  estimateQuantiles(fractions, ans.data());
+  return ans;
+}
+
+template <typename T, typename A, typename C>
+template <typename Iter>
+void KllSketch<T, A, C>::estimateQuantiles(
+    const folly::Range<Iter>& fractions,
+    T* out) {
+  VELOX_USER_CHECK_GT(n_, 0, "estimateQuantiles called on empty sketch");
+  if (!isLevelZeroSorted_) {
+    std::sort(&items_[levels_[0]], &items_[levels_[1]], C());
+    isLevelZeroSorted_ = true;
+  }
+  using Entry = typename std::pair<T, uint64_t>;
+  using AllocEntry =
+      typename std::allocator_traits<A>::template rebind_alloc<Entry>;
+  std::vector<Entry, AllocEntry> entries(allocator_);
+  entries.reserve(levels_.back());
+  for (int level = 0; level < numLevels(); ++level) {
+    auto oldLen = entries.size();
+    for (int i = levels_[level]; i < levels_[level + 1]; ++i) {
+      entries.emplace_back(items_[i], 1 << level);
+    }
+    if (oldLen > 0) {
+      std::inplace_merge(
+          entries.begin(),
+          entries.begin() + oldLen,
+          entries.end(),
+          [](auto& x, auto& y) { return C()(x.first, y.first); });
+    }
+  }
+  uint64_t totalWeight = 0;
+  for (auto& [_, w] : entries) {
+    auto newTotalWeight = totalWeight + w;
+    // Only count the number of elements strictly smaller.
+    w = totalWeight;
+    totalWeight = newTotalWeight;
+  }
+  int i = 0;
+  for (auto& q : fractions) {
+    VELOX_CHECK_GE(q, 0.0);
+    VELOX_CHECK_LE(q, 1.0);
+    if (fractions[i] == 0.0) {
+      out[i++] = minValue_;
+      continue;
+    }
+    if (fractions[i] == 1.0) {
+      out[i++] = maxValue_;
+      continue;
+    }
+    uint64_t maxWeight = q * totalWeight;
+    auto it = std::lower_bound(
+        entries.begin(),
+        entries.end(),
+        std::make_pair(T{}, maxWeight),
+        [](auto& x, auto& y) { return x.second < y.second; });
+    if (it == entries.end()) {
+      out[i++] = entries.back().first;
+    } else {
+      out[i++] = it->first;
+    }
+  }
+}
+
+template <typename T, typename A, typename C>
+template <typename Iter>
+void KllSketch<T, A, C>::merge(const folly::Range<Iter>& others) {
+  auto newN = n_;
+  for (auto& other : others) {
+    if (other.n_ == 0) {
+      continue;
+    }
+    if (newN == 0) {
+      minValue_ = other.minValue_;
+      maxValue_ = other.maxValue_;
+    } else {
+      minValue_ = std::min(minValue_, other.minValue_, C());
+      maxValue_ = std::max(maxValue_, other.maxValue_, C());
+    }
+    newN += other.n_;
+  }
+  if (newN == n_) {
+    return;
+  }
+  // Merge bottom level.
+  for (auto& other : others) {
+    for (uint32_t j = other.levels_[0]; j < other.levels_[1]; ++j) {
+      items_[insertPosition()] = other.items_[j];
+    }
+  }
+  // Merge higher levels.
+  auto tmpNumItems = getNumRetained();
+  auto provisionalNumLevels = numLevels();
+  for (auto& other : others) {
+    if (other.numLevels() >= 2) {
+      tmpNumItems += other.levels_.back() - other.levels_[1];
+      provisionalNumLevels = std::max(provisionalNumLevels, other.numLevels());
+    }
+  }
+  if (tmpNumItems > getNumRetained()) {
+    std::vector<T, A> workbuf(tmpNumItems);
+    const uint8_t ub = 1 + detail::floorLog2(newN, 1);
+    const size_t workLevelsSize = ub + 2;
+    std::vector<uint32_t, AllocU32> worklevels(workLevelsSize, 0, allocator_);
+    std::vector<uint32_t, AllocU32> outlevels(workLevelsSize, 0, allocator_);
+    // Populate work arrays.
+    worklevels[0] = 0;
+    std::move(&items_[levels_[0]], &items_[levels_[1]], &workbuf[0]);
+    worklevels[1] = safeLevelSize(0);
+    // Merge each level, each level in all sketches are already sorted.
+    for (uint8_t lvl = 1; lvl < provisionalNumLevels; ++lvl) {
+      using Entry = std::pair<const T*, const T*>;
+      using AllocEntry =
+          typename std::allocator_traits<A>::template rebind_alloc<Entry>;
+      auto gt = [](const Entry& x, const Entry& y) {
+        return C()(*y.first, *x.first);
+      };
+      std::priority_queue<Entry, std::vector<Entry, AllocEntry>, decltype(gt)>
+          pq(gt, allocator_);
+      if (auto sz = safeLevelSize(lvl); sz > 0) {
+        pq.emplace(&items_[levels_[lvl]], &items_[levels_[lvl] + sz]);
+      }
+      for (auto& other : others) {
+        if (auto sz = other.safeLevelSize(lvl); sz > 0) {
+          pq.emplace(
+              &other.items_[other.levels_[lvl]],
+              &other.items_[other.levels_[lvl] + sz]);
+        }
+      }
+      int outIndex = worklevels[lvl];
+      while (!pq.empty()) {
+        auto [s, t] = pq.top();
+        pq.pop();
+        workbuf[outIndex++] = *s++;
+        if (s < t) {
+          pq.emplace(s, t);
+        }
+      }
+      worklevels[lvl + 1] = outIndex;
+    }
+    auto result = detail::generalCompress<T, C>(
+        k_,
+        provisionalNumLevels,
+        workbuf.data(),
+        worklevels.data(),
+        outlevels.data(),
+        isLevelZeroSorted_,
+        randomBit_);
+    VELOX_DCHECK_LE(result.finalNumLevels, ub);
+    // Now we need to transfer the results back into "this" sketch.
+    items_.resize(result.finalCapacity);
+    const auto freeSpaceAtBottom = result.finalCapacity - result.finalNumItems;
+    std::move(
+        &workbuf[outlevels[0]],
+        &workbuf[outlevels[0] + result.finalNumItems],
+        &items_[freeSpaceAtBottom]);
+    levels_.resize(result.finalNumLevels + 1);
+    const auto offset = freeSpaceAtBottom - outlevels[0];
+    for (unsigned lvl = 0; lvl < levels_.size(); ++lvl) {
+      levels_[lvl] = outlevels[lvl] + offset;
+    }
+  }
+  n_ = newN;
+  VELOX_DCHECK_EQ(detail::sumSampleWeights(numLevels(), levels_.data()), n_);
+}
+
+} // namespace facebook::velox::functions::kll

--- a/velox/functions/lib/KllSketch.cpp
+++ b/velox/functions/lib/KllSketch.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/KllSketch.h"
+
+namespace facebook::velox::functions::kll {
+
+uint16_t kFromEpsilon(double eps) {
+  return ceil(exp(1.0285 * log(2.296 / eps)));
+}
+
+namespace detail {
+
+namespace {
+
+constexpr uint8_t kMinBufferWidth = 8;
+constexpr uint8_t kMaxLevel = 60;
+
+double powerOfTwoThirds(int n) {
+  static const auto kMemo = [] {
+    std::array<double, kMaxLevel> memo;
+    for (int i = 0; i < kMaxLevel; ++i) {
+      memo[i] = pow(2.0 / 3.0, i);
+    }
+    return memo;
+  }();
+  return kMemo[n];
+}
+
+} // namespace
+
+uint32_t computeTotalCapacity(uint16_t k, uint8_t numLevels) {
+  uint32_t total = 0;
+  for (uint8_t h = 0; h < numLevels; ++h) {
+    total += levelCapacity(k, numLevels, h);
+  }
+  return total;
+}
+
+uint16_t levelCapacity(uint16_t k, uint8_t numLevels, uint8_t height) {
+  VELOX_DCHECK_LT(height, numLevels);
+  VELOX_DCHECK_LE(numLevels, kMaxLevel);
+  return std::max<uint16_t>(
+      kMinBufferWidth, k * powerOfTwoThirds(numLevels - height - 1));
+}
+
+uint8_t floorLog2(uint64_t p, uint64_t q) {
+  for (uint8_t ans = 0;; ++ans) {
+    q <<= 1;
+    if (p < q) {
+      return ans;
+    }
+  }
+}
+
+uint64_t sumSampleWeights(uint8_t numLevels, const uint32_t* levels) {
+  uint64_t total = 0;
+  uint64_t weight = 1;
+  for (uint8_t lvl = 0; lvl < numLevels; lvl++) {
+    total += weight * (levels[lvl + 1] - levels[lvl]);
+    weight *= 2;
+  }
+  return total;
+}
+
+} // namespace detail
+} // namespace facebook::velox::functions::kll

--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <random>
+
+#include "folly/Random.h"
+#include "folly/Range.h"
+
+namespace facebook::velox::functions::kll {
+
+constexpr uint16_t kDefaultK = 200;
+
+/// Estimate the proper k value to ensure the error bound epsilon.
+uint16_t kFromEpsilon(double epsilon);
+
+/// Implementation of KLL sketch that can achieve nearly optimal
+/// accuracy per retained item.
+///
+/// This sketch is configured with a parameter k, which affects the
+/// size of the sketch and its estimation error.
+///
+/// The estimation error is commonly called epsilon and is a fraction
+/// between zero and one.  Larger values of k result in smaller values
+/// of epsilon.  Epsilon is always with respect to the quantile and
+/// cannot be applied to the corresponding values.
+///
+/// The default k of 200 yields a "single-sided" epsilon of about
+/// 1.33%.
+///
+/// See https://arxiv.org/abs/1603.05346v2 for more details.
+template <
+    typename T,
+    typename Allocator = std::allocator<T>,
+    typename Compare = std::less<T>>
+struct KllSketch {
+  KllSketch(
+      uint16_t k = kll::kDefaultK,
+      const Allocator& = Allocator(),
+      uint32_t seed = folly::Random::rand32());
+
+  /// Add one new value to the sketch.
+  void insert(T value);
+
+  /// Merge this sketch with values from multiple other sketches.
+  /// @tparam Iter Iterator type dereferenceable to the same type as this sketch
+  ///  (KllSketch<T, Allocator, Compare>)
+  /// @param sketches Range of sketches to be merged to this one
+  template <typename Iter>
+  void merge(const folly::Range<Iter>& sketches);
+
+  /// Estimate the value of the given quantile.
+  /// @param quantile Quantile in [0, 1] to be estimated
+  T estimateQuantile(double quantile);
+
+  /// Estimate the values of the given quantiles.  This is more
+  /// efficient than calling estimateQuantile(double) repeatedly.
+  /// @tparam Iter Iterator type dereferenceable to double
+  /// @param quantiles Range of quantiles in [0, 1] to be estimated
+  template <typename Iter>
+  std::vector<T, Allocator> estimateQuantiles(
+      const folly::Range<Iter>& quantiles);
+
+  /// The total number of values being added to the sketch.
+  size_t totalCount() const {
+    return n_;
+  }
+
+ private:
+  uint32_t insertPosition();
+  int findLevelToCompact() const;
+  void addEmptyTopLevelToCompletelyFullSketch();
+
+  template <typename Iter>
+  void estimateQuantiles(const folly::Range<Iter>& fractions, T* out);
+
+  uint8_t numLevels() const {
+    return levels_.size() - 1;
+  }
+
+  uint32_t getNumRetained() const {
+    return levels_.back() - levels_[0];
+  }
+
+  uint32_t safeLevelSize(uint8_t level) const {
+    return level < numLevels() ? levels_[level + 1] - levels_[level] : 0;
+  }
+
+  using AllocU32 = typename std::allocator_traits<
+      Allocator>::template rebind_alloc<uint32_t>;
+
+  uint16_t k_;
+  Allocator allocator_;
+  std::independent_bits_engine<folly::Random::DefaultGenerator, 1, uint32_t>
+      randomBit_;
+  size_t n_;
+  T minValue_;
+  T maxValue_;
+  std::vector<T, Allocator> items_;
+  std::vector<uint32_t, AllocU32> levels_;
+  bool isLevelZeroSorted_;
+};
+
+} // namespace facebook::velox::functions::kll
+
+#include "velox/functions/lib/KllSketch-inl.h"

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <random>
+
+#include <folly/Benchmark.h>
+#include <folly/Random.h>
+#include <folly/portability/GFlags.h>
+#include <folly/stats/TDigest.h>
+
+#include "velox/functions/lib/KllSketch.h"
+
+namespace facebook::velox::functions::kll::test {
+namespace {
+
+template <
+    typename T,
+    typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+auto distribution(unsigned len) {
+  return std::uniform_int_distribution<T>(0, len);
+}
+
+template <
+    typename T,
+    typename std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+auto distribution(unsigned) {
+  return std::uniform_real_distribution<T>(0, 1);
+}
+
+template <typename T>
+void populateValues(int len, std::vector<T>& out) {
+  folly::Random::DefaultGenerator gen(folly::Random::rand32());
+  auto dist = distribution<T>(len);
+  out.resize(len);
+  for (int i = 0; i < len; ++i) {
+    out[i] = dist(gen);
+  }
+}
+
+template <typename T>
+int insertTDigest(int iters) {
+  constexpr int kBufSize = 4096;
+  std::vector<T> values;
+  std::vector<double> buf;
+  BENCHMARK_SUSPEND {
+    populateValues(iters, values);
+    buf.reserve(kBufSize);
+  }
+  folly::TDigest digest;
+  for (int i = 0; i < iters;) {
+    int size = std::min(iters - i, kBufSize);
+    for (int j = 0; j < size; ++j) {
+      buf.push_back(values[i + j]);
+    }
+    digest = digest.merge(buf);
+    buf.clear();
+    i += size;
+  }
+  return iters;
+}
+
+template <typename T>
+int insertKllSketch(int iters) {
+  std::vector<T> values;
+  BENCHMARK_SUSPEND {
+    populateValues(iters, values);
+  }
+  KllSketch<T> kll;
+  for (int i = 0; i < iters; ++i) {
+    kll.insert(values[i]);
+  }
+  return iters;
+}
+
+void mergeTDigest(int iters, int maxSize, int count) {
+  std::vector<folly::TDigest> digests;
+  BENCHMARK_SUSPEND {
+    std::vector<double> values;
+    for (int i = 0; i < count; ++i) {
+      populateValues(maxSize, values);
+      folly::TDigest digest;
+      digests.push_back(digest.merge(values));
+      values.clear();
+    }
+  }
+  for (int i = 0; i < iters; ++i) {
+    folly::TDigest::merge(digests);
+  }
+}
+
+void mergeKllSketch(int iters, int maxSize, int count) {
+  std::vector<KllSketch<double>> sketches;
+  BENCHMARK_SUSPEND {
+    std::vector<double> values;
+    for (int i = 0; i < count; ++i) {
+      populateValues(maxSize, values);
+      KllSketch<double> kll;
+      for (auto v : values) {
+        kll.insert(v);
+      }
+      sketches.push_back(std::move(kll));
+      values.clear();
+    }
+  }
+  assert(sketches.size() >= 2); // get rid of the lint warning
+  for (int i = 0; i < iters; ++i) {
+    sketches[0].merge(folly::Range(&sketches[1], count - 1));
+  }
+}
+
+#define DEFINE_WITH_TYPE(name, type)  \
+  int name##_##type(int, int iters) { \
+    return name<type>(iters);         \
+  }
+
+DEFINE_WITH_TYPE(insertTDigest, int64_t);
+DEFINE_WITH_TYPE(insertTDigest, double);
+DEFINE_WITH_TYPE(insertKllSketch, int64_t);
+DEFINE_WITH_TYPE(insertKllSketch, double);
+
+#undef DEFINE_WITH_TYPE
+
+BENCHMARK_PARAM_MULTI(insertTDigest_int64_t, 1e5);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_int64_t, 1e5);
+BENCHMARK_PARAM_MULTI(insertTDigest_double, 1e5);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_double, 1e5);
+BENCHMARK_DRAW_LINE();
+BENCHMARK_PARAM_MULTI(insertTDigest_int64_t, 1e6);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_int64_t, 1e6);
+BENCHMARK_PARAM_MULTI(insertTDigest_double, 1e6);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_double, 1e6);
+BENCHMARK_DRAW_LINE();
+BENCHMARK_PARAM_MULTI(insertTDigest_int64_t, 1e7);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_int64_t, 1e7);
+BENCHMARK_PARAM_MULTI(insertTDigest_double, 1e7);
+BENCHMARK_RELATIVE_PARAM_MULTI(insertKllSketch_double, 1e7);
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(mergeTDigest, 1e6x2, 1e6, 2);
+BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x2, 1e6, 2);
+BENCHMARK_NAMED_PARAM(mergeTDigest, 1e6x20, 1e6, 20);
+BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x20, 1e6, 20);
+BENCHMARK_NAMED_PARAM(mergeTDigest, 1e6x40, 1e6, 40);
+BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x40, 1e6, 40);
+BENCHMARK_NAMED_PARAM(mergeTDigest, 1e6x80, 1e6, 80);
+BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x80, 1e6, 80);
+
+// ============================================================================
+// [...]chmarks/ApproxPercentileBenchmark.cpp     relative  time/iter   iters/s
+// ============================================================================
+// insertTDigest_int64_t(1e5)                                 43.99ns    22.73M
+// insertKllSketch_int64_t(1e5)                    110.48%    39.82ns    25.11M
+// insertTDigest_double(1e5)                                  44.40ns    22.52M
+// insertKllSketch_double(1e5)                     98.266%    45.19ns    22.13M
+// ----------------------------------------------------------------------------
+// insertTDigest_int64_t(1e6)                                 45.30ns    22.07M
+// insertKllSketch_int64_t(1e6)                    119.63%    37.87ns    26.41M
+// insertTDigest_double(1e6)                                  46.94ns    21.30M
+// insertKllSketch_double(1e6)                      109.3%    42.95ns    23.28M
+// ----------------------------------------------------------------------------
+// insertTDigest_int64_t(1e7)                                 48.24ns    20.73M
+// insertKllSketch_int64_t(1e7)                    132.98%    36.28ns    27.57M
+// insertTDigest_double(1e7)                                  51.89ns    19.27M
+// insertKllSketch_double(1e7)                     123.69%    41.95ns    23.84M
+// ----------------------------------------------------------------------------
+// mergeTDigest(1e6x2)                                         3.56us   280.64K
+// mergeKllSketch(1e6x2)                           13.483%    26.43us    37.84K
+// mergeTDigest(1e6x20)                                      184.50us     5.42K
+// mergeKllSketch(1e6x20)                          23.704%   778.35us     1.28K
+// mergeTDigest(1e6x40)                                      248.06us     4.03K
+// mergeKllSketch(1e6x40)                          12.369%     2.01ms    498.62
+// mergeTDigest(1e6x80)                                      739.31us     1.35K
+// mergeKllSketch(1e6x80)                          15.133%     4.89ms    204.69
+
+} // namespace
+} // namespace facebook::velox::functions::kll::test
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -13,8 +13,13 @@
 # limitations under the License.
 add_executable(
   velox_functions_lib_test
-  ArrayBuilderTest.cpp DateTimeFormatterTest.cpp IsNullTest.cpp
-  IsNotNullTest.cpp JodaDateTimeTest.cpp Re2FunctionsTest.cpp)
+  ArrayBuilderTest.cpp
+  DateTimeFormatterTest.cpp
+  IsNullTest.cpp
+  IsNotNullTest.cpp
+  JodaDateTimeTest.cpp
+  KllSketchTest.cpp
+  Re2FunctionsTest.cpp)
 
 add_test(velox_functions_lib_test velox_functions_lib_test)
 

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/KllSketch.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::functions::kll::test {
+namespace {
+
+// Error bound for k = 200.
+constexpr double kEpsilon = 0.0133;
+
+// Generate linearly spaced values between [0, 1].
+std::vector<double> linspace(int len) {
+  VELOX_DCHECK_GE(len, 2);
+  std::vector<double> out(len);
+  double step = 1.0 / (len - 1);
+  for (int i = 0; i < len; ++i) {
+    out[i] = i * step;
+  }
+  return out;
+}
+
+TEST(KllSketchTest, oneItem) {
+  KllSketch<double> kll;
+  EXPECT_EQ(kll.totalCount(), 0);
+  kll.insert(1.0);
+  EXPECT_EQ(kll.totalCount(), 1);
+  EXPECT_EQ(kll.estimateQuantile(0.0), 1.0);
+  EXPECT_EQ(kll.estimateQuantile(0.5), 1.0);
+  EXPECT_EQ(kll.estimateQuantile(1.0), 1.0);
+}
+
+TEST(KllSketchTest, exactMode) {
+  constexpr int N = 128;
+  KllSketch<int> kll(N);
+  for (int i = 0; i < N; ++i) {
+    kll.insert(i);
+    EXPECT_EQ(kll.totalCount(), i + 1);
+  }
+  EXPECT_EQ(kll.estimateQuantile(0.0), 0);
+  EXPECT_EQ(kll.estimateQuantile(0.5), N / 2);
+  EXPECT_EQ(kll.estimateQuantile(1.0), N - 1);
+  auto q = linspace(N);
+  auto v = kll.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  for (int i = 0; i < N; ++i) {
+    EXPECT_EQ(v[i], i);
+  }
+}
+
+TEST(KllSketchTest, estimationMode) {
+  constexpr int N = 1e5;
+  constexpr int M = 1001;
+  KllSketch<double> kll(200, {}, 0);
+  for (int i = 0; i < N; ++i) {
+    kll.insert(i);
+    EXPECT_EQ(kll.totalCount(), i + 1);
+  }
+  EXPECT_EQ(kll.estimateQuantile(0.0), 0);
+  EXPECT_EQ(kll.estimateQuantile(1.0), N - 1);
+  auto q = linspace(M);
+  auto v = kll.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  ASSERT_TRUE(std::is_sorted(std::begin(v), std::end(v)));
+  for (int i = 0; i < M; ++i) {
+    EXPECT_NEAR(q[i], v[i] / N, kEpsilon);
+  }
+}
+
+TEST(KllSketchTest, randomInput) {
+  constexpr int N = 1e5;
+  constexpr int M = 1001;
+  KllSketch<double> kll(kDefaultK, {}, 0);
+  std::default_random_engine gen(0);
+  std::normal_distribution<> dist;
+  double values[N];
+  for (int i = 0; i < N; ++i) {
+    values[i] = dist(gen);
+    kll.insert(values[i]);
+  }
+  EXPECT_EQ(kll.totalCount(), N);
+  std::sort(std::begin(values), std::end(values));
+  auto q = linspace(M);
+  auto v = kll.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  ASSERT_TRUE(std::is_sorted(std::begin(v), std::end(v)));
+  for (int i = 0; i < M; ++i) {
+    auto it = std::lower_bound(std::begin(values), std::end(values), v[i]);
+    double actualQ = 1.0 * (it - std::begin(values)) / N;
+    EXPECT_NEAR(q[i], actualQ, kEpsilon);
+  }
+}
+
+TEST(KllSketchTest, merge) {
+  constexpr int N = 1e4;
+  constexpr int M = 1001;
+  KllSketch<double> kll1(kDefaultK, {}, 0);
+  KllSketch<double> kll2(kDefaultK, {}, 0);
+  for (int i = 0; i < N; ++i) {
+    kll1.insert(i);
+    kll2.insert(2 * N - i - 1);
+  }
+  kll1.merge(folly::Range(&kll2, 1));
+  EXPECT_EQ(kll1.totalCount(), 2 * N);
+  auto q = linspace(M);
+  auto v = kll1.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  ASSERT_TRUE(std::is_sorted(std::begin(v), std::end(v)));
+  for (int i = 0; i < M; ++i) {
+    EXPECT_NEAR(q[i], v[i] / (2 * N), kEpsilon);
+  }
+}
+
+TEST(KllSketchTest, mergeRandom) {
+  constexpr int N = 1e4;
+  constexpr int M = 1001;
+  std::default_random_engine gen(0);
+  std::uniform_int_distribution<> distN(1, N);
+  int n1 = distN(gen), n2 = distN(gen);
+  std::vector<double> values;
+  values.reserve(n1 + n2);
+  KllSketch<double> kll1(kDefaultK, {}, 0);
+  KllSketch<double> kll2(kDefaultK, {}, 0);
+  std::normal_distribution<> distV;
+  for (int i = 0; i < n1; ++i) {
+    double v = distV(gen);
+    values.push_back(v);
+    kll1.insert(v);
+  }
+  for (int i = 0; i < n2; ++i) {
+    double v = distV(gen);
+    values.push_back(v);
+    kll2.insert(v);
+  }
+  std::sort(values.begin(), values.end());
+  kll1.merge(folly::Range(&kll2, 1));
+  EXPECT_EQ(kll1.totalCount(), n1 + n2);
+  auto q = linspace(M);
+  auto v = kll1.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  ASSERT_TRUE(std::is_sorted(std::begin(v), std::end(v)));
+  for (int i = 0; i < M; ++i) {
+    auto it = std::lower_bound(std::begin(values), std::end(values), v[i]);
+    double actualQ = 1.0 * (it - std::begin(values)) / values.size();
+    EXPECT_NEAR(q[i], actualQ, kEpsilon);
+  }
+}
+
+TEST(KllSketchTest, mergeMultiple) {
+  constexpr int N = 1e4;
+  constexpr int M = 1001;
+  constexpr int kSketchCount = 10;
+  std::vector<KllSketch<double>> sketches;
+  for (int i = 0; i < kSketchCount; ++i) {
+    KllSketch<double> kll(kDefaultK, {}, 0);
+    for (int j = 0; j < N; ++j) {
+      kll.insert(j + i * N);
+    }
+    sketches.push_back(std::move(kll));
+  }
+  KllSketch<double> kll(kDefaultK, {}, 0);
+  kll.merge(folly::Range(sketches.begin(), sketches.end()));
+  EXPECT_EQ(kll.totalCount(), N * kSketchCount);
+  auto q = linspace(M);
+  auto v = kll.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  ASSERT_TRUE(std::is_sorted(std::begin(v), std::end(v)));
+  for (int i = 0; i < M; ++i) {
+    EXPECT_NEAR(q[i], v[i] / (N * kSketchCount), kEpsilon);
+  }
+}
+
+TEST(KllSketchTest, mergeEmpty) {
+  KllSketch<double> kll, kll2;
+  kll.insert(1.0);
+  kll.merge(folly::Range(&kll2, 1));
+  EXPECT_EQ(kll.totalCount(), 1);
+  EXPECT_EQ(kll.estimateQuantile(0.5), 1.0);
+  kll2.merge(folly::Range(&kll, 1));
+  EXPECT_EQ(kll2.totalCount(), 1);
+  EXPECT_EQ(kll2.estimateQuantile(0.5), 1.0);
+}
+
+TEST(KllSketchTest, kFromEpsilon) {
+  EXPECT_EQ(kFromEpsilon(kEpsilon), kDefaultK);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::kll::test


### PR DESCRIPTION
Summary:
The current T-Digest implementation does not have a bounded
error, thus unable to provide a reliable guarantee for accuracy.  So
we want to reimplement the function using KLL sketch.

Subsequent diffs will be created for serialization/deserialization and aggregation functions.

Differential Revision: D35009274

