### PR TITLE
Fix reuse of nullsInReadRange_ in the DWRF reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h
@@ -77,6 +77,11 @@ void SelectiveColumnReader::prepareRead(
     const uint64_t* incomingNulls) {
   seekTo(offset, scanSpec_->readsNullsOnly());
   vector_size_t numRows = rows.back() + 1;
+
+  // Do not re-use unless singly-referenced.
+  if (nullsInReadRange_ && !nullsInReadRange_->unique()) {
+    nullsInReadRange_.reset();
+  }
   readNulls(numRows, incomingNulls, nullptr, nullsInReadRange_);
   // We check for all nulls and no nulls. We expect both calls to
   // bits::isAllSet to fail early in the common case. We could do a


### PR DESCRIPTION
DWRF reader was re-using nullsInReadRange_ buffer unconditionally. When buffer
was multiply-referenced, re-use caused memory corruption.

A specific scenario where this was happening is the following.

SELECT * FROM t WHERE a || ',' || b || ',' || c = '...'

This query crashed while evaluating remaining filter a || ',' || b || ',' || c = '...'.

The reader produced first batch of data with 10k rows. Only 4 of these were
non-null for 'a'. All columns were dictionary encoded and columns 'b' and 'c'
had constant values for non-null rows of 'a'. The nulls buffer of 'a' was a
reference to reader's nullsInReadRange_ buffer.

HiveConnector evaluated the filter on this data and stored the results in
HiveConnector:filterResults_ vector. These results were dictionary encoded
using nulls buffer from 'a'. Now, filterResults_'s nulls buffer became a
reference to reader's nullsInReadRange_.

While reading next batch of data, the reader re-used and modified the
nullsInReadRange_ buffer. This corrupted HiveConnector:filterResults_ so that
entries that used to be null appeared non-null and accessing them hit undefined
values in the indices buffer.