### PR TITLE
[WIP] Decimal signature

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -33,6 +33,7 @@ Supported types are:
   * TIMESTAMP
   * REAL
   * DOUBLE
+  * DECIMAL
   * VARCHAR
   * VARBINARY
   * OPAQUE*

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -59,11 +59,46 @@ bool SignatureBinder::tryBind() {
   return true;
 }
 
+bool SignatureBinder::tryBindDecimalTypes(
+    const exec::TypeSignature& decimalSignature,
+    const TypePtr& actualType) {
+  // get precision and scale from the actual type and bind to a variable in the
+  // decimal signature.
+  auto& longVariables = decimalSignature.longVariables();
+  std::vector<uint8_t> parameters;
+
+  if (actualType->kind() == TypeKind::SHORT_DECIMAL) {
+    DecimalType<TypeKind::SHORT_DECIMAL>::getDecimalParameters(
+        actualType, parameters);
+  } else {
+    DecimalType<TypeKind::LONG_DECIMAL>::getDecimalParameters(
+        actualType, parameters);
+  }
+  uint8_t pos = 0;
+  for (auto variable : longVariables) {
+    VELOX_USER_CHECK(
+        !longVariableBindings_.count(variable),
+        "Decimal long variable repeated: {}",
+        decimalSignature.toString())
+    longVariableBindings_.try_emplace(variable, parameters[pos++]);
+  }
+  VELOX_USER_CHECK(
+      pos == 2,
+      "Decimal Signature cannot have more than two long variables",
+      decimalSignature.toString());
+  return true;
+}
+
 bool SignatureBinder::tryBind(
     const exec::TypeSignature& typeSignature,
     const TypePtr& actualType) {
   if (isAny(typeSignature)) {
     return true;
+  }
+
+  if (actualType->kind() == TypeKind::SHORT_DECIMAL ||
+      actualType->kind() == TypeKind::LONG_DECIMAL) {
+    return tryBindDecimalTypes(typeSignature, actualType);
   }
 
   auto it = bindings_.find(typeSignature.baseType());
@@ -101,8 +136,23 @@ bool SignatureBinder::tryBind(
   return it->second->kindEquals(actualType);
 }
 
+TypePtr SignatureBinder::tryResolveDecimalType() const {
+  std::vector<int32_t> parameters;
+  (*signature_.computeLongVariablestFunction())(
+      longVariableBindings_, parameters);
+  VELOX_USER_CHECK(
+      parameters.size() == 2,
+      "Decimal return type must have only two parameters, {}",
+      signature_.returnType().toString());
+  return DECIMAL(parameters[0], parameters[1]);
+}
+
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature) const {
+  if (typeSignature.baseType() == "SHORT_DECIMAL" ||
+      typeSignature.baseType() == "LONG_DECIMAL") {
+    return tryResolveDecimalType();
+  }
   return tryResolveType(typeSignature, bindings_);
 }
 

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -58,5 +58,10 @@ class SignatureBinder {
   const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;
   std::unordered_map<std::string, TypePtr> bindings_;
+  std::unordered_map<std::string, int32_t> longVariableBindings_;
+  bool tryBindDecimalTypes(
+      const TypeSignature& decimalSignature,
+      const TypePtr& decimalType);
+  TypePtr tryResolveDecimalType() const;
 };
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   ArrayMinMax.cpp
   ArrayPosition.cpp
   Coalesce.cpp
+  DecimalOperators.cpp
   ElementAt.cpp
   FilterFunctions.cpp
   FromUnixTime.cpp

--- a/velox/functions/prestosql/DecimalOperators.cpp
+++ b/velox/functions/prestosql/DecimalOperators.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/type/DecimalUtils.cpp"
+
+namespace facebook::velox::functions {
+namespace {
+
+class DecimalAddFunction : public exec::VectorFunction {
+ public:
+  DecimalAddFunction(uint8_t aRescale, uint8_t bRescale)
+      : aRescale_(aRescale), bRescale_(bRescale) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args, // Each arg is Array of integers
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    auto num = std::min(args[0]->size(), args[1]->size());
+    FlatVector<int64_t>* aFlatVector = args[0]->asFlatVector<int64_t>();
+    FlatVector<int64_t>* bFlatVector = args[1]->asFlatVector<int64_t>();
+    // Initialize flat results vector.
+    BaseVector::ensureWritable(rows, outputType, context->pool(), result);
+    BufferPtr resultValues =
+        (*result)->as<FlatVector<int64_t>>()->mutableValues(rows.size());
+    auto rawValues = resultValues->asMutable<int64_t>();
+
+    auto processRow = [&](vector_size_t row) {
+      std::vector<int64_t> rescaledValues;
+      rescale(aFlatVector, bFlatVector, row, rescaledValues);
+      rawValues[row] = rescaledValues[0] + rescaledValues[1];
+    };
+    rows.applyToSelected([&](vector_size_t row) { processRow(row); });
+  }
+
+ private:
+  void rescale(
+      FlatVector<int64_t>* aFlatVector,
+      FlatVector<int64_t>* bFlatVector,
+      const vector_size_t i,
+      std::vector<int64_t>& rescaled) const {
+    rescaled.push_back(
+        aFlatVector->isNullAt(i)
+            ? 0
+            : aFlatVector->valueAt(i) * pow(10, aRescale_));
+    rescaled.push_back(
+        bFlatVector->isNullAt(i)
+            ? 0
+            : bFlatVector->valueAt(i) * pow(10, bRescale_));
+  }
+  const uint8_t aRescale_;
+  const uint8_t bRescale_;
+};
+
+// Function callback to compute the return type precision and scale.
+void computeReturnPrecisionScale(
+    const std::unordered_map<std::string, std::int32_t>& variablesBinding,
+    std::vector<int32_t>& output) {
+  // min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale,
+  // b_scale) + 1)
+  const uint8_t a_precision = variablesBinding.find("a_precision")->second;
+  const uint8_t b_precision = variablesBinding.find("b_precision")->second;
+  const uint8_t a_scale = variablesBinding.find("a_scale")->second;
+  const uint8_t b_scale = variablesBinding.find("b_scale")->second;
+  output.push_back(std::min(
+      38,
+      std::max(a_precision - a_scale, b_precision - b_scale) +
+          std::max(a_scale, b_scale) + 1));
+  output.push_back(std::max(a_scale, b_scale));
+}
+std::vector<std::shared_ptr<exec::FunctionSignature>> decimalAddSignature() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType(
+              "SHORT_DECIMAL(r_precision,r_scale)", {"r_precision", "r_scale"})
+          .argumentType(
+              "SHORT_DECIMAL(a_precision,a_scale)", {"a_precision", "a_scale"})
+          .argumentType(
+              "SHORT_DECIMAL(b_precision,b_scale)", {"b_precision", "b_scale"})
+          .computeLongVariablesBinding(&computeReturnPrecisionScale)
+          .build()};
+}
+
+std::shared_ptr<exec::VectorFunction> createDecimalAddFunction(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  ShortDecimalTypePtr aType =
+      std::dynamic_pointer_cast<const ShortDecimalType>(inputArgs[0].type);
+  ShortDecimalTypePtr bType =
+      std::dynamic_pointer_cast<const ShortDecimalType>(inputArgs[1].type);
+  uint8_t aRescale = computeRescaleFactor(aType->scale(), bType->scale());
+  uint8_t bRescale = computeRescaleFactor(bType->scale(), aType->scale());
+  return std::make_shared<DecimalAddFunction>(aRescale, bRescale);
+}
+}; // namespace
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_add_short_short,
+    decimalAddSignature(),
+    createDecimalAddFunction);
+
+}; // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -50,6 +50,7 @@ void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, "array_except");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_duplicates, "array_duplicates");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, "arrays_overlap");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_add_short_short, "add_short_short");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_slice, "slice");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, "zip");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, "array_position");

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -46,6 +46,29 @@ class ArraysOverlapTest : public FunctionBaseTest {
   }
 
   template <typename T>
+  void testDecimalExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    VectorPtr result =
+        evaluate<SimpleVector<T>>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+    ASSERT_EQ(result->type()->toString(), expected->type()->toString());
+  }
+
+  void testDecimalAdd() {
+    auto rightVec = std::vector<std::optional<int64_t>>{123456789, 111111111};
+    auto leftVec = std::vector<std::optional<int64_t>>{987654321, 123456789};
+    auto right = makeShortDecimalFaltVector(rightVec, 9, 5);
+    auto left = makeShortDecimalFaltVector(leftVec, 9, 3);
+    auto expectedVec =
+        std::vector<std::optional<int64_t>>{98888888889, 12456790011};
+    auto expected = makeShortDecimalFaltVector(expectedVec, 12, 5);
+    testDecimalExpr<int64_t>(
+        expected, "add_short_short(c0, c1)", {right, left});
+  }
+
+  template <typename T>
   void testInt() {
     auto array1 = makeNullableArrayVector<T>(
         {{1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt},
@@ -94,6 +117,10 @@ class ArraysOverlapTest : public FunctionBaseTest {
   }
 }; // class ArraysOverlap
 } // namespace
+
+TEST_F(ArraysOverlapTest, decimalTest) {
+  testDecimalAdd();
+}
 
 TEST_F(ArraysOverlapTest, intArrays) {
   testInt<int8_t>();

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   Timestamp.cpp
   TimestampConversion.cpp
   Date.cpp
+  DecimalUtils.cpp
   Filter.cpp
   Subfield.cpp
   Tokenizer.cpp)

--- a/velox/type/DecimalUtils.cpp
+++ b/velox/type/DecimalUtils.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+
+uint8_t computeRescaleFactor(const uint8_t fromScale, const uint8_t toScale) {
+  return std::max(0, toScale - fromScale);
+}

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -596,6 +596,13 @@ std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
   return std::make_shared<LongDecimalType>(precision, scale);
 }
 
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale) {
+  if (precision <= DecimalType<TypeKind::SHORT_DECIMAL>::kMaxPrecision) {
+    return SHORT_DECIMAL(precision, scale);
+  }
+  return LONG_DECIMAL(precision, scale);
+}
+
 std::shared_ptr<const Type> createScalarType(TypeKind kind) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(createScalarType, kind);
 }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -59,6 +59,8 @@ const std::unordered_map<std::string, TypeKind>& getTypeStringMap() {
       {"VARBINARY", TypeKind::VARBINARY},
       {"TIMESTAMP", TypeKind::TIMESTAMP},
       {"DATE", TypeKind::DATE},
+      {"SHORT_DECIMAL", TypeKind::SHORT_DECIMAL},
+      {"LONG_DECIMAL", TypeKind::LONG_DECIMAL},
       {"ARRAY", TypeKind::ARRAY},
       {"MAP", TypeKind::MAP},
       {"ROW", TypeKind::ROW},
@@ -102,6 +104,8 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
       {TypeKind::VARBINARY, "VARBINARY"},
       {TypeKind::TIMESTAMP, "TIMESTAMP"},
       {TypeKind::DATE, "DATE"},
+      {TypeKind::SHORT_DECIMAL, "SHORT_DECIMAL"},
+      {TypeKind::LONG_DECIMAL, "LONG_DECIMAL"},
       {TypeKind::ARRAY, "ARRAY"},
       {TypeKind::MAP, "MAP"},
       {TypeKind::ROW, "ROW"},
@@ -579,6 +583,18 @@ KOSKI_DEFINE_SCALAR_ACCESSOR(DATE);
 KOSKI_DEFINE_SCALAR_ACCESSOR(UNKNOWN);
 
 #undef KOSKI_DEFINE_SCALAR_ACCESSOR
+
+std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<ShortDecimalType>(precision, scale);
+}
+
+std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<LongDecimalType>(precision, scale);
+}
 
 std::shared_ptr<const Type> createScalarType(TypeKind kind) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(createScalarType, kind);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -515,7 +515,11 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 
 #undef VELOX_FLUENT_CAST
 
+using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
+using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
 using TypePtr = std::shared_ptr<const Type>;
+using ShortDecimalTypePtr = std::shared_ptr<const ShortDecimalType>;
+using LongDecimalTypePtr = std::shared_ptr<const LongDecimalType>;
 
 template <TypeKind KIND>
 class TypeBase : public Type {
@@ -536,9 +540,6 @@ class TypeBase : public Type {
     return TypeTraits<KIND>::name;
   }
 };
-
-using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
-using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
 
 /// This class represents the Decimal Type to represent the fixed-point numbers
 /// in Velox. The parameter "precision" represents the number of digits the
@@ -587,6 +588,15 @@ class DecimalType : public ScalarType<KIND> {
     obj["name"] = "Type";
     obj["type"] = toString();
     return obj;
+  }
+
+  static void getDecimalParameters(
+      const TypePtr& actualType,
+      std::vector<uint8_t>& parameters) {
+    auto decimalType =
+        std::dynamic_pointer_cast<const DecimalType<KIND>>(actualType);
+    parameters.push_back(decimalType->precision());
+    parameters.push_back(decimalType->scale());
   }
 
  private:
@@ -1028,6 +1038,8 @@ std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
 std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
     const uint8_t precision,
     const uint8_t scale);
+
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale);
 
 template <typename Class>
 std::shared_ptr<const OpaqueType> OPAQUE() {

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -287,6 +287,12 @@ std::string variant::toJson() const {
       auto& date = value<TypeKind::DATE>();
       return '"' + date.toString() + '"';
     }
+    case TypeKind::SHORT_DECIMAL: {
+      VELOX_NYI();
+    }
+    case TypeKind::LONG_DECIMAL: {
+      VELOX_NYI();
+    }
     case TypeKind::OPAQUE: {
       // Return expression that we can't parse back - we use toJson for
       // debugging only. Variant::serialize should actually serialize the data.

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -105,6 +105,20 @@ struct VariantTypeTraits<TypeKind::ARRAY> {
   using stored_type = std::vector<variant>;
 };
 
+template <>
+struct VariantTypeTraits<TypeKind::SHORT_DECIMAL> {
+  using native_type = typename TypeTraits<TypeKind::SHORT_DECIMAL>::NativeType;
+  // @TODO: This just a place holder. Replace with ShortDecimalVariant
+  using stored_type = int64_t;
+};
+
+template <>
+struct VariantTypeTraits<TypeKind::LONG_DECIMAL> {
+  using native_type = typename TypeTraits<TypeKind::LONG_DECIMAL>::NativeType;
+  // @TODO: This just a place holder. Replace with LongDecimalVariant
+  using stored_type = int128_t;
+};
+
 struct OpaqueCapsule {
   std::shared_ptr<const OpaqueType> type;
   std::shared_ptr<void> obj;

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -117,6 +117,24 @@ TEST(Type, Date) {
   EXPECT_EQ(date->begin(), date->end());
 }
 
+TEST(Type, Decimal) {
+  auto shortDecimal = SHORT_DECIMAL(10, 5);
+  EXPECT_EQ(shortDecimal->toString(), "SHORT_DECIMAL(10,5)");
+  EXPECT_EQ(shortDecimal->size(), 0);
+  EXPECT_THROW(shortDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(shortDecimal->kind(), TypeKind::SHORT_DECIMAL);
+  EXPECT_STREQ(shortDecimal->kindName(), "SHORT_DECIMAL");
+  EXPECT_EQ(shortDecimal->begin(), shortDecimal->end());
+
+  auto longDecimal = LONG_DECIMAL(10, 5);
+  EXPECT_EQ(longDecimal->toString(), "LONG_DECIMAL(10,5)");
+  EXPECT_EQ(longDecimal->size(), 0);
+  EXPECT_THROW(longDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(longDecimal->kind(), TypeKind::LONG_DECIMAL);
+  EXPECT_STREQ(longDecimal->kindName(), "LONG_DECIMAL");
+  EXPECT_EQ(longDecimal->begin(), longDecimal->end());
+}
+
 TEST(Type, DateToString) {
   Date epoch(0);
   EXPECT_EQ(epoch.toString(), "1970-01-01");

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -338,6 +338,10 @@ VectorPtr BaseVector::create(
           true /*isSorted*/,
           0 /*representedBytes*/);
     }
+    case TypeKind::SHORT_DECIMAL:
+    case TypeKind::LONG_DECIMAL: {
+      return createEmpty<TypeKind::SHORT_DECIMAL>(size, pool, type);
+    }
     default:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
           createEmpty, kind, size, pool, type);

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -148,6 +148,14 @@ class VectorTestBase {
     return vectorMaker_.flatVectorNullable(data, type);
   }
 
+  FlatVectorPtr<int64_t> makeShortDecimalFaltVector(
+      std::vector<std::optional<int64_t>>& vec,
+      const uint8_t precision,
+      uint8_t scale) {
+    const TypePtr& type = SHORT_DECIMAL(precision, scale);
+    return vectorMaker_.flatVectorNullable<int64_t>(vec, type);
+  }
+
   template <typename T, int TupleIndex, typename TupleType>
   FlatVectorPtr<T> makeFlatVector(const std::vector<TupleType>& data) {
     return vectorMaker_.flatVector<T, TupleIndex, TupleType>(data);


### PR DESCRIPTION
1. Decimal Arithmetic operations need to support function signatures of the format:
` DECIMAL(r_precision,r_scale) ADD (DECIMAL(a_precision, a_scale), DECIMAL(b_precision, b_scale))`

2. `SignatureBinder` doesn’t support binding variables to literals. Only binds Type variables to Types.
     Introduced `longVariablesBindings_` member in `SignatureBinder` to map variables like a_precision, a_scale etc, to their long literals in the incoming function call.

3. SignatureBinder cannot resolve return types that have variable parameters. For decimaltype, the return type must be inferred from the precision and scales of the inputs. To support this, introduced a function pointer member to the `FunctionSignature`. The `SignatureBinder` will invoke this function pointer at the time of resolving the return type.

Testing:
1. Compilation succeeds.
2. Test crashes because the DECIMAL operation is not implemented yet.
