### PR TITLE
Fix Parquet reader

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -51,6 +51,7 @@ class ParquetRowReader : public dwio::common::RowReader {
   memory::MemoryPool& pool_;
   RowTypePtr rowType_;
   std::vector<::duckdb::LogicalType> duckdbRowType_;
+  velox::common::ScanSpec* scanSpec_;
 };
 
 class ParquetReader : public dwio::common::Reader {

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -161,10 +161,7 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6, 2, 10);
 }
 
-// This test started to fail after dynamic filters
-// are always pushed that was introduced in
-// https://github.com/facebookincubator/velox/pull/1314
-TEST_F(ParquetTpchTest, DISABLED_Q18) {
+TEST_F(ParquetTpchTest, Q18) {
   assertQuery(18, 5, 30);
 }
 

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -683,6 +683,10 @@ class BigintValuesUsingHashTable final : public Filter {
     return max_;
   }
 
+  const std::vector<int64_t>& values() const {
+    return values_;
+  }
+
   std::string toString() const final {
     return fmt::format(
         "BigintValuesUsingHashTable: [{}, {}] {}",


### PR DESCRIPTION
Parquet reader didn't use ScanSpec to figure out the output layout. In case of
q18 this resulted in the reader returning columns in the wrong order, i.e.
(custkey, orderkey) instead of (orderkey, custkey). 

Also, added support for kBigintValuesUsingHashTable filter, a contribution from 
Ge (@gggrace14).