### PR TITLE
Update RawScanState filterCache after ScanState filterCache resize

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -84,6 +84,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
         strideLenVInt,
         INT_BYTE_SIZE);
   }
+  scanState_.updateRawState();
 }
 
 uint64_t SelectiveStringDictionaryColumnReader::skip(uint64_t numValues) {
@@ -145,13 +146,13 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
 
     loadDictionary(
         *strideDictStream_, *strideDictLengthDecoder_, scanState_.dictionary2);
-    scanState_.updateRawState();
   }
   lastStrideIndex_ = nextStride;
   dictionaryValues_ = nullptr;
 
   scanState_.filterCache.resize(
       scanState_.dictionary.numValues + scanState_.dictionary2.numValues);
+  scanState_.updateRawState();
   simd::memset(
       scanState_.filterCache.data() + scanState_.dictionary.numValues,
       FilterResult::kUnknown,


### PR DESCRIPTION
Summary:
RawScanState is not updated after the changing of the filterCache buffer location.

filterCache buffer location got changed after calling resize() and the raw pointer of filterCache_ in RawScanState still points to the original one.

This causes silent heap used after free exception sometimes. This issue was discovered by ASAN

Differential Revision: D36015102

