### PR TITLE
Upgrade DuckDB to v0.3.5-dev256

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -74,8 +74,9 @@ std::string normalizeFuncName(std::string input) {
   return (it == kLookup.end()) ? input : it->second;
 }
 
-// Convert duckDB operator name to Velox function. Coalesce and subscript needs
-// special treatment because `ExpressionTypeToOperator` returns an empty string.
+// Convert duckDB operator name to Velox function. Some expression types such as
+// coalesce and subscript need special treatment because
+// `ExpressionTypeToOperator` returns an empty string.
 std::string duckOperatorToVelox(ExpressionType type) {
   switch (type) {
     case ExpressionType::OPERATOR_IS_NULL:
@@ -86,6 +87,8 @@ std::string duckOperatorToVelox(ExpressionType type) {
       return "subscript";
     case ExpressionType::COMPARE_IN:
       return "in";
+    case ExpressionType::OPERATOR_NOT:
+      return "not";
     default:
       return normalizeFuncName(ExpressionTypeToOperator(type));
   }

--- a/velox/duckdb/functions/DuckFunctions.cpp
+++ b/velox/duckdb/functions/DuckFunctions.cpp
@@ -578,8 +578,9 @@ class DuckDBFunction : public exec::VectorFunction {
     auto result = std::make_unique<DuckDBFunctionData>();
     result->inputTypes = move(inputTypes);
     std::string error;
+    bool castParameters;
     result->functionIndex = ::duckdb::Function::BindFunction(
-        set_[0].name, set_, result->inputTypes, error);
+        set_[0].name, set_, result->inputTypes, error, castParameters);
     if (result->functionIndex >= set_.size()) {
       // binding error: cannot bind this function with the provided parameters
       throw std::runtime_error(error);

--- a/velox/dwio/parquet/reader/duckdb/InputStreamFileSystem.h
+++ b/velox/dwio/parquet/reader/duckdb/InputStreamFileSystem.h
@@ -110,7 +110,8 @@ class InputStreamFileSystem : public ::duckdb::FileSystem {
 
   bool ListFiles(
       const std::string& /*directory*/,
-      const std::function<void(std::string, bool)>& /*callback*/) override {
+      const std::function<void(const std::string&, bool)>& /*callback*/)
+      override {
     VELOX_NYI();
   }
 
@@ -131,7 +132,9 @@ class InputStreamFileSystem : public ::duckdb::FileSystem {
     VELOX_NYI();
   }
 
-  std::vector<std::string> Glob(const std::string& /*path*/) override {
+  std::vector<std::string> Glob(
+      const std::string& /*path*/,
+      ::duckdb::FileOpener* /*opener*/ = nullptr) override {
     VELOX_NYI();
   }
 

--- a/velox/external/duckdb/parquet-amalgamation.hpp
+++ b/velox/external/duckdb/parquet-amalgamation.hpp
@@ -7133,7 +7133,7 @@ public:
 			throw std::runtime_error("Decode bit width too large");
 		}
 		byte_encoded_len = ((bit_width_ + 7) / 8);
-		max_val = (1 << bit_width_) - 1;
+		max_val = (uint64_t(1) << bit_width_) - 1;
 	}
 
 	template <typename T>
@@ -7185,12 +7185,12 @@ private:
 	ByteBuffer buffer_;
 
 	/// Number of bits needed to encode the value. Must be between 0 and 64.
-	int bit_width_;
+	uint32_t bit_width_;
 	uint64_t current_value_;
 	uint32_t repeat_count_;
 	uint32_t literal_count_;
 	uint8_t byte_encoded_len;
-	uint32_t max_val;
+	uint64_t max_val;
 
 	uint8_t bitpack_pos = 0;
 
@@ -7410,12 +7410,16 @@ public:
 
 	virtual void Skip(idx_t num_values);
 
-	const LogicalType &Type();
-	const SchemaElement &Schema();
+	ParquetReader &Reader();
+	const LogicalType &Type() const;
+	const SchemaElement &Schema() const;
+	idx_t FileIdx() const;
+	idx_t MaxDefine() const;
+	idx_t MaxRepeat() const;
 
 	virtual idx_t GroupRowsAvailable();
 
-	unique_ptr<BaseStatistics> Stats(const std::vector<ColumnChunk> &columns);
+	virtual unique_ptr<BaseStatistics> Stats(const std::vector<ColumnChunk> &columns);
 
 protected:
 	// readers that use the default Read() need to implement those
@@ -7574,10 +7578,17 @@ public:
 	    : ParquetReader(allocator, move(file_handle_p), vector<LogicalType>(), string()) {
 	}
 
-	ParquetReader(ClientContext &context, string file_name, const vector<LogicalType> &expected_types_p,
+	ParquetReader(ClientContext &context, string file_name, const vector<string> &names,
+	              const vector<LogicalType> &expected_types_p, const vector<column_t> &column_ids,
 	              ParquetOptions parquet_options, const string &initial_filename = string());
 	ParquetReader(ClientContext &context, string file_name, ParquetOptions parquet_options)
-	    : ParquetReader(context, move(file_name), vector<LogicalType>(), parquet_options, string()) {
+	    : ParquetReader(context, move(file_name), vector<string>(), vector<LogicalType>(), vector<column_t>(),
+	                    parquet_options, string()) {
+	}
+	ParquetReader(ClientContext &context, string file_name, const vector<LogicalType> &expected_types_p,
+	              ParquetOptions parquet_options)
+	    : ParquetReader(context, move(file_name), vector<string>(), expected_types_p, vector<column_t>(),
+	                    parquet_options, string()) {
 	}
 	~ParquetReader();
 
@@ -7604,7 +7615,8 @@ public:
 	static LogicalType DeriveLogicalType(const SchemaElement &s_ele, bool binary_as_string);
 
 private:
-	void InitializeSchema(const vector<LogicalType> &expected_types_p, const string &initial_filename_p);
+	void InitializeSchema(const vector<string> &names, const vector<LogicalType> &expected_types_p,
+	                      const vector<column_t> &column_ids, const string &initial_filename_p);
 	bool ScanInternal(ParquetReaderScanState &state, DataChunk &output);
 	unique_ptr<ColumnReader> CreateReader(const duckdb_parquet::format::FileMetaData *file_meta_data);
 
@@ -7623,6 +7635,12 @@ private:
 
 private:
 	unique_ptr<FileHandle> file_handle;
+	//! column-id map, used when reading multiple parquet files since separate parquet files might have columns at
+	//! different positions e.g. the first file might have column "a" at position 0, the second at position 1, etc
+	vector<column_t> column_id_map;
+	//! Map of column_id -> cast, used when reading multiple parquet files when parquet files have diverging types
+	//! for the same column
+	unordered_map<column_t, LogicalType> cast_map;
 };
 
 } // namespace duckdb

--- a/velox/external/duckdb/tpch/dbgen/bm_utils.cpp
+++ b/velox/external/duckdb/tpch/dbgen/bm_utils.cpp
@@ -446,7 +446,7 @@ set_state(int table, long sf, long procs, long step, DSS_HUGE *extra_rows) {
 		/* need to set seeds of child in case there's a dependency */
 		/* NOTE: this assumes that the parent and child have the same base row
 		 * count */
-		if (tdefs[table].child != DBGEN_NONE)
+		if (tdefs[table].child != NONE)
 			tdefs[tdefs[table].child].gen_seed(0, rowcount);
 	}
 	if (step > procs) /* moving to the end to generate updates */

--- a/velox/external/duckdb/tpch/dbgen/dbgen.cpp
+++ b/velox/external/duckdb/tpch/dbgen/dbgen.cpp
@@ -28,7 +28,7 @@ seed_t DBGenGlobals::Seed[MAX_STREAM + 1] = {
     {PART, 1841581359, 0, 1},                  /* P_TYPE_SD    2 */
     {PART, 1193163244, 0, 1},                  /* P_SIZE_SD    3 */
     {PART, 727633698, 0, 1},                   /* P_CNTR_SD    4 */
-    {DBGEN_NONE, 933588178, 0, 1},                   /* text pregeneration  5 */
+    {NONE, 933588178, 0, 1},                   /* text pregeneration  5 */
     {PART, 804159733, 0, 2},                   /* P_CMNT_SD    6 */
     {PSUPP, 1671059989, 0, SUPP_PER_PART},     /* PS_QTY_SD    7 */
     {PSUPP, 1051288424, 0, SUPP_PER_PART},     /* PS_SCST_SD   8 */
@@ -75,15 +75,15 @@ seed_t DBGenGlobals::Seed[MAX_STREAM + 1] = {
 double DBGenGlobals::dM = 2147483647.0;
 tdef DBGenGlobals::tdefs[10] = {
     {"part.tbl", "part table", 200000, NULL, NULL, PSUPP, 0},
-    {"partsupp.tbl", "partsupplier table", 200000, NULL, NULL, DBGEN_NONE, 0},
-    {"supplier.tbl", "suppliers table", 10000, NULL, NULL, DBGEN_NONE, 0},
-    {"customer.tbl", "customers table", 150000, NULL, NULL, DBGEN_NONE, 0},
+    {"partsupp.tbl", "partsupplier table", 200000, NULL, NULL, NONE, 0},
+    {"supplier.tbl", "suppliers table", 10000, NULL, NULL, NONE, 0},
+    {"customer.tbl", "customers table", 150000, NULL, NULL, NONE, 0},
     {"orders.tbl", "order table", 150000, NULL, NULL, LINE, 0},
-    {"lineitem.tbl", "lineitem table", 150000, NULL, NULL, DBGEN_NONE, 0},
+    {"lineitem.tbl", "lineitem table", 150000, NULL, NULL, NONE, 0},
     {"orders.tbl", "orders/lineitem tables", 150000, NULL, NULL, LINE, 0},
     {"part.tbl", "part/partsupplier tables", 200000, NULL, NULL, PSUPP, 0},
-    {"nation.tbl", "nation table", NATIONS_MAX, NULL, NULL, DBGEN_NONE, 0},
-    {"region.tbl", "region table", NATIONS_MAX, NULL, NULL, DBGEN_NONE, 0},
+    {"nation.tbl", "nation table", NATIONS_MAX, NULL, NULL, NONE, 0},
+    {"region.tbl", "region table", NATIONS_MAX, NULL, NULL, NONE, 0},
 };
 
 static seed_t *Seed = DBGenGlobals::Seed;

--- a/velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h
+++ b/velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h
@@ -40,7 +40,7 @@
 #define printf(...)
 #define fprintf(...)
 
-#define DBGEN_NONE -1
+#define NONE -1
 #define PART 0
 #define PSUPP 1
 #define SUPP 2

--- a/velox/external/duckdb/tpch/tpch-extension.cpp
+++ b/velox/external/duckdb/tpch/tpch-extension.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
+#include "duckdb/main/client_context.hpp"
 #endif
 
 #include "dbgen/dbgen.hpp"
@@ -26,12 +27,10 @@ struct DBGenFunctionData : public TableFunctionData {
 	bool overwrite = false;
 };
 
-static unique_ptr<FunctionData> DbgenBind(ClientContext &context, vector<Value> &inputs,
-                                          named_parameter_map_t &named_parameters,
-                                          vector<LogicalType> &input_table_types, vector<string> &input_table_names,
+static unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableFunctionBindInput &input,
                                           vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_unique<DBGenFunctionData>();
-	for (auto &kv : named_parameters) {
+	for (auto &kv : input.named_parameters) {
 		if (kv.first == "sf") {
 			result->sf = DoubleValue::Get(kv.second);
 		} else if (kv.first == "schema") {
@@ -48,7 +47,7 @@ static unique_ptr<FunctionData> DbgenBind(ClientContext &context, vector<Value> 
 }
 
 static void DbgenFunction(ClientContext &context, const FunctionData *bind_data, FunctionOperatorData *operator_state,
-                          DataChunk *input, DataChunk &output) {
+                          DataChunk &output) {
 	auto &data = (DBGenFunctionData &)*bind_data;
 	if (data.finished) {
 		return;
@@ -71,9 +70,7 @@ unique_ptr<FunctionOperatorData> TPCHInit(ClientContext &context, const Function
 	return move(result);
 }
 
-static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, vector<Value> &inputs,
-                                              named_parameter_map_t &named_parameters,
-                                              vector<LogicalType> &input_table_types, vector<string> &input_table_names,
+static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, TableFunctionBindInput &input,
                                               vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("query_nr");
 	return_types.emplace_back(LogicalType::INTEGER);
@@ -85,7 +82,7 @@ static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, vector<Val
 }
 
 static void TPCHQueryFunction(ClientContext &context, const FunctionData *bind_data,
-                              FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
+                              FunctionOperatorData *operator_state, DataChunk &output) {
 	auto &data = (TPCHData &)*operator_state;
 	idx_t tpch_queries = 22;
 	if (data.offset >= tpch_queries) {
@@ -105,10 +102,7 @@ static void TPCHQueryFunction(ClientContext &context, const FunctionData *bind_d
 	output.SetCardinality(chunk_count);
 }
 
-static unique_ptr<FunctionData> TPCHQueryAnswerBind(ClientContext &context, vector<Value> &inputs,
-                                                    named_parameter_map_t &named_parameters,
-                                                    vector<LogicalType> &input_table_types,
-                                                    vector<string> &input_table_names,
+static unique_ptr<FunctionData> TPCHQueryAnswerBind(ClientContext &context, TableFunctionBindInput &input,
                                                     vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("query_nr");
 	return_types.emplace_back(LogicalType::INTEGER);
@@ -123,7 +117,7 @@ static unique_ptr<FunctionData> TPCHQueryAnswerBind(ClientContext &context, vect
 }
 
 static void TPCHQueryAnswerFunction(ClientContext &context, const FunctionData *bind_data,
-                                    FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
+                                    FunctionOperatorData *operator_state, DataChunk &output) {
 	auto &data = (TPCHData &)*operator_state;
 	idx_t tpch_queries = 22;
 	vector<double> scale_factors {0.01, 0.1, 1};
@@ -212,3 +206,7 @@ DUCKDB_EXTENSION_API const char *tpch_version() {
 	return duckdb::DuckDB::LibraryVersion();
 }
 }
+
+#ifndef DUCKDB_EXTENSION_MAIN
+#error DUCKDB_EXTENSION_MAIN not defined
+#endif


### PR DESCRIPTION
DuckDB recently fixed a bug with the `histogram` aggregation function (https://github.com/duckdb/duckdb/pull/3531). Upgrade DuckDB so that we can use it in tests.

Files velox/duckdb/conversion/DuckParser.cpp, velox/duckdb/functions/DuckFunctions.cpp, and velox/dwio/parquet/reader/duckdb/InputStreamFileSystem.h are manually modified. Other files are generated automatically according to https://github.com/facebookincubator/velox/tree/main/velox/duckdb#readme.