### PR TITLE
Improve PlanBuilder::tableScan

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -69,6 +69,28 @@ class PlanBuilder {
       const std::vector<std::string>& subfieldFilters = {},
       const std::string& remainingFilter = "");
 
+  /// Add a TableScanNode to scan a Hive table.
+  ///
+  /// @param tableName The name of the table to scan.
+  /// @param outputType List of column names and types to read from the table.
+  /// @param columnAliases Optional aliases for the column names. The key is the
+  /// alias (name in 'outputType'), value is the name in the files.
+  /// @param subfieldFilters A list of SQL expressions for the range filters to
+  /// apply to individual columns. Should use column name aliases, not column
+  /// names in the files. Supported filters are: column <= value, column <
+  /// value, column >= value, column > value, column = value, column IN (v1,
+  /// v2,.. vN), column < v1 OR column >= v2.
+  /// @param remainingFilter SQL expression for the additional conjunct. May
+  /// include multiple columns and SQL functions. Should use column name
+  /// aliases, not column names in the files. The remainingFilter is AND'ed
+  /// with all the subfieldFilters.
+  PlanBuilder& tableScan(
+      const std::string& tableName,
+      const RowTypePtr& outputType,
+      const std::unordered_map<std::string, std::string>& columnAliases = {},
+      const std::vector<std::string>& subfieldFilters = {},
+      const std::string& remainingFilter = "");
+
   PlanBuilder& tableScan(
       const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,


### PR DESCRIPTION
Add a version of PlanBuilder::tableScan() that allows to specify table name and
column aliases in addition to SQL expressions for range and remaining filters.

This allows to write TPC-H query plans more easily. Here is an example from q6:

```
.tableScan(
    kLineitem,
    selectedRowType,
    fileColumnNames,
    {"l_discount between 0.05 and 0.07",
     "l_quantity < 24.0"})
```