### PR TITLE
Add stopAtNull compare flag.

### DIFF
--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -17,6 +17,7 @@
 #include <folly/Benchmark.h>
 #include <gflags/gflags.h>
 
+#include "velox/common/base/CompareFlags.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -54,7 +55,7 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
     size_t sum = 0;
 
     for (auto i = 0; i < vectorSize_; i++) {
-      sum += vector->compare(vector.get(), i, i, flags);
+      sum += *vector->compare(vector.get(), i, i, kFlags);
     }
     folly::doNotOptimizeAway(sum);
     return vectorSize_;
@@ -66,7 +67,7 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
     size_t sum = 0;
     auto flatVector = flatVector_->as<FlatVector<int64_t>>();
     for (auto i = 0; i < vectorSize_; i++) {
-      sum += flatVector->compare(flatVector, i, vectorSize_ - i - 1, flags);
+      sum += *flatVector->compare(flatVector, i, vectorSize_ - i - 1, kFlags);
     }
     folly::doNotOptimizeAway(sum);
     return vectorSize_;
@@ -78,7 +79,7 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
   VectorPtr rowVector_;
 
  private:
-  static constexpr CompareFlags flags{true, true, false};
+  static constexpr CompareFlags kFlags{true, true, false, false};
 
   const size_t vectorSize_;
   SelectivityVector rows_;

--- a/velox/common/base/CompareFlags.h
+++ b/velox/common/base/CompareFlags.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+// Describes value collation in comparison.
+struct CompareFlags {
+  // This flag will be ignored if stopAtNull is true.
+  bool nullsFirst = true;
+
+  bool ascending = true;
+
+  // When true, comparison should return non-0 early when sizes mismatch.
+  bool equalsOnly = false;
+
+  // When true, the compare returns std::nullopt if null encountered.
+  bool stopAtNull = false;
+};
+
+} // namespace facebook::velox

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -416,6 +416,8 @@ int RowContainer::compareComplexType(
     const DecodedVector& decoded,
     vector_size_t index,
     CompareFlags flags) {
+  VELOX_DCHECK(!flags.stopAtNull, "not supported compare flag");
+
   ByteStream stream;
   prepareRead(row, offset, stream);
   return serde_.compare(stream, decoded, index, flags);
@@ -434,6 +436,8 @@ int32_t RowContainer::compareComplexType(
     const Type* type,
     int32_t offset,
     CompareFlags flags) {
+  VELOX_DCHECK(!flags.stopAtNull, "not supported compare flag");
+
   ByteStream leftStream;
   ByteStream rightStream;
   prepareRead(left, offset, leftStream);

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -73,7 +73,7 @@ class RowVector : public BaseVector {
     return VectorEncoding::Simple::ROW;
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,
       vector_size_t otherIndex,
@@ -271,7 +271,7 @@ class ArrayVector : public BaseVector {
     return VectorEncoding::Simple::ARRAY;
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,
       vector_size_t otherIndex,
@@ -438,7 +438,7 @@ class MapVector : public BaseVector {
     return VectorEncoding::Simple::MAP;
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,
       vector_size_t otherIndex,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -306,7 +306,7 @@ class ConstantVector final : public SimpleVector<T> {
     // nothing to do
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,
       vector_size_t otherIndex,
@@ -314,15 +314,11 @@ class ConstantVector final : public SimpleVector<T> {
     if constexpr (!std::is_same_v<T, ComplexType>) {
       if (other->isConstantEncoding()) {
         auto otherConstant = other->asUnchecked<ConstantVector<T>>();
-        if (isNull_) {
-          if (otherConstant->isNull_) {
-            return 0;
-          }
-          return flags.nullsFirst ? -1 : 1;
+        if (isNull_ || otherConstant->isNull_) {
+          return BaseVector::compareNulls(
+              isNull_, otherConstant->isNull_, flags);
         }
-        if (otherConstant->isNull_) {
-          return flags.nullsFirst ? 1 : -1;
-        }
+
         auto result =
             SimpleVector<T>::comparePrimitiveAsc(value_, otherConstant->value_);
         return flags.ascending ? result : result * -1;

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -128,7 +128,7 @@ class FunctionVector : public BaseVector {
     functions_.push_back(callable);
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* /*other*/,
       vector_size_t /*index*/,
       vector_size_t /*otherIndex*/,

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -163,7 +163,7 @@ class LazyVector : public BaseVector {
     loader_->load(rows, hook, &vector_);
   }
 
-  int32_t compare(
+  std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,
       vector_size_t otherIndex,

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(velox_vector_test_lib velox_vector)
 
 add_executable(
   velox_vector_test
+  VectorCompareTest.cpp
   VectorMakerTest.cpp
   VectorTest.cpp
   VectorEstimateFlatSizeTest.cpp

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <optional>
+
+#include "velox/vector/tests/VectorTestBase.h"
+
+namespace facebook::velox {
+class VectorCompareTest : public testing::Test,
+                          public velox::test::VectorTestBase {
+ public:
+  bool static constexpr kExpectNull = true;
+  bool static constexpr kExpectNotNull = false;
+  bool static constexpr kEqualsOnly = true;
+
+  void testCompareWithStopAtNull(
+      const VectorPtr& vector,
+      vector_size_t index1,
+      vector_size_t index2,
+      bool expectNull,
+      bool equalsOnly = false) {
+    CompareFlags testFlags;
+    testFlags.stopAtNull = true;
+    testFlags.equalsOnly = equalsOnly;
+
+    ASSERT_EQ(
+        expectNull,
+        !vector->compare(vector.get(), index1, index2, testFlags).has_value());
+
+    ASSERT_TRUE(vector->compare(vector.get(), index1, index2, CompareFlags())
+                    .has_value());
+  }
+};
+
+TEST_F(VectorCompareTest, compareStopAtNullFlat) {
+  auto flatVector = vectorMaker_.flatVectorNullable<int32_t>({1, std::nullopt});
+
+  testCompareWithStopAtNull(flatVector, 0, 0, kExpectNotNull);
+  testCompareWithStopAtNull(flatVector, 0, 1, kExpectNull);
+  testCompareWithStopAtNull(flatVector, 1, 0, kExpectNull);
+  testCompareWithStopAtNull(flatVector, 1, 1, kExpectNull);
+}
+
+TEST_F(VectorCompareTest, compareStopAtNullArray) {
+  auto test = [&](const std::optional<std::vector<std::optional<int64_t>>>&
+                      array1,
+                  const std::optional<std::vector<std::optional<int64_t>>>&
+                      array2,
+                  bool expectNull,
+                  bool equalsOnly = false) {
+    auto vector = vectorMaker_.arrayVectorNullable<int64_t>({array1, array2});
+    testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+  };
+
+  test(std::nullopt, std::nullopt, kExpectNull);
+  test(std::nullopt, {{1}}, kExpectNull);
+  test({{1}}, std::nullopt, kExpectNull);
+
+  test({{1, 2, 3}}, {{1, 2, 3}}, kExpectNotNull);
+
+  // Checking the first element is enough to determine the result of the
+  // compare.
+  test({{1, std::nullopt}}, {{6, 2}}, kExpectNotNull);
+
+  test({{1, std::nullopt}}, {{1, 2}}, kExpectNull);
+
+  // When two arrays are of different sizes the checked elements are:
+  // equalsOnly=true  -> none.
+  // equalsOnly=false -> the size of the smallest.
+  test({{}}, {{std::nullopt, std::nullopt}}, kExpectNotNull);
+  test({{1, 2}}, {{1, 2, std::nullopt}}, kExpectNotNull);
+  test({{std::nullopt}}, {{std::nullopt, std::nullopt}}, kExpectNull);
+
+  // Since the two arrays are of different size and equalsOnly is enabled, no
+  // elements is read and hence no null encountered.
+  test(
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt, std::nullopt}},
+      kExpectNotNull,
+      kEqualsOnly);
+
+  // Since kEqualsOnly = false, the first two elements will be read.
+  test(
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt, std::nullopt}},
+      kExpectNull);
+
+  test(
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+      kExpectNull,
+      kEqualsOnly);
+
+  test(
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+      kExpectNull);
+}
+
+TEST_F(VectorCompareTest, compareStopAtNullMap) {
+  using map_t =
+      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>;
+  auto test = [&](const map_t& map1,
+                  const map_t& map2,
+                  bool expectNull,
+                  bool equalsOnly = false) {
+    auto vector = makeNullableMapVector<int64_t, int64_t>({map1, map2});
+    testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+  };
+
+  test({{{1, 2}, {3, 4}}}, {{{1, 2}, {3, 4}}}, kExpectNotNull);
+
+  // Null map entries.
+  test(std::nullopt, {{{1, 2}, {3, 4}}}, kExpectNull);
+  test({{{1, 2}, {3, 4}}}, std::nullopt, kExpectNull);
+
+  // Null in values should be read.
+  test({{{1, std::nullopt}, {3, 4}}}, {{{1, 2}, {3, 4}}}, kExpectNull);
+  test({{{1, 2}, {3, 4}}}, {{{1, 2}, {3, std::nullopt}}}, kExpectNull);
+  test(
+      {{{1, std::nullopt}, {2, std::nullopt}}},
+      {{{1, std::nullopt}, {2, std::nullopt}}},
+      kExpectNull);
+
+  // Compare will find results before reading null.
+  // All keys are compared before values.
+  test({{{1, std::nullopt}, {3, 4}}}, {{{2, 2}, {3, 4}}}, kExpectNotNull);
+  test(
+      {{{1, std::nullopt}, {2, std::nullopt}}},
+      {{{1, std::nullopt}, {3, std::nullopt}}},
+      kExpectNotNull);
+  test(
+      {{{2, std::nullopt}, {1, std::nullopt}}},
+      {{{1, std::nullopt}, {3, std::nullopt}}},
+      kExpectNotNull);
+
+  // Different sizes.
+  test({{{1, 2}, {1, std::nullopt}}}, {{{1, std::nullopt}}}, kExpectNotNull);
+  test(
+      {{{1, 2}, {1, std::nullopt}}},
+      {{{1, std::nullopt}}},
+      kExpectNotNull,
+      kEqualsOnly);
+}
+
+TEST_F(VectorCompareTest, compareStopAtNullRow) {
+  auto test =
+      [&](const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
+              row1,
+          const std::tuple<std::optional<int64_t>, std::optional<int64_t>>&
+              row2,
+          bool expectNull,
+          bool equalsOnly = false) {
+        auto vector = vectorMaker_.rowVector(
+            {vectorMaker_.flatVectorNullable<int64_t>(
+                 {std::get<0>(row1), std::get<0>(row2)}),
+             vectorMaker_.flatVectorNullable<int64_t>(
+                 {std::get<1>(row1), std::get<1>(row2)})});
+
+        testCompareWithStopAtNull(vector, 0, 1, expectNull, equalsOnly);
+      };
+
+  test({1, 2}, {2, 3}, kExpectNotNull);
+  test({1, 2}, {1, 2}, kExpectNotNull);
+  test({2, std::nullopt}, {1, 2}, kExpectNotNull);
+
+  test({1, 2}, {1, std::nullopt}, kExpectNull);
+  test({1, std::nullopt}, {1, 2}, kExpectNull);
+  test({1, 2}, {std::nullopt, 2}, kExpectNull);
+}
+} // namespace facebook::velox

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -19,11 +19,13 @@
 #include <stdio.h>
 #include "velox/common/memory/ByteStream.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/BaseVector.h"
 #include "velox/vector/BiasVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/LazyVector.h"
+#include "velox/vector/TypeAliases.h"
 #include "velox/vector/VectorTypeUtils.h"
 #include "velox/vector/tests/VectorMaker.h"
 


### PR DESCRIPTION
Summary:
- When `stopAtNull` is set, the compare operation will stop if a null is encountered and
returns std::nullopt. This diff adds such a flag and tests it.

- This diff also separates the compare flag used by row containers and Velox vector, since the
earlier does not need `stopAtNull` nor `equalsOnly`. (not used at least for now there)

Order of visiting elements:
A. Arrays:
- if `equalsOnly`. is enabled then if the two arrays are of different sizes no elements should be visited,
Otherwise, elements are visited starting from index 0 until a null or non-equal element is encountered.

- If equalsOnly is not enabled elements in from 0 to min(size1, size2) are visited l a null or non-equal
elements encountered.

B. Maps:
- All keys are visited first. if (equals only enabled, they are not visited but that won't affect stopAtNull
 since keys cant be null).
- If all keys are the same, and maps are of the same size (note that keys can't be null) then all values
are visited in order until null or non-equal elements are encountered.

The order above matches the presto behaviour of detecting nulls during comparisons.

Differential Revision: D35124621

