### PR TITLE
Fix lifetime of StreamArena in IO executor

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -402,6 +402,16 @@ class IOBufOutputStream : public OutputStream {
     out_->startWrite(initialSize);
   }
 
+  explicit IOBufOutputStream(
+      std::shared_ptr<memory::MappedMemory> mappedMemory,
+      OutputStreamListener* listener = nullptr,
+      int32_t initialSize = memory::MappedMemory::kPageSize)
+      : OutputStream(listener),
+        arena_(std::make_shared<StreamArena>(std::move(mappedMemory))),
+        out_(std::make_unique<ByteStream>(arena_.get())) {
+    out_->startWrite(initialSize);
+  }
+
   void write(const char* s, std::streamsize count) override {
     out_->appendStringPiece(folly::StringPiece(s, count));
     if (listener_) {

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -377,7 +377,9 @@ class MappedMemory {
 // be a child of the Driver/Task level tracker. in this way
 // MappedMemory activity can be attributed to individual operators and
 // these operators can be requested to spill or limit their memory utilization.
-class ScopedMappedMemory final : public MappedMemory {
+class ScopedMappedMemory final
+    : public MappedMemory,
+      public std::enable_shared_from_this<ScopedMappedMemory> {
  public:
   ScopedMappedMemory(
       MappedMemory* FOLLY_NONNULL parent,

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -32,6 +32,11 @@ class StreamArena {
   explicit StreamArena(memory::MappedMemory* mappedMemory)
       : mappedMemory_(mappedMemory), allocation_(mappedMemory) {}
 
+  explicit StreamArena(std::shared_ptr<memory::MappedMemory> mappedMemory)
+      : mappedMemoryShared_(std::move(mappedMemory)),
+        mappedMemory_(mappedMemoryShared_.get()),
+        allocation_(mappedMemory_) {}
+
   virtual ~StreamArena() = default;
 
   // Sets range to refer  to at least one page of writable memory owned by
@@ -53,6 +58,10 @@ class StreamArena {
   }
 
  private:
+  // if 'this' has an indefinite lifetime, e.g. is passed to an IO
+  // executor and the MappedMemory is a scoped one, then the lifetime
+  // of the MappedMemory must be extended to outlive 'this'.
+  std::shared_ptr<memory::MappedMemory> mappedMemoryShared_;
   memory::MappedMemory* mappedMemory_;
   // All allocations.
   std::vector<std::unique_ptr<memory::MappedMemory::Allocation>> allocations_;

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -78,9 +78,14 @@ BlockingReason Destination::flush(
   }
   // Upper limit of message size with no columns.
   constexpr int32_t kMinMessageSize = 128;
+  auto scopedMappedMemory =
+      dynamic_cast<memory::ScopedMappedMemory*>(current_->mappedMemory());
+  VELOX_CHECK(
+      scopedMappedMemory,
+      "The mappedMemory for outgoing data in PartitionedOutput must be scoped");
   auto listener = bufferManager.newListener();
   IOBufOutputStream stream(
-      *current_->mappedMemory(),
+      scopedMappedMemory->shared_from_this(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
   current_->flush(&stream);


### PR DESCRIPTION
Adds a shared_ptr to a ScopedMappedMemory to StreamArena for the case
where this has an indefinite lifetime that may exceed that of the
originating Operator. This happens when query results are passed to
proxygen in presto_cpp and the query is cancelled. The cancellation
grees the IOBufs of the message, which in turn hold shared ownership
of a StreamArena, which owns the memory backing the IOBufs.

Adds enable_shared_from_this to ScopedMappedMemory. This allows
handing off shared ownership to IOBufs produced by PartitionedOutput.