### PR TITLE
Push down dynamic filters by default

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -368,8 +368,6 @@ void HiveDataSource::addDynamicFilter(
     fieldSpec.setFilter(filter->clone());
   }
   scanSpec_->resetCachedValues();
-
-  rowReader_->resetFilterCaches();
 }
 
 void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {

--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -149,11 +149,10 @@ filtering or dynamic filter pushdown.
 
 
 Velox implements this optimization by leveraging VectorHashers that contain full
-knowledge about the join key values on the build side. HashProbe operator
-tracks the selectivity of each join key independently. For each key that drops
-at least a third of the rows, an in-list filter is constructed using the set of
-distinct values stored in the corresponding VectorHasher. These filters are
-then pushed down into the TableScan operator and make their way into the
+knowledge about the join key values on the build side. For each join key
+with not too many distinct values, an in-list filter is constructed using the set
+of distinct values stored in the corresponding VectorHasher. These filters
+are then pushed down into the TableScan operator and make their way into the
 HiveConnector which uses them to (1) prune files and row groups based on
 statistics and (2) filter out rows when reading the data.
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -493,7 +493,7 @@ bool Driver::mayPushdownAggregation(Operator* aggregation) const {
 }
 
 std::unordered_set<ChannelIndex> Driver::canPushdownFilters(
-    Operator* FOLLY_NONNULL filterSource,
+    const Operator* FOLLY_NONNULL filterSource,
     const std::vector<ChannelIndex>& channels) const {
   int filterSourceIndex = -1;
   for (auto i = 0; i < operators_.size(); ++i) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -230,7 +230,7 @@ class Driver {
   // Returns a subset of channels for which there are operators upstream from
   // filterSource that accept dynamically generated filters.
   std::unordered_set<ChannelIndex> canPushdownFilters(
-      Operator* FOLLY_NONNULL filterSource,
+      const Operator* FOLLY_NONNULL filterSource,
       const std::vector<ChannelIndex>& channels) const;
 
   // Returns the Operator with 'planNodeId.' or nullptr if not

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -123,7 +123,7 @@ class LocalExchangeSourceOperator : public SourceOperator {
       const std::string& planNodeId,
       int partition);
 
-  std::string toString() override {
+  std::string toString() const override {
     return fmt::format("LocalExchangeSourceOperator({})", partition_);
   }
 
@@ -158,7 +158,7 @@ class LocalPartition : public Operator {
       DriverCtx* ctx,
       const std::shared_ptr<const core::LocalPartitionNode>& planNode);
 
-  std::string toString() override {
+  std::string toString() const override {
     return fmt::format("LocalPartition({})", numPartitions_);
   }
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -242,7 +242,7 @@ void Operator::recordBlockingTime(uint64_t start) {
   stats_.blockedWallNanos += (now - start) * 1000;
 }
 
-std::string Operator::toString() {
+std::string Operator::toString() const {
   std::stringstream out;
   if (auto task = operatorCtx_->task()) {
     auto driverCtx = operatorCtx_->driverCtx();

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -336,7 +336,7 @@ class Operator {
 
   void recordBlockingTime(uint64_t start);
 
-  virtual std::string toString();
+  virtual std::string toString() const;
 
   velox::memory::MemoryPool* pool() {
     return operatorCtx_->pool();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -605,26 +605,31 @@ TEST_F(HashJoinTest, antiJoin) {
 }
 
 TEST_F(HashJoinTest, dynamicFilters) {
+  const int32_t numSplits = 20;
+  const int32_t numRowsProbe = 1024;
+  const int32_t numRowsBuild = 100;
+
   std::vector<RowVectorPtr> leftVectors;
-  leftVectors.reserve(20);
+  leftVectors.reserve(numSplits);
 
-  auto leftFiles = makeFilePaths(20);
+  auto leftFiles = makeFilePaths(numSplits);
 
-  for (int i = 0; i < 20; i++) {
+  for (int i = 0; i < numSplits; i++) {
     auto rowVector = makeRowVector({
-        makeFlatVector<int32_t>(1'024, [&](auto row) { return row - i * 10; }),
-        makeFlatVector<int64_t>(1'024, [](auto row) { return row; }),
+        makeFlatVector<int32_t>(
+            numRowsProbe, [&](auto row) { return row - i * 10; }),
+        makeFlatVector<int64_t>(numRowsProbe, [](auto row) { return row; }),
     });
     leftVectors.push_back(rowVector);
     writeToFile(leftFiles[i]->path, rowVector);
   }
 
   // 100 key values in [35, 233] range.
-  auto rightKey =
-      makeFlatVector<int32_t>(100, [](auto row) { return 35 + row * 2; });
+  auto rightKey = makeFlatVector<int32_t>(
+      numRowsBuild, [](auto row) { return 35 + row * 2; });
   auto rightVectors = {makeRowVector({
       rightKey,
-      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(numRowsBuild, [](auto row) { return row; }),
   })};
 
   createDuckDbTable("t", {leftVectors});
@@ -667,7 +672,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
-    EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
 
     // Semi join.
     op = PlanBuilder(planNodeIdGenerator)
@@ -690,7 +695,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
-    EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
   // Basic push-down with column names projected out of the table scan having
@@ -720,7 +725,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
-    EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
   // Push-down that requires merging filters.
@@ -745,6 +750,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
   // Push-down that turns join into a no-op.
@@ -765,7 +771,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
-    EXPECT_LT(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
   // Push-down that requires merging filters and turns join into a no-op.
@@ -790,9 +796,10 @@ TEST_F(HashJoinTest, dynamicFilters) {
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
     EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
-  // Disable filter push-down by using highly selective filter in the scan.
+  // Push-down with highly selective filter in the scan.
   {
     // Inner join.
     auto filters =
@@ -813,9 +820,10 @@ TEST_F(HashJoinTest, dynamicFilters) {
         op,
         {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 200");
-    EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
-    EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
-    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+    EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
+    EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
 
     // Semi join.
     op = PlanBuilder(planNodeIdGenerator)
@@ -831,9 +839,10 @@ TEST_F(HashJoinTest, dynamicFilters) {
         op,
         {{leftScanId, leftFiles}},
         "SELECT t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u) AND t.c0 < 200");
-    EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
-    EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
-    EXPECT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+    EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
+    EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
+    EXPECT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
+    EXPECT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
   }
 
   // Disable filter push-down by using values in place of scan.
@@ -847,7 +856,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     auto task = assertQuery(op, "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
-    EXPECT_EQ(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_EQ(numRowsProbe * numSplits, getInputPositions(task, 1));
   }
 
   // Disable filter push-down by using an expression as the join key on the
@@ -868,7 +877,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
         "SELECT t.c1 + 1 FROM t, u WHERE (t.c0 + 1) = u.c0");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);
-    EXPECT_EQ(getInputPositions(task, 1), 1024 * 20);
+    EXPECT_EQ(numRowsProbe * numSplits, getInputPositions(task, 1));
   }
 }
 


### PR DESCRIPTION
Today HashProbe needs to read at least 10K rows from TableScan before it is
able to check the selectivity of the dynamic filters on it and decide
whether to push down the filters to TableScan and HiveConnector.
That is, pushdown of dynamic filters is adaptive. We see bad performance
when TableScan outputs >10K rows with a highly selective and expensive static
filter applied before the dynamic filter is pushed down and does less expensive
filtering and pruning. On the other hand, the benefit of this approach is
it allows HashProbe to read inputs in parallel when it is blocked waiting
for the HashBuild results to arrive.

This change makes it default behavior to push down dynamic filters, removes
the filter selectivity check for pushdown and makes HashProbe start to call
on TableScan only after the dynamic filters are available that are derived
from HashBuild VectorHashers.

 depends-on https://github.com/facebookincubator/velox/pull/1370