### PR TITLE
Set RowContainer rowSize for out-of-line data and accumulators

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -156,6 +156,7 @@ void HashStringAllocator::newSlab(int32_t size) {
 
   // Write end  marker.
   *reinterpret_cast<uint32_t*>(run + available) = Header::kArenaEnd;
+  cumulativeBytes_ += available;
 
   // Add the new memory to the free list: Placement construct a header
   // that covers the space from start to the end marker and add this
@@ -272,6 +273,7 @@ HashStringAllocator::allocateFromFreeList(
   if (next) {
     next->clearPreviousFree();
   }
+  cumulativeBytes_ += found->size();
   if (isFinalSize) {
     freeRestOfBlock(found, preferredSize);
   }
@@ -288,6 +290,7 @@ void HashStringAllocator::free(Header* _header) {
     }
     VELOX_CHECK(!header->isFree());
     freeBytes_ += header->size() + sizeof(Header);
+    cumulativeBytes_ -= header->size();
     Header* next = header->next();
     if (next) {
       VELOX_CHECK(!next->isPreviousFree());

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -161,14 +161,18 @@ TEST_F(HashStringAllocatorTest, stlAllocator) {
   {
     std::vector<double, StlAllocator<double>> data(
         StlAllocator<double>(instance_.get()));
+    uint32_t counter{0};
+    {
+      RowSizeTracker trackSize(counter, *instance_);
 
-    // The contiguous size goes to 80K, rounded to 128K by
-    // std::vector. This covers making an extra-large slab in the
-    // allocator.
-    for (auto i = 0; i < 10'000; i++) {
-      data.push_back(i);
+      // The contiguous size goes to 80K, rounded to 128K by
+      // std::vector. This covers making an extra-large slab in the
+      // allocator.
+      for (auto i = 0; i < 10'000; i++) {
+        data.push_back(i);
+      }
     }
-
+    EXPECT_LE(128 * 1024, counter);
     for (auto i = 0; i < 10'000; i++) {
       ASSERT_EQ(i, data[i]);
     }

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -370,6 +370,7 @@ void RowContainer::storeComplexType(
     row[nullByte] |= nullMask;
     return;
   }
+  RowSizeTracker tracker(row[rowSizeOffset_], stringAllocator_);
   ByteStream stream(&stringAllocator_, false, false);
   auto position = stringAllocator_.newWrite(stream);
   serde_.serialize(*decoded.base(), decoded.index(index), stream);

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -138,6 +138,11 @@ class RowContainer {
              : 0);
   }
 
+  // The row size excluding any out-of-line stored variable length values.
+  int32_t fixedRowSize() const {
+    return fixedRowSize_;
+  }
+
   // Adds 'rows' to the free rows list and frees any associated
   // variable length data.
   void eraseRows(folly::Range<char**> rows);
@@ -413,6 +418,7 @@ class RowContainer {
     }
     *reinterpret_cast<T*>(row + offset) = decoded.valueAt<T>(index);
     if constexpr (std::is_same<T, StringView>::value) {
+      RowSizeTracker tracker(row[rowSizeOffset_], stringAllocator_);
       stringAllocator_.copyMultipart(row, offset);
     }
   }
@@ -426,6 +432,7 @@ class RowContainer {
     using T = typename TypeTraits<Kind>::NativeType;
     *reinterpret_cast<T*>(group + offset) = decoded.valueAt<T>(index);
     if constexpr (std::is_same<T, StringView>::value) {
+      RowSizeTracker tracker(group[rowSizeOffset_], stringAllocator_);
       stringAllocator_.copyMultipart(group, offset);
     }
   }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -113,6 +113,15 @@ class RowContainerTest : public testing::Test {
     }
   }
 
+  void checkSizes(std::vector<char*>& rows, RowContainer& data) {
+    int64_t sum = 0;
+    for (auto row : rows) {
+      sum += data.rowSize(row) - data.fixedRowSize();
+    }
+    auto usage = data.stringAllocator().cumulativeBytes();
+    EXPECT_EQ(usage, sum);
+  }
+
   // Stores the input vector in Row Container, extracts it and compares.
   void roundTrip(const VectorPtr& input) {
     // Create row container.
@@ -315,6 +324,7 @@ TEST_F(RowContainerTest, types) {
   EXPECT_EQ(kNumRows, data->listRows(&iter, kNumRows, rows.data()));
   EXPECT_EQ(data->listRows(&iter, kNumRows, rows.data()), 0);
 
+  checkSizes(rows, *data);
   SelectivityVector allRows(kNumRows);
   for (auto column = 0; column < batch->childrenSize(); ++column) {
     if (column < keys.size()) {
@@ -328,6 +338,7 @@ TEST_F(RowContainerTest, types) {
       data->store(decoded, index, rows[index], column);
     }
   }
+  checkSizes(rows, *data);
   data->checkConsistency();
   auto copy = std::static_pointer_cast<RowVector>(
       BaseVector::create(batch->type(), batch->size(), pool_.get()));


### PR DESCRIPTION
Adds a RowSizeTracker utility to HashStringAllocator. This is a scoped
guard that updates a size counter with the delta in allocation between
creation and destruction. Approximate row sizes are needed for
spilling and for deciding aggregation and hash join result vector
sizes. Both need to keep a reasonable batch size in the presence of
outlier row sizes.  The counter is maintained with saturating
semantics so that it does not wrap around. A counter set at max value
signifies that the item is large and should in any case be the last in
its batch of spilling or result set. Exactly how large it is does not
affect this decision. Something that is too large t to be copied into
a vector by itself will fail the query.

This applies to assigning variable width values in RowContainer and to
variable size aggregates in a group by.

Adds RowSizeTracker to RowContainer setters and variable width
accumulators.