### PR TITLE
Correct nullptr + offset scenario to pass ASAN check in dwrf

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -729,7 +729,7 @@ CoalesceIoStats readPins(
         VELOX_CHECK_EQ(offsetInRuns, size);
       },
       [&](int32_t size, std::vector<folly::Range<char*>>& ranges) {
-        ranges.push_back(folly::Range<char*>(nullptr, size));
+        ranges.push_back(folly::Range<char*>(ReadFile::skipMarker(), size));
       },
       readFunc);
 }

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -26,6 +26,11 @@
 
 namespace facebook::velox {
 
+char* FOLLY_NONNULL ReadFile::skipMarker() {
+  static char skipMarker;
+  return &skipMarker;
+}
+
 std::string_view
 InMemoryReadFile::pread(uint64_t offset, uint64_t length, void* buf) const {
   bytesRead_ += length;
@@ -47,7 +52,7 @@ uint64_t InMemoryReadFile::preadv(
   }
   for (auto& range : buffers) {
     auto copySize = std::min<size_t>(range.size(), file_.size() - offset);
-    if (range.data()) {
+    if (!shouldSkip(range.data())) {
       memcpy(range.data(), file_.data() + offset, copySize);
     }
     offset += copySize;
@@ -108,7 +113,7 @@ uint64_t LocalReadFile::preadv(
   std::vector<struct iovec> iovecs;
   iovecs.reserve(buffers.size());
   for (auto& range : buffers) {
-    if (!range.data()) {
+    if (shouldSkip(range.data())) {
       auto skipSize = range.size();
       while (skipSize) {
         auto bytes = std::min<size_t>(sizeof(droppedBytes), skipSize);

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -55,12 +55,17 @@ class ReadFile {
 
   // Reads starting at 'offset' into the memory referenced by the
   // Ranges in 'buffers'. The buffers are filled left to right. A
-  // buffer with nullptr data will cause its size worth of bytes to be skipped.
+  // buffer with skip() in data will cause its size worth of bytes to be
+  // skipped.
   virtual uint64_t preadv(
       uint64_t /*offset*/,
       const std::vector<folly::Range<char*>>& /*buffers*/) const {
     VELOX_NYI("preadv not supported");
   }
+
+  // Returns a special char* that indicates that a range that begins
+  // with this should be skipped in preadv.
+  static char* FOLLY_NONNULL skipMarker();
 
   // Like preadv but may execute asynchronously and returns the read
   // size or exception via SemiFuture. Use hasPreadvAsync() to check
@@ -100,6 +105,12 @@ class ReadFile {
 
   virtual void resetBytesRead() {
     bytesRead_ = 0;
+  }
+
+  // Returns true if the range starting at 'begin' should be skipped in
+  // preadv(). Accepts nullptr and the special value skip().
+  static bool shouldSkip(char* FOLLY_NONNULL begin) {
+    return begin == skipMarker();
   }
 
  protected:

--- a/velox/common/file/FileTest.cpp
+++ b/velox/common/file/FileTest.cpp
@@ -56,10 +56,10 @@ void readData(ReadFile* readFile) {
   char tail[7];
   std::vector<folly::Range<char*>> buffers = {
       folly::Range<char*>(head, sizeof(head)),
-      folly::Range<char*>(nullptr, 500000),
+      folly::Range<char*>(ReadFile::skipMarker(), 500000),
       folly::Range<char*>(middle, sizeof(middle)),
       folly::Range<char*>(
-          nullptr,
+          ReadFile::skipMarker(),
           15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) - sizeof(tail)),
       folly::Range<char*>(tail, sizeof(tail))};
   ASSERT_EQ(15 + kOneMB, readFile->preadv(0, buffers));

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -116,7 +116,7 @@ class S3ReadFile final : public ReadFile {
     preadInternal(offset, length, static_cast<char*>(result.data()));
     size_t resultOffset = 0;
     for (auto range : buffers) {
-      if (range.data()) {
+      if (!shouldSkip(range.data())) {
         memcpy(range.data(), &(result.data()[resultOffset]), range.size());
       }
       resultOffset += range.size();

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   velox_exception
   velox_dwio_common_encryption
   velox_dwio_common_compression
+  velox_file
   velox_memory
   Boost::regex
   ${FOLLY_WITH_DEPENDENCIES}

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -108,7 +108,7 @@ class InputStream {
       common::LogType logType) {
     uint64_t bufferOffset = 0;
     for (auto& range : buffers) {
-      if (range.data()) {
+      if (!ReadFile::shouldSkip(range.data())) {
         read(range.data(), range.size(), offset + bufferOffset, logType);
       }
       bufferOffset += range.size();

--- a/velox/dwio/dwrf/common/FloatingPointDecoder.h
+++ b/velox/dwio/dwrf/common/FloatingPointDecoder.h
@@ -30,7 +30,7 @@ class FloatingPointDecoder {
       : input_(std::move(input)) {}
 
   TData readValue() {
-    if (bufferStart_ + sizeof(TData) <= bufferEnd_) {
+    if (bufferStart_ != nullptr && bufferStart_ + sizeof(TData) <= bufferEnd_) {
       TData value = *reinterpret_cast<const TData*>(bufferStart_);
       bufferStart_ += sizeof(TData);
       return value;

--- a/velox/dwio/dwrf/common/StreamUtil.h
+++ b/velox/dwio/dwrf/common/StreamUtil.h
@@ -31,7 +31,7 @@ static inline void skipBytes(
     SeekableInputStream* input,
     const char*& bufferStart,
     const char*& bufferEnd) {
-  if (bufferStart + numBytes <= bufferEnd) {
+  if (bufferStart != nullptr && bufferStart + numBytes <= bufferEnd) {
     bufferStart += numBytes;
     return;
   }

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -140,7 +140,8 @@ inline bool SelectiveStringDirectColumnReader::try8Consecutive(
     int32_t start,
     const int32_t* rows,
     int32_t row) {
-  const char* data = bufferStart_ + start + bytesToSkip_;
+  const char* data =
+      bufferStart_ == nullptr ? nullptr : bufferStart_ + start + bytesToSkip_;
   if (!data || bufferEnd_ - data < start + 8 * 12) {
     return false;
   }
@@ -251,7 +252,7 @@ folly::StringPiece SelectiveStringDirectColumnReader::readValue(
     int32_t length) {
   skipBytes(bytesToSkip_, blobStream_.get(), bufferStart_, bufferEnd_);
   bytesToSkip_ = 0;
-  if (bufferStart_ + length <= bufferEnd_) {
+  if (bufferStart_ != nullptr && bufferStart_ + length <= bufferEnd_) {
     bytesToSkip_ = length;
     return folly::StringPiece(bufferStart_, length);
   }


### PR DESCRIPTION
Summary: ASAN does not allow nullptr + an offset to be present from its UndefinedBehavior category. We need to clean these places up so that ASAN can run without issues.

Differential Revision: D35948895

