### PR TITLE
clamp produces undefined behavior

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -169,6 +169,7 @@ struct ClampFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void
   call(TInput& result, const TInput& v, const TInput& lo, const TInput& hi) {
+    VELOX_USER_CHECK_LE(lo, hi, "Lo > hi in clamp.");
     result = std::clamp(v, lo, hi);
   }
 };

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -572,5 +572,28 @@ TEST_F(ArithmeticTest, pi) {
   EXPECT_EQ(piValue(), M_PI);
 }
 
+TEST_F(ArithmeticTest, clamp) {
+  const auto clamp = [&](std::optional<int64_t> v,
+                         std::optional<int64_t> lo,
+                         std::optional<int64_t> hi) {
+    return evaluateOnce<int64_t>("clamp(c0, c1, c2)", v, lo, hi);
+  };
+
+  // lo < v < hi => v.
+  EXPECT_EQ(0, clamp(0, -1, 1));
+  // v < lo => lo.
+  EXPECT_EQ(-1, clamp(-2, -1, 1));
+  // v > hi => hi.
+  EXPECT_EQ(1, clamp(2, -1, 1));
+  // v == lo => v.
+  EXPECT_EQ(-1, clamp(-1, -1, 1));
+  // v == hi => v.
+  EXPECT_EQ(1, clamp(1, -1, 1));
+  // lo == hi != v => lo.
+  EXPECT_EQ(-1, clamp(2, -1, -1));
+  // lo > hi => VeloxUserError.
+  EXPECT_THROW(clamp(0, 1, -1), VeloxUserError);
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
The clamp UDF is just a wrapper around std::clamp which is documented to have
undefined behavior when lo > hi.

In some implementations there is an assert that crashes the process if lo > hi (how I
discovered the issue).

I checked and could not find a clamp UDF in Presto (since this function is defined in
prestosql/Artithmetic.h).

Free to choose the behavior I added a user check that throws an exception (instead of
crashing with SIGABRT) when lo > hi.

Reviewed By: mbasmanova

Differential Revision: D36018659

