### PR TITLE
Improve usability of PlanBuilder::xxxAggregation

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
@@ -69,7 +69,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   void assertSelectWithAgg(
       std::vector<std::string>&& outputColumnNames,
       const std::vector<std::string>& aggregates,
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::string& sql) {
     auto plan = PlanBuilder()
                     .tableScan(getRowType(std::move(outputColumnNames)))
@@ -83,7 +83,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
       std::vector<std::string>&& outputColumnNames,
       common::test::SubfieldFilters filters,
       const std::vector<std::string>& aggregates,
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::string& sql) {
     auto rowType = getRowType(std::move(outputColumnNames));
 
@@ -178,9 +178,9 @@ TEST_F(ParquetTableScanTest, basic) {
   assertSelectWithAgg(
       {"a", "b"}, {"min(a)", "max(b)"}, {}, "SELECT min(a), max(b) FROM tmp");
   assertSelectWithAgg(
-      {"b", "a"}, {"max(b)"}, {0}, "SELECT max(b), a FROM tmp group by a");
+      {"b", "a"}, {"max(b)"}, {"a"}, "SELECT max(b), a FROM tmp GROUP BY a");
   assertSelectWithAgg(
-      {"a", "b"}, {"max(a)"}, {1}, "SELECT max(a), b FROM tmp group by b");
+      {"a", "b"}, {"max(a)"}, {"b"}, "SELECT max(a), b FROM tmp GROUP BY b");
 
   // With filter and aggregation
   assertSelectWithFilterAndAgg(
@@ -205,8 +205,8 @@ TEST_F(ParquetTableScanTest, basic) {
       {"b", "a"},
       common::test::singleSubfieldFilter("a", common::test::lessThan(3)),
       {"max(b)"},
-      {0},
-      "SELECT max(b), a FROM tmp WHERE a < 3 group by a");
+      {"a"},
+      "SELECT max(b), a FROM tmp WHERE a < 3 GROUP BY a");
 }
 
 TEST_F(ParquetTableScanTest, countStar) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -188,10 +188,8 @@ static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
 
 class AggregationTest : public OperatorTestBase {
  protected:
-  std::vector<RowVectorPtr> makeVectors(
-      const std::shared_ptr<const RowType>& rowType,
-      vector_size_t size,
-      int numVectors) {
+  std::vector<RowVectorPtr>
+  makeVectors(const RowTypePtr& rowType, vector_size_t size, int numVectors) {
     std::vector<RowVectorPtr> vectors;
     for (int32_t i = 0; i < numVectors; ++i) {
       auto vector = std::dynamic_pointer_cast<RowVector>(
@@ -220,7 +218,7 @@ class AggregationTest : public OperatorTestBase {
     auto op = PlanBuilder()
                   .values(vectors)
                   .aggregation(
-                      {rowType_->getChildIdx(keyName)},
+                      {keyName},
                       aggregates,
                       {},
                       core::AggregationNode::Step::kPartial,
@@ -269,7 +267,7 @@ class AggregationTest : public OperatorTestBase {
     auto op = PlanBuilder()
                   .values(vectors)
                   .aggregation(
-                      {0, 1, 6},
+                      {"c0", "c1", "c6"},
                       aggregates,
                       {},
                       core::AggregationNode::Step::kPartial,
@@ -342,7 +340,7 @@ class AggregationTest : public OperatorTestBase {
     }
   }
 
-  std::shared_ptr<const RowType> rowType_{
+  RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
           {BIGINT(),
            SMALLINT(),
@@ -469,7 +467,7 @@ TEST_F(AggregationTest, aggregateOfNulls) {
   auto op = PlanBuilder()
                 .values(vectors)
                 .aggregation(
-                    {0},
+                    {"c0"},
                     {"sum(c1)", "min(c1)", "max(c1)"},
                     {},
                     core::AggregationNode::Step::kPartial,
@@ -494,85 +492,85 @@ TEST_F(AggregationTest, aggregateOfNulls) {
 
 TEST_F(AggregationTest, hashmodes) {
   rng_.seed(1);
-  std::vector<std::string> keyNames = {"C0", "C1", "C2", "C3", "C4", "C5"};
-  std::vector<std::shared_ptr<const Type>> types = {
-      BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()};
-  rowType_ = std::make_shared<RowType>(std::move(keyNames), std::move(types));
+  auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()});
 
   std::vector<RowVectorPtr> batches;
 
   // 20K rows with all at low cardinality.
-  makeModeTestKeys(rowType_, 20000, 2, 2, 2, 4, 4, 4, batches);
+  makeModeTestKeys(rowType, 20000, 2, 2, 2, 4, 4, 4, batches);
   // 20K rows with all at slightly higher cardinality, still in array range.
-  makeModeTestKeys(rowType_, 20000, 2, 2, 2, 4, 16, 4, batches);
+  makeModeTestKeys(rowType, 20000, 2, 2, 2, 4, 16, 4, batches);
   // 100K rows with cardinality outside of array range. We transit to
   // generic hash table from normalized keys when running out of quota
   // for distinct string storage for the sixth key.
-  makeModeTestKeys(rowType_, 100000, 1000000, 2, 2, 4, 4, 1000000, batches);
+  makeModeTestKeys(rowType, 100000, 1000000, 2, 2, 4, 4, 1000000, batches);
   createDuckDbTable(batches);
-  auto op = PlanBuilder()
-                .values(batches)
-                .singleAggregation({0, 1, 2, 3, 4, 5}, {"sum(1)"})
-                .planNode();
+  auto op =
+      PlanBuilder()
+          .values(batches)
+          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(1)"})
+          .planNode();
 
   assertQuery(
       op,
       "SELECT c0, c1, C2, C3, C4, C5, sum(1) FROM tmp "
-      " GROUP BY c0, C1, C2, c3, C4, C5");
+      " GROUP BY c0, c1, c2, c3, c4, c5");
 }
 
 TEST_F(AggregationTest, rangeToDistinct) {
   rng_.seed(1);
-  std::vector<std::string> keyNames = {"C0", "C1", "C2", "C3", "C4", "C5"};
-  std::vector<std::shared_ptr<const Type>> types = {
-      BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()};
-  rowType_ = std::make_shared<RowType>(std::move(keyNames), std::move(types));
+  auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), SMALLINT(), TINYINT(), VARCHAR(), VARCHAR(), VARCHAR()});
 
   std::vector<RowVectorPtr> batches;
   // 20K rows with all at low cardinality. c0 is a range.
-  makeModeTestKeys(rowType_, 20000, 2000, 2, 2, 4, 4, 4, batches);
+  makeModeTestKeys(rowType, 20000, 2000, 2, 2, 4, 4, 4, batches);
   // 20 rows that make c0 represented as distincts.
-  makeModeTestKeys(rowType_, 20, 200000000, 2, 2, 4, 4, 4, batches);
+  makeModeTestKeys(rowType, 20, 200000000, 2, 2, 4, 4, 4, batches);
   // More keys in the low cardinality range. We see if these still hit
   // after the re-encoding of c0.
-  makeModeTestKeys(rowType_, 10000, 2000, 2, 2, 4, 4, 4, batches);
+  makeModeTestKeys(rowType, 10000, 2000, 2, 2, 4, 4, 4, batches);
 
   createDuckDbTable(batches);
-  auto op = PlanBuilder()
-                .values(batches)
-                .singleAggregation({0, 1, 2, 3, 4, 5}, {"sum(1)"})
-                .planNode();
+  auto op =
+      PlanBuilder()
+          .values(batches)
+          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(1)"})
+          .planNode();
 
   assertQuery(
       op,
-      "SELECT c0, c1, C2, C3, C4, C5, sum(1) FROM tmp "
-      " GROUP BY c0, C1, C2, c3, C4, C5");
+      "SELECT c0, c1, c2, c3, c4, c5, sum(1) FROM tmp "
+      " GROUP BY c0, c1, c2, c3, c4, c5");
 }
 
 TEST_F(AggregationTest, allKeyTypes) {
   // Covers different key types. Unlike the integer/string tests, the
   // hash table begins life in the generic mode, not array or
   // normalized key. Add types here as they become supported.
-  std::vector<std::string> keyNames = {"C0", "C1", "C2", "C3", "C4", "C5"};
-  std::vector<std::shared_ptr<const Type>> types = {
-      DOUBLE(), REAL(), BIGINT(), INTEGER(), BOOLEAN(), VARCHAR()};
-  rowType_ = std::make_shared<RowType>(std::move(keyNames), std::move(types));
+  auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {DOUBLE(), REAL(), BIGINT(), INTEGER(), BOOLEAN(), VARCHAR()});
 
   std::vector<RowVectorPtr> batches;
   for (auto i = 0; i < 10; ++i) {
     batches.push_back(std::static_pointer_cast<RowVector>(
-        BatchMaker::createBatch(rowType_, 100, *pool_)));
+        BatchMaker::createBatch(rowType, 100, *pool_)));
   }
   createDuckDbTable(batches);
-  auto op = PlanBuilder()
-                .values(batches)
-                .singleAggregation({0, 1, 2, 3, 4, 5}, {"sum(1)"})
-                .planNode();
+  auto op =
+      PlanBuilder()
+          .values(batches)
+          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(1)"})
+          .planNode();
 
   assertQuery(
       op,
-      "SELECT c0, c1, C2, C3, C4, C5, sum(1) FROM tmp "
-      " GROUP BY c0, C1, C2, c3, C4, C5");
+      "SELECT c0, c1, c2, c3, c4, c5, sum(1) FROM tmp "
+      " GROUP BY c0, c1, c2, c3, c4, c5");
 }
 
 TEST_F(AggregationTest, partialAggregationMemoryLimit) {
@@ -599,7 +597,7 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
   // Distinct aggregation.
   params.planNode = PlanBuilder()
                         .values(vectors)
-                        .partialAggregation({0}, {})
+                        .partialAggregation({"c0"}, {})
                         .finalAggregation()
                         .planNode();
 
@@ -608,7 +606,7 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
   // Count aggregation.
   params.planNode = PlanBuilder()
                         .values(vectors)
-                        .partialAggregation({0}, {"count(1)"})
+                        .partialAggregation({"c0"}, {"count(1)"})
                         .finalAggregation()
                         .planNode();
 

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -168,7 +168,7 @@ TEST_F(LocalPartitionTest, partition) {
     auto builder = PlanBuilder(planNodeIdGenerator);
     auto scanNode = builder.tableScan(rowType).planNode();
     scanNodeIds.push_back(scanNode->id());
-    return builder.partialAggregation({0}, {"count(1)"}).planNode();
+    return builder.partialAggregation({"c0"}, {"count(1)"}).planNode();
   };
 
   auto op = PlanBuilder(planNodeIdGenerator)
@@ -179,7 +179,7 @@ TEST_F(LocalPartitionTest, partition) {
                         scanAggNode(),
                         scanAggNode(),
                     })
-                .partialAggregation({0}, {"count(1)"})
+                .partialAggregation({"c0"}, {"count(1)"})
                 .planNode();
 
   createDuckDbTable(vectors);
@@ -279,7 +279,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
                         scanNode(),
                         scanNode(),
                     })
-                .partialAggregation({0}, {"count(1)"})
+                .partialAggregation({"c0"}, {"count(1)"})
                 .planNode();
 
   CursorParameters params;
@@ -518,9 +518,9 @@ TEST_F(LocalPartitionTest, multipleExchanges) {
                                  tableScanNode(),
                                  tableScanNode(),
                              })
-                         .partialAggregation({0, 1}, {"count(1)"})
+                         .partialAggregation({"c0", "c1"}, {"count(1)"})
                          .planNode()})
-                .partialAggregation({0}, {"count(1)", "sum(a0)"})
+                .partialAggregation({"c0"}, {"count(1)", "sum(a0)"})
                 .planNode();
 
   createDuckDbTable(vectors);

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -129,7 +129,7 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
     partialAggPlan = PlanBuilder()
                          .tableScan(rowType_)
                          .project({"c0 % 10 AS c0", "c1"})
-                         .partialAggregation({0}, {"sum(c1)"})
+                         .partialAggregation({"c0"}, {"sum(c1)"})
                          .partitionedOutput({"c0"}, 3)
                          .planNode();
 
@@ -144,7 +144,7 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan = PlanBuilder()
                        .exchange(partialAggPlan->outputType())
-                       .finalAggregation({0}, {"sum(a0)"}, {BIGINT()})
+                       .finalAggregation({"c0"}, {"sum(a0)"}, {BIGINT()})
                        .partitionedOutput({}, 1)
                        .planNode();
 
@@ -170,7 +170,7 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
     partialAggPlan = PlanBuilder()
                          .tableScan(rowType_)
                          .project({"c0 % 10 AS c0", "c1 % 2 AS c1", "c2"})
-                         .partialAggregation({0, 1}, {"sum(c2)"})
+                         .partialAggregation({"c0", "c1"}, {"sum(c2)"})
                          .partitionedOutput({"c0", "c1"}, 3)
                          .planNode();
 
@@ -185,7 +185,7 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan = PlanBuilder()
                        .exchange(partialAggPlan->outputType())
-                       .finalAggregation({0, 1}, {"sum(a0)"}, {BIGINT()})
+                       .finalAggregation({"c0", "c1"}, {"sum(a0)"}, {BIGINT()})
                        .partitionedOutput({}, 1)
                        .planNode();
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -163,7 +163,7 @@ TEST_F(PlanNodeToStringTest, aggregation) {
   // Group-by aggregation.
   plan = PlanBuilder()
              .values({data_})
-             .singleAggregation({0}, {"sum(c1) AS a", "avg(c2) AS b"})
+             .singleAggregation({"c0"}, {"sum(c1) AS a", "avg(c2) AS b"})
              .planNode();
 
   ASSERT_EQ("-> Aggregation\n", plan->toString());

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1541,7 +1541,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
       PlanBuilder()
           .tableScan(rowType_)
           .partialAggregation(
-              {5}, {"max(c0)", "sum(c1)", "sum(c2)", "sum(c3)", "sum(c4)"})
+              {"c5"}, {"max(c0)", "sum(c1)", "sum(c2)", "sum(c3)", "sum(c4)"})
           .planNode();
 
   auto task = assertQuery(
@@ -1554,7 +1554,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .singleAggregation(
-               {5}, {"max(c0)", "max(c1)", "max(c2)", "max(c3)", "max(c4)"})
+               {"c5"}, {"max(c0)", "max(c1)", "max(c2)", "max(c3)", "max(c4)"})
            .planNode();
 
   task = assertQuery(
@@ -1567,7 +1567,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .singleAggregation(
-               {5}, {"min(c0)", "min(c1)", "min(c2)", "min(c3)", "min(c4)"})
+               {"c5"}, {"min(c0)", "min(c1)", "min(c2)", "min(c3)", "min(c4)"})
            .planNode();
 
   task = assertQuery(
@@ -1582,7 +1582,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .project({"c0 % 5", "c1"})
-           .singleAggregation({0}, {"sum(c1)"})
+           .singleAggregation({"p0"}, {"sum(c1)"})
            .planNode();
 
   task =
@@ -1595,7 +1595,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   // aggregation.
   op = PlanBuilder()
            .tableScan(rowType_, {}, "length(c5) % 2 = 0")
-           .singleAggregation({5}, {"max(c0)"})
+           .singleAggregation({"c5"}, {"max(c0)"})
            .planNode();
   task = assertQuery(
       op,
@@ -1609,7 +1609,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   // LazyVector
   op = PlanBuilder()
            .tableScan(rowType_)
-           .singleAggregation({5}, {"min(c0)", "max(c0)"})
+           .singleAggregation({"c5"}, {"min(c0)", "max(c0)"})
            .planNode();
   task = assertQuery(
       op, {filePath}, "SELECT c5, min(c0), max(c0) FROM tmp GROUP BY 1");
@@ -1618,7 +1618,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .project({"c5", "c0", "c0 + c1 AS c0_plus_c1"})
-           .singleAggregation({0}, {"min(c0)", "max(c0_plus_c1)"})
+           .singleAggregation({"c5"}, {"min(c0)", "max(c0_plus_c1)"})
            .planNode();
   task = assertQuery(
       op, {filePath}, "SELECT c5, min(c0), max(c0 + c1) FROM tmp GROUP BY 1");
@@ -1627,7 +1627,7 @@ TEST_P(TableScanTest, aggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .project({"c5", "c0 + 1 as a", "c1 + 2 as b", "c2 + 3 as c"})
-           .singleAggregation({0}, {"min(a)", "max(b)", "sum(c)"})
+           .singleAggregation({"c5"}, {"min(a)", "max(b)", "sum(c)"})
            .planNode();
   task = assertQuery(
       op,
@@ -1645,7 +1645,7 @@ TEST_P(TableScanTest, bitwiseAggregationPushdown) {
   auto op = PlanBuilder()
                 .tableScan(rowType_)
                 .singleAggregation(
-                    {5},
+                    {"c5"},
                     {"bitwise_and_agg(c0)",
                      "bitwise_and_agg(c1)",
                      "bitwise_and_agg(c2)",
@@ -1660,7 +1660,7 @@ TEST_P(TableScanTest, bitwiseAggregationPushdown) {
   op = PlanBuilder()
            .tableScan(rowType_)
            .singleAggregation(
-               {5},
+               {"c5"},
                {"bitwise_or_agg(c0)",
                 "bitwise_or_agg(c1)",
                 "bitwise_or_agg(c2)",

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -754,8 +754,8 @@ PlanBuilder::createAggregateMasks(
 }
 
 PlanBuilder& PlanBuilder::aggregation(
-    const std::vector<ChannelIndex>& groupingKeys,
-    const std::vector<ChannelIndex>& preGroupedKeys,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& preGroupedKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
     core::AggregationNode::Step step,
@@ -778,7 +778,7 @@ PlanBuilder& PlanBuilder::aggregation(
 }
 
 PlanBuilder& PlanBuilder::streamingAggregation(
-    const std::vector<ChannelIndex>& groupingKeys,
+    const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
     core::AggregationNode::Step step,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -172,7 +172,7 @@ class PlanBuilder {
   /// will produce output columns k1, k2, min_a and a1, assuming the names of
   /// the first two input columns are k1 and k2.
   PlanBuilder& partialAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks = {}) {
     return aggregation(
@@ -194,7 +194,7 @@ class PlanBuilder {
   // to specify the result types for aggregates which cannot infer result type
   // solely from the types of the intermediate results.
   PlanBuilder& finalAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<TypePtr>& resultTypes) {
     return aggregation(
@@ -213,7 +213,7 @@ class PlanBuilder {
   PlanBuilder& intermediateAggregation();
 
   PlanBuilder& intermediateAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<TypePtr>& resultTypes) {
     return aggregation(
@@ -227,7 +227,7 @@ class PlanBuilder {
   }
 
   PlanBuilder& singleAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates) {
     return aggregation(
         groupingKeys,
@@ -239,7 +239,7 @@ class PlanBuilder {
   }
 
   PlanBuilder& aggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
@@ -250,8 +250,8 @@ class PlanBuilder {
   }
 
   PlanBuilder& aggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
-      const std::vector<ChannelIndex>& preGroupedKeys,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& preGroupedKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
@@ -259,7 +259,7 @@ class PlanBuilder {
       const std::vector<TypePtr>& resultTypes = {});
 
   PlanBuilder& partialStreamingAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks = {}) {
     return streamingAggregation(
@@ -271,7 +271,7 @@ class PlanBuilder {
   }
 
   PlanBuilder& finalStreamingAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<TypePtr>& resultTypes = {}) {
     return streamingAggregation(
@@ -284,7 +284,7 @@ class PlanBuilder {
   }
 
   PlanBuilder& streamingAggregation(
-      const std::vector<ChannelIndex>& groupingKeys,
+      const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,

--- a/velox/functions/prestosql/aggregates/benchmarks/PushdownBenchmark.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/PushdownBenchmark.cpp
@@ -38,8 +38,7 @@ namespace {
 
 class PushdownBenchmark : public HiveConnectorTestBase {
  public:
-  explicit PushdownBenchmark(const std::shared_ptr<const RowType>& rowType)
-      : rowType_(rowType) {
+  explicit PushdownBenchmark(const RowTypePtr& rowType) : rowType_(rowType) {
     HiveConnectorTestBase::SetUp();
     vectors_ = HiveConnectorTestBase::makeVectors(
         rowType_, kNumVectors, kRowsPerVector);
@@ -96,7 +95,7 @@ class PushdownBenchmark : public HiveConnectorTestBase {
 
  private:
   std::vector<RowVectorPtr> vectors_;
-  std::shared_ptr<const RowType> rowType_;
+  RowTypePtr rowType_;
   std::shared_ptr<TempFilePath> filePath_;
 };
 

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -20,7 +20,7 @@
 namespace facebook::velox::aggregate::test {
 
 std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
-    const std::shared_ptr<const RowType>& rowType,
+    const RowTypePtr& rowType,
     vector_size_t size,
     int numVectors) {
   std::vector<RowVectorPtr> vectors;

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
@@ -21,10 +21,8 @@ namespace facebook::velox::aggregate::test {
 
 class AggregationTestBase : public exec::test::OperatorTestBase {
  protected:
-  std::vector<RowVectorPtr> makeVectors(
-      const std::shared_ptr<const RowType>& rowType,
-      vector_size_t size,
-      int numVectors);
+  std::vector<RowVectorPtr>
+  makeVectors(const RowTypePtr& rowType, vector_size_t size, int numVectors);
 };
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -117,27 +117,27 @@ class ApproxDistinctTest : public AggregationTestBase {
 
     auto op = PlanBuilder()
                   .values({makeRowVector({keys, values})})
-                  .singleAggregation({0}, {"approx_distinct(c1)"})
+                  .singleAggregation({"c0"}, {"approx_distinct(c1)"})
                   .planNode();
     assertQuery(op, expected);
 
     op = PlanBuilder()
              .values({makeRowVector({keys, values})})
-             .partialAggregation({0}, {"approx_distinct(c1)"})
+             .partialAggregation({"c0"}, {"approx_distinct(c1)"})
              .finalAggregation()
              .planNode();
     assertQuery(op, expected);
 
     op = PlanBuilder()
              .values({makeRowVector({keys, values})})
-             .singleAggregation({0}, {"approx_set(c1)"})
+             .singleAggregation({"c0"}, {"approx_set(c1)"})
              .project({"c0", "cardinality(a0)"})
              .planNode();
     assertQuery(op, expected);
 
     op = PlanBuilder()
              .values({makeRowVector({keys, values})})
-             .partialAggregation({0}, {"approx_set(c1)"})
+             .partialAggregation({"c0"}, {"approx_set(c1)"})
              .finalAggregation()
              .project({"c0", "cardinality(a0)"})
              .planNode();
@@ -214,13 +214,13 @@ TEST_F(ApproxDistinctTest, groupByAllNulls) {
   auto expected = toRowVector(expectedResult);
   auto op = PlanBuilder()
                 .values({makeRowVector({keys, values})})
-                .singleAggregation({0}, {"approx_distinct(c1)"})
+                .singleAggregation({"c0"}, {"approx_distinct(c1)"})
                 .planNode();
   assertQuery(op, expected);
 
   op = PlanBuilder()
            .values({makeRowVector({keys, values})})
-           .partialAggregation({0}, {"approx_distinct(c1)"})
+           .partialAggregation({"c0"}, {"approx_distinct(c1)"})
            .finalAggregation()
            .planNode();
   assertQuery(op, expected);

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -109,12 +109,14 @@ class ApproxPercentileTest : public AggregationTestBase {
     auto call = functionCall(true, weights.get(), percentile, accuracy);
     auto rows = weights ? makeRowVector({keys, values, weights})
                         : makeRowVector({keys, values});
-    auto op =
-        PlanBuilder().values({rows}).singleAggregation({0}, {call}).planNode();
+    auto op = PlanBuilder()
+                  .values({rows})
+                  .singleAggregation({"c0"}, {call})
+                  .planNode();
     assertQuery(op, expectedResult);
     op = PlanBuilder()
              .values({rows})
-             .partialAggregation({0}, {call})
+             .partialAggregation({"c0"}, {call})
              .finalAggregation()
              .planNode();
     assertQuery(op, expectedResult);

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -37,7 +37,7 @@ TEST_F(ArrayAggTest, groupBy) {
   // 90], repeated 10 times.
   batches.push_back(
       std::static_pointer_cast<RowVector>(velox::test::BatchMaker::createBatch(
-          ROW({"C0", "a"}, {INTEGER(), ARRAY(VARCHAR())}), 100, *pool_)));
+          ROW({"c0", "a"}, {INTEGER(), ARRAY(VARCHAR())}), 100, *pool_)));
   // We divide the rows into 10 groups.
   auto keys = batches[0]->childAt(0)->as<FlatVector<int32_t>>();
   for (auto i = 0; i < keys->size(); ++i) {
@@ -54,7 +54,7 @@ TEST_F(ArrayAggTest, groupBy) {
   CursorParameters params;
   params.planNode = PlanBuilder()
                         .values(batches)
-                        .partialAggregation({0}, {"array_agg(A)"})
+                        .partialAggregation({"c0"}, {"array_agg(A)"})
                         .finalAggregation()
                         .planNode();
 
@@ -84,10 +84,10 @@ TEST_F(ArrayAggTest, groupBy) {
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .localPartition(
-                            {"C0"},
+                            {"c0"},
                             {PlanBuilder(planNodeIdGenerator)
                                  .values(batches)
-                                 .partialAggregation({0}, {"array_agg(A)"})
+                                 .partialAggregation({"c0"}, {"array_agg(A)"})
                                  .planNode()})
                         .intermediateAggregation()
                         .planNode();

--- a/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
@@ -24,7 +24,7 @@ namespace {
 
 class BitwiseAggregationTest : public AggregationTestBase {
  protected:
-  std::shared_ptr<const RowType> rowType_{
+  RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4"},
           {BIGINT(), TINYINT(), SMALLINT(), INTEGER(), BIGINT()})};
 };
@@ -71,7 +71,7 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
                    .values(vectors)
                    .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                    .partialAggregation(
-                       {0},
+                       {"p0"},
                        {"bitwise_or_agg(c1)",
                         "bitwise_or_agg(c2)",
                         "bitwise_or_agg(c3)",
@@ -88,7 +88,7 @@ TEST_F(BitwiseAggregationTest, bitwiseOr) {
                         .values(vectors)
                         .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                         .partialAggregation(
-                            {0},
+                            {"p0"},
                             {"bitwise_or_agg(c1)",
                              "bitwise_or_agg(c2)",
                              "bitwise_or_agg(c3)",
@@ -144,7 +144,7 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
                    .values(vectors)
                    .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                    .partialAggregation(
-                       {0},
+                       {"p0"},
                        {"bitwise_and_agg(c1)",
                         "bitwise_and_agg(c2)",
                         "bitwise_and_agg(c3)",
@@ -161,7 +161,7 @@ TEST_F(BitwiseAggregationTest, bitwiseAnd) {
                         .values(vectors)
                         .project({"c0 % 10", "c1", "c2", "c3", "c4"})
                         .partialAggregation(
-                            {0},
+                            {"p0"},
                             {"bitwise_and_agg(c1)",
                              "bitwise_and_agg(c2)",
                              "bitwise_and_agg(c3)",

--- a/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
@@ -64,7 +64,7 @@ TEST_P(BoolAndOrTest, basic) {
   agg = PlanBuilder()
             .values(vectors)
             .project({"c0 % 10", "c1"})
-            .partialAggregation({0}, {partialAgg})
+            .partialAggregation({"p0"}, {partialAgg})
             .planNode();
   assertQuery(
       agg,
@@ -75,7 +75,7 @@ TEST_P(BoolAndOrTest, basic) {
   agg = PlanBuilder()
             .values(vectors)
             .project({"c0 % 10", "c1"})
-            .partialAggregation({0}, {partialAgg})
+            .partialAggregation({"p0"}, {partialAgg})
             .finalAggregation()
             .planNode();
   assertQuery(
@@ -88,7 +88,7 @@ TEST_P(BoolAndOrTest, basic) {
             .values(vectors)
             .filter("c0 % 2 = 0")
             .project({"c0 % 11", "c1"})
-            .partialAggregation({0}, {partialAgg})
+            .partialAggregation({"p0"}, {partialAgg})
             .planNode();
 
   assertQuery(

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -113,7 +113,7 @@ class ChecksumAggregateTest : public AggregationTestBase {
 
     auto agg = PlanBuilder()
                    .values(rowVectors)
-                   .partialAggregation({0}, {"checksum(c1)"})
+                   .partialAggregation({"c0"}, {"checksum(c1)"})
                    .finalAggregation()
                    .project({"to_base64(a0) AS c0"})
                    .planNode();
@@ -135,7 +135,7 @@ class ChecksumAggregateTest : public AggregationTestBase {
                               {"c0"},
                               {PlanBuilder(planNodeIdGenerator)
                                    .values(rowVectors)
-                                   .partialAggregation({0}, {"checksum(c1)"})
+                                   .partialAggregation({"c0"}, {"checksum(c1)"})
                                    .planNode()})
                           .intermediateAggregation()
                           .project({"a0"})

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -24,7 +24,7 @@ namespace {
 
 class CountAggregation : public AggregationTestBase {
  protected:
-  std::shared_ptr<const RowType> rowType_{
+  RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7"},
           {BIGINT(),
            SMALLINT(),
@@ -73,8 +73,8 @@ TEST_F(CountAggregation, count) {
 
   agg = PlanBuilder()
             .values(vectors)
-            .project({"c0 % 10", "c1"})
-            .partialAggregation({0}, {"count(1)"})
+            .project({"c0 % 10 AS c0_mod_10", "c1"})
+            .partialAggregation({"c0_mod_10"}, {"count(1)"})
             .finalAggregation()
             .planNode();
   assertQuery(agg, "SELECT c0 % 10, count(1) FROM tmp GROUP BY 1");
@@ -82,7 +82,7 @@ TEST_F(CountAggregation, count) {
   agg = PlanBuilder()
             .values(vectors)
             .project({"c0 % 10 AS c0_mod_10", "c7"})
-            .partialAggregation({0}, {"count(c7)"})
+            .partialAggregation({"c0_mod_10"}, {"count(c7)"})
             .planNode();
   assertQuery(agg, "SELECT c0 % 10, count(c7) FROM tmp GROUP BY 1");
 
@@ -96,7 +96,7 @@ TEST_F(CountAggregation, count) {
                             {PlanBuilder(planNodeIdGenerator)
                                  .values(vectors)
                                  .project({"c0 % 10", "c1"})
-                                 .partialAggregation({0}, {"count(1)"})
+                                 .partialAggregation({"p0"}, {"count(1)"})
                                  .planNode()})
                         .intermediateAggregation()
                         .planNode();

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -32,7 +32,7 @@ class CovarianceAggregationTest
 
     auto op = PlanBuilder()
                   .values({data})
-                  .partialAggregation({0}, {partialAgg})
+                  .partialAggregation({"c0"}, {partialAgg})
                   .finalAggregation()
                   .project({"c0", "round(a0, cast(2 as integer))"})
                   .planNode();
@@ -41,7 +41,7 @@ class CovarianceAggregationTest
 
     op = PlanBuilder()
              .values({data})
-             .singleAggregation({0}, {partialAgg})
+             .singleAggregation({"c0"}, {partialAgg})
              .project({"c0", "round(a0, cast(2 as integer))"})
              .planNode();
 
@@ -49,17 +49,17 @@ class CovarianceAggregationTest
 
     op = PlanBuilder()
              .values({data})
-             .partialAggregation({0}, {partialAgg})
+             .partialAggregation({"c0"}, {partialAgg})
              .planNode();
 
     auto partialResults = getResults(op);
 
-    op =
-        PlanBuilder()
-            .values({partialResults})
-            .finalAggregation({0}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
-            .project({"c0", "round(a0, cast(2 as integer))"})
-            .planNode();
+    op = PlanBuilder()
+             .values({partialResults})
+             .finalAggregation(
+                 {"c0"}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
+             .project({"c0", "round(a0, cast(2 as integer))"})
+             .planNode();
     assertQuery(op, sql);
   }
 

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -36,7 +36,7 @@ TEST_F(MapAggTest, finalGroupBy) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .partialAggregation({0}, {"map_agg(c1, c2)"})
+                .partialAggregation({"c0"}, {"map_agg(c1, c2)"})
                 .finalAggregation()
                 .planNode();
 
@@ -66,7 +66,7 @@ TEST_F(MapAggTest, groupBy) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .singleAggregation({0}, {"map_agg(c1, c2)"})
+                .singleAggregation({"c0"}, {"map_agg(c1, c2)"})
                 .planNode();
 
   auto expectedResult = {makeRowVector(
@@ -85,15 +85,16 @@ TEST_F(MapAggTest, groupBy) {
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
 
   CursorParameters params;
-  params.planNode = PlanBuilder(planNodeIdGenerator)
-                        .localPartition(
-                            {"c0"},
-                            {PlanBuilder(planNodeIdGenerator)
-                                 .values(vectors)
-                                 .partialAggregation({0}, {"map_agg(c1, c2)"})
-                                 .planNode()})
-                        .intermediateAggregation()
-                        .planNode();
+  params.planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .localPartition(
+              {"c0"},
+              {PlanBuilder(planNodeIdGenerator)
+                   .values(vectors)
+                   .partialAggregation({"c0"}, {"map_agg(c1, c2)"})
+                   .planNode()})
+          .intermediateAggregation()
+          .planNode();
   params.maxDrivers = 2;
 
   exec::test::assertQuery(params, expectedResult);

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -52,7 +52,7 @@ class MinMaxByAggregationTest : public AggregationTestBase {
     }
   }
 
-  std::shared_ptr<const RowType> rowType_{
+  RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
           {TINYINT(),
            SMALLINT(),
@@ -67,8 +67,8 @@ TEST_F(MinMaxByAggregationTest, maxByPartialConst) {
   // Const values.
   auto vectors = {
       makeRowVector({
-          BaseVector::createConstant(5, 10, pool_.get()),
-          BaseVector::createConstant(10, 10, pool_.get()),
+          makeConstant(5, 10),
+          makeConstant(10, 10),
       }),
   };
 
@@ -83,8 +83,8 @@ TEST_F(MinMaxByAggregationTest, maxByPartialConst) {
 TEST_F(MinMaxByAggregationTest, maxByPartialConstNull) {
   auto vectors = {
       makeRowVector({
-          BaseVector::createConstant(5, 10, pool_.get()),
-          BaseVector::createNullConstant(BIGINT(), 10, pool_.get()),
+          makeConstant(5, 10),
+          makeNullConstant(TypeKind::BIGINT, 10),
       }),
   };
 
@@ -137,7 +137,7 @@ TEST_F(MinMaxByAggregationTest, maxByPartialGroupByNullCase) {
 
   auto partialAgg = PlanBuilder()
                         .values(vectors)
-                        .partialAggregation({2}, {"max_by(c0, c1)"})
+                        .partialAggregation({"c2"}, {"max_by(c0, c1)"})
                         .planNode();
   assertQuery(
       partialAgg,
@@ -172,7 +172,7 @@ TEST_F(MinMaxByAggregationTest, maxByFinalGroupByNullCase) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .partialAggregation({2}, {"max_by(c0, c1)"})
+                .partialAggregation({"c2"}, {"max_by(c0, c1)"})
                 .finalAggregation()
                 .planNode();
   assertQuery(op, "SELECT * FROM( VALUES (1, NULL), (2, 5), (3, NULL)) AS t");
@@ -198,7 +198,7 @@ TEST_F(MinMaxByAggregationTest, maxByGroupBy) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .partialAggregation({2}, {"max_by(c0, c1)"})
+                .partialAggregation({"c2"}, {"max_by(c0, c1)"})
                 .finalAggregation()
                 .planNode();
   assertQuery(
@@ -248,7 +248,7 @@ TEST_F(MinMaxByAggregationTest, minByFinalGroupByNullCase) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .partialAggregation({2}, {"min_by(c0, c1)"})
+                .partialAggregation({"c2"}, {"min_by(c0, c1)"})
                 .finalAggregation()
                 .planNode();
   assertQuery(op, "SELECT * FROM( VALUES (1, 5), (2, NULL), (3, 5)) AS t");
@@ -274,7 +274,7 @@ TEST_F(MinMaxByAggregationTest, minByGroupBy) {
 
   auto op = PlanBuilder()
                 .values(vectors)
-                .partialAggregation({2}, {"min_by(c0, c1)"})
+                .partialAggregation({"c2"}, {"min_by(c0, c1)"})
                 .finalAggregation()
                 .planNode();
   assertQuery(

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -49,7 +49,7 @@ TEST_F(SumTest, sumTinyint) {
   agg = PlanBuilder()
             .values(vectors)
             .project({"c0 % 10", "c1"})
-            .partialAggregation({0}, {"sum(c1)"})
+            .partialAggregation({"p0"}, {"sum(c1)"})
             .planNode();
   assertQuery(agg, "SELECT c0 % 10, sum(c1) FROM tmp GROUP BY 1");
 
@@ -57,7 +57,7 @@ TEST_F(SumTest, sumTinyint) {
   agg = PlanBuilder()
             .values(vectors)
             .project({"c0 % 10", "c1"})
-            .partialAggregation({0}, {"sum(c1)"})
+            .partialAggregation({"p0"}, {"sum(c1)"})
             .finalAggregation()
             .planNode();
   assertQuery(agg, "SELECT c0 % 10, sum(c1) FROM tmp GROUP BY 1");
@@ -67,7 +67,7 @@ TEST_F(SumTest, sumTinyint) {
             .values(vectors)
             .filter("c0 % 2 = 0")
             .project({"c0 % 11", "c1"})
-            .partialAggregation({0}, {"sum(c1)"})
+            .partialAggregation({"p0"}, {"sum(c1)"})
             .planNode();
   assertQuery(
       agg, "SELECT c0 % 11, sum(c1) FROM tmp WHERE c0 % 2 = 0 GROUP BY 1");
@@ -142,7 +142,7 @@ TEST_F(SumTest, sumWithMask) {
            .values(vectors)
            .project({"c4", "c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
-               {0}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
+               {"c4"}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()
            .planNode();
   assertQuery(
@@ -158,7 +158,7 @@ TEST_F(SumTest, sumWithMask) {
            .filter("c3 % 2 = 0")
            .project({"c4", "c0", "c1", "c2 % 2 = 0 AS m0", "c3 % 3 = 0 AS m1"})
            .partialAggregation(
-               {0}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
+               {"c4"}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
            .finalAggregation()
            .planNode();
   assertQuery(
@@ -179,7 +179,7 @@ TEST_F(SumTest, boolKey) {
 
   auto agg = PlanBuilder()
                  .values({vector})
-                 .partialAggregation({0}, {"sum(c1)"})
+                 .partialAggregation({"c0"}, {"sum(c1)"})
                  .planNode();
   assertQuery(agg, "SELECT c0, sum(c1) FROM tmp GROUP BY 1");
 }
@@ -192,7 +192,7 @@ TEST_F(SumTest, emptyValues) {
 
   auto agg = PlanBuilder()
                  .values({vector})
-                 .partialAggregation({0}, {"sum(c1)"})
+                 .partialAggregation({"c0"}, {"sum(c1)"})
                  .planNode();
   assertQuery(agg, "SELECT 1 LIMIT 0");
 }

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -66,7 +66,7 @@ class FunctionBaseTest : public testing::Test,
 
   std::shared_ptr<const core::ITypedExpr> makeTypedExpr(
       const std::string& text,
-      const std::shared_ptr<const RowType>& rowType) {
+      const RowTypePtr& rowType) {
     auto untyped = parse::parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_.pool());
   }
@@ -223,7 +223,7 @@ class FunctionBaseTest : public testing::Test,
   /// @param body Body of the lambda as SQL expression.
   void registerLambda(
       const std::string& name,
-      const std::shared_ptr<const RowType>& signature,
+      const RowTypePtr& signature,
       TypePtr rowType,
       const std::string& body) {
     core::Expressions::registerLambda(


### PR DESCRIPTION
Update PlanBuilder.{partial, final, intermediate, single}Aggregation methods to
take grouping keys by name instead of by index.