### PR TITLE
Stricter coordinated flush policy as protection against OOMs

### DIFF
--- a/velox/dwio/common/FlushPolicy.h
+++ b/velox/dwio/common/FlushPolicy.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::dwio::common {
+
+struct StripeProgress {
+  explicit StripeProgress() = default;
+  StripeProgress(
+      int64_t stripeIndex,
+      int64_t totalMemoryUsage,
+      int64_t stripeSizeEstimate)
+      : stripeIndex{stripeIndex},
+        totalMemoryUsage{totalMemoryUsage},
+        stripeSizeEstimate{stripeSizeEstimate} {}
+
+  int64_t stripeIndex{0};
+  int64_t totalMemoryUsage{0};
+  // hide first stripe special case in customer side.
+  int64_t stripeSizeEstimate{0};
+
+  bool compare(const StripeProgress& other) const {
+    return stripeSizeEstimate < other.stripeSizeEstimate;
+  }
+};
+
+// Specific formats can extend this interface to do additional
+// checks and customize how the decisions are combined.
+class IFlushPolicy {
+ public:
+  virtual ~IFlushPolicy() = default;
+  virtual bool shouldFlush(StripeProgress&& stripeProgress) = 0;
+  virtual void close() = 0;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -40,6 +40,8 @@ void Writer::write(const VectorPtr& slice) {
     VELOX_CHECK_GT(length, 0);
     if (shouldFlush(context, length)) {
       abandonLowValueDictionaries();
+      // D35354681 will avoid unnecessarily churns in the
+      // flush policy.
       if (shouldFlush(context, length)) {
         flush();
       }

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -69,7 +69,7 @@ class WriterContext : public CompressionBufferPool {
       handler_ = std::make_unique<encryption::EncryptionHandler>();
     }
     validateConfigs();
-    LOG(INFO) << fmt::format("Compression config: {}", compression);
+    VLOG(1) << fmt::format("Compression config: {}", compression);
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }


### PR DESCRIPTION
Summary:
Previously the `shouldFlush()` path of coordinator just returns true for the writer elected to flush and free up memory under memory pressure, and doesn't have a way to have other writers wait for said flush. Consequently, memory pressure threshold has to be set to be a much lower percent of total budget. It was a cheap and loose heuristic to keep under global memory budget. This is undesirable as it would trigger premature flushes more often and impact read efficiency.

This iteration implements waiting for the rest of the writers and allows us to actually protect against OOMs as long as we leave enough memory for complete execution of one writer + memory increment from one batch for each writer on the host. In other words, it changes from a heuristics to a robust and rare guardrail mechanism. The protection is important for the worker layer resource management against underestimation.

For any typical writer task attempting to produce 72MB stripes, the required head room would be <0.5GB + 8MB for each parallel writer. This means we can actually set the memory threshold to >90% for a realistic 32GB memory budget production tier.

Differential Revision: D35263955

