### PR TITLE
Add number of splits and threads to printPlanWithStats

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -457,6 +457,7 @@ void Driver::addStatsToTask() {
   for (auto& op : operators_) {
     auto& stats = op->stats();
     stats.memoryStats.update(op->pool()->getMemoryUsageTracker());
+    stats.driverIds.insert(driverCtx()->driverId);
     task_->addOperatorStats(stats);
   }
 }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -457,7 +457,7 @@ void Driver::addStatsToTask() {
   for (auto& op : operators_) {
     auto& stats = op->stats();
     stats.memoryStats.update(op->pool()->getMemoryUsageTracker());
-    stats.driverIds.insert(driverCtx()->driverId);
+    stats.driverCount = 1;
     task_->addOperatorStats(stats);
   }
 }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -457,7 +457,7 @@ void Driver::addStatsToTask() {
   for (auto& op : operators_) {
     auto& stats = op->stats();
     stats.memoryStats.update(op->pool()->getMemoryUsageTracker());
-    stats.driverCount = 1;
+    stats.numDrivers = 1;
     task_->addOperatorStats(stats);
   }
 }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -326,6 +326,7 @@ void OperatorStats::add(const OperatorStats& other) {
   for (const auto& stat : other.runtimeStats) {
     runtimeStats[stat.first].merge(stat.second);
   }
+  driverIds.insert(other.driverIds.begin(), other.driverIds.end());
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -327,7 +327,7 @@ void OperatorStats::add(const OperatorStats& other) {
     runtimeStats[stat.first].merge(stat.second);
   }
 
-  driverCount += other.driverCount;
+  numDrivers += other.numDrivers;
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -326,7 +326,8 @@ void OperatorStats::add(const OperatorStats& other) {
   for (const auto& stat : other.runtimeStats) {
     runtimeStats[stat.first].merge(stat.second);
   }
-  driverIds.insert(other.driverIds.begin(), other.driverIds.end());
+
+  driverCount += other.driverCount;
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -130,7 +130,7 @@ struct OperatorStats {
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
 
-  int driverCount = 0;
+  int numDrivers = 0;
 
   OperatorStats(
       int32_t _operatorId,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -129,6 +129,7 @@ struct OperatorStats {
   MemoryStats memoryStats;
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
+  std::set<int> driverIds;
 
   OperatorStats(
       int32_t _operatorId,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -129,7 +129,8 @@ struct OperatorStats {
   MemoryStats memoryStats;
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
-  std::set<int> driverIds;
+
+  int driverCount = 0;
 
   OperatorStats(
       int32_t _operatorId,

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -57,9 +57,9 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   // useful. Each operator could have been executed in different pipelines with
   // different number of drivers.
   if (!isMultiOperatorNode()) {
-    driverCount += stats.driverCount;
+    numDrivers += stats.numDrivers;
   } else {
-    driverCount = 0;
+    numDrivers = 0;
   }
 
   numSplits += stats.numSplits;
@@ -81,8 +81,8 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes);
 
-  if (driverCount > 0) {
-    out << ", Threads: " << driverCount;
+  if (numDrivers > 0) {
+    out << ", Threads: " << numDrivers;
   }
 
   if (numSplits > 0) {

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -52,14 +52,16 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   for (const auto& entry : stats.runtimeStats) {
     customStats[entry.first].merge(entry.second);
   }
+
   // Populating drivers for plan nodes with multiple operators is not useful.
   // Each operator could have been executed in different pipelines with
   // different number of drivers.
   if (!isMultiOperatorNode()) {
-    driverIds.insert(stats.driverIds.begin(), stats.driverIds.end());
+    driverCount += stats.driverCount;
   } else {
-    driverIds.clear();
+    driverCount = 0;
   }
+
   numSplits += stats.numSplits;
 }
 
@@ -79,12 +81,12 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes);
 
-  if (!driverIds.empty()) {
-    out << ", Threads: " << driverIds.size();
+  if (driverCount > 0) {
+    out << ", Threads: " << driverCount;
   }
 
   if (numSplits > 0) {
-    out << ", NumSplits: " << numSplits;
+    out << ", Splits: " << numSplits;
   }
   return out.str();
 }

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -20,8 +20,6 @@
 namespace facebook::velox::exec {
 
 void PlanNodeStats::add(const OperatorStats& stats) {
-  addTotals(stats);
-
   auto it = operatorStats.find(stats.operatorType);
   if (it != operatorStats.end()) {
     it->second->addTotals(stats);
@@ -30,6 +28,7 @@ void PlanNodeStats::add(const OperatorStats& stats) {
     opStats->addTotals(stats);
     operatorStats.emplace(stats.operatorType, std::move(opStats));
   }
+  addTotals(stats);
 }
 
 void PlanNodeStats::addTotals(const OperatorStats& stats) {
@@ -53,6 +52,15 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   for (const auto& entry : stats.runtimeStats) {
     customStats[entry.first].merge(entry.second);
   }
+  // Populating drivers for plan nodes with multiple operators is not useful.
+  // Each operator could have been executed in different pipelines with
+  // different number of drivers.
+  if (!isMultiOperatorNode()) {
+    driverIds.insert(stats.driverIds.begin(), stats.driverIds.end());
+  } else {
+    driverIds.clear();
+  }
+  numSplits += stats.numSplits;
 }
 
 std::string PlanNodeStats::toString(bool includeInputStats) const {
@@ -60,7 +68,7 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
   if (includeInputStats) {
     out << "Input: " << inputRows << " rows (" << succinctBytes(inputBytes)
         << "), ";
-    if (rawInputRows != inputRows) {
+    if ((rawInputRows > 0) && (rawInputRows != inputRows)) {
       out << "Raw Input: " << rawInputRows << " rows ("
           << succinctBytes(rawInputBytes) << "), ";
     }
@@ -70,6 +78,14 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
       << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes);
+
+  if (!driverIds.empty()) {
+    out << ", Threads: " << driverIds.size();
+  }
+
+  if (numSplits > 0) {
+    out << ", NumSplits: " << numSplits;
+  }
   return out.str();
 }
 
@@ -135,13 +151,13 @@ std::string printPlanWithStats(
         const bool includeInputStats = leafPlanNodes.count(planNodeId) > 0;
         stream << stats.toString(includeInputStats);
 
-        // Include break down by operator type if there are more than one of
-        // these.
-        if (stats.operatorStats.size() > 1) {
+        // Include break down by operator type for plan nodes with multiple
+        // operators. Print input rows and sizes for all such nodes.
+        if (stats.isMultiOperatorNode()) {
           for (const auto& entry : stats.operatorStats) {
             stream << std::endl;
             stream << indentation << entry.first << ": "
-                   << entry.second->toString(includeInputStats);
+                   << entry.second->toString(true);
 
             if (includeCustomStats) {
               printCustomStats(

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -53,8 +53,8 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
     customStats[entry.first].merge(entry.second);
   }
 
-  // Populating drivers for plan nodes with multiple operators is not useful.
-  // Each operator could have been executed in different pipelines with
+  // Populating number of drivers for plan nodes with multiple operators is not
+  // useful. Each operator could have been executed in different pipelines with
   // different number of drivers.
   if (!isMultiOperatorNode()) {
     driverCount += stats.driverCount;

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -85,7 +85,7 @@ struct PlanNodeStats {
   std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
 
   /// Drivers that executed the pipeline.
-  std::set<int> driverIds;
+  int driverCount{0};
 
   /// Number of total splits.
   int numSplits{0};

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -84,7 +84,7 @@ struct PlanNodeStats {
   /// Breakdown of stats by operator type.
   std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
 
-  /// Drivers that executed the pipeline.
+  /// Number of drivers that executed the pipeline.
   int driverCount{0};
 
   /// Number of total splits.

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -85,7 +85,7 @@ struct PlanNodeStats {
   std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
 
   /// Number of drivers that executed the pipeline.
-  int driverCount{0};
+  int numDrivers{0};
 
   /// Number of total splits.
   int numSplits{0};

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -84,10 +84,20 @@ struct PlanNodeStats {
   /// Breakdown of stats by operator type.
   std::unordered_map<std::string, std::unique_ptr<PlanNodeStats>> operatorStats;
 
+  /// Drivers that executed the pipeline.
+  std::set<int> driverIds;
+
+  /// Number of total splits.
+  int numSplits{0};
+
   /// Add stats for a single operator instance.
   void add(const OperatorStats& stats);
 
   std::string toString(bool includeInputStats = false) const;
+
+  bool isMultiOperatorNode() const {
+    return operatorStats.size() > 1;
+  }
 
  private:
   void addTotals(const OperatorStats& stats);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -705,7 +705,7 @@ TEST_P(TableScanTest, statsBasedSkippingBool) {
   EXPECT_EQ(20'000, getTableScanStats(task).rawInputRows);
   EXPECT_EQ(2, getSkippedStridesStat(task));
   EXPECT_EQ(1, getTableScanStats(task).numSplits);
-  EXPECT_EQ(1, getTableScanStats(task).driverIds.size());
+  EXPECT_EQ(1, getTableScanStats(task).driverCount);
 
   subfieldFilters = singleSubfieldFilter("c1", boolEqual(false));
   task = assertQuery("SELECT c0 FROM tmp WHERE c1 = false");

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -704,6 +704,8 @@ TEST_P(TableScanTest, statsBasedSkippingBool) {
   auto task = assertQuery("SELECT c0 FROM tmp WHERE c1 = true");
   EXPECT_EQ(20'000, getTableScanStats(task).rawInputRows);
   EXPECT_EQ(2, getSkippedStridesStat(task));
+  EXPECT_EQ(1, getTableScanStats(task).numSplits);
+  EXPECT_EQ(1, getTableScanStats(task).driverIds.size());
 
   subfieldFilters = singleSubfieldFilter("c1", boolEqual(false));
   task = assertQuery("SELECT c0 FROM tmp WHERE c1 = false");

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -705,7 +705,7 @@ TEST_P(TableScanTest, statsBasedSkippingBool) {
   EXPECT_EQ(20'000, getTableScanStats(task).rawInputRows);
   EXPECT_EQ(2, getSkippedStridesStat(task));
   EXPECT_EQ(1, getTableScanStats(task).numSplits);
-  EXPECT_EQ(1, getTableScanStats(task).driverCount);
+  EXPECT_EQ(1, getTableScanStats(task).numDrivers);
 
   subfieldFilters = singleSubfieldFilter("c1", boolEqual(false));
   task = assertQuery("SELECT c0 FROM tmp WHERE c1 = false");


### PR DESCRIPTION
Add split and driver counts to OperatorStats and PlanNodeStats.

Extend the output of printPlanWithStats to include the number of splits for leaf
nodes and the number of threads (drivers used by the pipeline). The number of
threads is excluded for plan nodes that contain multiple operators. 

Also, print input stats for all operators that belong to plan nodes with
multiple operators.

Sample partial output for q18 without custom stats.

```
-> LocalPartition[]
       Output: 1248 rows (145.60MB), Cpu time: 500.19ms, Blocked wall time: 6.10s, Peak memory: 0B
       LocalPartition: Input: 624 rows (72.77MB), Output: 624 rows (72.77MB), Cpu time: 498.21ms, Blocked wall time: 62.29ms, Peak memory: 0B, Threads: 8
       LocalExchangeSource: Input: 624 rows (72.83MB), Output: 624 rows (72.83MB), Cpu time: 1.98ms, Blocked wall time: 6.03s, Peak memory: 0B, Threads: 1
      -> HashJoin[INNER o_custkey=c_custkey]
         Output: 624 rows (72.77MB), Cpu time: 950.41ms, Blocked wall time: 2.90s, Peak memory: 37.00MB
         HashBuild: Input: 1500000 rows (0B), Output: 0 rows (0B), Cpu time: 689.25ms, Blocked wall time: 511.59ms, Peak memory: 36.00MB, Threads: 8
         HashProbe: Input: 624 rows (48.38MB), Output: 624 rows (72.77MB), Cpu time: 261.16ms, Blocked wall time: 2.39s, Peak memory: 1.00MB, Threads: 8
        -> HashJoin[INNER o_orderkey=l_orderkey]
           Output: 624 rows (48.38MB), Cpu time: 18.29ms, Blocked wall time: 44.45s, Peak memory: 2.00MB
           HashBuild: Input: 624 rows (14.03KB), Output: 0 rows (0B), Cpu time: 1.34ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Threads: 1
           HashProbe: Input: 80619 rows (48.33MB), Output: 624 rows (48.38MB), Cpu time: 16.95ms, Blocked wall time: 44.45s, Peak memory: 1.00MB, Threads: 8
          -> TableScan[Table: orders]
             Input: 80619 rows (48.33MB), Raw Input: 14861668 rows (224.66MB), Output: 80619 rows (48.33MB), Cpu time: 560.08ms, Blocked wall time: 81.00us, Peak memory: 24.00MB, Threads: 8, Splits: 80
```