### PR TITLE
Add support for encoded intermediate results

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -151,6 +151,10 @@ std::shared_ptr<Task> assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,
     const std::vector<RowVectorPtr>& expectedResults);
 
+std::shared_ptr<Task> assertQuery(
+    const CursorParameters& params,
+    const std::vector<RowVectorPtr>& expectedResults);
+
 velox::variant readSingleValue(
     const std::shared_ptr<const core::PlanNode>& plan);
 


### PR DESCRIPTION
Aggregate::addIntermediateResults may receive encoded input if for example there
is a local exchange before intermediate or final aggregation. That's because
local exchange uses dictionary encoding to avoid copying the data. Some
aggregate functions, count, array_agg, map_agg and checksum, assumed that input
to addIntermediateResults is always flag. This commit removes this assumptions
and updates the aggregate function to handle encoded input.