### PR TITLE
Add config property to enable cpu usage tracking for expressions

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -50,7 +50,13 @@ class QueryConfig {
 
   // Whether to use the simplified expression evaluation path. False by default.
   static constexpr const char* kExprEvalSimplified =
-      "driver.expr_eval.simplified";
+      "expression.eval_simplified";
+
+  // Whether to track CPU usage for individual expressions (supported by call
+  // and cast expressions). False by default. Can be expensive when processing
+  // small batches, e.g. < 10K rows.
+  static constexpr const char* kExprTrackCpuUsage =
+      "expression.track_cpu_usage";
 
   // Flags used to configure the CAST operator:
 
@@ -162,6 +168,10 @@ class QueryConfig {
 
   bool exprEvalSimplified() const {
     return get<bool>(kExprEvalSimplified, false);
+  }
+
+  bool exprTrackCpuUsage() const {
+    return get<bool>(kExprTrackCpuUsage, false);
   }
 
  private:

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -623,7 +623,7 @@ void CastExpr::evalSpecialForm(
   auto toType = std::const_pointer_cast<const Type>(type_);
 
   stats_.numProcessedRows += rows.countSelected();
-  CpuWallTimer timer(stats_.timing);
+  auto timer = cpuWallTimer();
   apply(rows, input, context, fromType, toType, result);
 }
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -26,13 +26,15 @@ class CastExpr : public SpecialForm {
  public:
   /// @param type The target type of the cast expression
   /// @param expr The expression to cast
+  /// @param trackCpuUsage Whether to track CPU usage
   /// @param nullOnFailure Whether to throw or return null if cast is not
   /// possible
-  CastExpr(
-      std::shared_ptr<const Type> type,
-      ExprPtr&& expr,
-      bool nullOnFailure = false)
-      : SpecialForm(type, std::vector<ExprPtr>({expr}), kCast.data()),
+  CastExpr(TypePtr type, ExprPtr&& expr, bool trackCpuUsage, bool nullOnFailure)
+      : SpecialForm(
+            type,
+            std::vector<ExprPtr>({expr}),
+            kCast.data(),
+            trackCpuUsage),
         nullOnFailure_(nullOnFailure) {}
 
   void evalSpecialForm(
@@ -81,8 +83,8 @@ class CastExpr : public SpecialForm {
       const SelectivityVector& rows,
       VectorPtr& input,
       exec::EvalCtx* context,
-      const std::shared_ptr<const Type>& fromType,
-      const std::shared_ptr<const Type>& toType,
+      const TypePtr& fromType,
+      const TypePtr& toType,
       VectorPtr* result);
 
   VectorPtr applyMap(

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -19,7 +19,11 @@
 namespace facebook::velox::exec {
 
 CoalesceExpr::CoalesceExpr(TypePtr type, std::vector<ExprPtr>&& inputs)
-    : SpecialForm(std::move(type), std::move(inputs), kCoalesce) {
+    : SpecialForm(
+          std::move(type),
+          std::move(inputs),
+          kCoalesce,
+          false /* trackCpuUsage */) {
   for (auto i = 1; i < inputs_.size(); i++) {
     VELOX_USER_CHECK_EQ(
         inputs_[0]->type()->kind(),

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1117,7 +1117,7 @@ void Expr::applyFunction(
     EvalCtx* context,
     VectorPtr* result) {
   stats_.numProcessedRows += rows.countSelected();
-  CpuWallTimer timer(stats_.timing);
+  auto timer = cpuWallTimer();
 
   computeIsAsciiForInputs(vectorFunction_.get(), inputValues_, rows);
   auto isAscii = type()->isVarchar()


### PR DESCRIPTION
When evaluating expressions on small batches (< 10K rows), CpuWallTimer shows up
at the top of the profile. This can also be seen by modifying
SimpleArithmetic.cpp benchmark to use 1K row vectors instead of 1M row. Without
cpu tracking the benchmark is 3x faster.

1K row vectors with cpu tracking on:

```
multiply                                                    2.50ns   400.76M
multiplySameColumn                                          2.35ns   426.34M
multiplyHalfNull                                            3.29ns   303.91M
multiplyConstant                                            2.42ns   412.68M
multiplyNested                                              5.18ns   193.18M
multiplyNestedDeep                                         13.25ns    75.48M
----------------------------------------------------------------------------
multiplyOutputVoid                                          2.46ns   406.27M
multiplyOutputNullable                                      2.41ns   414.14M
multiplyOutputAlwaysNull                                    4.21ns   237.33M
----------------------------------------------------------------------------
plusUnchecked                                               2.28ns   438.32M
plusChecked                                                 5.22ns   191.64M
```

1K row vectors without cpu tracking off:

```
multiply                                                  730.18ps     1.37G
multiplySameColumn                                        569.72ps     1.76G
multiplyHalfNull                                            1.57ns   636.43M
multiplyConstant                                          691.41ps     1.45G
multiplyNested                                              1.73ns   578.73M
multiplyNestedDeep                                          4.64ns   215.54M
----------------------------------------------------------------------------
multiplyOutputVoid                                        682.54ps     1.47G
multiplyOutputNullable                                    654.18ps     1.53G
multiplyOutputAlwaysNull                                    2.60ns   384.45M
----------------------------------------------------------------------------
plusUnchecked                                             634.35ps     1.58G
plusChecked                                                 3.67ns   272.52M
```

Add configuration property "expression.track_cpu_usage" to control whether cpu usage tracking for expressions is on of off. The default is off. 