### PR TITLE
Enable more comprehensive testing for aggregate functions

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -17,6 +17,9 @@
 #include "AggregationTestBase.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 
+using facebook::velox::exec::test::CursorParameters;
+using facebook::velox::exec::test::PlanBuilder;
+
 namespace facebook::velox::aggregate::test {
 
 std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
@@ -30,6 +33,137 @@ std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
     vectors.push_back(vector);
   }
   return vectors;
+}
+
+void AggregationTestBase::testAggregations(
+    const std::vector<RowVectorPtr>& data,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::string& duckDbSql) {
+  testAggregations(data, groupingKeys, aggregates, {}, duckDbSql);
+}
+
+void AggregationTestBase::testAggregations(
+    const std::vector<RowVectorPtr>& data,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& postAggregationProjections,
+    const std::string& duckDbSql) {
+  testAggregations(
+      [&](PlanBuilder& builder) { builder.values(data); },
+      groupingKeys,
+      aggregates,
+      postAggregationProjections,
+      duckDbSql);
+}
+
+void AggregationTestBase::testAggregations(
+    std::function<void(PlanBuilder&)> makeSource,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::string& duckDbSql) {
+  testAggregations(makeSource, groupingKeys, aggregates, {}, duckDbSql);
+}
+
+void AggregationTestBase::testAggregations(
+    std::function<void(PlanBuilder&)> makeSource,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& postAggregationProjections,
+    const std::string& duckDbSql) {
+  // Run partial + final.
+  {
+    PlanBuilder builder;
+    makeSource(builder);
+    builder.partialAggregation(groupingKeys, aggregates).finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+    assertQuery(builder.planNode(), duckDbSql);
+  }
+
+  // Run single.
+  {
+    PlanBuilder builder;
+    makeSource(builder);
+    builder.singleAggregation(groupingKeys, aggregates);
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+    assertQuery(builder.planNode(), duckDbSql);
+  }
+
+  // Run partial + intermediate + final.
+  {
+    PlanBuilder builder;
+    makeSource(builder);
+    builder.partialAggregation(groupingKeys, aggregates)
+        .intermediateAggregation()
+        .finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+    assertQuery(builder.planNode(), duckDbSql);
+  }
+
+  // Run partial + local exchange + final.
+  if (!groupingKeys.empty()) {
+    auto planNodeIdGenerator =
+        std::make_shared<exec::test::PlanNodeIdGenerator>();
+    PlanBuilder sourceBuilder{planNodeIdGenerator};
+    makeSource(sourceBuilder);
+
+    auto builder =
+        PlanBuilder(planNodeIdGenerator)
+            .localPartition(
+                groupingKeys,
+                {sourceBuilder.partialAggregation(groupingKeys, aggregates)
+                     .planNode()})
+            .finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    CursorParameters params;
+    params.planNode = builder.planNode();
+    params.maxDrivers = 2;
+    assertQuery(params, duckDbSql);
+  }
+
+  // Run partial + local exchange + intermediate + local exchange + final.
+  {
+    auto planNodeIdGenerator =
+        std::make_shared<exec::test::PlanNodeIdGenerator>();
+    PlanBuilder sourceBuilder{planNodeIdGenerator};
+    makeSource(sourceBuilder);
+
+    PlanBuilder partialBuilder{planNodeIdGenerator};
+    if (groupingKeys.empty()) {
+      partialBuilder.localPartitionRoundRobin(
+          {sourceBuilder.partialAggregation(groupingKeys, aggregates)
+               .planNode()});
+    } else {
+      partialBuilder.localPartition(
+          groupingKeys,
+          {sourceBuilder.partialAggregation(groupingKeys, aggregates)
+               .planNode()});
+    }
+
+    auto builder =
+        PlanBuilder(planNodeIdGenerator)
+            .localPartition(
+                groupingKeys,
+                {partialBuilder.intermediateAggregation().planNode()})
+            .finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    CursorParameters params;
+    params.planNode = builder.planNode();
+    params.maxDrivers = 2;
+    assertQuery(params, duckDbSql);
+  }
 }
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -22,12 +22,6 @@
 using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::aggregate::test {
-namespace {
-int64_t decodeChecksum(const std::string& checksum) {
-  auto decoded = encoding::Base64::decode(checksum);
-  return *reinterpret_cast<const int64_t*>(decoded.data());
-}
-} // namespace
 
 class ChecksumAggregateTest : public AggregationTestBase {
  protected:
@@ -43,57 +37,14 @@ class ChecksumAggregateTest : public AggregationTestBase {
       VectorPtr inputVector,
       const std::string& expectedChecksum) {
     auto rowVectors = std::vector{makeRowVector({inputVector})};
+
+    // DuckDB doesn't have checksum aggregation, so we will just pass in
+    // expected values to compare.
     const auto expectedDuckDbSql =
         fmt::format("VALUES (CAST(\'{}\' AS VARCHAR))", expectedChecksum);
 
-    // DuckDB doesnt have checksum aggregation, so we will just pass in
-    // expected values to compare.
-    auto agg = PlanBuilder()
-                   .values(rowVectors)
-                   .partialAggregation({}, {"checksum(c0)"})
-                   .finalAggregation()
-                   .project({"to_base64(a0) as c0"})
-                   .planNode();
-    assertQuery(agg, expectedDuckDbSql);
-
-    agg = PlanBuilder()
-              .values(rowVectors)
-              .singleAggregation({}, {"checksum(c0)"})
-              .project({"to_base64(a0) as c0"})
-              .planNode();
-    assertQuery(agg, expectedDuckDbSql);
-
-    agg = PlanBuilder()
-              .values(rowVectors)
-              .partialAggregation({}, {"checksum(c0)"})
-              .intermediateAggregation()
-              .finalAggregation()
-              .project({"to_base64(a0) as c0"})
-              .planNode();
-    assertQuery(agg, expectedDuckDbSql);
-
-    // Add local exchange before intermediate aggregation.
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-    CursorParameters params;
-    params.planNode =
-        PlanBuilder(planNodeIdGenerator)
-            .localPartition(
-                {},
-                {PlanBuilder(planNodeIdGenerator)
-                     .localPartitionRoundRobin(
-                         {PlanBuilder(planNodeIdGenerator)
-                              .values(rowVectors)
-                              .partialAggregation({}, {"checksum(c0)"})
-                              .planNode()})
-                     .intermediateAggregation()
-                     .planNode()})
-            .finalAggregation()
-            .project({"to_base64(a0) as c0"})
-            .planNode();
-
-    params.maxDrivers = 2;
-
-    assertQuery(params, expectedDuckDbSql);
+    testAggregations(
+        rowVectors, {}, {"checksum(c0)"}, {"to_base64(a0)"}, expectedDuckDbSql);
   }
 
   template <typename G, typename T>
@@ -111,38 +62,15 @@ class ChecksumAggregateTest : public AggregationTestBase {
       expectedResults.push_back(fmt::format("(\'{}\')", checksum));
     }
 
-    auto agg = PlanBuilder()
-                   .values(rowVectors)
-                   .partialAggregation({"c0"}, {"checksum(c1)"})
-                   .finalAggregation()
-                   .project({"to_base64(a0) AS c0"})
-                   .planNode();
-    assertQuery(agg, "VALUES " + boost::algorithm::join(expectedResults, ","));
+    const auto expectedDuckDbSql =
+        "VALUES " + boost::algorithm::join(expectedResults, ",");
 
-    // Add local exchange before intermediate aggregation.
-    std::vector<std::string> expectedInts;
-    expectedInts.reserve(expectedChecksums.size());
-    for (const auto& checksum : expectedChecksums) {
-      expectedInts.push_back(
-          fmt::format("({}::bigint)", decodeChecksum(checksum)));
-    }
-
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-
-    CursorParameters params;
-    params.planNode = PlanBuilder(planNodeIdGenerator)
-                          .localPartition(
-                              {"c0"},
-                              {PlanBuilder(planNodeIdGenerator)
-                                   .values(rowVectors)
-                                   .partialAggregation({"c0"}, {"checksum(c1)"})
-                                   .planNode()})
-                          .intermediateAggregation()
-                          .project({"a0"})
-                          .planNode();
-    params.maxDrivers = 2;
-
-    assertQuery(params, "VALUES " + boost::algorithm::join(expectedInts, ","));
+    testAggregations(
+        rowVectors,
+        {"c0"},
+        {"checksum(c1)"},
+        {"to_base64(a0)"},
+        expectedDuckDbSql);
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -30,74 +30,20 @@ class CovarianceAggregationTest
     auto sql = fmt::format(
         "SELECT c0, round({}(c1, c2), 2) FROM tmp GROUP BY 1", aggName);
 
-    auto op = PlanBuilder()
-                  .values({data})
-                  .partialAggregation({"c0"}, {partialAgg})
-                  .finalAggregation()
-                  .project({"c0", "round(a0, cast(2 as integer))"})
-                  .planNode();
-
-    assertQuery(op, sql);
-
-    op = PlanBuilder()
-             .values({data})
-             .singleAggregation({"c0"}, {partialAgg})
-             .project({"c0", "round(a0, cast(2 as integer))"})
-             .planNode();
-
-    assertQuery(op, sql);
-
-    op = PlanBuilder()
-             .values({data})
-             .partialAggregation({"c0"}, {partialAgg})
-             .planNode();
-
-    auto partialResults = getResults(op);
-
-    op = PlanBuilder()
-             .values({partialResults})
-             .finalAggregation(
-                 {"c0"}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
-             .project({"c0", "round(a0, cast(2 as integer))"})
-             .planNode();
-    assertQuery(op, sql);
+    testAggregations(
+        {data},
+        {"c0"},
+        {partialAgg},
+        {"c0", "round(a0, cast(2 as integer))"},
+        sql);
   }
 
   void testGlobalAgg(const std::string& aggName, const RowVectorPtr& data) {
     auto partialAgg = fmt::format("{}(c1, c2)", aggName);
     auto sql = fmt::format("SELECT round({}(c1, c2), 2) FROM tmp", aggName);
 
-    auto op = PlanBuilder()
-                  .values({data})
-                  .partialAggregation({}, {partialAgg})
-                  .finalAggregation()
-                  .project({"round(a0, cast(2 as integer))"})
-                  .planNode();
-
-    assertQuery(op, sql);
-
-    op = PlanBuilder()
-             .values({data})
-             .singleAggregation({}, {partialAgg})
-             .project({"round(a0, cast(2 as integer))"})
-             .planNode();
-
-    assertQuery(op, sql);
-
-    op = PlanBuilder()
-             .values({data})
-             .partialAggregation({}, {partialAgg})
-             .planNode();
-
-    auto partialResults = getResults(op);
-
-    op = PlanBuilder()
-             .values({partialResults})
-             .finalAggregation({}, {fmt::format("{}(a0)", aggName)}, {DOUBLE()})
-             .project({"round(a0, cast(2 as integer))"})
-             .planNode();
-
-    assertQuery(op, sql);
+    testAggregations(
+        {data}, {}, {partialAgg}, {"round(a0, cast(2 as integer))"}, sql);
   }
 };
 


### PR DESCRIPTION
Introduce AggregationTestBase::testAggregations helper method to test a variety
of logically equivalent plans to compute aggregations using combinations of
partial, final, single, and intermediate aggregations with and without local
exchanges.

The new helper method generates the following plans, runs them and verifies results against DuckDB:
     - partial -> final
     - single
     - partial -> intermediate -> final
     - partial -> local exchange -> final
     - partial -> local exchange -> intermediate -> local exchange -> final

To use the new method in a test one needs to provide a function to build the plan all the way up to the aggregation, specify grouping keys, aggregates and a corresponding DuckDB SQL:

```
     testAggregations(
         [&](PlanBuilder& builder) {
             builder
                 .values(vectors)
                 .project({"c0 % 10 AS c0_mod_10", "c1"});
         },
      {"c0_mod_10"},
      {"sum(c1)"},
      "SELECT c0 % 10, sum(c1) FROM tmp GROUP BY 1");
```

Updated Count/Checksum/Variance/CovarianceAggregationTests to use the new method.