### PR TITLE
Return abandonDictionary result

### DIFF
--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -330,31 +330,34 @@ class IntegerColumnWriter : public ColumnWriter {
 
   // This incurs additional memory usage. A good long term adjustment but not
   // viable mitigation to memory pressure.
-  void tryAbandonDictionaries(bool force) override {
+  bool tryAbandonDictionaries(bool force) override {
     // TODO: hopefully not required in the future, but need to solve the problem
     // of replacing/deleting streams.
     if (!useDictionaryEncoding_ || !firstStripe_) {
-      return;
+      return false;
     }
 
     useDictionaryEncoding_ = shouldKeepDictionary() && !force;
-    if (!useDictionaryEncoding_) {
-      initStreamWriters(useDictionaryEncoding_);
-      // Record direct encoding stream starting position.
-      recordDirectEncodingStreamPositions(0);
-      convertToDirectEncoding();
-      // Suppress the stream used to initialize dictionary encoder.
-      // TODO: passing factory method into the dict encoder also works
-      // around this problem but has messier code organization.
-      context_.suppressStream(StreamIdentifier{
-          id_,
-          context_.shareFlatMapDictionaries ? 0 : sequence_,
-          0,
-          StreamKind::StreamKind_DICTIONARY_DATA});
-      dictEncoder_.clear();
-      rows_.clear();
-      strideOffsets_.clear();
+    if (useDictionaryEncoding_) {
+      return false;
     }
+
+    initStreamWriters(useDictionaryEncoding_);
+    // Record direct encoding stream starting position.
+    recordDirectEncodingStreamPositions(0);
+    convertToDirectEncoding();
+    // Suppress the stream used to initialize dictionary encoder.
+    // TODO: passing factory method into the dict encoder also works
+    // around this problem but has messier code organization.
+    context_.suppressStream(StreamIdentifier{
+        id_,
+        context_.shareFlatMapDictionaries ? 0 : sequence_,
+        0,
+        StreamKind::StreamKind_DICTIONARY_DATA});
+    dictEncoder_.clear();
+    rows_.clear();
+    strideOffsets_.clear();
+    return true;
   }
 
  private:
@@ -922,23 +925,26 @@ class StringColumnWriter : public ColumnWriter {
     }
   }
 
-  void tryAbandonDictionaries(bool force) override {
+  bool tryAbandonDictionaries(bool force) override {
     // TODO: hopefully not required in the future, but need to solve the problem
     // of replacing/deleting streams.
     if (!useDictionaryEncoding_ || !firstStripe_) {
-      return;
+      return false;
     }
 
     useDictionaryEncoding_ = shouldKeepDictionary() && !force;
-    if (!useDictionaryEncoding_) {
-      initStreamWriters(useDictionaryEncoding_);
-      // Record direct encoding stream starting position.
-      recordDirectEncodingStreamPositions(0);
-      convertToDirectEncoding();
-      dictEncoder_.clear();
-      rows_.clear();
-      strideOffsets_.clear();
+    if (useDictionaryEncoding_) {
+      return false;
     }
+
+    initStreamWriters(useDictionaryEncoding_);
+    // Record direct encoding stream starting position.
+    recordDirectEncodingStreamPositions(0);
+    convertToDirectEncoding();
+    dictEncoder_.clear();
+    rows_.clear();
+    strideOffsets_.clear();
+    return true;
   }
 
  protected:

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -122,10 +122,13 @@ class ColumnWriter {
   // Determine whether dictionary is the right encoding to use when writing
   // the first stripe. We will continue using the same decision for all
   // subsequent stripes.
-  virtual void tryAbandonDictionaries(bool force) {
+  // Returns whether or not an encoding change is performed.
+  virtual bool tryAbandonDictionaries(bool force) {
+    bool result = false;
     for (auto& child : children_) {
-      child->tryAbandonDictionaries(force);
+      result = result || child->tryAbandonDictionaries(force);
     }
+    return result;
   }
 
   static std::unique_ptr<ColumnWriter> create(

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -39,8 +39,11 @@ void Writer::write(const VectorPtr& slice) {
     length = std::min(length, slice->size() - offset);
     VELOX_CHECK_GT(length, 0);
     if (shouldFlush(context, length)) {
-      abandonLowValueDictionaries();
-      if (shouldFlush(context, length)) {
+      bool decision = true;
+      if (abandonLowValueDictionaries()) {
+        decision = shouldFlush(context, length);
+      }
+      if (decision) {
         flush();
       }
     }

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -66,8 +66,8 @@ class Writer : public WriterShared {
     writer_->writeFileStats(statsFactory);
   }
 
-  void abandonLowValueDictionaries() {
-    writer_->tryAbandonDictionaries(false);
+  bool abandonLowValueDictionaries() {
+    return writer_->tryAbandonDictionaries(false);
   }
 
   void abandonDictionariesImpl() override {

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -69,7 +69,7 @@ class WriterContext : public CompressionBufferPool {
       handler_ = std::make_unique<encryption::EncryptionHandler>();
     }
     validateConfigs();
-    LOG(INFO) << fmt::format("Compression config: {}", compression);
+    VLOG(1) << fmt::format("Compression config: {}", compression);
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }


### PR DESCRIPTION
Summary:
Return whether we actually performed the encoding change, this informs decisions to re-evaluate memory footprint. If we didn't perform the encoding change, we can save one call to flush policy.

This is relevant due to writer coordination in trabant. When we actually abandon dictionary it's good to let coordinated flush policy re-evaluate global memory pressure and we'll end up flushing a bigger stripe.

The rest of the changes are test refactoring and additional test coverage. It doesn't seem that abandonLowValueDictionary was thoroughly tested.

Differential Revision: D35354681

