### PR TITLE
Add materialize for StringView

### DIFF
--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -111,10 +111,6 @@ struct StringView {
     return size_;
   }
 
-  std::string getString() const {
-    return std::string(data(), size());
-  }
-
   friend std::ostream& operator<<(
       std::ostream& os,
       const StringView& stringView) {
@@ -191,16 +187,24 @@ struct StringView {
     return std::string(data(), size());
   }
 
+  std::string str() const {
+    return *this;
+  }
+
+  std::string getString() const {
+    return *this;
+  }
+
+  std::string materialize() const {
+    return *this;
+  }
+
   operator folly::dynamic() const {
     return folly::dynamic(folly::StringPiece(data(), size()));
   }
 
   explicit operator std::string_view() const {
     return std::string_view(data(), size());
-  }
-
-  std::string str() const {
-    return std::string(data(), size());
   }
 
   const char* begin() const {

--- a/velox/type/tests/StringViewTest.cpp
+++ b/velox/type/tests/StringViewTest.cpp
@@ -34,6 +34,7 @@ TEST(StringView, basic) {
     } else {
       EXPECT_EQ(view.data(), subText.data());
     }
+    EXPECT_EQ(view.materialize(), subText);
     EXPECT_EQ(view.getString(), subText);
     EXPECT_EQ(view, StringView(subText.data(), subText.size()));
 


### PR DESCRIPTION
Summary: to be consistent with ArrayView and MapView, materialize is added as well to StringView.

Reviewed By: kevinwilfong

Differential Revision: D35623645

