### PR TITLE
Prepare for async prefetch

### DIFF
--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_process ProcessBase.cpp StackTrace.cpp TraceContext.cpp)
 
-target_link_libraries(velox_process ${FOLLY_WITH_DEPENDENCIES} glog::glog)
+target_link_libraries(velox_process velox_flag_definitions
+                      ${FOLLY_WITH_DEPENDENCIES} glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -160,10 +160,10 @@ static void makeFieldSpecs(
   }
 }
 
-std::unique_ptr<common::ScanSpec> makeScanSpec(
+std::shared_ptr<common::ScanSpec> makeScanSpec(
     const SubfieldFilters& filters,
     const std::shared_ptr<const RowType>& rowType) {
-  auto spec = std::make_unique<common::ScanSpec>("root");
+  auto spec = std::make_shared<common::ScanSpec>("root");
   makeFieldSpecs("", 0, rowType, spec.get());
 
   for (auto& pair : filters) {
@@ -273,7 +273,7 @@ HiveDataSource::HiveDataSource(
     readerOutputType_ = ROW(std::move(names), std::move(types));
   }
 
-  rowReaderOpts_.setScanSpec(scanSpec_.get());
+  rowReaderOpts_.setScanSpec(scanSpec_);
 
   ioStats_ = std::make_shared<dwio::common::IoStatistics>();
 }
@@ -407,7 +407,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
         ioStats_,
         executor_,
         readerOpts_);
-    readerOpts_.setBufferedInputFactory(bufferedInputFactory_.get());
+    readerOpts_.setBufferedInputFactory(bufferedInputFactory_);
   } else if (dataCache_) {
     auto dataCacheConfig = std::make_shared<dwio::common::DataCacheConfig>();
     dataCacheConfig->cache = dataCache_;

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -194,8 +194,8 @@ class HiveDataSource : public DataSource {
   FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
   velox::memory::MemoryPool* FOLLY_NONNULL pool_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
-  std::unique_ptr<dwrf::BufferedInputFactory> bufferedInputFactory_;
-  std::unique_ptr<common::ScanSpec> scanSpec_;
+  std::shared_ptr<dwrf::BufferedInputFactory> bufferedInputFactory_;
+  std::shared_ptr<common::ScanSpec> scanSpec_;
   std::shared_ptr<HiveConnectorSplit> split_;
   dwio::common::ReaderOptions readerOpts_;
   dwio::common::RowReaderOptions rowReaderOpts_;

--- a/velox/dwio/common/IoStatistics.cpp
+++ b/velox/dwio/common/IoStatistics.cpp
@@ -88,6 +88,32 @@ IoStatistics::operationStats() const {
   return operationStats_;
 }
 
+void IoStatistics::merge(const IoStatistics& other) {
+  rawBytesRead_ += other.rawBytesRead_;
+  rawBytesWritten_ += other.rawBytesWritten_;
+
+  rawOverreadBytes_ += other.rawOverreadBytes_;
+  prefetch_.merge(other.prefetch_);
+  read_.merge(other.read_);
+  ramHit_.merge(other.ramHit_);
+  ssdRead_.merge(other.ssdRead_);
+  queryThreadIoLatency_.merge(other.queryThreadIoLatency_);
+  std::lock_guard<std::mutex> l(operationStatsMutex_);
+  for (auto& item : other.operationStats_) {
+    operationStats_[item.first].merge(item.second);
+  }
+}
+
+void OperationCounters::merge(const OperationCounters& other) {
+  resourceThrottleCount += other.resourceThrottleCount;
+  localThrottleCount += other.localThrottleCount;
+  globalThrottleCount += other.globalThrottleCount;
+  retryCount += other.retryCount;
+  latencyInMs += other.latencyInMs;
+  requestCount += other.requestCount;
+  delayInjectedInSecs += other.delayInjectedInSecs;
+}
+
 folly::dynamic serialize(const OperationCounters& counters) {
   folly::dynamic json = folly::dynamic::object;
   json["latencyInMs"] = counters.latencyInMs;

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -37,6 +37,8 @@ struct OperationCounters {
   uint64_t latencyInMs{0};
   uint64_t requestCount{0};
   uint64_t delayInjectedInSecs{0};
+
+  void merge(const OperationCounters& other);
 };
 
 class IoCounter {
@@ -52,6 +54,11 @@ class IoCounter {
   void increment(uint64_t bytes) {
     ++count_;
     bytes_ += bytes;
+  }
+
+  void merge(const IoCounter& other) {
+    bytes_ += other.bytes_;
+    count_ += other.count_;
   }
 
  private:
@@ -103,6 +110,8 @@ class IoStatistics {
       const uint64_t delayInjectedInSecs);
 
   std::unordered_map<std::string, OperationCounters> operationStats() const;
+
+  void merge(const IoStatistics& other);
 
   folly::dynamic getOperationStatsSnapshot() const;
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -95,7 +95,7 @@ class RowReaderOptions {
   bool returnFlatVector_ = false;
   ErrorTolerance errorTolerance_;
   std::shared_ptr<ColumnSelector> selector_;
-  velox::common::ScanSpec* scanSpec_ = nullptr;
+  std::shared_ptr<velox::common::ScanSpec> scanSpec_ = nullptr;
   // Node id for map column to a list of keys to be projected as a struct.
   std::unordered_map<uint32_t, std::vector<std::string>> flatmapNodeIdAsStruct_;
 
@@ -228,11 +228,11 @@ class RowReaderOptions {
     return errorTolerance_;
   }
 
-  velox::common::ScanSpec* getScanSpec() const {
+  const std::shared_ptr<velox::common::ScanSpec> getScanSpec() const {
     return scanSpec_;
   }
 
-  void setScanSpec(velox::common::ScanSpec* scanSpec) {
+  void setScanSpec(std::shared_ptr<velox::common::ScanSpec> scanSpec) {
     scanSpec_ = scanSpec;
   }
 
@@ -315,7 +315,7 @@ class ReaderOptions {
   SerDeOptions serDeOptions;
   std::shared_ptr<DataCacheConfig> dataCacheConfig_;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
-  velox::dwrf::BufferedInputFactory* bufferedInputFactory_ = nullptr;
+  std::shared_ptr<velox::dwrf::BufferedInputFactory> bufferedInputFactory_;
 
  public:
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
@@ -451,7 +451,7 @@ class ReaderOptions {
   }
 
   ReaderOptions& setBufferedInputFactory(
-      velox::dwrf::BufferedInputFactory* factory) {
+      std::shared_ptr<velox::dwrf::BufferedInputFactory> factory) {
     bufferedInputFactory_ = factory;
     return *this;
   }
@@ -516,11 +516,13 @@ class ReaderOptions {
     return serDeOptions;
   }
 
-  encryption::DecrypterFactory* getDecrypterFactory() const {
-    return decrypterFactory_.get();
+  const std::shared_ptr<encryption::DecrypterFactory> getDecrypterFactory()
+      const {
+    return decrypterFactory_;
   }
 
-  velox::dwrf::BufferedInputFactory* getBufferedInputFactory() const {
+  std::shared_ptr<velox::dwrf::BufferedInputFactory> getBufferedInputFactory()
+      const {
     return bufferedInputFactory_;
   }
 };

--- a/velox/dwio/dwrf/common/BufferedInput.cpp
+++ b/velox/dwio/dwrf/common/BufferedInput.cpp
@@ -211,9 +211,10 @@ std::tuple<const char*, uint64_t> BufferedInput::readInternal(
 }
 
 //  static
-BufferedInputFactory* BufferedInputFactory::baseFactory() {
-  static auto instance = std::make_unique<BufferedInputFactory>();
-  return instance.get();
+std::shared_ptr<BufferedInputFactory>
+BufferedInputFactory::baseFactoryShared() {
+  static auto instance = std::make_shared<BufferedInputFactory>();
+  return instance;
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -157,7 +157,11 @@ class BufferedInputFactory {
   }
 
   // Returns a static factory for producing basic BufferedInput instances.
-  static BufferedInputFactory* FOLLY_NONNULL baseFactory();
+  static std::shared_ptr<BufferedInputFactory> baseFactoryShared();
+
+  static BufferedInputFactory* FOLLY_NONNULL baseFactory() {
+    return baseFactoryShared().get();
+  }
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
@@ -202,8 +202,8 @@ DwrfReaderShared::DwrfReaderShared(
           options.getDecrypterFactory(),
           options.getBufferedInputFactory()
               ? options.getBufferedInputFactory()
-              : BufferedInputFactory::baseFactory(),
-          options.getDataCacheConfig().get())),
+              : BufferedInputFactory::baseFactoryShared(),
+          options.getDataCacheConfig())),
       options_(options) {}
 
 std::unique_ptr<StripeInformation> DwrfReaderShared::getStripe(
@@ -383,7 +383,7 @@ uint64_t DwrfReaderShared::getMemoryUse(
 }
 
 void DwrfRowReaderShared::startNextStripe() {
-  if (newStripeLoaded) {
+  if (newStripeLoaded || currentStripe >= lastStripe) {
     return;
   }
 

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.h
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.h
@@ -49,8 +49,6 @@ class DwrfRowReaderShared : public StrideIndexProvider,
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;
 
   // internal methods
-  void startNextStripe();
-
   std::optional<size_t> estimatedRowSizeHelper(
       const proto::Footer& footer,
       const dwio::common::Statistics& stats,
@@ -130,6 +128,9 @@ class DwrfRowReaderShared : public StrideIndexProvider,
 
   // Estimate the row size for projected columns
   std::optional<size_t> estimatedRowSize() const override;
+  // Creates column reader tree and may start prefetch of frequently read
+  // columns.
+  void startNextStripe();
 };
 
 class DwrfReaderShared : public dwio::common::Reader {

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -64,10 +64,10 @@ class ReaderBase {
   ReaderBase(
       memory::MemoryPool& pool,
       std::unique_ptr<dwio::common::InputStream> stream,
-      dwio::common::encryption::DecrypterFactory* factory = nullptr,
-      BufferedInputFactory* bufferedInputFactory =
-          BufferedInputFactory::baseFactory(),
-      dwio::common::DataCacheConfig* dataCacheConfig = nullptr);
+      std::shared_ptr<dwio::common::encryption::DecrypterFactory>
+          decryptorFactory = nullptr,
+      std::shared_ptr<BufferedInputFactory> bufferedInputFactory = nullptr,
+      std::shared_ptr<dwio::common::DataCacheConfig> dataCacheConfig = nullptr);
 
   // create reader base from metadata
   ReaderBase(
@@ -219,7 +219,7 @@ class ReaderBase {
   }
 
   dwio::common::DataCacheConfig* getDataCacheConfig() const {
-    return dataCacheConfig_;
+    return dataCacheConfig_.get();
   }
 
   google::protobuf::Arena* arena() const {
@@ -237,10 +237,11 @@ class ReaderBase {
   std::unique_ptr<proto::PostScript> postScript_;
   proto::Footer* footer_ = nullptr;
   std::unique_ptr<StripeMetadataCache> cache_;
+  // Keeps factory alive for possibly async prefetch.
+  std::shared_ptr<dwio::common::encryption::DecrypterFactory> decryptorFactory_;
   std::unique_ptr<encryption::DecryptionHandler> handler_;
-  BufferedInputFactory* bufferedInputFactory_ =
-      BufferedInputFactory::baseFactory();
-  dwio::common::DataCacheConfig* dataCacheConfig_ = nullptr;
+  std::shared_ptr<BufferedInputFactory> bufferedInputFactory_;
+  std::shared_ptr<dwio::common::DataCacheConfig> dataCacheConfig_ = nullptr;
 
   std::unique_ptr<BufferedInput> input_;
   std::shared_ptr<const RowType> schema_;

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -480,7 +480,8 @@ inline void SelectiveColumnReader::addValue(const folly::StringPiece value) {
 
 class SelectiveColumnReaderFactory : public ColumnReaderFactory {
  public:
-  explicit SelectiveColumnReaderFactory(common::ScanSpec* scanSpec)
+  explicit SelectiveColumnReaderFactory(
+      std::shared_ptr<common::ScanSpec> scanSpec)
       : scanSpec_(scanSpec) {}
   std::unique_ptr<ColumnReader> build(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -488,13 +489,17 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       StripeStreams& stripe,
       FlatMapContext flatMapContext) override {
     auto reader = SelectiveColumnReader::build(
-        requestedType, dataType, stripe, scanSpec_, std::move(flatMapContext));
+        requestedType,
+        dataType,
+        stripe,
+        scanSpec_.get(),
+        std::move(flatMapContext));
     reader->setIsTopLevel();
     return reader;
   }
 
  private:
-  common::ScanSpec* const scanSpec_;
+  std::shared_ptr<common::ScanSpec> const scanSpec_;
 };
 
 // Template parameter to indicate no hook in fast scan path. This is

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
+#include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 
 namespace facebook::velox::dwrf {
 
@@ -56,6 +57,10 @@ class StripeReaderBase {
 
   ReaderBase& getReader() const {
     return *reader_;
+  }
+
+  std::shared_ptr<ReaderBase> readerBaseShared() {
+    return reader_;
   }
 
   const encryption::DecryptionHandler& getDecryptionHandler() const {

--- a/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
@@ -62,7 +62,7 @@ void E2EFilterTestBase::makeDataset(
   auto spec = filterGenerator->makeScanSpec(SubfieldFilters{});
 
   uint64_t timeWithNoFilter = 0;
-  readWithoutFilter(spec.get(), batches_, timeWithNoFilter);
+  readWithoutFilter(spec, batches_, timeWithNoFilter);
 }
 
 void E2EFilterTestBase::addRowGroupSpecificData() {
@@ -170,7 +170,7 @@ void E2EFilterTestBase::makeNotNull(int32_t firstRow) {
 }
 
 void E2EFilterTestBase::readWithoutFilter(
-    ScanSpec* spec,
+    std::shared_ptr<ScanSpec> spec,
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
   auto input = std::make_unique<MemoryInputStream>(
@@ -217,7 +217,7 @@ void E2EFilterTestBase::readWithoutFilter(
 }
 
 void E2EFilterTestBase::readWithFilter(
-    ScanSpec* spec,
+    std::shared_ptr<ScanSpec> spec,
     const std::vector<RowVectorPtr>& batches,
     const std::vector<uint32_t>& hitRows,
     uint64_t& time,
@@ -315,12 +315,11 @@ void E2EFilterTestBase::testFilterSpecs(
       filterGenerator->makeSubfieldFilters(filterSpecs, batches_, hitRows);
   auto spec = filterGenerator->makeScanSpec(std::move(filters));
   uint64_t timeWithFilter = 0;
-  readWithFilter(spec.get(), batches_, hitRows, timeWithFilter, false);
+  readWithFilter(spec, batches_, hitRows, timeWithFilter, false);
 
   if (FLAGS_timing_repeats) {
     for (auto i = 0; i < FLAGS_timing_repeats; ++i) {
-      readWithFilter(
-          spec.get(), batches_, hitRows, timeWithFilter, false, true);
+      readWithFilter(spec, batches_, hitRows, timeWithFilter, false, true);
     }
   }
   // Redo the test with LazyVectors for non-filtered columns.
@@ -328,9 +327,9 @@ void E2EFilterTestBase::testFilterSpecs(
   for (auto& childSpec : spec->children()) {
     childSpec->setExtractValues(false);
   }
-  readWithFilter(spec.get(), batches_, hitRows, timeWithFilter, false);
+  readWithFilter(spec, batches_, hitRows, timeWithFilter, false);
   timeWithFilter = 0;
-  readWithFilter(spec.get(), batches_, hitRows, timeWithFilter, true);
+  readWithFilter(spec, batches_, hitRows, timeWithFilter, true);
 }
 
 void E2EFilterTestBase::testRowGroupSkip(

--- a/velox/dwio/dwrf/test/E2EFilterTestBase.h
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.h
@@ -201,12 +201,12 @@ class E2EFilterTestBase : public testing::Test {
       std::unique_ptr<dwio::common::InputStream> input) = 0;
 
   void readWithoutFilter(
-      ScanSpec* spec,
+      std::shared_ptr<ScanSpec> spec,
       const std::vector<RowVectorPtr>& batches,
       uint64_t& time);
 
   void readWithFilter(
-      ScanSpec* spec,
+      std::shared_ptr<ScanSpec> spec,
       const std::vector<RowVectorPtr>& batches,
       const std::vector<uint32_t>& hitRows,
       uint64_t& time,

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
@@ -335,9 +335,9 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
   return specs;
 }
 
-std::unique_ptr<ScanSpec> FilterGenerator::makeScanSpec(
+std::shared_ptr<ScanSpec> FilterGenerator::makeScanSpec(
     SubfieldFilters filters) {
-  auto spec = std::make_unique<ScanSpec>("root");
+  auto spec = std::make_shared<ScanSpec>("root");
   makeFieldSpecs("", 0, rowType_, spec.get());
 
   for (auto& pair : filters) {

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.h
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.h
@@ -328,7 +328,7 @@ class FilterGenerator {
   std::vector<FilterSpec> makeRandomSpecs(
       const std::vector<std::string>& filterable,
       int32_t countX100);
-  std::unique_ptr<ScanSpec> makeScanSpec(SubfieldFilters filters);
+  std::shared_ptr<ScanSpec> makeScanSpec(SubfieldFilters filters);
 
   inline folly::Random::DefaultGenerator& rng() {
     return rng_;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -236,7 +236,8 @@ ParquetRowReader::ParquetRowReader(
     duckdbRowType_.push_back(duckDbType);
 
     if (options.getScanSpec()) {
-      auto veloxFilter = findFilter(projection[i].name, options.getScanSpec());
+      auto veloxFilter =
+          findFilter(projection[i].name, options.getScanSpec().get());
       if (veloxFilter) {
         toDuckDbFilter(i, duckDbType, veloxFilter.value(), filters_);
       }

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -51,7 +51,7 @@ class ParquetRowReader : public dwio::common::RowReader {
   memory::MemoryPool& pool_;
   RowTypePtr rowType_;
   std::vector<::duckdb::LogicalType> duckdbRowType_;
-  velox::common::ScanSpec* scanSpec_;
+  std::shared_ptr<velox::common::ScanSpec> scanSpec_;
 };
 
 class ParquetReader : public dwio::common::Reader {

--- a/velox/dwio/parquet/tests/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetReaderTest.cpp
@@ -100,8 +100,8 @@ class ParquetReaderTest : public testing::Test {
     EXPECT_EQ(reader.next(1000, result), 0);
   }
 
-  std::unique_ptr<common::ScanSpec> makeScanSpec(const RowTypePtr& rowType) {
-    auto scanSpec = std::make_unique<common::ScanSpec>("");
+  std::shared_ptr<common::ScanSpec> makeScanSpec(const RowTypePtr& rowType) {
+    auto scanSpec = std::make_shared<common::ScanSpec>("");
 
     for (auto i = 0; i < rowType->size(); ++i) {
       auto child =
@@ -134,7 +134,7 @@ class ParquetReaderTest : public testing::Test {
     }
 
     auto rowReaderOpts = getReaderOpts(fileSchema);
-    rowReaderOpts.setScanSpec(scanSpec.get());
+    rowReaderOpts.setScanSpec(scanSpec);
     auto rowReader = reader.createRowReader(rowReaderOpts);
     assertReadExpected(*rowReader, expected);
   }
@@ -176,7 +176,7 @@ TEST_F(ParquetReaderTest, readSampleFull) {
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   auto rowReader = reader.createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(20, 1), rangeVector<double>(20, 1)});
@@ -192,7 +192,7 @@ TEST_F(ParquetReaderTest, readSampleRange1) {
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(0, 200);
   auto rowReader = reader.createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
@@ -209,7 +209,7 @@ TEST_F(ParquetReaderTest, readSampleRange2) {
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(200, 500);
   auto rowReader = reader.createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
@@ -226,7 +226,7 @@ TEST_F(ParquetReaderTest, readSampleEmptyRange) {
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(300, 10);
   auto rowReader = reader.createRowReader(rowReaderOpts);
 
@@ -294,7 +294,7 @@ TEST_F(ParquetReaderTest, dateRead) {
 
   auto rowReaderOpts = getReaderOpts(dateSchema());
   auto scanSpec = makeScanSpec(dateSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   auto rowReader = reader.createRowReader(rowReaderOpts);
 
   auto expected = vectorMaker_->rowVector({rangeVector<Date>(25, -5)});
@@ -335,7 +335,7 @@ TEST_F(ParquetReaderTest, intRead) {
 
   auto rowReaderOpts = getReaderOpts(intSchema());
   auto scanSpec = makeScanSpec(intSchema());
-  rowReaderOpts.setScanSpec(scanSpec.get());
+  rowReaderOpts.setScanSpec(scanSpec);
   auto rowReader = reader.createRowReader(rowReaderOpts);
 
   auto expected = vectorMaker_->rowVector(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -65,7 +65,7 @@ core::ExecCtx* OperatorCtx::execCtx() const {
   return execCtx_.get();
 }
 
-std::unique_ptr<connector::ConnectorQueryCtx>
+std::shared_ptr<connector::ConnectorQueryCtx>
 OperatorCtx::createConnectorQueryCtx(
     const std::string& connectorId,
     const std::string& planNodeId) const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -169,7 +169,7 @@ class OperatorCtx {
   // Makes an extract of QueryCtx for use in a connector. 'planNodeId'
   // is the id of the calling TableScan. This and the task id identify
   // the scan for column access tracking.
-  std::unique_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
+  std::shared_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
       const std::string& connectorId,
       const std::string& planNodeId) const;
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -63,7 +63,7 @@ class TableScan : public SourceOperator {
   ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
   bool needNewSplit_ = true;
   std::shared_ptr<connector::Connector> connector_;
-  std::unique_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
+  std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::shared_ptr<connector::DataSource> dataSource_;
   bool noMoreSplits_ = false;
   // Dynamic filters to add to the data source when it gets created.

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -71,7 +71,7 @@ class TableWriter : public Operator {
   bool closed_;
   DriverCtx* driverCtx_;
   std::shared_ptr<connector::Connector> connector_;
-  std::unique_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
+  std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::shared_ptr<connector::DataSink> dataSink_;
   std::shared_ptr<connector::ConnectorInsertTableHandle> insertTableHandle_;
 };


### PR DESCRIPTION
Make different reader adjunct objects owned by shared_ptr. This is
needed so that we can prepare multiple copies of readers for different
splits/stripes on different threads for. In the case of cancellation
we could end up with references to freed memory.
This applies to

* ScanSpec
* BufferedInputFactory
* DecryptorFactory
* ConnectorQueryCtx

Other relevant objects like DataCacheConfig are already shared.