### PR TITLE
Use a non-nullptr special value  to indicate skip in pread

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -729,7 +729,7 @@ CoalesceIoStats readPins(
         VELOX_CHECK_EQ(offsetInRuns, size);
       },
       [&](int32_t size, std::vector<folly::Range<char*>>& ranges) {
-        ranges.push_back(folly::Range<char*>(nullptr, size));
+        ranges.push_back(folly::Range<char*>(ReadFile::skip(), size));
       },
       readFunc);
 }

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -47,7 +47,7 @@ uint64_t InMemoryReadFile::preadv(
   }
   for (auto& range : buffers) {
     auto copySize = std::min<size_t>(range.size(), file_.size() - offset);
-    if (range.data()) {
+    if (!shouldSkip(range.data())) {
       memcpy(range.data(), file_.data() + offset, copySize);
     }
     offset += copySize;
@@ -108,7 +108,7 @@ uint64_t LocalReadFile::preadv(
   std::vector<struct iovec> iovecs;
   iovecs.reserve(buffers.size());
   for (auto& range : buffers) {
-    if (!range.data()) {
+    if (shouldSkip(range.data())) {
       auto skipSize = range.size();
       while (skipSize) {
         auto bytes = std::min<size_t>(sizeof(droppedBytes), skipSize);

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -55,11 +55,19 @@ class ReadFile {
 
   // Reads starting at 'offset' into the memory referenced by the
   // Ranges in 'buffers'. The buffers are filled left to right. A
-  // buffer with nullptr data will cause its size worth of bytes to be skipped.
+  // buffer with skip() in data will cause its size worth of bytes to be
+  // skipped.
   virtual uint64_t preadv(
       uint64_t /*offset*/,
       const std::vector<folly::Range<char*>>& /*buffers*/) const {
     VELOX_NYI("preadv not supported");
+  }
+
+  // Returns a special char* that indicates that a range that begins
+  // with this should be skipped in preadv.
+  static char* FOLLY_NONNULL skip() {
+    static char skipMarker;
+    return &skipMarker;
   }
 
   // Like preadv but may execute asynchronously and returns the read
@@ -103,6 +111,12 @@ class ReadFile {
   }
 
  protected:
+  // True if the range starting at 'begin' should be skipped in preadv().
+  // Accepts nullptr and the special value skip().
+  static bool shouldSkip(char* FOLLY_NULLABLE begin) {
+    return !begin || begin == skip();
+  }
+
   mutable std::atomic<uint64_t> bytesRead_ = 0;
 };
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -116,7 +116,7 @@ class S3ReadFile final : public ReadFile {
     preadInternal(offset, length, static_cast<char*>(result.data()));
     size_t resultOffset = 0;
     for (auto range : buffers) {
-      if (range.data()) {
+      if (!shouldSkip(range.data())) {
         memcpy(range.data(), &(result.data()[resultOffset]), range.size());
       }
       resultOffset += range.size();


### PR DESCRIPTION
Undefined Behavior Sanitizer errors out when using a folly::Range with
a nullptr as start of data to indicate a skip in
ReadFile::preadv(). Therefore we indicate this with the special char*
value of ReadFile::skip() instead.