### PR TITLE
Add Checkpointing for SsdCache

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -27,7 +27,8 @@ SsdCache::SsdCache(
     std::string_view filePrefix,
     uint64_t maxBytes,
     int32_t numShards,
-    folly::Executor* executor)
+    folly::Executor* executor,
+    int64_t checkpointIntervalBytes)
     : filePrefix_(filePrefix),
       numShards_(numShards),
       groupStats_(std::make_unique<FileGroupStats>()),
@@ -39,7 +40,10 @@ SsdCache::SsdCache(
   int32_t fileMaxRegions = bits::roundUp(maxBytes, sizeQuantum) / sizeQuantum;
   for (auto i = 0; i < numShards_; ++i) {
     files_.push_back(std::make_unique<SsdFile>(
-        fmt::format("{}{}", filePrefix_, i), i, fileMaxRegions));
+        fmt::format("{}{}", filePrefix_, i),
+        i,
+        fileMaxRegions,
+        checkpointIntervalBytes / numShards));
   }
 }
 
@@ -49,6 +53,9 @@ SsdFile& SsdCache::file(uint64_t fileId) {
 }
 
 bool SsdCache::startWrite() {
+  if (isShutdown_) {
+    return false;
+  }
   if (0 == writesInProgress_.fetch_add(numShards_)) {
     // No write was pending, so now all shards are counted as writing.
     return true;
@@ -134,6 +141,16 @@ std::string SsdCache::toString() const {
 void SsdCache::deleteFiles() {
   for (auto& file : files_) {
     file->deleteFile();
+  }
+}
+
+void SsdCache::shutdown() {
+  isShutdown_ = true;
+  while (writesInProgress_) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+  }
+  for (auto& file : files_) {
+    file->checkpoint(true);
   }
 }
 

--- a/velox/common/caching/SsdFileTracker.h
+++ b/velox/common/caching/SsdFileTracker.h
@@ -58,6 +58,11 @@ class SsdFileTracker {
       int32_t numRegions,
       const std::vector<int32_t>& regionPins);
 
+  // Expose the region access data. Used in checkpointing cache state.
+  std::vector<int64_t>& regionScores() {
+    return regionScores_;
+  }
+
  private:
   static constexpr int32_t kDecayInterval = 1000;
 


### PR DESCRIPTION
Adds a mechanism for writing a recoverable checkpoint every so many
bytes written into SSD cache.  The checkpoint records the cache size,
the access frequencies, the ids of files present in the cache and the
file id, offset to SSD cache location map.  When evictions take place
after a checkpoint, the cleared regions are logged synchronously
before allowing overwrite. In this way, if on restart we find a well
formed checkpoint file and an eviction log, we can restore the cache
state . The entries that fall on evicted regions are not included in
the recovery. If logging or writing a checkpoint file fails, the
checkpoint data is deleted and no further checkpointing takes place.


When a cache shard is initialized, the we check for existence of a
checkpoint file and eviction log. If both exist and the log is well
formed, each SsdFile in the cache is initialized from its own
checkpoint. If the file is not well formed the checkpoint data is
deleted and the cache shard starts from an empty state.