### PR TITLE
Reuse memory more often when evaluating simple functions

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -141,7 +141,37 @@ class SimpleFunctionAdapter : public VectorFunction {
       const TypePtr& outputType,
       EvalCtx* context,
       VectorPtr* result) const override {
-    ApplyContext applyContext{&rows, outputType, context, result};
+    auto* reusableResult = result;
+    // If result is null, check if one of the arguments can be re-used for
+    // storing the result. This is possible if all the following conditions are
+    // met:
+    // - result type is a fixed-width type,
+    // - function doesn't produce nulls,
+    // - an argument has the same type as result,
+    // - the argument has flat encoding,
+    // - the argument is singly-referenced and has singly-referenced values
+    // and nulls buffers.
+    if constexpr (
+        !FUNC::can_produce_null_output && !FUNC::udf_has_callNullFree) {
+      if (!reusableResult->get()) {
+        if (args.size() > 0 && outputType->isPrimitiveType() &&
+            outputType->isFixedWidth()) {
+          for (auto& arg : args) {
+            if (arg->type()->kindEquals(outputType)) {
+              if (BaseVector::isReusableFlatVector(arg)) {
+                // Re-use arg for result. We rely on the fact that for each row
+                // we read arguments before computing and writing out the
+                // result.
+                reusableResult = &arg;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    ApplyContext applyContext{&rows, outputType, context, reusableResult};
 
     // Enable fast all-ASCII path if all string inputs are ASCII and the
     // function provides ASCII-only path.
@@ -151,14 +181,25 @@ class SimpleFunctionAdapter : public VectorFunction {
 
     // If this UDF can take the fast path iteration, we set all active rows as
     // non-nulls in the result vector. The assumption is that the majority of
-    // rows will return non-null values (and hence won't have to touch the null
-    // buffer during iteration).
-    if constexpr (fastPathIteration) {
-      (*result)->clearNulls(rows);
+    // rows will return non-null values (and hence won't have to touch the
+    // null buffer during iteration).
+    // If this function doesn't produce nulls, then one of its arguments may be
+    // used for storing results. In this case, do not clear the nulls before
+    // processing these.
+    if constexpr (
+        fastPathIteration &&
+        (FUNC::can_produce_null_output || FUNC::udf_has_callNullFree)) {
+      (*reusableResult)->clearNulls(rows);
     }
 
     DecodedArgs decodedArgs{rows, args, context};
     unpack<0>(applyContext, true, decodedArgs);
+
+    if constexpr (
+        fastPathIteration && !FUNC::can_produce_null_output &&
+        !FUNC::udf_has_callNullFree) {
+      (*reusableResult)->clearNulls(rows);
+    }
 
     // Check if the function reuses input strings for the result, and add
     // references to input string buffers to all result vectors.
@@ -168,8 +209,10 @@ class SimpleFunctionAdapter : public VectorFunction {
       VELOX_CHECK_EQ(args[reuseStringsFromArg]->typeKind(), TypeKind::VARCHAR);
 
       tryAcquireStringBuffer(
-          result->get(), decodedArgs.at(reuseStringsFromArg)->base());
+          reusableResult->get(), decodedArgs.at(reuseStringsFromArg)->base());
     }
+
+    *result = std::move(*reusableResult);
   }
 
   // Acquire string buffer from source if vector is a string flat vector.
@@ -239,8 +282,8 @@ class SimpleFunctionAdapter : public VectorFunction {
               const DecodedArgs& packed,
               TReader&... readers) const {
     if constexpr (isVariadicType<arg_at<POSITION>>::value) {
-      // This should already be statically checked by the UDFHolder used to wrap
-      // the simple function, but checking again here just in case.
+      // This should already be statically checked by the UDFHolder used to
+      // wrap the simple function, but checking again here just in case.
       static_assert(
           POSITION == FUNC::num_args - 1,
           "Variadic args can only be used as the last argument to a function.");
@@ -314,9 +357,9 @@ class SimpleFunctionAdapter : public VectorFunction {
       auto* data = applyContext.result->mutableRawValues();
       auto writeResult = [&applyContext, &nullBuffer, &data](
                              auto row, bool notNull, auto out) INLINE_LAMBDA {
-        // For fast path iteration, all active rows were already set as non-null
-        // beforehand, so we only need to update the null buffer if the function
-        // returned null (which is not the common case).
+        // For fast path iteration, all active rows were already set as
+        // non-null beforehand, so we only need to update the null buffer if
+        // the function returned null (which is not the common case).
         if (notNull) {
           if constexpr (return_type_traits::typeKind == TypeKind::BOOLEAN) {
             bits::setBit(data, row, out);
@@ -358,10 +401,10 @@ class SimpleFunctionAdapter : public VectorFunction {
         }
       } else if (allNotNull) {
         applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
-          // Passing a stack variable have shown to be boost the performance of
-          // functions that repeatedly update the output.
-          // The opposite optimization (eliminating the temp) is easier to do
-          // by the compiler (assuming the function call is inlined).
+          // Passing a stack variable have shown to be boost the performance
+          // of functions that repeatedly update the output. The opposite
+          // optimization (eliminating the temp) is easier to do by the
+          // compiler (assuming the function call is inlined).
           typename return_type_traits::NativeType out{};
           bool notNull = doApplyNotNull<0>(row, out, readers...);
           writeResult(row, notNull, out);
@@ -477,7 +520,8 @@ class SimpleFunctionAdapter : public VectorFunction {
               T& target,
               R0& currentReader,
               const Values&... extra) const {
-    // Recurse through all the arguments to build the arg list at compile time.
+    // Recurse through all the arguments to build the arg list at compile
+    // time.
     if constexpr (std::is_reference<decltype(currentReader[idx])>::value) {
       return doApply<POSITION + 1>(
           idx,
@@ -525,10 +569,10 @@ class SimpleFunctionAdapter : public VectorFunction {
   // If we're guaranteed not to have any nulls, pass all parameters as
   // references.
   //
-  // Note that (*fn_).call() will internally dispatch the call to either call()
-  // or callNullable() (whichever is implemented by the user function). Default
-  // null behavior or not does not matter in this path since we don't have any
-  // nulls.
+  // Note that (*fn_).call() will internally dispatch the call to either
+  // call() or callNullable() (whichever is implemented by the user function).
+  // Default null behavior or not does not matter in this path since we don't
+  // have any nulls.
   template <
       size_t POSITION,
       typename R0,


### PR DESCRIPTION
When evaluating simple functions, check if one of the arguments can be re-used
for result. This is possible if 
1. result type is fixed-width (e.g. primitive type except for VARCHAR and VARBINARY);
2. function doesn't produce nulls, e.g. has void call() or callNullable() and doesn't have callNullFree(),
3. argument and result types match,
4. argument is flat, uniquely-referenced and has uniquely-referenced values and nulls buffers.

This change reduces then number of memory allocations for a simple `(f - 0.5) * 2.0 + 0.3` 
expression from 3 to 1. We evaluate 3 expressions:

* f1 = f - 0.5
* f2 = f1 * 2.0
* f3 = f2 + 0.3

We allocate new memory for f1, but then reuse it for f2 and f3. This can be visualized as:

* r = f - 0.5
* r = r * 2.0
* r = r + 0.3

Reusing argument for result is possible only if the processing loops over rows
and on each iteration reads the input, computes the result, then writes the
result. Here is a simple illustration:

```
std::vector<int> data;
for (int i = 0; i < data.size(); ++i) {
   data[i] = data[i]  + 5;
}
```

Requirements 1-4 above ensure that simple function evaluation matches this pattern.

For functions that produce nulls, the pattern of evaluation is different. It
involves (1) clearing nulls buffer of the result before the loop and(2) setting
null flags during the loop. This pattern is efficient for the case where null
results are very rare.

```
VectorPtr input;
VectorPtr result;

result.clearNulls();

for (int i = 0; i < input->size(); ++i) {
   auto result = func(input->valueAt(i));
   if (result is null) {
      result->setNull(i);
   } else {
      result->setValue(i);
   }
}
```

In this case, reusing input for result is not possible as `result.clearNulls()` 
will modify the input before it has been processed. However, if input
doesn't have any nulls to begin with, it can be reused for result.

It is tricky to reuse input for results for variable-width functions, e.g.
VARCHAR. FlatVector<StringView> contains fixed-width values buffer and zero or
more variable-width string buffers that contain variable-width strings.
Updating an entry in FlatVector<StringView> vector modifies an entry in values
buffer and appends the new string to one of the string buffers that has space
or allocates a whole new string buffer. After the loop, the vector stores all
the old strings (input) and all the new strings in the string buffers. The
vector uses a lot more memory than necessary. To adjust for that effect one
needs to update the vector to remove the string buffers that contain strings
that are no longer referenced. 

Similar challenge arise when considering reuse of arrays and maps where
modifying an entry involves appending to the elements, keys and values nested
vectors and requires cleanup after the loop. 

Benchmark results:

```
gcc version 8.5.0 20210514 (Red Hat 8.5.0-10) (GCC)

model name      : Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
cpu MHz         : 2999.998
cache size      : 25344 KB

====================================================================================================
velox_benchmark_basic_simple_arithmetic.json
====================================================================================================
    ✓ Pass: SimpleArithmetic.cpp/multiply                                  (1.12ns vs 1.11ns) +1.21%
    ✓ Pass: SimpleArithmetic.cpp/multiplySameColumn                        (0.57ns vs 0.56ns) +0.97%
    ✓ Pass: SimpleArithmetic.cpp/multiplyHalfNull                         (1.34ns vs 1.13ns) +15.15%
    ✓ Pass: SimpleArithmetic.cpp/multiplyConstant                         (0.67ns vs 0.59ns) +12.53%
    ✓ Pass: SimpleArithmetic.cpp/multiplyNested                           (7.64ns vs 1.79ns) +76.56%
    ✓ Pass: SimpleArithmetic.cpp/multiplyNestedDeep                     (18.87ns vs 13.02ns) +30.99%
    ✓ Pass: SimpleArithmetic.cpp/multiplyOutputVoid                       (1.17ns vs 1.00ns) +14.41%
    ✓ Pass: SimpleArithmetic.cpp/multiplyOutputNullable                   (1.15ns vs 1.02ns) +10.74%
    ✓ Pass: SimpleArithmetic.cpp/multiplyOutputAlwaysNull                  (1.52ns vs 1.49ns) +1.89%
    ✓ Pass: SimpleArithmetic.cpp/plusUnchecked                            (1.16ns vs 0.97ns) +16.53%
    ✓ Pass: SimpleArithmetic.cpp/plusChecked                              (3.56ns vs 3.19ns) +10.25%

Summary:
  Pass: 44 (2 are faster): 
    SimpleArithmetic.cpp/multiplyNested
    SimpleArithmetic.cpp/multiplyNestedDeep
```