### PR TITLE
Add support for Part/Supplier/PartSupp in DBGEN

### DIFF
--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -95,4 +95,16 @@ void DBGenIterator::genOrder(size_t index, order_t& order) {
   row_stop_h(ORDER);
 }
 
+void DBGenIterator::genSupplier(size_t index, supplier_t& supplier) {
+  row_start(SUPP);
+  mk_supp(index, &supplier);
+  row_stop_h(SUPP);
+}
+
+void DBGenIterator::genPart(size_t index, part_t& part) {
+  row_start(PART);
+  mk_part(index, &part);
+  row_stop_h(PART);
+}
+
 } // namespace facebook::velox::tpch

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -43,6 +43,8 @@ class DBGenIterator {
   // Generate different types of records.
   void genNation(size_t index, code_t& code);
   void genOrder(size_t index, order_t& order);
+  void genSupplier(size_t index, supplier_t& supplier);
+  void genPart(size_t index, part_t& part);
 
  private:
   // Should not instantiate directly.

--- a/velox/tpch/gen/TpchGen.h
+++ b/velox/tpch/gen/TpchGen.h
@@ -38,7 +38,7 @@ namespace facebook::velox::tpch {
 enum class Table {
   TBL_PART,
   TBL_SUPPLIER,
-  TBL_PARTSUP,
+  TBL_PARTSUPP,
   TBL_CUSTOMER,
   TBL_ORDERS,
   TBL_LINEITEM,
@@ -108,6 +108,63 @@ RowVectorPtr genTpchOrders(
 RowVectorPtr genTpchLineItem(
     size_t maxOrdersRows = 10000,
     size_t ordersOffset = 0,
+    size_t scaleFactor = 1,
+    memory::MemoryPool* pool =
+        &velox::memory::getProcessDefaultMemoryManager().getRoot());
+
+/// Returns a row vector containing at most `maxRows` rows of the "part"
+/// table, starting at `offset`, and given the scale factor. The row vector
+/// returned has the following schema:
+///
+///  p_partkey: BIGINT
+///  p_name: VARCHAR
+///  p_mfgr: VARCHAR
+///  p_brand: VARCHAR
+///  p_type: VARCHAR
+///  p_size: INTEGER
+///  p_container: VARCHAR
+///  p_retailprice: DOUBLE
+///  p_comment: VARCHAR
+///
+RowVectorPtr genTpchPart(
+    size_t maxRows = 10000,
+    size_t offset = 0,
+    size_t scaleFactor = 1,
+    memory::MemoryPool* pool =
+        &velox::memory::getProcessDefaultMemoryManager().getRoot());
+
+/// Returns a row vector containing at most `maxRows` rows of the "supplier"
+/// table, starting at `offset`, and given the scale factor. The row vector
+/// returned has the following schema:
+///
+///  s_suppkey: BIGINT
+///  s_name: VARCHAR
+///  s_address: VARCHAR
+///  s_nationkey: BIGINT
+///  s_phone: VARCHAR
+///  s_acctbal: DOUBLE
+///  s_comment: VARCHAR
+///
+RowVectorPtr genTpchSupplier(
+    size_t maxRows = 10000,
+    size_t offset = 0,
+    size_t scaleFactor = 1,
+    memory::MemoryPool* pool =
+        &velox::memory::getProcessDefaultMemoryManager().getRoot());
+
+/// Returns a row vector containing at most `maxRows` rows of the "partsupp"
+/// table, starting at `offset`, and given the scale factor. The row vector
+/// returned has the following schema:
+///
+///  ps_partkey: BIGINT
+///  ps_suppkey: BIGINT
+///  ps_availqty: INTEGER
+///  ps_supplycost: DOUBLE
+///  ps_comment: VARCHAR
+///
+RowVectorPtr genTpchPartSupp(
+    size_t maxRows = 10000,
+    size_t offset = 0,
     size_t scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());


### PR DESCRIPTION
Summary: Add support for three more tables in DBGEN: Part, Supplier, and PartSupp.

Reviewed By: Yuhta

Differential Revision: D35953989

