### PR TITLE
Fix lazy load of children of lazy struct

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnLoader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnLoader.cpp
@@ -67,6 +67,12 @@ void ColumnLoader::loadInternal(
   structReader_->advanceFieldReader(fieldReader_, offset);
   fieldReader_->scanSpec()->setValueHook(hook);
   fieldReader_->read(offset, effectiveRows, incomingNulls);
+  if (fieldReader_->type()->kind() == TypeKind::ROW) {
+    // 'fieldReader_' may itself produce LazyVectors. For this it must have its
+    // result row numbers set.
+    reinterpret_cast<SelectiveStructColumnReader*>(fieldReader_)
+        ->setLoadableRows(effectiveRows);
+  }
   if (!hook) {
     fieldReader_->getValues(effectiveRows, result);
     if (rows.size() != outputRows.size()) {

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -95,10 +95,15 @@ uint64_t SelectiveStructColumnReader::skip(uint64_t numValues) {
   // null. But because struct nulls are injected as nulls in child
   // readers, it is practical to keep the row numbers in terms of the
   // enclosing struct.
+  //
+  // Setting the 'readOffset_' in children is recursive so that nested
+  // nullable structs, where inner structs may advance less because of
+  // nulls above them still end up on the same row in terms of top
+  // level rows.
   for (auto& child : children_) {
     if (child) {
       child->skip(numNonNulls);
-      child->setReadOffset(child->readOffset() + numValues);
+      child->setReadOffsetRecursive(child->readOffset() + numValues);
     }
   }
   return numValues;

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -29,6 +29,10 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
       common::ScanSpec* scanSpec,
       FlatMapContext flatMapContext);
 
+  ~SelectiveStructColumnReader() {
+    numReads_ = 0xf7eedf7eed;
+  }
+
   void resetFilterCaches() override {
     for (auto& child : children_) {
       child->resetFilterCaches();
@@ -112,6 +116,16 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
         child->setIsTopLevel();
       }
     }
+  }
+
+  // Sets 'rows' as the set of rows for which 'this' or its children
+  // may be loaded as LazyVectors. When a struct is loaded as lazy,
+  // its children will be lazy if the struct does not add nulls. The
+  // children will reference the struct reader, whih must have a live
+  // and up-to-date set of rows for which children can be loaded.
+  void setLoadableRows(RowSet rows) {
+    setOutputRows(rows);
+    inputRows_ = outputRows_;
   }
 
  private:

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -221,3 +221,16 @@ TEST_F(E2EFilterTest, nullCompactRanges) {
       false,
       false);
 }
+
+TEST_F(E2EFilterTest, lazyStruct) {
+  testWithTypes(
+      "long_val:bigint,"
+      "outer_struct: struct<nested1:bigint, "
+      "inner_struct: struct<nested2: bigint>>",
+      [&]() {},
+      true,
+      {"long_val"},
+      10,
+      true,
+      false);
+}

--- a/velox/dwio/dwrf/test/E2EFilterTestBase.h
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.h
@@ -170,6 +170,8 @@ class E2EFilterTestBase : public testing::Test {
   // found in sampling is not changed.
   void makeNotNull(int32_t firstRow = 0);
 
+  void makeNotNullRecursive(int32_t firstRow, RowVectorPtr batch);
+
   virtual void writeToMemory(
       const TypePtr& type,
       const std::vector<RowVectorPtr>& batches,


### PR DESCRIPTION
A top level struct will make a lazy vector. A struct inside this will
nmake a lazy vector if the top level struct did not have any nulls.

When a lazy struct is loaded its children will be lazy if they are
aligned with top level rows, e.g. intervening structs do not add
nulls. When loading these children, the immediately containing struct
must have its 'outputRows_' set. These must be the row set for which
the lazy struct was loaded. Added
SelectiveStructColumnReader::loadableRows.

In E2EFiltertest, we add a test with multiple levels of nested structs and change the makeNotNull method to be recursive, ensure no nulls throughout a tree of structs. We then make the lazy branch of the test to make vectors recursively lazy. lazy structs will result in lazy struct members as long as the structs do not add nulls, i.e. all row numbers are aligned with top level rows.

In SelectiveStructColumnReader::seekTo, after advancing field readers,
set the current row recursively and not just for the immediate child.
Deeper nested column readers may advance less in their data stream due
to parents being null. Notwithstanding this, they must be set after
advance to the same top level row number as the top struct
reader. Failure to do this will advance them extra if the next batch
starts at anything except its row 0.