### PR TITLE
Add test for LazyVector::ensureLoadedRows()

### DIFF
--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/QueryAssertions.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::exec::test;
 
 class AssignUniqueIdTest : public OperatorTestBase {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -22,27 +22,12 @@
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/VectorHasher.h"
-#include "velox/vector/tests/VectorMaker.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 using namespace facebook::velox::dwio;
-
-namespace {
-static void assertEqualVectors(
-    const VectorPtr& expected,
-    const VectorPtr& actual,
-    const std::string& additionalContext = "") {
-  ASSERT_EQ(expected->size(), actual->size());
-
-  for (auto i = 0; i < expected->size(); i++) {
-    ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-        << "at " << i << ": " << expected->toString(i) << " vs. "
-        << actual->toString(i) << additionalContext;
-  }
-}
-} // namespace
 
 class RowContainerTest : public testing::Test {
  protected:

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -118,19 +118,6 @@ std::shared_ptr<const core::ITypedExpr> OperatorTestBase::parseExpr(
   return core::Expressions::inferTypes(untyped, rowType, pool_.get());
 }
 
-void OperatorTestBase::assertEqualVectors(
-    const VectorPtr& expected,
-    const VectorPtr& actual,
-    const std::string& additionalContext) {
-  ASSERT_EQ(expected->size(), actual->size());
-
-  for (auto i = 0; i < expected->size(); i++) {
-    ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-        << "at " << i << ": " << expected->toString(i) << " vs. "
-        << actual->toString(i) << additionalContext;
-  }
-}
-
 RowVectorPtr OperatorTestBase::getResults(
     std::shared_ptr<const core::PlanNode> planNode) {
   CursorParameters params;

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -119,10 +119,5 @@ class OperatorTestBase : public testing::Test,
   // Used as default MappedMemory if 'useAsyncCache_' is true. Created on first
   // use.
   static std::unique_ptr<cache::AsyncDataCache> asyncDataCache_;
-
-  void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual,
-      const std::string& additionalContext = "");
 };
 } // namespace facebook::velox::exec::test

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -23,6 +23,7 @@
 namespace {
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   SelectivityVector rows(vector.size());

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -25,6 +25,8 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
+
+using namespace facebook::velox::test;
 namespace {
 // Function that creates array with values 0...n-1.
 // Uses all possible functions in the array proxy interface.

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -25,19 +25,9 @@
 #include "velox/vector/TypeAliases.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 namespace {
-
-/// Returns indices buffer with sequential values going from size - 1 to 0.
-BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool) {
-  auto indices = allocateIndices(size, pool);
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (auto i = 0; i < size; i++) {
-    rawIndices[i] = size - 1 - i;
-  }
-  return indices;
-}
-
 /// Wraps input in a dictionary that reverses the order of rows.
 class TestingDictionaryFunction : public exec::VectorFunction {
  public:

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -18,8 +18,10 @@
 
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using functions::test::FunctionBaseTest;
 
 // This test suite tests the simplified eval engine by:
@@ -31,12 +33,6 @@ using functions::test::FunctionBaseTest;
 //
 class EvalSimplifiedTest : public FunctionBaseTest {
  protected:
-  void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
-    ASSERT_EQ(expected->size(), actual->size());
-    FunctionBaseTest::assertEqualVectors(
-        expected, actual, fmt::format(" (seed {}).", seed_));
-  }
-
   void assertExceptions(
       std::exception_ptr commonPtr,
       std::exception_ptr simplifiedPtr) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -26,7 +26,7 @@
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorEncoding.h"
-#include "velox/vector/tests/VectorMaker.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -555,20 +555,6 @@ class ExprTest : public testing::Test {
     exprs_ = std::make_unique<exec::ExprSet>(std::move(source), execCtx_.get());
     return exprs_->expr(0).get();
   }
-
-  // TODO Enable ASSERT_EQ for vectors
-  static void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual) {
-    ASSERT_EQ(expected->size(), actual->size());
-    ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    for (auto i = 0; i < expected->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ": expected " << expected->toString(i)
-          << ", but got " << actual->toString(i);
-    }
-  }
-
   std::shared_ptr<core::ConstantTypedExpr> makeConstantExpr(
       const VectorPtr& base,
       vector_size_t index) {

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -27,6 +27,8 @@
 namespace facebook::velox {
 namespace {
 
+using namespace facebook::velox::test;
+
 // Function that creates a map and covers all the map writer interface.
 template <typename T>
 struct Func {

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -32,6 +32,9 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::exec {
+
+using namespace facebook::velox::test;
+
 namespace {
 
 template <typename T>

--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -27,6 +27,9 @@
 #include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox {
+
+using namespace facebook::velox::test;
+
 class SimpleFunctionCallNullFreeTest
     : public functions::test::FunctionBaseTest {};
 

--- a/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
+++ b/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
@@ -34,6 +34,9 @@
 // null.
 
 namespace facebook::velox {
+
+using namespace facebook::velox::test;
+
 namespace {
 
 class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -32,6 +32,7 @@
 namespace {
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class SimpleFunctionTest : public functions::test::FunctionBaseTest {
  protected:

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -22,6 +22,9 @@
 #include "velox/vector/ConstantVector.h"
 
 namespace facebook::velox {
+
+using namespace facebook::velox::test;
+
 class TryExprTest : public functions::test::FunctionBaseTest {};
 
 TEST_F(TryExprTest, tryExpr) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -29,6 +29,9 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions {
+
+using namespace facebook::velox::test;
+
 namespace {
 
 std::shared_ptr<exec::VectorFunction> makeRegexExtract(

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/vector/tests/VectorMaker.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class ValueListTest : public functions::test::FunctionBaseTest {
  protected:

--- a/velox/functions/prestosql/tests/ArrayContainsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayContainsTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/vector/SelectivityVector.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMaxTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayMinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayMinTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -24,6 +24,8 @@
 
 namespace facebook::velox::functions::test {
 
+using namespace facebook::velox::test;
+
 class CastBaseTest : public FunctionBaseTest {
  protected:
   CastBaseTest() {
@@ -123,7 +125,7 @@ class CastBaseTest : public FunctionBaseTest {
       std::vector<std::optional<TFrom>> input,
       std::vector<std::optional<TTo>> expected) {
     auto inputVector = makeNullableFlatVector<TFrom>(input);
-    auto expectedVector = makeNullableFlatVector<TTo>(expected);
+    auto expectedVector = makeNullableFlatVector<TTo>(expected, toType);
 
     testCast<TTo>(fromType, toType, inputVector, expectedVector);
   }

--- a/velox/functions/prestosql/tests/CoalesceTest.cpp
+++ b/velox/functions/prestosql/tests/CoalesceTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class CoalesceTest : public functions::test::FunctionBaseTest {};
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
  protected:

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -21,7 +21,6 @@
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Type.h"
-#include "velox/vector/tests/VectorMaker.h"
 #include "velox/vector/tests/VectorTestBase.h"
 
 namespace facebook::velox::functions::test {
@@ -177,20 +176,6 @@ class FunctionBaseTest : public testing::Test,
         evaluate<SimpleVector<EvalType<ReturnType>>>(expr, rowVectorPtr);
     return result->isNullAt(0) ? std::optional<ReturnType>{}
                                : ReturnType(result->valueAt(0));
-  }
-
-  // TODO: Enable ASSERT_EQ for vectors
-  static void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual,
-      const std::string& additionalContext = "") {
-    ASSERT_EQ(expected->size(), actual->size());
-
-    for (auto i = 0; i < expected->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ": " << expected->toString(i) << " vs. "
-          << actual->toString(i) << additionalContext;
-    }
   }
 
   // Asserts that `func` throws `VeloxUserError`. Optionally, checks if

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 class InPredicateTest : public FunctionBaseTest {

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 class MapTest : public FunctionBaseTest {};

--- a/velox/functions/prestosql/tests/NotTest.cpp
+++ b/velox/functions/prestosql/tests/NotTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class NotTest : public functions::test::FunctionBaseTest {};
 

--- a/velox/functions/prestosql/tests/ReverseTest.cpp
+++ b/velox/functions/prestosql/tests/ReverseTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/SliceTest.cpp
+++ b/velox/functions/prestosql/tests/SliceTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
 
 namespace {

--- a/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
+++ b/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -27,6 +27,8 @@
 namespace facebook::velox::functions::sparksql::test {
 namespace {
 
+using namespace facebook::velox::test;
+
 using facebook::velox::functions::test::FunctionBaseTest;
 
 class ArraySortTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -25,6 +25,8 @@
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::functions::sparksql::test {
+
+using namespace facebook::velox::test;
 namespace {
 
 using facebook::velox::functions::test::FunctionBaseTest;

--- a/velox/functions/sparksql/tests/SplitFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/SplitFunctionsTest.cpp
@@ -18,6 +18,8 @@
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {
+
+using namespace facebook::velox::test;
 namespace {
 
 class SplitTest : public SparkFunctionBaseTest {

--- a/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/row/UnsafeRowParser.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 namespace facebook::velox::row {
 namespace {
@@ -661,18 +662,6 @@ class UnsafeRowComplexBatchDeserializerTests
         });
     return makeRowVector(
         {intVector, stringVector, intArrayVector, stringArrayVector});
-  }
-
-  static void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual) {
-    ASSERT_EQ(expected->size(), actual->size());
-    ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    for (auto i = 0; i < expected->size(); i++) {
-      EXPECT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ": expected " << expected->toString(i)
-          << ", but got " << actual->toString(i);
-    }
   }
 
   std::unique_ptr<memory::ScopedMemoryPool> pool_ =

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -22,11 +22,13 @@
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowParser.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 using namespace facebook::velox::row;
 
 namespace facebook::velox::row {
@@ -923,18 +925,6 @@ class UnsafeRowComplexDeserializerTests : public exec::test::OperatorTestBase {
         {intVector, stringVector, intArrayVector, stringArrayVector});
   }
 
-  static void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual) {
-    ASSERT_EQ(expected->size(), actual->size());
-    ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    for (auto i = 0; i < expected->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ": expected " << expected->toString(i)
-          << ", but got " << actual->toString(i);
-    }
-  }
-
   std::unique_ptr<memory::ScopedMemoryPool> pool_ =
       memory::getDefaultScopedMemoryPool();
   std::array<char[1024], kMaxBuffers> buffers_{};
@@ -958,7 +948,7 @@ TYPED_TEST(
   }
   VectorPtr outputVector = TypeParam::Deserialize(
       serializedVec, inputVector->type(), this->pool_.get());
-  this->assertEqualVectors(inputVector, outputVector);
+  assertEqualVectors(inputVector, outputVector);
 }
 
 TYPED_TEST(UnsafeRowComplexDeserializerTests, UnsafeRowDeserializationTests) {
@@ -971,7 +961,7 @@ TYPED_TEST(UnsafeRowComplexDeserializerTests, UnsafeRowDeserializationTests) {
       {std::string_view(this->buffers_[0], rowSize.value())},
       inputVector->type(),
       this->pool_.get());
-  this->assertEqualVectors(inputVector, outputVector);
+  assertEqualVectors(inputVector, outputVector);
 }
 
 TYPED_TEST(
@@ -990,7 +980,7 @@ TYPED_TEST(
        std::string_view(this->buffers_[1], nextRowSize.value())},
       inputVector->type(),
       this->pool_.get());
-  this->assertEqualVectors(inputVector, outputVector);
+  assertEqualVectors(inputVector, outputVector);
 }
 
 VectorFuzzer::Options fuzzerOptions() {
@@ -1024,7 +1014,7 @@ TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
       data += *size;
     }
     auto output = TypeParam::Deserialize(rowData, type, this->pool_.get());
-    this->assertEqualVectors(input, output);
+    assertEqualVectors(input, output);
   }
 }
 

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -25,6 +25,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 namespace facebook::velox::row {
 namespace {
@@ -37,17 +38,6 @@ class UnsafeRowFuzzTests : public ::testing::Test {
 
   void clearBuffer() {
     std::memset(buffer_, 0, 1024);
-  }
-
-  void assertEqualVectors(
-      const VectorPtr& expected,
-      const VectorPtr& actual,
-      const std::string& additionalContext = "") {
-    for (auto i = 0; i < expected->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ": " << expected->toString(i) << " vs. "
-          << actual->toString(i) << additionalContext;
-    }
   }
 
   std::unique_ptr<memory::ScopedMemoryPool> pool_ =

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -19,9 +19,10 @@
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
-#include "velox/vector/tests/VectorMaker.h"
+#include "velox/vector/tests/VectorTestBase.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
 
 class PrestoSerializerTest : public ::testing::Test {
  protected:
@@ -94,15 +95,6 @@ class PrestoSerializerTest : public ::testing::Test {
     std::vector<VectorPtr> childVectors = {a, b};
 
     return vectorMaker_->rowVector(childVectors);
-  }
-
-  void assertEqualVectors(VectorPtr actual, VectorPtr expected) {
-    ASSERT_EQ(actual->size(), expected->size());
-    for (int i = 0; i < expected->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
-          << "at " << i << ". Expected: " << expected->toString(i)
-          << ", got: " << actual->toString(i);
-    }
   }
 
   void testRoundTrip(VectorPtr vector) {

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   DecodedVectorTest.cpp
   SelectivityVectorTest.cpp
   EnsureWritableVectorTest.cpp
+  LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp)
 
 add_test(velox_vector_test velox_vector_test)

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class LazyVectorTest : public testing::Test, public VectorTestBase {};
+
+TEST_F(LazyVectorTest, lazyInDictionary) {
+  // We have a dictionary over LazyVector. We load for some indices in
+  // the dictionary. We check that the loads on the wrapped lazy
+  // vector are properly translated and deduplicated.
+  static constexpr int32_t kInnerSize = 100;
+  static constexpr int32_t kOuterSize = 1000;
+  auto base = makeFlatVector<int32_t>(kInnerSize, [](auto row) { return row; });
+  std::vector<vector_size_t> loadedRows;
+  auto lazy = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      kInnerSize,
+      std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
+        for (auto row : rows) {
+          loadedRows.push_back(row);
+        }
+        return base;
+      }));
+  auto wrapped = BaseVector::wrapInDictionary(
+      nullptr,
+      makeIndices(kOuterSize, [](auto row) { return row / 10; }),
+      kOuterSize,
+      lazy);
+
+  // We expect a single level of dictionary and rows loaded for the selected
+  // indices in rows.
+
+  SelectivityVector rows(kOuterSize, false);
+  // We select 3 rows, the 2 first fall on 0 and the last on 5 in 'base'.
+  rows.setValid(1, true);
+  rows.setValid(9, true);
+  rows.setValid(55, true);
+  rows.updateBounds();
+  LazyVector::ensureLoadedRows(wrapped, rows);
+  EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
+  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
+  EXPECT_EQ(loadedRows, (std::vector<vector_size_t>{0, 5}));
+}
+
+TEST_F(LazyVectorTest, lazyInDoubleDictionary) {
+  // We have dictionaries over LazyVector. We load for some indices in
+  // the top dictionary. The intermediate dictionaries refer to
+  // non-loaded items in the base of the LazyVector, including indices
+  // past its end. We check that we end up with one level of
+  // dictionary and have no dictionaries that are invalid by
+  // referring to uninitialized/nonexistent positions.
+  static constexpr int32_t kInnerSize = 100;
+  static constexpr int32_t kOuterSize = 1000;
+  auto base = makeFlatVector<int32_t>(kInnerSize, [](auto row) { return row; });
+  vector_size_t loadEnd = 0;
+  auto lazy = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      kInnerSize,
+      std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
+        loadEnd = rows.back() + 1;
+        return base;
+      }));
+  auto wrapped = BaseVector::wrapInDictionary(
+      nullptr,
+      makeIndices(kInnerSize, [](auto row) { return row; }),
+      kInnerSize,
+      BaseVector::wrapInDictionary(
+          nullptr,
+          makeIndices(kOuterSize, [](auto row) { return row; }),
+          kOuterSize,
+          lazy));
+
+  // We expect a single level of dictionary and rows loaded for kInnerSize first
+  // elements of 'lazy'.
+  SelectivityVector rows(kInnerSize);
+  LazyVector::ensureLoadedRows(wrapped, rows);
+  EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
+  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
+  EXPECT_EQ(kInnerSize, loadEnd);
+  assertEqualVectors(wrapped, base);
+}

--- a/velox/vector/tests/VectorTestBase.cpp
+++ b/velox/vector/tests/VectorTestBase.cpp
@@ -58,4 +58,17 @@ BufferPtr VectorTestBase::makeIndices(
   return indices;
 }
 
+void assertEqualVectors(
+    const VectorPtr& expected,
+    const VectorPtr& actual,
+    const std::string& additionalContext) {
+  ASSERT_EQ(expected->size(), actual->size()) << additionalContext;
+  ASSERT_EQ(expected->typeKind(), actual->typeKind());
+  for (auto i = 0; i < expected->size(); i++) {
+    ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
+        << "at " << i << ": expected " << expected->toString(i) << ", but got "
+        << actual->toString(i) << additionalContext;
+  }
+}
+
 } // namespace facebook::velox::test

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -18,10 +18,18 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/VectorMaker.h"
 
+#include <gtest/gtest.h>
+
 namespace facebook::velox::test {
 
 /// Returns indices buffer with sequential values going from size - 1 to 0.
 BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool);
+
+// TODO: enable ASSERT_EQ for vectors.
+void assertEqualVectors(
+    const VectorPtr& expected,
+    const VectorPtr& actual,
+    const std::string& additionalContext = "");
 
 class VectorTestBase {
  protected:


### PR DESCRIPTION
Checks that loaded rows are correctly translated via dictionaries.

Deduplicates assertEqualVectors.