### PR TITLE
Use smaller vectors in SimpleArithmetic benchmark

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -132,14 +132,14 @@ class SimpleArithmeticBenchmark
     rowVector_ = rowVector;
   }
 
-  // Runs `expression` `times` times.
+  // Runs `expression` `times` thousand times.
   size_t run(const std::string& expression, size_t times) {
     folly::BenchmarkSuspender suspender;
     auto exprSet = compileExpression(expression, inputType_);
     suspender.dismiss();
 
     size_t count = 0;
-    for (auto i = 0; i < times; i++) {
+    for (auto i = 0; i < times * 1'000; i++) {
       count += evaluate(exprSet, rowVector_)->size();
     }
     return count;
@@ -208,7 +208,7 @@ BENCHMARK_MULTI(plusChecked, n) {
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  benchmark = std::make_unique<SimpleArithmeticBenchmark>(1'000'000);
+  benchmark = std::make_unique<SimpleArithmeticBenchmark>(1'000);
   folly::runBenchmarks();
   benchmark.reset();
   return 0;


### PR DESCRIPTION
SimpleArithmetic benchmark used 1M row vectors which are much larger than
typical. Very large vectors can amortize per-vector processing costs and hide
issues like #1534. 

Change vector size to 1K rows for more representative benchmark.