### PR TITLE
Add benchmark for SelectivityVector

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -38,3 +38,7 @@ target_link_libraries(velox_benchmark_basic_comparison_conjunct
 add_executable(velox_benchmark_basic_decoded_vector DecodedVector.cpp)
 target_link_libraries(velox_benchmark_basic_decoded_vector
                       ${velox_benchmark_deps})
+
+add_executable(velox_benchmark_basic_selectivity_vector SelectivityVector.cpp)
+target_link_libraries(velox_benchmark_basic_selectivity_vector
+                      ${velox_benchmark_deps})

--- a/velox/benchmarks/basic/SelectivityVector.cpp
+++ b/velox/benchmarks/basic/SelectivityVector.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+
+class SelectivityVectorBenchmark
+    : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit SelectivityVectorBenchmark(size_t vectorSize)
+      : FunctionBenchmarkBase(),
+        vectorSize_(vectorSize),
+        rowsAll_(vectorSize),
+        rows99PerCent_(vectorSize),
+        rows50PerCent_(vectorSize),
+        rows10PerCent_(vectorSize),
+        rows1PerCent_(vectorSize) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = vectorSize_;
+    opts.nullChance = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+    flatVector_ = fuzzer.fuzzFlat(BIGINT());
+
+    for (size_t i = 0; i < vectorSize_; ++i) {
+      // Set half to invalid.
+      if (fuzzer.oneIn(2)) {
+        rows50PerCent_.setValid(i, false);
+      }
+
+      // Set 9/10 to invalid.
+      if (!fuzzer.oneIn(10)) {
+        rows10PerCent_.setValid(i, false);
+      }
+
+      // Set 99/100 to invalid.
+      if (!fuzzer.oneIn(100)) {
+        rows1PerCent_.setValid(i, false);
+      }
+
+      // Set 1/100 to invalid.
+      if (fuzzer.oneIn(100)) {
+        rows99PerCent_.setValid(i, false);
+      }
+    }
+
+    rowsAll_.updateBounds();
+    rows99PerCent_.updateBounds();
+    rows50PerCent_.updateBounds();
+    rows10PerCent_.updateBounds();
+    rows1PerCent_.updateBounds();
+  }
+
+  size_t runBaseline() {
+    const int64_t* flatBuffer = flatVector_->values()->as<int64_t>();
+    size_t sum = 0;
+
+    for (auto i = 0; i < vectorSize_; i++) {
+      sum += flatBuffer[i];
+    }
+    folly::doNotOptimizeAway(sum);
+    return vectorSize_;
+  }
+
+  size_t runSelectivityAll() {
+    return run(rowsAll_);
+  }
+
+  size_t runSelectivity50PerCent() {
+    return run(rows50PerCent_);
+  }
+
+  size_t runSelectivity10PerCent() {
+    return run(rows10PerCent_);
+  }
+
+  size_t runSelectivity1PerCent() {
+    return run(rows1PerCent_);
+  }
+
+  size_t runSelectivity99PerCent() {
+    return run(rows99PerCent_);
+  }
+
+ private:
+  size_t run(const SelectivityVector& rows) {
+    const int64_t* flatBuffer = flatVector_->values()->as<int64_t>();
+    size_t sum = 0;
+    rows.applyToSelected(
+        [&flatBuffer, &sum](auto row) { sum += flatBuffer[row]; });
+    folly::doNotOptimizeAway(sum);
+    return vectorSize_;
+  }
+
+  const size_t vectorSize_;
+  VectorPtr flatVector_;
+
+  SelectivityVector rowsAll_;
+  SelectivityVector rows99PerCent_;
+  SelectivityVector rows50PerCent_;
+  SelectivityVector rows10PerCent_;
+  SelectivityVector rows1PerCent_;
+};
+
+std::unique_ptr<SelectivityVectorBenchmark> benchmark;
+
+BENCHMARK_MULTI(sumBaselineAll) {
+  return benchmark->runBaseline();
+}
+
+BENCHMARK_MULTI(sumSelectivityAll) {
+  return benchmark->runSelectivityAll();
+}
+
+BENCHMARK_MULTI(sumSelectivity99PerCent) {
+  return benchmark->runSelectivity99PerCent();
+}
+
+BENCHMARK_MULTI(sumSelectivity50PerCent) {
+  return benchmark->runSelectivity50PerCent();
+}
+
+BENCHMARK_MULTI(sumSelectivity10PerCent) {
+  return benchmark->runSelectivity10PerCent();
+}
+
+BENCHMARK_MULTI(sumSelectivity1PerCent) {
+  return benchmark->runSelectivity1PerCent();
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  benchmark = std::make_unique<SelectivityVectorBenchmark>(10'000'000);
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -116,12 +116,12 @@ class VectorFuzzer {
     rng_.seed(seed);
   }
 
- private:
   // Returns true 1/n of times.
   bool oneIn(size_t n) {
     return folly::Random::oneIn(n, rng_);
   }
 
+ private:
   VectorPtr fuzz(const TypePtr& type, vector_size_t size);
 
   VectorPtr fuzzFlat(const TypePtr& type, vector_size_t size);


### PR DESCRIPTION
Summary:
Add micro-benchmark suite for SelectivityVector

```
============================================================================
[...]enchmarks/basic/SelectivityVector.cpp     relative  time/iter   iters/s
============================================================================
sumBaselineAll                                            208.20ps     4.80G
sumSelectivityAll                                         207.51ps     4.82G
sumSelectivity99PerCent                                   558.49ps     1.79G
sumSelectivity50PerCent                                   499.55ps     2.00G
sumSelectivity10PerCent                                   212.48ps     4.71G
sumSelectivity1PerCent                                      0.00fs  Infinity
```

Differential Revision: D35162141

