### PR TITLE
Fix BytesRange::testBytes for empty strings

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -353,6 +353,13 @@ int compareRanges(const char* lhs, size_t length, const std::string& rhs) {
 } // namespace
 
 bool BytesRange::testBytes(const char* value, int32_t length) const {
+  if (length == 0) {
+    // Empty string. value is null. This is the smallest possible string. It
+    // passes the filter if there is no lower bound or if it is also an empty
+    // string.
+    return lowerUnbounded_ || lower_.empty();
+  }
+
   if (singleValue_) {
     if (length != lower_.size()) {
       return false;

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -511,24 +511,28 @@ TEST(FilterTest, bytesRange) {
   EXPECT_TRUE(filter->testBytes("a", 1));
   EXPECT_FALSE(filter->testBytes("b", 1));
   EXPECT_FALSE(filter->testBytes("c", 1));
+  EXPECT_TRUE(filter->testBytes(nullptr, 0));
 
   // <= b
   filter = lessThanOrEqual("b");
   EXPECT_TRUE(filter->testBytes("a", 1));
   EXPECT_TRUE(filter->testBytes("b", 1));
   EXPECT_FALSE(filter->testBytes("c", 1));
+  EXPECT_TRUE(filter->testBytes(nullptr, 0));
 
   // >= b
   filter = greaterThanOrEqual("b");
   EXPECT_FALSE(filter->testBytes("a", 1));
   EXPECT_TRUE(filter->testBytes("b", 1));
   EXPECT_TRUE(filter->testBytes("c", 1));
+  EXPECT_FALSE(filter->testBytes(nullptr, 0));
 
   // > b
   filter = greaterThan("b");
   EXPECT_FALSE(filter->testBytes("a", 1));
   EXPECT_FALSE(filter->testBytes("b", 1));
   EXPECT_TRUE(filter->testBytes("c", 1));
+  EXPECT_FALSE(filter->testBytes(nullptr, 0));
 }
 
 TEST(FilterTest, bytesValues) {


### PR DESCRIPTION
Differential Revision: D36155036

