### PR TITLE
Add printExprWithStats helper function

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -632,13 +632,20 @@ void CastExpr::evalSpecialForm(
   inputs_[0]->eval(rows, context, &input);
   auto fromType = inputs_[0]->type();
   auto toType = std::const_pointer_cast<const Type>(type_);
+
+  stats_.numProcessedRows += rows.countSelected();
+  CpuWallTimer timer(stats_.timing);
   apply(rows, input, context, fromType, toType, result);
 }
 
-std::string CastExpr::toString() const {
+std::string CastExpr::toString(bool recursive) const {
   std::stringstream out;
   out << "cast(";
-  appendInputs(out);
+  if (recursive) {
+    appendInputs(out);
+  } else {
+    out << inputs_[0]->toString(false);
+  }
   out << " as " << type_->toString() << ")";
   return out.str();
 }

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -40,7 +40,7 @@ class CastExpr : public SpecialForm {
       EvalCtx* context,
       VectorPtr* result) override;
 
-  std::string toString() const override;
+  std::string toString(bool recursive = true) const override;
 
  private:
   /// @tparam To The cast target type

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -66,7 +66,7 @@ void ConstantExpr::evalSpecialFormSimplified(
   }
 }
 
-std::string ConstantExpr::toString() const {
+std::string ConstantExpr::toString(bool /*recursive*/) const {
   if (sharedSubexprValues_ == nullptr) {
     return fmt::format("{}:{}", value_.toJson(), type()->toString());
   } else {

--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -87,7 +87,7 @@ class ConstantExpr : public SpecialForm {
     return sharedSubexprValues_;
   }
 
-  std::string toString() const override;
+  std::string toString(bool recursive = true) const override;
 
  private:
   const variant value_;

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -157,7 +157,13 @@ class Expr {
     return inputs_;
   }
 
-  virtual std::string toString() const;
+  /// @param recursive If true, the output includes input expressions and all
+  /// their inputs recursively.
+  virtual std::string toString(bool recursive = true) const;
+
+  const ExprStats& stats() const {
+    return stats_;
+  }
 
  private:
   void setAllNulls(
@@ -431,5 +437,11 @@ class ExprSetSimplified : public ExprSet {
 std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<std::shared_ptr<const core::ITypedExpr>>&& source,
     core::ExecCtx* execCtx);
+
+/// Returns a string representation of the expression trees annotated with
+/// runtime statistics. Expected to be called after calling ExprSet::eval one or
+/// more times. If called before ExprSet::eval runtime statistics will be all
+/// zeros.
+std::string printExprWithStats(const ExprSet& exprSet);
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_expression_test
   ExprTest.cpp
+  ExprStatsTest.cpp
   CastExprTest.cpp
   MapWriterTest.cpp
   ArrayWriterTest.cpp
@@ -59,6 +60,7 @@ target_link_libraries(
   velox_vector_fuzzer
   gtest
   gtest_main
+  gmock
   ${FOLLY_WITH_DEPENDENCIES}
   ${gflags_LIBRARIES}
   glog::glog

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include "velox/core/Expressions.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class ExprStatsTest : public testing::Test, public VectorTestBase {
+ protected:
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  static RowTypePtr asRowType(const TypePtr& type) {
+    return std::dynamic_pointer_cast<const RowType>(type);
+  }
+
+  std::shared_ptr<const core::ITypedExpr> parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    auto untyped = parse::parseExpr(text);
+    return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+  }
+
+  std::unique_ptr<exec::ExprSet> compileExpressions(
+      const std::vector<std::string>& exprs,
+      const RowTypePtr& rowType) {
+    std::vector<std::shared_ptr<const core::ITypedExpr>> expressions;
+    expressions.reserve(exprs.size());
+    for (const auto& expr : exprs) {
+      expressions.emplace_back(parseExpression(expr, rowType));
+    }
+    return std::make_unique<exec::ExprSet>(
+        std::move(expressions), execCtx_.get());
+  }
+
+  VectorPtr evaluate(exec::ExprSet& exprSet, const RowVectorPtr& input) {
+    exec::EvalCtx context(execCtx_.get(), &exprSet, input.get());
+
+    SelectivityVector rows(input->size());
+    std::vector<VectorPtr> result(1);
+    exprSet.eval(rows, &context, &result);
+    return result[0];
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+};
+
+TEST_F(ExprStatsTest, printWithStats) {
+  vector_size_t size = 1'024;
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),
+  });
+
+  auto rowType = asRowType(data->type());
+  {
+    auto exprSet =
+        compileExpressions({"(c0 + 3) * c1", "(c0 + c1) % 2 = 0"}, rowType);
+
+    // Check stats before evaluation.
+    ASSERT_EQ(
+        exec::printExprWithStats(*exprSet),
+        "multiply [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "   plus [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "      cast(c0 as BIGINT) [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "         c0 [cpu time: 0ns, rows: 0] -> INTEGER\n"
+        "      3:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "   cast(c1 as BIGINT) [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "      c1 [cpu time: 0ns, rows: 0] -> INTEGER\n"
+        "\n"
+        "eq [cpu time: 0ns, rows: 0] -> BOOLEAN\n"
+        "   mod [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "      cast(plus as BIGINT) [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "         plus [cpu time: 0ns, rows: 0] -> INTEGER\n"
+        "            c0 [cpu time: 0ns, rows: 0] -> INTEGER\n"
+        "            c1 [cpu time: 0ns, rows: 0] -> INTEGER\n"
+        "      2:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT\n"
+        "   0:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT\n");
+
+    evaluate(*exprSet, data);
+
+    // Check stats after evaluation.
+    ASSERT_THAT(
+        exec::printExprWithStats(*exprSet),
+        ::testing::MatchesRegex(
+            "multiply .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "   plus .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "      cast.c0 as BIGINT. .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "         c0 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "      3:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"
+            "   cast.c1 as BIGINT. .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "      c1 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "\n"
+            "eq .cpu time: .+, rows: 1024. -> BOOLEAN\n"
+            "   mod .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "      cast.plus as BIGINT. .cpu time: .+, rows: 1024. -> BIGINT\n"
+            "         plus .cpu time: .+, rows: 1024. -> INTEGER\n"
+            "            c0 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "            c1 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "      2:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"
+            "   0:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"));
+  }
+
+  // Use dictionary encoding to repeat each row 5 times.
+  auto indices = makeIndices(size, [](auto row) { return row / 5; });
+  data = makeRowVector({
+      wrapInDictionary(indices, size, data->childAt(0)),
+      wrapInDictionary(indices, size, data->childAt(1)),
+  });
+
+  {
+    auto exprSet =
+        compileExpressions({"(c0 + 3) * c1", "(c0 + c1) % 2 = 0"}, rowType);
+    evaluate(*exprSet, data);
+
+    ASSERT_THAT(
+        exec::printExprWithStats(*exprSet),
+        ::testing::MatchesRegex(
+            "multiply .cpu time: .+, rows: 205. -> BIGINT\n"
+            "   plus .cpu time: .+, rows: 205. -> BIGINT\n"
+            "      cast.c0 as BIGINT. .cpu time: .+, rows: 205. -> BIGINT\n"
+            "         c0 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "      3:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"
+            "   cast.c1 as BIGINT. .cpu time: .+, rows: 205. -> BIGINT\n"
+            "      c1 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "\n"
+            "eq .cpu time: .+, rows: 205. -> BOOLEAN\n"
+            "   mod .cpu time: .+, rows: 205. -> BIGINT\n"
+            "      cast.plus as BIGINT. .cpu time: .+, rows: 205. -> BIGINT\n"
+            "         plus .cpu time: .+, rows: 205. -> INTEGER\n"
+            "            c0 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "            c1 .cpu time: 0ns, rows: 0. -> INTEGER\n"
+            "      2:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"
+            "   0:BIGINT .cpu time: 0ns, rows: 0. -> BIGINT\n"));
+  }
+}


### PR DESCRIPTION
Add helper function to print expression tree annotation with runtime stats such
as cpu time and number of processed rows.

Also, add cpu time tracking for Cast expression. Tracking for other built-in
expressions such as AND, OR, SWITCH will come in follow-up PRs.

Here are some examples:

2 expressions evaluated on flat vectors of size 1024: `(c0 + 3) * c1`, `(c0 + c1) % 2 = 0`

```
multiply [cpu time: 53.70us, rows: 1024] -> BIGINT
   plus [cpu time: 70.69us, rows: 1024] -> BIGINT
      cast(c0 as BIGINT) [cpu time: 132.21us, rows: 1024] -> BIGINT
         c0 [cpu time: 0ns, rows: 0] -> INTEGER
      3:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
   cast(c1 as BIGINT) [cpu time: 67.17us, rows: 1024] -> BIGINT
      c1 [cpu time: 0ns, rows: 0] -> INTEGER

eq [cpu time: 87.21us, rows: 1024] -> BOOLEAN
   mod [cpu time: 55.06us, rows: 1024] -> BIGINT
      cast(plus as BIGINT) [cpu time: 64.71us, rows: 1024] -> BIGINT
         plus [cpu time: 60.85us, rows: 1024] -> INTEGER
            c0 [cpu time: 0ns, rows: 0] -> INTEGER
            c1 [cpu time: 0ns, rows: 0] -> INTEGER
      2:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
   0:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
```

2 expressions evaluated on dictionary-encoded vectors of size 1024 where each
row is repeated 5 times: `(c0 + 3) * c1`, `(c0 + c1) % 2 = 0`. Notice that
evaluation happened only on 1/5 of the rows.

```
multiply [cpu time: 35.52us, rows: 205] -> BIGINT
   plus [cpu time: 46.66us, rows: 205] -> BIGINT
      cast(c0 as BIGINT) [cpu time: 80.15us, rows: 205] -> BIGINT
         c0 [cpu time: 0ns, rows: 0] -> INTEGER
      3:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
   cast(c1 as BIGINT) [cpu time: 34.44us, rows: 205] -> BIGINT
      c1 [cpu time: 0ns, rows: 0] -> INTEGER

eq [cpu time: 43.46us, rows: 205] -> BOOLEAN
   mod [cpu time: 35.93us, rows: 205] -> BIGINT
      cast(plus as BIGINT) [cpu time: 34.83us, rows: 205] -> BIGINT
         plus [cpu time: 34.43us, rows: 205] -> INTEGER
            c0 [cpu time: 0ns, rows: 0] -> INTEGER
            c1 [cpu time: 0ns, rows: 0] -> INTEGER
      2:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
   0:BIGINT [cpu time: 0ns, rows: 0] -> BIGINT
```