### PR TITLE
FileWriter to handle instrumentation

### DIFF
--- a/velox/dwio/dwrf/writer/CMakeLists.txt
+++ b/velox/dwio/dwrf/writer/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_dwrf_common
   velox_dwio_dwrf_utils
+  velox_time
   velox_vector
   ${LZ4}
   ${LZO}

--- a/velox/dwio/dwrf/writer/FlushPolicy.cpp
+++ b/velox/dwio/dwrf/writer/FlushPolicy.cpp
@@ -40,7 +40,7 @@ bool DefaultFlushPolicy::operator()(
               context.stripeIndex == 0 ? outputStreamSize : 0),
           dictionaryMemUsage);
   if (decision) {
-    LOG(INFO) << fmt::format(
+    VLOG(1) << fmt::format(
         "overMemoryBudget: {}, dictionaryMemUsage: {}, outputStreamSize: {}, generalMemUsage: {}, estimatedStripeSize: {}",
         overMemoryBudget,
         dictionaryMemUsage,

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -26,7 +26,7 @@ struct WriterOptions : public WriterOptionsShared {};
 class Writer : public WriterShared {
  public:
   Writer(
-      WriterOptions& options,
+      const WriterOptions& options,
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool)
       : WriterShared{options, std::move(sink), pool} {

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -57,6 +57,11 @@ class WriterBase {
     return *writerSink_;
   }
 
+  const WriterSink& getSink() const {
+    DWIO_ENSURE_NOT_NULL(writerSink_);
+    return *writerSink_;
+  }
+
   void addUserMetadata(const std::string& key, const std::string& value) {
     userMetadata_[key] = value;
   }

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest_prod.h>
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Compression.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
@@ -495,6 +496,7 @@ class WriterContext : public CompressionBufferPool {
   const bool isStreamSizeAboveThresholdCheckEnabled;
   const uint64_t rawDataSizePerBatch;
   const dwio::common::MetricsLogPtr metricLogger;
+  CpuWallTiming flushTiming{};
 
   template <typename TestType>
   friend class WriterEncodingIndexTest;

--- a/velox/dwio/dwrf/writer/WriterShared.h
+++ b/velox/dwio/dwrf/writer/WriterShared.h
@@ -124,7 +124,7 @@ struct WriterOptionsShared {
 class WriterShared : public WriterBase {
  public:
   WriterShared(
-      WriterOptionsShared& options,
+      const WriterOptionsShared& options,
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& parentPool)
       : WriterBase{std::move(sink)},


### PR DESCRIPTION
Summary:
Add a templated wrapper class to handling writer instrumentation, which involves tracking the io stats from WS sink.

This wrapper can be applied outside of writer shim classes, as long as shim classes provide the specialization on how to extract some of the run stats through `OperationStatsExtractor`.

In addition to wiring up for trabant use cases. We also injected cpu measurement of flush time for velox dwrf writer, which is a more meaningful measurement than file close wall time. Flush time also allows us to more clearly calculate time spent on writes alone.

Differential Revision: D35103858

