### PR TITLE
Remove unnecessary Merge::planNodeId_ variable

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -268,7 +268,7 @@ std::vector<ChannelIndex> toChannels(
   return channels;
 }
 
-ChannelIndex exprToChannel(const core::ITypedExpr* expr, TypePtr type) {
+ChannelIndex exprToChannel(const core::ITypedExpr* expr, const TypePtr& type) {
   if (auto field = dynamic_cast<const core::FieldAccessTypedExpr*>(expr)) {
     return type->as<TypeKind::ROW>().getChildIdx(field->name());
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -427,7 +427,7 @@ std::vector<ChannelIndex> toChannels(
     const std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>&
         fields);
 
-ChannelIndex exprToChannel(const core::ITypedExpr* expr, TypePtr type);
+ChannelIndex exprToChannel(const core::ITypedExpr* expr, const TypePtr& type);
 
 /// Given an input type and output type that contains a subset of the input type
 /// columns possibly in different order returns the indices of the output


### PR DESCRIPTION
Also, fix clang-tidy warnings and replace std::shared_ptr<const RowType> with RowTypePtr for readability.