### PR TITLE
Build abstract and portable SIMD using xsimd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ set(POSITION_INDEPENDENT_CODE True)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -mavx2 -mfma -mavx -mf16c -mbmi2 -march=native -D USE_VELOX_COMMON_BASE"
+    "${CMAKE_CXX_FLAGS} -mavx2 -mfma -mavx -mf16c -mbmi2 -march=native -mno-avx512f -D USE_VELOX_COMMON_BASE"
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D HAS_UNCAUGHT_EXCEPTIONS")

--- a/velox/buffer/CMakeLists.txt
+++ b/velox/buffer/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_buffer StringViewBufferHolder.cpp)
 
-target_link_libraries(velox_buffer velox_memory ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(velox_buffer velox_memory velox_common_base
+                      ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(
   velox_common_base BitUtil.cpp RandomUtil.cpp RawVector.cpp RuntimeMetrics.cpp
                     SimdUtil.cpp SuccinctPrinter.cpp)
 
-target_link_libraries(velox_common_base velox_exception velox_process)
+target_link_libraries(velox_common_base velox_exception velox_process xsimd)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -14,29 +14,196 @@
  * limitations under the License.
  */
 
+#include <numeric>
+
 namespace facebook::velox::simd {
 
 namespace detail {
 
-// Copies one datum between *from and *to at the width of T. Uses
-// unaligned instructions if withd > 64 bits.
-template <typename T>
-inline void copyWord(void* to, const void* from) {
-  if constexpr (sizeof(T) == 32) {
-    *(__m256i_u*)to = *(__m256i_u*)from;
-  } else if constexpr (sizeof(T) == 16) {
-    *(__m128i_u*)to = *(__m128i_u*)from;
-  } else {
+template <typename T, typename A>
+xsimd::batch_bool<T, A> fromBitMaskImpl(int mask) {
+  static const auto kMemo = ({
+    constexpr int N = xsimd::batch_bool<T, A>::size;
+    static_assert(N <= 8);
+    std::array<xsimd::batch_bool<T, A>, (1 << N)> memo;
+    for (int i = 0; i < (1 << N); ++i) {
+      bool tmp[N];
+      for (int bit = 0; bit < N; ++bit) {
+        tmp[bit] = (i & (1 << bit)) ? true : false;
+      }
+      memo[i] = xsimd::batch_bool<T, A>::load_unaligned(tmp);
+    }
+    memo;
+  });
+  return kMemo[mask];
+}
+
+template <typename T, typename A>
+struct BitMask<T, A, 1> {
+  static constexpr int kAllSet = bits::lowMask(xsimd::batch_bool<T, A>::size);
+
+#if XSIMD_WITH_AVX2
+  static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx2&) {
+    return _mm256_movemask_epi8(mask);
+  }
+#endif
+
+#if XSIMD_WITH_SSE2
+  static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
+    return _mm_movemask_epi8(mask);
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct BitMask<T, A, 2> {
+  static constexpr int kAllSet = bits::lowMask(xsimd::batch_bool<T, A>::size);
+
+#if XSIMD_WITH_AVX2
+  static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx2&) {
+    // There is no intrinsic for extracting high bits of a 16x16
+    // vector.  Hence take every second bit of the high bits of a 32x1
+    // vector.
+    //
+    // NOTE: TVL might have a more efficient implementation for this.
+    return _pext_u32(_mm256_movemask_epi8(mask), 0xAAAAAAAA);
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct BitMask<T, A, 4> {
+  static constexpr int kAllSet = bits::lowMask(xsimd::batch_bool<T, A>::size);
+
+#if XSIMD_WITH_AVX
+  static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx&) {
+    return _mm256_movemask_ps(reinterpret_cast<__m256>(mask.data));
+  }
+#endif
+
+  static xsimd::batch_bool<T, A> fromBitMask(int mask, const xsimd::avx&) {
+    return UNLIKELY(mask == kAllSet) ? xsimd::batch_bool<T, A>(true)
+                                     : fromBitMaskImpl<T, A>(mask);
+  }
+};
+
+template <typename T, typename A>
+struct BitMask<T, A, 8> {
+  static constexpr int kAllSet = bits::lowMask(xsimd::batch_bool<T, A>::size);
+
+#if XSIMD_WITH_AVX
+  static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx&) {
+    return _mm256_movemask_pd(reinterpret_cast<__m256d>(mask.data));
+  }
+#endif
+
+  static xsimd::batch_bool<T, A> fromBitMask(int mask, const xsimd::avx&) {
+    return UNLIKELY(mask == kAllSet) ? xsimd::batch_bool<T, A>(true)
+                                     : fromBitMaskImpl<T, A>(mask);
+  }
+};
+
+} // namespace detail
+
+template <typename A>
+int32_t indicesOfSetBits(
+    const uint64_t* bits,
+    int32_t begin,
+    int32_t end,
+    int32_t* result,
+    const A&) {
+  if (end <= begin) {
+    return 0;
+  }
+  int32_t row = begin & ~63;
+  auto originalResult = result;
+  int32_t endWord = bits::roundUp(end, 64) / 64;
+  auto firstWord = begin / 64;
+  for (auto wordIndex = firstWord; wordIndex < endWord; ++wordIndex) {
+    uint64_t word = bits[wordIndex];
+    if (!word) {
+      row += 64;
+      continue;
+    }
+    if (wordIndex == firstWord && begin) {
+      word &= bits::highMask(64 - (begin - firstWord * 64));
+      if (!word) {
+        row += 64;
+        continue;
+      }
+    }
+    if (wordIndex == endWord - 1) {
+      int32_t lastBits = end - (endWord - 1) * 64;
+      if (lastBits < 64) {
+        word &= bits::lowMask(lastBits);
+        if (!word) {
+          break;
+        }
+      }
+    }
+    if (result - originalResult < (row >> 2)) {
+      do {
+        *result++ = __builtin_ctzll(word) + row;
+        word = word & (word - 1);
+      } while (word);
+      row += 64;
+    } else {
+      for (auto byteCnt = 0; byteCnt < 8; ++byteCnt) {
+        uint8_t byte = word;
+        word = word >> 8;
+        if (byte) {
+          static_assert(xsimd::batch<int32_t, A>::size <= 8);
+          auto indices =
+              xsimd::batch<int32_t, A>::load_aligned(byteSetBits(byte));
+          (indices + row).store_unaligned(result);
+          result += __builtin_popcount(byte);
+        }
+        row += 8;
+      }
+    }
+  }
+  return result - originalResult;
+}
+
+template <typename T, typename A>
+xsimd::batch_bool<T, A> leadingMask(int n, const A&) {
+  constexpr int N = xsimd::batch_bool<T, A>::size;
+  static const auto kMemo = ({
+    std::array<xsimd::batch_bool<T, A>, N> memo;
+    bool tmp[N]{};
+    for (int i = 0; i < N; ++i) {
+      memo[i] = xsimd::batch_bool<T, A>::load_unaligned(tmp);
+      tmp[i] = true;
+    }
+    memo;
+  });
+  return LIKELY(n >= N) ? xsimd::batch_bool<T, A>(true) : kMemo[n];
+}
+
+namespace detail {
+
+template <typename T, typename A>
+struct CopyWord {
+  static void apply(void* to, const void* from) {
     *reinterpret_cast<T*>(to) = *reinterpret_cast<const T*>(from);
   }
-}
+};
+
+template <typename A>
+struct CopyWord<xsimd::batch<int8_t, A>, A> {
+  static void apply(void* to, const void* from) {
+    xsimd::batch<int8_t, A>::load_unaligned(
+        reinterpret_cast<const int8_t*>(from))
+        .store_unaligned(reinterpret_cast<int8_t*>(to));
+  }
+};
 
 // Copies one element of T and advances 'to', 'from', and 'bytes' by
 // sizeof(T). Returns false if 'bytes' went to 0.
-template <typename T>
+template <typename T, typename A>
 inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
   if (bytes >= sizeof(T)) {
-    copyWord<T>(to, from);
+    CopyWord<T, A>::apply(to, from);
     bytes -= sizeof(T);
     if (!bytes) {
       return false;
@@ -49,39 +216,47 @@ inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
 }
 } // namespace detail
 
-inline void memcpy(void* to, const void* from, int32_t bytes) {
-  constexpr int32_t kByteWidth = Vectors<int64_t>::VSize * sizeof(int64_t);
-  while (bytes >= kByteWidth) {
-    if (!detail::copyNextWord<__m256i_u>(to, from, bytes)) {
+template <typename A>
+void memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
+  while (bytes >= batchByteSize(arch)) {
+    if (!detail::copyNextWord<xsimd::batch<int8_t, A>, A>(to, from, bytes)) {
       return;
     }
   }
-  if (!detail::copyNextWord<__m128i_u>(to, from, bytes)) {
+  while (bytes >= sizeof(int64_t)) {
+    if (!detail::copyNextWord<int64_t, A>(to, from, bytes)) {
+      return;
+    }
+  }
+  if (!detail::copyNextWord<int32_t, A>(to, from, bytes)) {
     return;
   }
-  if (!detail::copyNextWord<int64_t>(to, from, bytes)) {
+  if (!detail::copyNextWord<int16_t, A>(to, from, bytes)) {
     return;
   }
-  if (!detail::copyNextWord<int32_t>(to, from, bytes)) {
-    return;
-  }
-  if (!detail::copyNextWord<int16_t>(to, from, bytes)) {
-    return;
-  }
-  detail::copyNextWord<int8_t>(to, from, bytes);
+  detail::copyNextWord<int8_t, A>(to, from, bytes);
 }
 
 namespace detail {
-template <typename T>
-inline bool setNextWord(void*& to, T data, int32_t& bytes) {
+
+template <typename T, typename A>
+struct SetWord {
+  static void apply(void* to, T data) {
+    *reinterpret_cast<T*>(to) = data;
+  }
+};
+
+template <typename A>
+struct SetWord<xsimd::batch<int8_t, A>, A> {
+  static void apply(void* to, xsimd::batch<int8_t, A> data) {
+    data.store_unaligned(reinterpret_cast<int8_t*>(to));
+  }
+};
+
+template <typename T, typename A>
+inline bool setNextWord(void*& to, T data, int32_t& bytes, const A&) {
   if (bytes >= sizeof(T)) {
-    if constexpr (sizeof(T) == 32) {
-      *reinterpret_cast<__m256i_u*>(to) = data;
-    } else if constexpr (sizeof(T) == 16) {
-      *reinterpret_cast<__m128i_u*>(to) = data;
-    } else {
-      *reinterpret_cast<T*>(to) = data;
-    }
+    SetWord<T, A>::apply(to, data);
     bytes -= sizeof(T);
     if (!bytes) {
       return false;
@@ -94,31 +269,408 @@ inline bool setNextWord(void*& to, T data, int32_t& bytes) {
 
 } // namespace detail
 
-inline void memset(void* to, char data, int32_t bytes) {
-  constexpr int32_t kByteWidth = Vectors<int64_t>::VSize * sizeof(int64_t);
-  if (bytes >= kByteWidth) {
-    __m256i_u data256 = _mm256_set1_epi8(data);
-    while (bytes >= kByteWidth) {
-      if (!detail::setNextWord<__m256i_u>(to, data256, bytes)) {
-        return;
-      }
+template <typename A>
+void memset(void* to, char data, int32_t bytes, const A& arch) {
+  auto v = xsimd::batch<int8_t, A>::broadcast(data);
+  while (bytes >= batchByteSize(arch)) {
+    if (!detail::setNextWord(to, v, bytes, arch)) {
+      return;
     }
   }
-  __m128i_u data128 = _mm_set1_epi8(data);
-  if (!detail::setNextWord<__m128i_u>(to, data128, bytes)) {
+  int64_t data64 = *reinterpret_cast<int64_t*>(&v);
+  while (bytes >= sizeof(int64_t)) {
+    if (!detail::setNextWord<int64_t>(to, data64, bytes, arch)) {
+      return;
+    }
+  }
+  if (!detail::setNextWord<int32_t>(to, data64, bytes, arch)) {
     return;
   }
-  int64_t data64 = data128[0];
-  if (!detail::setNextWord<int64_t>(to, data64, bytes)) {
+  if (!detail::setNextWord<int16_t>(to, data64, bytes, arch)) {
     return;
   }
-  if (!detail::setNextWord<int32_t>(to, data64, bytes)) {
-    return;
-  }
-  if (!detail::setNextWord<int16_t>(to, data64, bytes)) {
-    return;
-  }
-  detail::setNextWord<int8_t>(to, data64, bytes);
+  detail::setNextWord<int8_t>(to, data64, bytes, arch);
 }
+
+namespace detail {
+
+template <typename T, typename A>
+struct Gather<T, int32_t, A, 2> {
+  using VIndexType = xsimd::batch<int32_t, A>;
+
+  // Load 8 indices only.
+  static VIndexType loadIndices(const int32_t* indices, const A& arch) {
+    return Gather<int32_t, int32_t, A>::loadIndices(indices, arch);
+  }
+};
+
+template <typename T, typename A>
+struct Gather<T, int32_t, A, 4> {
+  using VIndexType = xsimd::batch<int32_t, A>;
+
+#if XSIMD_WITH_AVX
+  static VIndexType loadIndices(const int32_t* indices, const xsimd::avx&) {
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(indices));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A>
+  apply(const T* base, VIndexType vindex, const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_i32gather_epi32(
+            reinterpret_cast<const int32_t*>(base), vindex, kScale));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A> maskApply(
+      xsimd::batch<T, A> src,
+      xsimd::batch_bool<T, A> mask,
+      const T* base,
+      VIndexType vindex,
+      const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_mask_i32gather_epi32(
+            reinterpret_cast<__m256i>(src.data),
+            reinterpret_cast<const int32_t*>(base),
+            vindex,
+            reinterpret_cast<__m256i>(mask.data),
+            kScale));
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct Gather<T, int32_t, A, 8> {
+#if XSIMD_WITH_AVX
+  static xsimd::batch<int32_t, xsimd::sse2> loadIndices(
+      const int32_t* indices,
+      const xsimd::avx&) {
+    return _mm_lddqu_si128(reinterpret_cast<const __m128i*>(indices));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A> apply(
+      const T* base,
+      xsimd::batch<int32_t, xsimd::sse2> vindex,
+      const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_i32gather_epi64(
+            reinterpret_cast<const long long*>(base), vindex, kScale));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A> maskApply(
+      xsimd::batch<T, A> src,
+      xsimd::batch_bool<T, A> mask,
+      const T* base,
+      xsimd::batch<int32_t, xsimd::sse2> vindex,
+      const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_mask_i32gather_epi64(
+            reinterpret_cast<__m256i>(src.data),
+            reinterpret_cast<const long long*>(base),
+            vindex,
+            reinterpret_cast<__m256i>(mask.data),
+            kScale));
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct Gather<T, int64_t, A, 8> {
+  using VIndexType = xsimd::batch<int64_t, A>;
+
+#if XSIMD_WITH_AVX
+  static VIndexType loadIndices(const int64_t* indices, const xsimd::avx&) {
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(indices));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A>
+  apply(const T* base, VIndexType vindex, const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_i64gather_epi64(
+            reinterpret_cast<const long long*>(base), vindex, kScale));
+  }
+#endif
+
+#if XSIMD_WITH_AVX2
+  template <int kScale>
+  static xsimd::batch<T, A> maskApply(
+      xsimd::batch<T, A> src,
+      xsimd::batch_bool<T, A> mask,
+      const T* base,
+      VIndexType vindex,
+      const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_mask_i64gather_epi64(
+            src,
+            reinterpret_cast<const long long*>(base),
+            vindex,
+            mask,
+            kScale));
+  }
+#endif
+};
+
+// Concatenates the low 16 bits of each lane in 'x' and 'y' and
+// returns the result as 16x16 bits.
+template <typename A>
+xsimd::batch<int16_t, A> pack32(
+    xsimd::batch<int32_t, A> x,
+    xsimd::batch<int32_t, A> y,
+    const xsimd::avx2&);
+
+#if XSIMD_WITH_AVX2
+template <typename A>
+xsimd::batch<int16_t, A> pack32(
+    xsimd::batch<int32_t, A> x,
+    xsimd::batch<int32_t, A> y,
+    const xsimd::avx2&) {
+  constexpr int64_t k64Low16 = 0x0000ffff0000ffff;
+  auto lows = _mm256_inserti128_si256(x, _mm256_extracti128_si256(y, 0), 1);
+  auto highs = _mm256_inserti128_si256(y, _mm256_extracti128_si256(x, 1), 0);
+  return _mm256_packus_epi32(lows & k64Low16, highs & k64Low16);
+}
+#endif
+
+template <typename T, typename A, size_t kSizeT = sizeof(T)>
+struct Permute;
+
+template <typename T, typename A>
+struct Permute<T, A, 4> {
+#if XSIMD_WITH_AVX2
+  static xsimd::batch<T, A> apply(
+      xsimd::batch<T, A> data,
+      xsimd::batch<int32_t, A> idx,
+      const xsimd::avx2&) {
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_permutevar8x32_epi32(reinterpret_cast<__m256i>(data.data), idx));
+  }
+#endif
+
+#if XSIMD_WITH_AVX
+  static HalfBatch<T, A>
+  apply(HalfBatch<T, A> data, HalfBatch<int32_t, A> idx, const xsimd::avx&) {
+    return reinterpret_cast<typename HalfBatch<T, A>::register_type>(
+        _mm_permutevar_ps(reinterpret_cast<__m128>(data.data), idx));
+  }
+#endif
+};
+
+} // namespace detail
+
+template <int kScale, typename A>
+xsimd::batch<int16_t, A> gather(
+    const int16_t* base,
+    const int32_t* indices,
+    int numIndices,
+    const A& arch) {
+  auto first = maskGather<int32_t, int32_t, kScale>(
+      xsimd::batch<int32_t, A>::broadcast(0),
+      leadingMask<int32_t>(numIndices, arch),
+      reinterpret_cast<const int32_t*>(base),
+      indices,
+      arch);
+  xsimd::batch<int32_t, A> second;
+  if (numIndices > 8) {
+    second = maskGather<int32_t, int32_t, kScale>(
+        xsimd::batch<int32_t, A>::broadcast(0),
+        leadingMask<int32_t>(numIndices - 8, arch),
+        reinterpret_cast<const int32_t*>(base),
+        indices + 8,
+        arch);
+  } else {
+    second = xsimd::batch<int32_t, A>::broadcast(0);
+  }
+  return detail::pack32(first, second, arch);
+}
+
+template <typename A>
+uint8_t gather8Bits(
+    const void* bits,
+    xsimd::batch<int32_t, A> vindex,
+    int32_t numIndices,
+    const A& arch) {
+  // Computes 8 byte addresses, and 8 bit masks.  The low bits of the
+  // row select the bit mask, the rest of the bits are the byte
+  // offset.  There is an AND wich will be zero if the bit is not set.
+  // This is finally converted to a mask with a negated SIMD
+  // comparison with 0.
+  static const xsimd::batch<int32_t, A> kByteBits = {
+      1, 2, 4, 8, 16, 32, 64, 128};
+  auto maskV = detail::Permute<int32_t, A>::apply(kByteBits, vindex & 7, arch);
+  auto zero = xsimd::batch<int32_t, A>::broadcast(0);
+  auto data = detail::Gather<int32_t, int32_t, A>::template maskApply<1>(
+      zero,
+      leadingMask<int32_t>(numIndices, arch),
+      reinterpret_cast<const int32_t*>(bits),
+      vindex >> 3,
+      arch);
+  return allSetBitMask<int32_t>(arch) ^ toBitMask((data & maskV) == zero, arch);
+}
+
+namespace detail {
+
+template <typename T, typename A>
+struct Extract<T, A, 4> {
+#if XSIMD_WITH_AVX
+  template <int kIndex>
+  static T apply(xsimd::batch<T, A> data, const xsimd::avx&) {
+    return _mm256_extract_epi32(data, kIndex);
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct Extract<T, A, 8> {
+#if XSIMD_WITH_AVX
+  template <int kIndex>
+  static T apply(xsimd::batch<T, A> data, const xsimd::avx&) {
+    return _mm256_extract_epi64(data, kIndex);
+  }
+#endif
+};
+
+template <typename A>
+struct GetHalf<int64_t, int32_t, A> {
+#if XSIMD_WITH_AVX2
+  template <bool kSecond>
+  static xsimd::batch<int64_t, A> apply(
+      xsimd::batch<int32_t, A> data,
+      const xsimd::avx2&) {
+    return _mm256_cvtepi32_epi64(_mm256_extracti128_si256(data, kSecond));
+  }
+#endif
+};
+
+template <typename A>
+struct GetHalf<uint64_t, int32_t, A> {
+#if XSIMD_WITH_AVX2
+  template <bool kSecond>
+  static xsimd::batch<uint64_t, A> apply(
+      xsimd::batch<int32_t, A> data,
+      const xsimd::avx2&) {
+    return _mm256_cvtepu32_epi64(_mm256_extracti128_si256(data, kSecond));
+  }
+#endif
+};
+
+} // namespace detail
+
+namespace detail {
+
+// Indices to use in 8x32 bit permute for extracting words from 4x64
+// bits.  The entry at 5 (bits 0 and 2 set) is {0, 1, 4, 5, 4, 5, 6,
+// 7}, meaning 64 bit words at 0 and 2 are moved in front (to 0, 1).
+extern int32_t permute4x64Indices[16][8];
+
+#if XSIMD_WITH_AVX2
+template <typename A, int kLane>
+__m128i
+filterHalf(xsimd::batch<int16_t, A> data, int mask, const xsimd::avx2&) {
+  xsimd::batch<int32_t, A> data32 =
+      _mm256_cvtepi16_epi32(_mm256_extracti128_si256(data, kLane));
+  auto out32 = filter(data32, mask, A{});
+  return _mm_packs_epi32(
+      _mm256_extractf128_si256(out32, 0), _mm256_extractf128_si256(out32, 1));
+}
+#endif
+
+template <typename T, typename A>
+struct Filter<T, A, 2> {
+#if XSIMD_WITH_AVX2
+  static xsimd::batch<T, A>
+  apply(xsimd::batch<T, A> data, int mask, const xsimd::avx2& arch) {
+    xsimd::batch<T, A> ans;
+    auto mask1 = mask & 0xFF;
+    *reinterpret_cast<__m128i_u*>(&ans) =
+        detail::filterHalf<A, 0>(data, mask1, arch);
+    *reinterpret_cast<__m128i_u*>(
+        reinterpret_cast<int16_t*>(&ans) + __builtin_popcount(mask1)) =
+        detail::filterHalf<A, 1>(data, mask >> 8, arch);
+    return ans;
+  }
+#endif
+};
+
+template <typename T, typename A>
+struct Filter<T, A, 4> {
+  static xsimd::batch<T, A>
+  apply(xsimd::batch<T, A> data, int mask, const A& arch) {
+    auto vindex = xsimd::batch<int32_t, A>::load_aligned(byteSetBits[mask]);
+    return Permute<T, A>::apply(data, vindex, arch);
+  }
+
+  static HalfBatch<T, A> apply(HalfBatch<T, A> data, int mask, const A& arch) {
+    auto vindex = HalfBatch<int32_t, A>::load_aligned(byteSetBits[mask]);
+    return Permute<T, A>::apply(data, vindex, arch);
+  }
+};
+
+template <typename T, typename A>
+struct Filter<T, A, 8> {
+#if XSIMD_WITH_AVX2
+  static xsimd::batch<T, A>
+  apply(xsimd::batch<T, A> data, int mask, const xsimd::avx2&) {
+    auto vindex =
+        xsimd::batch<int32_t, A>::load_aligned(permute4x64Indices[mask]);
+    return reinterpret_cast<typename xsimd::batch<T, A>::register_type>(
+        _mm256_permutevar8x32_epi32(
+            reinterpret_cast<__m256i>(data.data), vindex));
+  }
+#endif
+};
+
+template <typename A>
+struct Crc32<uint64_t, A> {
+#if XSIMD_WITH_SSE4_2
+  static uint32_t
+  apply(uint32_t checksum, uint64_t value, const xsimd::sse4_2&) {
+    return _mm_crc32_u64(checksum, value);
+  }
+#endif
+
+#if XSIMD_WITH_AVX
+  static uint32_t apply(uint32_t checksum, uint64_t value, const xsimd::avx&) {
+    return apply(checksum, value, xsimd::sse4_2{});
+  }
+#endif
+};
+
+} // namespace detail
+
+template <typename T, typename A>
+xsimd::batch<T, A> iota(const A&) {
+  static const auto kMemo = ({
+    constexpr int N = xsimd::batch<T, A>::size;
+    T tmp[N];
+    std::iota(tmp, tmp + N, 0);
+    xsimd::load_unaligned(tmp);
+  });
+  return kMemo;
+}
+
+namespace detail {
+
+template <typename T, typename A>
+struct HalfBatchImpl<
+    T,
+    A,
+    std::enable_if_t<std::is_base_of<xsimd::avx, A>::value>> {
+  using Type = xsimd::batch<T, xsimd::sse2>;
+};
+
+} // namespace detail
 
 } // namespace facebook::velox::simd

--- a/velox/common/base/SimdUtil.cpp
+++ b/velox/common/base/SimdUtil.cpp
@@ -19,20 +19,18 @@
 
 namespace facebook::velox::simd {
 
-using V32 = Vectors<int32_t>;
-using V64 = Vectors<int64_t>;
+namespace detail {
 
-int64_t V64::int64Masks_[16][4];
-int64_t V64::int64LeadingMasks_[4][4];
-int32_t V64::int64PermuteIndices_[16][8];
-int32_t V32::byteSetBits_[256][8];
-int32_t V32::int32LeadingMasks_[8][8];
-int32_t V32::int32Masks_[256][8];
-int32_t V32::iota_[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+alignas(kPadding) int32_t byteSetBits[256][8];
+alignas(kPadding) int32_t permute4x64Indices[16][8];
 
-void V32::initialize() {
+} // namespace detail
+
+namespace {
+
+void initByteSetBits() {
   for (int32_t i = 0; i < 256; ++i) {
-    int32_t* entry = byteSetBits_[i];
+    int32_t* entry = detail::byteSetBits[i];
     int32_t fill = 0;
     for (auto b = 0; b < 8; ++b) {
       if (i & (1 << b)) {
@@ -43,23 +41,13 @@ void V32::initialize() {
       entry[fill] = fill;
     }
   }
-  for (auto i = 0; i < 256; ++i) {
-    for (auto bit = 0; bit < 8; ++bit) {
-      int32Masks_[i][bit] = (i & (1 << bit)) ? -1 : 0;
-    }
-  }
-  for (auto size = 0; size < Vectors<int32_t>::VSize; ++size) {
-    for (auto i = 0; i < size; ++i) {
-      int32LeadingMasks_[size][i] = -1;
-    }
-  }
 }
 
-void V64::initialize() {
-  for (auto i = 0; i < 16; ++i) {
-    int32_t* result = int64PermuteIndices_[i];
+void initPermute4x64Indices() {
+  for (int i = 0; i < 16; ++i) {
+    int32_t* result = detail::permute4x64Indices[i];
     int32_t fill = 0;
-    for (auto bit = 0; bit < 4; ++bit) {
+    for (int bit = 0; bit < 4; ++bit) {
       if (i & (1 << bit)) {
         result[fill++] = bit * 2;
         result[fill++] = bit * 2 + 1;
@@ -69,83 +57,19 @@ void V64::initialize() {
       result[fill] = fill;
     }
   }
-  for (auto i = 0; i < 16; ++i) {
-    for (auto bit = 0; bit < 4; ++bit) {
-      int64Masks_[i][bit] = (i & (1 << bit)) ? -1 : 0;
-    }
-  }
-  for (auto size = 0; size < V64::VSize; ++size) {
-    for (auto i = 0; i < size; ++i) {
-      int64LeadingMasks_[size][i] = -1;
-    }
-  }
 }
+
+} // namespace
 
 bool initializeSimdUtil() {
   static bool inited = false;
   if (inited) {
     return true;
   }
-  V32::initialize();
-  V64::initialize();
+  initByteSetBits();
+  initPermute4x64Indices();
   inited = true;
   return true;
-}
-
-int32_t indicesOfSetBits(
-    const uint64_t* bits,
-    int32_t begin,
-    int32_t end,
-    int32_t* result) {
-  if (end <= begin) {
-    return 0;
-  }
-  int32_t row = begin & ~63;
-  auto originalResult = result;
-  int32_t endWord = bits::roundUp(end, 64) / 64;
-  auto firstWord = begin / 64;
-  for (auto wordIndex = firstWord; wordIndex < endWord; ++wordIndex) {
-    uint64_t word = bits[wordIndex];
-    if (!word) {
-      row += 64;
-      continue;
-    }
-    if (wordIndex == firstWord && begin) {
-      word &= bits::highMask(64 - (begin - firstWord * 64));
-      if (!word) {
-        row += 64;
-        continue;
-      }
-    }
-    if (wordIndex == endWord - 1) {
-      int32_t lastBits = end - (endWord - 1) * 64;
-      if (lastBits < 64) {
-        word &= bits::lowMask(lastBits);
-        if (!word) {
-          break;
-        }
-      }
-    }
-    if (result - originalResult < (row >> 2)) {
-      do {
-        *result++ = __builtin_ctzll(word) + row;
-        word = word & (word - 1);
-      } while (word);
-      row += 64;
-    } else {
-      for (auto byteCnt = 0; byteCnt < 8; ++byteCnt) {
-        uint8_t byte = word;
-        word = word >> 8;
-        if (byte) {
-          __m256si indices = V32::load(&V32::byteSetBits()[byte]);
-          V32::store(result, indices + row);
-          result += __builtin_popcount(byte);
-        }
-        row += 8;
-      }
-    }
-  }
-  return result - originalResult;
 }
 
 static bool FB_ANONYMOUS_VARIABLE(g_simdConstants) = initializeSimdUtil();

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -16,62 +16,26 @@
 
 #pragma once
 
-#include <immintrin.h>
 #include <cstdint>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 
 #include <folly/Likely.h>
-
-// Types for 256 bit vectors of short and int, not defined in avx
-// headers. Global namespace, like in the avx headers. AVX headers use
-// __m256i (4x64 bits) for all integer vectors regardless of lane
-// width. Here we declare types that differentiate between different
-// lane widths so that we can use gcc/clang vector extensions,
-// e.g. write vector + scalar and have the right addition generated
-// based on the number of lanes in the type.
-
-typedef long long __m256i
-    __attribute__((__vector_size__(32), __may_alias__, __aligned__(32)));
-
-typedef long long __m256i_u
-    __attribute__((__vector_size__(32), __may_alias__, __aligned__(1)));
-
-typedef int32_t __m256si __attribute__((__vector_size__(32), __may_alias__));
-
-typedef int32_t __m256si_u
-    __attribute__((__vector_size__(32), __may_alias__, __aligned__(1)));
-
-typedef int16_t __m256hi __attribute__((__vector_size__(32), __may_alias__));
-
-typedef int16_t __m256hi_u
-    __attribute__((__vector_size__(32), __may_alias__, __aligned__(1)));
-
-typedef int8_t __m256qi_u
-    __attribute__((__vector_size__(32), __may_alias__, __aligned__(1)));
-
-typedef int8_t __m256qi __attribute__((__vector_size__(32), __may_alias__));
-
-// 128 bit types missing from avx headers.
-typedef int32_t __m128si __attribute__((__vector_size__(16), __may_alias__));
-
-typedef int32_t __m128si_u
-    __attribute__((__vector_size__(16), __may_alias__, __aligned__(1)));
-
-typedef int16_t __m128hi __attribute__((__vector_size__(16), __may_alias__));
-
-typedef int16_t __m128hi_u
-    __attribute__((__vector_size__(16), __may_alias__, __aligned__(1)));
-
-typedef int8_t __m128qi __attribute__((__vector_size__(16), __may_alias__));
-
-typedef int8_t __m128qi_u
-    __attribute__((__vector_size__(16), __may_alias__, __aligned__(1)));
+#include <xsimd/xsimd.hpp>
 
 namespace facebook::velox::simd {
-// Width of the widest store. This much space is left at ends of
-// blocks to allow full width writes at block ends.
-constexpr int32_t kPadding = 32;
+
+// Width of the widest store.
+template <typename A = xsimd::default_arch>
+constexpr int32_t batchByteSize(const A& = {}) {
+  return sizeof(xsimd::types::simd_register<int8_t, A>);
+}
+
+// The largest batch size we ever support (in case we support multiple
+// architectures).  This much space is left at ends of blocks to allow
+// full width writes at block ends.  Minimum to 32 to keep backward
+// compatibility.
+constexpr int32_t kPadding = std::max(32, batchByteSize());
 
 // Initializes constant lookup tables. Call this explicitly if the
 // lookup tables are referenced in static initialization. The tables
@@ -83,599 +47,253 @@ bool initializeSimdUtil();
 // 'begin' to 'end' are considered and the return value is the number
 // of found set bits. For bits 0xff and begin 2 and end 5 we have a return value
 // of 3 and indices is set to {2, 3, 4}.
+template <typename A = xsimd::default_arch>
 int32_t indicesOfSetBits(
     const uint64_t* bits,
     int32_t begin,
     int32_t end,
-    int32_t* indices);
+    int32_t* indices,
+    const A& = {});
 
-// Casts an arbitrary 256 bit vector to __m256i, which all integer intrinsics
-// expect.
-template <typename T>
-inline __m256i to256i(T x) {
-  return reinterpret_cast<__m256i>(x);
-}
-using ByteSetBitsType = int32_t[256][8];
-
-const ByteSetBitsType& byteSetBits();
-
-// Struct template defining common SIMD operations for different lane widths.
-// See comments in Vectors<int64_t>.
-template <typename T>
-struct Vectors {
-  // Number of elements in the widest supported vector of T.
-  static constexpr int32_t VSize =
-      std::is_same<T, bool>::value ? 256 : 32 / sizeof(T);
-};
-
-template <>
-struct Vectors<int64_t> {
-  // Type of one lane.
-  using T = int64_t;
-
-  // Number of lanes in widest supported vector.
-  static constexpr int32_t VSize = 4;
-
-  // Type to use for referenced type of an unaligned pointer. The type
-  // accurately represents the number and width of lanes.
-  using TV = __m256i_u;
-  // Result type of comparison. Integer vector with the same lane
-  // width and number of lanes. Differs from TV for floating point
-  // vectors.
-  using CompareType = __m256i;
-
-  // Value of compareBitMask(xx) where all lanes are
-  // true. compareBitMask produces a bit mask representing the truth
-  // values for a SIMD compare of this type, e.g. compareEq. Note that
-  // in AVX the compare result is a vector of the shape of the compare
-  // operands and in AVX512 this is a bit mask. So compareResult is a
-  // mask extracting load in AVX and no-op in AVX512. 4 bits set for 4
-  // lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
-
-  // Returns a vector with all lanes set to 'value'.
-  static auto setAll(int64_t value) {
-    return _mm256_set1_epi64x(value);
-  }
-
-  // Returns the equality comparison result of 'left' and 'right'. Use
-  // compareBitMask(compareEq(x, y)) to get the result as a bit mask
-  // with one bit per lane of x and y. This abstracts away the
-  // different return types of compares in AVX and AVX512.
-  static auto compareEq(TV left, TV right) {
-    return _mm256_cmpeq_epi64(left, right);
-  }
-
-  // Returns x > y for each lane. See compareEq for interpretation of return
-  // value.
-  static auto compareGt(TV left, TV right) {
-    return _mm256_cmpgt_epi64(left, right);
-  }
-
-  // Returns a word representing the result of a vector comparison.
-  static auto compareBitMask(TV wide) {
-    return _mm256_movemask_pd(reinterpret_cast<__m256d>(wide));
-  }
-
-  // Returns the indices of one bits in the result of compareBitMask
-  // as a vector of int32 of the ppropriate width. (4x32 for 64 bit
-  // lanes and 8x32 for 32 bit lanes).
-  static auto compareSetBits(uint8_t bits) {
-    return *reinterpret_cast<const __m128si_u*>(byteSetBits()[bits]);
-  }
-
-  // Loads the vector at 'values'.
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
-
-  // Stores 'data' into '*ptr'.
-  static void store(void* ptr, TV data) {
-    *reinterpret_cast<TV*>(ptr) = data;
-  }
-
-  // Casts 'source' to be a pointer to TV.
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
-
-  // Loads a vector of indices forgather32 of of TV. This loads 4x32
-  // for 64 bit and 8x32 for 32 bit gather.
-  static __m128si loadGather32Indices(const int32_t* indices) {
-    return *(__m128si_u*)indices;
-  }
-
-  // Returns a mask with the left 'n' lanes enabled. Note that AVX
-  // masks have the width of the operands and AVX512 maska have a bit
-  // per lane.
-  static __m256i leadingMask(int32_t n) {
-    return LIKELY(n >= VSize) ? setAll(-1) : load(&int64LeadingMasks_[n]);
-  }
-
-  // Returns a mask for a masked operation where a one bit in 'mask'
-  // indicates an active lane. This would be identity in AVX 512 and
-  // in other systems this is widening each bit to a full lane. A
-  // lookup table seems to be the most effective means for this. A
-  // pdep from bits to uint64 and then widening with sign extension
-  // would be more instructions.
-  static __m256i mask(int32_t mask) {
-    return UNLIKELY(mask == (1 << VSize) - 1) ? setAll(-1)
-                                              : load(&int64Masks_[mask]);
-  }
-
-  // Loads 4x64 non-contiguous words with 64 bit indices.
-  template <uint8_t scale = 8>
-  static auto gather64(const void* base, TV indices) {
-    return _mm256_i64gather_epi64(
-        reinterpret_cast<const long long int*>(base), indices, scale);
-  }
-
-  // Loads  non-contiguous words with 32 bit indices.
-  template <uint8_t scale = 8>
-  static auto gather32(const void* base, __m128si indices) {
-    return _mm256_i32gather_epi64(
-        reinterpret_cast<const long long int*>(base), (__m128i)indices, scale);
-  }
-
-  // Loads 4x 64 bit words with 32 bit indices for the lanes selected by
-  // 'mask'. 'source' is used to fill the lanes not selected by
-  // 'mask'.
-  template <uint8_t scale = 8>
-  static auto
-  maskGather32(TV source, TV mask, const void* base, __m128si indices) {
-    return _mm256_mask_i32gather_epi64(
-        source,
-        reinterpret_cast<const long long int*>(base),
-        (__m128i)indices,
-        mask,
-        scale);
-  }
-
-  // Widens 4x32 unsigned values to 4x64.
-  static auto from32u(__m128si x) {
-    return _mm256_cvtepu32_epi64((__m128i)x);
-  }
-
-  // Widens 4x32 signed values to 4x64.
-  static auto from32(__m128si x) {
-    return _mm256_cvtepi32_epi64((__m128i)x);
-  }
-
-  // Returns the value of the 'ith' lane.
-  template <uint8_t i>
-  static int64_t extract(TV v) {
-    return _mm256_extract_epi64(v, i);
-  }
-
-  static const auto& permuteIndices() {
-    return int64PermuteIndices_;
-  }
-
-  static void initialize();
-
- private:
-  // Indices to use in 8x32 bit permute for extracting words from 4x64
-  // bits.  The entry at 5 (bits 0 and 2 set) is {0, 1, 4, 5, 4, 5, 6,
-  // 7}, meaning 64 bit words at 0 and 2 are moved
-  // in front (to 0, 1).
-  static int32_t int64PermuteIndices_[16][8];
-
-  // Masks for masked instructions on 64 bit operations. Each bit of the
-  // byte index is repeated 64 times.
-  static int64_t int64Masks_[16][4];
-
-  // Masks for masked 64 bit instructions that select the first n lanes.
-  static int64_t int64LeadingMasks_[4][4];
-};
-
-// See Vectors<int64_t> for comments.
-template <>
-struct Vectors<int32_t> {
-  using T = int32_t;
-  using TV = __m256si_u;
-  using CompareType = __m256si;
-  static constexpr int32_t VSize = 8;
-  // 0xff, 8 bits for 8 lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
-
-  // Returns a vector of <0, 1, 2, 3, 4, 5, 6, 7}.
-  static TV iota() {
-    return load(&iota_);
-  }
-
-  static auto setAll(T value) {
-    return (__m256si)_mm256_set1_epi32(value);
-  }
-
-  static auto compareEq(TV left, TV right) {
-    return (TV)_mm256_cmpeq_epi32(to256i(left), to256i(right));
-  }
-
-  static auto compareGt(TV left, TV right) {
-    return (TV)_mm256_cmpgt_epi32(to256i(left), to256i(right));
-  }
-
-  static auto compareBitMask(TV wide) {
-    return _mm256_movemask_ps(reinterpret_cast<__m256>(wide));
-  }
-
-  static auto compareSetBits(uint8_t bits) {
-    return *reinterpret_cast<const __m256si_u*>(&byteSetBits()[bits]);
-  }
-
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
-
-  static void store(void* ptr, TV data) {
-    *reinterpret_cast<__m256i_u*>(ptr) = (__m256i)data;
-  }
-
-  static void store(void* ptr, __m128si data) {
-    *reinterpret_cast<__m128i_u*>(ptr) = (__m128i)data;
-  }
-
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
-
-  static auto loadGather32Indices(const int32_t* indices) {
-    return load(indices);
-  }
-
-  static __m256si leadingMask(int32_t n) {
-    return LIKELY(n >= VSize) ? setAll(-1) : load(&int32LeadingMasks_[n]);
-  }
-
-  static __m256si mask(int32_t mask) {
-    return UNLIKELY(mask == (1 << VSize) - 1) ? setAll(-1)
-                                              : load(&int32Masks_[mask]);
-  }
-
-  template <uint8_t scale = 4>
-  static auto gather32(const void* base, TV indices) {
-    return (TV)_mm256_i32gather_epi32(
-        reinterpret_cast<const int*>(base), to256i(indices), scale);
-  }
-
-  template <uint8_t scale = 4>
-  static auto maskGather32(TV source, TV mask, const void* base, TV indices) {
-    return (TV)_mm256_mask_i32gather_epi32(
-        to256i(source),
-        reinterpret_cast<const int*>(base),
-        to256i(indices),
-        to256i(mask),
-        scale);
-  }
-
-  template <uint8_t i>
-  static int32_t extract(TV v) {
-    return _mm256_extract_epi32(to256i(v), i);
-  }
-
-  // Widens the lower or upper 4 lanes to unsigned 4x64.
-  template <uint8_t i>
-  static auto as4x64u(TV x) {
-    return _mm256_cvtepu32_epi64(_mm256_extracti128_si256(to256i(x), i));
-  }
-
-  template <uint8_t i>
-  static auto as4x64(TV x) {
-    return _mm256_cvtepi32_epi64(_mm256_extracti128_si256(to256i(x), i));
-  }
-
-  static const ByteSetBitsType& byteSetBits() {
-    return byteSetBits_;
-  }
-
-  static void initialize();
-
- private:
-  static int32_t iota_[8];
-  // Offsets of set bits in all distinct bytes. For example, element at
-  // index 42 is {1, 3, 5, 3, 4, 5, 6, 7}, because 42 has bits 1, 3 and
-  // 5 set. The remaining positions are set to be their own index in the
-  // array. This can be used as a permute index vector for extracting
-  // values at positions in a bit mask. Suppose that a comparison
-  // produced bit mask 42. The vector at 42 would extract the values for
-  // which the compare was true to the left of the permute result
-  // vector. Another use of this is for translating bitmaps to vectors
-  // of positions of set bits.  See indicesOfSetBits for example of
-  // usage.
-  static int32_t byteSetBits_[256][8];
-
-  // Mask for 32 bit masked instructions that selects n first lanes.
-  static int32_t int32LeadingMasks_[8][8];
-
-  // Masks for masked instructions on 32 bit operations. Each bit of the
-  // byte index is repeated 32 times.
-  static int32_t int32Masks_[256][8];
-};
-
-inline const ByteSetBitsType& byteSetBits() {
-  return Vectors<int32_t>::byteSetBits();
+namespace detail {
+extern int32_t byteSetBits[256][8];
 }
 
-// See Vectors<int64_t> for comments.
-template <>
-struct Vectors<int16_t> {
-  using T = int16_t;
-  using TV = __m256hi_u;
-  using CompareType = __m256hi;
-  static constexpr int32_t VSize = 16;
-  // 0xffff,  16 bits for 16 lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
+// Offsets of set bits in a byte. For example, for byte 42 it returns
+// {1, 3, 5, 3, 4, 5, 6, 7}, because 42 has bits 1, 3 and 5 set. The
+// remaining positions are set to be their own index in the
+// array. This can be used as a permute index vector for extracting
+// values at positions in a bit mask. Suppose that a comparison
+// produced bit mask 42. The vector at 42 would extract the values for
+// which the compare was true to the left of the permute result
+// vector. Another use of this is for translating bitmaps to vectors
+// of positions of set bits.  See indicesOfSetBits for example of
+// usage.
+inline const int32_t* byteSetBits(uint8_t byte) {
+  return detail::byteSetBits[byte];
+}
 
-  static auto setAll(T value) {
-    return (TV)_mm256_set1_epi16(value);
-  }
+namespace detail {
+template <typename T, typename A, typename = void>
+struct HalfBatchImpl;
+}
 
-  static auto compareEq(TV left, TV right) {
-    return (TV)_mm256_cmpeq_epi16(to256i(left), to256i(right));
-  }
+// Get a batch with same element type but half the number of lanes.
+// For example if the max width of batch is 256 bits, this returns 128
+// bits register type.
+template <typename T, typename A = xsimd::default_arch>
+using HalfBatch = typename detail::HalfBatchImpl<T, A>::Type;
 
-  static auto compareGt(TV left, TV right) {
-    return (TV)_mm256_cmpgt_epi16(to256i(left), to256i(right));
-  }
+namespace detail {
+template <typename T, typename IndexType, typename A, int kSizeT = sizeof(T)>
+struct Gather;
+}
 
-  static auto compareBitMask(TV wide) {
-    // There is no intrinsic for extracting high bits of a 16x16
-    // vector. Hence take every second bit of the high bits of a 32x1
-    // vector.
-    return _pext_u32(
-        _mm256_movemask_epi8(reinterpret_cast<__m256i>(wide)), 0xaaaaaaaa);
-  }
+// Load certain number of indices from memory into a batch that is
+// suitable for calling 'gather' with data type 'T' and index type
+// 'IndexType'.
+//
+// For example, on an architecture with maximum 256-bits vector, when
+// T = int64_t and IndexType = int32_t, 'gather' will return a
+// batch<int64_t> which has 4 lanes, so this function will load 4
+// 32-bits indices.
+template <typename T, typename IndexType, typename A = xsimd::default_arch>
+auto loadGatherIndices(const IndexType* indices, const A& arch = {}) {
+  return detail::Gather<T, IndexType, A>::loadIndices(indices, arch);
+}
 
-  static auto compareSetBits(uint8_t bits) {
-    return *(__m256si_u*)&byteSetBits()[bits];
-  }
+// Gather data from memory location specified in 'base' and 'vindex'
+// into a batch, i.e. returning 'dst' where
+//
+//   dst[i] = *(base + vindex[i])
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename IndexArch,
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A> gather(
+    const T* base,
+    xsimd::batch<IndexType, IndexArch> vindex,
+    const A& arch = {}) {
+  using Impl = detail::Gather<T, IndexType, A>;
+  return Impl::template apply<kScale>(base, vindex, arch);
+}
 
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
+// Same as 'gather' above except the indices are read from memory.
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A>
+gather(const T* base, const IndexType* indices, const A& arch = {}) {
+  auto vindex = detail::Gather<T, IndexType, A>::loadIndices(indices, arch);
+  return gather<T, IndexType, kScale>(base, vindex, arch);
+}
 
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
+// Gather only data where mask[i] is set; otherwise keep the data in
+// src[i].
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename IndexArch,
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A> maskGather(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    xsimd::batch<IndexType, IndexArch> vindex,
+    const A& arch = {}) {
+  return detail::Gather<T, IndexType, A>::template maskApply<kScale>(
+      src, mask, base, vindex, arch);
+}
 
-  static void store(void* ptr, TV data) {
-    *reinterpret_cast<TV*>(ptr) = data;
-  }
+// Same as 'maskGather' above but read indices from memory.
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A> maskGather(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    const IndexType* indices,
+    const A& arch = {}) {
+  auto vindex = detail::Gather<T, IndexType, A>::loadIndices(indices, arch);
+  return maskGather<T, IndexType, kScale>(src, mask, base, vindex, arch);
+}
 
-  // Loads 8x32. There is no gather32 for 16x16. See gather16x32.
-  static auto loadGather32Indices(const int32_t* indices) {
-    return Vectors<int32_t>::load(indices);
-  }
+// Loads up to 16 non-contiguous 16 bit values from 32-bit indices at 'indices'.
+template <int kScale = sizeof(int16_t), typename A = xsimd::default_arch>
+xsimd::batch<int16_t, A> gather(
+    const int16_t* base,
+    const int32_t* indices,
+    int numIndices,
+    const A& = {});
 
-  static __m256si leadingMask(int32_t /*n*/) {
-    static_assert("No masks for 16 bit width. Use gather16x32.");
-    return __m256si();
-  }
+// Loads up to 8 disjoint bits at bit offsets 'indices' and returns
+// these as a bit mask.
+template <typename A = xsimd::default_arch>
+uint8_t gather8Bits(
+    const void* bits,
+    xsimd::batch<int32_t, A> vindex,
+    int32_t numIndices,
+    const A& = {});
 
-  static TV gather32(const void* /*base*/, __m256si /*indices*/) {
-    static_assert("Use gather16x32 instead");
-    return TV();
-  }
+// Same as 'gather8Bits' above but read indices from memory.
+template <typename A = xsimd::default_arch>
+uint8_t gather8Bits(
+    const void* bits,
+    const int32_t* indices,
+    int32_t numIndices,
+    const A& arch = {}) {
+  return gather8Bits(
+      bits, loadGatherIndices<int32_t>(indices, arch), numIndices, arch);
+}
 
-  template <uint8_t scale = 4>
-  static TV maskGather32(
-      TV /*source*/,
-      __m256si /*mask*/,
-      const void* /*base*/,
-      __m256si /*indices*/) {
-    static_assert("Use gather16x32 instead");
-    return TV();
-  }
+namespace detail {
+template <typename T, typename A, size_t kSizeT = sizeof(T)>
+struct BitMask;
+}
 
-  // Widens the lower or upper 8x16 to 8x32 unsigned.
-  static __m256si as8x32u(__m128hi x) {
-    return reinterpret_cast<__m256si>(
-        _mm256_cvtepi16_epi32(reinterpret_cast<__m128i>(x)));
-  }
-};
+// Returns a mask with the left 'n' lanes enabled.
+template <typename T, typename A = xsimd::default_arch>
+xsimd::batch_bool<T, A> leadingMask(int n, const A& = {});
 
-// See Vectors<int64_t> for comments.
-template <>
-struct Vectors<int8_t> {
-  using T = int8_t;
-  using TV = __m256qi_u;
-  using CompareType = __m256qi;
-  static constexpr int32_t VSize = 32;
-  // 32 bits for 32 lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
+// Returns a word representing the result of a vector comparison,
+// using 1 bit per element.
+template <typename T, typename A = xsimd::default_arch>
+auto toBitMask(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
+  return detail::BitMask<T, A>::toBitMask(mask, arch);
+}
 
-  static auto setAll(T value) {
-    return (__m256qi)_mm256_set1_epi8(value);
-  }
+// Get a vector mask from bit mask.
+template <typename T, typename BitMaskType, typename A = xsimd::default_arch>
+xsimd::batch_bool<T, A> fromBitMask(BitMaskType bitMask, const A& arch = {}) {
+  return detail::BitMask<T, A>::fromBitMask(bitMask, arch);
+}
 
-  static auto compareEq(TV left, TV right) {
-    return (TV)_mm256_cmpeq_epi8(to256i(left), to256i(right));
-  }
+// Returns a bitmask equivalent to a batch_bool with all lanes set to
+// true.
+template <typename T, typename A = xsimd::default_arch>
+auto allSetBitMask(const A& = {}) {
+  return detail::BitMask<T, A>::kAllSet;
+}
 
-  static auto compareGt(TV left, TV right) {
-    return (TV)_mm256_cmpgt_epi8(to256i(left), to256i(right));
-  }
+namespace detail {
+template <typename T, typename A, size_t kSizeT = sizeof(T)>
+struct Filter;
+}
 
-  static auto compareBitMask(TV wide) {
-    return _mm256_movemask_epi8(to256i(wide));
-  }
+// Rearrange elements in data, move data[i] to front of the vector if
+// bitMask[i] is set.
+template <typename T, typename BitMaskType, typename A = xsimd::default_arch>
+xsimd::batch<T, A>
+filter(xsimd::batch<T, A> data, BitMaskType bitMask, const A& arch = {}) {
+  return detail::Filter<T, A>::apply(data, bitMask, arch);
+}
 
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
+// Same as 'filter' on full-sized vector, except this one operate on a
+// half-sized vector.
+template <typename T, typename BitMaskType, typename A = xsimd::default_arch>
+HalfBatch<T, A>
+filter(HalfBatch<T, A> data, BitMaskType bitMask, const A& arch = {}) {
+  return detail::Filter<T, A>::apply(data, bitMask, arch);
+}
 
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
+namespace detail {
+template <typename T, typename A, size_t kSizeT = sizeof(T)>
+struct Extract;
+}
 
-  __m256si as8x32u(__m128hi x) {
-    return reinterpret_cast<__m256si>(
-        _mm256_cvtepi8_epi32(reinterpret_cast<__m128i>(x)));
-  }
-};
+template <int kIndex, typename T, typename A = xsimd::default_arch>
+T extract(xsimd::batch<T, A> data, const A& arch = {}) {
+  return detail::Extract<T, A>::template apply<kIndex>(data, arch);
+}
 
-// See Vectors<int64_t> for comments.
-template <>
-struct Vectors<double> {
-  using T = double;
-  static constexpr int32_t VSize = 4;
-  using CompareType = __m256i;
-  // 4 bits for 4 lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
+namespace detail {
+template <typename To, typename From, typename A>
+struct GetHalf;
+}
 
-  using TV4 = __m256d_u;
-  using TV = __m256d_u;
+// Get either first or second half of the vector.  The type 'To' is as
+// twice as large as 'From' to keep the vector size same.
+template <
+    typename To,
+    bool kSecond,
+    typename From,
+    typename A = xsimd::default_arch>
+xsimd::batch<To, A> getHalf(xsimd::batch<From, A> data, const A& arch = {}) {
+  return detail::GetHalf<To, From, A>::template apply<kSecond>(data, arch);
+}
 
-  static auto setAll(T value) {
-    return _mm256_set1_pd(value);
-  }
+namespace detail {
+template <typename T, typename A>
+struct Crc32;
+}
 
-  static auto compareEq(TV left, TV right) {
-    return reinterpret_cast<__m256i>(_mm256_cmp_pd(left, right, _CMP_EQ_OQ));
-  }
+// Calculate the CRC32 checksum.
+template <typename A = xsimd::default_arch>
+uint32_t crc32U64(uint32_t checksum, uint64_t value, const A& arch = {}) {
+  return detail::Crc32<uint64_t, A>::apply(checksum, value, arch);
+}
 
-  static auto compareGt(TV left, TV right) {
-    return reinterpret_cast<__m256i>(_mm256_cmp_pd(left, right, _CMP_GT_OQ));
-  }
+// Return a vector consisting {0, 1, ..., n} where 'n' is the number
+// of lanes.
+template <typename T, typename A = xsimd::default_arch>
+xsimd::batch<T, A> iota(const A& = {});
 
-  static auto compareBitMask(__m256i wide) {
-    return _mm256_movemask_pd(reinterpret_cast<__m256d>(wide));
-  }
-
-  static auto compareSetBits(uint8_t bits) {
-    return *(__m128si_u*)&byteSetBits()[bits];
-  }
-
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
-
-  static void store(void* ptr, TV data) {
-    *reinterpret_cast<TV*>(ptr) = data;
-  }
-
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
-
-  static __m128si loadGather32Indices(const int32_t* indices) {
-    return *(__m128si_u*)indices;
-  }
-
-  static __m256i leadingMask(int32_t n) {
-    return Vectors<int64_t>::leadingMask(n);
-  }
-
-  template <uint8_t scale = 8>
-  static auto gather32(const void* base, __m128si indices) {
-    return _mm256_i32gather_pd(
-        reinterpret_cast<const double*>(base), (__m128i)indices, scale);
-  }
-
-  template <uint8_t scale = 8>
-  static auto
-  maskGather32(TV source, __m256i mask, const void* base, __m128si indices) {
-    return _mm256_mask_i32gather_pd(
-        source,
-        reinterpret_cast<const double*>(base),
-        (__m128i)indices,
-        reinterpret_cast<__m256d>(mask),
-        scale);
-  }
-};
-
-// See Vectors<int64_t> for comments.
-template <>
-struct Vectors<float> {
-  using T = float;
-  using TV = __m256_u;
-  using CompareType = __m256si;
-  static constexpr int32_t VSize = 8;
-  // 8 bits for 8 lanes.
-  static constexpr uint32_t kAllTrue = bits::lowMask(VSize);
-
-  static auto setAll(T value) {
-    return _mm256_set1_ps(value);
-  }
-
-  static auto compareEq(TV left, TV right) {
-    return reinterpret_cast<__m256si>(_mm256_cmp_ps(left, right, _CMP_EQ_OQ));
-  }
-
-  static auto compareGt(TV left, TV right) {
-    return reinterpret_cast<__m256si>(_mm256_cmp_ps(left, right, _CMP_GT_OQ));
-  }
-
-  static auto compareBitMask(__m256si wide) {
-    return _mm256_movemask_ps(reinterpret_cast<__m256>(wide));
-  }
-
-  static auto compareSetBits(uint8_t bits) {
-    return *(__m256si_u*)&byteSetBits()[bits];
-  }
-
-  static TV load(const void* values) {
-    return *reinterpret_cast<const TV*>(values);
-  }
-
-  static void store(void* ptr, TV data) {
-    *reinterpret_cast<TV*>(ptr) = data;
-  }
-
-  static TV* pointer(void* source) {
-    return reinterpret_cast<TV*>(source);
-  }
-
-  static __m256si loadGather32Indices(const int32_t* indices) {
-    return *(__m256si_u*)indices;
-  }
-
-  static auto leadingMask(int32_t n) {
-    return Vectors<int32_t>::leadingMask(n);
-  }
-
-  template <uint8_t scale = 4>
-  static auto gather32(const void* base, __m256si indices) {
-    return _mm256_i32gather_ps(
-        reinterpret_cast<const float*>(base), to256i(indices), scale);
-  }
-
-  template <uint8_t scale = 4>
-  static auto
-  maskGather32(TV source, __m256si mask, const void* base, __m256si indices) {
-    return _mm256_mask_i32gather_ps(
-        source,
-        reinterpret_cast<const float*>(base),
-        (__m256i)indices,
-        reinterpret_cast<__m256>(mask),
-        scale);
-  }
-};
-
-// Returns a __m256i with all elements set to value. The width of each element
-// is the width of T.
-template <typename T>
-__m256i setAll256i(T value) {
-  if constexpr (
-      std::is_same<T, int64_t>::value || std::is_same<T, uint64_t>::value) {
-    return _mm256_set1_epi64x(value);
-  } else if constexpr (
-      std::is_same<T, int32_t>::value || std::is_same<T, uint32_t>::value) {
-    return _mm256_set1_epi32(value);
-  } else if constexpr (
-      std::is_same<T, int16_t>::value || std::is_same<T, uint16_t>::value) {
-    return _mm256_set1_epi16(value);
-  } else if constexpr (
-      std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value) {
-    return _mm256_set1_epi8(value);
-  } else if constexpr (std::is_same<T, bool>::value) {
-    return value ? _mm256_set1_epi64x(-1) : _mm256_set1_epi64x(0);
-  } else if constexpr (std::is_same<T, double>::value) {
-    return reinterpret_cast<__m256i>(_mm256_set1_pd(value));
-  } else if constexpr (std::is_same<T, float>::value) {
-    return reinterpret_cast<__m256i>(_mm256_set1_ps(value));
+// Returns a batch with all elements set to value.  For batch<bool> we
+// use one bit to represent one element.
+template <typename T, typename A = xsimd::default_arch>
+xsimd::batch<T, A> setAll(T value, const A& = {}) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return xsimd::batch<T, A>(xsimd::broadcast<int64_t, A>(value ? -1 : 0));
   } else {
-    VELOX_FAIL("Vectors::setAll256i - Invalid simd type");
+    return xsimd::broadcast<T, A>(value);
   }
 }
 
@@ -687,96 +305,13 @@ inline T* addBytes(T* pointer, int32_t bytes) {
 
 // 'memcpy' implementation that copies at maximum width and unrolls
 // when 'bytes' is constant.
-inline void memcpy(void* to, const void* from, int32_t bytes);
+template <typename A = xsimd::default_arch>
+void memcpy(void* to, const void* from, int32_t bytes, const A& = {});
 
-//  memset implementation that writes at maximum width and unrolls
-//  for constant values of 'bytes'.
-inline void memset(void* to, char data, int32_t bytes);
-
-// Concatenates the low 16 bits of each lane in 'first8' and 'last8'
-// and returns the result as 16x16 bits.
-inline __m256hi concat8x32to16x16u(__m256si first8, __m256si last8) {
-  constexpr int64_t k64Low16 = 0x0000ffff0000ffff;
-  auto lows = _mm256_inserti128_si256(
-      to256i(first8), _mm256_extracti128_si256(to256i(last8), 0), 1);
-  auto highs = _mm256_inserti128_si256(
-      to256i(last8), _mm256_extracti128_si256(to256i(first8), 1), 0);
-  return (__m256hi)_mm256_packus_epi32(lows & k64Low16, highs & k64Low16);
-}
-
-// Loads up to 16 non-contiguous 16 bit values from 32-bit indices at 'indices'.
-template <uint8_t scale = 2>
-inline __m256hi
-gather16x32(const void* base, const int32_t* indices, int numIndices) {
-  using V32 = Vectors<int32_t>;
-  auto first = V32::maskGather32<scale>(
-      V32::setAll(0), V32::leadingMask(numIndices), base, V32::load(indices));
-  __m256si second;
-  if (numIndices > 8) {
-    second = V32::maskGather32<scale>(
-        V32::setAll(0),
-        V32::leadingMask(numIndices - 8),
-        base,
-        V32::load(indices + 8));
-  } else {
-    second = V32::setAll(0);
-  }
-  return concat8x32to16x16u(first, second);
-}
-
-// Loads up to 8 disjoint bits at bit offsets [indices' and returns
-// these as a bit mask.
-inline uint8_t
-gather8Bits(const uint64_t* bits, __m256si indices, int32_t numIndices) {
-  using V32 = Vectors<int32_t>;
-  static const __m256si byteBits = {1, 2, 4, 8, 16, 32, 64, 128};
-  auto zero = V32::setAll(0);
-  auto maskV = (__m256si)_mm256_permutevar8x32_epi32(
-      (__m256i)byteBits, (__m256i)(indices & 7));
-  auto data = V32::maskGather32<1>(
-      zero, V32::leadingMask(numIndices), bits, indices >> 3);
-  return V32::kAllTrue ^
-      V32::compareBitMask(V32::compareEq(data & maskV, zero));
-}
-
-inline uint8_t
-gather8Bits(const uint64_t* bits, const int32_t* indices, int32_t numIndices) {
-  return gather8Bits(bits, Vectors<int32_t>::load(indices), numIndices);
-}
-
-template <typename TData, typename TIndices>
-void storePermute(void* /*ptr*/, TData /*data*/, TIndices /*indices*/) {
-  static_assert("storePermute undefined");
-}
-
-template <>
-inline void storePermute(void* ptr, __m256si data, __m256si indices) {
-  *(__m256i_u*)ptr =
-      _mm256_permutevar8x32_epi32((__m256i)data, (__m256i)indices);
-}
-
-template <>
-inline void storePermute(void* ptr, __m128si data, __m128si indices) {
-  *(__m128_u*)ptr = _mm_permutevar_ps((__m128)data, (__m128i)indices);
-}
-
-// Stores the half of 'data' given by 'lane' into 'ptr' after
-// permuting it by 'indices'. 'data' is interpreted as a vector of
-// 16x16 bits.
-template <uint8_t lane, typename TData, typename TIndices>
-void storePermute16(void* /*ptr*/, TData /*data*/, TIndices /*indices*/) {
-  static_assert("storePermute16 not defined");
-}
-
-template <uint8_t lane>
-void storePermute16(void* ptr, __m256i data, __m256si indices) {
-  __m256i data32 =
-      _mm256_cvtepi16_epi32(_mm256_extracti128_si256(simd::to256i(data), lane));
-  auto permuted = _mm256_permutevar8x32_epi32(data32, to256i(indices));
-  *reinterpret_cast<__m128i_u*>(ptr) = _mm_packs_epi32(
-      _mm256_extractf128_si256(permuted, 0),
-      _mm256_extractf128_si256(permuted, 1));
-}
+// memset implementation that writes at maximum width and unrolls for
+// constant values of 'bytes'.
+template <typename A = xsimd::default_arch>
+void memset(void* to, char data, int32_t bytes, const A& = {});
 
 // Calls a different instantiation of a template function according to
 // 'numBytes'.

--- a/velox/common/base/tests/RawVectorTest.cpp
+++ b/velox/common/base/tests/RawVectorTest.cpp
@@ -20,8 +20,6 @@
 
 using namespace facebook::velox;
 
-using V64 = simd::Vectors<int64_t>;
-
 TEST(RawVectorTest, basic) {
   raw_vector<int32_t> ints;
   EXPECT_TRUE(ints.empty());
@@ -38,10 +36,10 @@ TEST(RawVectorTest, padding) {
   EXPECT_EQ(1000, ints.size());
   // Check padding. Write a vector right below start and right after
   // capacity. These should fit and give no error with asan.
-  V64::store(simd::addBytes(ints.data(), -simd::kPadding), V64::setAll(-1));
-  V64::store(
-      simd::addBytes(ints.data(), ints.capacity() * sizeof(int32_t)),
-      V64::setAll(-1));
+  auto v = xsimd::batch<int64_t>::broadcast(-1);
+  v.store_unaligned(simd::addBytes(ints.data(), -simd::kPadding));
+  v.store_unaligned(
+      simd::addBytes(ints.data(), ints.capacity() * sizeof(int32_t)));
 }
 
 TEST(RawVectorTest, resize) {

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
 
 target_link_libraries(
   velox_dwio_common
+  velox_buffer
   velox_exception
   velox_dwio_common_encryption
   velox_dwio_common_compression

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(
 
 add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
 
-target_link_libraries(velox_dwio_common_data_buffer_benchmark velox_memory
-                      velox_dwio_common_exception ${FOLLY} ${FOLLY_BENCHMARK})
+target_link_libraries(
+  velox_dwio_common_data_buffer_benchmark velox_dwio_common velox_memory
+  velox_dwio_common_exception ${FOLLY} ${FOLLY_BENCHMARK})

--- a/velox/dwio/dwrf/common/IntDecoder.cpp
+++ b/velox/dwio/dwrf/common/IntDecoder.cpp
@@ -197,6 +197,8 @@ inline void bulkZigzagDecode(int32_t size, T* data) {
   }
 }
 
+#if XSIMD_WITH_AVX2
+
 // Stores each byte of 'bytes' as a int64_t at output[0] ... output[3]
 inline void unpack4x1(int32_t bytes, uint64_t*& output) {
   *reinterpret_cast<__m256i_u*>(output) =
@@ -232,6 +234,8 @@ inline void unpack4x2(uint64_t vints, uint64_t*& output) {
       _mm256_cvtepi16_epi64(_mm_set1_epi64(reinterpret_cast<__m64>(decoded)));
   output += 4;
 }
+
+#endif
 
 // Returns true if the next extract is part of 'rows'.
 inline bool isEnabled(
@@ -292,7 +296,7 @@ inline void clipTrailingStores(
 }
 
 template <typename T>
-__attribute__((__target__("bmi2"))) FOLLY_ALWAYS_INLINE void varintSwitch(
+FOLLY_ALWAYS_INLINE void varintSwitch(
     uint64_t word,
     uint64_t controlBits,
     const char*& pos,

--- a/velox/dwio/dwrf/test/DecoderUtilTest.cpp
+++ b/velox/dwio/dwrf/test/DecoderUtilTest.cpp
@@ -24,12 +24,6 @@
 using namespace facebook::velox;
 using namespace facebook::velox::dwrf;
 
-using V64 = simd::Vectors<int64_t>;
-using V32 = simd::Vectors<int32_t>;
-using V16 = simd::Vectors<int16_t>;
-using VD = simd::Vectors<double>;
-using VF = simd::Vectors<float>;
-
 class DecoderUtilTest : public testing::Test {
  protected:
   void SetUp() override {
@@ -146,6 +140,7 @@ class DecoderUtilTest : public testing::Test {
   folly::Random::DefaultGenerator rng_;
 };
 
+// Running for about 13 seconds.
 TEST_F(DecoderUtilTest, nonNullsFromSparse) {
   // We cover cases with different null frequencies and different density of
   // access.

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -52,7 +52,10 @@ class BaseHashTable {
  public:
   using normalized_key_t = uint64_t;
 
-  using TagVector = __m128i;
+#if XSIMD_WITH_SSE2
+  using TagVector = xsimd::batch<uint8_t, xsimd::sse2>;
+#endif
+
   using MaskType = uint16_t;
 
   // 2M entries, i.e. 16MB is the largest array based hash table.
@@ -198,11 +201,8 @@ class BaseHashTable {
   }
 
   /// Loads a vector of tags for bulk comparison.
-  template <typename T>
-  static TagVector loadTags(T* tags, int32_t tagIndex) {
-    auto tagPtr =
-        reinterpret_cast<TagVector*>(reinterpret_cast<char*>(tags) + tagIndex);
-    return _mm_load_si128(tagPtr);
+  static TagVector loadTags(uint8_t* tags, int32_t tagIndex) {
+    return TagVector::load_unaligned(tags + tagIndex);
   }
 
   /// Loads the payload row pointer corresponding to the tag at 'index'.

--- a/velox/exec/VectorHasher-inl.h
+++ b/velox/exec/VectorHasher-inl.h
@@ -14,28 +14,27 @@
  * limitations under the License.
  */
 namespace facebook::velox::exec {
-template <>
-inline bool VectorHasher::tryMapToRangeSimd(
-    const int64_t* values,
+
+template <typename T>
+bool VectorHasher::tryMapToRangeSimd(
+    const T* values,
     const SelectivityVector& rows,
     uint64_t* result) {
   bool inRange = true;
-  __m256i allLow = _mm256_set1_epi64x(min_);
-  __m256i allHigh = _mm256_set1_epi64x(max_);
-  __m256i allOne = _mm256_set1_epi64x(1);
+  auto allLow = xsimd::broadcast<T>(min_);
+  auto allHigh = xsimd::broadcast<T>(max_);
+  auto allOne = xsimd::broadcast<T>(1);
   vector_size_t row = rows.begin();
-  for (; row + 4 <= rows.end(); row += 4) {
-    __m256i data = _mm256_loadu_si256((__m256i*)(values + row));
-    // value > max_
-    int32_t gtMax = _mm256_movemask_epi8(_mm256_cmpgt_epi64(data, allHigh));
-    // value < min_
-    int32_t ltMin = _mm256_movemask_epi8(_mm256_cmpgt_epi64(allLow, data));
-    // result = (value - low) + 1
+  constexpr int kWidth = xsimd::batch<T>::size;
+  for (; row + kWidth <= rows.end(); row += kWidth) {
+    auto data = xsimd::load_unaligned(values + row);
+    int32_t gtMax = simd::toBitMask(data > allHigh);
+    int32_t ltMin = simd::toBitMask(data < allLow);
     // value - (low - 1) doesn't work when low is the lowest possible (e.g.
     // std::numeric_limits<int64_t>::min())
-    _mm256_storeu_si256(
-        (__m256i*)(result + row),
-        _mm256_add_epi64(_mm256_sub_epi64(data, allLow), allOne));
+    if constexpr (sizeof(T) == sizeof(uint64_t)) {
+      (data - allLow + allOne).store_unaligned(result + row);
+    }
     if ((gtMax | ltMin) != 0) {
       inRange = false;
       break;
@@ -49,87 +48,17 @@ inline bool VectorHasher::tryMapToRangeSimd(
         inRange = false;
         break;
       }
-      result[row] = value - min_ + 1;
+      if constexpr (sizeof(T) == sizeof(uint64_t)) {
+        result[row] = value - min_ + 1;
+      }
     }
-  }
-  return inRange;
-}
-
-template <>
-inline bool VectorHasher::tryMapToRangeSimd(
-    const int32_t* values,
-    const SelectivityVector& rows,
-    uint64_t* result) {
-  bool inRange = true;
-  __m256i allLow = _mm256_set1_epi32(min_);
-  __m256i allHigh = _mm256_set1_epi32(max_);
-  vector_size_t row = rows.begin();
-  for (; row + 8 <= rows.end(); row += 8) {
-    __m256i data = _mm256_loadu_si256((__m256i*)(values + row));
-    // value > max_
-    int32_t gtMax = _mm256_movemask_epi8(_mm256_cmpgt_epi32(data, allHigh));
-    // value < min_
-    int32_t ltMin = _mm256_movemask_epi8(_mm256_cmpgt_epi32(allLow, data));
-    if ((gtMax | ltMin) != 0) {
-      inRange = false;
-      break;
-    }
-  }
-
-  if (inRange) {
-    for (; row < rows.end(); row++) {
-      auto value = values[row];
-      if (value > max_ || value < min_) {
-        inRange = false;
-        break;
+    if constexpr (sizeof(T) != sizeof(uint64_t)) {
+      for (row = rows.begin(); row < rows.end(); row++) {
+        result[row] = values[row] - min_ + 1;
       }
     }
   }
-
-  if (inRange) {
-    for (row = rows.begin(); row < rows.end(); row++) {
-      result[row] = values[row] - min_ + 1;
-    }
-  }
   return inRange;
 }
 
-template <>
-inline bool VectorHasher::tryMapToRangeSimd(
-    const int16_t* values,
-    const SelectivityVector& rows,
-    uint64_t* result) {
-  bool inRange = true;
-  __m256i allLow = _mm256_set1_epi16(min_);
-  __m256i allHigh = _mm256_set1_epi16(max_);
-  vector_size_t row = rows.begin();
-  for (; row + 16 <= rows.end(); row += 16) {
-    __m256i data = _mm256_loadu_si256((__m256i*)(values + row));
-    // value > max_
-    int32_t gtMax = _mm256_movemask_epi8(_mm256_cmpgt_epi16(data, allHigh));
-    // value < min_
-    int32_t ltMin = _mm256_movemask_epi8(_mm256_cmpgt_epi16(allLow, data));
-    if ((gtMax | ltMin) != 0) {
-      inRange = false;
-      break;
-    }
-  }
-
-  if (inRange) {
-    for (; row < rows.end(); row++) {
-      auto value = values[row];
-      if (value > max_ || value < min_) {
-        inRange = false;
-        break;
-      }
-    }
-  }
-
-  if (inRange) {
-    for (row = rows.begin(); row < rows.end(); row++) {
-      result[row] = values[row] - min_ + 1;
-    }
-  }
-  return inRange;
-}
 } // namespace facebook::velox::exec

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -53,9 +53,6 @@ namespace facebook::velox::exec {
     }                                                                    \
   }()
 
-using V32 = simd::Vectors<int32_t>;
-using V64 = simd::Vectors<int64_t>;
-
 namespace {
 template <TypeKind Kind>
 uint64_t hashOne(DecodedVector& decoded, vector_size_t index) {

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -82,7 +82,7 @@ struct UniqueValueHasher {
   size_t operator()(const UniqueValue& value) const {
     auto size = value.size();
     if (size <= sizeof(int64_t)) {
-      return _mm_crc32_u64(value.data(), 1);
+      return simd::crc32U64(value.data(), 1);
     }
 
     uint64_t hash = 1;
@@ -91,7 +91,7 @@ struct UniqueValueHasher {
     size_t wordIndex = 0;
     auto numFullWords = size / 8;
     for (; wordIndex < numFullWords; ++wordIndex) {
-      hash = _mm_crc32_u64(*(data + wordIndex), hash);
+      hash = simd::crc32U64(*(data + wordIndex), hash);
     }
 
     auto numBytesRemaining = size - wordIndex * 8;
@@ -99,7 +99,7 @@ struct UniqueValueHasher {
       auto lastWord = bits::loadPartialWord(
           reinterpret_cast<const uint8_t*>(data + wordIndex),
           numBytesRemaining);
-      hash = _mm_crc32_u64(lastWord, hash);
+      hash = simd::crc32U64(lastWord, hash);
     }
 
     return hash;

--- a/velox/experimental/codegen/code_generator/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/CMakeLists.txt
@@ -33,6 +33,6 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 add_library(velox_codegen_code_generator ExprCodeGenerator.cpp)
-target_link_libraries(velox_codegen_code_generator velox_codegen_ast
+target_link_libraries(velox_codegen_code_generator velox_core velox_codegen_ast
                       velox_codegen_udf_manager velox_memory)
 target_link_libraries(velox_codegen_code_generator velox_codegen_proto)

--- a/velox/experimental/codegen/transform/utils/CMakeLists.txt
+++ b/velox/experimental/codegen/transform/utils/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(velox_transform_utils INTERFACE)
+target_link_libraries(velox_transform_utils INTERFACE velox_core)
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/velox/experimental/codegen/utils/timer/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/utils/timer/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(velox_experimental_codegen_utils_timer_test TimerTests.cpp
                                                            ClockTests.cpp)
 
 target_link_libraries(velox_experimental_codegen_utils_timer_test
-                      velox_codegen_utils_timer gtest gtest_main)
+                      velox_codegen_utils_timer gtest gtest_main xsimd)
 
 add_test(velox_experimental_codegen_utils_timer_test
          velox_experimental_codegen_utils_timer_test)

--- a/velox/experimental/codegen/utils/timer/tests/ClockTests.cpp
+++ b/velox/experimental/codegen/utils/timer/tests/ClockTests.cpp
@@ -16,7 +16,7 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <xmmintrin.h>
+#include <xsimd/xsimd.hpp> // @manual
 #include <chrono>
 #include "boost/accumulators/accumulators.hpp"
 #include "boost/accumulators/statistics.hpp"
@@ -103,7 +103,7 @@ void printClockStatistics(const std::string& clockName, size_t iterations) {
       fmt::format("{} [] with cold cache", clockName),
       [](auto& timePoints, size_t i) -> void { timePoints[i] = Clock::now(); },
       iterations);
-
+#if XSIMD_WITH_SSE2
   testClock<Clock, true>(
       fmt::format("{} non temporal with hot cache", clockName),
       [](auto& timePoints, size_t i) -> void {
@@ -122,6 +122,7 @@ void printClockStatistics(const std::string& clockName, size_t iterations) {
             *reinterpret_cast<__m64*>(&n));
       },
       iterations);
+#endif
 }
 
 /// Compute basic statistics acros an event sequence

--- a/velox/experimental/codegen/utils/timer/tests/TARGETS_disabled
+++ b/velox/experimental/codegen/utils/timer/tests/TARGETS_disabled
@@ -7,6 +7,7 @@ cpp_unittest(
         "TimerTests.cpp",
     ],
     deps = [
+        "fbsource//third-party/xsimd:xsimd",  # @manual
         "//velox/experimental/codegen/utils/timer:velox_codegen_utils_timer",
     ],
     external_deps = [

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,4 +13,4 @@
 # limitations under the License.
 add_library(velox_presto_types JsonType.cpp)
 
-target_link_libraries(velox_presto_types velox_memory)
+target_link_libraries(velox_presto_types velox_memory velox_expression)

--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -18,4 +18,4 @@ endif()
 
 add_library(velox_row UnsafeRow24Deserializer.cpp)
 
-target_link_libraries(velox_row velox_memory)
+target_link_libraries(velox_row velox_memory velox_type velox_vector)

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -124,13 +124,13 @@ class BiasVector : public SimpleVector<T> {
   }
 
   /**
-   * Loads a 256bit vector of data at the virtual byteOffset given
+   * Loads a SIMD vector of data at the virtual byteOffset given
    * Note this method is implemented on each vector type, but is intentionally
    * not virtual for performance reasons
    *
    * @param byteOffset - the byte offset to laod from
    */
-  __m256i loadSIMDValueBufferAt(size_t index) const;
+  xsimd::batch<T> loadSIMDValueBufferAt(size_t index) const;
 
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
@@ -164,95 +164,23 @@ class BiasVector : public SimpleVector<T> {
   }
 
  private:
-  template <int32_t StorageSizeInBytes>
-  inline const __m256i loadSIMDInternal(size_t byteOffset) const {
-    // Note Intel simd instructions below load values in reverse index order
-    auto startIndex = byteOffset / sizeof(T);
-    if constexpr (std::is_same<T, int64_t>::value) {
-      DCHECK(
-          StorageSizeInBytes == 4 || StorageSizeInBytes == 2 ||
-          StorageSizeInBytes == 1)
-          << "Invalid Bias storage width";
-      if constexpr (StorageSizeInBytes == 4) {
-        return _mm256_set_epi64x(
-            int32Ptr_[startIndex + 3],
-            int32Ptr_[startIndex + 2],
-            int32Ptr_[startIndex + 1],
-            int32Ptr_[startIndex]);
-      } else if constexpr (StorageSizeInBytes == 2) {
-        return _mm256_set_epi64x(
-            int16Ptr_[startIndex + 3],
-            int16Ptr_[startIndex + 2],
-            int16Ptr_[startIndex + 1],
-            int16Ptr_[startIndex]);
-      } else if constexpr (StorageSizeInBytes == 1) {
-        return _mm256_set_epi64x(
-            int8Ptr_[startIndex + 3],
-            int8Ptr_[startIndex + 2],
-            int8Ptr_[startIndex + 1],
-            int8Ptr_[startIndex]);
-      }
-    } else if constexpr (std::is_same<T, int32_t>::value) {
-      DCHECK(StorageSizeInBytes == 2 || StorageSizeInBytes == 1)
-          << "Invalid Bias storage width";
-      if constexpr (StorageSizeInBytes == 2) {
-        return _mm256_set_epi32(
-            int16Ptr_[startIndex + 7],
-            int16Ptr_[startIndex + 6],
-            int16Ptr_[startIndex + 5],
-            int16Ptr_[startIndex + 4],
-            int16Ptr_[startIndex + 3],
-            int16Ptr_[startIndex + 2],
-            int16Ptr_[startIndex + 1],
-            int16Ptr_[startIndex]);
-      } else if constexpr (StorageSizeInBytes == 1) {
-        return _mm256_set_epi32(
-            int8Ptr_[startIndex + 7],
-            int8Ptr_[startIndex + 6],
-            int8Ptr_[startIndex + 5],
-            int8Ptr_[startIndex + 4],
-            int8Ptr_[startIndex + 3],
-            int8Ptr_[startIndex + 2],
-            int8Ptr_[startIndex + 1],
-            int8Ptr_[startIndex]);
-      }
-    } else if constexpr (std::is_same<T, int16_t>::value) {
-      DCHECK(StorageSizeInBytes == 1) << "Invalid Bias storage width";
-      return _mm256_set_epi16(
-          int8Ptr_[startIndex + 15],
-          int8Ptr_[startIndex + 14],
-          int8Ptr_[startIndex + 13],
-          int8Ptr_[startIndex + 12],
-          int8Ptr_[startIndex + 11],
-          int8Ptr_[startIndex + 10],
-          int8Ptr_[startIndex + 9],
-          int8Ptr_[startIndex + 8],
-          int8Ptr_[startIndex + 7],
-          int8Ptr_[startIndex + 6],
-          int8Ptr_[startIndex + 5],
-          int8Ptr_[startIndex + 4],
-          int8Ptr_[startIndex + 3],
-          int8Ptr_[startIndex + 2],
-          int8Ptr_[startIndex + 1],
-          int8Ptr_[startIndex]);
-    }
-
-    throw std::runtime_error("Unsupported type");
+  template <typename U>
+  inline xsimd::batch<T> loadSIMDInternal(size_t byteOffset) const {
+    auto mem = reinterpret_cast<const U*>(
+        rawValues_ + byteOffset / sizeof(T) * sizeof(U));
+    return xsimd::batch<T>::load_unaligned(mem);
   }
 
   TypeKind valueType_;
   BufferPtr values_;
   const uint8_t* rawValues_;
-  const int8_t* int8Ptr_ = nullptr;
-  const int16_t* int16Ptr_ = nullptr;
-  const int32_t* int32Ptr_ = nullptr;
 
   // Note: there is no 64 bit internal array as the largest number type we
   // support is 64 bit and all biasing requires a smaller internal type.
   T bias_;
 
   // Used to debias several values at a time.
-  __m256i biasBuffer_;
+  std::conditional_t<can_simd, xsimd::batch<T>, char> biasBuffer_;
 };
 
 template <typename T>

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(
   VectorStream.cpp)
 
 target_link_libraries(velox_vector velox_encode velox_memory velox_time
-                      velox_type)
+                      velox_type velox_buffer)
 
 add_subdirectory(arrow)
 add_subdirectory(fuzzer)

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -99,14 +99,14 @@ class DictionaryVector : public SimpleVector<T> {
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
   /**
-   * Loads a 256bit vector of data at the virtual byteOffset given
+   * Loads a SIMD vector of data at the virtual byteOffset given
    * Note this method is implemented on each vector type, but is intentionally
    * not virtual for performance reasons
    *
    * @param index at which to start the vector load
    * @return the vector of values starting at the given index
    */
-  __m256i loadSIMDValueBufferAt(size_t index) const;
+  xsimd::batch<T> loadSIMDValueBufferAt(size_t index) const;
 
   inline TypeKind getIndexType() const {
     return indexType_;

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -141,13 +141,13 @@ class FlatVector final : public SimpleVector<T> {
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
   /**
-   * Loads a 256bit vector of data at the virtual byteOffset given
+   * Loads a SIMD vector of data at the virtual byteOffset given
    * Note this method is implemented on each vector type, but is intentionally
    * not virtual for performance reasons
    *
    * @param byteOffset - the byte offset to load from
    */
-  __m256i loadSIMDValueBufferAt(size_t index) const;
+  xsimd::batch<T> loadSIMDValueBufferAt(size_t index) const;
 
   // dictionary vector makes internal use here for SIMD functions
   template <typename X>

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -98,7 +98,7 @@ class SequenceVector : public SimpleVector<T> {
    *
    * @param byteOffset - the byte offset to laod from
    */
-  __m256i loadSIMDValueBufferAt(size_t index) const;
+  xsimd::batch<T> loadSIMDValueBufferAt(size_t index) const;
 
   /**
    * Returns a shared_ptr to the underlying byte buffer holding the values for


### PR DESCRIPTION
Summary: This change replaces all Intel intrinsics with portable xsimd wrappers.  It only runs on AVX2 chips for now.  Subsequent changes will make it portable to SSE4.2 and NEON.

Differential Revision: D35579863

