### PR TITLE
More types in HivePartitionFunction

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -88,32 +89,11 @@ void hashTyped<TypeKind::REAL>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  static_assert(sizeof(float) == sizeof(uint32_t));
-  auto f = [](float value) {
-    uint32_t ret;
-    memcpy(&ret, &value, sizeof ret);
-    return ret;
-  };
-  abstractHashTyped<float>(values, size, mix, hashes, f);
+  hashTyped<TypeKind::INTEGER>(values, size, mix, hashes);
 }
 
 int32_t hashInt64(int64_t value) {
   return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
-}
-
-template <>
-void hashTyped<TypeKind::DOUBLE>(
-    const DecodedVector& values,
-    vector_size_t size,
-    bool mix,
-    std::vector<uint32_t>& hashes) {
-  static_assert(sizeof(float) == sizeof(uint32_t));
-  auto f = [](double value) {
-    int64_t buff;
-    memcpy(&buff, &value, sizeof buff);
-    return hashInt64(buff);
-  };
-  abstractHashTyped<double>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -124,6 +104,15 @@ void hashTyped<TypeKind::BIGINT>(
     std::vector<uint32_t>& hashes) {
   auto f = [](int64_t value) { return hashInt64(value); };
   abstractHashTyped<int64_t>(values, size, mix, hashes, f);
+}
+
+template <>
+void hashTyped<TypeKind::DOUBLE>(
+    const DecodedVector& values,
+    vector_size_t size,
+    bool mix,
+    std::vector<uint32_t>& hashes) {
+  hashTyped<TypeKind::BIGINT>(values, size, mix, hashes);
 }
 
 #if defined(__has_feature)

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -35,10 +35,10 @@ void abstractHashTyped(
     const DecodedVector& values,
     vector_size_t size,
     bool mix,
-    std::vector<uint32_t>& hashes,
-    std::function<uint32_t(const T&)> const& f) {
+    std::function<uint32_t(const T&)> const& hashOne,
+    std::vector<uint32_t>& hashes) {
   for (auto i = 0; i < size; ++i) {
-    const uint32_t hash = (values.isNullAt(i)) ? 0 : f(values.valueAt<T>(i));
+    const uint32_t hash = (values.isNullAt(i)) ? 0 : hashOne(values.valueAt<T>(i));
     hashes[i] = mix ? hashes[i] * 31 + hash : hash;
   }
 }
@@ -49,8 +49,8 @@ void hashTyped<TypeKind::BOOLEAN>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](bool value) { return value ? 1 : 0; };
-  abstractHashTyped<bool>(values, size, mix, hashes, f);
+  auto hashBool = [](bool value) { return value ? 1 : 0; };
+  abstractHashTyped<bool>(values, size, mix, hashBool, hashes);
 }
 
 template <>
@@ -59,8 +59,8 @@ void hashTyped<TypeKind::TINYINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](int8_t value) { return static_cast<uint32_t>(value); };
-  abstractHashTyped<int8_t>(values, size, mix, hashes, f);
+  auto hashTinyint = [](int8_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int8_t>(values, size, mix, hashTinyint, hashes);
 }
 
 template <>
@@ -69,8 +69,8 @@ void hashTyped<TypeKind::SMALLINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](int16_t value) { return static_cast<uint32_t>(value); };
-  abstractHashTyped<int16_t>(values, size, mix, hashes, f);
+  auto hashSmallint = [](int16_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int16_t>(values, size, mix, hashSmallint, hashes);
 }
 
 template <>
@@ -79,8 +79,8 @@ void hashTyped<TypeKind::INTEGER>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](int32_t value) { return static_cast<uint32_t>(value); };
-  abstractHashTyped<int32_t>(values, size, mix, hashes, f);
+  auto hashInteger = [](int32_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int32_t>(values, size, mix, hashInteger, hashes);
 }
 
 template <>
@@ -102,8 +102,7 @@ void hashTyped<TypeKind::BIGINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](int64_t value) { return hashInt64(value); };
-  abstractHashTyped<int64_t>(values, size, mix, hashes, f);
+  abstractHashTyped<int64_t>(values, size, mix, hashInt64, hashes);
 }
 
 template <>
@@ -135,8 +134,8 @@ void hashTypedStringView(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](const StringView& value) { return hashBytes(value, 0); };
-  abstractHashTyped<StringView>(values, size, mix, hashes, f);
+  auto hashStringView = [](const StringView& value) { return hashBytes(value, 0); };
+  abstractHashTyped<StringView>(values, size, mix, hashStringView, hashes);
 }
 
 template <>
@@ -167,8 +166,7 @@ void hashTyped<TypeKind::TIMESTAMP>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](const Timestamp& value) { return hashTimestamp(value); };
-  abstractHashTyped<Timestamp>(values, size, mix, hashes, f);
+  abstractHashTyped<Timestamp>(values, size, mix, hashTimestamp, hashes);
 }
 
 template <>
@@ -177,8 +175,8 @@ void hashTyped<TypeKind::DATE>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto f = [](const Date& value) { return value.days(); };
-  abstractHashTyped<Date>(values, size, mix, hashes, f);
+  auto hashDate = [](const Date& value) { return value.days(); };
+  abstractHashTyped<Date>(values, size, mix, hashDate, hashes);
 }
 
 void hash(

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include <bit>
 
 namespace facebook::velox::connector::hive {
 

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -38,7 +38,8 @@ void abstractHashTyped(
     std::function<uint32_t(const T&)> const& hashOne,
     std::vector<uint32_t>& hashes) {
   for (auto i = 0; i < size; ++i) {
-    const uint32_t hash = (values.isNullAt(i)) ? 0 : hashOne(values.valueAt<T>(i));
+    const uint32_t hash =
+        (values.isNullAt(i)) ? 0 : hashOne(values.valueAt<T>(i));
     hashes[i] = mix ? hashes[i] * 31 + hash : hash;
   }
 }
@@ -69,7 +70,9 @@ void hashTyped<TypeKind::SMALLINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto hashSmallint = [](int16_t value) { return static_cast<uint32_t>(value); };
+  auto hashSmallint = [](int16_t value) {
+    return static_cast<uint32_t>(value);
+  };
   abstractHashTyped<int16_t>(values, size, mix, hashSmallint, hashes);
 }
 
@@ -134,7 +137,9 @@ void hashTypedStringView(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  auto hashStringView = [](const StringView& value) { return hashBytes(value, 0); };
+  auto hashStringView = [](const StringView& value) {
+    return hashBytes(value, 0);
+  };
   abstractHashTyped<StringView>(values, size, mix, hashStringView, hashes);
 }
 

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -29,12 +29,12 @@ void hashTyped(
       TypeTraits<kind>::name);
 }
 
-template <typename T>
+template <typename T, typename Func>
 void abstractHashTyped(
     const DecodedVector& values,
     vector_size_t size,
     bool mix,
-    std::function<uint32_t(const T&)> const& hashOne,
+    Func&& hashOne,
     std::vector<uint32_t>& hashes) {
   for (auto i = 0; i < size; ++i) {
     const uint32_t hash =

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -103,14 +103,14 @@ void hashTyped<TypeKind::REAL>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    static_assert(sizeof(float) == sizeof(uint32_t));
+  static_assert(sizeof(float) == sizeof(uint32_t));
   for (auto i = 0; i < size; ++i) {
     uint32_t hash;
     if (values.isNullAt(i)) {
       hash = 0;
     } else {
-        auto val = values.valueAt<float>(i);
-        memcpy(&hash, &val, sizeof hash);
+      auto val = values.valueAt<float>(i);
+      memcpy(&hash, &val, sizeof hash);
     }
 
     hashes[i] = mix ? hashes[i] * 31 + hash : hash;
@@ -127,16 +127,16 @@ void hashTyped<TypeKind::DOUBLE>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    static_assert(sizeof(float) == sizeof(uint32_t));
+  static_assert(sizeof(float) == sizeof(uint32_t));
   for (auto i = 0; i < size; ++i) {
     int32_t hash;
     if (values.isNullAt(i)) {
       hash = 0;
     } else {
-        auto val_double = values.valueAt<double>(i);
-        int64_t val_int64;
-        memcpy(&val_int64, &val_double, sizeof val_int64);
-        hash = hashInt64(val_int64);
+      auto val_double = values.valueAt<double>(i);
+      int64_t val_int64;
+      memcpy(&val_int64, &val_double, sizeof val_int64);
+      hash = hashInt64(val_int64);
     }
 
     hashes[i] = mix ? hashes[i] * 31 + hash : hash;
@@ -189,7 +189,7 @@ void hashTyped<TypeKind::VARCHAR>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    hashTypedStringView(values, size, mix, hashes);
+  hashTypedStringView(values, size, mix, hashes);
 }
 
 template <>
@@ -198,11 +198,11 @@ void hashTyped<TypeKind::VARBINARY>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    hashTypedStringView(values, size, mix, hashes);
+  hashTypedStringView(values, size, mix, hashes);
 }
 
 int32_t hashTimestamp(Timestamp ts) {
-    return hashInt64((ts.getSeconds() << 30) | ts.getNanos());
+  return hashInt64((ts.getSeconds() << 30) | ts.getNanos());
 }
 
 template <>

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -49,8 +49,8 @@ void hashTyped<TypeKind::BOOLEAN>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    auto f = [](bool value) { return value ? 1 : 0; };
-    abstractHashTyped<bool>(values, size, mix, hashes, f);
+  auto f = [](bool value) { return value ? 1 : 0; };
+  abstractHashTyped<bool>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -59,8 +59,8 @@ void hashTyped<TypeKind::TINYINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    auto f = [](int8_t value) { return static_cast<uint32_t>(value); };
-    abstractHashTyped<int8_t>(values, size, mix, hashes, f);
+  auto f = [](int8_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int8_t>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -69,8 +69,8 @@ void hashTyped<TypeKind::SMALLINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    auto f = [](int16_t value) { return static_cast<uint32_t>(value); };
-    abstractHashTyped<int16_t>(values, size, mix, hashes, f);
+  auto f = [](int16_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int16_t>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -79,8 +79,8 @@ void hashTyped<TypeKind::INTEGER>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-    auto f = [](int32_t value) { return static_cast<uint32_t>(value); };
-    abstractHashTyped<int32_t>(values, size, mix, hashes, f);
+  auto f = [](int32_t value) { return static_cast<uint32_t>(value); };
+  abstractHashTyped<int32_t>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -90,12 +90,12 @@ void hashTyped<TypeKind::REAL>(
     bool mix,
     std::vector<uint32_t>& hashes) {
   static_assert(sizeof(float) == sizeof(uint32_t));
-    auto f = [](float value) {
-        uint32_t ret;
-        memcpy(&ret, &value, sizeof ret);
-        return ret;
-    };
-    abstractHashTyped<float>(values, size, mix, hashes, f);
+  auto f = [](float value) {
+    uint32_t ret;
+    memcpy(&ret, &value, sizeof ret);
+    return ret;
+  };
+  abstractHashTyped<float>(values, size, mix, hashes, f);
 }
 
 int32_t hashInt64(int64_t value) {
@@ -110,11 +110,11 @@ void hashTyped<TypeKind::DOUBLE>(
     std::vector<uint32_t>& hashes) {
   static_assert(sizeof(float) == sizeof(uint32_t));
   auto f = [](double value) {
-      int64_t buff;
-      memcpy(&buff, &value, sizeof buff);
-      return hashInt64(buff);
+    int64_t buff;
+    memcpy(&buff, &value, sizeof buff);
+    return hashInt64(buff);
   };
-    abstractHashTyped<double>(values, size, mix, hashes, f);
+  abstractHashTyped<double>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -123,12 +123,8 @@ void hashTyped<TypeKind::BIGINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-<<<<<<< HEAD
-    auto f = [](int64_t value) { return hashInt64(value); };
-=======
   auto f = [](int64_t value) { return hashInt64(value); };
->>>>>>> remove redundent
-    abstractHashTyped<int64_t>(values, size, mix, hashes, f);
+  abstractHashTyped<int64_t>(values, size, mix, hashes, f);
 }
 
 #if defined(__has_feature)
@@ -151,12 +147,8 @@ void hashTypedStringView(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-<<<<<<< HEAD
-    auto f = [](const StringView & value) { return hashBytes(value, 0); };
-=======
-  auto f = [](const StringView & value) { return hashBytes(value, 0); };
->>>>>>> remove redundent
-    abstractHashTyped<StringView>(values, size, mix, hashes, f);
+  auto f = [](const StringView& value) { return hashBytes(value, 0); };
+  abstractHashTyped<StringView>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -187,12 +179,8 @@ void hashTyped<TypeKind::TIMESTAMP>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-<<<<<<< HEAD
-    auto f = [](const Timestamp & value) { return hashTimestamp(value); };
-=======
-  auto f = [](const Timestamp & value) { return hashTimestamp(value); };
->>>>>>> remove redundent
-    abstractHashTyped<Timestamp>(values, size, mix, hashes, f);
+  auto f = [](const Timestamp& value) { return hashTimestamp(value); };
+  abstractHashTyped<Timestamp>(values, size, mix, hashes, f);
 }
 
 template <>
@@ -201,12 +189,8 @@ void hashTyped<TypeKind::DATE>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
-<<<<<<< HEAD
-    auto f = [](const Date & value) { return value.days(); };
-=======
-  auto f = [](const Date & value) { return value.days(); };
->>>>>>> remove redundent
-    abstractHashTyped<Date>(values, size, mix, hashes, f);
+  auto f = [](const Date& value) { return value.days(); };
+  abstractHashTyped<Date>(values, size, mix, hashes, f);
 }
 
 void hash(

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -42,6 +42,24 @@ void hashTyped<TypeKind::BOOLEAN>(
   }
 }
 
+template <>
+void hashTyped<TypeKind::TINYINT>(
+    const DecodedVector& values,
+    vector_size_t size,
+    bool mix,
+    std::vector<uint32_t>& hashes) {
+    for (auto i = 0; i < size; ++i) {
+        uint32_t hash;
+        if (values.isNullAt(i)) {
+            hash = 0;
+        } else {
+            hash = static_cast<uint32_t>(values.valueAt<int8_t>(i));
+        }
+
+        hashes[i] = mix ? hashes[i] * 31 + hash : hash;
+    }
+}
+
 int32_t hashInt64(int64_t value) {
   return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
 }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -36,7 +36,7 @@ void abstractHashTyped(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes,
-    std::function<uint32_t(const T&)> f) {
+    std::function<uint32_t(const T&)> const& f) {
   for (auto i = 0; i < size; ++i) {
     const uint32_t hash = (values.isNullAt(i)) ? 0 : f(values.valueAt<T>(i));
     hashes[i] = mix ? hashes[i] * 31 + hash : hash;
@@ -123,7 +123,11 @@ void hashTyped<TypeKind::BIGINT>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
+<<<<<<< HEAD
     auto f = [](int64_t value) { return hashInt64(value); };
+=======
+  auto f = [](int64_t value) { return hashInt64(value); };
+>>>>>>> remove redundent
     abstractHashTyped<int64_t>(values, size, mix, hashes, f);
 }
 
@@ -147,7 +151,11 @@ void hashTypedStringView(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
+<<<<<<< HEAD
     auto f = [](const StringView & value) { return hashBytes(value, 0); };
+=======
+  auto f = [](const StringView & value) { return hashBytes(value, 0); };
+>>>>>>> remove redundent
     abstractHashTyped<StringView>(values, size, mix, hashes, f);
 }
 
@@ -179,7 +187,11 @@ void hashTyped<TypeKind::TIMESTAMP>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
+<<<<<<< HEAD
     auto f = [](const Timestamp & value) { return hashTimestamp(value); };
+=======
+  auto f = [](const Timestamp & value) { return hashTimestamp(value); };
+>>>>>>> remove redundent
     abstractHashTyped<Timestamp>(values, size, mix, hashes, f);
 }
 
@@ -189,7 +201,11 @@ void hashTyped<TypeKind::DATE>(
     vector_size_t size,
     bool mix,
     std::vector<uint32_t>& hashes) {
+<<<<<<< HEAD
     auto f = [](const Date & value) { return value.days(); };
+=======
+  auto f = [](const Date & value) { return value.days(); };
+>>>>>>> remove redundent
     abstractHashTyped<Date>(values, size, mix, hashes, f);
 }
 

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -154,8 +154,12 @@ TEST_F(HivePartitionFunctionTest, Timestamp) {
   std::vector<std::optional<Timestamp>> values = {
       std::nullopt,
       Timestamp(100'000, 900'000),
-      Timestamp(std::numeric_limits<int64_t>::min(), std::numeric_limits<uint64_t>::min()),
-      Timestamp(std::numeric_limits<int64_t>::max(), std::numeric_limits<uint64_t>::max()),
+      Timestamp(
+          std::numeric_limits<int64_t>::min(),
+          std::numeric_limits<uint64_t>::min()),
+      Timestamp(
+          std::numeric_limits<int64_t>::max(),
+          std::numeric_limits<uint64_t>::max()),
   };
   auto vector = vm_.flatVectorNullable(values);
 
@@ -168,9 +172,9 @@ TEST_F(HivePartitionFunctionTest, Timestamp) {
 TEST_F(HivePartitionFunctionTest, Date) {
   auto values = vm_.flatVectorNullable<Date>(
       {std::nullopt,
-    Date(2'000'000'000),
-      Date(std::numeric_limits<int32_t>::min()),
-      Date(std::numeric_limits<int32_t>::max())});
+       Date(2'000'000'000),
+       Date(std::numeric_limits<int32_t>::min()),
+       Date(std::numeric_limits<int32_t>::max())});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 1});

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -83,3 +83,17 @@ TEST_F(HivePartitionFunctionTest, bool) {
   assertPartitions(values, 500, {0, 1, 0, 0, 1});
   assertPartitions(values, 997, {0, 1, 0, 0, 1});
 }
+
+TEST_F(HivePartitionFunctionTest, int8_t) {
+  auto values =
+      vm_.flatVectorNullable<int8_t>(
+          {std::nullopt,
+           64,
+           std::numeric_limits<int8_t>::min(),
+           std::numeric_limits<int8_t>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 0, 1});
+  assertPartitions(values, 500, {0, 64, 20, 127});
+  assertPartitions(values, 997, {0, 64, 355, 127});
+}

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -127,20 +127,20 @@ TEST_F(HivePartitionFunctionTest, real) {
   auto values = vm_.flatVectorNullable<float>(
       {std::nullopt,
        2'000'000'000.0,
-       std::numeric_limits<float>::min(),
+       std::numeric_limits<float>::lowest(),
        std::numeric_limits<float>::max()});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
-  assertPartitions(values, 2, {0, 0, 0, 1});
-  assertPartitions(values, 500, {0, 348, 108, 39});
-  assertPartitions(values, 997, {0, 544, 847, 632});
+  assertPartitions(values, 2, {0, 0, 1, 1});
+  assertPartitions(values, 500, {0, 348, 39, 39});
+  assertPartitions(values, 997, {0, 544, 632, 632});
 }
 
 TEST_F(HivePartitionFunctionTest, double) {
   auto values = vm_.flatVectorNullable<double>(
       {std::nullopt,
        300'000'000'000.5,
-       std::numeric_limits<double>::min(),
+       std::numeric_limits<double>::lowest(),
        std::numeric_limits<double>::max()});
 
   assertPartitions(values, 1, {0, 0, 0, 0});

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -85,15 +85,95 @@ TEST_F(HivePartitionFunctionTest, bool) {
 }
 
 TEST_F(HivePartitionFunctionTest, int8_t) {
-  auto values =
-      vm_.flatVectorNullable<int8_t>(
-          {std::nullopt,
-           64,
-           std::numeric_limits<int8_t>::min(),
-           std::numeric_limits<int8_t>::max()});
+  auto values = vm_.flatVectorNullable<int8_t>(
+      {std::nullopt,
+       64,
+       std::numeric_limits<int8_t>::min(),
+       std::numeric_limits<int8_t>::max()});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 1});
   assertPartitions(values, 500, {0, 64, 20, 127});
   assertPartitions(values, 997, {0, 64, 355, 127});
+}
+
+TEST_F(HivePartitionFunctionTest, int16_t) {
+  auto values = vm_.flatVectorNullable<int16_t>(
+      {std::nullopt,
+       30'000,
+       std::numeric_limits<int16_t>::min(),
+       std::numeric_limits<int16_t>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 0, 1});
+  assertPartitions(values, 500, {0, 0, 380, 267});
+  assertPartitions(values, 997, {0, 90, 616, 863});
+}
+
+TEST_F(HivePartitionFunctionTest, int32_t) {
+  auto values = vm_.flatVectorNullable<int32_t>(
+      {std::nullopt,
+       2'000'000'000,
+       std::numeric_limits<int32_t>::min(),
+       std::numeric_limits<int32_t>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 0, 1});
+  assertPartitions(values, 500, {0, 0, 0, 147});
+  assertPartitions(values, 997, {0, 54, 0, 482});
+}
+
+TEST_F(HivePartitionFunctionTest, float) {
+  auto values = vm_.flatVectorNullable<float>(
+      {std::nullopt,
+       2'000'000'000.0,
+       std::numeric_limits<float>::min(),
+       std::numeric_limits<float>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 0, 1});
+  assertPartitions(values, 500, {0, 348, 108, 39});
+  assertPartitions(values, 997, {0, 544, 847, 632});
+}
+
+TEST_F(HivePartitionFunctionTest, double) {
+  auto values = vm_.flatVectorNullable<double>(
+      {std::nullopt,
+       300'000'000'000.5,
+       std::numeric_limits<double>::min(),
+       std::numeric_limits<double>::max()});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 1, 0, 0});
+  assertPartitions(values, 500, {0, 349, 76, 76});
+  assertPartitions(values, 997, {0, 63, 729, 729});
+}
+
+TEST_F(HivePartitionFunctionTest, Timestamp) {
+  // TODO Fix flatVectorNullable to set Timestamp.
+  std::vector<std::optional<Timestamp>> values = {
+      std::nullopt,
+      Timestamp(100'000, 900'000),
+      Timestamp(std::numeric_limits<int64_t>::min(), std::numeric_limits<uint64_t>::min()),
+      Timestamp(std::numeric_limits<int64_t>::max(), std::numeric_limits<uint64_t>::max()),
+  };
+  auto vector = vm_.flatVectorNullable(values);
+
+  assertPartitions(vector, 1, {0, 0, 0, 0});
+  assertPartitions(vector, 2, {0, 0, 0, 0});
+  assertPartitions(vector, 500, {0, 284, 0, 0});
+  assertPartitions(vector, 997, {0, 514, 0, 0});
+}
+
+TEST_F(HivePartitionFunctionTest, Date) {
+  auto values = vm_.flatVectorNullable<Date>(
+      {std::nullopt,
+    Date(2'000'000'000),
+      Date(std::numeric_limits<int32_t>::min()),
+      Date(std::numeric_limits<int32_t>::max())});
+
+  assertPartitions(values, 1, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 0, 1});
+  assertPartitions(values, 500, {0, 0, 0, 147});
+  assertPartitions(values, 997, {0, 54, 0, 482});
 }

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -49,7 +49,7 @@ class HivePartitionFunctionTest : public ::testing::Test {
   test::VectorMaker vm_{pool_.get()};
 };
 
-TEST_F(HivePartitionFunctionTest, int64) {
+TEST_F(HivePartitionFunctionTest, bigint) {
   auto values = vm_.flatVectorNullable<int64_t>(
       {std::nullopt,
        300'000'000'000,
@@ -62,7 +62,7 @@ TEST_F(HivePartitionFunctionTest, int64) {
   assertPartitions(values, 997, {0, 852, 0, 0});
 }
 
-TEST_F(HivePartitionFunctionTest, string) {
+TEST_F(HivePartitionFunctionTest, varchar) {
   // TODO Fix flatVectorNullable to set stringBuffers.
   std::vector<std::optional<std::string>> values = {
       std::nullopt, "", "test string", "\u5f3a\u5927\u7684Presto\u5f15\u64ce"};
@@ -74,7 +74,7 @@ TEST_F(HivePartitionFunctionTest, string) {
   assertPartitions(vector, 997, {0, 0, 894, 831});
 }
 
-TEST_F(HivePartitionFunctionTest, bool) {
+TEST_F(HivePartitionFunctionTest, boolean) {
   auto values =
       vm_.flatVectorNullable<bool>({std::nullopt, true, false, false, true});
 
@@ -84,7 +84,7 @@ TEST_F(HivePartitionFunctionTest, bool) {
   assertPartitions(values, 997, {0, 1, 0, 0, 1});
 }
 
-TEST_F(HivePartitionFunctionTest, int8_t) {
+TEST_F(HivePartitionFunctionTest, tinyint) {
   auto values = vm_.flatVectorNullable<int8_t>(
       {std::nullopt,
        64,
@@ -97,7 +97,7 @@ TEST_F(HivePartitionFunctionTest, int8_t) {
   assertPartitions(values, 997, {0, 64, 355, 127});
 }
 
-TEST_F(HivePartitionFunctionTest, int16_t) {
+TEST_F(HivePartitionFunctionTest, smallint) {
   auto values = vm_.flatVectorNullable<int16_t>(
       {std::nullopt,
        30'000,
@@ -110,7 +110,7 @@ TEST_F(HivePartitionFunctionTest, int16_t) {
   assertPartitions(values, 997, {0, 90, 616, 863});
 }
 
-TEST_F(HivePartitionFunctionTest, int32_t) {
+TEST_F(HivePartitionFunctionTest, integer) {
   auto values = vm_.flatVectorNullable<int32_t>(
       {std::nullopt,
        2'000'000'000,
@@ -123,7 +123,7 @@ TEST_F(HivePartitionFunctionTest, int32_t) {
   assertPartitions(values, 997, {0, 54, 0, 482});
 }
 
-TEST_F(HivePartitionFunctionTest, float) {
+TEST_F(HivePartitionFunctionTest, real) {
   auto values = vm_.flatVectorNullable<float>(
       {std::nullopt,
        2'000'000'000.0,
@@ -149,7 +149,7 @@ TEST_F(HivePartitionFunctionTest, double) {
   assertPartitions(values, 997, {0, 63, 729, 729});
 }
 
-TEST_F(HivePartitionFunctionTest, Timestamp) {
+TEST_F(HivePartitionFunctionTest, timestamp) {
   // TODO Fix flatVectorNullable to set Timestamp.
   std::vector<std::optional<Timestamp>> values = {
       std::nullopt,
@@ -169,7 +169,7 @@ TEST_F(HivePartitionFunctionTest, Timestamp) {
   assertPartitions(vector, 997, {0, 514, 0, 0});
 }
 
-TEST_F(HivePartitionFunctionTest, Date) {
+TEST_F(HivePartitionFunctionTest, date) {
   auto values = vm_.flatVectorNullable<Date>(
       {std::nullopt,
        Date(2'000'000'000),


### PR DESCRIPTION
Add support for more types in `HivePartitionFunction`:
- `TINYINT`
- `SMALLINT`
- `INTEGER`
- `REAL`
- `DOUBLE`
- `VARBINARY`
- `TIMESTAMP`
- `DATE`

Fixes #327