### PR TITLE
Fix to_unixtime(timestamp_with_time_zone)

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -39,7 +39,7 @@ struct ToUnixtimeFunction {
       double& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     const auto milliseconds = *timestampWithTimezone.template at<0>();
-    Timestamp timestamp{milliseconds / kMillisecondsInSecond, 0UL};
+    auto timestamp = Timestamp::fromMillis(milliseconds);
     timestamp.toGMT(*timestampWithTimezone.template at<1>());
     result = toUnixtime(timestamp);
     return true;

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -123,6 +123,15 @@ TEST_F(DateTimeFunctionsTest, toUnixtime) {
   EXPECT_EQ(1639426380, toUnixtimeWTZ(1639426440000, "+00:01"));
   EXPECT_EQ(1639476840, toUnixtimeWTZ(1639426440000, "-14:00"));
   EXPECT_EQ(1639376040, toUnixtimeWTZ(1639426440000, "+14:00"));
+  // test floating point and negative time
+  EXPECT_EQ(16394.26, toUnixtimeWTZ(16394260, "+00:00"));
+  EXPECT_EQ(5594.26, toUnixtimeWTZ(16394260, "+03:00"));
+  EXPECT_EQ(1994.26, toUnixtimeWTZ(16394260, "+04:00"));
+  EXPECT_EQ(41594.26, toUnixtimeWTZ(16394260, "-07:00"));
+  EXPECT_EQ(16454.26, toUnixtimeWTZ(16394260, "-00:01"));
+  EXPECT_EQ(16334.26, toUnixtimeWTZ(16394260, "+00:01"));
+  EXPECT_EQ(66794.26, toUnixtimeWTZ(16394260, "-14:00"));
+  EXPECT_EQ(-34005.74, toUnixtimeWTZ(16394260, "+14:00"));
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtimeRountTrip) {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -52,11 +52,21 @@ struct Timestamp {
   }
 
   static Timestamp fromMillis(int64_t millis) {
-    return Timestamp(millis / 1'000, (millis % 1'000) * 1'000'000);
+    if (millis >= 0) {
+      return Timestamp(millis / 1'000, (millis % 1'000) * 1'000'000);
+    }
+    auto second = millis / 1'000 - 1;
+    auto nano = ((millis - second * 1'000) % 1'000) * 1'000'000;
+    return Timestamp(second, nano);
   }
 
   static Timestamp fromMicros(int64_t micros) {
-    return Timestamp(micros / 1'000'000, (micros % 1'000'000) * 1'000);
+    if (micros >= 0) {
+      return Timestamp(micros / 1'000'000, (micros % 1'000'000) * 1'000);
+    }
+    auto second = micros / 1'000'000 - 1;
+    auto nano = ((micros - second * 1'000'000) % 1'000'000) * 1'000;
+    return Timestamp(second, nano);
   }
 
   // Assuming the timestamp represents a time at zone, converts it to the GMT

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_executable(
-  velox_type_test StringViewTest.cpp TypeTest.cpp FilterTest.cpp
-                  SubfieldTest.cpp TimestampConversionTest.cpp VariantTest.cpp)
+  velox_type_test
+  StringViewTest.cpp
+  TypeTest.cpp
+  FilterTest.cpp
+  SubfieldTest.cpp
+  TimestampConversionTest.cpp
+  VariantTest.cpp
+  TimestampTest.cpp)
 
 add_test(velox_type_test velox_type_test)
 

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/Timestamp.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox {
+namespace {
+
+TEST(TimestampTest, fromMillisAndMicros) {
+  Timestamp ts1(-1000, 123 * 1'000'000);
+  EXPECT_EQ(ts1, Timestamp::fromMillis(ts1.toMillis()));
+  EXPECT_EQ(ts1, Timestamp::fromMicros(ts1.toMicros()));
+
+  Timestamp ts2(1000, 123 * 1'000'000);
+  EXPECT_EQ(ts2, Timestamp::fromMillis(ts2.toMillis()));
+  EXPECT_EQ(ts2, Timestamp::fromMicros(ts2.toMicros()));
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
The existing implementation of `to_unixtime(timestamp_with_time_zone)` ignores nanoseconds and thus only preserve precision in seconds. This doesn't match the behavior of existing Presto query.

In this diff,
1.we fix `to_unixtime(timestamp_with_time_zone)` by constructing timestamp via `Timestamp::fromMillis(milliseconds);`  which takes all milliseconds into account.
2.we fix `Timestamp::fromMillis(...)` with input to be negative value.

Differential Revision: D35033633

