### PR TITLE
Add ExprSetListener

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
-#include "velox/expression/Expr.h"
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/ControlExpr.h"
+#include "velox/expression/Expr.h"
 #include "velox/expression/ExprCompiler.h"
 #include "velox/expression/VarSetter.h"
 #include "velox/expression/VectorFunction.h"
@@ -29,6 +32,43 @@ DEFINE_bool(
     "use of simplified expression evaluation path.");
 
 namespace facebook::velox::exec {
+
+namespace {
+folly::Synchronized<std::vector<std::shared_ptr<ExprSetListener>>>&
+listeners() {
+  static folly::Synchronized<std::vector<std::shared_ptr<ExprSetListener>>>
+      kListeners;
+  return kListeners;
+}
+} // namespace
+
+bool registerExprSetListener(std::shared_ptr<ExprSetListener> listener) {
+  return listeners().withWLock([&](auto& listeners) {
+    for (const auto& existingListener : listeners) {
+      if (existingListener == listener) {
+        // Listener already registered. Do not register again.
+        return false;
+      }
+    }
+    listeners.push_back(std::move(listener));
+    return true;
+  });
+}
+
+bool unregisterExprSetListener(
+    const std::shared_ptr<ExprSetListener>& listener) {
+  return listeners().withWLock([&](auto& listeners) {
+    for (auto it = listeners.begin(); it != listeners.end(); ++it) {
+      if ((*it) == listener) {
+        listeners.erase(it);
+        return true;
+      }
+    }
+
+    // Listener not found.
+    return false;
+  });
+}
 
 namespace {
 
@@ -1172,6 +1212,41 @@ ExprSet::ExprSet(
     : execCtx_(execCtx) {
   exprs_ = compileExpressions(
       std::move(sources), execCtx, this, enableConstantFolding);
+}
+
+namespace {
+void addStats(
+    const exec::Expr& expr,
+    std::unordered_map<std::string, exec::ExprStats>& stats) {
+  // Do not aggregate empty stats.
+  if (expr.stats().numProcessedRows) {
+    stats[expr.name()].add(expr.stats());
+  }
+
+  for (const auto& input : expr.inputs()) {
+    addStats(*input, stats);
+  }
+}
+
+std::string makeUuid() {
+  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+}
+} // namespace
+
+ExprSet::~ExprSet() {
+  listeners().withRLock([&](auto& listeners) {
+    if (!listeners.empty()) {
+      std::unordered_map<std::string, exec::ExprStats> stats;
+      for (const auto& expr : exprs()) {
+        addStats(*expr, stats);
+      }
+
+      auto uuid = makeUuid();
+      for (auto& listener : listeners) {
+        listener->onCompletion(uuid, {stats});
+      }
+    }
+  });
 }
 
 void ExprSet::eval(


### PR DESCRIPTION
Add a mechanism to register a listener to receive runtime statistics about
expression evaluation at destruction of ExprSet. This is useful for logging and
debugging. An earlier PR #1404 introduced a similar mechanism to receive 
runtime statistics about Task execution.