### PR TITLE
Fix crash in HashProbe::ensureLoadedIfNotAtEnd

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -580,9 +580,9 @@ void HashProbe::ensureLoadedIfNotAtEnd(ChannelIndex channel) {
       passingInputRows_.setAll();
     } else {
       passingInputRows_.clearAll();
-      auto numInput = input_->size();
+      auto hitsSize = lookup_->hits.size();
       auto hits = lookup_->hits.data();
-      for (auto i = 0; i < numInput; ++i) {
+      for (auto i = 0; i < hitsSize; ++i) {
         if (hits[i]) {
           passingInputRows_.setValid(i, true);
         }


### PR DESCRIPTION
Fix a crash in HashProbe::ensureLoadedIfNotAtEnd caused by invalid memory access, i.e. accessing lookup_->hits.data() past the end.

```
*** Signal 11 (SIGSEGV) (0x7f1fc05fe000) received by PID 239 (pthread TID 0x7ecbbbfac700) (linux TID 8874) (code: invalid permissions for mapped object), stack trace: ***
```

Add a test to reproduce the crash. Without the fix, the test fails in ASAN mode:

```
AddressSanitizer: heap-buffer-overflow velox/exec/HashProbe.cpp:586 in facebook::velox::exec::HashProbe::ensureLoadedIfNotAtEnd(unsigned int)
```