### PR TITLE
Change functions in Velox directory to use the new writer interface.

### DIFF
--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -71,14 +71,14 @@ struct NonDefaultBehaviorFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   bool callNullable(
-      out_type<Array<int32_t>>& out,
+      out_type<ArrayWriterT<int32_t>>& out,
       const arg_type<Array<int32_t>>* input) {
-    out.append(kCallNullable);
+    out.push_back(kCallNullable);
 
     if (input) {
       for (auto i : *input) {
         if (i.has_value()) {
-          out.append(i.value());
+          out.push_back(*i);
         }
       }
     }
@@ -87,12 +87,12 @@ struct NonDefaultBehaviorFunction {
   }
 
   bool callNullFree(
-      out_type<Array<int32_t>>& out,
+      out_type<ArrayWriterT<int32_t>>& out,
       const null_free_arg_type<Array<int32_t>>& input) {
-    out.append(kCallNullFree);
+    out.push_back(kCallNullFree);
 
     for (auto i : input) {
-      out.append(i);
+      out.push_back(i);
     }
 
     return true;
@@ -100,8 +100,10 @@ struct NonDefaultBehaviorFunction {
 };
 
 TEST_F(SimpleFunctionCallNullFreeTest, nonDefaultBehavior) {
-  registerFunction<NonDefaultBehaviorFunction, Array<int32_t>, Array<int32_t>>(
-      {"non_default_behavior"});
+  registerFunction<
+      NonDefaultBehaviorFunction,
+      ArrayWriterT<int32_t>,
+      Array<int32_t>>({"non_default_behavior"});
 
   // Make a vector with a NULL.
   auto arrayVectorWithNull = makeVectorWithNullArrays<int32_t>(

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -55,7 +55,7 @@ struct NonDefaultWithArrayInitFunction {
   }
 
   bool callNullable(
-      out_type<Array<int32_t>>& out,
+      out_type<ArrayWriterT<int32_t>>& out,
       const arg_type<int32_t>* first,
       const arg_type<Array<int32_t>>* /*second*/) {
     if (!first) {
@@ -64,10 +64,10 @@ struct NonDefaultWithArrayInitFunction {
 
     if (!elements_.empty()) {
       for (auto i : elements_) {
-        out.append(i + *first);
+        out.push_back(i + *first);
       }
     } else {
-      out.append(*first);
+      out.push_back(*first);
     }
 
     return true;
@@ -83,7 +83,7 @@ struct NonDefaultWithArrayInitFunction {
 TEST_F(SimpleFunctionInitTest, initializationArray) {
   registerFunction<
       NonDefaultWithArrayInitFunction,
-      Array<int32_t>,
+      ArrayWriterT<int32_t>,
       int32_t,
       Array<int32_t>>({"non_default_behavior_with_init"});
 

--- a/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
@@ -126,21 +126,6 @@ struct SimpleGeneralInterface {
   }
 };
 
-template <typename T>
-struct SimpleOld {
-  template <typename TOut>
-  bool call(TOut& out, const int64_t& n) {
-    for (int i = 0; i < n; i++) {
-      if (WITH_NULLS && i % 5) {
-        out.append(std::nullopt);
-      } else {
-        out.append(i);
-      }
-    }
-    return true;
-  }
-};
-
 class ArrayWriterBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   ArrayWriterBenchmark() : FunctionBenchmarkBase() {
@@ -150,7 +135,6 @@ class ArrayWriterBenchmark : public functions::test::FunctionBenchmarkBase {
         {"simple_push_back"});
     registerFunction<SimpleGeneralInterface, ArrayWriterT<int64_t>, int64_t>(
         {"simple_general"});
-    registerFunction<SimpleOld, Array<int64_t>, int64_t>({"simple_old"});
 
     facebook::velox::exec::registerVectorFunction(
         "vector_resize_optimized",


### PR DESCRIPTION
Summary:
This is part is step one towards deprecating old writers.
A following diff will replace ArrayWriterT and switch out_type<Array> meaning, the same for all other types.

Differential Revision: D35625851

