### PR TITLE
Add dbgen wrapper to generate Vectors for `Nation`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ endif()
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)
+include_directories(SYSTEM velox/external/duckdb/tpch/dbgen/include)
 
 include(CTest) # include after project() but before add_subdirectory()
 

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 if(${VELOX_ENABLE_DUCKDB})
   add_subdirectory(duckdb)
   add_subdirectory(external/duckdb)
+  add_subdirectory(tpch/gen)
 endif()
 
 if(${VELOX_CODEGEN_SUPPORT})

--- a/velox/external/duckdb/tpch/dbgen/bm_utils.cpp
+++ b/velox/external/duckdb/tpch/dbgen/bm_utils.cpp
@@ -446,7 +446,7 @@ set_state(int table, long sf, long procs, long step, DSS_HUGE *extra_rows) {
 		/* need to set seeds of child in case there's a dependency */
 		/* NOTE: this assumes that the parent and child have the same base row
 		 * count */
-		if (tdefs[table].child != NONE)
+		if (tdefs[table].child != DBGEN_NONE)
 			tdefs[tdefs[table].child].gen_seed(0, rowcount);
 	}
 	if (step > procs) /* moving to the end to generate updates */

--- a/velox/external/duckdb/tpch/dbgen/dbgen.cpp
+++ b/velox/external/duckdb/tpch/dbgen/dbgen.cpp
@@ -28,7 +28,7 @@ seed_t DBGenGlobals::Seed[MAX_STREAM + 1] = {
     {PART, 1841581359, 0, 1},                  /* P_TYPE_SD    2 */
     {PART, 1193163244, 0, 1},                  /* P_SIZE_SD    3 */
     {PART, 727633698, 0, 1},                   /* P_CNTR_SD    4 */
-    {NONE, 933588178, 0, 1},                   /* text pregeneration  5 */
+    {DBGEN_NONE, 933588178, 0, 1},                   /* text pregeneration  5 */
     {PART, 804159733, 0, 2},                   /* P_CMNT_SD    6 */
     {PSUPP, 1671059989, 0, SUPP_PER_PART},     /* PS_QTY_SD    7 */
     {PSUPP, 1051288424, 0, SUPP_PER_PART},     /* PS_SCST_SD   8 */
@@ -75,15 +75,15 @@ seed_t DBGenGlobals::Seed[MAX_STREAM + 1] = {
 double DBGenGlobals::dM = 2147483647.0;
 tdef DBGenGlobals::tdefs[10] = {
     {"part.tbl", "part table", 200000, NULL, NULL, PSUPP, 0},
-    {"partsupp.tbl", "partsupplier table", 200000, NULL, NULL, NONE, 0},
-    {"supplier.tbl", "suppliers table", 10000, NULL, NULL, NONE, 0},
-    {"customer.tbl", "customers table", 150000, NULL, NULL, NONE, 0},
+    {"partsupp.tbl", "partsupplier table", 200000, NULL, NULL, DBGEN_NONE, 0},
+    {"supplier.tbl", "suppliers table", 10000, NULL, NULL, DBGEN_NONE, 0},
+    {"customer.tbl", "customers table", 150000, NULL, NULL, DBGEN_NONE, 0},
     {"orders.tbl", "order table", 150000, NULL, NULL, LINE, 0},
-    {"lineitem.tbl", "lineitem table", 150000, NULL, NULL, NONE, 0},
+    {"lineitem.tbl", "lineitem table", 150000, NULL, NULL, DBGEN_NONE, 0},
     {"orders.tbl", "orders/lineitem tables", 150000, NULL, NULL, LINE, 0},
     {"part.tbl", "part/partsupplier tables", 200000, NULL, NULL, PSUPP, 0},
-    {"nation.tbl", "nation table", NATIONS_MAX, NULL, NULL, NONE, 0},
-    {"region.tbl", "region table", NATIONS_MAX, NULL, NULL, NONE, 0},
+    {"nation.tbl", "nation table", NATIONS_MAX, NULL, NULL, DBGEN_NONE, 0},
+    {"region.tbl", "region table", NATIONS_MAX, NULL, NULL, DBGEN_NONE, 0},
 };
 
 static seed_t *Seed = DBGenGlobals::Seed;

--- a/velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h
+++ b/velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h
@@ -40,7 +40,7 @@
 #define printf(...)
 #define fprintf(...)
 
-#define NONE -1
+#define DBGEN_NONE -1
 #define PART 0
 #define PSUPP 1
 #define SUPP 2

--- a/velox/tpch/gen/CMakeLists.txt
+++ b/velox/tpch/gen/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(velox_tpch_gen TpchGen.cpp)
+
+target_link_libraries(velox_tpch_gen velox_memory velox_vector dbgen duckdb)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/tpch/gen/TpchGen.cpp
+++ b/velox/tpch/gen/TpchGen.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/tpch/gen/TpchGen.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dbgen_gunk.hpp"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dsstypes.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::tpch {
+
+namespace {
+
+// The cardinality of the LINEITEM table is not a strict multiple of SF since
+// the number of lineitems in an order is chosen at random with an average of
+// four. This function contains the row count for all authorized scale factors
+// (as described by the TPC-H spec), and approximates the remaining.
+constexpr size_t getLineItemRowCount(size_t scaleFactor) {
+  switch (scaleFactor) {
+    case 1:
+      return 6'001'215;
+    case 10:
+      return 59'986'052;
+    case 30:
+      return 179'998'372;
+    case 100:
+      return 600'037'902;
+    case 300:
+      return 1'799'989'091;
+    case 1'000:
+      return 5'999'989'709;
+    case 3'000:
+      return 18'000'048'306;
+    case 10'000:
+      return 59'999'994'267;
+    case 30'000:
+      return 179'999'978'268;
+    case 100'000:
+      return 599'999'969'200;
+    default:
+      break;
+  }
+  return 6'000'000 * scaleFactor;
+}
+
+} // namespace
+
+constexpr size_t getRowCount(Table table, size_t scaleFactor) {
+  switch (table) {
+    case Table::TBL_PART:
+      return 200'000 * scaleFactor;
+    case Table::TBL_SUPPLIER:
+      return 10'000 * scaleFactor;
+    case Table::TBL_PARTSUP:
+      return 800'000 * scaleFactor;
+    case Table::TBL_CUSTOMER:
+      return 150'000 * scaleFactor;
+    case Table::TBL_ORDERS:
+      return 1'500'000 * scaleFactor;
+    case Table::TBL_NATION:
+      return 25;
+    case Table::TBL_REGION:
+      return 5;
+    case Table::TBL_LINEITEM:
+      return getLineItemRowCount(scaleFactor);
+  }
+  return 0; // make gcc happy.
+}
+
+RowVectorPtr genTpchNation(
+    size_t maxRows,
+    size_t offset,
+    size_t scaleFactor,
+    memory::MemoryPool* pool) {
+  size_t rowCount = getRowCount(Table::TBL_NATION, scaleFactor);
+  size_t vectorSize = std::min(rowCount - offset, maxRows);
+
+  // Create schema and allocate vectors.
+  static TypePtr nationRowType =
+      ROW({"n_nationkey", "n_name", "n_regionkey", "n_comment"},
+          {BIGINT(), VARCHAR(), BIGINT(), VARCHAR()});
+  std::vector<VectorPtr> children = {
+      BaseVector::create(BIGINT(), vectorSize, pool),
+      BaseVector::create(VARCHAR(), vectorSize, pool),
+      BaseVector::create(BIGINT(), vectorSize, pool),
+      BaseVector::create(VARCHAR(), vectorSize, pool),
+  };
+
+  auto nationKeyVector = children[0]->asFlatVector<int64_t>();
+  auto nameVector = children[1]->asFlatVector<StringView>();
+  auto regionKeyVector = children[2]->asFlatVector<int64_t>();
+  auto commentVector = children[3]->asFlatVector<StringView>();
+
+  // load_dists()/cleanup_dists() need to be called to ensure the global
+  // variables required by dbgen are populated.
+  load_dists();
+  code_t code;
+
+  // Dbgen generates the dataset one row at a time, so we need to transpose it
+  // into a columnar format.
+  for (size_t i = 0; i < vectorSize; ++i) {
+    row_start(NATION);
+    mk_nation(i + offset + 1, &code);
+    nationKeyVector->set(i, code.code);
+    nameVector->set(i, StringView(code.text, strlen(code.text)));
+    regionKeyVector->set(i, code.join);
+    commentVector->set(i, StringView(code.comment, code.clen));
+    row_stop_h(NATION);
+  }
+  cleanup_dists();
+
+  return std::make_shared<RowVector>(
+      pool, nationRowType, BufferPtr(nullptr), vectorSize, std::move(children));
+}
+
+} // namespace facebook::velox::tpch

--- a/velox/tpch/gen/TpchGen.h
+++ b/velox/tpch/gen/TpchGen.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::tpch {
+
+/// This file uses TPC-H DBGEN to generate data encoded using Velox Vectors.
+///
+/// The basic input for the API is the TPC-H table name (the Table enum), the
+/// TPC-H scale factor, the maximum batch size, and the offset. The common usage
+/// is to make successive calls to this API advancing the offset parameter,
+/// until all records were read. Clients might also assign different slices of
+/// the range "[0, getRowCount(Table, scaleFactor)[" to different threads in
+/// order to generate datasets in parallel.
+///
+/// If not enough records are available given a particular scale factor and
+/// offset, less than maxRows records might be returned.
+///
+/// Data is always returned in a RowVector.
+
+enum class Table {
+  TBL_PART,
+  TBL_SUPPLIER,
+  TBL_PARTSUP,
+  TBL_CUSTOMER,
+  TBL_ORDERS,
+  TBL_LINEITEM,
+  TBL_NATION,
+  TBL_REGION,
+};
+
+/// Returns the row count for a particular TPC-H table given a scale factor, as
+/// defined in the spec available at:
+///
+///  https://www.tpc.org/tpch/
+constexpr size_t getRowCount(Table table, size_t scaleFactor);
+
+/// Returns a row vector containing at most `maxRows` rows of the "nation"
+/// table, starting at `offset`, and given the scale factor. The row vector
+/// returned has the following schema:
+///
+///  n_nationkey: BIGINT
+///  n_name: VARCHAR
+///  n_regionkey: BIGINT
+///  n_comment: VARCHAR
+///
+RowVectorPtr genTpchNation(
+    size_t maxRows = 10000,
+    size_t offset = 0,
+    size_t scaleFactor = 1,
+    memory::MemoryPool* pool =
+        &velox::memory::getProcessDefaultMemoryManager().getRoot());
+
+} // namespace facebook::velox::tpch

--- a/velox/tpch/gen/tests/CMakeLists.txt
+++ b/velox/tpch/gen/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(velox_tpch_gen_test TpchGenTest.cpp)
+
+add_test(velox_tpch_gen_test velox_tpch_gen_test)
+
+target_link_libraries(velox_tpch_gen_test velox_tpch_gen velox_type
+                      velox_vector gtest gtest_main)

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/tpch/gen/TpchGen.h"
+#include "velox/type/StringView.h"
+#include "velox/vector/FlatVector.h"
+
+namespace {
+
+using namespace facebook::velox;
+using namespace facebook::velox::tpch;
+
+TEST(TpchGenTestNation, default) {
+  auto rowVector = genTpchNation();
+  ASSERT_NE(rowVector, nullptr);
+  EXPECT_EQ(4, rowVector->childrenSize());
+  EXPECT_EQ(25, rowVector->size());
+
+  auto nationKey = rowVector->childAt(0)->asFlatVector<int64_t>();
+  auto nationName = rowVector->childAt(1)->asFlatVector<StringView>();
+
+  EXPECT_EQ(0, nationKey->valueAt(0));
+  EXPECT_EQ("ALGERIA"_sv, nationName->valueAt(0));
+
+  // Ensure we won't crash while accessing any of the columns.
+  LOG(INFO) << rowVector->toString(0);
+
+  EXPECT_EQ(24, nationKey->valueAt(24));
+  EXPECT_EQ("UNITED STATES"_sv, nationName->valueAt(24));
+  LOG(INFO) << rowVector->toString(24);
+}
+
+// Ensure scale factor doesn't affect Nation table.
+TEST(TpchGenTestNation, scaleFactor) {
+  auto rowVector = genTpchNation(10000, 0, 1000);
+  ASSERT_NE(rowVector, nullptr);
+
+  EXPECT_EQ(4, rowVector->childrenSize());
+  EXPECT_EQ(25, rowVector->size());
+}
+
+TEST(TpchGenTestNation, smallBatch) {
+  auto rowVector = genTpchNation(10);
+  ASSERT_NE(rowVector, nullptr);
+
+  EXPECT_EQ(4, rowVector->childrenSize());
+  EXPECT_EQ(10, rowVector->size());
+
+  auto nationKey = rowVector->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(0, nationKey->valueAt(0));
+  EXPECT_EQ(9, nationKey->valueAt(9));
+}
+
+TEST(TpchGenTestNation, smallBatchWithOffset) {
+  auto rowVector = genTpchNation(10, 5);
+  ASSERT_NE(rowVector, nullptr);
+
+  EXPECT_EQ(4, rowVector->childrenSize());
+  EXPECT_EQ(10, rowVector->size());
+
+  auto nationKey = rowVector->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(5, nationKey->valueAt(0));
+  EXPECT_EQ(14, nationKey->valueAt(9));
+}
+
+TEST(TpchGenTestNation, smallBatchPastEnd) {
+  auto rowVector = genTpchNation(10, 20);
+  ASSERT_NE(rowVector, nullptr);
+
+  EXPECT_EQ(4, rowVector->childrenSize());
+  EXPECT_EQ(5, rowVector->size());
+
+  auto nationKey = rowVector->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(20, nationKey->valueAt(0));
+  EXPECT_EQ(24, nationKey->valueAt(4));
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
Adding a wrapper around dbgen to generate TPC-H synthetic data and
return them as RowVector. For now only adding Nation tables, but as we agree on
the API I'll go ahead an add the other tables.
.
Note that for now I'm wrapping around duckDB's dbgen, but only using vanilla
dbgen. So in the next diffs we can add our own copy of dbgen (by vendoring it
or a submodule), and remove the duckDB dependency.

Differential Revision: D35634474

