### PR TITLE
Add LocalPartitionNode.type property

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -355,8 +355,16 @@ void MergeExchangeNode::addDetails(std::stringstream& stream) const {
   addSortingKeys(stream, sortingKeys_, sortingOrders_);
 }
 
-void LocalPartitionNode::addDetails(std::stringstream& /* stream */) const {
+void LocalPartitionNode::addDetails(std::stringstream& stream) const {
   // Nothing to add.
+  switch (type_) {
+    case Type::kGather:
+      stream << "GATHER";
+      break;
+    case Type::kRepartition:
+      stream << "REPARTITION";
+      break;
+  }
 }
 
 void EnforceSingleRowNode::addDetails(std::stringstream& /* stream */) const {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -201,17 +201,20 @@ uint32_t maxDrivers(const DriverFactory& driverFactory) {
         return 1;
       }
     } else if (
-        auto localMerge =
-            std::dynamic_pointer_cast<const core::LocalMergeNode>(node)) {
+        auto localExchange =
+            std::dynamic_pointer_cast<const core::LocalPartitionNode>(node)) {
+      // Local gather must run single-threaded.
+      if (localExchange->type() == core::LocalPartitionNode::Type::kGather) {
+        return 1;
+      }
+    } else if (std::dynamic_pointer_cast<const core::LocalMergeNode>(node)) {
       // Local merge must run single-threaded.
       return 1;
-    } else if (
-        auto mergeExchange =
-            std::dynamic_pointer_cast<const core::MergeExchangeNode>(node)) {
-      // MergeExchange must run single-threaded.
+    } else if (std::dynamic_pointer_cast<const core::MergeExchangeNode>(node)) {
+      // Merge exchange must run single-threaded.
       return 1;
     } else if (std::dynamic_pointer_cast<const core::MergeJoinNode>(node)) {
-      // MergeJoinNode must run single-threaded.
+      // Merge join must run single-threaded.
       return 1;
     } else if (
         auto tableWrite =

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -353,7 +353,14 @@ TEST_F(PlanNodeToStringTest, localPartition) {
           .planNode();
 
   ASSERT_EQ("-> LocalPartition\n", plan->toString());
-  ASSERT_EQ("-> LocalPartition[]\n", plan->toString(true, false));
+  ASSERT_EQ("-> LocalPartition[REPARTITION]\n", plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .localPartition({}, {PlanBuilder().values({data_}).planNode()})
+             .planNode();
+
+  ASSERT_EQ("-> LocalPartition\n", plan->toString());
+  ASSERT_EQ("-> LocalPartition[GATHER]\n", plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, partitionedOutput) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -605,7 +605,12 @@ PlanBuilder& PlanBuilder::localPartition(
   auto partitionFunctionFactory =
       createPartitionFunctionFactory(inputType, keyIndices, keys);
   planNode_ = std::make_shared<core::LocalPartitionNode>(
-      nextPlanNodeId(), partitionFunctionFactory, outputType, sources);
+      nextPlanNodeId(),
+      keyIndices.empty() ? core::LocalPartitionNode::Type::kGather
+                         : core::LocalPartitionNode::Type::kRepartition,
+      partitionFunctionFactory,
+      outputType,
+      sources);
   return *this;
 }
 


### PR DESCRIPTION
Allow to explicitly specify whether LocalPartitionNode should collect
mutli-threaded input into a single stream for single-threaded processing.