### PR TITLE
Upgrade GTest submodule to 1.11 (from 1.10)

### DIFF
--- a/velox/experimental/codegen/compiler_utils/CompilerOptions.h
+++ b/velox/experimental/codegen/compiler_utils/CompilerOptions.h
@@ -29,6 +29,7 @@ namespace facebook::velox::codegen::compiler_utils {
 struct CompilerOptions {
   CompilerOptions() = default;
   CompilerOptions(const CompilerOptions& options) = default;
+  CompilerOptions& operator=(const CompilerOptions& other) = default;
 
   std::string optimizationLevel;
   std::vector<std::string> extraCompileOptions;

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -115,8 +115,8 @@ template <typename BaseIterator>
 class SkipNullsIterator {
   using Iterator = SkipNullsIterator<BaseIterator>;
   using iterator_category = std::input_iterator_tag;
-  using value_type = typename std::result_of<decltype (&BaseIterator::value)(
-      BaseIterator)>::type;
+  using value_type = typename std::
+      invoke_result<decltype(&BaseIterator::value), BaseIterator>::type;
   using difference_type = int;
   using pointer = PointerWrapper<value_type>;
   using reference = value_type;

--- a/velox/type/Tree.h
+++ b/velox/type/Tree.h
@@ -33,8 +33,7 @@ class TreeIterator {
   typedef std::forward_iterator_tag iterator_category;
   typedef int64_t difference_type;
 
-  TreeIterator(const Tree<const T>& tree, size_t idx)
-      : tree_(tree), idx_{idx} {}
+  TreeIterator(const Tree<T>& tree, size_t idx) : tree_(tree), idx_{idx} {}
 
   self_type operator++() {
     // prefix
@@ -66,7 +65,7 @@ class TreeIterator {
   }
 
  private:
-  const Tree<const T>& tree_;
+  const Tree<T>& tree_;
   size_t idx_;
 };
 
@@ -75,7 +74,7 @@ class Tree {
  public:
   using const_reference = const T&;
   using reference_type = const_reference;
-  using const_iterator = TreeIterator<const T>;
+  using const_iterator = TreeIterator<T>;
   using iterator = const_iterator;
 
   using difference_type = uint64_t;


### PR DESCRIPTION
Summary: This PR fixes the build failure when using MacOSX12.3.sdk. 

First, there is a compilation error in the source code of GTest ver 1.10, so we upgrade the GTest submodule to ver 1.11.

The upgrade to GTest  1.11 then triggers another compilation error coming from `velox::Tree`. The error is caused by `velox::Tree::cbegin()` trying to construct a `velox::TreeIterator` with a `const velox::Tree<T>` object, but velox::TreeIterator's constructor expects a `const velox::Tree<const T>`. And there is no known conversion from `const velox::Tree<T>` to `const velox::Tree<const T>`. So we remove the inner "const" from `const velox::Tree<const T>`.

In addition, `std::result_of` is depreciated in MacOSX12.3.sdk. So we replace `std::result_of` with `std::invoke_result` in Velox source code. The compiler also complains that the implicit copy assignment operator for `CompilerOptions` is disabled because it has a user-declared copy constructor. So we add the default copy assignment operator for `CompilerOptions` as well.


Differential Revision: D35293292

