### PR TITLE
Add support for "double != const" and "float != const" filters.

### DIFF
--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -35,11 +35,17 @@ namespace facebook::velox::dwrf {
 
 template <typename T, typename Filter>
 __m256i testSimd(Filter& filter, __m256i values) {
-  if (std::is_same<T, double>::value || std::is_same<T, int64_t>::value) {
+  if (std::is_same<T, int64_t>::value) {
     return filter.test4x64(values);
   }
-  if (std::is_same<T, float>::value || std::is_same<T, int32_t>::value) {
+  if (std::is_same<T, double>::value) {
+    return filter.test4xDouble(values);
+  }
+  if (std::is_same<T, int32_t>::value) {
     return reinterpret_cast<__m256i>(filter.test8x32(values));
+  }
+  if (std::is_same<T, float>::value) {
+    return reinterpret_cast<__m256i>(filter.test8xFloat(values));
   }
   if (std::is_same<T, int16_t>::value) {
     return reinterpret_cast<__m256i>(filter.test16x16(values));

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -251,6 +251,14 @@ std::unique_ptr<common::Filter> makeEqualFilter(
   }
 }
 
+std::unique_ptr<common::Filter> makeNotEqualFilter(
+    const std::shared_ptr<const core::ITypedExpr>& valueExpr) {
+  std::vector<std::unique_ptr<common::Filter>> filters;
+  filters.emplace_back(makeLessThanFilter(valueExpr));
+  filters.emplace_back(makeGreaterThanFilter(valueExpr));
+  return std::make_unique<common::MultiRange>(std::move(filters), false, false);
+}
+
 std::unique_ptr<common::Filter> makeBetweenFilter(
     const std::shared_ptr<const core::ITypedExpr>& lowerExpr,
     const std::shared_ptr<const core::ITypedExpr>& upperExpr) {
@@ -294,6 +302,10 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
     } else if (call->name() == "eq") {
       if (auto field = asField(call, 0)) {
         return {Subfield(field->name()), makeEqualFilter(call->inputs()[1])};
+      }
+    } else if (call->name() == "neq") {
+      if (auto field = asField(call, 0)) {
+        return {Subfield(field->name()), makeNotEqualFilter(call->inputs()[1])};
       }
     } else if (call->name() == "lte") {
       if (auto field = asField(call, 0)) {

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -562,6 +562,20 @@ bool MultiRange::testBytesRange(
   return false;
 }
 
+bool MultiRange::testDoubleRange(double min, double max, bool hasNull) const {
+  if (hasNull && nullAllowed_) {
+    return true;
+  }
+
+  for (const auto& filter : filters_) {
+    if (filter->testDoubleRange(min, max, hasNull)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 std::unique_ptr<Filter> MultiRange::mergeWith(const Filter* other) const {
   switch (other->kind()) {
     // Rules of MultiRange with IsNull/IsNotNull

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -131,6 +131,16 @@ class Filter {
         testInt64(x[2]) ? -1LL : 0LL,
         testInt64(x[3]) ? -1LL : 0LL);
   }
+
+  __m256i test4xDouble(__m256i x) {
+    auto d = reinterpret_cast<__m256d>(x);
+    return _mm256_setr_epi64x(
+        testDouble(d[0]) ? -1LL : 0LL,
+        testDouble(d[1]) ? -1LL : 0LL,
+        testDouble(d[2]) ? -1LL : 0LL,
+        testDouble(d[3]) ? -1LL : 0LL);
+  }
+
   virtual __m256si test8x32(__m256i x) {
     auto as32 = reinterpret_cast<__m256si>(x);
     return (__m256si)_mm256_setr_epi32(
@@ -142,6 +152,19 @@ class Filter {
         testInt64(simd::Vectors<int32_t>::extract<5>(as32)) ? -1 : 0,
         testInt64(simd::Vectors<int32_t>::extract<6>(as32)) ? -1 : 0,
         testInt64(simd::Vectors<int32_t>::extract<7>(as32)) ? -1 : 0);
+  }
+
+  __m256si test8xFloat(__m256i x) {
+    auto f = reinterpret_cast<__m256>(x);
+    return (__m256si)_mm256_setr_epi32(
+        testFloat(f[0]) ? -1 : 0,
+        testFloat(f[1]) ? -1 : 0,
+        testFloat(f[2]) ? -1 : 0,
+        testFloat(f[3]) ? -1 : 0,
+        testFloat(f[4]) ? -1 : 0,
+        testFloat(f[5]) ? -1 : 0,
+        testFloat(f[6]) ? -1 : 0,
+        testFloat(f[7]) ? -1 : 0);
   }
 
   virtual __m256hi test16x16(__m256i x) {
@@ -1320,12 +1343,14 @@ class MultiRange final : public Filter {
 
   bool testBytes(const char* value, int32_t length) const final;
 
-  bool testLength(int32_t length) const override;
+  bool testLength(int32_t length) const final;
 
   bool testBytesRange(
       std::optional<std::string_view> min,
       std::optional<std::string_view> max,
-      bool hasNull) const override;
+      bool hasNull) const final;
+
+  bool testDoubleRange(double min, double max, bool hasNull) const final;
 
   const std::vector<std::unique_ptr<Filter>>& filters() const {
     return filters_;


### PR DESCRIPTION
Summary:
We have "Filter(MultiRange, deterministic, null not allowed): testDoubleRange() is not supported." error returned fo simple queries like
SELECT SUM(total_gmv_amount) FROM deltoid3.fb_order_buyer_deltoid_rid WHERE total_gmv_amount != 0;
and
SELECT SUM(discount) FROM lineitem WHERE discount != 0;
where column if od DOUBLE type.

Same for FLOAT (and even worse if you don't cast the const to REAL type (T118041563).

In Presto filter "(var != const)" is replaced by double ranged filter "in (-inf, const) and (const, +inf)".
So, here we implement the Filter classes members that were missing to support such filters.

Differential Revision: D35877426

