### PR TITLE
Remove encoding switch safety check

### DIFF
--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -369,11 +369,6 @@ class WriterContext : public CompressionBufferPool {
     return ceil(flushOverheadRatioTracker_.getEstimatedRatio() * dataRawSize);
   }
 
-  // At this point we won't have data to estimate flush overhead.
-  int64_t getEstimatedEncodingSwitchOverhead() const {
-    return stripeRawSize;
-  }
-
   bool checkLowMemoryMode() const {
     return checkLowMemoryMode_;
   }


### PR DESCRIPTION
Summary:
The encoding switch check really is redundant due to how the current memory budget control plane works:
* writer always checks whether the incoming batch would cause the writer to breach memory budget at flush time and flushes before writing it if necessary.
* Though technically the peak memory increase for switching encoding is always guaranteed to be higher than writing the current data with dictionary encoding due to writing the original values instead of indices, we use a very very conservative estimate for flush overhead check at the first stripe.

That being said, we will wrap this away for StaticBudgetFlushPolicy only in case for power users and not by default. The static budget flush policy (when an actual memory budget is specified) would cause a very early flush in the first stripe due to the overestimation and only becomes more reasonable afterward.

Differential Revision: D35541938

