### PR TITLE
Fix merge join

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -156,7 +156,10 @@ int32_t MergeJoin::compare(
   return 0;
 }
 
-bool MergeJoin::findEndOfMatch(Match& match, const RowVectorPtr& input) {
+bool MergeJoin::findEndOfMatch(
+    Match& match,
+    const RowVectorPtr& input,
+    const std::vector<ChannelIndex>& keys) {
   if (match.complete) {
     return true;
   }
@@ -168,7 +171,7 @@ bool MergeJoin::findEndOfMatch(Match& match, const RowVectorPtr& input) {
 
   vector_size_t endIndex = 0;
   while (endIndex < numInput &&
-         compareLeft(input, endIndex, prevInput, prevIndex) == 0) {
+         compare(keys, input, endIndex, keys, prevInput, prevIndex) == 0) {
     ++endIndex;
   }
 
@@ -417,7 +420,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
 
     if (input_) {
       // Look for continuation of a match on the left and/or right sides.
-      if (!findEndOfMatch(leftMatch_.value(), input_)) {
+      if (!findEndOfMatch(leftMatch_.value(), input_, leftKeys_)) {
         // Continue looking for the end of the match.
         input_ = nullptr;
         return nullptr;
@@ -434,7 +437,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
     }
 
     if (rightInput_) {
-      if (!findEndOfMatch(rightMatch_.value(), rightInput_)) {
+      if (!findEndOfMatch(rightMatch_.value(), rightInput_, rightKeys_)) {
         // Continue looking for the end of the match.
         rightInput_ = nullptr;
         return nullptr;

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -137,12 +137,15 @@ class MergeJoin : public Operator {
   };
 
   /// Given a partial set of rows with matching keys (match) finds all rows from
-  /// the start of the 'input' batch that also have maching keys. Updates
+  /// the start of the 'input' batch that also have matching keys. Updates
   /// 'match' to include the newly identified rows. Returns true if found the
   /// last matching row and set match.complete to true. If all rows in 'input'
-  /// have matching keys, add 'input' to 'match' and returns false to ensure
+  /// have matching keys, adds 'input' to 'match' and returns false to ensure
   /// that next batch of input is checked for more matching rows.
-  bool findEndOfMatch(Match& match, const RowVectorPtr& input);
+  bool findEndOfMatch(
+      Match& match,
+      const RowVectorPtr& input,
+      const std::vector<ChannelIndex>& keys);
 
   /// Initialize 'output_' vector using 'ouputType_' and 'outputBatchSize_' if
   /// it is null.

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -128,7 +128,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
                         {"u_c0"},
                         PlanBuilder(planNodeIdGenerator)
                             .values(right)
-                            .project({"c0 AS u_c0", "c1 AS u_c1"})
+                            .project({"c1 AS u_c1", "c0 AS u_c0"})
                             .planNode(),
                         "",
                         {"c0", "c1", "u_c1"},
@@ -159,7 +159,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
                    {"u_c0"},
                    PlanBuilder(planNodeIdGenerator)
                        .values(right)
-                       .project({"c0 as u_c0", "c1 as u_c1"})
+                       .project({"c1 as u_c1", "c0 as u_c0"})
                        .planNode(),
                    "",
                    {"c0", "c1", "u_c1"},


### PR DESCRIPTION
Merge join could return incorrect results (fewer matches) if join key column
indices on the left and right didn't match, e.g. `join(leftKeys = {2}, rightKeys
= {2})` worked, but `join(leftKeys = {2}, rightKeys = {1})` didn't.
