### PR TITLE
Fix constant peeling with exceptions and TRY

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -100,8 +100,18 @@ void EvalCtx::setWrapped(
     return;
   }
   if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
-    *result = BaseVector::wrapInConstant(
-        rows.size(), constantWrapIndex_, std::move(source));
+    if (errors_ && constantWrapIndex_ < errors_->size() &&
+        !errors_->isNullAt(constantWrapIndex_)) {
+      // If the single row caused an error that will be caught by a TRY
+      // upstream source may be not initialized, or otherwise in a bad state.
+      // Just return NULL, the value won't be used and TRY is just going to
+      // NULL out the result anyway.
+      *result =
+          BaseVector::createNullConstant(expr->type(), rows.size(), pool());
+    } else {
+      *result = BaseVector::wrapInConstant(
+          rows.size(), constantWrapIndex_, std::move(source));
+    }
     return;
   }
   VELOX_CHECK(false, "Bad expression wrap encoding {}", wrapEncoding_);


### PR DESCRIPTION
Summary:
When ConstantVectors wrap another Vector, if the type is scalar, they'll copy the value out
of the wrapped vector into a member variable value_.  When the value is a StringView, it
will be copied into a std::string, so the value isn't lost when the wrapped Vector is
deallocated.

With TRY, if an exception is thrown evaluating a peeled constant Varchar, that StringView
will be uninitialized and point to a random location in memory.  This leads to undefined
behavior/ASAN errors when attempting to wrap the result in a ConstantVector.

This diff attempts to fix the issue by first checking if the errors bit is set for that row, in
which case we just allocate a NULL constant (the TRY will NULL out the value for these
rows anyway).

Differential Revision: D35731759

