### PR TITLE
Add context to exceptions from evalSpecialForm()

### DIFF
--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -25,6 +25,9 @@ void ConstantExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   if (!sharedSubexprValues_) {
     sharedSubexprValues_ =
         BaseVector::createConstant(value_, 1, context->execCtx()->pool());
@@ -55,6 +58,9 @@ void ConstantExpr::evalSpecialFormSimplified(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   // Simplified path should never ask us to write to a vector that was already
   // pre-allocated.
   VELOX_CHECK(*result == nullptr);
@@ -79,6 +85,9 @@ void FieldReference::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   if (*result) {
     BaseVector::ensureWritable(rows, type_, context->pool(), result);
   }
@@ -149,6 +158,9 @@ void FieldReference::evalSpecialFormSimplified(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   auto row = context->row();
   *result = row->childAt(index(context));
   BaseVector::flattenVector(result, rows.end());
@@ -158,6 +170,9 @@ void SwitchExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   LocalSelectivityVector remainingRows(context, rows.end());
   *remainingRows.get() = rows;
 
@@ -352,6 +367,9 @@ void ConjunctExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   // TODO Revisit error handling
   bool throwOnError = *context->mutableThrowOnError();
   VarSetter saveError(context->mutableThrowOnError(), false);
@@ -702,6 +720,9 @@ void LambdaExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   if (!typeWithCapture_) {
     makeTypeWithCapture(context);
   }
@@ -754,6 +775,9 @@ void TryExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx* context,
     VectorPtr* result) {
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
   VarSetter throwOnError(context->mutableThrowOnError(), false);
   // It's possible with nested TRY expressions that some rows already threw
   // exceptions in earlier expressions that haven't been handled yet. To avoid

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -16,6 +16,7 @@
 
 #include <limits>
 #include "velox/buffer/Buffer.h"
+#include "velox/common/base/VeloxException.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/ControlExpr.h"
 #include "velox/expression/VectorFunction.h"
@@ -186,7 +187,7 @@ class CastExprTest : public functions::test::FunctionBaseTest {
       EXPECT_THROW(
           evaluate<FlatVector<typename CppToType<TTo>::NativeType>>(
               castFunction + "(c0 as " + typeString + ")", rowVector),
-          std::invalid_argument);
+          VeloxException);
       return;
     }
     // run try cast and get the result vector
@@ -379,7 +380,7 @@ TEST_F(CastExprTest, truncateVsRound) {
   EXPECT_THROW(
       (testCast<int32_t, int8_t>(
           "tinyint", {1111111, 2, 3, 1000, -100101}, {71, 2, 3, -24, -5})),
-      std::invalid_argument);
+      folly::ConversionError);
 }
 
 TEST_F(CastExprTest, nullInputs) {
@@ -610,8 +611,7 @@ TEST_F(CastExprTest, testNullOnFailure) {
   testComplexCast("c0", input, expected, true);
 
   // nullOnFailure is false, so we should throw.
-  EXPECT_THROW(
-      testComplexCast("c0", input, expected, false), std::invalid_argument);
+  EXPECT_THROW(testComplexCast("c0", input, expected, false), VeloxUserError);
 }
 
 TEST_F(CastExprTest, toString) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -135,7 +135,7 @@ struct Converter<
         return folly::to<T>(v);
       }
     } catch (const std::exception& e) {
-      throw std::invalid_argument(e.what());
+      VELOX_USER_FAIL(e.what());
     }
   }
 
@@ -147,7 +147,7 @@ struct Converter<
         return folly::to<T>(folly::StringPiece(v));
       }
     } catch (const std::exception& e) {
-      throw std::invalid_argument(e.what());
+      VELOX_USER_FAIL(e.what());
     }
   }
 
@@ -159,7 +159,7 @@ struct Converter<
         return folly::to<T>(v);
       }
     } catch (const std::exception& e) {
-      throw std::invalid_argument(e.what());
+      VELOX_USER_FAIL(e.what());
     }
   }
 
@@ -288,7 +288,7 @@ struct Converter<
     try {
       return folly::to<T>(v);
     } catch (const std::exception& e) {
-      throw std::invalid_argument(e.what());
+      VELOX_USER_FAIL(e.what());
     }
   }
 


### PR DESCRIPTION
Summary: Context information about the expression being evaluated was added to error messages thrown in Expr::eval() in https://github.com/facebookincubator/velox/pull/1138. This diff add the context infomration to errors messages thrown in evalSpecialForm() and evalSpecialFormSimplified() of ConstantExpr, FieldReference, SwitchExpr, ConjunctExpr, LambdaExpr, and CastExpr.

Differential Revision: D35557075

