### PR TITLE
Include input stats for nodes derived from AbstractJoinNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -411,7 +411,7 @@ void PlanNode::toString(
     bool recursive,
     size_t indentationSize,
     std::function<void(
-        const PlanNodeId& planNodeId,
+        const PlanNode& planNode,
         const std::string& indentation,
         std::stringstream& stream)> addContext) const {
   const std::string indentation(indentationSize, ' ');
@@ -428,7 +428,7 @@ void PlanNode::toString(
   if (addContext) {
     auto contextIndentation = indentation + "   ";
     stream << contextIndentation;
-    addContext(id_, contextIndentation, stream);
+    addContext(*this, contextIndentation, stream);
     stream << std::endl;
   }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -115,7 +115,7 @@ class PlanNode {
       bool detailed = false,
       bool recursive = false,
       std::function<void(
-          const PlanNodeId& planNodeId,
+          const PlanNode& planNode,
           const std::string& indentation,
           std::stringstream& stream)> addContext = nullptr) const {
     std::stringstream stream;
@@ -142,7 +142,7 @@ class PlanNode {
       bool recursive,
       size_t indentationSize,
       std::function<void(
-          const PlanNodeId& planNodeId,
+          const PlanNode& planNode,
           const std::string& indentation,
           std::stringstream& stream)> addContext) const;
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -82,10 +82,10 @@ TEST_F(PlanNodeToStringTest, recursiveAndDetailed) {
 }
 
 TEST_F(PlanNodeToStringTest, withContext) {
-  auto addContext = [](const core::PlanNodeId& planNodeId,
+  auto addContext = [](const core::PlanNode& planNode,
                        const std::string& /* indentation */,
                        std::stringstream& stream) {
-    stream << "Context for " << planNodeId;
+    stream << "Context for " << planNode.id();
   };
 
   ASSERT_EQ(
@@ -126,11 +126,11 @@ TEST_F(PlanNodeToStringTest, withContext) {
 }
 
 TEST_F(PlanNodeToStringTest, withMultiLineContext) {
-  auto addContext = [](const core::PlanNodeId& planNodeId,
+  auto addContext = [](const core::PlanNode& planNode,
                        const std::string& indentation,
                        std::stringstream& stream) {
-    stream << "Context for " << planNodeId << ": line 1" << std::endl;
-    stream << indentation << "Context for " << planNodeId << ": line 2";
+    stream << "Context for " << planNode.id() << ": line 1" << std::endl;
+    stream << indentation << "Context for " << planNode.id() << ": line 2";
   };
 
   ASSERT_EQ(


### PR DESCRIPTION
Input stats are currently only printed for leaf nodes. This PR allows including input stats for Join nodes.
This PR also does a minor refactor of iterators of type `for (const auto& entry : stats.operatorStats)` to  `for (const auto& [opName, opStats] : stats.operatorStats)` inside `PlanNodeStats.cpp`

Output of printPlanWithStats before this change
```
HashJoin[INNER o_custkey=c_custkey]
Output: 244 rows (29626235 bytes), Cpu time: 809572544ns, Blocked wall time: 7670539000ns, Peak memory: 55574528 bytes
HashBuild: Output: 0 rows (0 bytes), Cpu time: 698417478ns, Blocked wall time: 1161888000ns, Peak memory: 54525952 bytes
HashProbe: Output: 244 rows (29626235 bytes), Cpu time: 111155066ns, Blocked wall time: 6508651000ns, Peak memory: 1048576 bytes
```
Output of printPlanWithStats after this change
```
HashJoin[INNER o_custkey=c_custkey]
Input: 1500624 rows (50725389 bytes), Raw Input: 0 rows (0 bytes), Output: 624 rows (76300877 bytes), Cpu time: 953904744ns, Blocked wall time: 11614288000ns, Peak memory: 38797312 bytes
HashBuild: Input: 1500000 rows (0 bytes), Raw Input: 0 rows (0 bytes), Output: 0 rows (0 bytes), Cpu time: 707924088ns, Blocked wall time: 891212000ns, Peak memory: 37748736 bytes
HashProbe: Input: 624 rows (50725389 bytes), Raw Input: 0 rows (0 bytes), Output: 624 rows (76300877 bytes), Cpu time: 245980656ns, Blocked wall time: 10723076000ns, Peak memory: 1048576 bytes
```

Note that `HashBuild` now is also easy to understand as we do not have to look for the corresponding operator feeding it.