### PR TITLE
Add date_parse shortcut to unblock Deltoid

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -62,6 +62,23 @@ int main(int argc, char** argv) {
       // cardinality passing a VARBINARY (since HLL's implementation uses an
       // alias to VARBINARY).
       "cardinality",
+      // Common path throws and simplified path not throwing. This is due to an
+      // exception thrown in initializate() method of date_parse udf.
+      //
+      // What happened was in common path initialize() was called with an
+      // invalid input that triggers the throw, while in simplified path
+      // initialize() was called with a nullptr input value because it is not
+      // constant folded and not triggering the throw.
+      //
+      // Ideally simplified path should throw in the call() method of the udf
+      // but due to null optimization call() was never called for both. This
+      // brings up the inconsistency for the 2 paths.
+      //
+      // There was previous effort that tried to address this issue by delaying
+      // the throw of exceptions during constant folding. But initialize() is
+      // called prior to constant folding so this case is not caught up.
+      // TODO: T117753276
+      "date_parse",
   };
   return FuzzerRunner::run(FLAGS_only, FLAGS_steps, FLAGS_seed, skipFunctions);
 }

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -718,6 +718,56 @@ struct DateFormatFunction {
 };
 
 template <typename T>
+struct DateParseFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr folly::StringPiece supportedFormat{"%Y-%m-%d"};
+  static constexpr folly::StringPiece correspondingJodaFormat{"YYYY-MM-dd"};
+
+  std::optional<JodaFormatter> format_;
+  std::optional<int64_t> sessionTzID_;
+
+  void validateFormat(const velox::StringView& format) {
+    if (format != supportedFormat) {
+      VELOX_USER_FAIL(
+          "'date_parse' function currently only supports '%Y-%m-%d' format but "
+          "'",
+          format,
+          "' is provided");
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* /*input*/,
+      const arg_type<Varchar>* formatString) {
+    if (formatString != nullptr) {
+      validateFormat(*formatString);
+      format_.emplace(correspondingJodaFormat.data());
+    }
+
+    auto sessionTzName = config.sessionTimezone();
+    if (!sessionTzName.empty()) {
+      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& format) {
+    validateFormat(format);
+    if (!format_.has_value()) {
+      format_.emplace(correspondingJodaFormat.data());
+    }
+    auto jodaResult = format_->parse(input);
+    int16_t timezoneId = sessionTzID_.value_or(0);
+    jodaResult.timestamp.toGMT(timezoneId);
+    result = jodaResult.timestamp;
+    return true;
+  }
+};
+
+template <typename T>
 struct ParseDateTimeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -70,8 +70,8 @@ void registerSimpleFunctions() {
       TimestampWithTimezone,
       Varchar,
       Varchar>({"parse_datetime"});
-  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
-      {"date_format"});
+  registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
+      {"date_parse"});
 }
 } // namespace
 


### PR DESCRIPTION
Summary: This is a shortcut version to support Deltoid workload as it only has %Y-%m-%d format for date_parse function.

Differential Revision: D35736708

