### PR TITLE
Small correction in exception message.

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -110,7 +110,7 @@ HashAggregation::HashAggregation(
         "Unexpected result type for an aggregation: {}, expected {}, step {}",
         aggResultType->toString(),
         expectedType->toString(),
-        static_cast<int32_t>(aggregationNode->step()));
+        core::AggregationNode::stepName(aggregationNode->step()));
   }
 
   if (isDistinct_) {


### PR DESCRIPTION
Summary: Use the name of the aggregation step rather than integer.

Reviewed By: amitkdutta

Differential Revision: D35090534

