### PR TITLE
Writer logging cleanup

### DIFF
--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -110,7 +110,7 @@ class MetricsLog {
     bool close;
   };
 
-  virtual void logStripeFlush(const StripeFlushMetrics& metrics) const {};
+  virtual void logStripeFlush(const StripeFlushMetrics& /* metrics */) const {}
 
   struct FileCloseMetrics {
     std::string writerVersion;
@@ -123,26 +123,13 @@ class MetricsLog {
     uint64_t rowCount;
     uint64_t rawDataSize;
     uint64_t numOfStreams;
+    // NOTE: these are memory footprints after the final flush.
+    int64_t totalMemory;
+    int64_t dictionaryMemory;
+    int64_t generalMemory;
   };
 
-  virtual void logFileClose(
-      const FileCloseMetrics& metrics,
-      // TODO: as we implement memory tracking, this should be per
-      // writer memory usage.
-      std::function<uint64_t()> memoryEstimate) const {};
-
-  virtual void logFileClose(
-      const std::string& writerVersion,
-      size_t footerLength,
-      size_t fileSize,
-      size_t cacheSize,
-      size_t numCacheBlocks,
-      int32_t cacheMode,
-      size_t numOfStripes,
-      size_t rowCount,
-      size_t rawDataSize,
-      size_t numOfStreams,
-      size_t totalMemory) const {}
+  virtual void logFileClose(const FileCloseMetrics& /* metrics */) const {}
 
   static std::shared_ptr<const MetricsLog> voidLog() {
     static std::shared_ptr<const MetricsLog> log{new MetricsLog("")};

--- a/velox/dwio/common/tests/DwioMetricsLogFactoryTest.cpp
+++ b/velox/dwio/common/tests/DwioMetricsLogFactoryTest.cpp
@@ -53,9 +53,7 @@ class TestingDwioMetricsLog : public MetricsLog {
 
   void logStripeFlush(const StripeFlushMetrics& /* unused */) const override {}
 
-  void logFileClose(
-      const FileCloseMetrics& /* unused */,
-      std::function<uint64_t()> /* unused */) const override {}
+  void logFileClose(const FileCloseMetrics& /* unused */) const override {}
 
  private:
   bool ioLogging_;

--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -541,17 +541,25 @@ void WriterShared::flushInternal(bool close) {
 
   if (close) {
     context.metricLogger->logFileClose(
-        writerVersionToString(context.getConfig(Config::WRITER_VERSION)),
-        footer.contentlength(),
-        sink.size(),
-        sink.getCacheSize(),
-        sink.getCacheOffsets().size() - 1,
-        static_cast<int32_t>(sink.getCacheMode()),
-        context.stripeIndex,
-        context.stripeRowCount,
-        context.stripeRawSize,
-        context.getStreamCount(),
-        context.getTotalMemoryUsage());
+        dwio::common::MetricsLog::FileCloseMetrics{
+            .writerVersion = writerVersionToString(
+                context.getConfig(Config::WRITER_VERSION)),
+            .footerLength = footer.contentlength(),
+            .fileSize = sink.size(),
+            .cacheSize = sink.getCacheSize(),
+            .numCacheBlocks = sink.getCacheOffsets().size() - 1,
+            .cacheMode = static_cast<int32_t>(sink.getCacheMode()),
+            .numOfStripes = context.stripeIndex,
+            .rowCount = context.stripeRowCount,
+            .rawDataSize = context.stripeRawSize,
+            .numOfStreams = context.getStreamCount(),
+            .totalMemory = context.getTotalMemoryUsage(),
+            .dictionaryMemory =
+                context.getMemoryUsage(MemoryUsageCategory::DICTIONARY)
+                    .getCurrentBytes(),
+            .generalMemory =
+                context.getMemoryUsage(MemoryUsageCategory::GENERAL)
+                    .getCurrentBytes()});
   }
 }
 


### PR DESCRIPTION
Summary:
Some cleanup to make the usage of columns more consistent.
e.g. the use of K_MC_* columns, the columns we use to log row count and raw data size.

Additional logging is added for memory usage at file close time.

Reviewed By: weizheng10

Differential Revision: D35463287

