### PR TITLE
Fix Mapped Pages Counting for allocateContiguous()

### DIFF
--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -186,8 +186,9 @@ class MappedMemoryTest : public testing::TestWithParam<bool> {
           EXPECT_EQ(kCapacity, instance_->numAllocated());
           if (useMmap_) {
             // The allocator has everything allocated and half mapped, with the
-            // other half mapped by the contiguous allocation.
-            EXPECT_EQ(kCapacity / 2, instance_->numMapped());
+            // other half mapped by the contiguous allocation. numMapped()
+            // includes the contiguous allocation.
+            EXPECT_EQ(kCapacity, instance_->numMapped());
           }
           if (!allocateContiguous(available / 2, nullptr, large)) {
             FAIL()
@@ -442,6 +443,126 @@ TEST_P(MappedMemoryTest, minSizeClass) {
       tracker->getCurrentUserBytes());
   mappedMemory->free(result);
   EXPECT_EQ(0, tracker->getCurrentUserBytes());
+}
+
+TEST_P(MappedMemoryTest, externalAdvise) {
+  if (!useMmap_) {
+    return;
+  }
+  constexpr int32_t kSmallSize = 16;
+  constexpr int32_t kLargeSize = 32 * kSmallSize + 1;
+  auto instance = dynamic_cast<MmapAllocator*>(MappedMemory::getInstance());
+  std::vector<std::unique_ptr<MappedMemory::Allocation>> allocations;
+  auto numAllocs = kCapacity / kSmallSize;
+  allocations.reserve(numAllocs);
+  for (int32_t i = 0; i < numAllocs; ++i) {
+    allocations.push_back(std::make_unique<MappedMemory::Allocation>(instance));
+    EXPECT_TRUE(allocate(kSmallSize, *allocations.back().get()));
+  }
+  // We allocated and mapped the capacity. Now free half, leaving the memory
+  // still mapped.
+  allocations.resize(numAllocs / 2);
+  EXPECT_TRUE(instance->checkConsistency());
+  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize);
+  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
+  std::vector<MappedMemory::ContiguousAllocation> large(2);
+  EXPECT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, large[0]));
+  // The same number are mapped but some got advised away to back the large
+  // allocation. One kSmallSize got advised away but not fully used because
+  // kLargeSize is not a multiple of kSmallSize.
+  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize - kSmallSize + 1);
+  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize + kLargeSize);
+  EXPECT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, large[1]));
+  large.clear();
+  EXPECT_EQ(instance->numAllocated(), allocations.size() * kSmallSize);
+  // After freeing 2xkLargeSize, We have unmapped 2*LargeSize at the free and
+  // another (kSmallSize - 1 when allocating the first kLargeSize. Of the 15
+  // that this unmapped, 1 was taken by the second large alloc. So, the mapped
+  // pages is total - (2 * kLargeSize) - 14. The unused unmapped are 15 pages
+  // after the first and 14 after the second allocContiguous().
+  EXPECT_EQ(
+      instance->numMapped(),
+      kSmallSize * numAllocs - (2 * kLargeSize) -
+          (kSmallSize - (2 * (kLargeSize % kSmallSize))));
+  EXPECT_TRUE(instance->checkConsistency());
+}
+
+TEST_P(MappedMemoryTest, allocContiguousFail) {
+  if (!useMmap_) {
+    return;
+  }
+  // Covers edge cases of
+  constexpr int32_t kSmallSize = 16;
+  constexpr int32_t kLargeSize = kCapacity / 2;
+  auto instance = dynamic_cast<MmapAllocator*>(MappedMemory::getInstance());
+  std::vector<std::unique_ptr<MappedMemory::Allocation>> allocations;
+  auto numAllocs = kCapacity / kSmallSize;
+  int64_t trackedBytes = 0;
+  auto trackCallback = [&](int64_t delta) { trackedBytes += delta; };
+  allocations.reserve(numAllocs);
+  for (int32_t i = 0; i < numAllocs; ++i) {
+    allocations.push_back(std::make_unique<MappedMemory::Allocation>(instance));
+    EXPECT_TRUE(allocate(kSmallSize, *allocations.back().get()));
+  }
+  // We allocated and mapped the capacity. Now free half, leaving the memory
+  // still mapped.
+  allocations.resize(numAllocs / 2);
+  EXPECT_TRUE(instance->checkConsistency());
+  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize);
+  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
+  MappedMemory::ContiguousAllocation large;
+  EXPECT_TRUE(instance->allocateContiguous(
+      kLargeSize / 2, nullptr, large, trackCallback));
+  EXPECT_TRUE(instance->checkConsistency());
+
+  // The allocation should go through because there is 1/2 of
+  // kLargeSize already in large[0], 1/2 of kLargeSize free and
+  // kSmallSize given as collateral. This does not go through because
+  // we inject a failure in advising away the collateral.
+  instance->injectFailure(MmapAllocator::Failure::kMadvise);
+  EXPECT_FALSE(instance->allocateContiguous(
+      kLargeSize + kSmallSize, allocations.back().get(), large, trackCallback));
+  EXPECT_TRUE(instance->checkConsistency());
+  // large and allocations.back() were both freed and nothing was allocated.
+  EXPECT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
+  // An extra kSmallSize were freed.
+  EXPECT_EQ(-kSmallSize * MappedMemory::kPageSize, trackedBytes);
+  // Remove the cleared item from the end.
+  allocations.pop_back();
+
+  trackedBytes = 0;
+  EXPECT_TRUE(instance->allocateContiguous(
+      kLargeSize / 2, nullptr, large, trackCallback));
+  instance->injectFailure(MmapAllocator::Failure::kMmap);
+  // Should go through because 1/2 of kLargeSize + kSmallSize free and 1/2 of
+  // kLargeSize already in large. Fails because mmap after advise away fails.
+  EXPECT_FALSE(instance->allocateContiguous(
+      kLargeSize + 2 * kSmallSize,
+      allocations.back().get(),
+      large,
+      trackCallback));
+  // large and allocations.back() were both freed and nothing was allocated.
+  EXPECT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
+  EXPECT_EQ(-kSmallSize * MappedMemory::kPageSize, trackedBytes);
+  allocations.pop_back();
+  EXPECT_TRUE(instance->checkConsistency());
+
+  trackedBytes = 0;
+  EXPECT_TRUE(instance->allocateContiguous(
+      kLargeSize / 2, nullptr, large, trackCallback));
+  // We succeed without injected failure.
+  EXPECT_TRUE(instance->allocateContiguous(
+      kLargeSize + 3 * kSmallSize,
+      allocations.back().get(),
+      large,
+      trackCallback));
+  EXPECT_EQ(kCapacity, instance->numMapped());
+  EXPECT_EQ(kCapacity, instance->numAllocated());
+  // Size grew by kLargeSize + 2 * kSmallSize (one kSmallSize item was freed, so
+  // no not 3 x kSmallSize).
+  EXPECT_EQ(
+      (kLargeSize + 2 * kSmallSize) * MappedMemory::kPageSize, trackedBytes);
+  EXPECT_TRUE(instance->checkConsistency());
 }
 
 TEST_P(MappedMemoryTest, allocateBytes) {


### PR DESCRIPTION
When allocating pages with MmapAllocator::allocateContiguous, we first
check that numAllocated_ has room for the number of pages that are
needed after releasing collateral and the previous contents of the
allocation.  If so, the allocation is possible but may need pages that are backing freed allocations in the different size classes to be advised away.

This was not taking place in if there were existing contiguous allocations that were counted in numExternalMapped_.

We change the meaning of numMapped_ to be the total number of pages
that are backed by memory, whether in the size classes or outside with
allocateContiguous (anonymous standalone mmap). numExternalMapped_ is
not the number of outstanding pages in standalone mmaps from
allocateContiguous but it is included in the numMapped_ count. In this
way, given capacity_, numMapped_ and the number of pages that were
allocated without backing memory, we always know how much we must
advise away from freed memory backed allocations.  This capacity is
available since the total to be covered is never over capacity_.