### PR TITLE
Improve usability of PlanBuilder::partitionedOutput

### DIFF
--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -173,7 +173,7 @@ TEST_F(LocalPartitionTest, partition) {
 
   auto op = PlanBuilder(planNodeIdGenerator)
                 .localPartition(
-                    {0},
+                    {"c0"},
                     {
                         scanAggNode(),
                         scanAggNode(),
@@ -273,7 +273,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
 
   auto op = PlanBuilder(planNodeIdGenerator)
                 .localPartition(
-                    {0},
+                    {"c0"},
                     {
                         scanNode(),
                         scanNode(),
@@ -353,7 +353,7 @@ TEST_F(LocalPartitionTest, outputLayoutGather) {
                         valuesNode(2),
                     },
                     // Change column order: (c0, c1) -> (c1, c0).
-                    {1, 0})
+                    {"c1", "c0"})
                 .singleAggregation({}, {"count(1)", "min(c0)", "max(c1)"})
                 .planNode();
 
@@ -370,7 +370,7 @@ TEST_F(LocalPartitionTest, outputLayoutGather) {
                    valuesNode(2),
                },
                // Drop column: (c0, c1) -> (c1).
-               {1})
+               {"c1"})
            .singleAggregation({}, {"count(1)", "min(c1)", "max(c1)"})
            .planNode();
 
@@ -422,14 +422,14 @@ TEST_F(LocalPartitionTest, outputLayoutPartition) {
   params.planNode =
       PlanBuilder(planNodeIdGenerator)
           .localPartition(
-              {0},
+              {"c0"},
               {
                   valuesNode(0),
                   valuesNode(1),
                   valuesNode(2),
               },
               // Change column order: (c0, c1) -> (c1, c0).
-              {1, 0})
+              {"c1", "c0"})
           .partialAggregation({}, {"count(1)", "min(c0)", "max(c1)"})
           .planNode();
 
@@ -441,14 +441,14 @@ TEST_F(LocalPartitionTest, outputLayoutPartition) {
   params.planNode =
       PlanBuilder(planNodeIdGenerator)
           .localPartition(
-              {0},
+              {"c0"},
               {
                   valuesNode(0),
                   valuesNode(1),
                   valuesNode(2),
               },
               // Drop column: (c0, c1) -> (c1).
-              {1})
+              {"c1"})
           .partialAggregation({}, {"count(1)", "min(c1)", "max(c1)"})
           .planNode();
 
@@ -459,7 +459,7 @@ TEST_F(LocalPartitionTest, outputLayoutPartition) {
   planNodeIdGenerator->reset();
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .localPartition(
-                            {0},
+                            {"c0"},
                             {
                                 valuesNode(0),
                                 valuesNode(1),
@@ -509,10 +509,10 @@ TEST_F(LocalPartitionTest, multipleExchanges) {
   // exchange re-partitions the results on just the first key.
   auto op = PlanBuilder(planNodeIdGenerator)
                 .localPartition(
-                    {0},
+                    {"c0"},
                     {PlanBuilder(planNodeIdGenerator)
                          .localPartition(
-                             {0, 1},
+                             {"c0", "c1"},
                              {
                                  tableScanNode(),
                                  tableScanNode(),

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -348,7 +348,7 @@ TEST_F(PlanNodeToStringTest, unnest) {
 TEST_F(PlanNodeToStringTest, localPartition) {
   auto plan =
       PlanBuilder()
-          .localPartition({0}, {PlanBuilder().values({data_}).planNode()})
+          .localPartition({"c0"}, {PlanBuilder().values({data_}).planNode()})
           .planNode();
 
   ASSERT_EQ("-> LocalPartition\n", plan->toString());
@@ -364,7 +364,7 @@ TEST_F(PlanNodeToStringTest, localPartition) {
 
 TEST_F(PlanNodeToStringTest, partitionedOutput) {
   auto plan =
-      PlanBuilder().values({data_}).partitionedOutput({0}, 4).planNode();
+      PlanBuilder().values({data_}).partitionedOutput({"c0"}, 4).planNode();
 
   ASSERT_EQ("-> PartitionedOutput\n", plan->toString());
   ASSERT_EQ("-> PartitionedOutput[HASH(c0) 4]\n", plan->toString(true, false));
@@ -381,7 +381,7 @@ TEST_F(PlanNodeToStringTest, partitionedOutput) {
 
   plan = PlanBuilder()
              .values({data_})
-             .partitionedOutput({1, 2}, 5, true)
+             .partitionedOutput({"c1", "c2"}, 5, true)
              .planNode();
 
   ASSERT_EQ("-> PartitionedOutput\n", plan->toString());

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1870,10 +1870,11 @@ TEST_P(TableScanTest, groupedExecutionWithOutputBuffer) {
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, vectors);
 
-  auto planFragment = PlanBuilder()
-                          .tableScan(rowType_)
-                          .partitionedOutput({}, 1, {0, 1, 2, 3, 4, 5})
-                          .planFragment();
+  auto planFragment =
+      PlanBuilder()
+          .tableScan(rowType_)
+          .partitionedOutput({}, 1, {"c0", "c1", "c2", "c3", "c4", "c5"})
+          .planFragment();
   planFragment.numSplitGroups = 10;
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   auto queryCtx = core::QueryCtx::createForTest();

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -303,23 +303,23 @@ class PlanBuilder {
       const std::string& name);
 
   PlanBuilder& partitionedOutput(
-      const std::vector<ChannelIndex>& keyIndices,
+      const std::vector<std::string>& keys,
       int numPartitions,
-      const std::vector<ChannelIndex>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {});
 
   PlanBuilder& partitionedOutputBroadcast(
-      const std::vector<ChannelIndex>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {});
 
   PlanBuilder& partitionedOutput(
-      const std::vector<ChannelIndex>& keyIndices,
+      const std::vector<std::string>& keys,
       int numPartitions,
       bool replicateNullsAndAny,
-      const std::vector<ChannelIndex>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {});
 
   PlanBuilder& localPartition(
-      const std::vector<ChannelIndex>& keyIndices,
+      const std::vector<std::string>& keys,
       const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
-      const std::vector<ChannelIndex>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {});
 
   // 'leftKeys' and 'rightKeys' are column names of the output of the
   // previous PlanNode and 'build', respectively. 'output' is a subset of

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -288,7 +288,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
   auto bigOrders =
       PlanBuilder(planNodeIdGenerator)
           .localPartition(
-              {0}, // l_orderkey
+              {"l_orderkey"},
               {PlanBuilder(planNodeIdGenerator)
                    .tableScan(
                        lineitemSelectedRowType,

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -84,7 +84,7 @@ TEST_F(ArrayAggTest, groupBy) {
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .localPartition(
-                            {0},
+                            {"C0"},
                             {PlanBuilder(planNodeIdGenerator)
                                  .values(batches)
                                  .partialAggregation({0}, {"array_agg(A)"})

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -120,7 +120,7 @@ class ChecksumAggregateTest : public AggregationTestBase {
       CursorParameters params;
       params.planNode = PlanBuilder(planNodeIdGenerator)
                             .localPartition(
-                                {0},
+                                {"c0"},
                                 {PlanBuilder(planNodeIdGenerator)
                                      .values(rowVectors)
                                      .partialAggregation({0}, {"checksum(c1)"})

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -105,7 +105,7 @@ TEST_F(CountAggregation, count) {
     CursorParameters params;
     params.planNode = PlanBuilder(planNodeIdGenerator)
                           .localPartition(
-                              {0},
+                              {"p0"},
                               {PlanBuilder(planNodeIdGenerator)
                                    .values(vectors)
                                    .project({"c0 % 10", "c1"})

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -87,7 +87,7 @@ TEST_F(MapAggTest, groupBy) {
   CursorParameters params;
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .localPartition(
-                            {0},
+                            {"c0"},
                             {PlanBuilder(planNodeIdGenerator)
                                  .values(vectors)
                                  .partialAggregation({0}, {"map_agg(c1, c2)"})


### PR DESCRIPTION
Update PlanBuilder.{partitionedOutput, partitionedOutputBroadcast,
localPartition} methods to take partitioning keys and output columns by name
instead of by index.