### PR TITLE
Faster TreeOfLosers

### DIFF
--- a/velox/exec/TreeOfLosers.h
+++ b/velox/exec/TreeOfLosers.h
@@ -15,103 +15,217 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <vector>
 
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/SimdUtil.h"
+
+#include <folly/Likely.h>
+
 namespace facebook::velox {
 
-template <typename Value, typename Source>
+// Abstract class defining the interface for a stream of values to be
+// merged by TreeOfLosers or MergeArray. In addition to these, the
+// MergeStream must have a way of accessing its first value and
+// popping off the first value. TreeOfLosers and similar do not call
+// these, so these are left out of this interface.
+class MergeStream {
+  // True if this has a value. If this returns true, it is valid to
+  // call <. A false value means that there will not be any more data
+  // in 'this'.
+  virtual bool hasData() const = 0;
+
+  // Returns true if the first element of 'this' is less than the first element
+  // of 'other'. hasData() must be true of 'this' and 'other'.
+  virtual bool operator<(const MergeStream& other) const = 0;
+};
+
+// Implements a tree of losers algorithm for merging ordered
+// streams. The TreeOfLosers owns two or more instances of
+// Stream. At each call of next(), it returns the Stream that has
+// the lowest value as first value from the set of Streams. It
+// returns nullptr when all Streams are at end. The order is
+// determined by Stream::operator<.
+template <typename Stream, typename TIndex = uint16_t>
 class TreeOfLosers {
  public:
-  class Node {
-   public:
-    Node(std::unique_ptr<Source>&& source) : source_(std::move(source)) {}
-    Node(std::unique_ptr<Node> left, std::unique_ptr<Node>&& right)
-        : left_(std::move(left)), right_(std::move(right)) {}
+  TreeOfLosers(std::vector<std::unique_ptr<Stream>> streams)
+      : streams_(std::move(streams)) {
+    static_assert(std::is_base_of<MergeStream, Stream>::value);
+    VELOX_CHECK_LT(streams_.size(), std::numeric_limits<TIndex>::max());
+    VELOX_CHECK_GT(streams_.size(), 1);
 
-    template <typename Compare>
-    std::optional<Value> front(const Compare& compare) {
-      if (atEnd_) {
-        return std::nullopt;
-      }
-      if (value_.has_value()) {
-        return value_;
-      }
-      if (source_) {
-        if (source_->atEnd()) {
-          atEnd_ = true;
-          return std::nullopt;
-        }
-        value_ = source_->next();
-        return std::optional<Value>(value_);
-      }
-      auto leftValue = left_->front(compare);
-      auto rightValue = right_->front(compare);
-      if (!leftValue.has_value()) {
-        if (!rightValue.has_value()) {
-          atEnd_ = true;
-          return std::nullopt;
-        }
-        value_ = rightValue;
-        right_->pop();
-        return value_;
-      }
-      if (!rightValue.has_value()) {
-        value_ = leftValue;
-        left_->pop();
-        return value_;
-      }
-      int32_t result = compare(leftValue.value(), rightValue.value());
-      if (result <= 0) {
-        value_ = leftValue;
-        left_->pop();
-      } else {
-        value_ = rightValue;
-        right_->pop();
-      }
-      return value_;
+    int32_t size = 0;
+    int32_t levelSize = 1;
+    int32_t numStreams = streams_.size();
+    while (numStreams > levelSize) {
+      size += levelSize;
+      levelSize *= 2;
     }
 
-    void pop() {
-      value_ = std::nullopt;
-    }
+    if (numStreams == bits::nextPowerOfTwo(numStreams)) {
+      // All leaves are on last level.
+      firstStream_ = size;
+    } else {
+      // Some of the streams are on the last level and some on the level before.
+      // The first stream follows the last inner node in the node numbering.
 
-    std::optional<Value> value_;
-    bool atEnd_ = false;
-    std::unique_ptr<Node> left_;
-    std::unique_ptr<Node> right_;
-    std::unique_ptr<Source> source_;
-  };
-
-  TreeOfLosers(std::vector<std::unique_ptr<Source>>&& sources) {
-    std::vector<std::unique_ptr<Node>> level(sources.size());
-    for (auto i = 0; i < sources.size(); ++i) {
-      level[i] = std::make_unique<Node>(std::move(sources[i]));
+      auto secondLastSize = levelSize / 2;
+      auto overflow = numStreams - secondLastSize;
+      auto streamsOnSecondLast = secondLastSize - overflow;
+      // Suppose 12 streams. The last level has 16 places, the second
+      // last 8. If we fill the second last level we have 8 streams
+      // and 4 left over. These 4 need parents on the second last
+      // level. So, we end up with 4 inner nodes on the second last
+      // level and 8 nodes on the last level. The streams at the left
+      // of the second last level become inner nodes and their streams
+      // move to the level below.
+      firstStream_ = (size - secondLastSize) + overflow;
     }
-    while (level.size() > 1) {
-      std::vector<std::unique_ptr<Node>> nextLevel;
-      for (auto i = 0; i < level.size(); i += 2) {
-        if (i <= level.size() - 2) {
-          nextLevel.push_back(std::make_unique<Node>(
-              std::move(level[i]), std::move(level[i + 1])));
-        } else {
-          nextLevel.push_back(std::move(level[i]));
-        }
-      }
-      level = std::move(nextLevel);
-    }
-    root_ = std::move(level[0]);
+    values_.resize(firstStream_, kEmpty);
   }
 
-  template <typename Compare>
-  std::optional<Value> next(const Compare& compare) {
-    auto value = root_->front(compare);
-    root_->pop();
-    return value;
+  // Returns the stream with the lowest first element. The caller is
+  // expected to pop off the first element of the stream before
+  // calling this again. Returns nullptr when all streams are at end.
+  Stream* next() {
+    if (UNLIKELY(lastIndex_ == kEmpty)) {
+      lastIndex_ = first(0);
+    } else {
+      lastIndex_ = propagate(
+          parent(firstStream_ + lastIndex_),
+          streams_[lastIndex_]->hasData() ? lastIndex_ : kEmpty);
+    }
+    return lastIndex_ == kEmpty ? nullptr : streams_[lastIndex_].get();
   }
 
  private:
-  std::unique_ptr<Node> root_;
+  static constexpr TIndex kEmpty = std::numeric_limits<TIndex>::max();
+
+  TIndex first(TIndex node) {
+    if (node >= firstStream_) {
+      return streams_[node - firstStream_]->hasData() ? node - firstStream_
+                                                      : kEmpty;
+    }
+    auto left = first(leftChild(node));
+    auto right = first(rightChild(node));
+    if (left == kEmpty) {
+      return right;
+    } else if (right == kEmpty) {
+      return left;
+    } else if (*streams_[left] < *streams_[right]) {
+      values_[node] = right;
+      return left;
+    } else {
+      values_[node] = left;
+      return right;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE TIndex propagate(TIndex node, TIndex value) {
+    while (UNLIKELY(values_[node] == kEmpty)) {
+      if (UNLIKELY(node == 0)) {
+        return value;
+      }
+      node = parent(node);
+    }
+    for (;;) {
+      if (UNLIKELY(values_[node] == kEmpty)) {
+        // The value goes past the node and the node stays empty.
+      } else if (UNLIKELY(value == kEmpty)) {
+        value = values_[node];
+        values_[node] = kEmpty;
+      } else if (*streams_[values_[node]] < *streams_[value]) {
+        // The node had the lower value, the value stays here and the previous
+        // value goes up.
+        std::swap(value, values_[node]);
+      } else {
+        // The value is less than the value in the node, No action, the value
+        // goes up.
+        ;
+      }
+      if (UNLIKELY(node == 0)) {
+        return value;
+      }
+      node = parent(node);
+    }
+  }
+
+  static TIndex parent(TIndex node) {
+    return (node - 1) / 2;
+  }
+
+  static TIndex leftChild(TIndex node) {
+    return node * 2 + 1;
+  }
+
+  static TIndex rightChild(TIndex node) {
+    return node * 2 + 2;
+  }
+  std::vector<TIndex> values_;
+  std::vector<std::unique_ptr<Stream>> streams_;
+  TIndex lastIndex_ = kEmpty;
+  int32_t firstStream_;
 };
+
+// Array-based merging structure implementing the same interface as
+// TreOfLosers. The streams are sorted on their first value. The
+// first stream is returned and then reinserted in the array at the
+// position corresponding to the new element after the caller has
+// popped off the previous first value.
+template <typename Stream>
+class MergeArray {
+ public:
+  MergeArray(std::vector<std::unique_ptr<Stream>> streams) {
+    static_assert(std::is_base_of<MergeStream, Stream>::value);
+    for (auto& stream : streams) {
+      if (stream->hasData()) {
+        streams_.push_back(std::move(stream));
+      }
+    }
+    std::sort(
+        streams_.begin(),
+        streams_.end(),
+        [](const auto& left, const auto& right) { return *left < *right; });
+  }
+
+  // Returns the stream with the lowest first element. The caller is
+  // expected to pop off the first element of the stream before
+  // calling this again. Returns nullptr when all streams are at end.
+  Stream* next() {
+    if (UNLIKELY(isFirst_)) {
+      isFirst_ = false;
+      if (streams_.empty()) {
+        return nullptr;
+      }
+      // stream has data, else it would not be here after construction.
+      return streams_[0].get();
+    }
+    if (!streams_[0]->hasData()) {
+      streams_.erase(streams_.begin());
+      return streams_.empty() ? nullptr : streams_[0].get();
+    }
+    auto rawStreams = reinterpret_cast<Stream**>(streams_.data());
+    auto first = rawStreams[0];
+    auto it = std::lower_bound(
+        rawStreams + 1,
+        rawStreams + streams_.size(),
+        first,
+        [](const Stream* left, const Stream* right) { return *left < *right; });
+    auto offset = it - rawStreams;
+    if (offset > 1) {
+      simd::memcpy(rawStreams, rawStreams + 1, (offset - 1) * sizeof(Stream*));
+      it[-1] = first;
+    }
+    return streams_[0].get();
+  }
+
+ private:
+  bool isFirst_{true};
+  std::vector<std::unique_ptr<Stream>> streams_;
+};
+
 } // namespace facebook::velox

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -15,3 +15,8 @@ add_executable(velox_exec_vector_hasher_benchmark VectorHasherBenchmark.cpp)
 
 target_link_libraries(velox_exec_vector_hasher_benchmark velox_exec
                       velox_vector_test_lib ${FOLLY_BENCHMARK})
+
+add_executable(velox_merge_benchmark MergeBenchmark.cpp)
+
+target_link_libraries(velox_merge_benchmark velox_exec velox_vector_test_lib
+                      ${FOLLY_BENCHMARK} gtest gtest_main)

--- a/velox/exec/benchmarks/MergeBenchmark.cpp
+++ b/velox/exec/benchmarks/MergeBenchmark.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/exec/TreeOfLosers.h"
+#include "velox/exec/tests/utils/MergeTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+TestData narrow;
+TestData medium;
+TestData wide;
+
+BENCHMARK(narrowTree) {
+  MergeTestBase::test<TreeOfLosers<TestingStream>>(narrow, false);
+}
+
+BENCHMARK_RELATIVE(narrowArray) {
+  MergeTestBase::test<MergeArray<TestingStream>>(narrow, false);
+}
+
+BENCHMARK(mediumTree) {
+  MergeTestBase::test<TreeOfLosers<TestingStream>>(medium, false);
+}
+
+BENCHMARK_RELATIVE(mediumArray) {
+  MergeTestBase::test<MergeArray<TestingStream>>(medium, false);
+}
+
+BENCHMARK(wideTree) {
+  MergeTestBase::test<TreeOfLosers<TestingStream>>(wide, false);
+}
+
+BENCHMARK_RELATIVE(wideArray) {
+  MergeTestBase::test<MergeArray<TestingStream>>(wide, false);
+}
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  MergeTestBase test;
+  test.seed(1);
+  narrow = test.makeTestData(100'000'000, 7);
+  medium = test.makeTestData(10'000'0000, 37);
+  wide = test.makeTestData(10'000'0000, 1029);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/tests/TreeOfLosersTest.cpp
+++ b/velox/exec/tests/TreeOfLosersTest.cpp
@@ -13,93 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/TreeOfLosers.h"
-#include "velox/common/base/Exceptions.h"
-
-#include <folly/Random.h>
-
-#include <gtest/gtest.h>
-#include <algorithm>
-#include <optional>
+#include "velox/exec/tests/utils/MergeTestBase.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
 
-class TreeOfLosersTest : public testing::Test {
+class TreeOfLosersTest : public testing::Test, public MergeTestBase {
  protected:
   void SetUp() override {
-    rng_.seed(1);
+    seed(1);
   }
 
-  folly::Random::DefaultGenerator rng_;
-};
-
-struct Value {
-  uint32_t value;
-
-  bool operator<(const Value& other) {
-    return value < other.value;
-  }
-  bool operator==(const Value& other) {
-    return value == other.value;
+  void testBoth(int32_t numValues, int32_t numStreams) {
+    TestData testData = makeTestData(numValues, numStreams);
+    test<TreeOfLosers<TestingStream>>(testData, true);
+    test<MergeArray<TestingStream>>(testData, true);
   }
 };
-
-class Source {
- public:
-  Source(std::vector<uint32_t>&& numbers) : numbers_(std::move(numbers)) {}
-
-  bool atEnd() const {
-    return numbers_.empty();
-  }
-
-  Value next() {
-    VELOX_CHECK(!numbers_.empty());
-    auto value = numbers_.back();
-    numbers_.pop_back();
-    return Value{value};
-  }
-
- private:
-  std::vector<uint32_t> numbers_;
-};
-
-int compare(Value left, Value right) {
-  return left < right ? -1 : left == right ? 0 : 1;
-}
 
 TEST_F(TreeOfLosersTest, merge) {
-  constexpr int32_t kNumValues = 1000000;
-  constexpr int32_t kNumRuns = 17;
-  std::vector<uint32_t> data;
-  for (auto i = 0; i < kNumValues; ++i) {
-    data.push_back(folly::Random::rand32(rng_));
-  }
-  std::vector<std::vector<uint32_t>> runs;
-  int32_t offset = 0;
-  for (auto i = 0; i < kNumRuns; ++i) {
-    int size =
-        i == kNumRuns - 1 ? data.size() - offset : data.size() / kNumRuns;
-    runs.emplace_back();
-    runs.back().insert(
-        runs.back().begin(),
-        data.begin() + offset,
-        data.begin() + offset + size);
-    std::sort(
-        runs.back().begin(),
-        runs.back().end(),
-        [](uint32_t left, uint32_t right) { return left > right; });
-    offset += size;
-  }
-  std::sort(data.begin(), data.end());
-
-  std::vector<std::unique_ptr<Source>> sources;
-  for (auto& run : runs) {
-    sources.push_back(std::make_unique<Source>(std::move(run)));
-  }
-  TreeOfLosers<Value, Source> tree(std::move(sources));
-  for (auto expected : data) {
-    auto result = tree.next(compare);
-    ASSERT_EQ(result.value().value, expected);
-  }
-  ASSERT_FALSE(tree.next(compare).has_value());
+  testBoth(11, 2);
+  testBoth(16, 32);
+  testBoth(17, 17);
+  testBoth(0, 9);
+  testBoth(5000000, 37);
 }

--- a/velox/exec/tests/utils/MergeTestBase.h
+++ b/velox/exec/tests/utils/MergeTestBase.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/time/Timer.h"
+#include "velox/exec/TreeOfLosers.h"
+
+#include <folly/Random.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <optional>
+
+namespace facebook::velox::exec::test {
+
+// Testing value struct for merge.
+class MergeValue {
+ public:
+  MergeValue() = default;
+
+  MergeValue(uint32_t value) : value_(value) {}
+
+  uint32_t value() const {
+    return value_;
+  }
+
+  int64_t payload() const {
+    return payload_;
+  }
+
+ private:
+  uint32_t value_ = 0;
+  uint64_t payload_ = 11;
+};
+
+// Testing source for sorted streams for merging.
+class TestingStream final : public MergeStream {
+ public:
+  TestingStream(std::vector<uint32_t>&& numbers)
+      : numbers_(std::move(numbers)) {}
+
+  bool hasData() const final {
+    if (!numbers_.empty()) {
+      current();
+      return true;
+    }
+    return false;
+  }
+
+  MergeValue* current() const {
+    if (numbers_.empty()) {
+      return nullptr;
+    }
+    if (!currentValid_) {
+      currentValid_ = true;
+      current_ = MergeValue(numbers_.back());
+    }
+    return &current_;
+  }
+
+  // Removes the first value. hasData() must have returned true before
+  // this. hasData() must again be called after this to check for end.
+  void pop() {
+    numbers_.pop_back();
+    currentValid_ = false;
+  }
+
+  bool operator<(const MergeStream& other) const final {
+    return current_.value() <
+        static_cast<const TestingStream&>(other).current_.value();
+  }
+
+ private:
+  // True if 'current_' is initialized.
+  mutable bool currentValid_{false};
+  mutable MergeValue current_;
+
+  // The reversed sequence of values 'this represents.
+  std::vector<uint32_t> numbers_;
+};
+
+// Test data for merging.
+struct TestData {
+  // Globally sorted sequence of test keys.
+  std::vector<uint32_t> data;
+
+  // 'data' divided over multiple locally sorted runs encapsulated in Sources.
+  std::vector<std::unique_ptr<TestingStream>> sources;
+};
+
+class MergeTestBase {
+ public:
+  void seed(int32_t seed) {
+    rng_.seed(seed);
+  }
+
+  // Makes 'numRuns' sorted streams totalling 'numValues' entries.
+  TestData makeTestData(int32_t numValues, int32_t numRuns) {
+    TestData data;
+    data.data.reserve(numValues);
+    for (auto i = 0; i < numValues; ++i) {
+      data.data.push_back(folly::Random::rand32(rng_));
+    }
+    std::vector<std::vector<uint32_t>> runs;
+    int32_t offset = 0;
+    for (auto i = 0; i < numRuns; ++i) {
+      int size = i == numRuns - 1 ? data.data.size() - offset
+                                  : data.data.size() / numRuns;
+      runs.emplace_back();
+      runs.back().insert(
+          runs.back().begin(),
+          data.data.begin() + offset,
+          data.data.begin() + offset + size);
+      std::sort(
+          runs.back().begin(),
+          runs.back().end(),
+          [](uint32_t left, uint32_t right) { return left > right; });
+      offset += size;
+    }
+    std::sort(data.data.begin(), data.data.end());
+
+    for (auto& run : runs) {
+      data.sources.push_back(std::make_unique<TestingStream>(std::move(run)));
+    }
+    return data;
+  }
+
+  // Reads the data in 'testData.runs' using the merging class MergeType. Checks
+  // that the results match the globally sorted data in 'testData' if check is
+  // true.
+  template <typename MergeType>
+  static void test(const TestData& testData, bool check) {
+    std::vector<std::unique_ptr<TestingStream>> sources;
+    for (auto& source : testData.sources) {
+      sources.push_back(std::make_unique<TestingStream>(*source));
+    }
+    MergeType merge(std::move(sources));
+    if (check) {
+      for (auto expected : testData.data) {
+        auto source = merge.next();
+        if (!source) {
+          FAIL() << "Premature end in merged stream";
+        }
+        auto result = source->current()->value();
+        ASSERT_EQ(result, expected);
+        source->pop();
+      }
+      ASSERT_FALSE(merge.next());
+    } else {
+      TestingStream* result;
+      while ((result = merge.next())) {
+        result->pop();
+      }
+    }
+  }
+
+ protected:
+  folly::Random::DefaultGenerator rng_;
+};
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Simplifies TreeOfLosers to work with raw pointers to each merge source. Encodes
a tree as an array of indices into the array of sources. The levels of a binary
tree are stored consecutively. The index of the left child of node i is i * 2 +
1 and the right child is at i * 2 + 2.

Implements the tree of losers algorithm iteratively. The initialization fills
the tree with values and returns the first value. The value at each node is the
greater value of its two children or kEmpty if the children are at end. The
next function pops a value off the previous winner and reinserts the winner at
in the parent of the leaf node representing the stream. The value goes up the
tree and if it wins and stays at the parent where it loses and the winner
(previous value of the node) continues upward.

Adds a class  MergeStream to document the interface expected from mergeable
sources.

Adds an alternate implementation of merge as a sorted array of sources. When
popping a value off a source, reinserts the array in the place corresponding to
the new first element and shifts the sources below the insertion point.

Adds a benchmark comparing the tree of losers to the sorted array of streams.
They are closely matched at small stream counts and the tree is better at large
counts.

```
narrowTree                                                    2.02s  493.94m
narrowArray                                      110.58%      1.83s  546.18m
mediumTree                                                    3.40s  294.27m
mediumArray                                      103.51%      3.28s  304.58m
wideTree                                                      6.73s  148.60m
wideArray                                         47.53%     14.16s   70.62m
```

Narrow is 7 streams, medium is 37 and wide is  1029 streams.