### PR TITLE
Add vector compare benchmarks.

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -43,3 +43,7 @@ target_link_libraries(velox_benchmark_basic_decoded_vector
 add_executable(velox_benchmark_basic_selectivity_vector SelectivityVector.cpp)
 target_link_libraries(velox_benchmark_basic_selectivity_vector
                       ${velox_benchmark_deps})
+
+add_executable(velox_benchmark_basic_vector_compare VectorCompare.cpp)
+target_link_libraries(velox_benchmark_basic_vector_compare
+                      ${velox_benchmark_deps} velox_vector_test_lib)

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+
+class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit VectorCompareBenchmark(size_t vectorSize)
+      : FunctionBenchmarkBase(), vectorSize_(vectorSize), rows_(vectorSize) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = vectorSize_;
+    opts.nullChance = 0;
+    opts.containerVariableLength = 1000;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    flatVector_ = fuzzer.fuzzFlat(BIGINT());
+
+    arrayVector_ =
+        fuzzer.fuzzComplex(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+
+    mapVector_ = fuzzer.fuzzComplex(
+        std::make_shared<MapType>(MapType(BIGINT(), BIGINT())));
+
+    rowVector_ = fuzzer.fuzzComplex(
+        vectorMaker_.rowType({BIGINT(), BIGINT(), BIGINT()}));
+  }
+
+  size_t run(const VectorPtr& vector) {
+    size_t sum = 0;
+
+    for (auto i = 0; i < vectorSize_; i++) {
+      sum += vector->compare(vector.get(), i, i, flags);
+    }
+    folly::doNotOptimizeAway(sum);
+    return vectorSize_;
+  }
+
+  VectorPtr flatVector_;
+  VectorPtr arrayVector_;
+  VectorPtr mapVector_;
+  VectorPtr rowVector_;
+
+ private:
+  static constexpr CompareFlags flags{true, true, false};
+
+  const size_t vectorSize_;
+  SelectivityVector rows_;
+};
+
+std::unique_ptr<VectorCompareBenchmark> benchmark;
+
+BENCHMARK_MULTI(compareSimilarFlat) {
+  return benchmark->run(benchmark->flatVector_);
+}
+
+BENCHMARK_MULTI(compareSimilarArray) {
+  return benchmark->run(benchmark->arrayVector_);
+}
+
+BENCHMARK_MULTI(CompareSimilarMap) {
+  return benchmark->run(benchmark->mapVector_);
+}
+
+BENCHMARK_MULTI(CompareSimilarRow) {
+  return benchmark->run(benchmark->rowVector_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  benchmark = std::make_unique<VectorCompareBenchmark>(1000);
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(velox_vector velox_encode velox_memory velox_time
 add_subdirectory(arrow)
 add_subdirectory(fuzzer)
 
-if(${VELOX_BUILD_TESTING})
+if(${VELOX_BUILD_TESTING} OR ${VELOX_ENABLE_BENCHMARKS_BASIC})
   add_subdirectory(tests)
   add_subdirectory(benchmarks)
 endif()


### PR DESCRIPTION
Summary:
I will use this to evaluate the overhead of the stopAtNull
flag added in another PR.

This also will help guide the optimization for the comparison.
```
============================================================================
velox/benchmarks/basic/VectorCompare.cpp     relative  time/iter   iters/s
============================================================================
compareFlat                                                 6.24ns   160.38M
compareArray                                               17.12ns    58.40M
CompareMap                                                 67.15ns    14.89M
CompareRow                                                 71.42ns    14.00M
----------------------------------------------------------------------------
```

Differential Revision: D35380855

