### PR TITLE
fix parse_datetime() to follow Presto semantic of TimestampWithTimezone

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -749,6 +749,7 @@ struct ParseDateTimeFunction {
     // no session timezone, fallback to 0 (GMT).
     int16_t timezoneId = jodaResult.timezoneId != -1 ? jodaResult.timezoneId
                                                      : sessionTzID_.value_or(0);
+    jodaResult.timestamp.toGMT(timezoneId);
     result = std::make_tuple(jodaResult.timestamp.toMillis(), timezoneId);
     return true;
   }

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1380,15 +1380,40 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
       TimestampWithTimezone(86400000, 0),
       parseDatetime("1970-01-02", "YYYY-MM-dd"));
 
+  // 118860000 is the number of milliseconds since epoch at 1970-01-02
+  // 09:01:00.000 UTC.
   EXPECT_EQ(
-      TimestampWithTimezone(86400000, util::getTimeZoneID("-09:00")),
-      parseDatetime("1970-01-02+00:00-09:00", "YYYY-MM-dd+HH:mmZZ"));
+      TimestampWithTimezone(118860000, util::getTimeZoneID("+00:00")),
+      parseDatetime("1970-01-02+09:01+00:00", "YYYY-MM-dd+HH:mmZZ"));
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, util::getTimeZoneID("-09:00")),
+      parseDatetime("1970-01-02+00:01-09:00", "YYYY-MM-dd+HH:mmZZ"));
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, util::getTimeZoneID("-02:00")),
+      parseDatetime("1970-01-02+07:01-02:00", "YYYY-MM-dd+HH:mmZZ"));
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, util::getTimeZoneID("+14:00")),
+      parseDatetime("1970-01-02+23:01+14:00", "YYYY-MM-dd+HH:mmZZ"));
 
   setQueryTimeZone("Asia/Kolkata");
 
+  // 66600000 is the number of millisecond since epoch at 1970-01-01
+  // 18:30:00.000 UTC.
   EXPECT_EQ(
-      TimestampWithTimezone(86400000, util::getTimeZoneID("Asia/Kolkata")),
+      TimestampWithTimezone(66600000, util::getTimeZoneID("Asia/Kolkata")),
       parseDatetime("1970-01-02+00:00", "YYYY-MM-dd+HH:mm"));
+  EXPECT_EQ(
+      TimestampWithTimezone(66600000, util::getTimeZoneID("-03:00")),
+      parseDatetime("1970-01-01+15:30-03:00", "YYYY-MM-dd+HH:mmZZ"));
+
+  // -66600000 is the number of millisecond since epoch at 1969-12-31
+  // 05:30:00.000 UTC.
+  EXPECT_EQ(
+      TimestampWithTimezone(-66600000, util::getTimeZoneID("Asia/Kolkata")),
+      parseDatetime("1969-12-31+11:00", "YYYY-MM-dd+HH:mm"));
+  EXPECT_EQ(
+      TimestampWithTimezone(-66600000, util::getTimeZoneID("+02:00")),
+      parseDatetime("1969-12-31+07:30+02:00", "YYYY-MM-dd+HH:mmZZ"));
 }
 
 TEST_F(DateTimeFunctionsTest, dateFormat) {


### PR DESCRIPTION
Summary: The current implementation of `parse_datetime(...) -> timestamp_with_timezone` assumes the timestamp field in TimestampWithTimezone represents the time at the specified zone, whereas in Presto, the timestamp field represents the GMT time. This difference in the semantics of TimestampWithTimezone between Velox and Presto caused some problem at other UDFs and we decided to follow Presto's at all Presto functions in Velox. This diff fix parse_datetime() such that the timestamp field in the result is the GMT time at that moment.

Differential Revision: D35104089

