### PR TITLE
Add memory allocations to printPlanWithStats

### DIFF
--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -33,12 +33,13 @@ struct IdentityProjection {
 };
 
 struct MemoryStats {
-  uint64_t userMemoryReservation = {};
-  uint64_t revocableMemoryReservation = {};
-  uint64_t systemMemoryReservation = {};
-  uint64_t peakUserMemoryReservation = {};
-  uint64_t peakSystemMemoryReservation = {};
-  uint64_t peakTotalMemoryReservation = {};
+  uint64_t userMemoryReservation{0};
+  uint64_t revocableMemoryReservation{0};
+  uint64_t systemMemoryReservation{0};
+  uint64_t peakUserMemoryReservation{0};
+  uint64_t peakSystemMemoryReservation{0};
+  uint64_t peakTotalMemoryReservation{0};
+  uint64_t numMemoryAllocations{0};
 
   void update(const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
     if (!tracker) {
@@ -49,6 +50,7 @@ struct MemoryStats {
     peakUserMemoryReservation = tracker->getPeakUserBytes();
     peakSystemMemoryReservation = tracker->getPeakSystemBytes();
     peakTotalMemoryReservation = tracker->getPeakTotalBytes();
+    numMemoryAllocations = tracker->getNumAllocs();
   }
 
   void add(const MemoryStats& other) {
@@ -61,6 +63,7 @@ struct MemoryStats {
         peakSystemMemoryReservation, other.peakSystemMemoryReservation);
     peakTotalMemoryReservation =
         std::max(peakTotalMemoryReservation, other.peakTotalMemoryReservation);
+    numMemoryAllocations += other.numMemoryAllocations;
   }
 
   void clear() {
@@ -70,6 +73,7 @@ struct MemoryStats {
     peakUserMemoryReservation = 0;
     peakSystemMemoryReservation = 0;
     peakTotalMemoryReservation = 0;
+    numMemoryAllocations = 0;
   }
 };
 

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -48,6 +48,7 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   blockedWallNanos += stats.blockedWallNanos;
 
   peakMemoryBytes += stats.memoryStats.peakTotalMemoryReservation;
+  numMemoryAllocations += stats.memoryStats.numMemoryAllocations;
 
   for (const auto& [name, runtimeStats] : stats.runtimeStats) {
     if (UNLIKELY(customStats.count(name) == 0)) {
@@ -83,7 +84,8 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
       << ")"
       << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
-      << ", Peak memory: " << succinctBytes(peakMemoryBytes);
+      << ", Peak memory: " << succinctBytes(peakMemoryBytes)
+      << ", Memory allocations: " << numMemoryAllocations;
 
   if (numDrivers > 0) {
     out << ", Threads: " << numDrivers;

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -78,6 +78,8 @@ struct PlanNodeStats {
   /// operator instances were running concurrently.
   uint64_t peakMemoryBytes{0};
 
+  uint64_t numMemoryAllocations{0};
+
   /// Operator-specific counters.
   std::unordered_map<std::string, RuntimeMetric> customStats;
 


### PR DESCRIPTION
Include number of memory allocations per operator in the output of
printPlanWithStats. This number shows how much memory is re-used (or not).

```
-> Aggregation[SINGLE a0 := sum(ROW["k1"]), a1 := sum(ROW["k2"])]
   Output: 1 rows (64B), Cpu time: 41.28ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 5, Threads: 1
  -> Project[expressions: (k1:BIGINT, mod(ROW["t_k0"],1000)), (k2:BIGINT, mod(ROW["u_k0"],1000))]
     Output: 708000 rows (13.71MB), Cpu time: 115.39ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2101, Threads: 1
    -> HashJoin[INNER t_k0=u_k0]
       Output: 708000 rows (41.27MB), Cpu time: 101.70ms, Blocked wall time: 5.56ms, Peak memory: 2.00MB, Memory allocations: 12
       HashBuild: Input: 8000 rows (241.25KB), Output: 0 rows (0B), Cpu time: 5.56ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 6, Threads: 1
       HashProbe: Input: 100000 rows (2.36MB), Output: 708000 rows (41.27MB), Cpu time: 96.14ms, Blocked wall time: 5.56ms, Peak memory: 1.00MB, Memory allocations: 6, Threads: 1
      -> Values[100000 rows in 100 vectors]
         Input: 0 rows (0B), Output: 100000 rows (2.36MB), Cpu time: 213.97us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
      -> Values[8000 rows in 10 vectors]
         Input: 0 rows (0B), Output: 8000 rows (241.25KB), Cpu time: 28.76us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
```