### PR TITLE
Optimize LocalMerge

### DIFF
--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -40,13 +40,11 @@ Merge::Merge(
       rowContainer_(std::make_unique<RowContainer>(
           outputType_->children(),
           operatorCtx_->mappedMemory())),
-      candidates_(Comparator(
+      comparator_(Comparator(
           outputType_,
           sortingKeys,
           sortingOrders,
           rowContainer_.get())),
-      extractedCols_(std::dynamic_pointer_cast<RowVector>(
-          BaseVector::create(outputType_, 1, operatorCtx_->pool()))),
       future_(false) {}
 
 BlockingReason Merge::isBlocked(ContinueFuture* future) {
@@ -61,12 +59,56 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 }
 
 BlockingReason Merge::pushSource(ContinueFuture* future, size_t sourceId) {
-  char* row = nullptr;
-  auto reason = sources_[sourceId]->next(future, &row);
-  if (reason == BlockingReason::kNotBlocked && row) {
-    candidates_.emplace(sourceId, row);
+  if (sourceCursors_.size() <= sourceId) {
+    sourceCursors_.resize(sourceId + 1);
   }
-  return reason;
+
+  auto& cursor = sourceCursors_[sourceId];
+  if (cursor.hasNext()) {
+    candidates_.push_back({sourceId, cursor.nextUnchecked()});
+    return BlockingReason::kNotBlocked;
+  }
+
+  if (cursor.atEnd) {
+    return BlockingReason::kNotBlocked;
+  }
+
+  RowVectorPtr data;
+  auto reason = sources_[sourceId]->next(data, future);
+  if (reason != BlockingReason::kNotBlocked) {
+    return reason;
+  }
+
+  if (data) {
+    VELOX_CHECK_LT(0, data->size());
+    cursor.reset(data, rowContainer_.get());
+    candidates_.push_back({sourceId, cursor.nextUnchecked()});
+  } else {
+    cursor.atEnd = true;
+  }
+
+  return BlockingReason::kNotBlocked;
+}
+
+void Merge::SourceCursor::reset(
+    const RowVectorPtr& data,
+    RowContainer* rowContainer) {
+  rows.clear();
+  index = 0;
+
+  SelectivityVector allRows(data->size());
+  rows.reserve(data->size());
+  for (int i = 0; i < data->size(); ++i) {
+    rows.emplace_back(rowContainer->newRow());
+  }
+
+  DecodedVector decoded;
+  for (int col = 0; col < data->childrenSize(); ++col) {
+    decoded.decode(*data->childAt(col), allRows);
+    for (int i = 0; i < data->size(); ++i) {
+      rowContainer->store(decoded, i, rows[i], col);
+    }
+  }
 }
 
 // Returns kNotBlocked if all sources ready and the priority queue has
@@ -107,6 +149,22 @@ bool Merge::isFinished() {
   return blockingReason_ == BlockingReason::kNotBlocked && candidates_.empty();
 }
 
+Merge::SourceRow Merge::nextOutputRow() {
+  size_t maxSource = 0;
+  for (auto i = 1; i < candidates_.size(); i++) {
+    if (comparator_(candidates_[maxSource], candidates_[i])) {
+      maxSource = i;
+    }
+  }
+
+  auto entry = candidates_[maxSource];
+  if (maxSource < candidates_.size() - 1) {
+    candidates_[maxSource] = candidates_.back();
+  }
+  candidates_.pop_back();
+  return entry;
+}
+
 RowVectorPtr Merge::getOutput() {
   blockingReason_ = ensureSourcesReady(&future_);
   if (blockingReason_ != BlockingReason::kNotBlocked) {
@@ -118,11 +176,8 @@ RowVectorPtr Merge::getOutput() {
   rows_.reserve(numRowsPerBatch);
 
   while (!candidates_.empty()) {
-    auto entry = candidates_.top();
-    candidates_.pop();
-
-    rows_.push_back(rowContainer_->addRow(entry.second, extractedCols_));
-
+    auto entry = nextOutputRow();
+    rows_.push_back(entry.second);
     blockingReason_ = pushSource(&future_, entry.first);
     if (blockingReason_ != BlockingReason::kNotBlocked) {
       currentSourcePos_ = entry.first;
@@ -139,7 +194,7 @@ RowVectorPtr Merge::getOutput() {
         BaseVector::create(outputType_, rows_.size(), operatorCtx_->pool()));
 
     rowContainer_->extractRows(rows_, result);
-    rowContainer_->clear();
+    rowContainer_->eraseRows(folly::Range(rows_.data(), rows_.size()));
     rows_.clear();
     return result;
   }
@@ -156,10 +211,16 @@ Merge::Comparator::Comparator(
   auto numKeys = sortingKeys.size();
   for (int i = 0; i < numKeys; ++i) {
     auto channel = exprToChannel(sortingKeys[i].get(), type);
-    VELOX_CHECK(
-        channel != kConstantChannel,
+    VELOX_CHECK_NE(
+        channel,
+        kConstantChannel,
         "Merge doesn't allow constant grouping keys");
-    keyInfo_.emplace_back(channel, sortingOrders[i]);
+    keyInfo_.emplace_back(
+        channel,
+        CompareFlags{
+            sortingOrders[i].isNullsFirst(),
+            sortingOrders[i].isAscending(),
+            false});
   }
 }
 
@@ -182,8 +243,10 @@ LocalMerge::LocalMerge(
 }
 
 BlockingReason LocalMerge::addMergeSources(ContinueFuture* /* future */) {
-  sources_ = operatorCtx_->task()->getLocalMergeSources(
-      operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+  if (sources_.empty()) {
+    sources_ = operatorCtx_->task()->getLocalMergeSources(
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+  }
   return BlockingReason::kNotBlocked;
 }
 

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -73,10 +73,7 @@ class Merge : public SourceOperator {
     bool operator()(const SourceRow& lhs, const SourceRow& rhs) {
       for (auto& key : keyInfo_) {
         if (auto result = rowContainer_->compare(
-                lhs.second,
-                rhs.second,
-                key.first,
-                {key.second.isNullsFirst(), key.second.isAscending(), false})) {
+                lhs.second, rhs.second, key.first, key.second)) {
           return result > 0;
         }
       }
@@ -84,19 +81,62 @@ class Merge : public SourceOperator {
     }
 
    private:
-    std::vector<std::pair<ChannelIndex, core::SortOrder>> keyInfo_;
+    std::vector<std::pair<ChannelIndex, CompareFlags>> keyInfo_;
     RowContainer* rowContainer_;
   };
 
+  /// Appends next row from the specified source to 'candidates_'. If
+  /// corresponding CursorSource has next row, returns that row and advances the
+  /// cursor. Otherwise, fetches next batch of source rows from MergeSource,
+  /// copies them to rowContainer_ and resets the cursor.
   BlockingReason pushSource(ContinueFuture* future, size_t sourceId);
 
   BlockingReason ensureSourcesReady(ContinueFuture* future);
 
+  /// Returns "max" row from 'candidates_' and removes that row from
+  /// 'candidates_'. Assumes 'candidates_' is not empty.
+  SourceRow nextOutputRow();
+
+  /// A cursor over an ordered batch of source rows copied into 'rowContainer_'.
+  struct SourceCursor {
+    /// Ordered source rows.
+    std::vector<char*> rows;
+    /// Index of the next row.
+    vector_size_t index{0};
+    /// True if source has been exhausted.
+    bool atEnd{false};
+
+    /// Returns true if there is a next row.
+    bool hasNext() {
+      return !atEnd && index < rows.size();
+    }
+
+    /// Returns next row and advances the cursor.
+    char* nextUnchecked() {
+      return rows[index++];
+    }
+
+    /// Copies the 'data' into 'rowContainer' and resets the cursor to point to
+    /// the first row.
+    void reset(const RowVectorPtr& data, RowContainer* rowContainer);
+  };
+
+  /// A list of cursors over batches of ordered source data. One per source.
+  /// Aligned with 'sources'.
+  std::vector<SourceCursor> sourceCursors_;
+
+  /// Ordered list of output rows.
   std::vector<char*> rows_;
+
+  /// Row container to store incoming batches of source data.
   std::unique_ptr<RowContainer> rowContainer_;
-  std::priority_queue<SourceRow, std::vector<SourceRow>, Comparator>
-      candidates_;
-  RowVectorPtr extractedCols_;
+
+  /// STL-compatible comparator to compare rows by sorting keys.
+  Comparator comparator_;
+
+  /// A list of "max" rows from each source. Used to pick the next output row.
+  std::vector<SourceRow> candidates_;
+
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
   ContinueFuture future_;
   size_t numSourcesAdded_ = 0;

--- a/velox/exec/MergeSource.h
+++ b/velox/exec/MergeSource.h
@@ -24,15 +24,15 @@ class MergeExchange;
 class MergeSource {
  public:
   virtual ~MergeSource() {}
-  virtual BlockingReason next(ContinueFuture* future, char** row) = 0;
+
+  virtual BlockingReason next(RowVectorPtr& data, ContinueFuture* future) = 0;
+
   virtual BlockingReason enqueue(
       RowVectorPtr input,
       ContinueFuture* future) = 0;
 
   // Factory methods to create MergeSources.
-  static std::shared_ptr<MergeSource> createLocalMergeSource(
-      const std::shared_ptr<const RowType>& rowType,
-      memory::MappedMemory* mappedMemory);
+  static std::shared_ptr<MergeSource> createLocalMergeSource();
 
   static std::shared_ptr<MergeSource> createMergeExchangeSource(
       MergeExchange* mergeExchange,

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -327,21 +327,6 @@ class RowContainer {
         ((batchSizeInBytes % fixedRowSize_) ? 1 : 0);
   }
 
-  // Adds new row to the row container and copy the 'srcRow' into the new row.
-  char* addRow(const char* srcRow, const RowVectorPtr& extractedCols) {
-    static const SelectivityVector kOneRow(1);
-
-    auto* destRow = newRow();
-    DecodedVector decoded;
-    for (int i = 0; i < keyTypes_.size(); ++i) {
-      RowContainer::extractColumn(
-          &srcRow, 1, columnAt(i), extractedCols->childAt(i));
-      decoded.decode(*extractedCols->childAt(i), kOneRow, true);
-      store(decoded, 0, destRow, i);
-    }
-    return destRow;
-  }
-
   // Extract column values for 'rows' into 'result'.
   void extractRows(const std::vector<char*>& rows, const RowVectorPtr& result) {
     VELOX_CHECK_EQ(rows.size(), result->size());

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1049,8 +1049,7 @@ std::shared_ptr<MergeSource> Task::addLocalMergeSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId,
     const RowTypePtr& rowType) {
-  auto source =
-      MergeSource::createLocalMergeSource(rowType, queryCtx()->mappedMemory());
+  auto source = MergeSource::createLocalMergeSource();
   splitGroupStates_[splitGroupId].localMergeSources[planNodeId].push_back(
       source);
   return source;


### PR DESCRIPTION
The starting point for this optimization was that merging 2 sources each having
80M rows was taking 2m. After the optimizations the same query takes 20s. The
changes are to (1) reduce unnecessary copying, (2) eliminate per-row locking
and (3) replace the use of std::priority_queue with a simple hand-written
logic. 

Before this change the data was copied many times. First, LocalMergeSource was
copying batches of rows into dedicated RowContainers's (see MergeSourceData
class). Next, the data was copied into a RowContainer used to accumulate merged
rows. Finally, the data was copied into output vector. When copying data
between RowContainers, the data was first copied from RowContainer into vector,
then written into the target RowContainers (see RowContainers::addRow method).
The new code is streamlined to copy data twice: first from vector into
RowContainer, then from RowContainer into output vector. A follow-up PR will
look into using TreeOfLoosers to avoid the copying into RowContainer and copy
directly from input to output.

Also, per-row locking is replaced with per-vector locking
(see LocalMergeSource::next). With this change locking no longer shows up in
the profile.

Here is the new profile showing lots of time taken by copying data into and
output of a RowContainer. We'll be looking to eliminate that copying in a
follow-up PR.

<img width="837" alt="Screen Shot 2022-03-23 at 12 06 48 PM" src="https://user-images.githubusercontent.com/27965151/159744101-f164f2fa-037d-4ab6-9c5a-5106744a42f3.png">

