### PR TITLE
Add monthly update for March 2022

### DIFF
--- a/velox/docs/conf.py
+++ b/velox/docs/conf.py
@@ -23,10 +23,17 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
+
 # sys.path.insert(0, os.path.abspath('.'))
 
+try:
+    sys.dont_write_bytecode = True
+except:
+    pass
+
+sys.path.insert(0, os.path.abspath("ext"))
 
 # -- Project information -----------------------------------------------------
 
@@ -39,7 +46,7 @@ copyright = "TBD"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["issue", "pr"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/velox/docs/ext/issue.py
+++ b/velox/docs/ext/issue.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# noinspection PyUnresolvedReferences
+from docutils import nodes, utils
+
+
+# noinspection PyDefaultArgument,PyUnusedLocal
+def issue_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    title = "#" + text
+    link = "https://github.com/facebookincubator/velox/issues/" + text
+    node = nodes.reference(text=title, refuri=link, **options)
+    return [node], []
+
+
+def setup(app):
+    app.add_role("issue", issue_role)
+
+    return {
+        "parallel_read_safe": True,
+    }

--- a/velox/docs/ext/pr.py
+++ b/velox/docs/ext/pr.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# noinspection PyUnresolvedReferences
+from docutils import nodes, utils
+
+
+# noinspection PyDefaultArgument,PyUnusedLocal
+def pr_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    title = "#" + text
+    link = "https://github.com/facebookincubator/velox/pull/" + text
+    node = nodes.reference(text=title, refuri=link, **options)
+    return [node], []
+
+
+def setup(app):
+    app.add_role("pr", pr_role)
+
+    return {
+        "parallel_read_safe": True,
+    }

--- a/velox/docs/monthly-updates.rst
+++ b/velox/docs/monthly-updates.rst
@@ -5,6 +5,7 @@ Monthly Updates
 .. toctree::
     :maxdepth: 1
 
+    monthly-updates/march-2022
     monthly-updates/february-2022
     monthly-updates/january-2022
     monthly-updates/december-2021

--- a/velox/docs/monthly-updates/march-2022.rst
+++ b/velox/docs/monthly-updates/march-2022.rst
@@ -1,0 +1,68 @@
+********************
+March 2022 Update
+********************
+
+Documentation
+-------------
+
+* Document :doc:`printPlanWithStats <../develop/debugging/print-plan-with-stats>` debugging tool.
+
+Core Library
+------------
+
+* Add support for UNNEST WITH ORDINALITY for single array or map.
+* Add support for filter to INNER and LEFT merge joins.
+* Add support for FULL OUTER hash join.
+* Add Substrait-to-Velox plan conversion.
+* Add exec::resolveAggregateFunction API to resolve aggregate function final and intermediate types based on function name and input types.
+* Add KLL sketch implementation to be used to implement :func:`approx_percentile` Presto function with accuracy parameter. :pr:`1247`
+* Add GTest as a submodule and upgrade it to 1.11.0 (from 1.10.0).
+* Reduce dependencies for VELOX_BUILD_MINIMAL build by removing GTest, GMock and compression libraries. :pr:`1292`
+* Simplify simple functions API to allow to provide void call method for functions that never return null for non-null inputs.
+* Optimize LocalMerge operator. :pr:`1264`
+* Optimize PartitionedOutput and Exchange operators by removing unnecessary data copy. :pr:`1127`
+* Optimize BaseVector::compare() for a pair of flat or a pair of constant vectors or scalar types. :pr:`1317`
+* Optimize BaseVector::copy() for flat vectors of scalar type. :pr:`1316`
+* Optimize aggregation by enabling pushdown into table scan in more cases. :pr:`1188`
+* Optimize simple functions that never return null for non-null input for 70% perf boost. :pr:`1152`
+* Fix bucket-by-bucket (grouped) execution of join queries.
+* Fix crashes and correctness bugs in joins and aggregations.
+
+Presto Functions
+----------------
+
+* Add support for CAST(x as JSON).
+* Add :func:`arrays_overlap` function.
+* Extend :func:`hour` function to support TIMESTAMP WITH TIME ZONE inputs.
+* Fix :func:`parse_datetime` and :func:`to_unixtime` semantics. :pr:`1277`
+* Fix :func:`approx_distinct` to return 0 instead of null with all inputs are null.
+
+Performance and Correctness Testing
+-----------------------------------
+
+* Add linux-benchmarks-basic CircleCI job to run micro benchmarks on each PR. Initial set of benchmarks covers SelectivityVector, DecodedVector, simple comparisons and conjuncts.
+* Add TPC-H benchmark with support for q1, q6 and q18.
+* Add support for approximate verification of REAL and DOUBLE values returned by test queries.
+* Add support for ORDER BY SQL clauses to PlanBuilder::localMerge() and PlanBuilder::orderBy().
+
+Debugging Experience
+--------------------
+
+* Improve error messages in expression evaluation by including the expression being evaluated. :pr:`1138`
+* Improve error messages in CAST expression by including the to and from types. :pr:`1150`
+* Add printPlanWithStats function to print query plan with runtime statistics.
+* Add SelectivityVector::toString() method.
+* Improve ConstantExpr::toString() to include constant value.
+* Add runtime statistic "loadedToValueHook" to track number of values processed via aggregation pushdown into scan.
+
+Credits
+-------
+
+Aditi Pandit, Amit Dutta, Amlan Nayak, Chad Austin, Chao Chen, David Greenberg,
+Deepak Majeti, Dimitri Bouche, Gilson Takaasi Gil, Hanqi Wu, Huameng Jiang,
+Jialiang Tan, im Meyering, Jimmy Lu, Karteek Murthy Samba Murthy, Kevin
+Wilfong, Krishna Pai, Laith Sakka, Liang Tao, MJ Deng, Masha Basmanova, Orri
+Erling, Paula Lahera, Pedro Eugenio Rocha Pedreira, Pradeep Garigipati, Richard
+Barnes, Rui Mo, Sagar Mittal, Sergey Pershin, Simon Marlow, Siva Muthusamy,
+Sridhar Anumandla, Victor Zverovich, Wei He, Wenlei Xie, Yoav Helfman, Yuan
+Chao Chou, Zhenyuan Zhao, tanjialiang


### PR DESCRIPTION
Also, add support for ``:pr:`1234` `` and ``:issue:`1234` `` syntax in the documentation.

Initially, I tried adding this support via sphinx_toolbox.github extension, but the syntax was a bit too verbose -``:github:pull:`1234` `` and ``:github:issue:`1234` `` - and I also needed to hardcode GitHub username in the conf.py. Hence, I ended up just copying the custom extension scripts from Presto.

https://sphinx-toolbox.readthedocs.io/en/stable/extensions/github.html#usage

--- requirements.txt

```
sphinx
sphinx_toolbox
```

--- conf.py

```
extensions = [
    'sphinx_toolbox.github',
]

github_username = "mbasmanova"
github_repository = "https://github.com/facebookincubator/velox"
```