### PR TITLE
Add destructor for HiveTableHandle.

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -40,6 +40,18 @@ static const char* kPath = "$path";
 static const char* kBucket = "$bucket";
 } // namespace
 
+HiveTableHandle::HiveTableHandle(
+    const std::string& tableName,
+    bool filterPushdownEnabled,
+    SubfieldFilters subfieldFilters,
+    const std::shared_ptr<const core::ITypedExpr>& remainingFilter)
+    : tableName_(tableName),
+      filterPushdownEnabled_(filterPushdownEnabled),
+      subfieldFilters_(std::move(subfieldFilters)),
+      remainingFilter_(remainingFilter) {}
+
+HiveTableHandle::~HiveTableHandle() {}
+
 std::string HiveTableHandle::toString() const {
   std::stringstream out;
   out << "Table: " << tableName_;

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -66,11 +66,9 @@ class HiveTableHandle : public ConnectorTableHandle {
       const std::string& tableName,
       bool filterPushdownEnabled,
       SubfieldFilters subfieldFilters,
-      const std::shared_ptr<const core::ITypedExpr>& remainingFilter)
-      : tableName_(tableName),
-        filterPushdownEnabled_(filterPushdownEnabled),
-        subfieldFilters_(std::move(subfieldFilters)),
-        remainingFilter_(remainingFilter) {}
+      const std::shared_ptr<const core::ITypedExpr>& remainingFilter);
+
+  ~HiveTableHandle() override;
 
   bool isFilterPushdownEnabled() const {
     return filterPushdownEnabled_;


### PR DESCRIPTION
Summary:
Add destructor for HiveTableHandle.
Otherwise we have undefined reference to `vtable for facebook::velox::connector::hive::HiveTableHandle' error on linux-parquet-S3-build.
Example: https://app.circleci.com/pipelines/github/facebookexternal/presto_cpp/4519/workflows/73c9affd-dd3c-4461-9c40-117b73bda8ea/jobs/16677

Differential Revision: D35135366

