### PR TITLE
Fix output of streaming aggregation

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -154,8 +154,7 @@ RowVectorPtr StreamingAggregation::createOutput(size_t numGroups) {
       BaseVector::create(outputType_, numGroups, pool()));
 
   for (auto i = 0; i < groupingKeys_.size(); ++i) {
-    rows_->extractColumn(
-        groups_.data(), numGroups, groupingKeys_[i], output->childAt(i));
+    rows_->extractColumn(groups_.data(), numGroups, i, output->childAt(i));
   }
 
   auto numKeys = groupingKeys_.size();

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -63,6 +63,18 @@ class StreamingAggregationTest : public OperatorTestBase {
         makeCursorParameters(plan, outputBatchSize),
         "SELECT c0, count(1), min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
 
+    plan = PlanBuilder()
+               .values(data)
+               .project({"c1", "c0"})
+               .partialStreamingAggregation(
+                   {1}, {"count(1)", "min(c1)", "max(c1)", "sum(c1)"})
+               .finalAggregation()
+               .planNode();
+
+    assertQuery(
+        makeCursorParameters(plan, outputBatchSize),
+        "SELECT c0, count(1), min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
+
     // Test aggregation masks: one aggregate without a mask, two with the same
     // mask, one with a different mask.
     plan = PlanBuilder()


### PR DESCRIPTION
Streaming aggregation used to produce incorrect output (nulls for grouping keys)
if grouping keys were not the first columns in the input, e.g. grouping by
columns 1, 2, 3 worked, but grouping by columns 3, 4, 5 didn't.