### PR TITLE
Disable Q18 in ParquetTpchTest

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -162,7 +162,7 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6, 2, 10);
 }
 
-TEST_F(ParquetTpchTest, Q18) {
+TEST_F(ParquetTpchTest, DISABLED_Q18) {
   assertQuery(18, 5, 30);
 }
 

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -162,6 +162,9 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6, 2, 10);
 }
 
+// This test started to fail after dynamic filters
+// are always pushed that was introduced in
+// https://github.com/facebookincubator/velox/pull/1314
 TEST_F(ParquetTpchTest, DISABLED_Q18) {
   assertQuery(18, 5, 30);
 }


### PR DESCRIPTION
This test started to fail after a change to always push down dynamic filters from 
joins into scans in: `https://github.com/facebookincubator/velox/pull/1314`
