### PR TITLE
Use numDrivers when numSplits is zero in OperatorStats. (#728)

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -352,7 +352,6 @@ class Exchange : public SourceOperator {
   std::unique_ptr<SerializedPage> currentPage_;
   std::unique_ptr<ByteStream> inputStream_;
   bool atEnd_{false};
-  size_t numSplits_{0}; // Number of splits we took to process so far.
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto_cpp/pull/728

Few changes:
- For all operators we now return the number of drivers in 'Threads' column at 'Operator Performance' tab on query web UI.
- For operators that have splits we return 'numSplits' runtime stats.
- For Exchange we started to keep split count in the stats_.numSplits rather than in the class member (which was removed).
- We now populate 'sumSquaredInputPositions' for operators that allow us to see these numbers at 'Query Plan' tab on query web UI: **Input avg.: 30.00 rows, Input std.dev.: 0.00%**
- We no longer sum operators' totalDrivers for a pipeline, but rather use the 1st operator's numDrivers for it.

Differential Revision: D36122048

