### PR TITLE
Benchmark multiple vector sizes in SimpleArithmetic

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -83,8 +83,7 @@ struct CheckedPlusFunction {
 class SimpleArithmeticBenchmark
     : public functions::test::FunctionBenchmarkBase {
  public:
-  explicit SimpleArithmeticBenchmark(size_t vectorSize)
-      : FunctionBenchmarkBase() {
+  explicit SimpleArithmeticBenchmark() : FunctionBenchmarkBase() {
     registerFunction<MultiplyVoidOutputFunction, double, double, double>(
         {"multiply"});
     registerFunction<MultiplyNullableOutputFunction, double, double, double>(
@@ -107,8 +106,14 @@ class SimpleArithmeticBenchmark
     });
 
     // Generate input data.
+    smallRowVector_ = makeRowVector(100);
+    mediumRowVector_ = makeRowVector(1'000);
+    largeRowVector_ = makeRowVector(10'000);
+  }
+
+  RowVectorPtr makeRowVector(vector_size_t size) {
     VectorFuzzer::Options opts;
-    opts.vectorSize = vectorSize;
+    opts.vectorSize = size;
     opts.nullChance = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
@@ -123,57 +128,67 @@ class SimpleArithmeticBenchmark
     fuzzer.setOptions(opts);
     children.emplace_back(fuzzer.fuzzFlat(DOUBLE())); // HalfNull
 
-    rowVector_ = std::make_shared<RowVector>(
-        pool(), inputType_, nullptr, vectorSize, std::move(children));
+    return std::make_shared<RowVector>(
+        pool(), inputType_, nullptr, size, std::move(children));
   }
 
-  void setInput(const TypePtr& inputType, const RowVectorPtr& rowVector) {
-    inputType_ = inputType;
-    rowVector_ = rowVector;
+  size_t runSmall(const std::string& expression, size_t times) {
+    return run(expression, times, smallRowVector_);
+  }
+
+  size_t runMedium(const std::string& expression, size_t times) {
+    return run(expression, times, mediumRowVector_);
+  }
+
+  size_t runLarge(const std::string& expression, size_t times) {
+    return run(expression, times, largeRowVector_);
   }
 
   // Runs `expression` `times` thousand times.
-  size_t run(const std::string& expression, size_t times) {
+  size_t
+  run(const std::string& expression, size_t times, const RowVectorPtr& input) {
     folly::BenchmarkSuspender suspender;
     auto exprSet = compileExpression(expression, inputType_);
     suspender.dismiss();
 
     size_t count = 0;
     for (auto i = 0; i < times * 1'000; i++) {
-      count += evaluate(exprSet, rowVector_)->size();
+      count += evaluate(exprSet, input)->size();
     }
     return count;
   }
 
  private:
   TypePtr inputType_;
-  RowVectorPtr rowVector_;
+  RowVectorPtr smallRowVector_;
+  RowVectorPtr mediumRowVector_;
+  RowVectorPtr largeRowVector_;
 };
 
 std::unique_ptr<SimpleArithmeticBenchmark> benchmark;
 
-BENCHMARK_MULTI(multiply, n) {
-  return benchmark->run("multiply(a, b)", n);
+BENCHMARK_MULTI(multiplySmall, n) {
+  return benchmark->runSmall("multiply(a, b)", n);
 }
 
-BENCHMARK_MULTI(multiplySameColumn, n) {
-  return benchmark->run("multiply(a, a)", n);
+BENCHMARK_MULTI(multiplySameColumnSmall, n) {
+  return benchmark->runSmall("multiply(a, a)", n);
 }
 
-BENCHMARK_MULTI(multiplyHalfNull, n) {
-  return benchmark->run("multiply(a, half_null)", n);
+BENCHMARK_MULTI(multiplyHalfNullSmall, n) {
+  return benchmark->runSmall("multiply(a, half_null)", n);
 }
 
-BENCHMARK_MULTI(multiplyConstant, n) {
-  return benchmark->run("multiply(a, constant)", n);
+BENCHMARK_MULTI(multiplyConstantSmall, n) {
+  return benchmark->runSmall("multiply(a, constant)", n);
 }
 
-BENCHMARK_MULTI(multiplyNested, n) {
-  return benchmark->run("multiply(multiply(a, b), b)", n);
+BENCHMARK_MULTI(multiplyNestedSmall, n) {
+  return benchmark->runSmall("multiply(multiply(a, b), b)", n);
 }
 
-BENCHMARK_MULTI(multiplyNestedDeep, n) {
-  return benchmark->run(
+BENCHMARK_MULTI(multiplyNestedDeepSmall, n) {
+  return benchmark->runSmall(
       "multiply(multiply(multiply(a, b), a), "
       "multiply(a, multiply(a, b)))",
       n);
@@ -181,26 +196,134 @@ BENCHMARK_MULTI(multiplyNestedDeep, n) {
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoid, n) {
-  return benchmark->run("multiply(a, b)", n);
+BENCHMARK_MULTI(multiplyOutputVoidSmall, n) {
+  return benchmark->runSmall("multiply(a, b)", n);
 }
 
-BENCHMARK_MULTI(multiplyOutputNullable, n) {
-  return benchmark->run("multiply_nullable_output(a, b)", n);
+BENCHMARK_MULTI(multiplyOutputNullableSmall, n) {
+  return benchmark->runSmall("multiply_nullable_output(a, b)", n);
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNull, n) {
-  return benchmark->run("multiply_null_output(a, b)", n);
+BENCHMARK_MULTI(multiplyOutputAlwaysNullSmall, n) {
+  return benchmark->runSmall("multiply_null_output(a, b)", n);
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(plusUnchecked, n) {
-  return benchmark->run("plus(c, d)", n);
+BENCHMARK_MULTI(plusUncheckedSmall, n) {
+  return benchmark->runSmall("plus(c, d)", n);
 }
 
-BENCHMARK_MULTI(plusChecked, n) {
-  return benchmark->run("checked_plus(c, d)", n);
+BENCHMARK_MULTI(plusCheckedSmall, n) {
+  return benchmark->runSmall("checked_plus(c, d)", n);
+}
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(multiplyMedium, n) {
+  return benchmark->runMedium("multiply(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplySameColumnMedium, n) {
+  return benchmark->runMedium("multiply(a, a)", n);
+}
+
+BENCHMARK_MULTI(multiplyHalfNullMedium, n) {
+  return benchmark->runMedium("multiply(a, half_null)", n);
+}
+
+BENCHMARK_MULTI(multiplyConstantMedium, n) {
+  return benchmark->runMedium("multiply(a, constant)", n);
+}
+
+BENCHMARK_MULTI(multiplyNestedMedium, n) {
+  return benchmark->runMedium("multiply(multiply(a, b), b)", n);
+}
+
+BENCHMARK_MULTI(multiplyNestedDeepMedium, n) {
+  return benchmark->runMedium(
+      "multiply(multiply(multiply(a, b), a), "
+      "multiply(a, multiply(a, b)))",
+      n);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(multiplyOutputVoidMedium, n) {
+  return benchmark->runMedium("multiply(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplyOutputNullableMedium, n) {
+  return benchmark->runMedium("multiply_nullable_output(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplyOutputAlwaysNullMedium, n) {
+  return benchmark->runMedium("multiply_null_output(a, b)", n);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(plusUncheckedMedium, n) {
+  return benchmark->runMedium("plus(c, d)", n);
+}
+
+BENCHMARK_MULTI(plusCheckedMedium, n) {
+  return benchmark->runMedium("checked_plus(c, d)", n);
+}
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(multiplyLarge, n) {
+  return benchmark->runLarge("multiply(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplySameColumnLarge, n) {
+  return benchmark->runLarge("multiply(a, a)", n);
+}
+
+BENCHMARK_MULTI(multiplyHalfNullLarge, n) {
+  return benchmark->runLarge("multiply(a, half_null)", n);
+}
+
+BENCHMARK_MULTI(multiplyConstantLarge, n) {
+  return benchmark->runLarge("multiply(a, constant)", n);
+}
+
+BENCHMARK_MULTI(multiplyNestedLarge, n) {
+  return benchmark->runLarge("multiply(multiply(a, b), b)", n);
+}
+
+BENCHMARK_MULTI(multiplyNestedDeepLarge, n) {
+  return benchmark->runLarge(
+      "multiply(multiply(multiply(a, b), a), "
+      "multiply(a, multiply(a, b)))",
+      n);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(multiplyOutputVoidLarge, n) {
+  return benchmark->runLarge("multiply(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplyOutputNullableLarge, n) {
+  return benchmark->runLarge("multiply_nullable_output(a, b)", n);
+}
+
+BENCHMARK_MULTI(multiplyOutputAlwaysNullLarge, n) {
+  return benchmark->runLarge("multiply_null_output(a, b)", n);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(plusUncheckedLarge, n) {
+  return benchmark->runLarge("plus(c, d)", n);
+}
+
+BENCHMARK_MULTI(plusCheckedLarge, n) {
+  return benchmark->runLarge("checked_plus(c, d)", n);
 }
 
 } // namespace
@@ -208,7 +331,7 @@ BENCHMARK_MULTI(plusChecked, n) {
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  benchmark = std::make_unique<SimpleArithmeticBenchmark>(1'000);
+  benchmark = std::make_unique<SimpleArithmeticBenchmark>();
   folly::runBenchmarks();
   benchmark.reset();
   return 0;


### PR DESCRIPTION
We are seeing that different application use vectors of different sizes. Some
use short vectors of ~100 rows, others medium size vectors of a few K rows, and
some use larger vectors of about a dozen K rows.

To cover the whole range of use cases, this change extends SimpleArithmetic
benchmark to test 3 different vector sizes: 100, 1K, 10K rows.