### PR TITLE
Unify compare() and equalValueAt.

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -261,7 +261,11 @@ class BaseVector {
   virtual bool equalValueAt(
       const BaseVector* other,
       vector_size_t index,
-      vector_size_t otherIndex) const = 0;
+      vector_size_t otherIndex) const {
+    static constexpr CompareFlags kEqualValueAtFlags = {
+        false, false, true /*equalOnly*/};
+    return compare(other, index, otherIndex, kEqualValueAtFlags) == 0;
+  }
 
   // Returns < 0 if 'this' at 'index' is less than 'other' at
   // 'otherIndex', 0 if equal and > 0 otherwise.

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -73,11 +73,6 @@ class RowVector : public BaseVector {
     return VectorEncoding::Simple::ROW;
   }
 
-  bool equalValueAt(
-      const BaseVector* other,
-      vector_size_t index,
-      vector_size_t otherIndex) const override;
-
   int32_t compare(
       const BaseVector* other,
       vector_size_t index,
@@ -276,11 +271,6 @@ class ArrayVector : public BaseVector {
     return VectorEncoding::Simple::ARRAY;
   }
 
-  bool equalValueAt(
-      const BaseVector* other,
-      vector_size_t index,
-      vector_size_t otherIndex) const override;
-
   int32_t compare(
       const BaseVector* other,
       vector_size_t index,
@@ -447,11 +437,6 @@ class MapVector : public BaseVector {
   VectorEncoding::Simple encoding() const override {
     return VectorEncoding::Simple::MAP;
   }
-
-  bool equalValueAt(
-      const BaseVector* other,
-      vector_size_t index,
-      vector_size_t otherIndex) const override;
 
   int32_t compare(
       const BaseVector* other,

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -128,13 +128,6 @@ class FunctionVector : public BaseVector {
     functions_.push_back(callable);
   }
 
-  bool equalValueAt(
-      const BaseVector* /*other*/,
-      vector_size_t /*index*/,
-      vector_size_t /*otherIndex*/) const override {
-    throw std::logic_error("equalValueAt not defined for FunctionVector");
-  }
-
   int32_t compare(
       const BaseVector* /*other*/,
       vector_size_t /*index*/,

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -163,13 +163,6 @@ class LazyVector : public BaseVector {
     loader_->load(rows, hook, &vector_);
   }
 
-  bool equalValueAt(
-      const BaseVector* other,
-      vector_size_t index,
-      vector_size_t otherIndex) const override {
-    return loadedVector()->equalValueAt(other, index, otherIndex);
-  }
-
   int32_t compare(
       const BaseVector* other,
       vector_size_t index,

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -146,31 +146,6 @@ class SimpleVector : public BaseVector {
   // value is technically undefined (currently implemented as default of T)
   virtual const T valueAt(vector_size_t idx) const = 0;
 
-  bool equalValueAt(
-      const BaseVector* other,
-      vector_size_t index,
-      vector_size_t otherIndex) const override {
-    other = other->loadedVector();
-    DCHECK(dynamic_cast<const SimpleVector<T>*>(other) != nullptr)
-        << "Attempting to compare vectors not of the same type";
-    bool otherNull = other->isNullAt(otherIndex);
-    if (isNullAt(index)) {
-      return otherNull;
-    }
-    if (otherNull) {
-      return false;
-    }
-    auto simpleVector = reinterpret_cast<const SimpleVector<T>*>(other);
-
-    if constexpr (std::is_floating_point<T>::value) {
-      T v1 = valueAt(index);
-      T v2 = simpleVector->valueAt(otherIndex);
-      return (v1 == v2) || (std::isnan(v1) && std::isnan(v2));
-    } else {
-      return valueAt(index) == simpleVector->valueAt(otherIndex);
-    }
-  }
-
   int32_t compare(
       const BaseVector* other,
       vector_size_t index,
@@ -433,23 +408,6 @@ inline void SimpleVector<ComplexType>::setMinMax(
 template <>
 inline void SimpleVector<std::shared_ptr<void>>::setMinMax(
     const folly::F14FastMap<std::string, std::string>& /*metaData*/) {}
-
-template <>
-inline bool SimpleVector<ComplexType>::equalValueAt(
-    const BaseVector* other,
-    vector_size_t index,
-    vector_size_t otherIndex) const {
-  auto otherNull = other->isNullAt(otherIndex);
-  if (isNullAt(index)) {
-    return otherNull;
-  } else if (otherNull) {
-    return false;
-  }
-  return wrappedVector()->equalValueAt(
-      other->wrappedVector(),
-      wrappedIndex(index),
-      other->wrappedIndex(otherIndex));
-}
 
 template <>
 inline int32_t SimpleVector<ComplexType>::compare(


### PR DESCRIPTION
Summary:
Unify compare() and equal Value to eliminate duplicate code.
Fix big in RowVector::compare found after the change.

Differential Revision: D35081136

