### PR TITLE
C++20 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
 executors:
   build:
     docker:
-      - image : prestocpp/velox-circleci:kpai-20220401
+      - image : prestocpp/velox-circleci:kevinwilfong-20220426
     resource_class: 2xlarge
     environment:
         CC:  /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -28,7 +28,7 @@ dnf_install epel-release dnf-plugins-core # For ccache, ninja
 dnf config-manager --set-enabled powertools
 dnf_install ninja-build ccache gcc-toolset-9 git wget which libevent-devel \
   openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
-  protobuf-devel fmt-devel libdwarf-devel curl-devel
+  protobuf-devel libdwarf-devel curl-devel
 
 dnf remove -y gflags
 
@@ -64,6 +64,7 @@ wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz 
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
 wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
+wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
 
 wait  # For cmake and source downloads to complete.
@@ -85,6 +86,8 @@ wait  # For cmake and source downloads to complete.
 cmake_install gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64 -DCMAKE_INSTALL_PREFIX:PATH=/usr
 cmake_install glog -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
 cmake_install snappy -DSNAPPY_BUILD_TESTS=OFF
+# folly depends on fmt so this needs to come first.
+cmake_install fmt -DFMT_TEST=OFF
 cmake_install folly
 # cmake_install ranges-v3
 

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -354,7 +354,7 @@ TEST(ExceptionTest, notNull) {
 TEST(ExceptionTest, expressionString) {
   size_t i = 1;
   size_t j = 100;
-  std::string msgTemplate =
+  constexpr auto msgTemplate =
       "Exception: VeloxRuntimeError"
       "\nError Source: RUNTIME"
       "\nError Code: INVALID_STATE"

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -69,7 +69,7 @@ class ParquetTpchTest : public testing::Test {
       fs::create_directory(tableDirectory);
       auto filePath = fmt::format("{}/file.parquet", tableDirectory);
       auto query = fmt::format(
-          duckDbParquetWriteSQL_.at(tableName),
+          fmt::runtime(duckDbParquetWriteSQL_.at(tableName)),
           tableName,
           filePath,
           kRowGroupSize);

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -380,16 +380,13 @@ TEST_F(Re2FunctionsTest, likePattern) {
 
   EXPECT_EQ(
       like(
-          u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 abc",
-          u8"\u4FE1\u5FF5 \u7231%"),
+          "\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 abc",
+          "\u4FE1\u5FF5 \u7231%"),
       true);
   EXPECT_EQ(
-      like(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ", u8"\u4FE1%\u7231%"),
-      true);
+      like("\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ", "\u4FE1%\u7231%"), true);
   EXPECT_EQ(
-      like(
-          u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ",
-          u8"\u7231\u4FE1%\u7231%"),
+      like("\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 ", "\u7231\u4FE1%\u7231%"),
       false);
 
   EXPECT_EQ(like("abc", "MEDIUM POLISHED%"), false);

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -152,7 +152,7 @@ TEST_F(ChecksumAggregateTest, varchars) {
   assertSingleGroupChecksum<StringView>({{}}, "h8rrhbF5N54=");
   assertSingleGroupChecksum<StringView>({"abcd"_sv}, "lGFxgnIYgPw=");
   assertSingleGroupChecksum<StringView>(
-      {u8"Thanks \u0020\u007F"_sv}, "oEh7YyEV+dM=");
+      {"Thanks \u0020\u007F"_sv}, "oEh7YyEV+dM=");
 }
 
 TEST_F(ChecksumAggregateTest, arrays) {

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -211,7 +211,7 @@ TEST_F(PrestoHasherTest, floats) {
 
 TEST_F(PrestoHasherTest, varchars) {
   assertHash<StringView>(
-      {"abcd"_sv, ""_sv, std::nullopt, u8"Thanks \u0020\u007F"_sv},
+      {"abcd"_sv, ""_sv, std::nullopt, "Thanks \u0020\u007F"_sv},
       {-2449070131962342708, -1205034819632174695, 0, 2911531567394159200});
 }
 

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -24,7 +24,7 @@ namespace {
 
 // Replace the given query's placeholders '{0}' with the given aggregation name.
 std::string genAggrQuery(const char* query, const char* aggrName) {
-  return fmt::format(query, aggrName);
+  return fmt::format(fmt::runtime(query), aggrName);
 }
 
 // Helper generates aggregation over column string.

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -207,8 +207,8 @@ class UrlBenchmark : public functions::test::FunctionBenchmarkBase {
         : vectorMaker_.rowVector({vectorUrls});
 
     auto queryString = isParameter ? "{}(c0, c1)" : "{}(c0)";
-    auto exprSet =
-        compileExpression(fmt::format(queryString, fnName), rowVector->type());
+    auto exprSet = compileExpression(
+        fmt::format(fmt::runtime(queryString), fnName), rowVector->type());
 
     suspender.dismiss();
 

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -65,15 +65,15 @@ TEST_F(JsonExtractScalarTest, simple) {
 TEST_F(JsonExtractScalarTest, utf8) {
   EXPECT_EQ(
       json_extract_scalar(R"({"k1":"I \u2665 UTF-8"})", "$.k1"),
-      u8"I \u2665 UTF-8");
+      "I \u2665 UTF-8");
   EXPECT_EQ(
-      json_extract_scalar(u8"{\"k1\":\"I \u2665 UTF-8\"}", "$.k1"),
-      u8"I \u2665 UTF-8");
+      json_extract_scalar("{\"k1\":\"I \u2665 UTF-8\"}", "$.k1"),
+      "I \u2665 UTF-8");
 
   EXPECT_EQ(
       json_extract_scalar(
-          u8"{\"k1\":\"I \U0001D11E playing in G-clef\"}", "$.k1"),
-      u8"I \U0001D11E playing in G-clef");
+          "{\"k1\":\"I \U0001D11E playing in G-clef\"}", "$.k1"),
+      "I \U0001D11E playing in G-clef");
 }
 
 TEST_F(JsonExtractScalarTest, invalidPath) {

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1314,11 +1314,11 @@ TEST_F(StringFunctionsTest, reverse) {
   EXPECT_EQ("koobecaF", reverse("Facebook"));
   EXPECT_EQ("ΨΧΦΥΤΣΣΡΠΟΞΝΜΛΚΙΘΗΖΕΔΓΒΑ", reverse("ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΣΤΥΦΧΨ"));
   EXPECT_EQ(
-      u8" \u2028 \u671B\u5E0C \u7231 \u5FF5\u4FE1",
-      reverse(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
+      " \u2028 \u671B\u5E0C \u7231 \u5FF5\u4FE1",
+      reverse("\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
   EXPECT_EQ(
-      u8"\u671B\u5E0C\u2014\u7231\u2014\u5FF5\u4FE1",
-      reverse(u8"\u4FE1\u5FF5\u2014\u7231\u2014\u5E0C\u671B"));
+      "\u671B\u5E0C\u2014\u7231\u2014\u5FF5\u4FE1",
+      reverse("\u4FE1\u5FF5\u2014\u7231\u2014\u5E0C\u671B"));
   EXPECT_EQ(expectedInvalidStr, reverse(invalidStr));
 }
 
@@ -1699,20 +1699,20 @@ TEST_F(StringFunctionsTest, trim) {
   EXPECT_EQ("a", trim("  a  "));
 
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      trim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      trim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      trim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      trim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      trim(u8" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      trim(" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      trim(u8"  \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      trim("  \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      trim(u8" \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      trim(" \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
 
   EXPECT_EQ(expectedComplexStr, trim(complexStr));
   EXPECT_EQ(
@@ -1739,20 +1739,20 @@ TEST_F(StringFunctionsTest, ltrim) {
   EXPECT_EQ("move fast", ltrim("\r\t move fast"));
   EXPECT_EQ("hello", ltrim("\n\t\r hello"));
 
-  EXPECT_EQ(u8"\u4F60\u597D", ltrim(u8" \u4F60\u597D"));
-  EXPECT_EQ(u8"\u4F60\u597D ", ltrim(u8" \u4F60\u597D "));
+  EXPECT_EQ("\u4F60\u597D", ltrim(" \u4F60\u597D"));
+  EXPECT_EQ("\u4F60\u597D ", ltrim(" \u4F60\u597D "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
-      ltrim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
+      ltrim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B ",
-      ltrim(u8" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B ",
+      ltrim(" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      ltrim(u8"  \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      ltrim("  \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      ltrim(u8" \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      ltrim(" \u2028 \u4FE1\u5FF5 \u7231 \u5E0C\u671B"));
 
   EXPECT_EQ(expectedComplexStr, ltrim(complexStr));
   EXPECT_EQ("Ψ\xFF\xFFΣΓΔA", ltrim("  \u2028 \r \t \n   Ψ\xFF\xFFΣΓΔA"));
@@ -1778,20 +1778,20 @@ TEST_F(StringFunctionsTest, rtrim) {
   EXPECT_EQ("move fast", rtrim("move fast\r\t "));
   EXPECT_EQ("hello", rtrim("hello\n\t\r "));
 
-  EXPECT_EQ(u8" \u4F60\u597D", rtrim(u8" \u4F60\u597D"));
-  EXPECT_EQ(u8" \u4F60\u597D", rtrim(u8" \u4F60\u597D "));
+  EXPECT_EQ(" \u4F60\u597D", rtrim(" \u4F60\u597D"));
+  EXPECT_EQ(" \u4F60\u597D", rtrim(" \u4F60\u597D "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      rtrim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      rtrim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
   EXPECT_EQ(
-      u8" \u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      rtrim(u8" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
+      " \u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      rtrim(" \u4FE1\u5FF5 \u7231 \u5E0C\u671B "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      rtrim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      rtrim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  "));
   EXPECT_EQ(
-      u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
-      rtrim(u8"\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B",
+      rtrim("\u4FE1\u5FF5 \u7231 \u5E0C\u671B \u2028 "));
 
   EXPECT_EQ(expectedComplexStr, rtrim(complexStr));
   EXPECT_EQ("     Ψ\xFF\xFFΣΓΔA", rtrim("     Ψ\xFF\xFFΣΓΔA \u2028 \r \t \n"));

--- a/velox/row/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/row/tests/UnsafeRowSerializerTest.cpp
@@ -256,7 +256,7 @@ TEST_F(UnsafeRowSerializerTests, StringsDynamic) {
   bool nulls[4] = {false, false, true, false};
   StringView elements[4] = {
       StringView("Hello, World!", 13),
-      StringView(u8"", 0),
+      StringView("", 0),
       StringView(),
       StringView("INLINE", 6)};
   auto stringVec =
@@ -448,11 +448,11 @@ TEST_F(UnsafeRowSerializerTests, arrayStringView) {
   ///  size: 6
   ///  [ hello, longString, emptyString, null, null, world]
   ///  nulls: 0b011000
-  auto hello = StringView(u8"Hello", 5);
+  auto hello = StringView("Hello", 5);
   auto longString =
-      StringView(u8"This is a rather long string.  Quite long indeed.", 49);
-  auto emptyString = StringView(u8"", 0);
-  auto world = StringView(u8"World", 5);
+      StringView("This is a rather long string.  Quite long indeed.", 49);
+  auto emptyString = StringView("", 0);
+  auto world = StringView("World", 5);
   auto placeHolder = StringView();
 
   auto flatVector = makeNullableFlatVector<StringView>(
@@ -706,8 +706,8 @@ TEST_F(UnsafeRowSerializerTests, map) {
   /// @TODO in the future if needed we can fix the map serializer/deserializer
   /// And add corresponding tests here again.
 
-  auto hello = StringView(u8"Hello", 5);
-  auto world = StringView(u8"World", 5);
+  auto hello = StringView("Hello", 5);
+  auto world = StringView("World", 5);
   auto placeHolder = StringView();
 
   auto keysFlatVector =

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -352,7 +352,7 @@ TEST(Type, OpaqueWithMetadata) {
   auto type = std::make_shared<OpaqueWithMetadataType>(123);
   auto type2 = std::make_shared<OpaqueWithMetadataType>(123);
   auto other = std::make_shared<OpaqueWithMetadataType>(234);
-  EXPECT_NE(*def, *type);
+  EXPECT_TRUE(def->operator!=(*type));
   EXPECT_EQ(*type, *type2);
   EXPECT_NE(*type, *other);
 
@@ -399,7 +399,7 @@ TEST(Type, Equality) {
   // scalar
   EXPECT_TRUE(*INTEGER() == *INTEGER());
   EXPECT_FALSE(*INTEGER() != *INTEGER());
-  EXPECT_FALSE(*INTEGER() == *REAL());
+  EXPECT_FALSE(INTEGER()->operator==(*REAL()));
 
   // map
   EXPECT_TRUE(*MAP(INTEGER(), REAL()) == *MAP(INTEGER(), REAL()));
@@ -431,9 +431,10 @@ TEST(Type, Equality) {
       *ROW({{"a", INTEGER()}, {"d", REAL()}}));
 
   // mix
-  EXPECT_FALSE(
-      *MAP(REAL(), INTEGER()) == *ROW({{"a", REAL()}, {"b", INTEGER()}}));
-  EXPECT_FALSE(*ARRAY(REAL()) == *ROW({{"a", REAL()}}));
+  EXPECT_FALSE(MAP(REAL(), INTEGER())
+                   ->
+                   operator==(*ROW({{"a", REAL()}, {"b", INTEGER()}})));
+  EXPECT_FALSE(ARRAY(REAL())->operator==(*ROW({{"a", REAL()}})));
 }
 
 TEST(Type, Cpp2Type) {


### PR DESCRIPTION
Summary:
This diff fixes a few incompatibility issues with C++ 20.

1) fmt::format checks at compile time that the format string is constexpr or implicitly constructed from a string literal.  There are a couple violations, wrapping them in fmt::runtime is less performant than making them constexpr, but they're in tests/uninteresting parts of benchmarks so it's fine.
2) A char8_t type was added for UTF-8 strings, this breaks implicit conversion of string literals using the u8 literal to strings.  This affected a few tests, but the u8 literal was unnecessary
3) Ambiguous equality expression warnings when comparing two different types.  With an expression like a == b the compiler will look up the equality function for a and the equality function for b and issue a warning if they're different functions.  We were explicitly doing this to test the inequality of different types in a few tests, explicitly calling the equality operator on the object produces the original behavior.

I also had to update the fmt dependency used in the setup-circleci.sh script.  The one available in dnf appears to be out of date, so I pulled the code from GitHub and built it, using the same version and in the same manner the other setup scripts prepare fmt.

Differential Revision: D35939375

