### PR TITLE
Remove CursorParameters.numResultDrivers

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -91,7 +91,6 @@ class TpchBenchmark {
   std::shared_ptr<Task> run(const TpchPlan& tpchPlan) {
     CursorParameters params;
     params.maxDrivers = FLAGS_num_drivers;
-    params.numResultDrivers = 1;
     params.planNode = tpchPlan.plan;
     const int numSplitsPerFile = FLAGS_num_splits_per_file;
 

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -104,7 +104,6 @@ class ParquetTpchTest : public testing::Test {
     };
     CursorParameters params;
     params.maxDrivers = kNumDrivers;
-    params.numResultDrivers = 1;
     params.planNode = tpchPlan.plan;
     return exec::test::assertQuery(params, addSplits, duckQuery, *duckDb_);
   }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -210,6 +210,12 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Returns time (ms) since the task execution ended or zero, if not finished.
   uint64_t timeSinceEndMs() const;
 
+  /// Returns the total number of drivers in the output pipeline, e.g. the
+  /// pipeline that produces the results.
+  uint32_t numOutputDrivers() const {
+    return numDrivers(getOutputPipelineId());
+  }
+
   /// Returns the number of running drivers.
   uint32_t numRunningDrivers() const {
     std::lock_guard<std::mutex> taskLock(mutex_);

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -135,7 +135,6 @@ TEST_F(CrossJoinTest, basic) {
   planNodeIdGenerator->reset();
   CursorParameters params;
   params.maxDrivers = 4;
-  params.numResultDrivers = 1;
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .values({leftVectors})
                         .crossJoin(

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -673,7 +673,6 @@ TEST_F(DriverTest, pauserNode) {
         true);
     params[i].maxDrivers =
         kThreadsPerTask * 2; // a number larger than kThreadsPerTask
-    params[i].numResultDrivers = kThreadsPerTask;
   }
   std::vector<std::thread> threads;
   threads.reserve(kNumTasks);
@@ -811,7 +810,6 @@ TEST_F(DriverTest, driverCreationThrow) {
     CursorParameters params;
     params.planNode = std::move(plan);
     params.maxDrivers = 5;
-    params.numResultDrivers = 1;
     getResults(params);
     FAIL() << "Expected exception.";
   } catch (const VeloxException& ex) {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -438,7 +438,6 @@ TEST_F(MergeJoinTest, numDrivers) {
   CursorParameters params;
   params.planNode = plan;
   params.maxDrivers = 5;
-  params.numResultDrivers = 1;
   auto task = assertQuery(params, "SELECT 2, 2");
   // We have two pipelines in the task and each must have 1 driver.
   EXPECT_EQ(2, task->numTotalDrivers());

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -44,7 +44,6 @@ class MergeTest : public OperatorTestBase {
       CursorParameters params;
       params.planNode = plan;
       params.maxDrivers = 2;
-      params.numResultDrivers = 1;
       assertQueryOrdered(
           params,
           "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) ORDER BY " +
@@ -103,7 +102,6 @@ class MergeTest : public OperatorTestBase {
         CursorParameters params;
         params.planNode = plan;
         params.maxDrivers = 2;
-        params.numResultDrivers = 1;
         assertQueryOrdered(
             params,
             "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) " +

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1875,8 +1875,8 @@ TEST_P(TableScanTest, groupedExecutionWithOutputBuffer) {
           .tableScan(rowType_)
           .partitionedOutput({}, 1, {"c0", "c1", "c2", "c3", "c4", "c5"})
           .planFragment();
-  planFragment.numSplitGroups = 10;
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
+  planFragment.numSplitGroups = 10;
   auto queryCtx = core::QueryCtx::createForTest();
   auto task = std::make_shared<exec::Task>(
       "0", std::move(planFragment), 0, std::move(queryCtx));
@@ -1951,16 +1951,14 @@ TEST_P(TableScanTest, groupedExecution) {
   CursorParameters params;
   params.planNode = tableScanNode(ROW({}, {}));
   params.maxDrivers = 2;
-  params.concurrentSplitGroups = 2;
   // We will have 10 split groups 'in total', but our task will only handle
   // three of them: 1, 5 and 8.
   // Split 0 is from split group 1.
   // Splits 1 and 2 are from split group 5.
   // Splits 3, 4 and 5 are from split group 8.
   params.executionStrategy = core::ExecutionStrategy::kGrouped;
-  params.numSplitGroups = 10;
-  // We'll only run 3 split groups, 2 drivers each.
-  params.numResultDrivers = 3 * 2;
+  params.numSplitGroups = 3;
+  params.numConcurrentSplitGroups = 2;
 
   // Create the cursor with the task underneath. It is not started yet.
   auto cursor = std::make_unique<TaskCursor>(params);

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -68,7 +68,8 @@ RowVectorPtr TaskQueue::dequeue() {
         if (totalBytes_ < maxBytes_ / 2) {
           mayContinue = std::move(producerUnblockPromises_);
         }
-      } else if (producersFinished_ == numProducers_) {
+      } else if (
+          numProducers_.has_value() && producersFinished_ == numProducers_) {
         return nullptr;
       }
       if (!vector) {
@@ -106,17 +107,16 @@ std::atomic<int32_t> TaskCursor::serial_;
 
 TaskCursor::TaskCursor(const CursorParameters& params)
     : maxDrivers_{params.maxDrivers},
-      concurrentSplitGroups_{params.concurrentSplitGroups} {
+      numConcurrentSplitGroups_{params.numConcurrentSplitGroups},
+      numSplitGroups_{params.numSplitGroups} {
   std::shared_ptr<core::QueryCtx> queryCtx;
   if (params.queryCtx) {
     queryCtx = params.queryCtx;
   } else {
     queryCtx = core::QueryCtx::createForTest();
   }
-  auto numProducers = params.numResultDrivers.has_value()
-      ? params.numResultDrivers.value()
-      : params.maxDrivers;
-  queue_ = std::make_shared<TaskQueue>(numProducers, params.bufferedBytes);
+
+  queue_ = std::make_shared<TaskQueue>(params.bufferedBytes);
   // Captured as a shared_ptr by the consumer callback of task_.
   auto queue = queue_;
   core::PlanFragment planFragment{
@@ -145,7 +145,8 @@ TaskCursor::TaskCursor(const CursorParameters& params)
 void TaskCursor::start() {
   if (!started_) {
     started_ = true;
-    exec::Task::start(task_, maxDrivers_, concurrentSplitGroups_);
+    exec::Task::start(task_, maxDrivers_, numConcurrentSplitGroups_);
+    queue_->setNumProducers(numSplitGroups_ * task_->numOutputDrivers());
   }
 }
 


### PR DESCRIPTION
CursorParameters.numResultDrivers was used to specify the number of threads that
are producing task results. In most cases this number is the same as
CursorParameters.maxDrivers, except when parallelism is restricted due to
operations that can only run single-threaded, e.g. final limit. If
numResultDrivers is specified incorrectly, the test would hang waiting for
non-existent producers. 

This behavior was confusing.

This change is to remove numResultDrivers parameter and get the number of
producers from the Task itself via Task::numOutputDrivers() API.