### PR TITLE
Make SelectiveColumnReaderBuilder to use SelectiveColumnReaderFactory

### DIFF
--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -103,11 +103,11 @@ class SelectiveColumnReaderBuilder {
     scanSpec_ = std::make_unique<common::ScanSpec>("root");
     makeFieldSpecs("", 0, rowType, scanSpec_.get());
 
-    return SelectiveColumnReader::build(
+    SelectiveColumnReaderFactory selectiveColumnReaderFactory(scanSpec_.get());
+    return selectiveColumnReaderFactory.build(
         cs.getSchemaWithId(),
         dataTypeWithId,
         stripe,
-        scanSpec_.get(),
         FlatMapContext::nonFlatMapContext());
   }
 


### PR DESCRIPTION
`SelectiveColumnReaderBuilder` in `TestColumnReader` directly uses
`SelectiveColumnReader::build()` to create `SelectiveColumnReader`. It does
not call `reader->setIsTopLevel()` and therefore some functions in
`SelectiveColumnReader` were not tested, e.g. `advanceFieldReader()`.
This commit changes `SelectiveColumnReaderBuilder` to use
`SelectiveColumnReaderFactory` instead, which updates the `isTopLevel`
field of the column readers for better test coverage.