### PR TITLE
Print output type of a plan node in printPlanWithStats

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -428,7 +428,7 @@ void PlanNode::toString(
     bool recursive,
     size_t indentationSize,
     std::function<void(
-        const PlanNodeId& planNodeId,
+        const PlanNode& planNode,
         const std::string& indentation,
         std::stringstream& stream)> addContext) const {
   const std::string indentation(indentationSize, ' ');
@@ -445,7 +445,7 @@ void PlanNode::toString(
   if (addContext) {
     auto contextIndentation = indentation + "   ";
     stream << contextIndentation;
-    addContext(id_, contextIndentation, stream);
+    addContext(*this, contextIndentation, stream);
     stream << std::endl;
   }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -123,7 +123,7 @@ class PlanNode {
       bool detailed = false,
       bool recursive = false,
       std::function<void(
-          const PlanNodeId& planNodeId,
+          const PlanNode& planNode,
           const std::string& indentation,
           std::stringstream& stream)> addContext = nullptr) const {
     std::stringstream stream;
@@ -150,7 +150,7 @@ class PlanNode {
       bool recursive,
       size_t indentationSize,
       std::function<void(
-          const PlanNodeId& planNodeId,
+          const PlanNode& planNode,
           const std::string& indentation,
           std::stringstream& stream)> addContext) const;
 

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -155,14 +155,15 @@ std::string printPlanWithStats(
   return plan.toString(
       true,
       true,
-      [&](const auto& planNodeId, const auto& indentation, auto& stream) {
-        const auto& stats = planStats[planNodeId];
-
+      [&](const auto& planNode, const auto& indentation, auto& stream) {
+        stream << "OutputType: " << planNode.outputType()->toString();
+        stream << std::endl;
         // Print input rows and sizes only for leaf plan nodes. Including this
         // information for other plan nodes is redundant as it is the same as
         // output of the source nodes.
-        const bool includeInputStats = leafPlanNodes.count(planNodeId) > 0;
-        stream << stats.toString(includeInputStats);
+        const bool includeInputStats = leafPlanNodes.count(planNode.id()) > 0;
+        const auto& stats = planStats[planNode.id()];
+        stream << indentation << stats.toString(includeInputStats);
 
         // Include break down by operator type for plan nodes with multiple
         // operators. Print input rows and sizes for all such nodes.


### PR DESCRIPTION
Adds output type of each plan node in printPlanWithStats.

Sample output for tpch q13:
```
Splits total: 160, finished: 160
-> OrderBy[custdist DESC NULLS LAST, c_count DESC NULLS LAST]
   OutputType: ROW<c_count:BIGINT,custdist:BIGINT>
   Output: 46 rows (896B), Cpu time: 136.45us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 5, Threads: 1
  -> Aggregation[SINGLE [c_count] custdist := count(0)]
     OutputType: ROW<c_count:BIGINT,custdist:BIGINT>
     Output: 46 rows (23.84KB), Cpu time: 46.51ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 7, Threads: 1
    -> Aggregation[FINAL [c_custkey] c_count := count(ROW["pc_count"])]
       OutputType: ROW<c_custkey:BIGINT,c_count:BIGINT>
       Output: 1500000 rows (34.29MB), Cpu time: 4.82s, Blocked wall time: 0ns, Peak memory: 56.00MB, Memory allocations: 4984, Threads: 1
      -> LocalPartition[GATHER]
         OutputType: ROW<c_custkey:BIGINT,pc_count:BIGINT>
         Output: 24704006 rows (565.79MB), Cpu time: 175.84ms, Blocked wall time: 13.05s, Peak memory: 0B, Memory allocations: 0
         LocalPartition: Input: 12352003 rows (282.89MB), Output: 12352003 rows (282.89MB), Cpu time: 82.05ms, Blocked wall time: 10.34s, Peak memory: 0B, Memory allocations: 0, Threads: 8
         LocalExchange: Input: 12352003 rows (282.89MB), Output: 12352003 rows (282.89MB), Cpu time: 93.79ms, Blocked wall time: 2.71s, Peak memory: 0B, Memory allocations: 0, Threads: 1
        -> Aggregation[PARTIAL [c_custkey] pc_count := count(ROW["o_orderkey"])]
           OutputType: ROW<c_custkey:BIGINT,pc_count:BIGINT>
           Output: 12352003 rows (282.89MB), Cpu time: 12.54s, Blocked wall time: 0ns, Peak memory: 32.00MB, Memory allocations: 41190, Threads: 8
          -> HashJoin[RIGHT o_custkey=c_custkey]
             OutputType: ROW<c_custkey:BIGINT,o_orderkey:BIGINT>
             Output: 15337604 rows (323.18MB), Cpu time: 11.70s, Blocked wall time: 1.98s, Peak memory: 17.00MB, Memory allocations: 16696
             HashBuild: Input: 1500000 rows (0B), Output: 0 rows (0B), Cpu time: 1.41s, Blocked wall time: 53.63ms, Peak memory: 16.00MB, Memory allocations: 577, Threads: 8
             HashProbe: Input: 14837583 rows (972.32MB), Output: 15337604 rows (323.18MB), Cpu time: 10.30s, Blocked wall time: 1.92s, Peak memory: 1.00MB, Memory allocations: 16119, Threads: 8
            -> TableScan[table: orders, remaining filter: (not(like(ROW["comment"],"%special%requests%")))]
               OutputType: ROW<o_custkey:BIGINT,o_comment:VARCHAR,o_orderkey:BIGINT>
               Input: 14837583 rows (1.17GB), Raw Input: 15000000 rows (315.15MB), Output: 14837583 rows (972.32MB), Cpu time: 24.06s, Blocked wall time: 509.00us, Peak memory: 36.00MB, Memory allocations: 36391, Threads: 8, Splits: 80
            -> TableScan[table: customer]
               OutputType: ROW<c_custkey:BIGINT>
               Input: 1500000 rows (0B), Output: 1500000 rows (0B), Cpu time: 64.73ms, Blocked wall time: 329.00us, Peak memory: 3.00MB, Memory allocations: 369, Threads: 8, Splits: 80

```