### PR TITLE
Add reader debug string as exception context reader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnLoader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnLoader.cpp
@@ -50,6 +50,13 @@ void ColumnLoader::loadInternal(
   auto outputRows = structReader_->outputRows();
   raw_vector<vector_size_t> selectedRows;
   RowSet effectiveRows;
+  ExceptionContextSetter exceptionContext(
+      {[](auto* reader) {
+         return static_cast<SelectiveStructColumnReader*>(reader)
+             ->debugString();
+       },
+       this});
+
   if (rows.size() == outputRows.size()) {
     // All the rows planned at creation are accessed.
     effectiveRows = outputRows;

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -33,7 +33,8 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
           scanSpec,
           dataType->type,
           std::move(flatMapContext)),
-      requestedType_{requestedType} {
+      requestedType_{requestedType},
+      debugString_(getExceptionContext().message()) {
   EncodingKey encodingKey{nodeType_->id, flatMapContext_.sequence};
   DWIO_ENSURE_EQ(encodingKey.node, dataType->id, "working on the same node");
   auto encoding = static_cast<int64_t>(stripe.getEncoding(encodingKey).kind());

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -124,6 +124,10 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
     inputRows_ = outputRows_;
   }
 
+  const std::string& debugString() const {
+    return debugString_;
+  }
+
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<SelectiveColumnReader>> children_;
@@ -134,6 +138,13 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
 
   // Dense set of rows to read in next().
   raw_vector<vector_size_t> rows_;
+
+  // Context information obtained from ExceptionContext. Stored here
+  // so that LazyVector readers under this can add this to their
+  // ExceptionContext. Allows contextualizing reader errors to split
+  // and query. Set at construction, which takes place on first
+  // use. If no ExceptionContext is in effect, this is "".
+  const std::string debugString_;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -70,5 +70,8 @@ class TableScan : public SourceOperator {
   std::unordered_map<ChannelIndex, std::shared_ptr<common::Filter>>
       pendingDynamicFilters_;
   int32_t readBatchSize_{kDefaultBatchSize};
+
+  // String shown in ExceptionContext inside DataSource and LazyVector loading.
+  std::string debugString_;
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Add reader debug string as exception context  

Adds an ExceptionContext around DataSource::next. Records the
exception context string in SelectiveStructColumnReader so that an
eventual LazyVector load can find this string and show it as context
of an eventual exception. Allows localizing the file and Task id
related to the error.
