### PR TITLE
Ensure we don't evaluate arguments for rows with an error

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -128,6 +128,7 @@ void EvalCtx::saveAndReset(ContextSaver* saver, const SelectivityVector& rows) {
   saver->wrap = std::move(wrap_);
   saver->wrapNulls = std::move(wrapNulls_);
   saver->wrapEncoding = wrapEncoding_;
+  saver->constantWrapIndex = constantWrapIndex_;
   wrapEncoding_ = VectorEncoding::Simple::FLAT;
   saver->nullsPruned = nullsPruned_;
   nullsPruned_ = false;
@@ -199,6 +200,7 @@ void EvalCtx::restore(ContextSaver* saver) {
   wrap_ = std::move(saver->wrap);
   wrapNulls_ = std::move(saver->wrapNulls);
   wrapEncoding_ = saver->wrapEncoding;
+  constantWrapIndex_ = saver->constantWrapIndex;
   finalSelection_ = saver->finalSelection;
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -237,6 +237,7 @@ struct ContextSaver {
   BufferPtr wrap;
   BufferPtr wrapNulls;
   VectorEncoding::Simple wrapEncoding;
+  vector_size_t constantWrapIndex;
   bool nullsPruned = false;
   // The selection of the context being saved.
   const SelectivityVector* rows;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1169,6 +1169,10 @@ void Expr::applySingleConstArgVectorFunction(
     args = {inputValue->valueVector()};
   }
 
+  ContextSaver saver;
+  context->saveAndReset(&saver, rows);
+  context->setConstantWrap(inputRow);
+
   VectorPtr tempResult;
   vectorFunction_->apply(*inputRows, args, type(), context, &tempResult);
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -956,24 +956,24 @@ void Expr::evalAll(
         return;
       }
     }
-  }
 
-  // If any errors occurred evaluating the arguments, it's possible (even
-  // likely) that the values for those arguments were not defined which could
-  // lead to undefined behavior if we try to evaluate the current function on
-  // them.  It's safe to skip evaluating them since the value for this branch
-  // of the expression tree will be NULL for those rows anyway.
-  if (context->errors()) {
-    if (remainingRows == &rows) {
-      nonNulls.allocate(rows.end());
-      *nonNulls.get() = rows;
-      remainingRows = nonNulls.get();
-    }
-    deselectErrors(context, *nonNulls.get());
-    if (!remainingRows->hasSelections()) {
-      inputValues_.clear();
-      setAllNulls(rows, context, result);
-      return;
+    // If any errors occurred evaluating the arguments, it's possible (even
+    // likely) that the values for those arguments were not defined which could
+    // lead to undefined behavior if we try to evaluate the current function on
+    // them.  It's safe to skip evaluating them since the value for this branch
+    // of the expression tree will be NULL for those rows anyway.
+    if (context->errors()) {
+      if (remainingRows == &rows) {
+        nonNulls.allocate(rows.end());
+        *nonNulls.get() = rows;
+        remainingRows = nonNulls.get();
+      }
+      deselectErrors(context, *nonNulls.get());
+      if (!remainingRows->hasSelections()) {
+        inputValues_.clear();
+        setAllNulls(rows, context, result);
+        return;
+      }
     }
   }
 

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -195,4 +195,19 @@ TEST_F(TryExprTest, evalSimplified) {
 
   assertEqualVectors(makeNullableFlatVector(expected), result);
 }
+
+TEST_F(TryExprTest, skipExecutionEvalSimplified) {
+  registerFunction<CountCallsFunction, int64_t, int64_t>(
+      {"count_calls"}, BIGINT());
+
+  std::vector<std::optional<int64_t>> expected{
+      0, std::nullopt, 1, std::nullopt, 2};
+  auto flatVector = makeFlatVector<StringView>(expected.size(), [&](auto row) {
+    return expected[row].has_value() ? "1" : "a";
+  });
+  auto result = evaluateSimplified<FlatVector<int64_t>>(
+      "try(count_calls(cast(c0 as integer)))", makeRowVector({flatVector}));
+
+  assertEqualVectors(makeNullableFlatVector(expected), result);
+}
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
While running the ExpressionFuzzer I noticed an inconsistency in the behavior of eval and
evalSimplified when wrapped with TRY.  With evalSimplified as soon as an expression
throws an exception for a given row, if that expression is an argument to a parent
expression, we won't evaluate the other arguments to that function at that row.  With eval
though, if the other arguments receive inputs that go through peeling we still evaluate them.

This comes from the fact that errors are not propagated to the new EvalContext that's
produced after peeling (though they are propagated back out of the EvalContext after
evaluation).  In addition, we only deselect the rows with errors right before evaluating the
function.  So when the argument is evaluated, it's lost the errors from its context, and
doesn't know to deselect certain rows.

Any attempt to figure this out would be complicated by the encoding, e.g. with peeled dictionary encoding rows after peeling don't map directly to rows before peeling.  An easy way to make sure we get it correct is to deselect the errors after immediately evaluating an
argument.  Going back to the dictionary encoding example, this way if all rows with a
particular value in the dictionary threw an exception, those rows will be excluded from
later evaluation and the value will naturally be skipped.

The cost of this approach is that we'll now invoke deselect errors for all arguments, even
SpecialForms.  Previously, it would only be invoked for evaluating expressions that weren't
SpecialForms.

Differential Revision: D36026546

