### PR TITLE
Add Decimal type

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -33,6 +33,7 @@ Supported types are:
   * TIMESTAMP
   * REAL
   * DOUBLE
+  * DECIMAL
   * VARCHAR
   * VARBINARY
   * OPAQUE*

--- a/velox/type/ShortDecimal.h
+++ b/velox/type/ShortDecimal.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/dynamic.h>
+#include <sstream>
+#include <string>
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/StringView.h"
+
+#pragma once
+
+namespace facebook::velox {
+
+struct ShortDecimal {
+ public:
+  constexpr ShortDecimal() : unscaledValue_(0) {}
+  constexpr ShortDecimal(int64_t value) : unscaledValue_(value) {}
+
+  int64_t unscaledValue() const {
+    return unscaledValue_;
+  }
+
+  bool operator==(const ShortDecimal& other) const {
+    return unscaledValue_ == other.unscaledValue_;
+  }
+
+  bool operator!=(const ShortDecimal& other) const {
+    return unscaledValue_ != other.unscaledValue_;
+  }
+
+  bool operator<(const ShortDecimal& other) const {
+    return unscaledValue_ < other.unscaledValue_;
+  }
+
+  bool operator<=(const ShortDecimal& other) const {
+    return unscaledValue_ <= other.unscaledValue_;
+  }
+
+  bool operator>(const ShortDecimal& other) const {
+    return unscaledValue_ > other.unscaledValue_;
+  }
+
+  bool operator>=(const ShortDecimal& other) const {
+    return unscaledValue_ >= other.unscaledValue_;
+  }
+
+  // Needed for serialization of FlatVector<ShortDecimal>
+  operator StringView() const {
+    VELOX_NYI();
+  }
+
+  std::string toString() const;
+
+  operator std::string() const {
+    return toString();
+  }
+
+  operator folly::dynamic() const {
+    return folly::dynamic(unscaledValue_);
+  }
+
+ private:
+  int64_t unscaledValue_;
+};
+} // namespace facebook::velox
+
+namespace std {
+template <>
+struct hash<::facebook::velox::ShortDecimal> {
+  size_t operator()(const ::facebook::velox::ShortDecimal& value) const {
+    return std::hash<int64_t>{}(value.unscaledValue());
+  }
+};
+
+std::string to_string(const ::facebook::velox::ShortDecimal& ts);
+
+} // namespace std
+
+namespace folly {
+template <>
+struct hasher<::facebook::velox::ShortDecimal> {
+  size_t operator()(const ::facebook::velox::ShortDecimal& value) const {
+    return std::hash<int64_t>{}(value.unscaledValue());
+  }
+};
+} // namespace folly

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -59,6 +59,8 @@ const std::unordered_map<std::string, TypeKind>& getTypeStringMap() {
       {"VARBINARY", TypeKind::VARBINARY},
       {"TIMESTAMP", TypeKind::TIMESTAMP},
       {"DATE", TypeKind::DATE},
+      {"SHORT_DECIMAL", TypeKind::SHORT_DECIMAL},
+      {"LONG_DECIMAL", TypeKind::LONG_DECIMAL},
       {"ARRAY", TypeKind::ARRAY},
       {"MAP", TypeKind::MAP},
       {"ROW", TypeKind::ROW},
@@ -102,6 +104,8 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
       {TypeKind::VARBINARY, "VARBINARY"},
       {TypeKind::TIMESTAMP, "TIMESTAMP"},
       {TypeKind::DATE, "DATE"},
+      {TypeKind::SHORT_DECIMAL, "SHORT_DECIMAL"},
+      {TypeKind::LONG_DECIMAL, "LONG_DECIMAL"},
       {TypeKind::ARRAY, "ARRAY"},
       {TypeKind::MAP, "MAP"},
       {TypeKind::ROW, "ROW"},
@@ -579,6 +583,25 @@ KOSKI_DEFINE_SCALAR_ACCESSOR(DATE);
 KOSKI_DEFINE_SCALAR_ACCESSOR(UNKNOWN);
 
 #undef KOSKI_DEFINE_SCALAR_ACCESSOR
+
+std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<ShortDecimalType>(precision, scale);
+}
+
+std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<LongDecimalType>(precision, scale);
+}
+
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale) {
+  if (precision <= DecimalType<TypeKind::SHORT_DECIMAL>::kMaxPrecision) {
+    return SHORT_DECIMAL(precision, scale);
+  }
+  return LONG_DECIMAL(precision, scale);
+}
 
 std::shared_ptr<const Type> createScalarType(TypeKind kind) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(createScalarType, kind);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -37,11 +37,14 @@
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/Date.h"
+#include "velox/type/ShortDecimal.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
 
 namespace facebook::velox {
+
+using int128_t = __int128_t;
 
 // Velox type system supports a small set of SQL-compatible composeable types:
 // BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, VARCHAR,
@@ -69,7 +72,8 @@ enum class TypeKind : int8_t {
   VARBINARY = 8,
   TIMESTAMP = 9,
   DATE = 10,
-
+  SHORT_DECIMAL = 11,
+  LONG_DECIMAL = 12,
   // Enum values for ComplexTypes start after 30 to leave
   // some values space to accommodate adding new scalar/native
   // types above.
@@ -95,7 +99,8 @@ std::ostream& operator<<(std::ostream& os, const TypeKind& kind);
 
 template <TypeKind KIND>
 class ScalarType;
-
+template <TypeKind KIND>
+class DecimalType;
 class ArrayType;
 class MapType;
 class RowType;
@@ -271,6 +276,32 @@ struct TypeTraits<TypeKind::DATE> {
   static constexpr bool isPrimitiveType = true;
   static constexpr bool isFixedWidth = true;
   static constexpr const char* name = "DATE";
+};
+
+template <>
+struct TypeTraits<TypeKind::SHORT_DECIMAL> {
+  using ImplType = DecimalType<TypeKind::SHORT_DECIMAL>;
+  using NativeType = ShortDecimal;
+  using DeepCopiedType = NativeType;
+  static constexpr uint32_t minSubTypes = 0;
+  static constexpr uint32_t maxSubTypes = 0;
+  static constexpr TypeKind typeKind = TypeKind::SHORT_DECIMAL;
+  static constexpr bool isPrimitiveType = true;
+  static constexpr bool isFixedWidth = true;
+  static constexpr const char* name = "SHORT_DECIMAL";
+};
+
+template <>
+struct TypeTraits<TypeKind::LONG_DECIMAL> {
+  using ImplType = DecimalType<TypeKind::LONG_DECIMAL>;
+  using NativeType = int128_t;
+  using DeepCopiedType = NativeType;
+  static constexpr uint32_t minSubTypes = 0;
+  static constexpr uint32_t maxSubTypes = 0;
+  static constexpr TypeKind typeKind = TypeKind::LONG_DECIMAL;
+  static constexpr bool isPrimitiveType = true;
+  static constexpr bool isFixedWidth = true;
+  static constexpr const char* name = "LONG_DECIMAL";
 };
 
 template <>
@@ -469,6 +500,8 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
   VELOX_FLUENT_CAST(Varbinary, VARBINARY)
   VELOX_FLUENT_CAST(Timestamp, TIMESTAMP)
   VELOX_FLUENT_CAST(Date, DATE)
+  VELOX_FLUENT_CAST(ShortDecimal, SHORT_DECIMAL)
+  VELOX_FLUENT_CAST(LongDecimal, LONG_DECIMAL)
   VELOX_FLUENT_CAST(Array, ARRAY)
   VELOX_FLUENT_CAST(Map, MAP)
   VELOX_FLUENT_CAST(Row, ROW)
@@ -505,6 +538,61 @@ class TypeBase : public Type {
   const char* kindName() const override {
     return TypeTraits<KIND>::name;
   }
+};
+
+using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
+using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
+
+/// This class represents the fixed-point numbers.
+/// The parameter "precision" represents the number of digits the
+/// Decimal Type can support and "scale" represents the number of digits to the
+/// right of the decimal point.
+template <TypeKind KIND>
+class DecimalType : public ScalarType<KIND> {
+ public:
+  static_assert(
+      KIND == TypeKind::SHORT_DECIMAL || KIND == TypeKind::LONG_DECIMAL);
+  static constexpr uint8_t kMaxPrecision =
+      KIND == TypeKind::SHORT_DECIMAL ? 18 : 38;
+
+  DecimalType(const uint8_t precision = 18, const uint8_t scale = 0)
+      : precision_(precision), scale_(scale) {
+    VELOX_CHECK_LE(scale, precision);
+    VELOX_CHECK_LE(precision, kMaxPrecision);
+  }
+
+  inline bool operator==(const Type& otherDecimal) const override {
+    if (this->kind() != otherDecimal.kind()) {
+      return false;
+    }
+    auto decimalType = static_cast<const DecimalType<KIND>&>(otherDecimal);
+    return (
+        decimalType.precision() == this->precision_ &&
+        decimalType.scale() == this->scale_);
+  }
+
+  inline const uint8_t precision() const {
+    return precision_;
+  }
+
+  inline const uint8_t scale() const {
+    return scale_;
+  }
+
+  std::string toString() const override {
+    return fmt::format("{}({},{})", TypeTraits<KIND>::name, precision_, scale_);
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = toString();
+    return obj;
+  }
+
+ private:
+  const uint8_t precision_;
+  const uint8_t scale_;
 };
 
 template <TypeKind KIND>
@@ -872,7 +960,6 @@ struct ComplexType {
 
 template <TypeKind KIND>
 struct TypeFactory {
-  // default factory
   static std::shared_ptr<const typename TypeTraits<KIND>::ImplType> create() {
     return TypeTraits<KIND>::ImplType::create();
   }
@@ -934,6 +1021,16 @@ std::shared_ptr<const MapType> MAP(
 std::shared_ptr<const TimestampType> TIMESTAMP();
 
 std::shared_ptr<const DateType> DATE();
+
+std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale);
+
+std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale);
+
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale);
 
 template <typename Class>
 std::shared_ptr<const OpaqueType> OPAQUE() {
@@ -1204,15 +1301,19 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
     }                                                                         \
   }()
 
-#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH_ALL(CLASS, FIELD, typeKind)   \
-  [&]() {                                                                 \
-    if ((typeKind) == ::facebook::velox::TypeKind::UNKNOWN) {             \
-      return CLASS<::facebook::velox::TypeKind::UNKNOWN>::FIELD;          \
-    } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {       \
-      return CLASS<::facebook::velox::TypeKind::OPAQUE>::FIELD;           \
-    } else {                                                              \
-      return VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind); \
-    }                                                                     \
+#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH_ALL(CLASS, FIELD, typeKind)    \
+  [&]() {                                                                  \
+    if ((typeKind) == ::facebook::velox::TypeKind::UNKNOWN) {              \
+      return CLASS<::facebook::velox::TypeKind::UNKNOWN>::FIELD;           \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {        \
+      return CLASS<::facebook::velox::TypeKind::OPAQUE>::FIELD;            \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL) { \
+      return CLASS<::facebook::velox::TypeKind::SHORT_DECIMAL>::FIELD;     \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL) {  \
+      return CLASS<::facebook::velox::TypeKind::LONG_DECIMAL>::FIELD;      \
+    } else {                                                               \
+      return VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind);  \
+    }                                                                      \
   }()
 
 // todo: union convenience creators

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -292,6 +292,8 @@ std::string variant::toJson() const {
       // debugging only. Variant::serialize should actually serialize the data.
       return "\"Opaque<" + value<TypeKind::OPAQUE>().type->toString() + ">\"";
     }
+    case TypeKind::SHORT_DECIMAL:
+    case TypeKind::LONG_DECIMAL:
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:
     case TypeKind::INVALID:

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -117,6 +117,50 @@ TEST(Type, date) {
   EXPECT_EQ(date->begin(), date->end());
 }
 
+TEST(Type, decimal) {
+  auto shortDecimal = SHORT_DECIMAL(10, 5);
+  EXPECT_EQ(shortDecimal->toString(), "SHORT_DECIMAL(10,5)");
+  EXPECT_EQ(shortDecimal->size(), 0);
+  EXPECT_THROW(shortDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(shortDecimal->kind(), TypeKind::SHORT_DECIMAL);
+  EXPECT_STREQ(shortDecimal->kindName(), "SHORT_DECIMAL");
+  EXPECT_EQ(shortDecimal->begin(), shortDecimal->end());
+  EXPECT_EQ(*SHORT_DECIMAL(10, 5), *shortDecimal);
+  EXPECT_NE(*SHORT_DECIMAL(9, 5), *shortDecimal);
+  EXPECT_NE(*SHORT_DECIMAL(10, 4), *shortDecimal);
+  try {
+    shortDecimal = SHORT_DECIMAL(19, 5);
+    FAIL();
+  } catch (const VeloxRuntimeError& e) {
+    EXPECT_EQ("(19 vs. 18)", e.message());
+  }
+  auto decimal = DECIMAL(10, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::SHORT_DECIMAL);
+  decimal = DECIMAL(18, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::SHORT_DECIMAL);
+}
+
+TEST(type, longDecimal) {
+  auto longDecimal = LONG_DECIMAL(30, 5);
+  EXPECT_EQ(longDecimal->toString(), "LONG_DECIMAL(30,5)");
+  EXPECT_EQ(longDecimal->size(), 0);
+  EXPECT_THROW(longDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(longDecimal->kind(), TypeKind::LONG_DECIMAL);
+  EXPECT_STREQ(longDecimal->kindName(), "LONG_DECIMAL");
+  EXPECT_EQ(longDecimal->begin(), longDecimal->end());
+  EXPECT_EQ(*LONG_DECIMAL(30, 5), *longDecimal);
+  EXPECT_NE(*LONG_DECIMAL(9, 5), *longDecimal);
+  EXPECT_NE(*LONG_DECIMAL(30, 3), *longDecimal);
+  try {
+    longDecimal = LONG_DECIMAL(39, 5);
+    FAIL();
+  } catch (const VeloxRuntimeError& e) {
+    EXPECT_EQ("(39 vs. 38)", e.message());
+  }
+  auto decimal = DECIMAL(20, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::LONG_DECIMAL);
+}
+
 TEST(Type, dateToString) {
   Date epoch(0);
   EXPECT_EQ(epoch.toString(), "1970-01-01");


### PR DESCRIPTION
Introduce decimal type:

1. Add two TypeKinds: SHORT_DECIMAL and LONG_DECIMAL.
2. Add a new Type class templated on the TypeKind `template<TypeKind> class DecimalType` to store precision and scale.
3. Add ShortDecimal struct to int64_t unscaled value. This is needed because the native int64_t is already
mapped to BIGINT.


|    TypeKind          |      Type class        |         Native Type    |   Type::toString()   |
|     :--:                   |        :--:                  |            :--:               |  :--:                          |
|   SHORT_DECIMAL| ShortDecimalType      |       ShortDecimal             |     SHORT_DECIMAL(p,s)       |
|   LONG_DECIMAL| LongDecimalType      |       int128_T             |     LONG_DECIMAL(p,s)       |

Helper function DECIMAL(p, s) is a convenience function for creating ShortDecimalType or LongDecimalType based on inputs.
