### PR TITLE
Fix RoContainer Null flags init and clear, add getters

### DIFF
--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -70,7 +70,7 @@ class AllocationPool {
   }
 
   // Returns number of bytes left at the end of the current run.
-  int32_t availableInRun() {
+  int32_t availableInRun() const {
     if (!allocation_.numRuns()) {
       return 0;
     }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -54,15 +54,16 @@ class RowContainerTest : public testing::Test {
 
   std::unique_ptr<RowContainer> makeRowContainer(
       const std::vector<TypePtr>& keyTypes,
-      const std::vector<TypePtr>& dependentTypes) {
+      const std::vector<TypePtr>& dependentTypes,
+      bool isJoinBuild = true) {
     static const std::vector<std::unique_ptr<Aggregate>> kEmptyAggregates;
     return std::make_unique<RowContainer>(
         keyTypes,
-        false,
+        !isJoinBuild,
         kEmptyAggregates,
         dependentTypes,
-        true,
-        true,
+        isJoinBuild,
+        isJoinBuild,
         true,
         true,
         mappedMemory_,
@@ -387,6 +388,11 @@ TEST_F(RowContainerTest, types) {
       }
     }
   }
+  // We check that there is unused space in rows and variable length
+  // data.
+  auto free = data->freeSpace();
+  EXPECT_LT(0, free.first);
+  EXPECT_LT(0, free.second);
 }
 
 TEST_F(RowContainerTest, erase) {
@@ -434,6 +440,32 @@ TEST_F(RowContainerTest, erase) {
   auto newRow = data->newRow();
   EXPECT_EQ(rowSet.end(), rowSet.find(newRow));
   data->checkConsistency();
+  data->clear();
+  EXPECT_EQ(0, data->numRows());
+  auto free = data->freeSpace();
+  EXPECT_EQ(0, free.first);
+  EXPECT_EQ(0, free.second);
+  data->checkConsistency();
+}
+
+TEST_F(RowContainerTest, initialNulls) {
+  std::vector<TypePtr> keys{INTEGER()};
+  std::vector<TypePtr> dependent{INTEGER()};
+  // Join build.
+  auto data = makeRowContainer(keys, dependent, true);
+  auto row = data->newRow();
+  auto isNullAt = [](const RowContainer& data, const char* row, int32_t i) {
+    auto column = data.columnAt(i);
+    return RowContainer::isNullAt(row, column.nullByte(), column.nullMask());
+  };
+
+  EXPECT_FALSE(isNullAt(*data, row, 0));
+  EXPECT_FALSE(isNullAt(*data, row, 1));
+  // Non-join build.
+  data = makeRowContainer(keys, dependent, false);
+  row = data->newRow();
+  EXPECT_FALSE(isNullAt(*data, row, 0));
+  EXPECT_FALSE(isNullAt(*data, row, 1));
 }
 
 TEST_F(RowContainerTest, rowSize) {


### PR DESCRIPTION
Initialize all bit fields (null flags and brobed, free etc) to
0. After this, set all aggregate null flags to 1 since aggregates
start as null.  Set free list of RowContainer to empty after
clear(). This makes non-aggregate fields of non-join RowContainer
start as non-null. Add 'isJoinBuild' parameter to test function
makeRowContainer().

Add getters for keys and dependent types and a function to query how
many rows/variable length bytes can be added without growing the
container.