### PR TITLE
Change materialize type of Opaque to T instead of shared_ptr<T>

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -415,6 +415,13 @@ struct MaterializeType<Row<T...>> {
   static constexpr bool requiresMaterialization = true;
 };
 
+template <typename T>
+struct MaterializeType<std::shared_ptr<T>> {
+  using nullable_t = T;
+  using null_free_t = T;
+  static constexpr bool requiresMaterialization = false;
+};
+
 template <>
 struct MaterializeType<Varchar> {
   using nullable_t = std::string;
@@ -429,11 +436,19 @@ struct MaterializeType<Varbinary> {
   static constexpr bool requiresMaterialization = false;
 };
 
+template <typename T>
+struct is_shared_ptr : std::false_type {};
+
+template <typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
+
 // Helper function that calls materialize on element if it's not primitive.
 template <typename VeloxType, typename T>
 auto materializeElement(const T& element) {
   if constexpr (MaterializeType<VeloxType>::requiresMaterialization) {
     return element.materialize();
+  } else if constexpr (is_shared_ptr<VeloxType>::value) {
+    return *element;
   } else {
     return element;
   }

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -388,10 +388,10 @@ TEST_F(NullableArrayViewTest, materializeArrayWithOpaque) {
   exec::VectorReader<Array<std::shared_ptr<int64_t>>> reader(
       decode(decoded, *result.get()));
 
-  std::vector<std::optional<std::shared_ptr<int64_t>>> array =
-      reader[0].materialize();
+  std::vector<std::optional<int64_t>> array = reader[0].materialize();
   ASSERT_EQ(array.size(), 2);
-  ASSERT_EQ(*array[0].value(), 1);
+  ASSERT_EQ(array[0].value(), 1);
+
   ASSERT_FALSE(array[1].has_value());
 }
 


### PR DESCRIPTION
Summary:
This satisfies the current need, the path of materializing is
slow anyway and copies all data.

If in the future different needs rise we can support multiple
materialize types.

Differential Revision: D35370437

