### PR TITLE
Faster Expr::eval

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -153,7 +153,9 @@ class SimpleArithmeticBenchmark
 
     size_t count = 0;
     for (auto i = 0; i < times * 1'000; i++) {
-      count += evaluate(exprSet, input)->size();
+      auto result = evaluate(exprSet, input);
+      count += result->size();
+      execCtx_.releaseVector(result);
     }
     return count;
   }

--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -124,8 +124,8 @@ class FieldReference : public SpecialForm {
     if (index_ != -1) {
       return index_;
     }
-    auto* rowType = dynamic_cast<const RowType*>(context.row()->type().get());
-    VELOX_CHECK(rowType, "The context has no row");
+    VELOX_DCHECK_EQ(context.row()->typeKind(), TypeKind::ROW);
+    auto* rowType = static_cast<const RowType*>(context.row()->type().get());
     index_ = rowType->getChildIdx(field_);
     return index_;
   }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -260,15 +260,14 @@ void Expr::eval(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
-  // Make sure to include current expression in the error message in case of an
-  // exception.
-  ExceptionContextSetter exceptionContext(
-      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
-
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
     result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
+  }
+
+  if (context.mode() == EvalMode::kFlatNonNull) {
+    return evalFlatNonNull(rows, context, result);
   }
 
   // Check if there are any IFs, ANDs or ORs. These expressions are special
@@ -282,10 +281,31 @@ void Expr::eval(
   // peeling and wrapping in the sub-nodes.
   //
   // TODO: Re-work the logic of deciding when to load which field.
-  if (!hasConditionals_ || distinctFields_.size() == 1) {
+  VarSetter mode(&context.mode(), context.mode());
+  if (context.mode() == EvalMode::kGeneric &&
+      (!hasConditionals_ || distinctFields_.size() == 1)) {
     // Load lazy vectors if any.
+    EvalMode newMode = EvalMode::kFlatNonNull;
+    bool allConstant = true;
     for (const auto& field : distinctFields_) {
-      context.ensureFieldLoaded(field->index(context), rows);
+      auto& vector = context.ensureFieldLoaded(field->index(context), rows);
+      auto encoding = vector->encoding();
+      if (encoding == VectorEncoding::Simple::CONSTANT) {
+        if (newMode == EvalMode::kFlatNonNull && vector->isNullAt(0)) {
+          newMode = EvalMode::kLazyLoaded;
+        }
+      } else {
+        allConstant = false;
+        if (newMode == EvalMode::kFlatNonNull && !vector->isFlatNonNull()) {
+          newMode = EvalMode::kLazyLoaded;
+        }
+      }
+    }
+    context.mode() = allConstant ? EvalMode::kLazyLoaded : newMode;
+
+    if (context.mode() == EvalMode::kFlatNonNull) {
+      evalFlatNonNull(rows, context, result);
+      return;
     }
   }
 
@@ -294,34 +314,40 @@ void Expr::eval(
     return;
   }
 
-  // Check if this expression has been evaluated already. If so, fetch and
-  // return the previously computed result.
-  if (checkGetSharedSubexprValues(rows, context, result)) {
+  // Return or update result of shared subexpr.
+  if (isMultiplyReferenced_) {
+    evalSharedSubexpr(rows, context, result);
     return;
   }
 
+  // Make sure to include current expression in the error message in case of
+  // an exception.
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
   evalEncodings(rows, context, result);
-
-  checkUpdateSharedSubexprValues(rows, context, result);
 }
 
-bool Expr::checkGetSharedSubexprValues(
+void Expr::evalSharedSubexpr(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
   // Common subexpression optimization and peeling off of encodings and lazy
   // vectors do not work well together. There are cases when expression
   // initially is evaluated on rows before peeling and later is evaluated on
-  // rows after peeling. In this case the row numbers in sharedSubexprRows_ are
-  // not comparable to 'rows'.
+  // rows after peeling. In this case the row numbers in sharedSubexprRows_
+  // are not comparable to 'rows'.
   //
   // For now, disable the optimization if any encodings have been peeled off.
-
-  if (!deterministic_ || !isMultiplyReferenced_ || !sharedSubexprValues_ ||
+  if (!deterministic_ ||
       context.wrapEncoding() != VectorEncoding::Simple::FLAT) {
-    return false;
+    evalEncodings(rows, context, result);
+    return;
   }
-
+  if (!sharedSubexprValues_) {
+    evalEncodings(rows, context, result);
+    updateSharedSubexprValues(rows, context, result);
+    return;
+  }
   if (!rows.isSubset(*sharedSubexprRows_)) {
     LocalSelectivityVector missingRowsHolder(context, rows);
     auto missingRows = missingRowsHolder.get();
@@ -340,18 +366,12 @@ bool Expr::checkGetSharedSubexprValues(
     evalEncodings(*missingRows, context, sharedSubexprValues_);
   }
   context.moveOrCopyResult(sharedSubexprValues_, rows, result);
-  return true;
 }
 
-void Expr::checkUpdateSharedSubexprValues(
+void Expr::updateSharedSubexprValues(
     const SelectivityVector& rows,
     EvalCtx& context,
     const VectorPtr& result) {
-  if (!isMultiplyReferenced_ || sharedSubexprValues_ ||
-      context.wrapEncoding() != VectorEncoding::Simple::FLAT) {
-    return;
-  }
-
   if (!sharedSubexprRows_) {
     sharedSubexprRows_ = context.execCtx()->getSelectivityVector(rows.size());
   }
@@ -568,6 +588,13 @@ void Expr::evalEncodings(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
+  if (context.mode() == EvalMode::kFlatNonNull) {
+    // We can come here in kFlatNonNull mode from shared subexprs. If the mode
+    // is on, we skip the peeling and nulls. We do not call evalFlatNonNull
+    // because this would redo the shared subexpr check.
+    evalAll(rows, context, result);
+    return;
+  }
   if (deterministic_ && !distinctFields_.empty()) {
     bool hasNonFlat = false;
     for (const auto& field : distinctFields_) {
@@ -678,7 +705,10 @@ void Expr::evalWithNulls(
     result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
   }
-
+  if (context.nullsPruned()) {
+    evalAll(rows, context, result);
+    return;
+  }
   if (propagatesNulls_) {
     bool mayHaveNulls = false;
     for (const auto& field : distinctFields_) {
@@ -921,6 +951,7 @@ void Expr::evalAll(
           remainingRows->begin(),
           remainingRows->end());
       if (!remainingRows->hasSelections()) {
+        context.releaseVectors(inputValues_);
         inputValues_.clear();
         setAllNulls(rows, context, result);
         return;
@@ -941,6 +972,7 @@ void Expr::evalAll(
     }
     deselectErrors(context, *nonNulls.get());
     if (!remainingRows->hasSelections()) {
+      context.releaseVectors(inputValues_);
       inputValues_.clear();
       setAllNulls(rows, context, result);
       return;
@@ -953,6 +985,87 @@ void Expr::evalAll(
   }
   if (remainingRows != &rows) {
     addNulls(rows, remainingRows->asRange().bits(), context, result);
+  }
+  context.releaseVectors(inputValues_);
+  inputValues_.clear();
+}
+
+void Expr::evalFlatNonNull(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  if (isMultiplyReferenced_ && !inputs_.empty()) {
+    evalSharedSubexpr(rows, context, result);
+    return;
+  }
+  ExceptionContextSetter exceptionContext(
+      {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
+
+  if (isSpecialForm()) {
+    evalSpecialForm(rows, context, result);
+    return;
+  }
+  LocalSelectivityVector nonNulls(context);
+  auto* remainingRows = &rows;
+
+  inputValues_.resize(inputs_.size());
+  bool tryPeelArgs = deterministic_;
+  bool anyUnique = false;
+  for (int32_t i = 0; i < inputs_.size(); ++i) {
+    inputs_[i]->evalFlatNonNull(*remainingRows, context, inputValues_[i]);
+    anyUnique = anyUnique || inputValues_[i].unique();
+    tryPeelArgs = tryPeelArgs && isPeelable(inputValues_[i]->encoding());
+    if (inputValues_[i]->mayHaveNulls()) {
+      if (remainingRows == &rows) {
+        nonNulls.allocate(rows.end());
+        *nonNulls.get() = rows;
+        remainingRows = nonNulls.get();
+        assert(remainingRows); // lint
+      }
+      nonNulls.get()->deselectNulls(
+          inputValues_[i]->flatRawNulls(rows),
+          remainingRows->begin(),
+          remainingRows->end());
+      if (!remainingRows->hasSelections()) {
+        inputValues_.clear();
+        setAllNulls(rows, context, result);
+        return;
+      }
+    }
+    // If any errors occurred evaluating the arguments, it's possible (even
+    // likely) that the values for those arguments were not defined which
+    // could lead to undefined behavior if we try to evaluate the current
+    // function on them.  It's safe to skip evaluating them since the value
+    // for this branch of the expression tree will be NULL for those rows
+    // anyway.
+    if (context.errors()) {
+      if (remainingRows == &rows) {
+        nonNulls.allocate(rows.end());
+        *nonNulls.get() = rows;
+        remainingRows = nonNulls.get();
+      }
+      deselectErrors(context, *nonNulls.get());
+      if (!remainingRows->hasSelections()) {
+        // Even though this is not supposed to produce nulls or check for them,
+        // the error value must be set to null to have an interpretable result
+        // vector.
+        setAllNulls(rows, context, result);
+        context.releaseVectors(inputValues_);
+        inputValues_.clear();
+        return;
+      }
+    }
+  }
+  if (!tryPeelArgs ||
+      !applyFunctionWithPeeling(rows, *remainingRows, context, result)) {
+    applyFunction(*remainingRows, context, result);
+  }
+  if (remainingRows != &rows) {
+    addNulls(rows, remainingRows->asRange().bits(), context, result);
+  }
+
+  if (anyUnique) {
+    context.releaseVectors(inputValues_);
   }
   inputValues_.clear();
 }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -228,6 +228,11 @@ class Expr {
   void
   evalAll(const SelectivityVector& rows, EvalCtx& context, VectorPtr& result);
 
+  void evalFlatNonNull(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result);
+
   // Adds nulls from 'rawNulls' to positions of 'result' given by
   // 'rows'. Ensures that '*result' is writable, of sufficient size
   // and that it can take nulls. Makes a new '*result' when
@@ -276,15 +281,16 @@ class Expr {
       EvalCtx& context,
       LocalSelectivityVector& nullHolder);
 
-  // If this is a common subexpression, checks if there is a previously
-  // calculated result and populates the 'result'.
-  bool checkGetSharedSubexprValues(
+  //  Checks if there is a
+  // previously calculated result and populates the 'result'. If no
+  // result, calculates and stores the result and 'rows'.
+  void evalSharedSubexpr(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result);
 
-  // If this is a common subexpression, stores the newly calculated result.
-  void checkUpdateSharedSubexprValues(
+  // Stores the newly calculated result of a common subexpression.
+  void updateSharedSubexprValues(
       const SelectivityVector& rows,
       EvalCtx& context,
       const VectorPtr& result);

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -85,7 +85,7 @@ class SimpleFunctionAdapter : public VectorFunction {
       // is unique, as is nulls.  We also know the size of the vector is
       // at least as large as the size of rows.
       if (!isResultReused) {
-        BaseVector::ensureWritable(*rows, outputType, context->pool(), _result);
+        context->ensureWritable(*rows, outputType, *_result);
       }
       result = reinterpret_cast<result_vector_t*>((*_result).get());
       resultWriter.init(*result);

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -24,6 +24,7 @@
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SequenceVector.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/VectorPool.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook {
@@ -490,13 +491,19 @@ void BaseVector::ensureWritable(
     const SelectivityVector& rows,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
-    VectorPtr* result) {
+    VectorPtr* result,
+    VectorPool* vectorPool) {
   if (!*result) {
-    *result = BaseVector::create(type, rows.size(), pool);
+    if (vectorPool) {
+      *result = vectorPool->get(type, rows.size(), *pool);
+    } else {
+      *result = BaseVector::create(type, rows.size(), pool);
+    }
     return;
   }
   auto resultType = (*result)->type();
   bool isUnknownType = resultType->containsUnknown();
+  const auto& createType = isUnknownType ? type : resultType;
   if ((*result)->encoding() == VectorEncoding::Simple::LAZY) {
     // TODO Figure out how to allow memory reuse for a newly loaded vector.
     // LazyVector holds a reference to loaded vector, hence, unique() check
@@ -522,8 +529,8 @@ void BaseVector::ensureWritable(
   // vector.
   auto targetSize = std::max<vector_size_t>(rows.size(), (*result)->size());
 
-  auto copy =
-      BaseVector::create(isUnknownType ? type : resultType, targetSize, pool);
+  auto copy = vectorPool ? vectorPool->get(createType, targetSize, *pool)
+                         : BaseVector::create(createType, targetSize, pool);
   SelectivityVector copyRows(
       std::min<vector_size_t>(targetSize, (*result)->size()));
   copyRows.deselect(rows);
@@ -654,8 +661,8 @@ bool isLazyNotLoaded(const BaseVector& vector) {
 
 // static
 bool BaseVector::isReusableFlatVector(const VectorPtr& vector) {
-  // If the main shared_ptr has more than one references, or if it's not a flat
-  // vector, can't reuse.
+  // If the main shared_ptr has more than one references, or if it's not a
+  // flat vector, can't reuse.
   if (!vector.unique() || !isFlat(vector->encoding())) {
     return false;
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -49,6 +49,8 @@ class SimpleVector;
 template <typename T>
 class FlatVector;
 
+class VectorPool;
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -472,7 +474,8 @@ class BaseVector {
       const SelectivityVector& rows,
       const TypePtr& type,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<BaseVector>* result);
+      std::shared_ptr<BaseVector>* result,
+      VectorPool* vectorPool = nullptr);
 
   virtual void ensureWritable(const SelectivityVector& rows);
 
@@ -730,6 +733,13 @@ class BaseVector {
   std::optional<ByteCount> representedByteCount_;
   std::optional<ByteCount> storageByteCount_;
   ByteCount inMemoryBytes_ = 0;
+
+#if 0
+  // Values of a scalar vector, interpretation depends on encoding. Defined here to provide non-virtual getter.
+  BufferPtr values_
+  // Caches values_.get()
+  void* rawValues_;
+#endif
 
  private:
   static std::shared_ptr<BaseVector> createInternal(

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -349,7 +349,8 @@ class ConstantVector final : public SimpleVector<T> {
     BaseVector::distinctValueCount_ = isNull_ ? 0 : 1;
     BaseVector::nullCount_ = isNull_ ? BaseVector::length_ : 0;
     if (valueVector_->isScalar()) {
-      auto simple = valueVector_->loadedVector()->as<SimpleVector<T>>();
+      auto simple =
+          valueVector_->loadedVector()->asUnchecked<SimpleVector<T>>();
       isNull_ = simple->isNullAt(index_);
       if (!isNull_) {
         value_ = simple->valueAt(index_);

--- a/velox/vector/VectorPool.h
+++ b/velox/vector/VectorPool.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox {
+
+// A thread-level cache of preallocated flat vectors of different types.
+class VectorPool {
+ public:
+  VectorPtr
+  get(const TypePtr& type, vector_size_t size, memory::MemoryPool& pool) {
+    auto kind = static_cast<int32_t>(type->kind());
+    if (kind < kNumCachedVectorTypes && size <= kMaxRecycleSize) {
+      return vectors_[kind].pop(type, size, pool);
+    }
+    return BaseVector::create(type, size, &pool);
+  }
+
+  // Moves vector into 'this' if it is flat, recursively singly referenced and
+  // there is space.
+  void release(VectorPtr& vector) {
+    if (!vector.unique() || vector->size() > kMaxRecycleSize) {
+      return;
+    }
+    auto kind = static_cast<int32_t>(vector->typeKind());
+    if (kind < kNumCachedVectorTypes) {
+      vectors_[kind].maybe_push_back(vector);
+    }
+  }
+
+  void release(std::vector<VectorPtr>& vectors) {
+    for (auto& vector : vectors) {
+      release(vector);
+    }
+  }
+
+ private:
+  static constexpr int32_t kNumCachedVectorTypes =
+      static_cast<int32_t>(TypeKind::ARRAY);
+  // Max number of elements for a vector to be recyclable. The larger
+  // the batch the less the win from recycling.
+  static constexpr vector_size_t kMaxRecycleSize = 64 * 1024;
+  static constexpr int32_t kNumPerType = 10;
+  struct TypePool {
+    int32_t size{0};
+    std::array<VectorPtr, kNumPerType> vectors;
+
+    void maybe_push_back(VectorPtr& vector) {
+      if (!vector->isRecyclable()) {
+        return;
+      }
+      if (size < kNumPerType) {
+        vector->prepareForReuse();
+        vectors[size++] = std::move(vector);
+      }
+    }
+
+    VectorPtr pop(
+        const TypePtr& type,
+        vector_size_t vectorSize,
+        memory::MemoryPool& pool) {
+      if (size) {
+        auto result = std::move(vectors[--size]);
+        if (UNLIKELY(result->rawNulls() != nullptr)) {
+          // This is a recyclable vector, no need to check uniqueness.
+          simd::memset(
+              const_cast<uint64_t*>(result->rawNulls()),
+              bits::kNotNullByte,
+              bits::roundUp(std::min<int32_t>(vectorSize, result->size()), 64) /
+                  8);
+        }
+        if (UNLIKELY(
+                result->typeKind() == TypeKind::VARCHAR ||
+                result->typeKind() == TypeKind::VARBINARY)) {
+          simd::memset(
+              const_cast<void*>(result->valuesAsVoid()),
+              0,
+              std::min<int32_t>(vectorSize, result->size()) *
+                  sizeof(StringView));
+        }
+        if (result->size() != vectorSize) {
+          result->resize(vectorSize);
+        }
+        return result;
+      }
+      return BaseVector::create(type, vectorSize, &pool);
+    }
+  };
+
+  // Caches of preallocated vectors indexed by typeKind.
+  std::array<TypePool, kNumCachedVectorTypes> vectors_;
+};
+
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   VectorTest.cpp
   VectorToStringTest.cpp
   VectorEstimateFlatSizeTest.cpp
+  VectorPoolTest.cpp
   VectorPrepareForReuseTest.cpp
   DecodedVectorTest.cpp
   SelectivityVectorTest.cpp

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/vector/VectorPool.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class VectorPoolTest : public testing::Test, public VectorTestBase {
+ protected:
+  // Makes 'size' strings of ''stringSize' characters.  If 'hasNulls' is true,
+  // sets 1/5 of the strings to null. If 'overwriteNulls' is true, there are
+  // null flags but no null values.
+  FlatVectorPtr<StringView> makeStrings(
+      vector_size_t size,
+      int32_t stringSize,
+      bool hasNulls,
+      bool overwriteNulls = false) {
+    std::string content;
+    content.resize(stringSize);
+    auto vector = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), size, pool_.get());
+    for (auto i = 0; i < size; ++i) {
+      bool isNull = hasNulls && (i % 5) == 1;
+      if (isNull) {
+        vector->setNull(i, true);
+      }
+      if (!isNull || overwriteNulls) {
+        std::fill(content.begin(), content.end(), static_cast<char>(i));
+        vector->set(i, StringView(content));
+      }
+    }
+    return vector;
+  }
+
+  VectorPool vectorPool_;
+};
+
+TEST_F(VectorPoolTest, strings) {
+  std::vector<VectorPtr> vectors;
+  std::vector<VectorPtr> secondReferences;
+  std::vector<BufferPtr> buffers;
+  // Element 0: recyclable
+  vectors.push_back(makeStrings(10000, 100, false));
+  // Element 1 - non-unique
+  vectors.push_back(makeStrings(10000, 100, false));
+  secondReferences.push_back(vectors.back());
+  // Element 2 - recyclable with nulls
+  vectors.push_back(makeStrings(10000, 100, true));
+  // Element 3 - recyclable with nulls array but no nulls
+  vectors.push_back(makeStrings(10000, 100, true, true));
+
+  // Element 4 - Not recyclable because buffers not uique
+  vectors.push_back(makeStrings(200000, 10, true));
+  buffers.push_back(vectors.back()->as<FlatVector<StringView>>()->values());
+  // Element 5: Recyclable but no recycle of string buffers
+  vectors.push_back(makeStrings(10, 2000000, false));
+  std::vector<BaseVector*> rawPointers;
+  for (auto& vector : vectors) {
+    rawPointers.push_back(vector.get());
+  }
+  vectorPool_.release(vectors);
+  EXPECT_TRUE(!vectors[0]);
+  EXPECT_FALSE(!vectors[1]);
+  EXPECT_TRUE(!vectors[2]);
+  EXPECT_TRUE(!vectors[3]);
+  EXPECT_FALSE(!vectors[4]);
+  EXPECT_TRUE(!vectors[5]);
+
+  vectors[5] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[5].get(), rawPointers[5]);
+  // Strings zeroed out.
+  EXPECT_EQ(0, vectors[5]->as<FlatVector<StringView>>()->valueAt(1).size());
+  // No buffers, the past ones were too large.
+  EXPECT_TRUE(
+      vectors[5]->as<FlatVector<StringView>>()->stringBuffers().empty());
+
+  vectors[3] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[3].get(), rawPointers[3]);
+  // No nulls array.
+  EXPECT_TRUE(!vectors[3]->rawNulls());
+
+  vectors[2] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_FALSE(!vectors[2]->rawNulls());
+  EXPECT_EQ(
+      0, BaseVector::countNulls(vectors[2]->nulls(), 0, vectors[2]->size()));
+
+  vectors[0] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[0].get(), rawPointers[0]);
+  // No nulls buffer.
+  EXPECT_TRUE(!vectors[0]->rawNulls());
+}


### PR DESCRIPTION
Faster Expr::eval

- Add recycling of intermediate result vectors.

- Add EvaMode to indicate if lazies have been loaded and if we only have non-null flat vectors left.

- Add a fast path for non-null flat vector Expr::eval.

- Do not check for lazy vectors inside an eval that already checked the operands with ensureFieldLoaded.

- Add fast exit from ensureFieldLoaded for flat vectors.

- Make context.nullsPruned() circumvent nulls checks after it is set.

- Make ensureWritable take an optional VectorPool for reuse.

- make copying a constant scalar to a FlatVector use applyToSelected
  to get a tight loop for contiguous places.


