### PR TITLE
Capture io stats in HiveFileWriter

### DIFF
--- a/velox/dwio/common/IoStatistics.cpp
+++ b/velox/dwio/common/IoStatistics.cpp
@@ -88,6 +88,27 @@ IoStatistics::operationStats() const {
   return operationStats_;
 }
 
+folly::dynamic serialize(const OperationCounters& counters) {
+  folly::dynamic json = folly::dynamic::object;
+  json["latencyInMs"] = counters.latencyInMs;
+  json["localThrottleCount"] = counters.localThrottleCount;
+  json["resourceThrottleCount"] = counters.resourceThrottleCount;
+  json["globalThrottleCount"] = counters.globalThrottleCount;
+  json["retryCount"] = counters.retryCount;
+  json["requestCount"] = counters.requestCount;
+  json["delayInjectedInSecs"] = counters.delayInjectedInSecs;
+  return json;
+}
+
+folly::dynamic IoStatistics::getOperationStatsSnapshot() const {
+  auto snapshot = operationStats();
+  folly::dynamic json = folly::dynamic::object;
+  for (auto stat : snapshot) {
+    json[stat.first] = serialize(stat.second);
+  }
+  return json;
+}
+
 } // namespace common
 } // namespace dwio
 } // namespace velox

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -101,6 +102,8 @@ class IoStatistics {
       const uint64_t delayInjectedInSecs);
 
   std::unordered_map<std::string, OperationCounters> operationStats() const;
+
+  folly::dynamic getOperationStatsSnapshot() const;
 
  private:
   std::atomic<uint64_t> rawBytesRead_{0};


### PR DESCRIPTION
Summary:
The bare minimum changes required to wire through some serialized run stats containing WS io stats per operation.

The approach is to introduce a RunStats object that contains the handle to all the relevant stats and can serialize itself.

Future diffs will start migrating trabant to depend on RunStats for all writer related stats (e.g. rows written, bytes written, cpu time). Then we will move RunStats concept as a first class citizen in dwio library.

Differential Revision: D34953514

