### PR TITLE
Correct nullptr + offset scenario to pass ASAN check

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -84,12 +84,11 @@ class S3FileSystemTest : public testing::Test {
     char tail[7];
     std::vector<folly::Range<char*>> buffers = {
         folly::Range<char*>(head, sizeof(head)),
-        folly::Range<char*>(nullptr, 500000),
+        folly::Range<char*>(nullptr, (char*)(uint64_t)500000),
         folly::Range<char*>(middle, sizeof(middle)),
         folly::Range<char*>(
             nullptr,
-            15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) -
-                sizeof(tail)),
+            (char*)(uint64_t)(15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) - sizeof(tail))),
         folly::Range<char*>(tail, sizeof(tail))};
     ASSERT_EQ(15 + kOneMB, readFile->preadv(0, buffers));
     ASSERT_EQ(std::string_view(head, sizeof(head)), "aaaaabbbbbcc");


### PR DESCRIPTION
Summary: ASAN does not allow nullptr + an offset to be present from its UndefinedBehavior category. We need to clean these places up so that ASAN can run without issues.

Differential Revision: D35919458

