### PR TITLE
Print output type in PlanNode::toString

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -440,7 +440,7 @@ void PlanNode::toString(
     addDetails(stream);
     stream << "]";
     stream << " -> ";
-    outputType()->printChildren(stream);
+    outputType()->printChildren(stream, ", ");
   }
   stream << std::endl;
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -440,8 +440,7 @@ void PlanNode::toString(
     addDetails(stream);
     stream << "]";
     stream << " -> ";
-    const auto& outputType = this->outputType();
-    outputType->printChildren(stream);
+    outputType()->printChildren(stream);
   }
   stream << std::endl;
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -433,12 +433,15 @@ void PlanNode::toString(
         std::stringstream& stream)> addContext) const {
   const std::string indentation(indentationSize, ' ');
 
-  stream << indentation << "-> " << name();
+  stream << indentation << "-- " << name();
 
   if (detailed) {
     stream << "[";
     addDetails(stream);
     stream << "]";
+    stream << " -> ";
+    const auto& outputType = this->outputType();
+    outputType->printChildren(stream);
   }
   stream << std::endl;
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -156,7 +156,7 @@ TEST_F(PlanNodeToStringTest, aggregation) {
 
   ASSERT_EQ("-- Aggregation\n", plan->toString());
   ASSERT_EQ(
-      "-- Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"])] -> a:BIGINT, b:ROW<\"\":DOUBLE, \"\":BIGINT>, c:BIGINT\n",
+      "-- Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"])] -> a:BIGINT, b:ROW<\"\":DOUBLE,\"\":BIGINT>, c:BIGINT\n",
       plan->toString(true, false));
 
   // Group-by aggregation.

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -52,32 +52,32 @@ class PlanNodeToStringTest : public testing::Test, public test::VectorTestBase {
 };
 
 TEST_F(PlanNodeToStringTest, basic) {
-  ASSERT_EQ("-> Project\n", plan_->toString());
+  ASSERT_EQ("-- Project\n", plan_->toString());
 }
 
 TEST_F(PlanNodeToStringTest, recursive) {
   ASSERT_EQ(
-      "-> Project\n"
-      "  -> Filter\n"
-      "    -> Project\n"
-      "      -> Filter\n"
-      "        -> Values\n",
+      "-- Project\n"
+      "  -- Filter\n"
+      "    -- Project\n"
+      "      -- Filter\n"
+      "        -- Values\n",
       plan_->toString(false, true));
 }
 
 TEST_F(PlanNodeToStringTest, detailed) {
   ASSERT_EQ(
-      "-> Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))]\n",
+      "-- Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n",
       plan_->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, recursiveAndDetailed) {
   ASSERT_EQ(
-      "-> Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))]\n"
-      "  -> Filter[expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)]\n"
-      "    -> Project[expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))]\n"
-      "      -> Filter[expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)]\n"
-      "        -> Values[5 rows in 1 vectors]\n",
+      "-- Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
+      "  -- Filter[expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)] -> out1:SMALLINT, out2:BIGINT\n"
+      "    -- Project[expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))] -> out1:SMALLINT, out2:BIGINT\n"
+      "      -- Filter[expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
+      "        -- Values[5 rows in 1 vectors] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan_->toString(true, true));
 }
 
@@ -89,38 +89,38 @@ TEST_F(PlanNodeToStringTest, withContext) {
   };
 
   ASSERT_EQ(
-      "-> Project\n"
+      "-- Project\n"
       "   Context for 4\n",
       plan_->toString(false, false, addContext));
 
   ASSERT_EQ(
-      "-> Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))]\n"
+      "-- Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
       "   Context for 4\n",
       plan_->toString(true, false, addContext));
 
   ASSERT_EQ(
-      "-> Project\n"
+      "-- Project\n"
       "   Context for 4\n"
-      "  -> Filter\n"
+      "  -- Filter\n"
       "     Context for 3\n"
-      "    -> Project\n"
+      "    -- Project\n"
       "       Context for 2\n"
-      "      -> Filter\n"
+      "      -- Filter\n"
       "         Context for 1\n"
-      "        -> Values\n"
+      "        -- Values\n"
       "           Context for 0\n",
       plan_->toString(false, true, addContext));
 
   ASSERT_EQ(
-      "-> Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))]\n"
+      "-- Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
       "   Context for 4\n"
-      "  -> Filter[expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)]\n"
+      "  -- Filter[expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)] -> out1:SMALLINT, out2:BIGINT\n"
       "     Context for 3\n"
-      "    -> Project[expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))]\n"
+      "    -- Project[expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))] -> out1:SMALLINT, out2:BIGINT\n"
       "       Context for 2\n"
-      "      -> Filter[expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)]\n"
+      "      -- Filter[expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
       "         Context for 1\n"
-      "        -> Values[5 rows in 1 vectors]\n"
+      "        -- Values[5 rows in 1 vectors] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
       "           Context for 0\n",
       plan_->toString(true, true, addContext));
 }
@@ -134,13 +134,13 @@ TEST_F(PlanNodeToStringTest, withMultiLineContext) {
   };
 
   ASSERT_EQ(
-      "-> Project\n"
+      "-- Project\n"
       "   Context for 4: line 1\n"
       "   Context for 4: line 2\n",
       plan_->toString(false, false, addContext));
 
   ASSERT_EQ(
-      "-> Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))]\n"
+      "-- Project[expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
       "   Context for 4: line 1\n"
       "   Context for 4: line 2\n",
       plan_->toString(true, false, addContext));
@@ -154,9 +154,9 @@ TEST_F(PlanNodeToStringTest, aggregation) {
                       {}, {"sum(c0) AS a", "avg(c1) AS b", "min(c2) AS c"})
                   .planNode();
 
-  ASSERT_EQ("-> Aggregation\n", plan->toString());
+  ASSERT_EQ("-- Aggregation\n", plan->toString());
   ASSERT_EQ(
-      "-> Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"])]\n",
+      "-- Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"])] -> a:BIGINT, b:ROW<\"\":DOUBLE, \"\":BIGINT>, c:BIGINT\n",
       plan->toString(true, false));
 
   // Group-by aggregation.
@@ -165,9 +165,9 @@ TEST_F(PlanNodeToStringTest, aggregation) {
              .singleAggregation({"c0"}, {"sum(c1) AS a", "avg(c2) AS b"})
              .planNode();
 
-  ASSERT_EQ("-> Aggregation\n", plan->toString());
+  ASSERT_EQ("-- Aggregation\n", plan->toString());
   ASSERT_EQ(
-      "-> Aggregation[SINGLE [c0] a := sum(ROW[\"c1\"]), b := avg(ROW[\"c2\"])]\n",
+      "-- Aggregation[SINGLE [c0] a := sum(ROW[\"c1\"]), b := avg(ROW[\"c2\"])] -> c0:SMALLINT, a:BIGINT, b:DOUBLE\n",
       plan->toString(true, false));
 }
 
@@ -186,8 +186,10 @@ TEST_F(PlanNodeToStringTest, hashJoin) {
                       {"t_c0", "t_c1", "u_c1"})
                   .planNode();
 
-  ASSERT_EQ("-> HashJoin\n", plan->toString());
-  ASSERT_EQ("-> HashJoin[INNER t_c0=u_c0]\n", plan->toString(true, false));
+  ASSERT_EQ("-- HashJoin\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[INNER t_c0=u_c0] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .values({data_})
@@ -204,9 +206,9 @@ TEST_F(PlanNodeToStringTest, hashJoin) {
                  core::JoinType::kLeft)
              .planNode();
 
-  ASSERT_EQ("-> HashJoin\n", plan->toString());
+  ASSERT_EQ("-- HashJoin\n", plan->toString());
   ASSERT_EQ(
-      "-> HashJoin[LEFT t_c0=u_c0, filter: gt(ROW[\"t_c1\"],ROW[\"u_c1\"])]\n",
+      "-- HashJoin[LEFT t_c0=u_c0, filter: gt(ROW[\"t_c1\"],ROW[\"u_c1\"])] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
       plan->toString(true, false));
 }
 
@@ -225,8 +227,10 @@ TEST_F(PlanNodeToStringTest, mergeJoin) {
                       {"t_c0", "t_c1", "u_c1"})
                   .planNode();
 
-  ASSERT_EQ("-> MergeJoin\n", plan->toString());
-  ASSERT_EQ("-> MergeJoin[INNER t_c0=u_c0]\n", plan->toString(true, false));
+  ASSERT_EQ("-- MergeJoin\n", plan->toString());
+  ASSERT_EQ(
+      "-- MergeJoin[INNER t_c0=u_c0] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .values({data_})
@@ -243,9 +247,9 @@ TEST_F(PlanNodeToStringTest, mergeJoin) {
                  core::JoinType::kLeft)
              .planNode();
 
-  ASSERT_EQ("-> MergeJoin\n", plan->toString());
+  ASSERT_EQ("-- MergeJoin\n", plan->toString());
   ASSERT_EQ(
-      "-> MergeJoin[LEFT t_c0=u_c0, filter: gt(ROW[\"t_c1\"],ROW[\"u_c1\"])]\n",
+      "-- MergeJoin[LEFT t_c0=u_c0, filter: gt(ROW[\"t_c1\"],ROW[\"u_c1\"])] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
       plan->toString(true, false));
 }
 
@@ -261,8 +265,10 @@ TEST_F(PlanNodeToStringTest, crossJoin) {
                       {"t_c0", "t_c1", "u_c1"})
                   .planNode();
 
-  ASSERT_EQ("-> CrossJoin\n", plan->toString());
-  ASSERT_EQ("-> CrossJoin[]\n", plan->toString(true, false));
+  ASSERT_EQ("-- CrossJoin\n", plan->toString());
+  ASSERT_EQ(
+      "-- CrossJoin[] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, orderBy) {
@@ -271,31 +277,36 @@ TEST_F(PlanNodeToStringTest, orderBy) {
                   .orderBy({"c1 ASC NULLS FIRST"}, true)
                   .planNode();
 
-  ASSERT_EQ("-> OrderBy\n", plan->toString());
+  ASSERT_EQ("-- OrderBy\n", plan->toString());
   ASSERT_EQ(
-      "-> OrderBy[PARTIAL c1 ASC NULLS FIRST]\n", plan->toString(true, false));
+      "-- OrderBy[PARTIAL c1 ASC NULLS FIRST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .values({data_})
              .orderBy({"c1 ASC NULLS FIRST", "c0 DESC NULLS LAST"}, false)
              .planNode();
 
-  ASSERT_EQ("-> OrderBy\n", plan->toString());
+  ASSERT_EQ("-- OrderBy\n", plan->toString());
   ASSERT_EQ(
-      "-> OrderBy[c1 ASC NULLS FIRST, c0 DESC NULLS LAST]\n",
+      "-- OrderBy[c1 ASC NULLS FIRST, c0 DESC NULLS LAST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, limit) {
   auto plan = PlanBuilder().values({data_}).limit(0, 10, true).planNode();
 
-  ASSERT_EQ("-> Limit\n", plan->toString());
-  ASSERT_EQ("-> Limit[PARTIAL 10]\n", plan->toString(true, false));
+  ASSERT_EQ("-- Limit\n", plan->toString());
+  ASSERT_EQ(
+      "-- Limit[PARTIAL 10] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder().values({data_}).limit(7, 12, false).planNode();
 
-  ASSERT_EQ("-> Limit\n", plan->toString());
-  ASSERT_EQ("-> Limit[12 offset 7]\n", plan->toString(true, false));
+  ASSERT_EQ("-- Limit\n", plan->toString());
+  ASSERT_EQ(
+      "-- Limit[12 offset 7] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, topN) {
@@ -304,34 +315,39 @@ TEST_F(PlanNodeToStringTest, topN) {
                   .topN({"c0 NULLS FIRST"}, 10, true)
                   .planNode();
 
-  ASSERT_EQ("-> TopN\n", plan->toString());
+  ASSERT_EQ("-- TopN\n", plan->toString());
   ASSERT_EQ(
-      "-> TopN[PARTIAL 10 c0 ASC NULLS FIRST]\n", plan->toString(true, false));
+      "-- TopN[PARTIAL 10 c0 ASC NULLS FIRST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .values({data_})
              .topN({"c1 NULLS FIRST", "c0 DESC"}, 10, false)
              .planNode();
 
-  ASSERT_EQ("-> TopN\n", plan->toString());
+  ASSERT_EQ("-- TopN\n", plan->toString());
   ASSERT_EQ(
-      "-> TopN[10 c1 ASC NULLS FIRST, c0 DESC NULLS LAST]\n",
+      "-- TopN[10 c1 ASC NULLS FIRST, c0 DESC NULLS LAST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, enforceSingleRow) {
   auto plan = PlanBuilder().values({data_}).enforceSingleRow().planNode();
 
-  ASSERT_EQ("-> EnforceSingleRow\n", plan->toString());
-  ASSERT_EQ("-> EnforceSingleRow[]\n", plan->toString(true, false));
+  ASSERT_EQ("-- EnforceSingleRow\n", plan->toString());
+  ASSERT_EQ(
+      "-- EnforceSingleRow[] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, assignUniqueId) {
   auto plan =
       PlanBuilder().values({data_}).assignUniqueId("unique_id", 123).planNode();
 
-  ASSERT_EQ("-> AssignUniqueId\n", plan->toString());
-  ASSERT_EQ("-> AssignUniqueId[]\n", plan->toString(true, false));
+  ASSERT_EQ("-- AssignUniqueId\n", plan->toString());
+  ASSERT_EQ(
+      "-- AssignUniqueId[] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT, unique_id:BIGINT\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, unnest) {
@@ -341,8 +357,10 @@ TEST_F(PlanNodeToStringTest, unnest) {
                   .unnest({"c1"}, {"a0"})
                   .planNode();
 
-  ASSERT_EQ("-> Unnest\n", plan->toString());
-  ASSERT_EQ("-> Unnest[a0]\n", plan->toString(true, false));
+  ASSERT_EQ("-- Unnest\n", plan->toString());
+  ASSERT_EQ(
+      "-- Unnest[a0] -> c1:INTEGER, a0_e:SMALLINT\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, localPartition) {
@@ -351,42 +369,52 @@ TEST_F(PlanNodeToStringTest, localPartition) {
           .localPartition({"c0"}, {PlanBuilder().values({data_}).planNode()})
           .planNode();
 
-  ASSERT_EQ("-> LocalPartition\n", plan->toString());
-  ASSERT_EQ("-> LocalPartition[REPARTITION]\n", plan->toString(true, false));
+  ASSERT_EQ("-- LocalPartition\n", plan->toString());
+  ASSERT_EQ(
+      "-- LocalPartition[REPARTITION] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .localPartition({}, {PlanBuilder().values({data_}).planNode()})
              .planNode();
 
-  ASSERT_EQ("-> LocalPartition\n", plan->toString());
-  ASSERT_EQ("-> LocalPartition[GATHER]\n", plan->toString(true, false));
+  ASSERT_EQ("-- LocalPartition\n", plan->toString());
+  ASSERT_EQ(
+      "-- LocalPartition[GATHER] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, partitionedOutput) {
   auto plan =
       PlanBuilder().values({data_}).partitionedOutput({"c0"}, 4).planNode();
 
-  ASSERT_EQ("-> PartitionedOutput\n", plan->toString());
-  ASSERT_EQ("-> PartitionedOutput[HASH(c0) 4]\n", plan->toString(true, false));
+  ASSERT_EQ("-- PartitionedOutput\n", plan->toString());
+  ASSERT_EQ(
+      "-- PartitionedOutput[HASH(c0) 4] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder().values({data_}).partitionedOutputBroadcast().planNode();
 
-  ASSERT_EQ("-> PartitionedOutput\n", plan->toString());
-  ASSERT_EQ("-> PartitionedOutput[BROADCAST]\n", plan->toString(true, false));
+  ASSERT_EQ("-- PartitionedOutput\n", plan->toString());
+  ASSERT_EQ(
+      "-- PartitionedOutput[BROADCAST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder().values({data_}).partitionedOutput({}, 1).planNode();
 
-  ASSERT_EQ("-> PartitionedOutput\n", plan->toString());
-  ASSERT_EQ("-> PartitionedOutput[SINGLE]\n", plan->toString(true, false));
+  ASSERT_EQ("-- PartitionedOutput\n", plan->toString());
+  ASSERT_EQ(
+      "-- PartitionedOutput[SINGLE] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .values({data_})
              .partitionedOutput({"c1", "c2"}, 5, true)
              .planNode();
 
-  ASSERT_EQ("-> PartitionedOutput\n", plan->toString());
+  ASSERT_EQ("-- PartitionedOutput\n", plan->toString());
   ASSERT_EQ(
-      "-> PartitionedOutput[HASH(c1, c2) 5 replicate nulls and any]\n",
+      "-- PartitionedOutput[HASH(c1, c2) 5 replicate nulls and any] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan->toString(true, false));
 }
 
@@ -397,8 +425,10 @@ TEST_F(PlanNodeToStringTest, localMerge) {
               {"c1 NULLS FIRST"}, {PlanBuilder().values({data_}).planNode()})
           .planNode();
 
-  ASSERT_EQ("-> LocalMerge\n", plan->toString());
-  ASSERT_EQ("-> LocalMerge[c1 ASC NULLS FIRST]\n", plan->toString(true, false));
+  ASSERT_EQ("-- LocalMerge\n", plan->toString());
+  ASSERT_EQ(
+      "-- LocalMerge[c1 ASC NULLS FIRST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
+      plan->toString(true, false));
 
   plan = PlanBuilder()
              .localMerge(
@@ -406,9 +436,9 @@ TEST_F(PlanNodeToStringTest, localMerge) {
                  {PlanBuilder().values({data_}).planNode()})
              .planNode();
 
-  ASSERT_EQ("-> LocalMerge\n", plan->toString());
+  ASSERT_EQ("-- LocalMerge\n", plan->toString());
   ASSERT_EQ(
-      "-> LocalMerge[c1 ASC NULLS FIRST, c0 DESC NULLS LAST]\n",
+      "-- LocalMerge[c1 ASC NULLS FIRST, c0 DESC NULLS LAST] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan->toString(true, false));
 }
 
@@ -416,8 +446,9 @@ TEST_F(PlanNodeToStringTest, exchange) {
   auto plan =
       PlanBuilder().exchange(ROW({"a", "b"}, {BIGINT(), VARCHAR()})).planNode();
 
-  ASSERT_EQ("-> Exchange\n", plan->toString());
-  ASSERT_EQ("-> Exchange[]\n", plan->toString(true, false));
+  ASSERT_EQ("-- Exchange\n", plan->toString());
+  ASSERT_EQ(
+      "-- Exchange[] -> a:BIGINT, b:VARCHAR\n", plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, tableScan) {
@@ -434,13 +465,14 @@ TEST_F(PlanNodeToStringTest, tableScan) {
                         "comment NOT LIKE '%special%request%'")
                     .planNode();
 
-    ASSERT_EQ("-> TableScan\n", plan->toString());
+    ASSERT_EQ("-- TableScan\n", plan->toString());
     const char* output =
-        "-> TableScan[table: hive_table, "
+        "-- TableScan[table: hive_table, "
         "range filters: [(discount, DoubleRange: [0.050000, 0.070000] no nulls), "
         "(quantity, DoubleRange: (-inf, 24.000000) no nulls), "
         "(shipdate, BytesRange: [1994-01-01, 1994-12-31] no nulls)], "
-        "remaining filter: (not(like(ROW[\"comment\"],\"%special%request%\")))]\n";
+        "remaining filter: (not(like(ROW[\"comment\"],\"%special%request%\")))] "
+        "-> discount:DOUBLE, quantity:DOUBLE, shipdate:VARCHAR, comment:VARCHAR\n";
     ASSERT_EQ(output, plan->toString(true, false));
   }
   {
@@ -450,7 +482,8 @@ TEST_F(PlanNodeToStringTest, tableScan) {
             .planNode();
 
     ASSERT_EQ(
-        "-> TableScan[table: hive_table, remaining filter: (not(like(ROW[\"comment\"],\"%special%request%\")))]\n",
+        "-- TableScan[table: hive_table, remaining filter: (not(like(ROW[\"comment\"],\"%special%request%\")))] "
+        "-> discount:DOUBLE, quantity:DOUBLE, shipdate:VARCHAR, comment:VARCHAR\n",
         plan->toString(true, false));
   }
 }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -332,7 +332,7 @@ bool RowType::operator==(const Type& other) const {
 
 void RowType::printChildren(
     std::stringstream& ss,
-    const std::string_view delimiter) const {
+    std::string_view delimiter) const {
   bool any = false;
   for (size_t i = 0; i < children_.size(); ++i) {
     if (any) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -330,9 +330,8 @@ bool RowType::operator==(const Type& other) const {
   return true;
 }
 
-void RowType::printChildren(
-    std::stringstream& ss,
-    std::string_view delimiter) const {
+void RowType::printChildren(std::stringstream& ss, std::string_view delimiter)
+    const {
   bool any = false;
   for (size_t i = 0; i < children_.size(); ++i) {
     if (any) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -330,13 +330,11 @@ bool RowType::operator==(const Type& other) const {
   return true;
 }
 
-std::string RowType::toString() const {
-  std::stringstream ss;
-  ss << (TypeTraits<TypeKind::ROW>::name) << "<";
+void RowType::printChildren(std::stringstream& ss) const {
   bool any = false;
   for (size_t i = 0; i < children_.size(); ++i) {
     if (any) {
-      ss << ',';
+      ss << ", ";
     }
     const auto& name = names_.at(i);
     if (isColumnNameRequiringEscaping(name)) {
@@ -347,6 +345,12 @@ std::string RowType::toString() const {
     ss << ':' << children_.at(i)->toString();
     any = true;
   }
+}
+
+std::string RowType::toString() const {
+  std::stringstream ss;
+  ss << (TypeTraits<TypeKind::ROW>::name) << "<";
+  printChildren(ss);
   ss << ">";
   return ss.str();
 }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -330,11 +330,13 @@ bool RowType::operator==(const Type& other) const {
   return true;
 }
 
-void RowType::printChildren(std::stringstream& ss) const {
+void RowType::printChildren(
+    std::stringstream& ss,
+    const std::string_view delimiter) const {
   bool any = false;
   for (size_t i = 0; i < children_.size(); ++i) {
     if (any) {
-      ss << ", ";
+      ss << delimiter;
     }
     const auto& name = names_.at(i);
     if (isColumnNameRequiringEscaping(name)) {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -701,7 +701,7 @@ class RowType : public TypeBase<TypeKind::ROW> {
   /// Print child names and types separated by 'delimiter'.
   void printChildren(
       std::stringstream& ss,
-      const std::string_view delimiter = ",") const;
+      std::string_view delimiter = ",") const;
 
   std::shared_ptr<RowType> unionWith(std::shared_ptr<RowType>& rowType) const;
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -698,8 +698,10 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   std::string toString() const override;
 
-  /// Print children's names and types as comma separated pairs.
-  void printChildren(std::stringstream& ss) const;
+  /// Print child names and types separated by 'delimiter'.
+  void printChildren(
+      std::stringstream& ss,
+      const std::string_view delimiter = ",") const;
 
   std::shared_ptr<RowType> unionWith(std::shared_ptr<RowType>& rowType) const;
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -699,9 +699,8 @@ class RowType : public TypeBase<TypeKind::ROW> {
   std::string toString() const override;
 
   /// Print child names and types separated by 'delimiter'.
-  void printChildren(
-      std::stringstream& ss,
-      std::string_view delimiter = ",") const;
+  void printChildren(std::stringstream& ss, std::string_view delimiter = ",")
+      const;
 
   std::shared_ptr<RowType> unionWith(std::shared_ptr<RowType>& rowType) const;
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -698,6 +698,9 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   std::string toString() const override;
 
+  // Print children name and type as comma separated pairs.
+  void printChildren(std::stringstream& ss) const;
+
   std::shared_ptr<RowType> unionWith(std::shared_ptr<RowType>& rowType) const;
 
   folly::dynamic serialize() const override;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -698,7 +698,7 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   std::string toString() const override;
 
-  // Print children name and type as comma separated pairs.
+  /// Print children's names and types as comma separated pairs.
   void printChildren(std::stringstream& ss) const;
 
   std::shared_ptr<RowType> unionWith(std::shared_ptr<RowType>& rowType) const;


### PR DESCRIPTION
Adds the output type of the plan node when `PlanNode::toString` is invoked with `detailed = true`.
Changes the prefix format of the output to `--`.

Example output
```
  -- Project[expressions: (out3:BIGINT, plus(cast ROW["out1"] as BIGINT,10))] -> out3:BIGINT
    -- Filter[expression: lt(mod(cast ROW["out1"] as BIGINT,10),8)] -> out1:SMALLINT, out2:BIGINT
      -- Project[expressions: (out1:SMALLINT, ROW["c0"]), (out2:BIGINT, plus(mod(cast ROW["c0"] as BIGINT,100),mod(cast ROW["c1"] as BIGINT,50)))] -> out1:SMALLINT, out2:BIGINT
        -- Filter[expression: lt(mod(cast ROW["c0"] as BIGINT,10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT
          -- Values[5 rows in 1 vectors] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT
```