### PR TITLE
Optimize LocalMerge operator

### DIFF
--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -15,12 +15,13 @@
  */
 #pragma once
 
-#include <memory>
 #include "velox/exec/Exchange.h"
 #include "velox/exec/MergeSource.h"
-#include "velox/exec/RowContainer.h"
+#include "velox/exec/TreeOfLosers.h"
 
 namespace facebook::velox::exec {
+
+class SourceStream;
 
 // Merge operator Implementation: This implementation uses priority queue
 // to perform a k-way merge of its inputs. It stops merging if any one of
@@ -29,7 +30,7 @@ class Merge : public SourceOperator {
  public:
   Merge(
       int32_t operatorId,
-      DriverCtx* ctx,
+      DriverCtx* driverCtx,
       RowTypePtr outputType,
       const std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>&
           sortingKeys,
@@ -57,90 +58,113 @@ class Merge : public SourceOperator {
   std::vector<std::shared_ptr<MergeSource>> sources_;
 
  private:
-  static const size_t kBatchSizeInBytes{2 * 1024 * 1024};
-  using SourceRow = std::pair<size_t, char*>;
+  void initializeTreeOfLosers();
 
-  class Comparator {
-   public:
-    Comparator(
-        const RowTypePtr& outputType,
-        const std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>&
-            sortingKeys,
-        const std::vector<core::SortOrder>& sortingOrders,
-        RowContainer* rowContainer);
+  /// Maximum number of rows in the output batch.
+  const uint32_t outputBatchSize_;
 
-    // Returns true if lhs > rhs, false otherwise.
-    bool operator()(const SourceRow& lhs, const SourceRow& rhs) {
-      for (auto& key : keyInfo_) {
-        if (auto result = rowContainer_->compare(
-                lhs.second, rhs.second, key.first, key.second)) {
-          return result > 0;
-        }
-      }
-      return false;
-    }
-
-   private:
-    std::vector<std::pair<ChannelIndex, CompareFlags>> keyInfo_;
-    RowContainer* rowContainer_;
-  };
-
-  /// Appends next row from the specified source to 'candidates_'. If
-  /// corresponding CursorSource has next row, returns that row and advances the
-  /// cursor. Otherwise, fetches next batch of source rows from MergeSource,
-  /// copies them to rowContainer_ and resets the cursor.
-  BlockingReason pushSource(ContinueFuture* future, size_t sourceId);
-
-  BlockingReason ensureSourcesReady(ContinueFuture* future);
-
-  /// Returns "max" row from 'candidates_' and removes that row from
-  /// 'candidates_'. Assumes 'candidates_' is not empty.
-  SourceRow nextOutputRow();
-
-  /// A cursor over an ordered batch of source rows copied into 'rowContainer_'.
-  struct SourceCursor {
-    /// Ordered source rows.
-    std::vector<char*> rows;
-    /// Index of the next row.
-    vector_size_t index{0};
-    /// True if source has been exhausted.
-    bool atEnd{false};
-
-    /// Returns true if there is a next row.
-    bool hasNext() {
-      return !atEnd && index < rows.size();
-    }
-
-    /// Returns next row and advances the cursor.
-    char* nextUnchecked() {
-      return rows[index++];
-    }
-
-    /// Copies the 'data' into 'rowContainer' and resets the cursor to point to
-    /// the first row.
-    void reset(const RowVectorPtr& data, RowContainer* rowContainer);
-  };
+  std::vector<std::pair<ChannelIndex, CompareFlags>> sortingKeys_;
 
   /// A list of cursors over batches of ordered source data. One per source.
   /// Aligned with 'sources'.
-  std::vector<SourceCursor> sourceCursors_;
+  std::vector<SourceStream*> streams_;
 
-  /// Ordered list of output rows.
-  std::vector<char*> rows_;
+  /// Used to merge data from two or more sources.
+  std::unique_ptr<TreeOfLosers<SourceStream>> treeOfLosers_;
 
-  /// Row container to store incoming batches of source data.
-  std::unique_ptr<RowContainer> rowContainer_;
+  /// Number of rows accumulated in 'output_' so far.
+  vector_size_t outputSize_{0};
 
-  /// STL-compatible comparator to compare rows by sorting keys.
-  Comparator comparator_;
+  bool finished_{false};
 
-  /// A list of "max" rows from each source. Used to pick the next output row.
-  std::vector<SourceRow> candidates_;
+  /// A list of blocking futures for sources. These are populates when a given
+  /// source is blocked waiting for the next batch of data.
+  std::vector<ContinueFuture> sourceBlockingFutures_;
+};
 
-  BlockingReason blockingReason_{BlockingReason::kNotBlocked};
-  ContinueFuture future_;
-  size_t numSourcesAdded_ = 0;
-  size_t currentSourcePos_ = 0;
+class SourceStream final : public MergeStream {
+ public:
+  SourceStream(
+      MergeSource* source,
+      const std::vector<std::pair<ChannelIndex, CompareFlags>>& sortingKeys,
+      uint32_t outputBatchSize)
+      : source_{source},
+        sortingKeys_{sortingKeys},
+        outputRows_(outputBatchSize, false),
+        sourceRows_(outputBatchSize) {
+    keyColumns_.reserve(sortingKeys.size());
+  }
+
+  /// Returns true and appends a future to 'futures' if needs to wait for the
+  /// source to produce data.
+  bool isBlocked(std::vector<ContinueFuture>& futures) {
+    if (needData_) {
+      return fetchMoreData(futures);
+    }
+    return false;
+  }
+
+  bool hasData() const override {
+    return !atEnd_;
+  }
+
+  /// Returns true if current source row is less then current source row in
+  /// 'other'.
+  bool operator<(const MergeStream& other) const override;
+
+  /// Advances to the next row. Returns true and appends a future to 'futures'
+  /// if runs out of rows in the current batch and needs to wait for the
+  /// source to produce the next batch. The return flag has the meaning of
+  /// 'is-blocked'.
+  bool pop(std::vector<ContinueFuture>& futures);
+
+  /// Records the output row number for the current row. Returns true if
+  /// current row is the last row in the current batch, in which case the
+  /// caller must call 'copyToOutput' before calling pop(). The caller must
+  /// call 'setOutputRow' before calling 'pop'. The output rows must
+  /// monotonically increase in between calls to 'copyToOutput'.
+  bool setOutputRow(vector_size_t row) {
+    outputRows_.setValid(row, true);
+    return currentSourceRow_ == data_->size() - 1;
+  }
+
+  /// Called if either current row is the last row in the current batch or the
+  /// caller accumulated enough output rows across all sources to produce an
+  /// output batch.
+  void copyToOutput(RowVectorPtr& output);
+
+ private:
+  bool fetchMoreData(std::vector<ContinueFuture>& futures);
+
+  MergeSource* source_;
+
+  const std::vector<std::pair<ChannelIndex, CompareFlags>>& sortingKeys_;
+
+  /// Ordered source rows.
+  RowVectorPtr data_;
+
+  /// Raw pointers to vectors corresponding to sorting key columns in the same
+  /// order as 'sortingKeys_'.
+  std::vector<BaseVector*> keyColumns_;
+
+  /// Index of the current row.
+  vector_size_t currentSourceRow_{0};
+
+  /// True if source has been exhausted.
+  bool atEnd_{false};
+
+  /// True if ran out of rows in 'data_' and needs to wait for the future
+  /// returned by 'source_->next()'.
+  bool needData_{true};
+
+  /// First source row that hasn't been copied out yet.
+  vector_size_t firstSourceRow_{0};
+
+  /// Output row numbers for source rows that haven't been copied out yet.
+  SelectivityVector outputRows_;
+
+  /// Reusable memory.
+  std::vector<vector_size_t> sourceRows_;
 };
 
 // LocalMerge merges its source's output into a single stream of

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -36,13 +36,20 @@ class MergeTest : public OperatorTestBase {
                       .localMerge(
                           {orderByClause},
                           {PlanBuilder(planNodeIdGenerator)
-                               .values(inputVectors)
+                               .values(inputVectors, true)
                                .orderBy({orderByClause}, true)
                                .planNode()})
                       .planNode();
 
+      CursorParameters params;
+      params.planNode = plan;
+      params.maxDrivers = 2;
+      params.numResultDrivers = 1;
       assertQueryOrdered(
-          plan, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+          params,
+          "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) ORDER BY " +
+              orderByClause,
+          {keyIndex});
 
       // Use multiple sources for local merge.
       std::vector<std::shared_ptr<const core::PlanNode>> sources;
@@ -81,21 +88,27 @@ class MergeTest : public OperatorTestBase {
         const std::vector<std::string> orderByClauses = {
             fmt::format("{} {}", key1, sortOrderSqls[i]),
             fmt::format("{} {}", key2, sortOrderSqls[j])};
-        const auto sql = fmt::format(
-            "SELECT * FROM tmp ORDER BY {}, {}",
-            orderByClauses[0],
-            orderByClauses[1]);
+        const auto orderBySql = fmt::format(
+            "ORDER BY {}, {}", orderByClauses[0], orderByClauses[1]);
         auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
         auto plan = PlanBuilder(planNodeIdGenerator)
                         .localMerge(
                             orderByClauses,
                             {PlanBuilder(planNodeIdGenerator)
-                                 .values(inputVectors)
+                                 .values(inputVectors, true)
                                  .orderBy(orderByClauses, true)
                                  .planNode()})
                         .planNode();
 
-        assertQueryOrdered(plan, sql, sortingKeys);
+        CursorParameters params;
+        params.planNode = plan;
+        params.maxDrivers = 2;
+        params.numResultDrivers = 1;
+        assertQueryOrdered(
+            params,
+            "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) " +
+                orderBySql,
+            sortingKeys);
 
         // Use multiple sources for local merge.
         std::vector<std::shared_ptr<const core::PlanNode>> sources;
@@ -109,7 +122,8 @@ class MergeTest : public OperatorTestBase {
                    .localMerge(orderByClauses, std::move(sources))
                    .planNode();
 
-        assertQueryOrdered(plan, sql, sortingKeys);
+        assertQueryOrdered(
+            plan, "SELECT * FROM tmp " + orderBySql, sortingKeys);
       }
     }
   }

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -54,6 +54,14 @@ class OperatorTestBase : public testing::Test,
   }
 
   std::shared_ptr<Task> assertQueryOrdered(
+      const CursorParameters& params,
+      const std::string& duckDbSql,
+      const std::vector<uint32_t>& sortingKeys) {
+    return test::assertQuery(
+        params, [&](auto*) {}, duckDbSql, duckDbQueryRunner_, sortingKeys);
+  }
+
+  std::shared_ptr<Task> assertQueryOrdered(
       const std::shared_ptr<const core::PlanNode>& plan,
       const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits,
       const std::string& duckDbSql,


### PR DESCRIPTION
- Remove extra copying into RowContainer.
- Use TreeOfLosers for merging.
- Copy rows to output in bulk.

This version is much faster than previous. Merging 7 streams of 80M rows each on
1 integer key is 27s vs original 70s and on 2 keys is 32s vs original 290s.
These numbers include optimizations for FlatVector::copyValuesAndNulls
(#1316) and BaseVector::compare (#1317)

1 flat int key
<img width="1047" alt="Screen Shot 2022-03-31 at 7 03 18 AM" src="https://user-images.githubusercontent.com/27965151/161041090-1750a8c0-9f82-4bb1-9e96-5bc2d4929691.png">

2 keys: flat and const:

<img width="1044" alt="Screen Shot 2022-03-31 at 7 03 44 AM" src="https://user-images.githubusercontent.com/27965151/161041104-c38a923d-96dc-4f05-bb2f-a42c2f409b62.png">

