### PR TITLE
Refactor thrid_party gtest include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,9 +296,4 @@ include_directories(.)
 install(FILES velox/type/Type.h DESTINATION "include/velox")
 
 add_subdirectory(third_party)
-
-# Include third party header files
-include_directories(third_party/googletest/googletest/include)
-include_directories(third_party/googletest/googlemock/include)
-
 add_subdirectory(velox)

--- a/velox/buffer/CMakeLists.txt
+++ b/velox/buffer/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_library(velox_buffer StringViewBufferHolder.cpp)
 
-target_link_libraries(velox_buffer ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(velox_buffer velox_memory ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/buffer/tests/CMakeLists.txt
+++ b/velox/buffer/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   velox_buffer
   gtest
   gtest_main
+  gmock
   glog::glog
   ${gflags_LIBRARIES}
   pthread)

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -27,5 +27,5 @@ add_library(
   MemoryUsageTracker.cpp
   StreamArena.cpp)
 
-target_link_libraries(velox_memory velox_flag_definitions velox_exception
+target_link_libraries(velox_memory velox_flag_definitions velox_exception gtest
                       ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   velox_exception
   velox_dwio_common_encryption
   velox_dwio_common_compression
+  velox_memory
   Boost::regex
   ${FOLLY_WITH_DEPENDENCIES}
   glog::glog)

--- a/velox/dwio/dwrf/utils/CMakeLists.txt
+++ b/velox/dwio/dwrf/utils/CMakeLists.txt
@@ -20,4 +20,5 @@ add_library(velox_dwio_dwrf_utils ProtoUtils.cpp BitIterator.h)
 
 add_dependencies(velox_dwio_dwrf_utils velox_dwio_dwrf_proto)
 
-target_link_libraries(velox_dwio_dwrf_utils velox_dwio_dwrf_proto velox_type)
+target_link_libraries(velox_dwio_dwrf_utils velox_dwio_dwrf_proto velox_type
+                      velox_memory)

--- a/velox/experimental/codegen/code_generator/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/CMakeLists.txt
@@ -34,5 +34,5 @@ if(${VELOX_BUILD_TESTING})
 endif()
 add_library(velox_codegen_code_generator ExprCodeGenerator.cpp)
 target_link_libraries(velox_codegen_code_generator velox_codegen_ast
-                      velox_codegen_udf_manager)
+                      velox_codegen_udf_manager velox_memory)
 target_link_libraries(velox_codegen_code_generator velox_codegen_proto)

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -31,4 +31,5 @@ target_link_libraries(
   velox_expression
   gtest
   gtest_main
+  gmock
   ${gflags_LIBRARIES})

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -12,3 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(velox_presto_types JsonType.cpp)
+
+target_link_libraries(velox_presto_types velox_memory)

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -36,4 +36,5 @@ target_link_libraries(
   ${FMT}
   gtest
   gtest_main
+  gmock
   ${gflags_LIBRARIES})

--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -17,3 +17,5 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_row UnsafeRow24Deserializer.cpp)
+
+target_link_libraries(velox_row velox_memory)

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   ${DOUBLE_CONVERSION}
   gtest
   gtest_main
+  gmock
   ${gflags_LIBRARIES}
   glog::glog)
 


### PR DESCRIPTION
`gtest` would config the right include path via `target_include_directories` https://github.com/google/googletest/blob/af29db7ec28d6df1c7f0f745186884091e602e07/googletest/CMakeLists.txt#L133-L141  if it's a dependency. So we don't need to manually add/maintain gtest third_party include directory.