### PR TITLE
Use KLL sketch in approx_percentile

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -22,8 +22,8 @@ target_link_libraries(
   ${FMT}
   ${GFLAGS_LIBRARIES})
 
-add_library(velox_common_base BitUtil.cpp RawVector.cpp SimdUtil.cpp
-                              SuccinctPrinter.cpp)
+add_library(velox_common_base BitUtil.cpp RandomUtil.cpp RawVector.cpp
+                              SimdUtil.cpp SuccinctPrinter.cpp)
 
 target_link_libraries(velox_common_base velox_exception velox_process)
 

--- a/velox/common/base/RandomUtil.cpp
+++ b/velox/common/base/RandomUtil.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/RandomUtil.h"
+
+#include <optional>
+
+#include <folly/Random.h>
+
+namespace facebook::velox::random {
+
+namespace {
+
+std::optional<uint32_t> customSeed;
+
+}
+
+void setSeed(uint32_t value) {
+  customSeed = value;
+}
+
+uint32_t getSeed() {
+  return customSeed ? *customSeed : folly::Random::rand32();
+}
+
+} // namespace facebook::velox::random

--- a/velox/common/base/RandomUtil.h
+++ b/velox/common/base/RandomUtil.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::velox::random {
+
+// Set a custom seed to be returned in all following getSeed() calls.
+// Should be only used in unit tests.
+void setSeed(uint32_t);
+
+// Return a true random seed unless setSeed() is called before.
+uint32_t getSeed();
+
+} // namespace facebook::velox::random

--- a/velox/functions/lib/KllSketch.cpp
+++ b/velox/functions/lib/KllSketch.cpp
@@ -27,7 +27,6 @@ namespace detail {
 namespace {
 
 constexpr uint8_t kMinBufferWidth = 8;
-constexpr uint8_t kMaxLevel = 60;
 
 double powerOfTwoThirds(int n) {
   static const auto kMemo = [] {

--- a/velox/functions/prestosql/aggregates/IOUtils.h
+++ b/velox/functions/prestosql/aggregates/IOUtils.h
@@ -31,6 +31,10 @@ struct OutputByteStream {
     offset_ += size;
   }
 
+  int32_t offset() const {
+    return offset_;
+  }
+
  private:
   char* data_;
   int32_t offset_;


### PR DESCRIPTION
Summary: Use KLL sketch to replace T-Digest implementation in `approx_percentile`.  This enables the variances with `accuracy` optional parameter.

Differential Revision: D35360228

