### PR TITLE
Close local exchange on task termination

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -404,6 +404,10 @@ void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
         splitGroupState.clear();
         self->ensureSplitGroupsAreBeingProcessedLocked(self);
       }
+    } else {
+      if (splitGroupState.activeDrivers == 0) {
+        splitGroupState.clear();
+      }
     }
     return;
   }
@@ -948,7 +952,7 @@ void Task::terminate(TaskState terminalState) {
       for (auto& pair : splitGroupState.second.bridges) {
         oldBridges.emplace_back(std::move(pair.second));
       }
-      splitGroupState.second.bridges.clear();
+      splitGroupState.second.clear();
     }
 
     // Collect all outstanding split promises from all splits state structures.

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -117,7 +117,7 @@ class TaskCursor {
     return current_;
   }
 
-  std::shared_ptr<Task> task() {
+  const std::shared_ptr<Task>& task() {
     return task_;
   }
 


### PR DESCRIPTION
Consider a query plan with two pipelines: 

- producer pipeline ends with a LocalPartition operator that feeds LocalExchangeSource(s) by calling LocalExchangeSource::enqueue and blocking if the source is full.

- consumer pipeline starts with a LocalExchangeSourceOperator operator that reads data from LocalExchangeSource(s) by calling LocalExchangeSource::next and blocking if source is empty.

Example 1:

```
   - Limit
      - LocalExchange
         - TableScan
```
- producer pipeline: LocalPartition <- TableScan
- consumer pipeline: Limit <- LocalExchangeSourceOperator

It is common for Limit operator to finish early before receiving all the data from the upstream. In this case producer pipeline has produced more data than will be needed and is blocked waiting for the data to be fetched. At the same time consumer pipeline finishes early, the Driver calls LocalExchangeSourceOperator::close and LocalExchangeSourceOperator never fetches the data. Producer ends up blocked forever.

If instead of Limit completing early, Task receives a cancellation, the same sequence of events will cause producer to be blocked forever.

Now, let's say the consumer (LocalExchangeSourceOperator) is blocked waiting for data and then producing pipeline generates an error and fails. The consumer stays blocked forever.

This change is to close LocalExchangeSource in case Task completes before all the data has been processed.

The new tests simulate the scenarios above. Before this change these were failing.

earlyCompletion test failed before the task got stuck in running state:

```
Value of: task->isFinished()
  Actual: false
Expected: true
```

earlyCancelation and producerError tests failed because a Driver got stuck in blocked state holding a reference to a Task forever:

```
Expected equality of these values:
  1
  task.use_count()
    Which is: 2
```