### PR TITLE
Optimize BaseVector::compare for flat vs. flat and const vs. const

### DIFF
--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -124,7 +124,7 @@ class RowContainerTest : public testing::Test {
     for (size_t row = 0; row < size; ++row) {
       EXPECT_TRUE(expected->equalValueAt(result.get(), row, row))
           << "at " << row << ": expected " << expected->toString(row)
-          << ", got " << result->toString();
+          << ", got " << result->toString(row);
     }
   }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -256,6 +256,32 @@ class FlatVector final : public SimpleVector<T> {
 
   void resize(vector_size_t size, bool setNotNull = true) override;
 
+  int32_t compare(
+      const BaseVector* other,
+      vector_size_t index,
+      vector_size_t otherIndex,
+      CompareFlags flags) const override {
+    if (other->encoding() == VectorEncoding::Simple::FLAT) {
+      auto otherFlat = other->asUnchecked<FlatVector<T>>();
+      bool otherNull = otherFlat->isNullAt(otherIndex);
+      if (BaseVector::isNullAt(index)) {
+        if (otherNull) {
+          return 0;
+        }
+        return flags.nullsFirst ? -1 : 1;
+      }
+      if (otherNull) {
+        return flags.nullsFirst ? 1 : -1;
+      }
+      auto thisValue = valueAtFast(index);
+      auto otherValue = otherFlat->valueAtFast(otherIndex);
+      auto result = SimpleVector<T>::comparePrimitiveAsc(thisValue, otherValue);
+      return flags.ascending ? result : result * -1;
+    }
+
+    return SimpleVector<T>::compare(other, index, otherIndex, flags);
+  }
+
   bool isScalar() const override {
     return true;
   }

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -367,6 +367,7 @@ class SimpleVector : public BaseVector {
     max_ = getMetaDataValue<T>(metaData, META_MAX);
   }
 
+ protected:
   int comparePrimitiveAsc(const T& left, const T& right) const {
     if constexpr (std::is_floating_point<T>::value) {
       bool isLeftNan = std::isnan(left);
@@ -381,7 +382,6 @@ class SimpleVector : public BaseVector {
     return left < right ? -1 : left == right ? 0 : 1;
   }
 
- protected:
   std::optional<bool> isSorted_ = std::nullopt;
 
   // Allows checking that access is with the same width of T as


### PR DESCRIPTION
Specialize BaseVector::compare for comparing two flat or two constant vectors of scalar type. Removing the overhead of generic processing speeds up local merge of 7 streams of 80M rows each on two keys (one flat integer and another constant integer) from 45s to 40s.

Profile before:
<img width="1065" alt="Screen Shot 2022-03-30 at 3 34 50 PM" src="https://user-images.githubusercontent.com/27965151/160920071-3b183140-2b23-49fe-9f45-259cabcefddb.png">

and after:
<img width="1060" alt="Screen Shot 2022-03-30 at 3 45 13 PM" src="https://user-images.githubusercontent.com/27965151/160920086-cc008bb6-ea7c-4534-aaf2-1d0365f6f225.png">

