### PR TITLE
Rename local exchange classes for clarity

### DIFF
--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -48,7 +48,7 @@ ExchangeNode                Exchange                                         Y
 MergeExchangeNode           MergeExchange                                    Y
 ValuesNode                  Values                                           Y
 LocalMergeNode              LocalMerge
-LocalPartitionNode          LocalPartition and LocalExchangeSourceOperator
+LocalPartitionNode          LocalPartition and LocalExchange
 EnforceSingleRowNode        EnforceSingleRow
 AssignUniqueIdNode          AssignUniqueId
 ==========================  ==============================================   ===========================
@@ -414,6 +414,8 @@ combines data from multiple streams into a single stream.
 
    * - Property
      - Description
+   * - Type
+     - Type of the exchange: gather or repartition.
    * - partitionFunctionFactory
      - Factory to make partition functions to use when calculating partitions for input rows.
    * - outputType

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -344,7 +344,7 @@ struct DriverFactory {
 
   /// Returns LocalPartition plan node ID if the pipeline gets data from a local
   /// exchange.
-  std::optional<core::PlanNodeId> needsLocalExchangeSource() const {
+  std::optional<core::PlanNodeId> needsLocalExchange() const {
     VELOX_CHECK(!planNodes.empty());
     if (auto exchangeNode =
             std::dynamic_pointer_cast<const core::LocalPartitionNode>(

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -378,7 +378,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         auto localPartitionNode =
             std::dynamic_pointer_cast<const core::LocalPartitionNode>(
                 planNode)) {
-      operators.push_back(std::make_unique<LocalExchangeSourceOperator>(
+      operators.push_back(std::make_unique<LocalExchange>(
           id,
           ctx.get(),
           localPartitionNode->outputType(),

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -283,20 +283,20 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
-  void createLocalExchangeSourcesLocked(
+  void createLocalExchangeQueuesLocked(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
       int numPartitions);
 
   void noMoreLocalExchangeProducers(uint32_t splitGroupId);
 
-  std::shared_ptr<LocalExchangeSource> getLocalExchangeSource(
+  std::shared_ptr<LocalExchangeQueue> getLocalExchangeQueue(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
       int partition);
 
-  const std::vector<std::shared_ptr<LocalExchangeSource>>&
-  getLocalExchangeSources(
+  const std::vector<std::shared_ptr<LocalExchangeQueue>>&
+  getLocalExchangeQueues(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -64,10 +64,10 @@ struct SplitsState {
   SplitsState& operator=(SplitsState const&) = delete;
 };
 
-/// Stores local exchange sources with the memory manager.
-struct LocalExchange {
+/// Stores local exchange queues with the memory manager.
+struct LocalExchangeState {
   std::shared_ptr<LocalExchangeMemoryManager> memoryManager;
-  std::vector<std::shared_ptr<LocalExchangeSource>> sources;
+  std::vector<std::shared_ptr<LocalExchangeQueue>> queues;
 };
 
 /// Stores inter-operator state (exchange, bridges) for split groups.
@@ -88,7 +88,7 @@ struct SplitGroupState {
       mergeJoinSources;
 
   /// Map of local exchanges keyed on LocalPartition plan node ID.
-  std::unordered_map<core::PlanNodeId, LocalExchange> localExchanges;
+  std::unordered_map<core::PlanNodeId, LocalExchangeState> localExchanges;
 
   /// Drivers created and still running for this split group.
   /// The split group is finished when this numbers reaches zero.


### PR DESCRIPTION
We used to have:

* LocalExchangeSourceOperator - an operator consuming data from local exchange
* LocalExchangeSource - the queue of data written to by LocalPartition operator and read from by LocalExchangeSourceOperator

LocalExchangeSourceOperator name was not consistent with other operator names: TableScan, FilterProject, LocalPartition, etc.

LocalExchangeSource name conflicts with another class in anonymous namespace in velox/exec/Exchange.cpp. That other class is an implementation of ExchangeSource that reads data from local PartitionedOutputBufferManager.

Here, we renamed the operator to LocalExchange and the queue to LocalExchangeQueue. The operator name is now consistent with all other operators and matches Exchange operator. LocalExchangeQueue no longer conflicts with LocalExchangeSource.