### PR TITLE
Fix Mac build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,6 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Make sure thrid_party include paths are added before system include paths
-add_subdirectory(third_party)
-
 set(Boost_USE_MULTITHREADED TRUE)
 find_package(
   Boost
@@ -297,5 +294,11 @@ include_directories(.)
 # TODO: Include all other installation files. For now just making sure this
 # generates an installable makefile.
 install(FILES velox/type/Type.h DESTINATION "include/velox")
+
+add_subdirectory(third_party)
+
+# Include third party header files
+include_directories(third_party/googletest/googletest/include)
+include_directories(third_party/googletest/googlemock/include)
 
 add_subdirectory(velox)

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -119,11 +119,6 @@ function install_build_prerequisites {
   pip3 install --user cmake-format regex
 }
 
-function install_googletest {
-  github_checkout google/googletest release-1.11.0
-  cmake_install
-}
-
 function install_fmt {
   github_checkout fmtlib/fmt 7.1.3
   cmake_install -DFMT_TEST=OFF
@@ -155,7 +150,6 @@ function install_velox_deps {
     run_and_time install_build_prerequisites
   fi
   run_and_time install_ranges_v3
-  run_and_time install_googletest
   run_and_time install_fmt
   run_and_time install_double_conversion
   run_and_time install_folly


### PR DESCRIPTION
Landing time race of b10b356c7b86f9eb9cd1dbf4328ab02962f3ae2c and
fee3273d227516f7ac7967824e604a34c8f8a95e.

CMake dependent path includes GTest 1.11 while submodule pins to 1.10.