### PR TITLE
applySingleConstArgVectorFunction loses exceptions

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -100,8 +100,18 @@ void EvalCtx::setWrapped(
     return;
   }
   if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
-    *result = BaseVector::wrapInConstant(
-        rows.size(), constantWrapIndex_, std::move(source));
+    if (errors_ && constantWrapIndex_ < errors_->size() &&
+        !errors_->isNullAt(constantWrapIndex_)) {
+      // If the single row caused an error that will be caught by a TRY
+      // upstream source may be not initialized, or otherwise in a bad state.
+      // Just return NULL, the value won't be used and TRY is just going to
+      // NULL out the result anyway.
+      *result =
+          BaseVector::createNullConstant(expr->type(), rows.size(), pool());
+    } else {
+      *result = BaseVector::wrapInConstant(
+          rows.size(), constantWrapIndex_, std::move(source));
+    }
     return;
   }
   VELOX_CHECK(false, "Bad expression wrap encoding {}", wrapEncoding_);

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -128,6 +128,7 @@ void EvalCtx::saveAndReset(ContextSaver* saver, const SelectivityVector& rows) {
   saver->wrap = std::move(wrap_);
   saver->wrapNulls = std::move(wrapNulls_);
   saver->wrapEncoding = wrapEncoding_;
+  saver->constantWrapIndex = constantWrapIndex_;
   wrapEncoding_ = VectorEncoding::Simple::FLAT;
   saver->nullsPruned = nullsPruned_;
   nullsPruned_ = false;
@@ -199,6 +200,7 @@ void EvalCtx::restore(ContextSaver* saver) {
   wrap_ = std::move(saver->wrap);
   wrapNulls_ = std::move(saver->wrapNulls);
   wrapEncoding_ = saver->wrapEncoding;
+  constantWrapIndex_ = saver->constantWrapIndex;
   finalSelection_ = saver->finalSelection;
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -237,6 +237,7 @@ struct ContextSaver {
   BufferPtr wrap;
   BufferPtr wrapNulls;
   VectorEncoding::Simple wrapEncoding;
+  vector_size_t constantWrapIndex;
   bool nullsPruned = false;
   // The selection of the context being saved.
   const SelectivityVector* rows;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1170,6 +1170,10 @@ void Expr::applySingleConstArgVectorFunction(
     args = {inputValue->valueVector()};
   }
 
+  ContextSaver saver;
+  context->saveAndReset(&saver, rows);
+  context->setConstantWrap(inputRow);
+
   VectorPtr tempResult;
   vectorFunction_->apply(*inputRows, args, type(), context, &tempResult);
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2675,3 +2675,33 @@ TEST_F(ExprTest, tryWithConstantFailure) {
       5, [](vector_size_t) { return 0; }, [](vector_size_t) { return true; });
   assertEqualVectors(expectedResult, evalResult);
 }
+
+TEST_F(ExprTest, applySingleConstantArg) {
+  // This test verifies the behavior of applySingleConstArgVectorFunction,
+  // particularly in the case where the single input row doesn't match the
+  // wrappedRow in the ConstantVector.
+
+  // Exceptions combined with TRY are useful for exposing issues in the
+  // translation between the input row and the wrappedRow.  In particular,
+  // if the translation is not done, the exception may be associated with the
+  // wrappedRow instead of the input row after execution, meaning that it gets
+  // lost.
+  registerFunction<AlwaysThrowsFunction, int64_t, int64_t>({"always_throws"});
+  // Using a dictionary wrapped constant scalar vector is very intentional.
+  // Using a scalar vector means that the wrappedRow is always 0.
+  // Using a dictionary vector with indices that never point to the value at
+  // position 0 ensures that the input row is 1.
+  // Hence we get the mismatch we're trying to test.
+  auto c0 = makeConstantVector((int64_t)1, 5);
+  auto c0Indices = makeIndices(5, [](auto row) { return row == 0 ? 1 : row; });
+  auto rowVector =
+      makeRowVector({BaseVector::wrapInDictionary(nullptr, c0Indices, 5, c0)});
+
+  auto evalResult = evaluate("try(always_throws(\"c0\"))", rowVector);
+
+  // If the translation is done incorrectly we will get garbage data in the
+  // output instead of NULL.
+  auto expectedResult = makeFlatVector<int64_t>(
+      5, [](vector_size_t) { return 0; }, [](vector_size_t) { return true; });
+  assertEqualVectors(expectedResult, evalResult);
+}

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2639,3 +2639,39 @@ TEST_F(ExprTest, specialFormPropagateNulls) {
       [](vector_size_t row) { return row == 4; });
   assertEqualVectors(expectedResult, evalResult);
 }
+
+namespace {
+template <typename T>
+struct AlwaysThrowsFunction {
+  template <typename TResult, typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TResult& /* out */, const TInput& /* in */) {
+    VELOX_CHECK(false);
+  }
+};
+} // namespace
+
+TEST_F(ExprTest, tryWithConstantFailure) {
+  // This test verifies the behavior of constant peeling on a function wrapped
+  // in a TRY.  Specifically the case when the UDF executed on the peeled
+  // Vector throws an exception on the constant value.
+
+  // When wrapping a peeled ConstantVector, the result is wrapped in a
+  // ConstantVector.  ConstantVector has special handling logic to copy the
+  // underlying string when the type is Varchar.  When an exception is thrown
+  // and the StringView isn't initialized, without special handling logic in
+  // EvalCtx this results in reading uninitialized memory triggering ASAN
+  // errors.
+  registerFunction<AlwaysThrowsFunction, Varchar, Varchar>({"always_throws"});
+  auto c0 = makeConstantVector("test", 5);
+  auto c1 = makeFlatVector<int64_t>(5, [](vector_size_t row) { return row; });
+  auto rowVector = makeRowVector({c0, c1});
+
+  // We use strpos and c1 to ensure that the constant is peeled before calling
+  // always_throws, not before the try.
+  auto evalResult =
+      evaluate("try(strpos(always_throws(\"c0\"), 't', c1))", rowVector);
+
+  auto expectedResult = makeFlatVector<int64_t>(
+      5, [](vector_size_t) { return 0; }, [](vector_size_t) { return true; });
+  assertEqualVectors(expectedResult, evalResult);
+}


### PR DESCRIPTION
Summary:
applySingleConstArgVectorFunction in Expr is a highly specialized way of invoking Vector
functions when there is only one non-literal argument to the function and it's constant.  In
this case, it does something similar to peeling where it copies the value into a flat vector if
necessary removing the Constant encoding.

There is a potential bug here because we are not saving the context.  If an error occurs it
happens at row X, where X is the wrappedIndex returned by the ConstantVector.
However, the row we're evaluating is row Y, the single row pointed to by rows.  Since
these don't match up TRY will not NULL out the value at row Y and we'll get garbage
results.

In addition, just saving the context is insufficient because chances are, the Constant was
peeled before the function was applied (this doesn't not remove the Constant encoding, it
only ensures we evaluate one row) this saves its own context, and when reapplying the
Constant wrapping to the result it uses the stored constantWrapIndex_ to figure out which
row the value is stored at, as well as which row to check for exceptions.  When we save
another context in applySingleConstArgVectorFunction it resets constantWrapIndex_ to 0,
we need to save and restore it to the original value to ensure the unpeeling still works.

Differential Revision: D35760752

