### PR TITLE
Override == and != operators for memory::Allocator class

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -896,6 +896,19 @@ class Allocator {
   void deallocate(T* p, size_t n) {
     pool.free(p, n * sizeof(T));
   }
+
+  template <typename T1>
+  bool operator==(const Allocator<T1>& rhs) const {
+    if constexpr (std::is_same<T, T1>::value) {
+      return &this->pool == &rhs.pool;
+    }
+    return false;
+  }
+
+  template <typename T1>
+  bool operator!=(const Allocator<T1>& rhs) const {
+    return !(*this == rhs);
+  }
 };
 } // namespace memory
 } // namespace velox


### PR DESCRIPTION
Summary: To make use of memory pool for large Allocation we require the Allocator interface which can be used in place of std::Allocator. This new Allocator interface can be used for allocation of vector, strings etc. To enable to do so we need to overload == and != operator as these are required method for allocator interface.

Differential Revision: D35981516

