### PR TITLE
Fix bugs exposed with stricter ASAN

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -729,7 +729,9 @@ CoalesceIoStats readPins(
         VELOX_CHECK_EQ(offsetInRuns, size);
       },
       [&](int32_t size, std::vector<folly::Range<char*>>& ranges) {
-        ranges.push_back(folly::Range<char*>(nullptr, size));
+        // This hack allows us to store the size of the gap in the Range,
+        // without actually allocating a buffer for it.
+        ranges.push_back(folly::Range<char*>(nullptr, (char*)(uint64_t)size));
       },
       readFunc);
 }

--- a/velox/common/file/FileTest.cpp
+++ b/velox/common/file/FileTest.cpp
@@ -56,11 +56,11 @@ void readData(ReadFile* readFile) {
   char tail[7];
   std::vector<folly::Range<char*>> buffers = {
       folly::Range<char*>(head, sizeof(head)),
-      folly::Range<char*>(nullptr, 500000),
+      folly::Range<char*>(nullptr, (char*)(uint64_t)500000),
       folly::Range<char*>(middle, sizeof(middle)),
       folly::Range<char*>(
           nullptr,
-          15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) - sizeof(tail)),
+          (char*)(uint64_t)(15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) - sizeof(tail))),
       folly::Range<char*>(tail, sizeof(tail))};
   ASSERT_EQ(15 + kOneMB, readFile->preadv(0, buffers));
   ASSERT_EQ(std::string_view(head, sizeof(head)), "aaaaabbbbbcc");

--- a/velox/dwio/dwrf/common/FloatingPointDecoder.h
+++ b/velox/dwio/dwrf/common/FloatingPointDecoder.h
@@ -30,7 +30,7 @@ class FloatingPointDecoder {
       : input_(std::move(input)) {}
 
   TData readValue() {
-    if (bufferStart_ + sizeof(TData) <= bufferEnd_) {
+    if (bufferEnd_ - bufferStart_ >= sizeof(TData)) {
       TData value = *reinterpret_cast<const TData*>(bufferStart_);
       bufferStart_ += sizeof(TData);
       return value;

--- a/velox/dwio/dwrf/common/StreamUtil.h
+++ b/velox/dwio/dwrf/common/StreamUtil.h
@@ -31,7 +31,8 @@ static inline void skipBytes(
     SeekableInputStream* input,
     const char*& bufferStart,
     const char*& bufferEnd) {
-  if (bufferStart + numBytes <= bufferEnd) {
+  // bufferStart and bufferEnd may be null if we haven't started reading yet.
+  if (bufferEnd - bufferStart >= numBytes) {
     bufferStart += numBytes;
     return;
   }

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -140,6 +140,10 @@ inline bool SelectiveStringDirectColumnReader::try8Consecutive(
     int32_t start,
     const int32_t* rows,
     int32_t row) {
+  // If we haven't read in a buffer yet.
+  if (!bufferStart_) {
+    return false;
+  }
   const char* data = bufferStart_ + start + bytesToSkip_;
   if (!data || bufferEnd_ - data < start + 8 * 12) {
     return false;
@@ -251,7 +255,9 @@ folly::StringPiece SelectiveStringDirectColumnReader::readValue(
     int32_t length) {
   skipBytes(bytesToSkip_, blobStream_.get(), bufferStart_, bufferEnd_);
   bytesToSkip_ = 0;
-  if (bufferStart_ + length <= bufferEnd_) {
+  // bufferStart_ may be null if length is 0 and this is the first string
+  // we're reading.
+  if (bufferEnd_ - bufferStart_ >= length) {
     bytesToSkip_ = length;
     return folly::StringPiece(bufferStart_, length);
   }

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -96,7 +96,7 @@ class EncryptedStatsTest : public Test {
 
     reader_ = std::make_unique<ReaderBase>(
         *scopedPool_,
-        nullptr,
+        std::make_unique<MemoryInputStream>(nullptr, 0),
         std::move(ps),
         footer,
         nullptr,

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <velox/dwio/common/MemoryInputStream.h>
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -67,7 +68,7 @@ class StripeLoadKeysTest : public Test {
 
     reader_ = std::make_unique<ReaderBase>(
         scopedPool_->getPool(),
-        nullptr,
+        std::make_unique<MemoryInputStream>(nullptr, 0),
         nullptr,
         footer,
         nullptr,

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -398,7 +398,12 @@ TEST(StripeStream, readEncryptedStreams) {
   *stripeFooter->add_encryptiongroups() = "";
 
   auto readerBase = std::make_shared<ReaderBase>(
-      pool, nullptr, std::move(ps), footer, nullptr, std::move(handler));
+      pool,
+      std::make_unique<MemoryInputStream>(nullptr, 0),
+      std::move(ps),
+      footer,
+      nullptr,
+      std::move(handler));
   auto stripeReader =
       std::make_unique<StripeReaderBase>(readerBase, stripeFooter);
   ColumnSelector selector{readerBase->getSchema(), {1, 2, 4}, true};
@@ -458,7 +463,12 @@ TEST(StripeStream, schemaMismatch) {
   pw.writeProto(*stripeFooter->add_encryptiongroups(), group, encrypter);
 
   auto readerBase = std::make_shared<ReaderBase>(
-      pool, nullptr, std::move(ps), footer, nullptr, std::move(handler));
+      pool,
+      std::make_unique<MemoryInputStream>(nullptr, 0),
+      std::move(ps),
+      footer,
+      nullptr,
+      std::move(handler));
   auto stripeReader =
       std::make_unique<StripeReaderBase>(readerBase, stripeFooter);
   // now, we read the file as if schema has changed

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -251,7 +251,7 @@ void PrestoHasher::hash<TypeKind::ROW>(
     // Hash only timestamp value.
     children_[0]->hash(baseRow->childAt(0), elementRows, childHashes);
     rows.applyToSelected([&](auto row) {
-      if (!baseRow->isNullAt(row)) {
+      if (!baseRow->isNullAt(indices[row])) {
         rawHashes[row] = rowChildHashes[indices[row]];
       } else {
         rawHashes[row] = 0;

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -88,7 +88,7 @@ class PrestoHasherTest : public testing::Test,
 
     for (size_t i = 0; i < vectorSize; ++i) {
       rawIndices[i] = i / 2;
-      modifiedExpected[i] = expected[i / 2];
+      modifiedExpected.push_back(expected[i / 2]);
     }
 
     dictionaryVector = BaseVector::wrapInDictionary(
@@ -98,6 +98,7 @@ class PrestoHasherTest : public testing::Test,
 
     // Subset of rows.
     auto subsetSize = vectorSize / 2;
+    modifiedExpected.resize(subsetSize);
     for (size_t i = 0; i < subsetSize; ++i) {
       rawIndices[i] = i * 2;
       modifiedExpected[i] = expected[i * 2];

--- a/velox/row/UnsafeRow24Deserializer.cpp
+++ b/velox/row/UnsafeRow24Deserializer.cpp
@@ -270,16 +270,19 @@ ArrayVectorPtr DeserializeArray(
       std::vector<const char*> elements(offsets[numArrays]);
       int elementCount = 0;
       for (int i = 0; i < numArrays; ++i) {
-        int64_t arrayLength = sizes[i];
-        const char* elementNulls = arrays[i] + sizeof(int64_t);
-        const char* elementPointer = elementNulls + nullSizeBytes(arrayLength);
-        for (int e = 0; e < arrayLength; ++e) {
-          elementBases[elementCount] = arrays[i];
-          elements[elementCount++] =
-              bits::isBitSet(elementNulls, e) ? nullptr : elementPointer;
-          elementPointer += sizeof(int64_t);
+        if (arrays[i]) {
+          int64_t arrayLength = sizes[i];
+          const char* elementNulls = arrays[i] + sizeof(int64_t);
+          const char* elementPointer =
+              elementNulls + nullSizeBytes(arrayLength);
+          for (int e = 0; e < arrayLength; ++e) {
+            elementBases[elementCount] = arrays[i];
+            elements[elementCount++] =
+                bits::isBitSet(elementNulls, e) ? nullptr : elementPointer;
+            elementPointer += sizeof(int64_t);
+          }
+          DCHECK_EQ(elementCount, offsets[i] + sizes[i]);
         }
-        DCHECK_EQ(elementCount, offsets[i] + sizes[i]);
       }
       elementsVector =
           DeserializeVariableLength(elementType, pool, elementBases, elements);


### PR DESCRIPTION
Summary:
Running the tests with a stricter ASAN exposed 1 actual bug, and a few places where we're  abusing pointers.

BUG: When hashing Rows (including timestamps with timezones) we were using the raw index instead of the decoded index at one point which was leading to incorrect results.  The test was broken because we had initialized a vector using a combination of reserve and [] instead of push_back, this was masking the issue in the test.

Other abuses:
1) This version of ASAN will not allow you to add scalars to nullptr.  We're comparing begin + size <= end in a bunch of places where begin and end are pointers which can be null.  In these cases we're doing the right thing when they're null, so swapping the order to end - begin >= size works around the ASAN.
2) We frequently use Range(nullptr, size) to allow us to access the size of a range, without actually allocating a buffer for it (e.g. for skipped ranges we want to skip over but not actually store the contents of).  The constructor for Range hits issue 1, casting the size to pointer works around the issue, while still allowing us to avoid the allocation.
3) In a bunch of tests we were initializing ReaderBase with a nullptr for stream, but ReaderBase dereferences stream in its constructor.  I have no idea how this was working, but I fixed it by passing in an empty MemoryInputStream.
4) In KllSketch, we were accessing values off the end of the vector using [].  It's using the address of the value off the end of the vector like the end() iterator.  I changed the logic to explicitly use pointer arithmetic on the vector's underlying array.

Differential Revision: D35988905

