### PR TITLE
Allow BaseVector.addNulls to grow the Vector

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -632,13 +632,11 @@ void Expr::addNulls(
     return;
   }
 
-  if (!result->unique() || !(*result)->mayAddNulls()) {
+  if (!result->unique() || !(*result)->isNullsWritable()) {
     BaseVector::ensureWritable(
         SelectivityVector::empty(), type(), context->pool(), result);
   }
-  if ((*result)->size() < rows.end()) {
-    (*result)->resize(rows.end());
-  }
+
   (*result)->addNulls(rawNulls, rows);
 }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -345,13 +345,26 @@ VectorPtr BaseVector::create(
 }
 
 void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
-  VELOX_CHECK(mayAddNulls());
-  VELOX_CHECK(length_ >= rows.end());
-  ensureNulls();
+  VELOX_CHECK(isNullsWritable());
+
+  // Resize the vector and nulls_ to fit the added nulls if necessary.
+  if (length_ < rows.end()) {
+    // If not all rows are null between the end of the current vector and the
+    // end of rows, this resize will produce non-null undefined values.
+    VELOX_CHECK(
+        rows.begin() <= length_ &&
+        rows.countSelected(length_, rows.end()) == rows.end() - length_ &&
+        (!bits || bits::countBits(bits, length_, rows.end()) == 0));
+    setSize(rows.end());
+    ensureNullsCapacity(rows.end());
+  } else {
+    ensureNulls();
+  }
+
   auto target = nulls_->asMutable<uint64_t>();
   const uint64_t* selected = rows.asRange().bits();
   if (!bits) {
-    // A A 1 in rows makes a 0 in nulls.
+    // A 1 in rows makes a 0 in nulls.
     bits::andWithNegatedBits(target, selected, rows.begin(), rows.end());
     return;
   }
@@ -368,7 +381,7 @@ void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
 }
 
 void BaseVector::clearNulls(const SelectivityVector& rows) {
-  VELOX_CHECK(mayAddNulls());
+  VELOX_CHECK(isNullsWritable());
   if (!nulls_) {
     return;
   }
@@ -390,7 +403,7 @@ void BaseVector::clearNulls(const SelectivityVector& rows) {
 }
 
 void BaseVector::clearNulls(vector_size_t begin, vector_size_t end) {
-  VELOX_CHECK(mayAddNulls());
+  VELOX_CHECK(isNullsWritable());
   if (!nulls_) {
     return;
   }

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -160,7 +160,7 @@ class BiasVector : public SimpleVector<T> {
     return true;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -188,7 +188,7 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_->wrappedIndex(rawIndices_[index]);
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -292,7 +292,7 @@ class FlatVector final : public SimpleVector<T> {
     return size;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return true;
   }
 

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -261,11 +261,22 @@ class SelectivityVector {
         bits::isAllSet(bits_.data(), 0, size_, true);
     return allSelected_.value();
   }
+
   /**
    * Iterate and count the number of selected values in this SelectivityVector
+   * in the provided range.
    */
+  vector_size_t countSelected(vector_size_t begin, vector_size_t end) const {
+    if (begin >= end_ || end <= begin_) {
+      return 0;
+    }
+
+    return bits::countBits(
+        bits_.data(), std::max(begin, begin_), std::min(end, end_));
+  }
+
   vector_size_t countSelected() const {
-    return bits::countBits(bits_.data(), begin_, end_);
+    return countSelected(begin_, end_);
   }
 
   vector_size_t size() const {

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -197,7 +197,7 @@ class SimpleVector : public BaseVector {
     return elementSize_;
   }
 
-  bool mayAddNulls() const override {
+  bool isNullsWritable() const override {
     return false;
   }
 

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -494,6 +494,34 @@ TEST(SelectivityVectorTest, toString) {
       "147 out of 1024 rows selected between 0 and 1023: 0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210, 217, 224, 231, 238, 245, 252, 259, 266, 273, 280, 287, 294, 301, 308, 315, 322, 329, 336, 343, 350, 357, 364, 371, 378, 385, 392, 399, 406, 413, 420, 427, 434, 441, 448, 455, 462, 469, 476, 483, 490, 497, 504, 511, 518, 525, 532, 539, 546, 553, 560, 567, 574, 581, 588, 595, 602, 609, 616, 623, 630, 637, 644, 651, 658, 665, 672, 679, 686, 693, 700, 707, 714, 721, 728, 735, 742, 749, 756, 763, 770, 777, 784, 791, 798, 805, 812, 819, 826, 833, 840, 847, 854, 861, 868, 875, 882, 889, 896, 903, 910, 917, 924, 931, 938, 945, 952, 959, 966, 973, 980, 987, 994, 1001, 1008, 1015, 1022");
 }
 
+TEST(SelectivityVectorTest, countSelected) {
+  SelectivityVector rows(10, false);
+  // Set bits 2, 4, 6, 8.
+  for (auto i = 2; i <= 8; i += 2) {
+    rows.setValid(i, true);
+  }
+  rows.updateBounds();
+
+  // Check the entire vector.
+  ASSERT_EQ(rows.countSelected(), 4);
+  // Check a subrange that includes all selected bits.
+  ASSERT_EQ(rows.countSelected(1, 9), 4);
+  // Check where end <= begin_.
+  ASSERT_EQ(rows.countSelected(0, 2), 0);
+  // Check where begin >= end.
+  ASSERT_EQ(rows.countSelected(9, 20), 0);
+  // Check end is not included in range.
+  ASSERT_EQ(rows.countSelected(4, 6), 1);
+  // Check end - 1 is included in range.
+  ASSERT_EQ(rows.countSelected(4, 7), 2);
+  // Check begin > end.
+  ASSERT_EQ(rows.countSelected(9, 0), 0);
+  // Check begin == end.
+  ASSERT_EQ(rows.countSelected(8, 8), 0);
+  // Check a single bit.
+  ASSERT_EQ(rows.countSelected(6, 7), 1);
+}
+
 } // namespace test
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary:
When we call setDictionaryWrap to peel dictionary encoding, and then setWrapped to
reapply the dictionary encoding the size of the DictionaryVector can change.  This is
because we do not use the original vector size, but rather rows.end() for the size of the new
unpeeled vector.

This causes problems when nulls are removed, as when we call addNulls, the
DictionaryVector may be smaller than the number of rows when there were nulls at the end
of the batch.  In this case, addNulls attempts to resize the DictionaryVector which is not
supported.

To fix this, I've modified addNulls to effectively resize the Vector to append NULLs,
provided that all the new elements are NULL (otherwise we'd end up with non-null
undefined values in the Vector).

This leads to a bit of an inconsistency where mayAddNulls may return true, while
addNulls may throw if not all the new elements are NULL.

Looking at mayAddNulls, we only call it in 4 places in the code base, 2 of which are in
clearNulls, which does not call addNulls.  This implies the intended use of this function is
to see if the Vector type supports modifying nulls, and changed the name to reflect this.
This also resolves that inconsistency.

Differential Revision: D35617668

