### PR TITLE
Rename Task::finished() to finishedLocked().

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1370,7 +1370,7 @@ StopReason Task::enterForTerminateLocked(ThreadState& state) {
 StopReason Task::leave(ThreadState& state) {
   std::lock_guard<std::mutex> l(mutex_);
   if (--numThreads_ == 0) {
-    finished();
+    finishedLocked();
   }
   state.clearThread();
   if (state.isTerminated) {
@@ -1404,7 +1404,7 @@ StopReason Task::enterSuspended(ThreadState& state) {
   if (reason == StopReason::kNone || reason == StopReason::kPause) {
     state.isSuspended = true;
     if (--numThreads_ == 0) {
-      finished();
+      finishedLocked();
     }
   }
   return StopReason::kNone;
@@ -1453,7 +1453,7 @@ StopReason Task::shouldStop() {
   return StopReason::kNone;
 }
 
-void Task::finished() {
+void Task::finishedLocked() {
   for (auto& promise : threadFinishPromises_) {
     promise.setValue(true);
   }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -506,7 +506,7 @@ class Task : public std::enable_shared_from_this<Task> {
       SplitsStore& splitsStore,
       exec::Split&& split);
 
-  void finished();
+  void finishedLocked();
 
   StopReason shouldStopLocked();
 


### PR DESCRIPTION
Summary: This method is being called under a lock.

Differential Revision: D35699012

