### PR TITLE
Add Spark function 'size'

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -174,12 +174,12 @@ class QueryConfig {
     return get<bool>(kExprTrackCpuUsage, false);
   }
 
- private:
   template <typename T>
   T get(const std::string& key, const T& defaultValue) const {
     return config_->get<T>(key, defaultValue);
   }
 
+ private:
   BaseConfigManager* config_;
 };
 } // namespace facebook::velox::core

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   Register.cpp
   RegisterArithmetic.cpp
   RegisterCompare.cpp
+  Size.cpp
   SplitFunctions.cpp
   String.cpp
   Subscript.cpp)

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -29,6 +29,7 @@
 #include "velox/functions/sparksql/RegexFunctions.h"
 #include "velox/functions/sparksql/RegisterArithmetic.h"
 #include "velox/functions/sparksql/RegisterCompare.h"
+#include "velox/functions/sparksql/Size.h"
 #include "velox/functions/sparksql/String.h"
 
 namespace facebook::velox::functions {
@@ -64,6 +65,9 @@ namespace sparksql {
 
 void registerFunctions(const std::string& prefix) {
   registerFunction<RandFunction, double>({"rand"});
+
+  // Register size functions
+  registerSize(prefix + "size");
 
   registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {prefix + "get_json_object"});

--- a/velox/functions/sparksql/Size.cpp
+++ b/velox/functions/sparksql/Size.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/Size.h"
+
+#include "velox/core/QueryConfig.h"
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+template <typename TExecParams>
+struct Size {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecParams);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const TInput* input /*input*/) {
+    legacySizeOfNull_ = config.get<bool>("legacySizeOfNull", true);
+  }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool callNullable(int64_t& out, const TInput* input) {
+    if (input == nullptr) {
+      if (legacySizeOfNull_) {
+        out = -1;
+        return true;
+      } else {
+        return false;
+      }
+    }
+    out = input->size();
+    return true;
+  }
+
+ private:
+  bool legacySizeOfNull_;
+};
+} // namespace
+
+void registerSize(const std::string& prefix) {
+  registerFunction<Size, int64_t, Array<Any>>({prefix});
+  registerFunction<Size, int64_t, Map<Any, Any>>({prefix});
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Size.h
+++ b/velox/functions/sparksql/Size.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+// Size Doc: https://spark.apache.org/docs/2.3.0/api/sql/index.html#size
+namespace facebook::velox::functions::sparksql {
+
+void registerSize(const std::string& prefix);
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   InTest.cpp
   LeastGreatestTest.cpp
   RegexFunctionsTest.cpp
+  SizeTest.cpp
   SortArrayTest.cpp
   SplitFunctionsTest.cpp
   StringTest.cpp

--- a/velox/functions/sparksql/tests/SizeTest.cpp
+++ b/velox/functions/sparksql/tests/SizeTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+
+#include <velox/core/QueryConfig.h>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+class SizeTest : public SparkFunctionBaseTest {
+ protected:
+  std::function<vector_size_t(vector_size_t /* row */)> sizeAt =
+      [](vector_size_t row) { return 1 + row % 7; };
+
+  void testSize(VectorPtr vector, vector_size_t numRows) {
+    auto result =
+        evaluate<SimpleVector<int64_t>>("size(c0)", makeRowVector({vector}));
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      if (vector->isNullAt(i)) {
+        EXPECT_EQ(result->valueAt(i), -1) << "at " << i;
+      } else {
+        EXPECT_EQ(result->valueAt(i), sizeAt(i)) << "at " << i;
+      }
+    }
+  }
+
+  void testSizeLegacyNull(VectorPtr vector, vector_size_t numRows) {
+    auto result =
+        evaluate<SimpleVector<int64_t>>("size(c0)", makeRowVector({vector}));
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      EXPECT_EQ(result->isNullAt(i), vector->isNullAt(i)) << "at " << i;
+    }
+  }
+
+  void setConfig(std::string configStr, bool value) {
+    execCtx_.queryCtx()->setConfigOverridesUnsafe({
+        {configStr, std::to_string(value)},
+    });
+  }
+
+  static inline vector_size_t valueAt(vector_size_t idx) {
+    return idx + 1;
+  }
+};
+
+TEST_F(SizeTest, sizetest) {
+  vector_size_t numRows = 100;
+  auto arrayVector =
+      makeArrayVector<int64_t>(numRows, sizeAt, valueAt, nullptr);
+  testSize(arrayVector, numRows);
+  arrayVector =
+      makeArrayVector<int64_t>(numRows, sizeAt, valueAt, nullEvery(5));
+  testSize(arrayVector, numRows);
+  auto mapVector = makeMapVector<int64_t, int64_t>(
+      numRows, sizeAt, valueAt, valueAt, nullptr);
+  testSize(mapVector, numRows);
+  mapVector = makeMapVector<int64_t, int64_t>(
+      numRows, sizeAt, valueAt, valueAt, nullEvery(5));
+  testSize(mapVector, numRows);
+}
+
+// Ensure that out if set to -1 if `legacySizeOfNull`
+// is specified.
+TEST_F(SizeTest, legacySizeOfNull) {
+  vector_size_t numRows = 100;
+  setConfig("legacySizeOfNull", false);
+  auto arrayVector =
+      makeArrayVector<int64_t>(numRows, sizeAt, valueAt, nullEvery(1));
+  testSizeLegacyNull(arrayVector, numRows);
+  auto mapVector = makeMapVector<int64_t, int64_t>(
+      numRows, sizeAt, valueAt, valueAt, nullEvery(1));
+  testSizeLegacyNull(mapVector, numRows);
+}
+
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Summary:
Add 'size' function similar to Presto's 'cardinality' function.

See https://spark.apache.org/docs/2.3.0/api/sql/index.html#size

Differential Revision: D35983189

