### PR TITLE
Remove Operator::output_ member variable

### DIFF
--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -71,16 +71,13 @@ bool AssignUniqueId::isFinished() {
 }
 
 void AssignUniqueId::generateIdColumn(vector_size_t size) {
-  // Try to re-use memory for the ID vector. This method populates results_[0],
-  // then getOutput() std::move's it into last child of output_.
-  VectorPtr result;
-  if (output_ && output_.unique()) {
-    BaseVector::prepareForReuse(output_->children().back(), size);
-    result = output_->children().back();
+  // Re-use memory for the ID vector if possible.
+  VectorPtr& result = results_[0];
+  if (result && result.unique()) {
+    BaseVector::prepareForReuse(result, size);
   } else {
     result = BaseVector::create(BIGINT(), size, pool());
   }
-  results_[0] = result;
 
   auto rawResults =
       result->asUnchecked<FlatVector<int64_t>>()->mutableRawValues();

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -62,12 +62,6 @@ class FilterProject : public Operator {
   // should return nullptr.
   bool allInputProcessed();
 
-  // Clears references to non-reusable vectors from 'output_' once an
-  // input is fully processed. This makes it more likely that
-  // producers will have singly referenced reusable vectors for the
-  // next batch.
-  void clearNonReusableOutput();
-
   // Evaluate filter on all rows. Return number of rows that passed the filter.
   // Populate filterEvalCtx_.selectedBits and selectedIndices with the indices
   // of the passing rows if only some rows pass the filter. If all or no rows

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -386,6 +386,15 @@ RowVectorPtr HashProbe::getNonMatchingOutputForRightJoin() {
   return output_;
 }
 
+void HashProbe::clearIdentityProjectedOutput() {
+  if (!output_ || !output_.unique()) {
+    return;
+  }
+  for (auto& projection : identityProjections_) {
+    output_->childAt(projection.outputChannel) = nullptr;
+  }
+}
+
 RowVectorPtr HashProbe::getOutput() {
   clearIdentityProjectedOutput();
   if (!input_) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -67,6 +67,14 @@ class HashProbe : public Operator {
   // Populate output columns.
   void fillOutput(vector_size_t size);
 
+  // Clears the columns of 'output_' that are projected from
+  // 'input_'. This should be done when preparing to produce a next
+  // batch of output to drop any lingering references to row
+  // number mappings or input vectors. In this way input vectors do
+  // not have to be copied and will be singly referenced by their
+  // producer.
+  void clearIdentityProjectedOutput();
+
   // Populate output columns with build-side rows that didn't match join
   // condition.
   RowVectorPtr getNonMatchingOutputForRightJoin();
@@ -187,6 +195,8 @@ class HashProbe : public Operator {
   // Keeps track of returned results between successive batches of
   // output for a batch of input.
   BaseHashTable::JoinResultIterator results_;
+
+  RowVectorPtr output_;
 
   // Input rows with no nulls in the join keys.
   SelectivityVector nonNullRows_;

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -72,6 +72,8 @@ class Merge : public SourceOperator {
   /// Used to merge data from two or more sources.
   std::unique_ptr<TreeOfLosers<SourceStream>> treeOfLosers_;
 
+  RowVectorPtr output_;
+
   /// Number of rows accumulated in 'output_' so far.
   vector_size_t outputSize_{0};
 

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -383,6 +383,8 @@ class MergeJoin : public Operator {
   /// A set of rows with matching keys on the right side.
   std::optional<Match> rightMatch_;
 
+  RowVectorPtr output_;
+
   /// Number of rows accumulated in the output_.
   vector_size_t outputSize_;
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -130,38 +130,6 @@ const std::string& OperatorCtx::taskId() const {
   return driverCtx_->task->taskId();
 }
 
-VectorPtr Operator::getResultVector(ChannelIndex index) {
-  // If there is a singly referenced results vector and it has a
-  // singly referenced flat child with singly referenced buffers, the
-  // child can be reused.
-  if (!output_ || !output_.unique()) {
-    return nullptr;
-  }
-
-  VectorPtr& vector = output_->childAt(index);
-  if (!vector) {
-    return nullptr;
-  }
-
-  if (BaseVector::isReusableFlatVector(vector)) {
-    vector->resize(0);
-    return std::move(vector);
-  }
-
-  return nullptr;
-}
-
-void Operator::getResultVectors(std::vector<VectorPtr>* result) {
-  if (resultProjections_.empty()) {
-    return;
-  }
-  result->resize(resultProjections_.back().inputChannel + 1);
-  for (auto& projection : resultProjections_) {
-    (*result)[projection.inputChannel] =
-        getResultVector(projection.outputChannel);
-  }
-}
-
 static bool isSequence(
     const vector_size_t* numbers,
     vector_size_t start,
@@ -184,19 +152,7 @@ RowVectorPtr Operator::fillOutput(vector_size_t size, BufferPtr mapping) {
     wrapResults = false;
   }
 
-  if (output_.unique()) {
-    output_->resize(size);
-  } else {
-    std::vector<VectorPtr> localColumns(outputType_->size());
-    output_ = std::make_shared<RowVector>(
-        operatorCtx_->pool(),
-        outputType_,
-        BufferPtr(nullptr),
-        size,
-        std::move(localColumns),
-        0 /*nullCount*/);
-  }
-  auto& columns = output_->children();
+  std::vector<VectorPtr> columns(outputType_->size());
   if (!identityProjections_.empty()) {
     auto input = input_->children();
     for (auto& projection : identityProjections_) {
@@ -207,31 +163,16 @@ RowVectorPtr Operator::fillOutput(vector_size_t size, BufferPtr mapping) {
   }
   for (auto& projection : resultProjections_) {
     columns[projection.outputChannel] = wrapResults
-        ? wrapChild(size, mapping, std::move(results_[projection.inputChannel]))
-        : std::move(results_[projection.inputChannel]);
+        ? wrapChild(size, mapping, results_[projection.inputChannel])
+        : results_[projection.inputChannel];
   }
-  return output_;
-}
 
-void Operator::inputProcessed() {
-  input_ = nullptr;
-  if (!output_.unique()) {
-    output_ = nullptr;
-    return;
-  }
-  auto& columns = output_->children();
-  for (auto& projection : identityProjections_) {
-    columns[projection.outputChannel] = nullptr;
-  }
-}
-
-void Operator::clearIdentityProjectedOutput() {
-  if (!output_ || !output_.unique()) {
-    return;
-  }
-  for (auto& projection : identityProjections_) {
-    output_->childAt(projection.outputChannel) = nullptr;
-  }
+  return std::make_shared<RowVector>(
+      operatorCtx_->pool(),
+      outputType_,
+      BufferPtr(nullptr),
+      size,
+      std::move(columns));
 }
 
 void Operator::recordBlockingTime(uint64_t start) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -306,7 +306,6 @@ class Operator {
   // should be called after this.
   virtual void close() {
     input_ = nullptr;
-    output_ = nullptr;
     results_.clear();
   }
 
@@ -355,31 +354,9 @@ class Operator {
  protected:
   static std::vector<std::unique_ptr<PlanNodeTranslator>>& translators();
 
-  // Clears the columns of 'output_' that are projected from
-  // 'input_'. This should be done when preparing to produce a next
-  // batch of output to drop any lingering references to row
-  // number mappings or input vectors. In this way input vectors do
-  // not have to be copied and will be singly referenced by their
-  // producer.
-  void clearIdentityProjectedOutput();
-
-  // Returns a previously used result vector if it exists and is suitable for
-  // reuse, nullptr otherwise.
-  VectorPtr getResultVector(ChannelIndex index);
-
-  // Fills 'result' with a vector for each input of
-  // 'resultProjection_'. These are recycled from 'output_' if
-  // suitable for reuse.
-  void getResultVectors(std::vector<VectorPtr>* result);
-
-  // Copies 'input_' and 'results_' into 'output_' according to
+  // Creates output vector from 'input_' and 'results_' according to
   // 'identityProjections_' and 'resultProjections_'.
   RowVectorPtr fillOutput(vector_size_t size, BufferPtr mapping);
-
-  // Drops references to identity projected columns from 'output_' and
-  // clears 'input_'. The producer will see its vectors as singly
-  // referenced.
-  void inputProcessed();
 
   std::unique_ptr<OperatorCtx> operatorCtx_;
   OperatorStats stats_;
@@ -388,10 +365,6 @@ class Operator {
   // Holds the last data from addInput until it is processed. Reset after the
   // input is processed.
   RowVectorPtr input_;
-
-  // Holds the last data returned by getOutput. References vectors
-  // from 'input_' and from 'results_'. Reused if singly referenced.
-  RowVectorPtr output_;
 
   bool noMoreInput_ = false;
   std::vector<IdentityProjection> identityProjections_;

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -186,6 +186,7 @@ class PartitionedOutput : public Operator {
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
   memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  RowVectorPtr output_;
 
   // Reusable memory.
   SelectivityVector rows_;

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include <immintrin.h>
 
 #include <folly/hash/Hash.h>
 
+#include <velox/vector/BaseVector.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/vector/BuilderTypeUtils.h"
@@ -229,7 +229,11 @@ void FlatVector<T>::copyValuesAndNulls(
   }
   if (source->encoding() == VectorEncoding::Simple::FLAT) {
     auto flat = source->asUnchecked<FlatVector<T>>();
-    if (source->typeKind() != TypeKind::UNKNOWN) {
+    if (flat->values()->size() == 0) {
+      // The vector must have all-null values.
+      VELOX_CHECK_EQ(
+          BaseVector::countNulls(flat->nulls(), 0, flat->size()), flat->size());
+    } else if (source->typeKind() != TypeKind::UNKNOWN) {
       if (Buffer::is_pod_like_v<T>) {
         memcpy(
             &rawValues_[targetIndex],


### PR DESCRIPTION
Part of #1237

Refactor Operator::fillOutput to not use output_ member variable, but instead
create a new RowVector from input_ and results_.

Refactor FilterProject and AssignUniqueId operator to stop using output_ member
variable and store computed values in results_.

Remove no longer needed Operator::getResultVectors, Operator::getResultVector
and Operator::inputProcessed methods.

Remove no longer needed FilterProject::clearNonReusableOutput method.

Move Operator::clearIdentityProjectedOutput to HashProbe as this is the only 
remaining user.

Finally move Operator::output_ member variable to a few operators that still use it.

Follow-up PRs need to add tests to check memory allocations for each of the 
operators and fix operators that do not reuse memory when possible.