### PR TITLE
Add blocked driver count stats

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -46,6 +46,8 @@ velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
   return task->addOperatorPool(pool);
 }
 
+std::atomic_uint64_t BlockingState::numBlockedDrivers_{0};
+
 BlockingState::BlockingState(
     std::shared_ptr<Driver> driver,
     ContinueFuture&& future,
@@ -61,6 +63,7 @@ BlockingState::BlockingState(
               .count()) {
   // Set before leaving the thread.
   driver_->state().hasBlockingFuture = true;
+  numBlockedDrivers_++;
 }
 
 // static

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -139,6 +139,10 @@ class BlockingState {
       Operator* FOLLY_NONNULL op,
       BlockingReason reason);
 
+  ~BlockingState() {
+    numBlockedDrivers_--;
+  }
+
   static void setResume(std::shared_ptr<BlockingState> state);
 
   Operator* FOLLY_NONNULL op() {
@@ -149,12 +153,20 @@ class BlockingState {
     return reason_;
   }
 
+  /// Returns total number of drivers process wide that are currently in blocked
+  /// state.
+  static uint64_t numBlockedDrivers() {
+    return numBlockedDrivers_;
+  }
+
  private:
   std::shared_ptr<Driver> driver_;
   ContinueFuture future_;
   Operator* FOLLY_NONNULL operator_;
   BlockingReason reason_;
   uint64_t sinceMicros_;
+
+  static std::atomic_uint64_t numBlockedDrivers_;
 };
 
 struct DriverCtx {


### PR DESCRIPTION
Summary: Add blocked driver count stats that reflects the total number of blocked drivers process wide

Reviewed By: amitkdutta, mbasmanova

Differential Revision: D35328191

