### PR TITLE
Fix InPredicate(Dictionary).

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -132,10 +132,10 @@ class InPredicate : public exec::VectorFunction {
     return std::make_shared<InPredicate>(std::move(filter));
   }
 
-  // x IN (2, null) returns null when x != 2 and true when x == 2
-  // null for x always produces null
+  // x IN (2, null) returns null when x != 2 and true when x == 2.
+  // Null for x always produces null, regardless of 'IN' list.
   bool isDefaultNullBehavior() const override {
-    return false;
+    return true;
   }
 
   void apply(


### PR DESCRIPTION
Summary:
InPredicate(Dictionary) can happen and it is not supported.
It happens that it can be fixed by returning TRUE from isDefaultNullBehavior(), which means that for 'x' = NULL "x in (list)" will always return null.
In that case the dictionary with nulls (in our case) will be properly flattened by the expr framework, while at the moment it is not the case.

Differential Revision: D35836866

