### PR TITLE
Implemented mapped memory allocator for memory pool

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -18,16 +18,77 @@
 
 #include "velox/common/base/BitUtil.h"
 
+DEFINE_bool(
+    use_mmap_allocator_for_memory_pool,
+    false,
+    "If true, use MmapMemoryAllocator to allocate memory for MemoryPool");
+
 namespace facebook {
 namespace velox {
 namespace memory {
+
 /* static */
-std::shared_ptr<MemoryAllocator> MemoryAllocator::createDefaultAllocator() {
-  return std::make_shared<MemoryAllocator>();
+std::shared_ptr<MmapMemoryAllocator>
+MmapMemoryAllocator::createDefaultAllocator() {
+  return std::make_shared<MmapMemoryAllocator>();
+}
+
+void* FOLLY_NULLABLE MmapMemoryAllocator::alloc(int64_t size) {
+  return mappedMemory_->allocateBytes(size);
+}
+
+void* FOLLY_NULLABLE
+MmapMemoryAllocator::allocZeroFilled(int64_t numMembers, int64_t sizeEach) {
+  auto totalBytes = numMembers * sizeEach;
+  auto* allocResult = alloc(totalBytes);
+  if (allocResult != nullptr) {
+    std::memset(allocResult, 0, totalBytes);
+  }
+  return allocResult;
+}
+
+void* FOLLY_NULLABLE MmapMemoryAllocator::allocAligned(
+    uint16_t /* alignment */,
+    int64_t /* size */) {
+  // TODO: Add functionality in MappedMemory to support allocAligned
+  VELOX_UNSUPPORTED("allocAligned is not supported for MmapMemoryAllocator.");
+}
+
+void* FOLLY_NULLABLE MmapMemoryAllocator::realloc(
+    void* FOLLY_NULLABLE p,
+    int64_t size,
+    int64_t newSize) {
+  auto* newAlloc = alloc(newSize);
+  if (p == nullptr || newAlloc == nullptr) {
+    return newAlloc;
+  }
+  std::memcpy(newAlloc, p, std::min(size, newSize));
+  free(p, size);
+  return newAlloc;
+}
+
+void* FOLLY_NULLABLE MmapMemoryAllocator::reallocAligned(
+    void* FOLLY_NULLABLE /* p */,
+    uint16_t /* alignment */,
+    int64_t /* size */,
+    int64_t /* newSize */) {
+  VELOX_UNSUPPORTED("reallocAligned is not supported for MmapMemoryAllocator.");
+}
+
+void MmapMemoryAllocator::free(void* FOLLY_NULLABLE p, int64_t size) {
+  if (p == nullptr) {
+    return;
+  }
+  mappedMemory_->freeBytes(p, size);
 }
 
 void* FOLLY_NULLABLE MemoryAllocator::alloc(int64_t size) {
   return std::malloc(size);
+}
+
+/* static */
+std::shared_ptr<MemoryAllocator> MemoryAllocator::createDefaultAllocator() {
+  return std::make_shared<MemoryAllocator>();
 }
 
 void* FOLLY_NULLABLE
@@ -138,7 +199,7 @@ std::unique_ptr<ScopedMemoryPool> MemoryPoolBase::addScopedChild(
   return std::make_unique<ScopedMemoryPool>(pool.getWeakPtr());
 }
 
-void MemoryPoolBase::dropChild(const MemoryPool* child) {
+void MemoryPoolBase::dropChild(const MemoryPool* FOLLY_NONNULL child) {
   folly::SharedMutex::WriteHolder guard{childrenMutex_};
   // Implicitly synchronized in dtor of child so it's impossible for
   // MemoryManager to access after destruction of child.
@@ -182,7 +243,10 @@ size_t MemoryPoolBase::getPreferredSize(size_t size) {
 }
 
 IMemoryManager& getProcessDefaultMemoryManager() {
-  return MemoryManager<>::getProcessDefaultManager();
+  if (FLAGS_use_mmap_allocator_for_memory_pool) {
+    return MemoryManager<MmapMemoryAllocator>::getProcessDefaultManager();
+  }
+  return MemoryManager<MemoryAllocator>::getProcessDefaultManager();
 }
 
 std::unique_ptr<ScopedMemoryPool> getDefaultScopedMemoryPool(int64_t cap) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -24,6 +24,8 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <folly/Synchronized.h>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <velox/common/base/Exceptions.h>
@@ -31,10 +33,10 @@
 #include "folly/Likely.h"
 #include "folly/Random.h"
 #include "folly/SharedMutex.h"
-#include "folly/experimental/FunctionScheduler.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
@@ -307,21 +309,53 @@ class ScopedMemoryPool final : public MemoryPool {
 // node tree.
 class MemoryAllocator {
  public:
-  // TODO: move to factory pattern with type trait.
   static std::shared_ptr<MemoryAllocator> createDefaultAllocator();
 
-  void* FOLLY_NULLABLE alloc(int64_t size);
-  void* FOLLY_NULLABLE allocZeroFilled(int64_t numMembers, int64_t sizeEach);
+  virtual ~MemoryAllocator() {}
+
+  virtual void* FOLLY_NULLABLE alloc(int64_t size);
+  virtual void* FOLLY_NULLABLE
+  allocZeroFilled(int64_t numMembers, int64_t sizeEach);
   // TODO: might be able to collapse this with templated class
-  void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size);
-  void* FOLLY_NULLABLE
+  virtual void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size);
+  virtual void* FOLLY_NULLABLE
   realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize);
-  void* FOLLY_NULLABLE reallocAligned(
+  virtual void* FOLLY_NULLABLE reallocAligned(
       void* FOLLY_NULLABLE p,
       uint16_t alignment,
       int64_t size,
       int64_t newSize);
-  void free(void* FOLLY_NULLABLE p, int64_t size);
+  virtual void free(void* FOLLY_NULLABLE p, int64_t size);
+};
+
+// An allocator that uses memory::MappedMemory to allocate memory. We leverage
+// MappedMemory for relatively small allocations. Allocations less than 3/4 of
+// smallest size class and larger than largest size class are delegated to
+// malloc still.
+class MmapMemoryAllocator : public MemoryAllocator {
+ public:
+  static std::shared_ptr<MmapMemoryAllocator> createDefaultAllocator();
+
+  MmapMemoryAllocator() : mappedMemory_(MappedMemory::getInstance()) {}
+  void* FOLLY_NULLABLE alloc(int64_t size) override;
+  void* FOLLY_NULLABLE
+  allocZeroFilled(int64_t numMembers, int64_t sizeEach) override;
+  void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size) override;
+  void* FOLLY_NULLABLE
+  realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override;
+  void* FOLLY_NULLABLE reallocAligned(
+      void* FOLLY_NULLABLE p,
+      uint16_t alignment,
+      int64_t size,
+      int64_t newSize) override;
+  void free(void* FOLLY_NULLABLE p, int64_t size) override;
+
+  MappedMemory* FOLLY_NONNULL mappedMemory() {
+    return mappedMemory_;
+  }
+
+ private:
+  MappedMemory* FOLLY_NONNULL mappedMemory_;
 };
 
 class MemoryPoolBase : public std::enable_shared_from_this<MemoryPoolBase>,

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -108,6 +108,10 @@ class MmapAllocator : public MappedMemory {
     injectedFailure_ = failure;
   }
 
+  MachinePageCount numExternalMapped() const {
+    return numExternalMapped_;
+  }
+
   std::string toString() const override;
 
   Stats stats() const override {

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/experimental/FunctionScheduler.h>
 #include "velox/connectors/Connector.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"


### PR DESCRIPTION
MemoryPool currently uses Jemalloc to allocate memory. The idea is to let MemoryPool to move away from Jemalloc and instead use MmapAllocator to allocate memory. The allocation scenarios can be largely devided to the following:
1. Tiny allocations:
   For allocation size that is less than 3/4 of the smallest size class in mapped memory, we delegate the job 
   to Jemalloc to minimize memory inefficiency. Consider smallest size to be 4096 bytes and user only needs 1024 bytes of memory. In this case if we still try to use mapped memory we will waste 3072 bytes of memory, having memory utilization efficiency of only 25%.
2. Small allocations:
   For allocation size that is larger than smallest size class but less than or equal to biggest size class, we use mapped memory to allocate memory. The allocated size will be rounded up to the closest size class. The allocated memory will, of course, be a contiguous chunk of memory equaling to the size class. This will likely create memory utilization inefficiency but we can overcome it by adding more size classes in between based on actual memory usage.
3. Large allocations:
   For allocation size that is larger than largest size class, we use contiguous allocation from mapped memory to allocate memory. There will not be memory utilization inefficiency in this case because an exact sized memory chunk will be mmaped instead of any rounding like in small allocation scenario.