### PR TITLE
Add query 13 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -28,6 +28,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/TpchQueryBuilder.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -78,6 +79,7 @@ class TpchBenchmark {
  public:
   void initialize() {
     functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
     parquet::registerParquetReaderFactory();
     dwrf::registerDwrfReaderFactory();
@@ -125,6 +127,11 @@ BENCHMARK(q1) {
 
 BENCHMARK(q6) {
   const auto planContext = queryBuilder->getQueryPlan(6);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q13) {
+  const auto planContext = queryBuilder->getQueryPlan(13);
   benchmark.run(planContext);
 }
 

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -80,6 +80,8 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ1Plan();
     case 6:
       return getQ6Plan();
+    case 13:
+      return getQ13Plan();
     case 18:
       return getQ18Plan();
     default:
@@ -191,6 +193,66 @@ TpchPlan TpchQueryBuilder::getQ6Plan() const {
   TpchPlan context;
   context.plan = std::move(plan);
   context.dataFiles[lineitemPlanNodeId] = getTableFilePaths(kLineitem);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ13Plan() const {
+  static const std::string kOrders = "orders";
+  static const std::string kCustomer = "customer";
+  std::vector<std::string> ordersColumns = {
+      "o_custkey", "o_comment", "o_orderkey"};
+  std::vector<std::string> customerColumns = {"c_custkey"};
+
+  auto ordersSelectedRowType = getRowType(kOrders, ordersColumns);
+  const auto& ordersFileColumns = getFileColumnNames(kOrders);
+
+  auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId customerScanNodeId;
+  core::PlanNodeId ordersScanNodeId;
+
+  auto notSpecialRequestOrders =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kOrders,
+              ordersSelectedRowType,
+              ordersFileColumns,
+              {},
+              "o_comment not like '%special%requests%'")
+          .capturePlanNodeId(ordersScanNodeId)
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localPartition(
+              {},
+              {PlanBuilder(planNodeIdGenerator)
+                   .tableScan(
+                       kCustomer, customerSelectedRowType, customerFileColumns)
+                   .capturePlanNodeId(customerScanNodeId)
+                   .hashJoin(
+                       {"c_custkey"},
+                       {"o_custkey"},
+                       notSpecialRequestOrders,
+                       "",
+                       {"c_custkey", "o_orderkey"},
+                       core::JoinType::kLeft)
+                   .partialAggregation(
+                       {"c_custkey"}, {"count(o_orderkey) as pc_count"})
+                   .planNode()})
+          .finalAggregation(
+              {"c_custkey"}, {"count(pc_count) as c_count"}, {BIGINT()})
+          .singleAggregation({"c_count"}, {"count(0) as custdist"})
+          .orderBy({"custdist DESC", "c_count DESC"}, false)
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[ordersScanNodeId] = getTableFilePaths(kOrders);
+  context.dataFiles[customerScanNodeId] = getTableFilePaths(kCustomer);
   context.dataFileFormat = format_;
   return context;
 }
@@ -326,7 +388,7 @@ const std::unordered_map<std::string, std::vector<std::string>>
             std::vector<std::string>{
                 "c_custkey",
                 "c_name",
-                "c_addres",
+                "c_address",
                 "c_nationkey",
                 "c_phone",
                 "c_acctbal",

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -78,6 +78,7 @@ class TpchQueryBuilder {
  private:
   TpchPlan getQ1Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ13Plan() const;
   TpchPlan getQ18Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(


### PR DESCRIPTION
Adds TPC-H query 13 to TpchQueryBuilder. 

Output of printPlanWithStats for TPC-H SF 10 using DWRF.
```
Execution time: 2.87s
Splits total: 160, finished: 160
-> OrderBy[custdist DESC NULLS LAST, c_count DESC NULLS LAST]
   Output: 46 rows (896B), Cpu time: 40.12us, Blocked wall time: 0ns, Peak memory: 1.00MB, Threads: 1
  -> Aggregation[SINGLE [c_count] custdist := count(0)]
     Output: 46 rows (23.84KB), Cpu time: 7.04ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Threads: 1
    -> Aggregation[FINAL [c_custkey] c_count := count(ROW["pc_count"])]
       Output: 1500000 rows (34.29MB), Cpu time: 1.04s, Blocked wall time: 0ns, Peak memory: 56.00MB, Threads: 1
      -> LocalPartition[GATHER]
         Output: 24704006 rows (565.79MB), Cpu time: 51.88ms, Blocked wall time: 3.77s, Peak memory: 0B
         LocalPartition: Input: 12352003 rows (282.89MB), Output: 12352003 rows (282.89MB), Cpu time: 20.15ms, Blocked wall time: 1.92s, Peak memory: 0B, Threads: 8
         LocalExchange: Input: 12352003 rows (282.89MB), Output: 12352003 rows (282.89MB), Cpu time: 31.73ms, Blocked wall time: 1.85s, Peak memory: 0B, Threads: 1
        -> Aggregation[PARTIAL [c_custkey] pc_count := count(ROW["o_orderkey"])]
           Output: 12352003 rows (282.89MB), Cpu time: 1.95s, Blocked wall time: 0ns, Peak memory: 32.00MB, Threads: 8
          -> HashJoin[RIGHT o_custkey=c_custkey]
             Output: 15337604 rows (323.18MB), Cpu time: 1.95s, Blocked wall time: 480.61ms, Peak memory: 17.00MB
             HashBuild: Input: 1500000 rows (0B), Output: 0 rows (0B), Cpu time: 183.88ms, Blocked wall time: 42.31ms, Peak memory: 16.00MB, Threads: 8
             HashProbe: Input: 14837583 rows (972.32MB), Output: 15337604 rows (323.18MB), Cpu time: 1.77s, Blocked wall time: 438.30ms, Peak memory: 1.00MB, Threads: 8
            -> TableScan[table: orders, remaining filter: (not(like(ROW["comment"],"%special%requests%")))]
               Input: 14837583 rows (1.17GB), Raw Input: 15000000 rows (315.15MB), Output: 14837583 rows (972.32MB), Cpu time: 16.86s, Blocked wall time: 265.00us, Peak memory: 36.00MB, Threads: 8, Splits: 80
            -> TableScan[table: customer]
               Input: 1500000 rows (0B), Output: 1500000 rows (0B), Cpu time: 57.15ms, Blocked wall time: 389.00us, Peak memory: 3.00MB, Threads: 8, Splits: 80
```