### PR TITLE
Fix: Read nullity from top-level vector during compare() instead of wrapped()

### DIFF
--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -420,10 +420,9 @@ inline int32_t SimpleVector<ComplexType>::compare(
   auto otherWrapped = other->wrappedVector();
   DCHECK(wrapped->encoding() == otherWrapped->encoding())
       << "Attempting to compare vectors not of the same type";
-  auto thisWrappedIndex = wrappedIndex(index);
-  auto otherWrappedIndex = other->wrappedIndex(otherIndex);
-  bool otherNull = otherWrapped->isNullAt(otherWrappedIndex);
-  if (wrapped->isNullAt(thisWrappedIndex)) {
+
+  bool otherNull = other->isNullAt(otherIndex);
+  if (isNullAt(index)) {
     if (otherNull) {
       return 0;
     }
@@ -432,6 +431,9 @@ inline int32_t SimpleVector<ComplexType>::compare(
   if (otherNull) {
     return flags.nullsFirst ? 1 : -1;
   }
+
+  auto otherWrappedIndex = other->wrappedIndex(otherIndex);
+  auto thisWrappedIndex = wrappedIndex(index);
   return wrapped->compare(
       otherWrapped, thisWrappedIndex, otherWrappedIndex, flags);
 }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -495,6 +495,7 @@ class VectorTest : public testing::Test {
     target->copy(source.get(), sourceSize, 0, sourceSize);
     for (int32_t i = 0; i < sourceSize; ++i) {
       EXPECT_TRUE(target->equalValueAt(source.get(), sourceSize + i, i));
+      EXPECT_TRUE(source->equalValueAt(target.get(), i, sourceSize + i));
     }
     // Check that uninitialized is copyable.
     target->resize(target->size() + 100);


### PR DESCRIPTION
Summary:
- Update SimpleVector<ComplexType>::compare() to correctly read
the nullity of the complex vectors from the top level wrap.

- Update the unit test to cover the updated code by invoking the
comparison on the complex vectors as well. VectorTest fail without the change.

Reviewed By: mbasmanova

Differential Revision: D35124118

