### PR TITLE
Improve TPCH q18 plan in TpchQueryBuilder

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -255,7 +255,7 @@ void ParquetRowReader::updateRuntimeStats(
     dwio::common::RuntimeStatistics& /*stats*/) const {}
 
 void ParquetRowReader::resetFilterCaches() {
-  VELOX_FAIL("ParquetRowReader::resetFilterCaches is NYI");
+  // No filter caches to reset.
 }
 
 std::optional<size_t> ParquetRowReader::estimatedRowSize() const {

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -290,6 +290,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
                    .partialAggregation({0}, {"sum(l_quantity) AS partial_sum"})
                    .planNode()})
           .finalAggregation({0}, {"sum(partial_sum) AS quantity"}, {DOUBLE()})
+          .filter("quantity > 300.0")
           .planNode();
 
   auto plan =
@@ -308,7 +309,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
                        {"o_orderkey"},
                        {"l_orderkey"},
                        bigOrders,
-                       "quantity > 300.0",
+                       "",
                        {"o_orderkey",
                         "o_custkey",
                         "o_orderdate",


### PR DESCRIPTION
Resolves https://github.com/facebookincubator/velox/issues/1259. I don't see other improvements to the plan.
The performance improved from
```
Num Drivers |  Execution time (secs)
      1     |         11.0
      4     |         8.6
      8     |         8.6
     16     |         9.2 
```
to 
```
Num Drivers |  Execution time (secs)
      1     |         7.5
      4     |         5.8
      8     |         5.6
     16     |         5.9 
```