### PR TITLE
Add option for TpchBenchmark to print custom statistics

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -51,12 +51,6 @@ static bool validateDataFormat(const char* flagname, const std::string& value) {
       << std::endl;
   return false;
 }
-
-static bool isFlagSet(const char* flagName) {
-  gflags::CommandLineFlagInfo flagInfo;
-  gflags::GetCommandLineFlagInfo(flagName, &flagInfo);
-  return !flagInfo.is_default;
-}
 } // namespace
 
 DEFINE_string(data_path, "", "Root path of TPC-H data");
@@ -137,18 +131,11 @@ BENCHMARK(q18) {
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
-  bool runQueryVerboseSet = isFlagSet("run_query_verbose");
-  if (not runQueryVerboseSet && isFlagSet("include_custom_stats")) {
-    std::cout
-        << "--include_custom_stats must be specified only with --run_query_verbose"
-        << std::endl;
-    exit(1);
-  }
   benchmark.initialize();
   queryBuilder =
       std::make_shared<TpchQueryBuilder>(toFileFormat(FLAGS_data_format));
   queryBuilder->initialize(FLAGS_data_path);
-  if (!runQueryVerboseSet) {
+  if (FLAGS_run_query_verbose == -1) {
     folly::runBenchmarks();
   } else {
     const auto queryPlan = queryBuilder->getQueryPlan(FLAGS_run_query_verbose);

--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -140,9 +140,6 @@ int main(int argc, char** argv) {
   } else {
     const auto queryPlan = queryBuilder->getQueryPlan(FLAGS_run_query_verbose);
     const auto task = benchmark.run(queryPlan);
-    // The Task can return results before the Driver is finished executing.
-    // Wait for the Task to finish. This will ensure the Drivers are finished
-    // executing and all the stats are updated.
     waitForTaskCompletion(task.get());
     const auto stats = task->taskStats();
     std::cout << fmt::format(

--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -51,6 +51,11 @@ static bool validateDataFormat(const char* flagname, const std::string& value) {
       << std::endl;
   return false;
 }
+
+void ensureTaskCompletion(exec::Task* task) {
+  // ASSERT_TRUE requires a function with return type void.
+  ASSERT_TRUE(waitForTaskCompletion(task));
+}
 } // namespace
 
 DEFINE_string(data_path, "", "Root path of TPC-H data");
@@ -140,7 +145,7 @@ int main(int argc, char** argv) {
   } else {
     const auto queryPlan = queryBuilder->getQueryPlan(FLAGS_run_query_verbose);
     const auto task = benchmark.run(queryPlan);
-    waitForTaskCompletion(task.get());
+    ensureTaskCompletion(task.get());
     const auto stats = task->taskStats();
     std::cout << fmt::format(
                      "Execution time: {}",

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -718,10 +718,10 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
   return {std::move(cursor), std::move(result)};
 }
 
-void waitForTaskCompletion(exec::Task* task) {
+void waitForTaskCompletion(exec::Task* task, uint64_t maxWaitMicros) {
   if (not task->isFinished()) {
     auto& executor = folly::QueuedImmediateExecutor::instance();
-    auto future = task->stateChangeFuture(1'000'000).via(&executor);
+    auto future = task->stateChangeFuture(maxWaitMicros).via(&executor);
     future.wait();
     EXPECT_TRUE(task->isFinished());
   }

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -764,7 +764,7 @@ std::shared_ptr<Task> assertQuery(
   }
   auto task = cursor->task();
 
-  waitForTaskCompletion(task.get());
+  EXPECT_TRUE(waitForTaskCompletion(task.get()));
 
   return task;
 }

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -720,9 +720,6 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
 
 void waitForTaskCompletion(exec::Task* task) {
   if (not task->isFinished()) {
-    // The Task can return results before the Driver is finished executing.
-    // Wait for the Task to finish before returning it to ensure it's stable
-    // e.g. the Driver isn't updating it anymore.
     auto& executor = folly::QueuedImmediateExecutor::instance();
     auto future = task->stateChangeFuture(1'000'000).via(&executor);
     future.wait();

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -718,13 +718,14 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
   return {std::move(cursor), std::move(result)};
 }
 
-void waitForTaskCompletion(exec::Task* task, uint64_t maxWaitMicros) {
+bool waitForTaskCompletion(exec::Task* task, uint64_t maxWaitMicros) {
   if (not task->isFinished()) {
     auto& executor = folly::QueuedImmediateExecutor::instance();
     auto future = task->stateChangeFuture(maxWaitMicros).via(&executor);
     future.wait();
-    EXPECT_TRUE(task->isFinished());
+    return task->isFinished();
   }
+  return true;
 }
 
 std::shared_ptr<Task> assertQuery(

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -111,10 +111,12 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits);
 
-// The Task can return results before the Driver is finished executing.
-// Wait for the Task to finish before returning to ensure it's stable
-// e.g. the Driver isn't updating it anymore.
-void waitForTaskCompletion(exec::Task* task);
+/// The Task can return results before the Driver is finished executing.
+/// Wait upto maxWaitMicros for the Task to finish before returning to ensure
+/// it's stable e.g. the Driver isn't updating it anymore.
+void waitForTaskCompletion(
+    exec::Task* task,
+    uint64_t maxWaitMicros = 1'000'000);
 
 std::shared_ptr<Task> assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -111,6 +111,8 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits);
 
+void waitForTaskCompletion(exec::Task* task);
+
 std::shared_ptr<Task> assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,
     const std::string& duckDbSql,

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -114,7 +114,8 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
 /// The Task can return results before the Driver is finished executing.
 /// Wait upto maxWaitMicros for the Task to finish before returning to ensure
 /// it's stable e.g. the Driver isn't updating it anymore.
-void waitForTaskCompletion(
+/// Returns true if the task is completed before maxWaitMicros expires.
+bool waitForTaskCompletion(
     exec::Task* task,
     uint64_t maxWaitMicros = 1'000'000);
 

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -111,6 +111,9 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits);
 
+// The Task can return results before the Driver is finished executing.
+// Wait for the Task to finish before returning to ensure it's stable
+// e.g. the Driver isn't updating it anymore.
 void waitForTaskCompletion(exec::Task* task);
 
 std::shared_ptr<Task> assertQuery(


### PR DESCRIPTION
Add  --include_custom_stats option that will include custom statistics along with execution statistics.

Also, add a check to ensure the drivers are finished before printing statistics.