### PR TITLE
Extend lifetime of LocalExchangeMemoryManager

### DIFF
--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -48,8 +48,10 @@ class LocalExchangeMemoryManager {
 /// Consumers call 'next' repeatedly to fetch the data.
 class LocalExchangeSource {
  public:
-  LocalExchangeSource(LocalExchangeMemoryManager* memoryManager, int partition)
-      : memoryManager_{memoryManager}, partition_{partition} {}
+  LocalExchangeSource(
+      std::shared_ptr<LocalExchangeMemoryManager> memoryManager,
+      int partition)
+      : memoryManager_{std::move(memoryManager)}, partition_{partition} {}
 
   std::string toString() const {
     return fmt::format("LocalExchangeSource({})", partition_);
@@ -94,7 +96,7 @@ class LocalExchangeSource {
  private:
   bool isFinishedLocked(const std::queue<RowVectorPtr>& queue) const;
 
-  LocalExchangeMemoryManager* memoryManager_;
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
   const int partition_;
   folly::Synchronized<std::queue<RowVectorPtr>> queue_;
   // Satisfied when data becomes available or all producers report that they

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1127,13 +1127,13 @@ void Task::createLocalExchangeSourcesLocked(
   // TODO(spershin): Should we have one memory manager for all local exchanges
   //  in all split groups?
   LocalExchange exchange;
-  exchange.memoryManager = std::make_unique<LocalExchangeMemoryManager>(
+  exchange.memoryManager = std::make_shared<LocalExchangeMemoryManager>(
       queryCtx_->config().maxLocalExchangeBufferSize());
 
   exchange.sources.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
     exchange.sources.emplace_back(
-        std::make_shared<LocalExchangeSource>(exchange.memoryManager.get(), i));
+        std::make_shared<LocalExchangeSource>(exchange.memoryManager, i));
   }
 
   splitGroupState.localExchanges.insert({planNodeId, std::move(exchange)});

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -66,7 +66,7 @@ struct SplitsState {
 
 /// Stores local exchange sources with the memory manager.
 struct LocalExchange {
-  std::unique_ptr<LocalExchangeMemoryManager> memoryManager;
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager;
   std::vector<std::shared_ptr<LocalExchangeSource>> sources;
 };
 


### PR DESCRIPTION
LocalExchangeSource may live for a little bit longer after Task::terminate which
clears runtime state including an instance of LocalExchangeMemoryManager. This
leads to accessing freed memory and triggers ASAN heap-use-after-free
failures.

```
SUMMARY: AddressSanitizer: heap-use-after-free velox/exec/LocalPartition.cpp:33 in facebook::velox::exec::LocalExchangeMemoryManager::increaseMemoryUsage(folly::SemiFuture<bool>*, long)
```

The fix is to allow LocalExchangeSource to extend lifetime of LocalExchangeMemoryManager 
via std::shared_ptr.