### PR TITLE
Tighten plan node ID check in Task::addSplitXxx APIs

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -97,6 +97,14 @@ class PlanNode {
   virtual const std::vector<std::shared_ptr<const PlanNode>>& sources()
       const = 0;
 
+  /// Returns true if this is a leaf plan node and corresponding operator
+  /// requires splits to make progress. ValueNode is a leaf node that doesn't
+  /// require splits, but TableScanNode and ExchangeNode are leaf nodes that
+  /// require splits.
+  virtual bool requiresSplits() const {
+    return false;
+  }
+
   /// Returns a set of leaf plan node IDs.
   std::unordered_set<core::PlanNodeId> leafPlanNodeIds() const;
 
@@ -322,6 +330,10 @@ class TableScanNode : public PlanNode {
 
   const RowTypePtr& outputType() const override {
     return outputType_;
+  }
+
+  bool requiresSplits() const override {
+    return true;
   }
 
   const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle() const {
@@ -550,6 +562,10 @@ class ExchangeNode : public PlanNode {
   }
 
   const std::vector<PlanNodePtr>& sources() const override;
+
+  bool requiresSplits() const override {
+    return true;
+  }
 
   std::string_view name() const override {
     return "Exchange";

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -68,7 +68,7 @@ bool unregisterTaskListener(const std::shared_ptr<TaskListener>& listener) {
 }
 
 namespace {
-void collectSourcePlanNodeIds(
+void collectSplitPlanNodeIds(
     const core::PlanNode* planNode,
     std::unordered_set<core::PlanNodeId>& allIds,
     std::unordered_set<core::PlanNodeId>& sourceIds) {
@@ -79,24 +79,28 @@ void collectSourcePlanNodeIds(
       planNode->id());
 
   // Check if planNode is a leaf node in the plan tree. If so, it is a source
-  // node and could use splits for processing.
+  // node and may use splits for processing.
   if (planNode->sources().empty()) {
-    sourceIds.insert(planNode->id());
+    // Not all leaf nodes require splits. ValuesNode doesn't. Check if this plan
+    // node requires splits.
+    if (planNode->requiresSplits()) {
+      sourceIds.insert(planNode->id());
+    }
     return;
   }
 
   for (const auto& child : planNode->sources()) {
-    collectSourcePlanNodeIds(child.get(), allIds, sourceIds);
+    collectSplitPlanNodeIds(child.get(), allIds, sourceIds);
   }
 }
 
-/// Returns a set of source (leaf) plan node IDs. Also, checks that plan node
-/// IDs are unique and throws if encounters duplicates.
-std::unordered_set<core::PlanNodeId> collectSourcePlanNodeIds(
+/// Returns a set IDs of source (leaf) plan nodes that require splits. Also,
+/// checks that plan node IDs are unique and throws if encounters duplicates.
+std::unordered_set<core::PlanNodeId> collectSplitPlanNodeIds(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   std::unordered_set<core::PlanNodeId> allIds;
   std::unordered_set<core::PlanNodeId> sourceIds;
-  collectSourcePlanNodeIds(planNode.get(), allIds, sourceIds);
+  collectSplitPlanNodeIds(planNode.get(), allIds, sourceIds);
   return sourceIds;
 }
 
@@ -136,7 +140,7 @@ Task::Task(
       planFragment_(std::move(planFragment)),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
-      sourcePlanNodeIds_(collectSourcePlanNodeIds(planFragment_.planNode)),
+      splitPlanNodeIds_(collectSplitPlanNodeIds(planFragment_.planNode)),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
       pool_(queryCtx_->pool()->addScopedChild("task_root")),
@@ -575,8 +579,8 @@ void Task::addSplit(const core::PlanNodeId& planNodeId, exec::Split&& split) {
 
 void Task::checkPlanNodeIdForSplit(const core::PlanNodeId& id) const {
   VELOX_USER_CHECK(
-      sourcePlanNodeIds_.find(id) != sourcePlanNodeIds_.end(),
-      "Splits can be associated only with source plan nodes. Plan node ID {} doesn't refer to a source node.",
+      splitPlanNodeIds_.find(id) != splitPlanNodeIds_.end(),
+      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID {} doesn't refer to such plan node.",
       id);
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -580,9 +580,9 @@ class Task : public std::enable_shared_from_this<Task> {
   const int destination_;
   const std::shared_ptr<core::QueryCtx> queryCtx_;
 
-  /// A set of source plan node IDs. Used to check plan node IDs specified in
-  /// split management methods.
-  const std::unordered_set<core::PlanNodeId> sourcePlanNodeIds_;
+  /// A set of IDs of leaf plan nodes that require splits. Used to check plan
+  /// node IDs specified in split management methods.
+  const std::unordered_set<core::PlanNodeId> splitPlanNodeIds_;
 
   // True if produces output via PartitionedOutputBufferManager.
   bool hasPartitionedOutput_ = false;

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -106,8 +106,7 @@ TEST_F(LocalPartitionTest, gather) {
                 .singleAggregation({}, {"count(1)", "min(c0)", "max(c0)"})
                 .planNode();
 
-  auto task = assertQuery(
-      op, std::vector<std::shared_ptr<TempFilePath>>{}, "SELECT 300, -71, 152");
+  auto task = assertQuery(op, "SELECT 300, -71, 152");
   verifyExchangeSourceOperatorStats(task, 300);
 
   auto filePaths = writeToFiles(vectors);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -51,8 +51,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   std::shared_ptr<exec::Task> assertQuery(
       const std::shared_ptr<const core::PlanNode>& plan,
       const std::string& duckDbSql) {
-    return assertQuery(
-        plan, std::vector<std::shared_ptr<TempFilePath>>(), duckDbSql);
+    return OperatorTestBase::assertQuery(plan, duckDbSql);
   }
 
   std::shared_ptr<exec::Task> assertQuery(


### PR DESCRIPTION
Not all leaf plan nodes support splits. For example, ValuesNode doesn't support
splits, while TableScanNode and ExchangeNode do.

Instroduce PlanNode::requiresSplit boolean to identify plan nodes that support
(and require) splits and use this information in Task::addSplitXxx APIs to fail
early if splits are added to the wrong plan nodes.

This change reduces the cases of query hang due to splits being added to the
wrong plan node.