### PR TITLE
Add back GTest package finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,10 +216,8 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)
 
-if(NOT ${VELOX_BUILD_MINIMAL})
-  find_package(GTest REQUIRED)
-  find_library(GMock gmock)
-endif()
+find_package(GTest REQUIRED)
+find_library(GMock gmock)
 
 find_package(gflags COMPONENTS shared)
 find_package(glog REQUIRED)


### PR DESCRIPTION
Removed in https://github.com/facebookincubator/velox/commit/3e9dd2c7fbb589f838e5878b09d319385fa3afaa

Turns out still required even for VELOX_MINIMAL_BUILD:
https://github.com/facebookincubator/velox/blob/3e9dd2c7fbb589f838e5878b09d319385fa3afaa/velox/common/memory/Memory.h#L29