### PR TITLE
dwio: switch to platform010

### DIFF
--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -83,7 +83,9 @@ class ReaderBase {
         footer_{footer},
         cache_{std::move(cache)},
         handler_{std::move(handler)},
-        input_{std::make_unique<BufferedInput>(*stream_, pool_)},
+        input_{
+            stream_ ? std::make_unique<BufferedInput>(*stream_, pool_)
+                    : nullptr},
         schema_{
             std::dynamic_pointer_cast<const RowType>(convertType(*footer_))},
         fileLength_{0},


### PR DESCRIPTION
Summary:
We should all be migrating to platform010, for the improved performance of its
generated code and for its improved diagnostics/portability.

Reviewed By: sunnar

Differential Revision: D35573244

