### PR TITLE
Allow seeking with HashStringAllocator and finalize in constant space

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -316,6 +316,82 @@ void HashStringAllocator::free(Header* _header) {
   } while (header);
 }
 
+//  static
+int64_t HashStringAllocator::offset(
+    Header* FOLLY_NONNULL header,
+    Position position) {
+  int64_t size = 0;
+  for (;;) {
+    bool continued = header->isContinued();
+    auto length = header->size() - (continued ? sizeof(void*) : 0);
+    auto begin = header->begin();
+    if (position.position >= begin && position.position <= begin + length) {
+      return size + (position.position - begin);
+    }
+    if (!continued) {
+      return -1;
+    }
+    size += length;
+    header = getNextContinued(header);
+  }
+}
+
+//  static
+HashStringAllocator::Position HashStringAllocator::seek(
+    Header* FOLLY_NONNULL header,
+    int64_t offset) {
+  int64_t size = 0;
+  for (;;) {
+    bool continued = header->isContinued();
+    auto length = header->size() - (continued ? sizeof(void*) : 0);
+    auto begin = header->begin();
+    if (offset <= size + length) {
+      return Position{header, begin + (offset - size)};
+    }
+    if (!continued) {
+      return {nullptr, nullptr};
+    }
+    size += length;
+    header = getNextContinued(header);
+  }
+}
+
+// static
+int64_t HashStringAllocator::available(const Position& position) {
+  auto header = position.header;
+  auto startOffset = position.position - position.header->begin();
+  // startOffset bytes from the first block are already used.
+  int64_t size = -startOffset;
+  for (;;) {
+    auto continued = header->isContinued();
+    auto length = header->size() - (continued ? sizeof(void*) : 0);
+    ;
+    size += length;
+    if (!continued) {
+      return size;
+    }
+    header = getNextContinued(header);
+    startOffset = 0;
+  }
+}
+
+void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
+  if (available(position) >= bytes) {
+    return;
+  }
+  ByteStream stream(this);
+  auto fromHeader = offset(position.header, position);
+  extendWrite(position, stream);
+  static char data[128];
+  while (bytes) {
+    auto written = std::min<size_t>(bytes, sizeof(data));
+    stream.append(folly::StringPiece(data, written));
+    bytes -= written;
+  }
+  finishWrite(stream, 0);
+  position = seek(position.header, fromHeader);
+}
+
 void HashStringAllocator::checkConsistency() const {
   uint64_t numFree = 0;
   uint64_t freeBytes = 0;

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -157,6 +157,44 @@ TEST_F(HashStringAllocatorTest, multipart) {
   instance_->checkConsistency();
 }
 
+TEST_F(HashStringAllocatorTest, rewrite) {
+  ByteStream stream(instance_.get());
+  auto header = instance_->allocate(5);
+  EXPECT_EQ(16, header->size()); // Rounds up to kMinAlloc.
+  HashStringAllocator::Position current{header, header->begin()};
+  for (auto i = 0; i < 10; ++i) {
+    instance_->extendWrite(current, stream);
+    stream.appendOne(123456789012345LL);
+    current = instance_->finishWrite(stream, 0);
+    auto offset = HashStringAllocator::offset(header, current);
+    EXPECT_EQ((i + 1) * sizeof(int64_t), offset);
+    // The allocated writable space from 'header' is at least the amount
+    // written.
+    auto avail = HashStringAllocator::available({header, header->begin()});
+    EXPECT_LE((i + 1) * sizeof(int64_t), avail);
+  }
+  EXPECT_EQ(-1, HashStringAllocator::offset(header, {nullptr, nullptr}));
+  for (auto repeat = 0; repeat < 2; ++repeat) {
+    auto position = HashStringAllocator::seek(header, sizeof(int64_t));
+    // We write the words at index 1 and 2.
+    instance_->extendWrite(position, stream);
+    stream.appendOne(12345LL);
+    stream.appendOne(67890LL);
+    position = instance_->finishWrite(stream, 0);
+    EXPECT_EQ(
+        3 * sizeof(int64_t), HashStringAllocator::offset(header, position));
+    HashStringAllocator::prepareRead(header, stream);
+    EXPECT_EQ(123456789012345LL, stream.read<int64_t>());
+    EXPECT_EQ(12345LL, stream.read<int64_t>());
+    EXPECT_EQ(67890LL, stream.read<int64_t>());
+  }
+  // The stream contains 3 int64_t's.
+  auto end = HashStringAllocator::seek(header, 3 * sizeof(int64_t));
+  EXPECT_EQ(0, HashStringAllocator::available(end));
+  instance_->ensureAvailable(32, end);
+  EXPECT_EQ(32, HashStringAllocator::available(end));
+}
+
 TEST_F(HashStringAllocatorTest, stlAllocator) {
   {
     std::vector<double, StlAllocator<double>> data(


### PR DESCRIPTION
Array and map aggregates should finalize without growing the accumulator. This is needed for writing spill because starting the spill write takes place when the container is full and requires finalizing the accumulators that are to be spilled.

Add offset() and seek() to HashStringAllocator. These allow
positioning the append point at a byte offset from the start of a
Header. This works transparently blocks. When a extendWrite is called
after setting the position to a byte offset, the tail after the
position is freed. But if the write extends past the end of the
present Header, the freed data can be reallocated since the write to
the container is single threaded. It is therefore possible to keep a
set amount of space in reserve after an accumulator. This makes it
possible to keep a known amount of space in reserve for an eventual
finalize that needs to write a new state.

Other variable width accumulators will be covered as a follow-up.