### PR TITLE
Revert PR 1363 Add debug time checks to BaseVector asUnchecked

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -132,14 +132,12 @@ class BaseVector {
   template <typename T>
   T* asUnchecked() {
     static_assert(std::is_base_of<BaseVector, T>::value);
-    DCHECK(dynamic_cast<const T*>(this) != nullptr);
     return static_cast<T*>(this);
   }
 
   template <typename T>
   const T* asUnchecked() const {
     static_assert(std::is_base_of<BaseVector, T>::value);
-    DCHECK(dynamic_cast<const T*>(this) != nullptr);
     return static_cast<const T*>(this);
   }
 


### PR DESCRIPTION
Summary:
We're still not sure why, but somehow this seems related to ExprTest.constantArray failing in the linux-build CircleCI job.

Reverting to fix trunk while we continue to investigate.

Differential Revision: D35450065

