### PR TITLE
velox/benchmarks/tpch/TpchBenchmark.cpp: loop variable: do not create a copy, per -Wrange-loop-construct

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -88,8 +88,8 @@ class TpchBenchmark {
     bool noMoreSplits = false;
     auto addSplits = [&](exec::Task* task) {
       if (!noMoreSplits) {
-        for (const auto entry : tpchPlan.dataFiles) {
-          for (const auto path : entry.second) {
+        for (const auto& entry : tpchPlan.dataFiles) {
+          for (const auto& path : entry.second) {
             auto const splits = HiveConnectorTestBase::makeHiveConnectorSplits(
                 path, numSplitsPerFile, tpchPlan.dataFileFormat);
             for (const auto& split : splits) {


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/benchmarks/tpch/TpchBenchmark.cpp:91:25: error: loop variable 'entry' creates a copy from type 'const std::pair<const std::basic_string<char>, std::vector<std::basic_string<char>>>' [-Werror,-Wrange-loop-construct]
  velox/benchmarks/tpch/TpchBenchmark.cpp:92:27: error: loop variable 'path' creates a copy from type 'const std::basic_string<char>' [-Werror,-Wrange-loop-construct]

Reviewed By: mbasmanova

Differential Revision: D35084166

