### PR TITLE
[WIP] Allow parallelism for final aggregation

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -683,7 +683,7 @@ class LocalPartitionNode : public PlanNode {
         "Local repartitioning node requires at least one source");
   }
 
-  static std::shared_ptr<LocalPartitionNode> single(
+  static std::shared_ptr<LocalPartitionNode> gather(
       const PlanNodeId& id,
       RowTypePtr outputType,
       std::vector<std::shared_ptr<const PlanNode>> sources) {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -168,15 +168,7 @@ uint32_t maxDrivers(const DriverFactory& driverFactory) {
     return count;
   }
   for (auto& node : driverFactory.planNodes) {
-    if (auto aggregation =
-            std::dynamic_pointer_cast<const core::AggregationNode>(node)) {
-      if (aggregation->step() == core::AggregationNode::Step::kFinal ||
-          aggregation->step() == core::AggregationNode::Step::kSingle) {
-        // final aggregations must run single-threaded
-        return 1;
-      }
-    } else if (
-        auto topN = std::dynamic_pointer_cast<const core::TopNNode>(node)) {
+    if (auto topN = std::dynamic_pointer_cast<const core::TopNNode>(node)) {
       if (!topN->isPartial()) {
         // final topN must run single-threaded
         return 1;


### PR DESCRIPTION
Summary:
Final and single aggregations can run multi-threaded as long as data is
partitioned on the grouping keys, but we used to artificially restrict these to
run single-threaded. This change lifts the restriction.

To make this work we must not ignore any local exchange node in the query plan.
Prestissimo used to silently drop gather and round-robin repartitioning local
exchanges. We no longer do that.

It is now possible that final aggregation runs after local repartitioning which
produces dictionary encoded vectors. It turns out that many aggregate functions
are not prepared to handle non-flat intermediate results. To avoid breaking
these we forcibly flatten intermediate results before feeding these to
aggregate functions.

There is now a local gather exchange upstream of the final Limit operator. When
Limit finishes early the producing pipeline before the exchange needs to be
notified so it can finish early as well.

Differential Revision: D35304854

