### PR TITLE
Decimal literal support

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -33,6 +33,7 @@ Supported types are:
   * TIMESTAMP
   * REAL
   * DOUBLE
+  * DECIMAL
   * VARCHAR
   * VARBINARY
   * OPAQUE*

--- a/velox/type/DecimalUtils.h
+++ b/velox/type/DecimalUtils.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/Type.h"
+namespace facebook::velox {
+
+static const int128_t POWERS_OF_TEN[]{
+    1,
+    10,
+    100,
+    1000,
+    10000,
+    100000,
+    1000000,
+    10000000,
+    100000000,
+    1000000000,
+    10000000000,
+    100000000000,
+    1000000000000,
+    10000000000000,
+    100000000000000,
+    1000000000000000,
+    10000000000000000,
+    100000000000000000,
+    1000000000000000000,
+    1000000000000000000 * (int128_t)10,
+    1000000000000000000 * (int128_t)100,
+    1000000000000000000 * (int128_t)1000,
+    1000000000000000000 * (int128_t)10000,
+    1000000000000000000 * (int128_t)100000,
+    1000000000000000000 * (int128_t)1000000,
+    1000000000000000000 * (int128_t)10000000,
+    1000000000000000000 * (int128_t)100000000,
+    1000000000000000000 * (int128_t)1000000000,
+    1000000000000000000 * (int128_t)10000000000,
+    1000000000000000000 * (int128_t)100000000000,
+    1000000000000000000 * (int128_t)1000000000000,
+    1000000000000000000 * (int128_t)10000000000000,
+    1000000000000000000 * (int128_t)100000000000000,
+    1000000000000000000 * (int128_t)1000000000000000,
+    1000000000000000000 * (int128_t)10000000000000000,
+    1000000000000000000 * (int128_t)100000000000000000,
+    1000000000000000000 * (int128_t)1000000000000000000,
+    1000000000000000000 * (int128_t)1000000000000000000 * (int128_t)10,
+    1000000000000000000 * (int128_t)1000000000000000000 * (int128_t)100};
+
+class DecimalCasts {
+ public:
+  static std::string ShortDecimalToString(
+      uint8_t precision,
+      uint8_t scale,
+      int64_t unscaledValue) {
+    std::string result;
+    if (unscaledValue < 0) {
+      result.append("-");
+      unscaledValue = ~unscaledValue + 1;
+    }
+    std::stringstream ss;
+    ss << unscaledValue;
+    std::string unscaledValueStr = ss.str();
+    return result.append(UnscaledValueToDecimalString(scale, unscaledValueStr));
+  }
+
+  static std::string LongDecimalToString(
+      uint8_t precision,
+      uint8_t scale,
+      int128_t unscaledValue) {
+    std::string result;
+    if (unscaledValue < 0) {
+      result.append("-");
+      unscaledValue = ~unscaledValue + 1;
+    }
+    auto unscaledValueStr = Int128ToString(unscaledValue);
+    return result.append(UnscaledValueToDecimalString(scale, unscaledValueStr));
+  }
+
+  static std::string Int128ToString(uint128_t number) {
+    std::stringstream ss;
+    std::string result;
+    if (number == 0)
+      return "0";
+    while (number) {
+      uint64_t remainder = number % POWERS_OF_TEN[18];
+      number = number / POWERS_OF_TEN[18];
+      ss << remainder;
+      result.insert(0, ss.str());
+      ss.str("");
+    }
+    return result;
+  }
+
+  static std::string UnscaledValueToDecimalString(
+      uint8_t scale,
+      std::string& unscaledValueStr) {
+    std::string result;
+    if (unscaledValueStr.length() <= scale) {
+      result.append("0");
+    } else {
+      result.append(
+          unscaledValueStr.substr(0, unscaledValueStr.length() - scale));
+    }
+
+    if (scale > 0) {
+      result.append(".");
+      if (unscaledValueStr.length() < scale) {
+        for (auto i = 0; i < scale - unscaledValueStr.length(); ++i) {
+          result.append("0");
+        }
+        result.append(unscaledValueStr);
+      } else {
+        result.append(
+            unscaledValueStr.substr(unscaledValueStr.length() - scale));
+      }
+    }
+    return result;
+  }
+}; // DecimalCasts
+} // namespace facebook::velox

--- a/velox/type/ShortDecimal.h
+++ b/velox/type/ShortDecimal.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/dynamic.h>
+#include <sstream>
+#include <string>
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/StringView.h"
+
+#pragma once
+
+namespace facebook::velox {
+
+struct ShortDecimal {
+ public:
+  constexpr ShortDecimal() : unscaledValue_(0) {}
+  constexpr ShortDecimal(int64_t value) : unscaledValue_(value) {}
+
+  int64_t unscaledValue() const {
+    return unscaledValue_;
+  }
+
+  bool operator==(const ShortDecimal& other) const {
+    return unscaledValue_ == other.unscaledValue_;
+  }
+
+  bool operator!=(const ShortDecimal& other) const {
+    return unscaledValue_ != other.unscaledValue_;
+  }
+
+  bool operator<(const ShortDecimal& other) const {
+    return unscaledValue_ < other.unscaledValue_;
+  }
+
+  bool operator<=(const ShortDecimal& other) const {
+    return unscaledValue_ <= other.unscaledValue_;
+  }
+
+  bool operator>(const ShortDecimal& other) const {
+    return unscaledValue_ > other.unscaledValue_;
+  }
+
+  bool operator>=(const ShortDecimal& other) const {
+    return unscaledValue_ >= other.unscaledValue_;
+  }
+
+  // Needed for serialization of FlatVector<ShortDecimal>
+  operator StringView() const {
+    VELOX_NYI();
+  }
+
+  std::string toString() const;
+
+  operator std::string() const {
+    return toString();
+  }
+
+  operator folly::dynamic() const {
+    return folly::dynamic(unscaledValue_);
+  }
+
+ private:
+  int64_t unscaledValue_;
+};
+} // namespace facebook::velox
+
+namespace std {
+template <>
+struct hash<::facebook::velox::ShortDecimal> {
+  size_t operator()(const ::facebook::velox::ShortDecimal& value) const {
+    return std::hash<int64_t>{}(value.unscaledValue());
+  }
+};
+
+std::string to_string(const ::facebook::velox::ShortDecimal& ts);
+
+} // namespace std
+
+namespace folly {
+template <>
+struct hasher<::facebook::velox::ShortDecimal> {
+  size_t operator()(const ::facebook::velox::ShortDecimal& value) const {
+    return std::hash<int64_t>{}(value.unscaledValue());
+  }
+};
+} // namespace folly

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -59,6 +59,8 @@ const std::unordered_map<std::string, TypeKind>& getTypeStringMap() {
       {"VARBINARY", TypeKind::VARBINARY},
       {"TIMESTAMP", TypeKind::TIMESTAMP},
       {"DATE", TypeKind::DATE},
+      {"SHORT_DECIMAL", TypeKind::SHORT_DECIMAL},
+      {"LONG_DECIMAL", TypeKind::LONG_DECIMAL},
       {"ARRAY", TypeKind::ARRAY},
       {"MAP", TypeKind::MAP},
       {"ROW", TypeKind::ROW},
@@ -102,6 +104,8 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
       {TypeKind::VARBINARY, "VARBINARY"},
       {TypeKind::TIMESTAMP, "TIMESTAMP"},
       {TypeKind::DATE, "DATE"},
+      {TypeKind::SHORT_DECIMAL, "SHORT_DECIMAL"},
+      {TypeKind::LONG_DECIMAL, "LONG_DECIMAL"},
       {TypeKind::ARRAY, "ARRAY"},
       {TypeKind::MAP, "MAP"},
       {TypeKind::ROW, "ROW"},
@@ -579,6 +583,25 @@ KOSKI_DEFINE_SCALAR_ACCESSOR(DATE);
 KOSKI_DEFINE_SCALAR_ACCESSOR(UNKNOWN);
 
 #undef KOSKI_DEFINE_SCALAR_ACCESSOR
+
+std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<ShortDecimalType>(precision, scale);
+}
+
+std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale) {
+  return std::make_shared<LongDecimalType>(precision, scale);
+}
+
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale) {
+  if (precision <= DecimalType<TypeKind::SHORT_DECIMAL>::kMaxPrecision) {
+    return SHORT_DECIMAL(precision, scale);
+  }
+  return LONG_DECIMAL(precision, scale);
+}
 
 std::shared_ptr<const Type> createScalarType(TypeKind kind) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(createScalarType, kind);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -37,11 +37,14 @@
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/Date.h"
+#include "velox/type/ShortDecimal.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
 
 namespace facebook::velox {
+
+using int128_t = __int128_t;
 
 // Velox type system supports a small set of SQL-compatible composeable types:
 // BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, VARCHAR,
@@ -69,7 +72,8 @@ enum class TypeKind : int8_t {
   VARBINARY = 8,
   TIMESTAMP = 9,
   DATE = 10,
-
+  SHORT_DECIMAL = 11,
+  LONG_DECIMAL = 12,
   // Enum values for ComplexTypes start after 30 to leave
   // some values space to accommodate adding new scalar/native
   // types above.
@@ -95,7 +99,8 @@ std::ostream& operator<<(std::ostream& os, const TypeKind& kind);
 
 template <TypeKind KIND>
 class ScalarType;
-
+template <TypeKind KIND>
+class DecimalType;
 class ArrayType;
 class MapType;
 class RowType;
@@ -271,6 +276,32 @@ struct TypeTraits<TypeKind::DATE> {
   static constexpr bool isPrimitiveType = true;
   static constexpr bool isFixedWidth = true;
   static constexpr const char* name = "DATE";
+};
+
+template <>
+struct TypeTraits<TypeKind::SHORT_DECIMAL> {
+  using ImplType = DecimalType<TypeKind::SHORT_DECIMAL>;
+  using NativeType = ShortDecimal;
+  using DeepCopiedType = NativeType;
+  static constexpr uint32_t minSubTypes = 0;
+  static constexpr uint32_t maxSubTypes = 0;
+  static constexpr TypeKind typeKind = TypeKind::SHORT_DECIMAL;
+  static constexpr bool isPrimitiveType = true;
+  static constexpr bool isFixedWidth = true;
+  static constexpr const char* name = "SHORT_DECIMAL";
+};
+
+template <>
+struct TypeTraits<TypeKind::LONG_DECIMAL> {
+  using ImplType = DecimalType<TypeKind::LONG_DECIMAL>;
+  using NativeType = int128_t;
+  using DeepCopiedType = NativeType;
+  static constexpr uint32_t minSubTypes = 0;
+  static constexpr uint32_t maxSubTypes = 0;
+  static constexpr TypeKind typeKind = TypeKind::LONG_DECIMAL;
+  static constexpr bool isPrimitiveType = true;
+  static constexpr bool isFixedWidth = true;
+  static constexpr const char* name = "LONG_DECIMAL";
 };
 
 template <>
@@ -469,6 +500,8 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
   VELOX_FLUENT_CAST(Varbinary, VARBINARY)
   VELOX_FLUENT_CAST(Timestamp, TIMESTAMP)
   VELOX_FLUENT_CAST(Date, DATE)
+  VELOX_FLUENT_CAST(ShortDecimal, SHORT_DECIMAL)
+  VELOX_FLUENT_CAST(LongDecimal, LONG_DECIMAL)
   VELOX_FLUENT_CAST(Array, ARRAY)
   VELOX_FLUENT_CAST(Map, MAP)
   VELOX_FLUENT_CAST(Row, ROW)
@@ -505,6 +538,61 @@ class TypeBase : public Type {
   const char* kindName() const override {
     return TypeTraits<KIND>::name;
   }
+};
+
+using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
+using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
+
+/// This class represents the fixed-point numbers.
+/// The parameter "precision" represents the number of digits the
+/// Decimal Type can support and "scale" represents the number of digits to the
+/// right of the decimal point.
+template <TypeKind KIND>
+class DecimalType : public ScalarType<KIND> {
+ public:
+  static_assert(
+      KIND == TypeKind::SHORT_DECIMAL || KIND == TypeKind::LONG_DECIMAL);
+  static constexpr uint8_t kMaxPrecision =
+      KIND == TypeKind::SHORT_DECIMAL ? 18 : 38;
+
+  DecimalType(const uint8_t precision = 18, const uint8_t scale = 0)
+      : precision_(precision), scale_(scale) {
+    VELOX_CHECK_LE(scale, precision);
+    VELOX_CHECK_LE(precision, kMaxPrecision);
+  }
+
+  inline bool operator==(const Type& otherDecimal) const override {
+    if (this->kind() != otherDecimal.kind()) {
+      return false;
+    }
+    auto decimalType = static_cast<const DecimalType<KIND>&>(otherDecimal);
+    return (
+        decimalType.precision() == this->precision_ &&
+        decimalType.scale() == this->scale_);
+  }
+
+  inline const uint8_t precision() const {
+    return precision_;
+  }
+
+  inline const uint8_t scale() const {
+    return scale_;
+  }
+
+  std::string toString() const override {
+    return fmt::format("{}({},{})", TypeTraits<KIND>::name, precision_, scale_);
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = toString();
+    return obj;
+  }
+
+ private:
+  const uint8_t precision_;
+  const uint8_t scale_;
 };
 
 template <TypeKind KIND>
@@ -872,7 +960,6 @@ struct ComplexType {
 
 template <TypeKind KIND>
 struct TypeFactory {
-  // default factory
   static std::shared_ptr<const typename TypeTraits<KIND>::ImplType> create() {
     return TypeTraits<KIND>::ImplType::create();
   }
@@ -934,6 +1021,16 @@ std::shared_ptr<const MapType> MAP(
 std::shared_ptr<const TimestampType> TIMESTAMP();
 
 std::shared_ptr<const DateType> DATE();
+
+std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale);
+
+std::shared_ptr<const LongDecimalType> LONG_DECIMAL(
+    const uint8_t precision,
+    const uint8_t scale);
+
+TypePtr DECIMAL(const uint8_t precision, const uint8_t scale);
 
 template <typename Class>
 std::shared_ptr<const OpaqueType> OPAQUE() {
@@ -1204,15 +1301,19 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
     }                                                                         \
   }()
 
-#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH_ALL(CLASS, FIELD, typeKind)   \
-  [&]() {                                                                 \
-    if ((typeKind) == ::facebook::velox::TypeKind::UNKNOWN) {             \
-      return CLASS<::facebook::velox::TypeKind::UNKNOWN>::FIELD;          \
-    } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {       \
-      return CLASS<::facebook::velox::TypeKind::OPAQUE>::FIELD;           \
-    } else {                                                              \
-      return VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind); \
-    }                                                                     \
+#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH_ALL(CLASS, FIELD, typeKind)    \
+  [&]() {                                                                  \
+    if ((typeKind) == ::facebook::velox::TypeKind::UNKNOWN) {              \
+      return CLASS<::facebook::velox::TypeKind::UNKNOWN>::FIELD;           \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {        \
+      return CLASS<::facebook::velox::TypeKind::OPAQUE>::FIELD;            \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL) { \
+      return CLASS<::facebook::velox::TypeKind::SHORT_DECIMAL>::FIELD;     \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL) {  \
+      return CLASS<::facebook::velox::TypeKind::LONG_DECIMAL>::FIELD;      \
+    } else {                                                               \
+      return VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind);  \
+    }                                                                      \
   }()
 
 // todo: union convenience creators

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -45,7 +45,7 @@
 namespace facebook::velox {
 
 using int128_t = __int128_t;
-
+using uint128_t = __uint128_t;
 // Velox type system supports a small set of SQL-compatible composeable types:
 // BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, VARCHAR,
 // VARBINARY, TIMESTAMP, DATE, ARRAY, MAP, ROW

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -292,6 +292,8 @@ std::string variant::toJson() const {
       // debugging only. Variant::serialize should actually serialize the data.
       return "\"Opaque<" + value<TypeKind::OPAQUE>().type->toString() + ">\"";
     }
+    case TypeKind::SHORT_DECIMAL:
+    case TypeKind::LONG_DECIMAL:
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:
     case TypeKind::INVALID:

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -292,7 +292,10 @@ std::string variant::toJson() const {
       // debugging only. Variant::serialize should actually serialize the data.
       return "\"Opaque<" + value<TypeKind::OPAQUE>().type->toString() + ">\"";
     }
-    case TypeKind::SHORT_DECIMAL:
+    case TypeKind::SHORT_DECIMAL: {
+      auto& shortDecimal = value<TypeKind::SHORT_DECIMAL>();
+      return '"' + shortDecimal.toString() + '"';
+    }
     case TypeKind::LONG_DECIMAL:
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 add_executable(
   velox_type_test
+  DecimalUtilsTest.cpp
   StringViewTest.cpp
   TypeTest.cpp
   FilterTest.cpp

--- a/velox/type/tests/DecimalUtilsTest.cpp
+++ b/velox/type/tests/DecimalUtilsTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/type/DecimalUtils.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include "velox/type/Type.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+#define MERGE_INT128(UPPER, LOWER) ((int128_t)UPPER << 64) | (LOWER)
+
+TEST(DecimalCast, shortDecimalToString) {
+  EXPECT_EQ("123.45", DecimalCasts::ShortDecimalToString(5, 2, 12345));
+  EXPECT_EQ("-12.345", DecimalCasts::ShortDecimalToString(5, 3, -12345));
+  EXPECT_EQ("0.12345", DecimalCasts::ShortDecimalToString(5, 5, 12345));
+  EXPECT_EQ("-0.12345", DecimalCasts::ShortDecimalToString(5, 5, -12345));
+  EXPECT_EQ("-0.00123", DecimalCasts::ShortDecimalToString(5, 5, -123));
+  EXPECT_EQ("0.00123", DecimalCasts::ShortDecimalToString(5, 5, 123));
+  EXPECT_EQ(
+      "-1234567890123.45678",
+      DecimalCasts::ShortDecimalToString(18, 5, -123456789012345678));
+  EXPECT_EQ(
+      "1234567890123.45678",
+      DecimalCasts::ShortDecimalToString(18, 5, 123456789012345678));
+  EXPECT_EQ(
+      "123456789012345678",
+      DecimalCasts::ShortDecimalToString(18, 0, 123456789012345678));
+  EXPECT_EQ("0.00", DecimalCasts::ShortDecimalToString(10, 2, 0));
+}
+
+TEST(DecimalCasts, longDecimalToString) {
+  EXPECT_EQ("0.12345", DecimalCasts::LongDecimalToString(5, 5, 12345));
+  EXPECT_EQ("-0.12345", DecimalCasts::LongDecimalToString(5, 5, -12345));
+  EXPECT_EQ("-0.00123", DecimalCasts::LongDecimalToString(5, 5, -123));
+  EXPECT_EQ("0.00123", DecimalCasts::LongDecimalToString(5, 5, 123));
+  EXPECT_EQ(
+      "-1134274556403128210683733967.9994482962",
+      DecimalCasts::LongDecimalToString(
+          38, 10, MERGE_INT128(0xF777777777777777, 0xEEEEEEEEEEEEEEEE)));
+  EXPECT_EQ(
+      "-0.00000000000000000259484199970181026066",
+      DecimalCasts::LongDecimalToString(
+          38, 38, MERGE_INT128(0xFFFFFFFFFFFFFFF1, 0xEEEEEEEEEEEEEEEE)));
+  EXPECT_EQ(
+      "1234567890123.45678",
+      DecimalCasts::LongDecimalToString(18, 5, 123456789012345678));
+  EXPECT_EQ(
+      "0.00000000000000000000000000000000000000",
+      DecimalCasts::LongDecimalToString(38, 38, 0));
+}

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -117,6 +117,50 @@ TEST(Type, date) {
   EXPECT_EQ(date->begin(), date->end());
 }
 
+TEST(Type, decimal) {
+  auto shortDecimal = SHORT_DECIMAL(10, 5);
+  EXPECT_EQ(shortDecimal->toString(), "SHORT_DECIMAL(10,5)");
+  EXPECT_EQ(shortDecimal->size(), 0);
+  EXPECT_THROW(shortDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(shortDecimal->kind(), TypeKind::SHORT_DECIMAL);
+  EXPECT_STREQ(shortDecimal->kindName(), "SHORT_DECIMAL");
+  EXPECT_EQ(shortDecimal->begin(), shortDecimal->end());
+  EXPECT_EQ(*SHORT_DECIMAL(10, 5), *shortDecimal);
+  EXPECT_NE(*SHORT_DECIMAL(9, 5), *shortDecimal);
+  EXPECT_NE(*SHORT_DECIMAL(10, 4), *shortDecimal);
+  try {
+    shortDecimal = SHORT_DECIMAL(19, 5);
+    FAIL();
+  } catch (const VeloxRuntimeError& e) {
+    EXPECT_EQ("(19 vs. 18)", e.message());
+  }
+  auto decimal = DECIMAL(10, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::SHORT_DECIMAL);
+  decimal = DECIMAL(18, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::SHORT_DECIMAL);
+}
+
+TEST(type, longDecimal) {
+  auto longDecimal = LONG_DECIMAL(30, 5);
+  EXPECT_EQ(longDecimal->toString(), "LONG_DECIMAL(30,5)");
+  EXPECT_EQ(longDecimal->size(), 0);
+  EXPECT_THROW(longDecimal->childAt(0), std::invalid_argument);
+  EXPECT_EQ(longDecimal->kind(), TypeKind::LONG_DECIMAL);
+  EXPECT_STREQ(longDecimal->kindName(), "LONG_DECIMAL");
+  EXPECT_EQ(longDecimal->begin(), longDecimal->end());
+  EXPECT_EQ(*LONG_DECIMAL(30, 5), *longDecimal);
+  EXPECT_NE(*LONG_DECIMAL(9, 5), *longDecimal);
+  EXPECT_NE(*LONG_DECIMAL(30, 3), *longDecimal);
+  try {
+    longDecimal = LONG_DECIMAL(39, 5);
+    FAIL();
+  } catch (const VeloxRuntimeError& e) {
+    EXPECT_EQ("(39 vs. 38)", e.message());
+  }
+  auto decimal = DECIMAL(20, 6);
+  EXPECT_EQ(decimal->kind(), TypeKind::LONG_DECIMAL);
+}
+
 TEST(Type, dateToString) {
   Date epoch(0);
   EXPECT_EQ(epoch.toString(), "1970-01-01");


### PR DESCRIPTION
Add support for parsing decimal literals like:

```
presto> select decimal'1.2';
 _col0 
-------
 1.2   
(1 row)
presto> select * from (values decimal '1234567890001234.56789', decimal '2234567890001234.12345');
         _col0
------------------------
 1234567890001234.56789
 2234567890001234.12345
```