### PR TITLE
Support non-Flat vector in CountAggregate::addSingleGroupIntermediateResults()

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -334,6 +334,10 @@ class PlanBuilder {
       const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
       const std::vector<std::string>& outputLayout = {});
 
+  PlanBuilder& localPartitionRoundRobin(
+      const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
+      const std::vector<std::string>& outputLayout = {});
+
   // 'leftKeys' and 'rightKeys' are column names of the output of the
   // previous PlanNode and 'build', respectively. 'output' is a subset of
   // column names from the left and right sides of the join to project out.


### PR DESCRIPTION
Summary:
Some queries might have local exchanges before INTERMEDIATE aggregation. The local exchanges produce dictionaries, so we need to expect these in CountAggregate::addSingleGroupIntermediateResults()
Example query: https://www.internalfb.com/intern/presto/query/?query_id=20220411_214537_01209_dehmi#sql
The diff:
* Adds support for any encoded vector in CountAggregate::addSingleGroupIntermediateResults().
* Adds support for RoundRobin Local Partition Node in PlanBuilder.
* Removes the check Partial Aggregation before the Final Aggregation.

Reviewed By: mbasmanova

Differential Revision: D35603243

