### PR TITLE
Add next split and next stripe prefetch

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -397,7 +397,11 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       readerOpts_.setDataCacheConfig(std::move(dataCacheConfig));
     }
     readerOpts_.getDataCacheConfig()->filenum = fileHandle_->uuid.id();
-    bufferedInputFactory_ = std::make_unique<dwrf::CachedBufferedInputFactory>(
+    cache::FileGroupStats* groupStats = asyncCache->ssdCache()
+        ? &asyncCache->ssdCache()->groupStats()
+        : nullptr;
+    auto tracker = Connector::getTracker(scanId_, readerOpts_.loadQuantum());
+    bufferedInputFactory_ = std::make_shared<dwrf::CachedBufferedInputFactory>(
         (asyncCache),
         Connector::getTracker(scanId_, readerOpts_.loadQuantum()),
         fileHandle_->groupId.id(),
@@ -511,10 +515,40 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       rowReaderOpts_.select(cs).range(split_->start, split_->length));
 }
 
+void HiveDataSource::setFromDataSource(
+    std::shared_ptr<DataSource> sourceShared) {
+  auto source = dynamic_cast<HiveDataSource*>(sourceShared.get());
+  VELOX_CHECK(source, "Bad DataSource type");
+  emptySplit_ = source->emptySplit_;
+  split_ = std::move(source->split_);
+  if (emptySplit_) {
+    // Leave old readers in place so tat their adaptation can be moved to a new
+    // reader.
+    return;
+  }
+  if (rowReader_) {
+    if (!source->rowReader_->moveAdaptationFrom(*rowReader_)) {
+      // The source had a reader that did not have state that could be
+      // advanced. Keep the old readers so that you can transfer the
+      // adaptation to the next non-empty one.
+      emptySplit_ = true;
+      return;
+    }
+  }
+  reader_ = std::move(source->reader_);
+  rowReader_ = std::move(source->rowReader_);
+  scanSpec_ = std::move(source->scanSpec_);
+  // New io will be accounted on the stats of 'source'. Add the existing
+  // balance to that.
+  source->ioStats_->merge(*ioStats_);
+  ioStats_ = std::move(source->ioStats_);
+}
+
 RowVectorPtr HiveDataSource::next(uint64_t size) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
   if (emptySplit_) {
-    resetSplit();
+    split_.reset();
+    // Keep readers around to hold adaptation.
     return nullptr;
   }
 
@@ -577,10 +611,7 @@ RowVectorPtr HiveDataSource::next(uint64_t size) {
 
 void HiveDataSource::resetSplit() {
   split_.reset();
-  // Make sure to destroy Reader and RowReader in the opposite order of
-  // creation, e.g. destroy RowReader first, then destroy Reader.
-  rowReader_.reset();
-  reader_.reset();
+  // Keep readers around to hold adaptation.
 }
 
 vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -161,6 +161,12 @@ class HiveDataSource : public DataSource {
 
   std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
 
+  bool allPrefetchIssued() const override {
+    return rowReader_ && rowReader_->allPrefetchIssued();
+  }
+
+  void setFromDataSource(std::shared_ptr<DataSource> source) override;
+
   int64_t estimatedRowSize() override;
 
  private:
@@ -255,6 +261,10 @@ class HiveConnector final : public Connector {
         executor_);
   }
 
+  bool supportsSplitPreload() override {
+    return true;
+  }
+
   std::shared_ptr<DataSink> createDataSink(
       std::shared_ptr<const RowType> inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
@@ -270,7 +280,7 @@ class HiveConnector final : public Connector {
         connectorQueryCtx->memoryPool());
   }
 
-  folly::Executor* FOLLY_NULLABLE executor() {
+  folly::Executor* FOLLY_NULLABLE executor() const override {
     return executor_;
   }
 

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -63,12 +63,25 @@ class RowReader {
    */
   virtual void resetFilterCaches() = 0;
 
+  // Moves the adaptively acquired filters/filter order from 'other'
+  // to 'this'. Returns true if 'this' is ready to read, false if
+  // 'this' is known to be empty.
+  virtual bool moveAdaptationFrom(RowReader& other) {
+    return true;
+  }
+
   /**
    * Get an estimated row size basing on available statistics. Can
    * differ from the actual row size due to variable-length values.
    * @return Estimate of the row size or std::nullopt if cannot estimate.
    */
   virtual std::optional<size_t> estimatedRowSize() const = 0;
+
+  // Returns true if the expected IO for 'this' is scheduled. If this
+  // is true it makes sense to prefetch the next split.
+  virtual bool allPrefetchIssued() const {
+    return false;
+  }
 };
 
 /**

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -104,6 +104,10 @@ class ColumnReader {
     VELOX_NYI();
   }
 
+  virtual void moveScanSpec(ColumnReader& other) {
+    VELOX_NYI();
+  }
+
   /**
    * Create a reader for the given stripe.
    */

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -16,7 +16,10 @@
 
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
+
+DEFINE_bool(prefetch_stripes, true, "Enable prefetch of stripes.");
 
 namespace facebook::velox::dwrf {
 
@@ -24,9 +27,18 @@ using dwio::common::InputStream;
 using dwio::common::ReaderOptions;
 using dwio::common::RowReaderOptions;
 
+bool DwrfRowReader::mayPrefetch() const {
+  return FLAGS_prefetch_stripes &&
+      getReader().bufferedInputFactory().executor();
+}
+
 std::unique_ptr<dwio::common::RowReader> DwrfReader::createRowReader(
     const RowReaderOptions& opts) const {
-  return std::make_unique<DwrfRowReader>(readerBase_, opts);
+  auto rowReader = std::make_unique<DwrfRowReader>(readerBase_, opts);
+  if (rowReader->mayPrefetch()) {
+    rowReader->startNextStripe();
+  }
+  return rowReader;
 }
 
 std::unique_ptr<DwrfRowReader> DwrfReader::createDwrfRowReader(
@@ -72,66 +84,156 @@ void DwrfRowReader::checkSkipStrides(
 }
 
 uint64_t DwrfRowReader::next(uint64_t size, VectorPtr& result) {
+  if (!mayPrefetch()) {
+    for (;;) {
+      if (currentStripe >= lastStripe) {
+        return 0;
+      }
+      auto numRows = nextInStripe(size, result);
+      if (currentRowInStripe >= rowsInCurrentStripe) {
+        currentStripe += 1;
+        currentRowInStripe = 0;
+        newStripeLoaded = false;
+      }
+      if (numRows) {
+        return numRows;
+      }
+    }
+  }
+
+  for (;;) {
+    if (currentStripe >= lastStripe) {
+      return 0;
+    }
+    DwrfRowReader* FOLLY_NONNULL rowReader;
+    if (currentStripe == firstStripe) {
+      rowReader = this;
+    } else {
+      if (startWithNewDelegate_) {
+        startWithNewDelegate_ = false;
+        delegate_ = readerForStripe(currentStripe);
+      }
+      rowReader = delegate_.get();
+    }
+    VELOX_CHECK(rowReader);
+    bool isFirstBatch = rowReader->currentRowInStripe == 0;
+    auto numRows = rowReader->nextInStripe(size, result);
+    if (isFirstBatch && currentStripe + 1 < lastStripe) {
+      // Start prefetch of next stripe after first batch of current.
+      preloadStripe(currentStripe + 1);
+    }
+    if (rowReader->currentRowInStripe >= rowReader->rowsInCurrentStripe) {
+      ++currentStripe;
+      startWithNewDelegate_ = true;
+    }
+    if (numRows) {
+      return numRows;
+    }
+  }
+}
+
+uint64_t DwrfRowReader::nextInStripe(uint64_t size, VectorPtr& result) {
   DWIO_ENSURE_GT(size, 0);
   auto& footer = getReader().getFooter();
   StatsContext context(
       getReader().getWriterName(), getReader().getWriterVersion());
 
-  for (;;) {
-    if (currentStripe >= lastStripe) {
-      if (lastStripe > 0) {
-        previousRow = firstRowOfStripe[lastStripe - 1] +
-            footer.stripes(lastStripe - 1).numberofrows();
-      } else {
-        previousRow = 0;
-      }
-      return 0;
+  if (currentStripe >= lastStripe) {
+    if (lastStripe > 0) {
+      previousRow = firstRowOfStripe[lastStripe - 1] +
+          footer.stripes(lastStripe - 1).numberofrows();
+    } else {
+      previousRow = 0;
     }
-
-    if (currentRowInStripe == 0) {
-      startNextStripe();
-    }
-
-    auto strideSize = footer.rowindexstride();
-    if (LIKELY(strideSize > 0)) {
-      checkSkipStrides(context, strideSize);
-    }
-
-    uint64_t rowsToRead = std::min(
-        static_cast<uint64_t>(size), rowsInCurrentStripe - currentRowInStripe);
-
-    if (rowsToRead > 0) {
-      // don't allow read to cross stride
-      if (LIKELY(strideSize > 0)) {
-        rowsToRead =
-            std::min(rowsToRead, strideSize - currentRowInStripe % strideSize);
-      }
-
-      // Record strideIndex for use by the columnReader_ which may delay actual
-      // reading of the data.
-      setStrideIndex(strideSize > 0 ? currentRowInStripe / strideSize : 0);
-
-      columnReader_->next(rowsToRead, result);
-    }
-
-    // update row number
-    previousRow = firstRowOfStripe[currentStripe] + currentRowInStripe;
-    currentRowInStripe += rowsToRead;
-    if (currentRowInStripe >= rowsInCurrentStripe) {
-      currentStripe += 1;
-      currentRowInStripe = 0;
-      newStripeLoaded = false;
-    }
-
-    if (rowsToRead > 0) {
-      return rowsToRead;
-    }
+    return 0;
   }
+
+  if (currentRowInStripe == 0) {
+    startNextStripe();
+  }
+
+  auto strideSize = footer.rowindexstride();
+  if (LIKELY(strideSize > 0)) {
+    checkSkipStrides(context, strideSize);
+  }
+
+  uint64_t rowsToRead = std::min(
+      static_cast<uint64_t>(size), rowsInCurrentStripe - currentRowInStripe);
+
+  if (rowsToRead > 0) {
+    // don't allow read to cross stride
+    if (LIKELY(strideSize > 0)) {
+      rowsToRead =
+          std::min(rowsToRead, strideSize - currentRowInStripe % strideSize);
+    }
+
+    // Record strideIndex for use by the columnReader_ which may delay actual
+    // reading of the data.
+    setStrideIndex(strideSize > 0 ? currentRowInStripe / strideSize : 0);
+
+    columnReader_->next(rowsToRead, result);
+  }
+
+  // update row number
+  previousRow = firstRowOfStripe[currentStripe] + currentRowInStripe;
+  currentRowInStripe += rowsToRead;
+  return rowsToRead;
+}
+
+void DwrfRowReader::preloadStripe(int32_t stripeIndex) {
+  auto it = prefetchedStripeReaders_.find(stripeIndex);
+  if (it != prefetchedStripeReaders_.end()) {
+    return;
+  }
+  auto executor = getReader().bufferedInputFactory().executor();
+  if (!executor) {
+    return;
+  }
+  auto& footer = getReader().getFooter();
+  DWIO_ENSURE_LT(stripeIndex, footer.stripes_size(), "invalid stripe index");
+  auto& stripe = footer.stripes(stripeIndex);
+
+  auto newOpts = options_;
+  newOpts.range(stripe.offset(), 1);
+  auto readerBase = readerBaseShared();
+  auto source = std::make_shared<AsyncSource<DwrfRowReader>>(
+      [readerBase, stripeIndex, newOpts]() {
+        auto stripeReader =
+            std::make_unique<DwrfRowReader>(readerBase, newOpts);
+        stripeReader->startNextStripe();
+        return stripeReader;
+      });
+  executor->add([source]() { source->prepare(); });
+  prefetchedStripeReaders_[stripeIndex] = std::move(source);
+}
+
+std::unique_ptr<DwrfRowReader> DwrfRowReader::readerForStripe(
+    int32_t stripeIndex) {
+  auto it = prefetchedStripeReaders_.find(stripeIndex);
+  if (it == prefetchedStripeReaders_.end()) {
+    return nullptr;
+  }
+  return it->second->move();
 }
 
 void DwrfRowReader::resetFilterCaches() {
   dynamic_cast<SelectiveColumnReader*>(columnReader())->resetFilterCaches();
   recomputeStridesToSkip_ = true;
+}
+
+bool DwrfRowReader::allPrefetchIssued() const {
+  return currentStripe + 1 >= lastStripe ||
+      prefetchedStripeReaders_.find(lastStripe - 1) !=
+      prefetchedStripeReaders_.end();
+}
+
+bool DwrfRowReader::moveAdaptationFrom(RowReader& other) {
+  auto otherReader = dynamic_cast<DwrfRowReader*>(&other);
+  if (!columnReader_ || !otherReader->columnReader_) {
+    return false;
+  }
+  columnReader_->moveScanSpec(*otherReader->columnReader_);
+  return true;
 }
 
 std::unique_ptr<DwrfReader> DwrfReader::create(

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -135,8 +135,7 @@ class ReaderBase {
   }
 
   const BufferedInputFactory& bufferedInputFactory() const {
-    return bufferedInputFactory_ ? *bufferedInputFactory_
-                                 : *BufferedInputFactory::baseFactory();
+    return *bufferedInputFactory_;
   }
 
   const std::unique_ptr<StripeMetadataCache>& getMetadataCache() const {

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -114,6 +114,11 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
     }
   }
 
+  void moveScanSpec(ColumnReader& other) override {
+    auto otherStruct = dynamic_cast<SelectiveStructColumnReader*>(&other);
+    scanSpec_->moveAdaptationFrom(*otherStruct->scanSpec_);
+  }
+
   // Sets 'rows' as the set of rows for which 'this' or its children
   // may be loaded as LazyVectors. When a struct is loaded as lazy,
   // its children will be lazy if the struct does not add nulls. The

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -18,6 +18,8 @@
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
 
+DEFINE_bool(enable_split_preload, true, "Prefetch split metadata");
+
 namespace facebook::velox::exec {
 
 TableScan::TableScan(
@@ -44,14 +46,18 @@ RowVectorPtr TableScan::getOutput() {
     if (needNewSplit_) {
       exec::Split split;
       auto reason = driverCtx_->task->getSplitOrFuture(
-          driverCtx_->splitGroupId, planNodeId(), split, blockingFuture_);
+          driverCtx_->splitGroupId,
+          planNodeId(),
+          split,
+          blockingFuture_,
+          maxPreloadedSplits_,
+          splitPreloader_);
       if (reason != BlockingReason::kNotBlocked) {
         return nullptr;
       }
 
       if (!split.hasConnectorSplit()) {
         noMoreSplits_ = true;
-
         if (dataSource_) {
           auto connectorStats = dataSource_->runtimeStats();
           for (const auto& [name, counter] : connectorStats) {
@@ -89,13 +95,32 @@ RowVectorPtr TableScan::getOutput() {
             "Got splits with different connector IDs");
       }
 
-      dataSource_->addSplit(connectorSplit);
+      if (connectorSplit->dataSource) {
+        // The AsyncSource returns a unique_ptr to a shared_ptr. The
+        // unique_ptr will be nullptr if there was a cancellation.
+        auto preparedPtr = connectorSplit->dataSource->move();
+        if (!preparedPtr) {
+          // There must be a cancellation.
+          VELOX_CHECK(operatorCtx_->task()->isCancelled());
+          return nullptr;
+        }
+        auto preparedDataSource = std::move(*preparedPtr);
+        dataSource_->setFromDataSource(std::move(preparedDataSource));
+      } else {
+        dataSource_->addSplit(connectorSplit);
+      }
       ++stats_.numSplits;
       setBatchSize();
     }
 
     const auto ioTimeStartMicros = getCurrentTimeMicro();
+    // Check for  cancellation since scans that filter everything out will not
+    // hit the check in Driver.
+    if (operatorCtx_->task()->isCancelled()) {
+      return nullptr;
+    }
     auto data = dataSource_->next(readBatchSize_);
+    checkPreload();
     stats().addRuntimeStat(
         "dataSourceWallNanos",
         RuntimeCounter(
@@ -114,6 +139,52 @@ RowVectorPtr TableScan::getOutput() {
 
     driverCtx_->task->splitFinished();
     needNewSplit_ = true;
+  }
+}
+
+void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
+  // The AsyncSource returns a unique_ptr to the shared_ptr of the
+  // DataSource. The callback may outlive the Task, hence it captures
+  // a shared_ptr to it. This is required to keep memory pools live
+  // for the duration. The callback checks for task cancellation to
+  // avoid needless work.
+  using DataSourcePtr = std::shared_ptr<connector::DataSource>;
+  split->dataSource = std::make_shared<AsyncSource<DataSourcePtr>>(
+      [type = outputType_,
+       table = tableHandle_,
+       columns = columnHandles_,
+       connector = connector_,
+       ctx = connectorQueryCtx_,
+       task = operatorCtx_->task(),
+       split]() -> std::unique_ptr<DataSourcePtr> {
+        if (task->isCancelled()) {
+          return nullptr;
+        }
+        auto ptr = std::make_unique<DataSourcePtr>();
+        *ptr = connector->createDataSource(type, table, columns, ctx.get());
+        if (task->isCancelled()) {
+          return nullptr;
+        }
+        (*ptr)->addSplit(split);
+        return ptr;
+      });
+}
+
+void TableScan::checkPreload() {
+  auto executor = connector_->executor();
+  if (!FLAGS_enable_split_preload || !executor ||
+      !connector_->supportsSplitPreload()) {
+    return;
+  }
+  if (dataSource_->allPrefetchIssued()) {
+    maxPreloadedSplits_ = driverCtx_->task->numDrivers(driverCtx_->driver);
+    if (!splitPreloader_) {
+      splitPreloader_ =
+          [executor, this](std::shared_ptr<connector::ConnectorSplit> split) {
+            preload(split);
+            executor->add([split]() { split->dataSource->prepare(); });
+          };
+    }
   }
 }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -52,6 +52,18 @@ class TableScan : public SourceOperator {
  private:
   static constexpr int32_t kDefaultBatchSize = 1024;
 
+  // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching
+  // splits is appropriate. The preloader will be applied to the
+  // 'first 'maxPreloadSplits' of the Tasks's split queue for 'this'
+  // when getting splits.
+  void checkPreload();
+
+  // Sets 'split->dataSource' to be a Asyncsource that makes a
+  // DataSource to read 'split'. This source will be prepared in the
+  // background on the executor of the connector. If the DataSource is
+  // needed before prepare is done, it will be made when needed.
+  void preload(std::shared_ptr<connector::ConnectorSplit> split);
+
   // Adjust batch size according to split information.
   void setBatchSize();
 
@@ -69,6 +81,17 @@ class TableScan : public SourceOperator {
   // Dynamic filters to add to the data source when it gets created.
   std::unordered_map<ChannelIndex, std::shared_ptr<common::Filter>>
       pendingDynamicFilters_;
+
+  int32_t maxPreloadedSplits_{0};
+
+  // Callback passed to getSplitOrFuture() for triggering async
+  // preload. The callback's lifetime is the lifetime of 'this'. This
+  // callback can schedule preloads on an executor. These preloads may
+  // outlive the Task and therefore need to capture a shared_ptr to
+  // it.
+  std::function<void(std::shared_ptr<connector::ConnectorSplit>)>
+      splitPreloader_{nullptr};
+
   int32_t readBatchSize_{kDefaultBatchSize};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -258,16 +258,22 @@ class Task : public std::enable_shared_from_this<Task> {
       std::shared_ptr<Task> self,
       Driver* FOLLY_NONNULL instance);
 
-  // Returns a split for the source operator corresponding to plan node with
-  // specified ID. If there are no splits and no-more-splits signal has been
-  // received, sets split to null and returns kNotBlocked. Otherwise, returns
-  // kWaitForSplit and sets a future that will complete when split becomes
-  // available or no-more-splits signal is received.
+  // Returns a split for the source operator corresponding to plan
+  // node with specified ID. If there are no splits and no-more-splits
+  // signal has been received, sets split to null and returns
+  // kNotBlocked. Otherwise, returns kWaitForSplit and sets a future
+  // that will complete when split becomes available or no-more-splits
+  // signal is received. If 'maxPreloadSplits' is given, ensures that
+  // so many of splits at the head of the queue are preloading. If
+  // they are not, calls preload on them to start preload.
   BlockingReason getSplitOrFuture(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
       exec::Split& split,
-      ContinueFuture& future);
+      ContinueFuture& future,
+      int32_t maxPreloadSplits = 0,
+      std::function<void(std::shared_ptr<connector::ConnectorSplit>)> preload =
+          nullptr);
 
   void splitFinished();
 
@@ -413,6 +419,14 @@ class Task : public std::enable_shared_from_this<Task> {
   // are to yield.
   StopReason shouldStop();
 
+  // Returns true if Driver or async executor threads for 'this'
+  // should silently stop and drop any results that may be
+  // pending. This is like shouldStop() but can be called multiple
+  // times since not affect a yield counter.
+  bool isCancelled() const {
+    return terminateRequested_;
+  }
+
   // Requests the Task to stop activity.  The returned future is
   // realized when all running threads have stopped running. Activity
   // can be resumed with resume() after the future is realized.
@@ -452,6 +466,10 @@ class Task : public std::enable_shared_from_this<Task> {
     return mutex_;
   }
 
+  int32_t numDrivers(Driver* caller) {
+    return driverFactories_[caller->driverCtx()->pipelineId]->numDrivers;
+  }
+
  private:
   /// Returns true if state is 'running'.
   bool isRunningLocked() const;
@@ -468,7 +486,10 @@ class Task : public std::enable_shared_from_this<Task> {
   BlockingReason getSplitOrFutureLocked(
       SplitsStore& splitsStore,
       exec::Split& split,
-      ContinueFuture& future);
+      ContinueFuture& future,
+      int32_t maxPreloadSplits = 0,
+      std::function<void(std::shared_ptr<connector::ConnectorSplit>)> preload =
+          nullptr);
 
   /// Creates for the given split group and fills up the 'SplitGroupState'
   /// structure, which stores inter-operator state (local exchange, bridges).


### PR DESCRIPTION
- Extends DataSource and Reader interfaces to allow passing adaptation between a current and an asynchronously prepared instance.


- Adds a capability to read the next stripe in the split to
  DwrfReader. A new dwrfReader is made for each next stripe. When te
  previous is at end, operations are delegated to the next one.

- Adds a look-ahead in Task split queue, This ensures that the next n
  splits will have preload pending before a TableScan actually starts
  reading one. TableScan sees if the split has a DataSource being
  prepared and initialized its existing DataSource by the dataSource
  being prepared. In this way adaptation is kept but readers for a
  different split are substituted for the readers of the previous one.


- Changes various scan-related objects (ScanSpec, DataCacheConfig,
  BufferedInputFactory) to be owned by shared_ptr or produced by a
  source std::function. This is necessary because a query could
  terminate while having prefetches pending. The objects referenced by
  the prefetch must stay live for the duration.