### PR TITLE
Remove Driver::task_ member variable

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -145,31 +145,21 @@ class CancelGuard {
 };
 } // namespace
 
-Driver::~Driver() {
-  if (task_) {
-    LOG(ERROR) << "Driver destructed while still in Task: "
-               << task_->toString();
-    DLOG(FATAL) << "Driver destructed while referencing task";
-  }
-}
-
 // static
 void Driver::enqueue(std::shared_ptr<Driver> driver) {
   // This is expected to be called inside the Driver's Tasks's mutex.
   driver->enqueueInternal();
-  auto& task = driver->task_;
-  if (!task) {
+  if (driver->closed_) {
     return;
   }
-  task->queryCtx()->executor()->add([driver]() { Driver::run(driver); });
+  driver->task()->queryCtx()->executor()->add(
+      [driver]() { Driver::run(driver); });
 }
 
 Driver::Driver(
     std::unique_ptr<DriverCtx> ctx,
     std::vector<std::unique_ptr<Operator>>&& operators)
-    : ctx_(std::move(ctx)),
-      task_(ctx_->task),
-      operators_(std::move(operators)) {
+    : ctx_(std::move(ctx)), operators_(std::move(operators)) {
   curOpIndex_ = operators_.size() - 1;
   // Operators need access to their Driver for adaptation.
   ctx_->driver = this;
@@ -249,10 +239,7 @@ StopReason Driver::runInternal(
     std::shared_ptr<BlockingState>* blockingState) {
   auto queuedTime = (getCurrentTimeMicro() - queueTimeStartMicros_) * 1'000;
   // Update the next operator's queueTime.
-  // Get 'task_' into a local because this could be unhooked from it on another
-  // thread.
-  auto task = task_;
-  auto stop = !task ? StopReason::kTerminate : task->enter(state_);
+  auto stop = closed_ ? StopReason::kTerminate : task()->enter(state_);
   if (stop != StopReason::kNone) {
     if (stop == StopReason::kTerminate) {
       // ctx_ still has a reference to the Task. 'this' is not on
@@ -278,10 +265,10 @@ StopReason Driver::runInternal(
         "queuedWallNanos", queuedTime);
   }
 
-  CancelGuard guard(task_.get(), &state_, [&](StopReason reason) {
+  CancelGuard guard(task().get(), &state_, [&](StopReason reason) {
     // This is run on error or cancel exit.
     if (reason == StopReason::kTerminate) {
-      task->setError(std::make_exception_ptr(VeloxRuntimeError(
+      task()->setError(std::make_exception_ptr(VeloxRuntimeError(
           __FILE__,
           __LINE__,
           __FUNCTION__,
@@ -305,7 +292,7 @@ StopReason Driver::runInternal(
 
     for (;;) {
       for (int32_t i = numOperators - 1; i >= 0; --i) {
-        stop = task_->shouldStop();
+        stop = task()->shouldStop();
         if (stop != StopReason::kNone) {
           guard.notThrown();
           return stop;
@@ -360,7 +347,7 @@ StopReason Driver::runInternal(
               i += 2;
               continue;
             } else {
-              stop = task_->shouldStop();
+              stop = task()->shouldStop();
               if (stop != StopReason::kNone) {
                 guard.notThrown();
                 return stop;
@@ -405,12 +392,12 @@ StopReason Driver::runInternal(
       }
     }
   } catch (velox::VeloxException& e) {
-    task_->setError(std::current_exception());
-    // The CancelPoolGuard will close 'self' and remove from task_.
+    task()->setError(std::current_exception());
+    // The CancelPoolGuard will close 'self' and remove from Task.
     return StopReason::kAlreadyTerminated;
   } catch (std::exception& e) {
-    task_->setError(std::current_exception());
-    // The CancelGuard will close 'self' and remove from task_.
+    task()->setError(std::current_exception());
+    // The CancelGuard will close 'self' and remove from Task.
     return StopReason::kAlreadyTerminated;
   }
 }
@@ -461,12 +448,12 @@ void Driver::addStatsToTask() {
     auto& stats = op->stats();
     stats.memoryStats.update(op->pool()->getMemoryUsageTracker());
     stats.numDrivers = 1;
-    task_->addOperatorStats(stats);
+    task()->addOperatorStats(stats);
   }
 }
 
 void Driver::close() {
-  if (!task_) {
+  if (closed_) {
     // Already closed.
     return;
   }
@@ -477,9 +464,8 @@ void Driver::close() {
   for (auto& op : operators_) {
     op->close();
   }
-  auto task = std::move(task_);
-
-  Task::removeDriver(task, this);
+  closed_ = true;
+  Task::removeDriver(ctx_->task, this);
 }
 
 void Driver::closeByTask() {
@@ -488,11 +474,7 @@ void Driver::closeByTask() {
   for (auto& op : operators_) {
     op->close();
   }
-  task_ = nullptr;
-}
-
-void Driver::disconnectFromTask() {
-  task_ = nullptr;
+  closed_ = true;
 }
 
 bool Driver::mayPushdownAggregation(Operator* aggregation) const {
@@ -570,7 +552,7 @@ Driver::findOperator(std::string_view planNodeId) const {
 }
 
 void Driver::setError(std::exception_ptr exception) {
-  ctx_->task->setError(exception);
+  task()->setError(exception);
 }
 
 std::string Driver::toString() {
@@ -601,7 +583,7 @@ SuspendedSection::~SuspendedSection() {
 }
 
 std::string Driver::label() const {
-  return fmt::format("<Driver {}:{}>", ctx_->task->taskId(), ctx_->driverId);
+  return fmt::format("<Driver {}:{}>", task()->taskId(), ctx_->driverId);
 }
 
 std::string blockingReasonToString(BlockingReason reason) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -201,8 +201,6 @@ class Driver {
       std::unique_ptr<DriverCtx> driverCtx,
       std::vector<std::unique_ptr<Operator>>&& operators);
 
-  ~Driver();
-
   static void run(std::shared_ptr<Driver> self);
 
   static void enqueue(std::shared_ptr<Driver> instance);
@@ -248,17 +246,13 @@ class Driver {
     return ctx_.get();
   }
 
-  std::shared_ptr<Task> task() const {
-    return task_;
+  const std::shared_ptr<Task>& task() const {
+    return ctx_->task;
   }
 
-  // Updates the stats in 'task_' and frees resources. Only called by Task for
+  // Updates the stats in Task and frees resources. Only called by Task for
   // closing non-running Drivers.
   void closeByTask();
-
-  // This is called if the creation of drivers failed and we want to disconnect
-  // driver from the task before driver's destruction.
-  void disconnectFromTask();
 
  private:
   void enqueueInternal();
@@ -274,9 +268,9 @@ class Driver {
   void pushdownFilters(int operatorIndex);
 
   std::unique_ptr<DriverCtx> ctx_;
-  std::shared_ptr<Task> task_;
+  std::atomic_bool closed_{false};
 
-  // Set via Task_ and serialized by 'task_'s mutex.
+  // Set via Task and serialized by Task's mutex.
   ThreadState state_;
 
   // Timer used to track down the time we are sitting in the driver queue.

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -328,52 +328,42 @@ void Task::createDriversLocked(
     std::shared_ptr<Task>& self,
     uint32_t splitGroupId,
     std::vector<std::shared_ptr<Driver>>& out) {
-  try {
-    auto& splitGroupState = self->splitGroupStates_[splitGroupId];
-    const auto numPipelines = driverFactories_.size();
-    for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
-      auto& factory = driverFactories_[pipeline];
-      const uint32_t driverIdOffset = factory->numDrivers * splitGroupId;
-      for (uint32_t partitionId = 0; partitionId < factory->numDrivers;
-           ++partitionId) {
-        out.emplace_back(factory->createDriver(
-            std::make_unique<DriverCtx>(
-                self,
-                driverIdOffset + partitionId,
-                pipeline,
-                splitGroupId,
-                partitionId),
-            self->exchangeClients_[pipeline],
-            [self](size_t i) {
-              return i < self->driverFactories_.size()
-                  ? self->driverFactories_[i]->numTotalDrivers
-                  : 0;
-            }));
-        ++splitGroupState.activeDrivers;
-      }
+  auto& splitGroupState = self->splitGroupStates_[splitGroupId];
+  const auto numPipelines = driverFactories_.size();
+  for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
+    auto& factory = driverFactories_[pipeline];
+    const uint32_t driverIdOffset = factory->numDrivers * splitGroupId;
+    for (uint32_t partitionId = 0; partitionId < factory->numDrivers;
+         ++partitionId) {
+      out.emplace_back(factory->createDriver(
+          std::make_unique<DriverCtx>(
+              self,
+              driverIdOffset + partitionId,
+              pipeline,
+              splitGroupId,
+              partitionId),
+          self->exchangeClients_[pipeline],
+          [self](size_t i) {
+            return i < self->driverFactories_.size()
+                ? self->driverFactories_[i]->numTotalDrivers
+                : 0;
+          }));
+      ++splitGroupState.activeDrivers;
     }
-    noMoreLocalExchangeProducers(splitGroupId);
-    ++numRunningSplitGroups_;
+  }
+  noMoreLocalExchangeProducers(splitGroupId);
+  ++numRunningSplitGroups_;
 
-    // Initialize operator stats using the 1st driver of each operator.
-    if (not initializedOpStats_) {
-      initializedOpStats_ = true;
-      size_t driverIndex{0};
-      for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
-        auto& factory = self->driverFactories_[pipeline];
-        out[driverIndex]->initializeOperatorStats(
-            self->taskStats_.pipelineStats[pipeline].operatorStats);
-        driverIndex += factory->numDrivers;
-      }
+  // Initialize operator stats using the 1st driver of each operator.
+  if (not initializedOpStats_) {
+    initializedOpStats_ = true;
+    size_t driverIndex{0};
+    for (auto pipeline = 0; pipeline < numPipelines; ++pipeline) {
+      auto& factory = self->driverFactories_[pipeline];
+      out[driverIndex]->initializeOperatorStats(
+          self->taskStats_.pipelineStats[pipeline].operatorStats);
+      driverIndex += factory->numDrivers;
     }
-  } catch (std::exception& e) {
-    // If one of the drivers threw in creation, we need to remove task pointer
-    // from already created drivers or we will face another throw (or even a
-    // crash).
-    for (auto& driver : out) {
-      driver->disconnectFromTask();
-    }
-    throw;
   }
 }
 


### PR DESCRIPTION
Before this change Driver held two references to task: direct (task_ member
variable) and via DriverCtx (ctx_.task). Direct reference was dropped in
Driver::closeByTask and Driver::disconnectFromTask, but the other references
remained until Driver is destroyed.

Having two references is redundant, hence, this change is to remove task_ member 
variable and use ctx_.task instead.