### PR TITLE
Update Presto function coverage in Velox.

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -60,55 +60,56 @@ for :doc:`all <functions/coverage>` and :doc:`most used
     ======================================  ======================================  ======================================  ==  ======================================
     Scalar Functions                                                                                                            Aggregate Functions
     ======================================================================================================================  ==  ======================================
-    :func:`abs`                             :func:`floor`                           :func:`quarter`                             :func:`approx_distinct`
-    :func:`acos`                            :func:`from_base`                       :func:`radians`                             :func:`approx_percentile`
-    :func:`array_constructor`               :func:`from_base64`                     :func:`rand`                                :func:`approx_set`
-    :func:`array_distinct`                  :func:`from_hex`                        :func:`random`                              :func:`arbitrary`
-    :func:`array_duplicates`                :func:`from_unixtime`                   :func:`reduce`                              :func:`array_agg`
-    :func:`array_except`                    :func:`greatest`                        :func:`regexp_extract`                      :func:`avg`
-    :func:`array_intersect`                 :func:`gt`                              :func:`regexp_extract_all`                  :func:`bitwise_and_agg`
-    :func:`array_join`                      :func:`gte`                             :func:`regexp_like`                         :func:`bitwise_or_agg`
-    :func:`array_max`                       :func:`hour`                            :func:`regexp_replace`                      :func:`bool_and`
-    :func:`array_min`                       in                                      :func:`replace`                             :func:`bool_or`
-    :func:`array_position`                  :func:`infinity`                        :func:`reverse`                             :func:`checksum`
-    :func:`asin`                            :func:`is_finite`                       :func:`round`                               :func:`corr`
-    :func:`atan`                            :func:`is_infinite`                     :func:`rpad`                                :func:`count`
-    :func:`atan2`                           :func:`is_nan`                          :func:`rtrim`                               :func:`count_if`
-    :func:`between`                         :func:`is_null`                         :func:`second`                              :func:`covar_pop`
-    :func:`bitwise_and`                     :func:`json_extract_scalar`             :func:`sign`                                :func:`covar_samp`
-    :func:`bitwise_arithmetic_shift_right`  :func:`least`                           :func:`sin`                                 :func:`every`
-    :func:`bitwise_left_shift`              :func:`length`                          :func:`slice`                               :func:`map_agg`
-    :func:`bitwise_logical_shift_right`     :func:`like`                            :func:`split`                               :func:`max`
-    :func:`bitwise_not`                     :func:`ln`                              :func:`split_part`                          :func:`max_by`
-    :func:`bitwise_or`                      :func:`log10`                           :func:`sqrt`                                :func:`merge`
-    :func:`bitwise_right_shift`             :func:`log2`                            :func:`strpos`                              :func:`min`
-    :func:`bitwise_right_shift_arithmetic`  :func:`lower`                           :func:`subscript`                           :func:`min_by`
-    :func:`bitwise_shift_left`              :func:`lpad`                            :func:`substr`                              :func:`stddev`
-    :func:`bitwise_xor`                     :func:`lt`                              :func:`tan`                                 :func:`stddev_pop`
-    :func:`cardinality`                     :func:`lte`                             :func:`tanh`                                :func:`stddev_samp`
-    :func:`cbrt`                            :func:`ltrim`                           :func:`to_base`                             :func:`sum`
-    :func:`ceil`                            :func:`map`                             :func:`to_base64`                           :func:`var_pop`
-    :func:`ceiling`                         :func:`map_concat`                      :func:`to_hex`                              :func:`var_samp`
-    :func:`chr`                             :func:`map_concat_empty_nulls`          :func:`to_unixtime`                         :func:`variance`
-    :func:`clamp`                           :func:`map_entries`                     :func:`to_utf8`
-    :func:`coalesce`                        :func:`map_filter`                      :func:`transform`
-    :func:`codepoint`                       :func:`map_keys`                        :func:`trim`
-    :func:`concat`                          :func:`map_values`                      :func:`upper`
-    :func:`contains`                        :func:`md5`                             :func:`url_decode`
-    :func:`cos`                             :func:`millisecond`                     :func:`url_encode`
-    :func:`cosh`                            :func:`minus`                           :func:`url_extract_fragment`
-    :func:`date_trunc`                      :func:`minute`                          :func:`url_extract_host`
-    :func:`day`                             :func:`mod`                             :func:`url_extract_parameter`
-    :func:`day_of_month`                    :func:`month`                           :func:`url_extract_path`
-    :func:`day_of_week`                     :func:`multiply`                        :func:`url_extract_port`
-    :func:`day_of_year`                     :func:`nan`                             :func:`url_extract_protocol`
-    :func:`divide`                          :func:`negate`                          :func:`url_extract_query`
-    :func:`dow`                             :func:`neq`                             :func:`width_bucket`
-    :func:`doy`                             not                                     :func:`xxhash64`
-    :func:`element_at`                      :func:`parse_datetime`                  :func:`year`
-    :func:`empty_approx_set`                :func:`pi`                              :func:`year_of_week`
-    :func:`eq`                              :func:`plus`                            :func:`yow`
-    :func:`exp`                             :func:`pow`                             :func:`zip`
-    :func:`filter`                          :func:`power`
+    :func:`abs`                             :func:`eq`                              :func:`power`                               :func:`approx_distinct`
+    :func:`acos`                            :func:`exp`                             :func:`quarter`                             :func:`approx_percentile`
+    :func:`array_constructor`               :func:`filter`                          :func:`radians`                             :func:`approx_set`
+    :func:`array_distinct`                  :func:`floor`                           :func:`rand`                                :func:`arbitrary`
+    :func:`array_duplicates`                :func:`from_base`                       :func:`random`                              :func:`array_agg`
+    :func:`array_except`                    :func:`from_base64`                     :func:`reduce`                              :func:`avg`
+    :func:`array_intersect`                 :func:`from_hex`                        :func:`regexp_extract`                      :func:`bitwise_and_agg`
+    :func:`array_join`                      :func:`from_unixtime`                   :func:`regexp_extract_all`                  :func:`bitwise_or_agg`
+    :func:`array_max`                       :func:`greatest`                        :func:`regexp_like`                         :func:`bool_and`
+    :func:`array_min`                       :func:`gt`                              :func:`regexp_replace`                      :func:`bool_or`
+    :func:`array_position`                  :func:`gte`                             :func:`replace`                             :func:`checksum`
+    :func:`arrays_overlap`                  :func:`hour`                            :func:`reverse`                             :func:`corr`
+    :func:`asin`                            in                                      :func:`round`                               :func:`count`
+    :func:`atan`                            :func:`infinity`                        :func:`rpad`                                :func:`count_if`
+    :func:`atan2`                           :func:`is_finite`                       :func:`rtrim`                               :func:`covar_pop`
+    :func:`between`                         :func:`is_infinite`                     :func:`second`                              :func:`covar_samp`
+    :func:`bit_count`                       :func:`is_nan`                          :func:`sha256`                              :func:`every`
+    :func:`bitwise_and`                     :func:`is_null`                         :func:`sign`                                :func:`map_agg`
+    :func:`bitwise_arithmetic_shift_right`  :func:`json_extract_scalar`             :func:`sin`                                 :func:`max`
+    :func:`bitwise_left_shift`              :func:`least`                           :func:`slice`                               :func:`max_by`
+    :func:`bitwise_logical_shift_right`     :func:`length`                          :func:`split`                               :func:`merge`
+    :func:`bitwise_not`                     :func:`like`                            :func:`split_part`                          :func:`min`
+    :func:`bitwise_or`                      :func:`ln`                              :func:`sqrt`                                :func:`min_by`
+    :func:`bitwise_right_shift`             :func:`log10`                           :func:`strpos`                              :func:`stddev`
+    :func:`bitwise_right_shift_arithmetic`  :func:`log2`                            :func:`subscript`                           :func:`stddev_pop`
+    :func:`bitwise_shift_left`              :func:`lower`                           :func:`substr`                              :func:`stddev_samp`
+    :func:`bitwise_xor`                     :func:`lpad`                            :func:`tan`                                 :func:`sum`
+    :func:`cardinality`                     :func:`lt`                              :func:`tanh`                                :func:`var_pop`
+    :func:`cbrt`                            :func:`lte`                             :func:`to_base`                             :func:`var_samp`
+    :func:`ceil`                            :func:`ltrim`                           :func:`to_base64`                           :func:`variance`
+    :func:`ceiling`                         :func:`map`                             :func:`to_hex`
+    :func:`chr`                             :func:`map_concat`                      :func:`to_unixtime`
+    :func:`clamp`                           :func:`map_concat_empty_nulls`          :func:`to_utf8`
+    :func:`coalesce`                        :func:`map_entries`                     :func:`transform`
+    :func:`codepoint`                       :func:`map_filter`                      :func:`trim`
+    :func:`concat`                          :func:`map_keys`                        :func:`upper`
+    :func:`contains`                        :func:`map_values`                      :func:`url_decode`
+    :func:`cos`                             :func:`md5`                             :func:`url_encode`
+    :func:`cosh`                            :func:`millisecond`                     :func:`url_extract_fragment`
+    :func:`date_add`                        :func:`minus`                           :func:`url_extract_host`
+    :func:`date_diff`                       :func:`minute`                          :func:`url_extract_parameter`
+    :func:`date_format`                     :func:`mod`                             :func:`url_extract_path`
+    :func:`date_trunc`                      :func:`month`                           :func:`url_extract_port`
+    :func:`day`                             :func:`multiply`                        :func:`url_extract_protocol`
+    :func:`day_of_month`                    :func:`nan`                             :func:`url_extract_query`
+    :func:`day_of_week`                     :func:`negate`                          :func:`width_bucket`
+    :func:`day_of_year`                     :func:`neq`                             :func:`xxhash64`
+    :func:`divide`                          not                                     :func:`year`
+    :func:`dow`                             :func:`parse_datetime`                  :func:`year_of_week`
+    :func:`doy`                             :func:`pi`                              :func:`yow`
+    :func:`element_at`                      :func:`plus`                            :func:`zip`
+    :func:`empty_approx_set`                :func:`pow`
     ======================================  ======================================  ======================================  ==  ======================================
-

--- a/velox/docs/functions/coverage.rst
+++ b/velox/docs/functions/coverage.rst
@@ -11,8 +11,10 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage th {background-color: lightblue; text-align: center;}
     table.coverage td:nth-child(6) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(2) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(7) {background-color: #6BA81E;}
@@ -63,6 +65,7 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(7) {background-color: #6BA81E;}
@@ -180,8 +183,8 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions
     ================================================================================================================================================================================================================  ==  ========================================
-    :func:`abs`                               date_diff                                 is_json_scalar                            render                                    st_points                                     :func:`approx_distinct`
-    :func:`acos`                              date_format                               :func:`is_nan`                            repeat                                    st_polygon                                    approx_most_frequent
+    :func:`abs`                               :func:`date_diff`                         is_json_scalar                            render                                    st_points                                     :func:`approx_distinct`
+    :func:`acos`                              :func:`date_format`                       :func:`is_nan`                            repeat                                    st_polygon                                    approx_most_frequent
     all_match                                 date_parse                                is_subnet_of                              :func:`replace`                           st_relate                                     :func:`approx_percentile`
     any_match                                 :func:`date_trunc`                        jaccard_index                             :func:`reverse`                           st_startpoint                                 :func:`approx_set`
     array_average                             :func:`day`                               json_array_contains                       rgb                                       st_symdifference                              :func:`arbitrary`
@@ -200,7 +203,7 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     array_sort                                features                                  :func:`ln`                                :func:`sin`                               :func:`tan`                                   convex_hull_agg
     array_sum                                 :func:`filter`                            localtime                                 :func:`slice`                             :func:`tanh`                                  :func:`corr`
     array_union                               flatten                                   localtimestamp                            spatial_partitions                        timezone_hour                                 :func:`count`
-    arrays_overlap                            flatten_geometry_collections              :func:`log10`                             :func:`split`                             timezone_minute                               :func:`count_if`
+    :func:`arrays_overlap`                    flatten_geometry_collections              :func:`log10`                             :func:`split`                             timezone_minute                               :func:`count_if`
     :func:`asin`                              :func:`floor`                             :func:`log2`                              :func:`split_part`                        :func:`to_base`                               :func:`covar_pop`
     :func:`atan`                              fnv1_32                                   :func:`lower`                             split_to_map                              :func:`to_base64`                             :func:`covar_samp`
     :func:`atan2`                             fnv1_64                                   :func:`lpad`                              split_to_multimap                         to_base64url                                  differential_entropy

--- a/velox/docs/functions/most_used_coverage.rst
+++ b/velox/docs/functions/most_used_coverage.rst
@@ -11,8 +11,10 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage th {background-color: lightblue; text-align: center;}
     table.coverage td:nth-child(6) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(2) {background-color: #6BA81E;}
@@ -56,6 +58,7 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage tr:nth-child(10) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
@@ -78,6 +81,7 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage tr:nth-child(17) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(7) {background-color: #6BA81E;}
@@ -90,7 +94,7 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     ===========================  ===========================  ===========================  ===========================  ===========================  ==  ===========================
     Scalar Functions                                                                                                                                     Aggregate Functions
     ===============================================================================================================================================  ==  ===========================
-    :func:`map`                  date_format                  :func:`element_at`           :func:`strpos`               arrays_overlap                   :func:`count`
+    :func:`map`                  :func:`date_format`          :func:`element_at`           :func:`strpos`               :func:`arrays_overlap`           :func:`count`
     :func:`lower`                :func:`json_extract_scalar`  :func:`abs`                  flatten                      from_big_endian_64               :func:`sum`
     json_format                  array_sort                   :func:`round`                :func:`trim`                 :func:`md5`                      :func:`max`
     :func:`upper`                transform_values             :func:`map_filter`           map_zip_with                 :func:`xxhash64`                 :func:`array_agg`
@@ -100,13 +104,12 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     :func:`contains`             sequence                     :func:`reduce`               any_match                    :func:`to_utf8`                  :func:`approx_distinct`
     :func:`map_concat`           :func:`substr`               :func:`greatest`             :func:`bitwise_and`          crc32                            :func:`count_if`
     :func:`length`               date                         :func:`date_trunc`           date_parse                   st_y                             :func:`approx_percentile`
-    :func:`from_unixtime`        :func:`is_nan`               date_diff                    bing_tile_at                 st_x                             :func:`avg`
+    :func:`from_unixtime`        :func:`is_nan`               :func:`date_diff`            bing_tile_at                 st_x                             :func:`avg`
     :func:`transform`            :func:`rand`                 :func:`array_max`            array_union                  now                              :func:`map_agg`
     :func:`to_unixtime`          :func:`filter`               from_iso8601_date            :func:`reverse`              truncate                         :func:`min_by`
     :func:`regexp_like`          :func:`sqrt`                 json_extract                 :func:`array_intersect`                                       :func:`stddev`
     :func:`array_join`           :func:`least`                :func:`mod`                  repeat                                                        set_agg
     :func:`replace`              json_parse                   :func:`array_distinct`       st_geometryfromtext                                           histogram
     :func:`regexp_replace`       map_from_entries             :func:`pow`                  :func:`split_part`                                            set_union
-    :func:`parse_datetime`       date_add                     :func:`power`                :func:`log10`                                                 :func:`merge`
+    :func:`parse_datetime`       :func:`date_add`             :func:`power`                :func:`log10`                                                 :func:`merge`
     ===========================  ===========================  ===========================  ===========================  ===========================  ==  ===========================
-


### PR DESCRIPTION
Summary:
Update Presto function coverage in Velox.

How:
As per /Users/spershin/git/presto_cpp/velox/velox/functions/prestosql/coverage/README.md
In working folder /Users/spershin/git/presto_cpp/velox/velox/functions/prestosql/coverage
run 'velox_prestosql_coverage' with no params, with '--all' and with --most_used.

Check correctness by generating html:

brew install sphinx-doc
export PATH="/usr/local/opt/sphinx-doc/bin:$PATH"
cd /Users/spershin/git/presto_cpp/velox/velox/docs
spershin@spershin-mbp docs % make html

Start by opening /Users/spershin/git/presto_cpp/velox/velox/docs/_build/html/index.html

Differential Revision: D35133838

