### PR TITLE
Fix DISTINCT + LIMIT queries

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -515,6 +515,16 @@ class Task : public std::enable_shared_from_this<Task> {
   // the promise/future pair.
   ContinueFuture makeFinishFutureLocked(const char* FOLLY_NONNULL comment);
 
+  bool isOutputPipeline(int pipelineId) const {
+    return driverFactories_[pipelineId]->outputDriver;
+  }
+
+  uint32_t numDrivers(int pipelineId) const {
+    return driverFactories_[pipelineId]->numDrivers;
+  }
+
+  int getOutputPipelineId() const;
+
   const std::string taskId_;
   core::PlanFragment planFragment_;
   const int destination_;

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -92,7 +92,14 @@ struct SplitGroupState {
 
   /// Drivers created and still running for this split group.
   /// The split group is finished when this numbers reaches zero.
-  uint32_t activeDrivers{0};
+  uint32_t numRunningDrivers{0};
+
+  /// The number of completed drivers in the output pipeline. When all drivers
+  /// in the output pipeline finish, the remaining running pipelines should stop
+  /// processing and transition to finished state as well. This happens when
+  /// there is a downstream operator that finishes before receiving all input,
+  /// e.g. Limit.
+  uint32_t numFinishedOutputDrivers{0};
 
   /// Clears the state.
   void clear() {

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/common/caching/DataCache.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/DataSink.h"
-#include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
@@ -32,28 +29,8 @@ using namespace facebook::velox::connector::hive;
 
 using facebook::velox::test::BatchMaker;
 
-class MultiFragmentTest : public OperatorTestBase {
+class MultiFragmentTest : public HiveConnectorTestBase {
  protected:
-  void SetUp() override {
-    OperatorTestBase::SetUp();
-    rowType_ =
-        ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
-            {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()});
-    filesystems::registerLocalFileSystem();
-    auto dataCache = std::make_unique<SimpleLRUDataCache>(/*size=*/1 << 30);
-    auto hiveConnector =
-        connector::getConnectorFactory(HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(kHiveConnectorId, nullptr, std::move(dataCache));
-    connector::registerConnector(hiveConnector);
-    dwrf::registerDwrfReaderFactory();
-  }
-
-  void TearDown() override {
-    dwrf::unregisterDwrfReaderFactory();
-    connector::unregisterConnector(kHiveConnectorId);
-    OperatorTestBase::TearDown();
-  }
-
   static std::string makeTaskId(const std::string& prefix, int num) {
     return fmt::format("local://{}-{}", prefix, num);
   }
@@ -67,36 +44,6 @@ class MultiFragmentTest : public OperatorTestBase {
     core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
         taskId, std::move(planFragment), destination, std::move(queryCtx));
-  }
-
-  void writeToFile(const std::string& filePath, RowVectorPtr vector) {
-    writeToFile(filePath, std::vector{vector});
-  }
-
-  void writeToFile(
-      const std::string& filePath,
-      const std::vector<RowVectorPtr>& vectors) {
-    facebook::velox::dwrf::WriterOptions options;
-    options.config = std::make_shared<facebook::velox::dwrf::Config>();
-    options.schema = rowType_;
-    auto sink = std::make_unique<facebook::velox::dwio::common::FileSink>(
-        filePath, facebook::velox::dwio::common::MetricsLog::voidLog());
-    facebook::velox::dwrf::Writer writer{options, std::move(sink), *pool_};
-
-    for (size_t i = 0; i < vectors.size(); ++i) {
-      writer.write(vectors[i]);
-    }
-    writer.close();
-  }
-
-  static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count) {
-    std::vector<std::shared_ptr<TempFilePath>> filePaths;
-
-    filePaths.reserve(count);
-    for (auto i = 0; i < count; ++i) {
-      filePaths.emplace_back(TempFilePath::create());
-    }
-    return filePaths;
   }
 
   std::vector<RowVectorPtr> makeVectors(int count, int rowsPerVector) {
@@ -165,7 +112,9 @@ class MultiFragmentTest : public OperatorTestBase {
     createDuckDbTable(vectors_);
   }
 
-  std::shared_ptr<const RowType> rowType_;
+  RowTypePtr rowType_{
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
   std::unordered_map<std::string, std::string> configSettings_;
   std::vector<std::shared_ptr<TempFilePath>> filePaths_;
   std::vector<RowVectorPtr> vectors_;
@@ -510,20 +459,31 @@ TEST_F(MultiFragmentTest, limit) {
   auto data = makeRowVector({makeFlatVector<int32_t>(
       1'000, [](auto row) { return row; }, nullEvery(7))});
 
+  auto file = TempFilePath::create();
+  writeToFile(file->path, {data});
+
   // Make leaf task: Values -> PartialLimit(1) -> Repartitioning(0).
   auto leafTaskId = makeTaskId("leaf", 0);
-  auto leafPlan = PlanBuilder()
-                      .values({data})
-                      .limit(0, 1, false)
-                      .partitionedOutput({}, 1)
-                      .planNode();
+  auto leafPlan =
+      PlanBuilder()
+          .tableScan(std::dynamic_pointer_cast<const RowType>(data->type()))
+          .limit(0, 10, false)
+          .partitionedOutput({}, 1)
+          .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   Task::start(leafTask, 1);
 
+  addSplit(leafTask.get(), "0", makeHiveSplit(file->path));
+
   // Make final task: Exchange -> FinalLimit(1).
-  auto plan = PlanBuilder()
-                  .exchange(leafPlan->outputType())
-                  .limit(0, 1, false)
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .localPartition(
+                      {},
+                      {PlanBuilder(planNodeIdGenerator)
+                           .exchange(leafPlan->outputType())
+                           .planNode()})
+                  .limit(0, 10, false)
                   .planNode();
 
   auto split =
@@ -540,6 +500,9 @@ TEST_F(MultiFragmentTest, limit) {
         task->addSplit("0", std::move(split));
         splitAdded = true;
       },
-      "SELECT null",
+      "VALUES (null), (1), (2), (3), (4), (5), (6), (7), (8), (9)",
       duckDbQueryRunner_);
+
+  ASSERT_TRUE(waitForTaskCompletion(task.get()));
+  ASSERT_TRUE(waitForTaskCompletion(leafTask.get()));
 }


### PR DESCRIPTION
Limit operator finishes early if the limit is reached before the operator
received all the input. In this case, the Driver closes all upstream operators
and finished early. If this is the only Driver in the Task, the Task finishes early
as well. However, when there are multiple pipelines, upstream pipelines need 
to be explicitly closed.

This change uses Task::terminate to finish upstream pipelines early when
output pipeline is finished and output has been consumed. This change 
applies only to un-grouped execution. With this change 
`SELECT DISTINCT c FROM t LIMIT 10` Presto queries finish quickly even 
when 't' is a very large table. Before this change such queries would finish 
only after all splits for 't' are enumerated and sent to workers, which could 
take minutes.

A more generic change would be to introduce a mechanism similar to 
Task::terminate which can finish early only a subset of pipelines in a Task, 
not all pipelines. This mechanism then could be used with grouped execution
to finish early pipelines only for a given split group. It could also be used to 
finish early upstream pipelines when a pipeline other than output pipeline 
finishes early.