### PR TITLE
Ensure DBGEN generated records are thread-safe and reproducible

### DIFF
--- a/velox/tpch/gen/CMakeLists.txt
+++ b/velox/tpch/gen/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_tpch_gen TpchGen.cpp)
+add_library(velox_tpch_gen TpchGen.cpp DBGenIterator.cpp)
 
 target_link_libraries(velox_tpch_gen velox_memory velox_vector dbgen duckdb)
 

--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/tpch/gen/DBGenIterator.h"
+
+#include <folly/Singleton.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dbgen_gunk.hpp"
+
+namespace facebook::velox::tpch {
+
+namespace {
+
+// DBGenLease is a singleton that controls access to the DBGEN C functions. It
+// handles initialization and cleanup of dbgen gunk structures, and set/unset of
+// global variables used by DBGEN.
+//
+// Only acquire instances of this class using folly::Singleton.
+class DBGenLease {
+ public:
+  DBGenLease() {
+    // load_dists()/cleanup_dists() need to be called to ensure the global
+    // variables required by dbgen are populated.
+    load_dists();
+  }
+  ~DBGenLease() {
+    cleanup_dists();
+  }
+
+  // Get a lease, or a permission to safely call internal dbgen functions.
+  std::unique_lock<std::mutex> getLease(size_t scaleFactor) {
+    auto lock = std::unique_lock<std::mutex>{mutex_};
+
+    // DBGEN takes the scale factor through this global variable.
+    scale = scaleFactor;
+
+    // This is tricky: dbgen code initializes seeds using hard-coded literals in
+    // the C codebase, which are updated every time a record is generated. In
+    // order to make these functions reproducible, before we make the first
+    // invocation we need to make a copy (a backup) of the initial state of
+    // these seeds. For subsequent leases, we restore that backed up state to
+    // ensure results are reproducible.
+    if (firstCall_) {
+      // Store the initial random seed.
+      memcpy(seedBackup_, seed_, sizeof(seed_t) * MAX_STREAM + 1);
+      firstCall_ = false;
+    } else {
+      // Restore random seeds from backup.
+      memcpy(seed_, seedBackup_, sizeof(seed_t) * MAX_STREAM + 1);
+    }
+    return lock;
+  }
+
+ private:
+  std::mutex mutex_;
+
+  seed_t* seed_{DBGenGlobals::Seed};
+  seed_t seedBackup_[MAX_STREAM + 1];
+  bool firstCall_{true};
+};
+
+// Make the object above a singleton.
+static folly::Singleton<DBGenLease> DBGenLeaseSingleton;
+
+} // namespace
+
+DBGenIterator DBGenIterator::create(size_t scaleFactor) {
+  auto dbGenLease = DBGenLeaseSingleton.try_get();
+  VELOX_CHECK_NOT_NULL(dbGenLease);
+  return DBGenIterator(dbGenLease->getLease(scaleFactor));
+}
+
+void DBGenIterator::genNation(size_t index, code_t& code) {
+  row_start(NATION);
+  mk_nation(index, &code);
+  row_stop_h(NATION);
+}
+
+void DBGenIterator::genOrder(size_t index, order_t& order) {
+  row_start(ORDER);
+  mk_order(index, &order, /*update-num=*/0);
+  row_stop_h(ORDER);
+}
+
+} // namespace facebook::velox::tpch

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dsstypes.h"
+
+namespace facebook::velox::tpch {
+
+/// This class exposes a thread-safe and reproducible iterator over TPC-H
+/// synthetically generated data, backed by DBGEN.
+///
+/// Note that because DBGEN is an old C codebase which relies on global
+/// variables for state, it is not possible to use the underlying functions to
+/// generate datasets in parallel. This class provides thread-safety by ensuring
+/// mutual exclusion (via mutex) when using iterators to generate data in
+/// parallel. This class follows RAII, so the internal lock will be held for as
+/// long as instances are in scope.
+class DBGenIterator {
+ public:
+  // Use this function to create instances of DBGEN iterators. This call might
+  // block in case other iterators are still in scope (and thus hold the
+  // internal lock).
+  static DBGenIterator create(size_t scaleFactor);
+
+  // Generate different types of records.
+  void genNation(size_t index, code_t& code);
+  void genOrder(size_t index, order_t& order);
+
+ private:
+  // Should not instantiate directly.
+  DBGenIterator(std::unique_lock<std::mutex>&& lease)
+      : lockGuard_(std::move(lease)) {}
+
+  // unique_lock instead of lock_guard so it's movable.
+  std::unique_lock<std::mutex> lockGuard_;
+};
+
+} // namespace facebook::velox::tpch


### PR DESCRIPTION
Summary:
Creating a DBGenIterator abstraction to handle thread-safety and
init/cleanup of structures needed by DBGEN's old C codebase.

Reviewed By: mbasmanova

Differential Revision: D35945001

