### PR TITLE
Support non-Flat vector for intermediate array_agg, map_agg, checksum

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -787,9 +787,11 @@ std::shared_ptr<Task> assertQuery(
 }
 
 velox::variant readSingleValue(
-    const std::shared_ptr<const core::PlanNode>& plan) {
+    const std::shared_ptr<const core::PlanNode>& plan,
+    int32_t maxDrivers) {
   CursorParameters params;
   params.planNode = plan;
+  params.maxDrivers = maxDrivers;
   auto result = readCursor(params, [](Task*) {});
 
   EXPECT_EQ(1, result.second.size());

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -164,7 +164,8 @@ std::shared_ptr<Task> assertQuery(
     const std::vector<RowVectorPtr>& expectedResults);
 
 velox::variant readSingleValue(
-    const std::shared_ptr<const core::PlanNode>& plan);
+    const std::shared_ptr<const core::PlanNode>& plan,
+    int32_t maxDrivers = 1);
 
 void assertEqualResults(
     const std::vector<RowVectorPtr>& expected,

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -159,15 +159,13 @@ class ChecksumAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushDown*/) override {
-    const auto& arg = args[0];
-    auto vector = arg->asUnchecked<FlatVector<int64_t>>();
-    VELOX_CHECK(vector);
-    auto rawValues = vector->rawValues();
+    decodedIntermediate_.decode(*args[0], rows);
+
     int64_t result = 0;
     bool clearGroupNull = false;
-    rows.applyToSelected([&](vector_size_t i) {
-      if (!vector->isNullAt(i)) {
-        safeAdd(result, rawValues[i]);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedIntermediate_.isNullAt(row)) {
+        safeAdd(result, decodedIntermediate_.valueAt<int64_t>(row));
         clearGroupNull = true;
       }
     });


### PR DESCRIPTION
Summary: Some queries might have local exchanges before INTERMEDIATE aggregation. The local exchanges produce dictionaries, so we need to expect these in addSingleGroupIntermediateResults() of the array_agg, map_agg and checksum aggregations.

Differential Revision: D35636100

