### PR TITLE
Fix Lifetimes in DriverTest.cancel

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -158,7 +158,8 @@ void Driver::enqueue(std::shared_ptr<Driver> driver) {
   if (!task) {
     return;
   }
-  task->queryCtx()->executor()->add([driver]() { Driver::run(driver); });
+  task->queryCtx()->executor()->add(
+      [driver]() { Driver::run(std::move(driver)); });
 }
 
 Driver::Driver(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -889,7 +889,7 @@ static void movePromisesOut(
   from.clear();
 }
 
-void Task::terminate(TaskState terminalState) {
+ContinueFuture Task::terminate(TaskState terminalState) {
   std::vector<std::shared_ptr<Driver>> offThreadDrivers;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -897,16 +897,25 @@ void Task::terminate(TaskState terminalState) {
       taskStats_.executionEndTimeMs = getCurrentTimeMs();
     }
     if (not isRunningLocked()) {
-      return;
+      return makeFinishFutureLocked("Task::terminate");
     }
     state_ = terminalState;
+    if (state_ == TaskState::kCanceled || state_ == TaskState::kAborted) {
+      try {
+        VELOX_FAIL(
+            state_ == TaskState::kCanceled ? "Cancelled"
+                                           : "Aborted for external error");
+      } catch (const std::exception& e) {
+        exception_ = std::current_exception();
+      }
+    }
+
     // Drivers that are on thread will see this at latest when they go off
     // thread.
     terminateRequested_ = true;
     // The drivers that are on thread will go off thread in time and
-    // finishFuture() allows syncing with this. 'numRunningDrivers_'
-    // is cleared here so that this is 0 right after terminate as
-    // tests expect.
+    // 'numRunningDrivers_' is cleared here so that this is 0 right
+    // after terminate as tests expect.
     numRunningDrivers_ = 0;
     stateChangedLocked();
     for (auto& driver : drivers_) {
@@ -965,6 +974,19 @@ void Task::terminate(TaskState terminalState) {
   for (auto& bridge : oldBridges) {
     bridge->cancel();
   }
+
+  std::lock_guard<std::mutex> l(mutex_);
+  return makeFinishFutureLocked("Task::terminate");
+}
+ContinueFuture Task::makeFinishFutureLocked(const char* FOLLY_NONNULL comment) {
+  auto [promise, future] = makeVeloxPromiseContract<bool>(comment);
+
+  if (numThreads_ == 0) {
+    promise.setValue(true);
+    return std::move(future);
+  }
+  threadFinishPromises_.push_back(std::move(promise));
+  return std::move(future);
 }
 
 void Task::addOperatorStats(OperatorStats& stats) {
@@ -1312,10 +1334,10 @@ StopReason Task::shouldStop() {
 }
 
 void Task::finished() {
-  for (auto& promise : pausePromises_) {
+  for (auto& promise : threadFinishPromises_) {
     promise.setValue(true);
   }
-  pausePromises_.clear();
+  threadFinishPromises_.clear();
 }
 
 StopReason Task::shouldStopLocked() {
@@ -1334,13 +1356,6 @@ StopReason Task::shouldStopLocked() {
 
 ContinueFuture Task::requestPauseLocked(bool pause) {
   pauseRequested_ = pause;
-
-  auto [promise, future] = makeVeloxPromiseContract<bool>("Task::requestPause");
-  if (numThreads_ == 0) {
-    promise.setValue(true);
-    return std::move(future);
-  }
-  pausePromises_.push_back(std::move(promise));
-  return std::move(future);
+  return makeFinishFutureLocked("Task::requestPause");
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -355,7 +355,7 @@ TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
 
   noMoreData(taskId);
   fetchEndMarker(taskId, 1, 10);
-  task->terminate(TaskState::kCanceled);
+  task->requestCancel();
   bufferManager_->removeTask(taskId);
 }
 

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -100,7 +100,7 @@ class TaskCursor {
   ~TaskCursor() {
     queue_->close();
     if (task_ && !atEnd_) {
-      task_->requestTerminate();
+      task_->requestCancel();
     }
   }
 


### PR DESCRIPTION
Rearrange Task Cancellation

- Make Task::terminate return a finish future that is realized wen
  there are no more threads in the Task.

- Make cancel/abort call terminate and return the future from terminate.

- Remove extra copy of shared_ptr when calling Driver::run().

- In DriverTest.pause/terminate, Synchronize the end of the test to be
  after the Drivers are actually off thread. This means that the Task
  does not outlive the TEST_F execution of DriverTest.cancel. If the
  Task outlieves that, freeing the ValuesNode in the plan will free
  the constant vectors after their pool is freed.

