### PR TITLE
Add FlatVector support for Decimal Type

### DIFF
--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # VELOX BASE
 add_subdirectory(buffer)
 add_subdirectory(common)

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -17,6 +17,8 @@
 #include "velox/buffer/Buffer.h"
 
 #include "folly/Range.h"
+#include "velox/type/LongDecimal.h"
+#include "velox/type/ShortDecimal.h"
 #include "velox/type/StringView.h"
 
 #include <sstream>
@@ -30,6 +32,8 @@ namespace velox {
 
 static_assert(Buffer::is_pod_like_v<int64_t>, "");
 static_assert(Buffer::is_pod_like_v<StringView>, "");
+static_assert(Buffer::is_pod_like_v<LongDecimal>, "");
+static_assert(Buffer::is_pod_like_v<ShortDecimal>, "");
 static_assert(Buffer::is_pod_like_v<folly::Range<const char*>>, "");
 static_assert(Buffer::is_pod_like_v<velox::Range<const char*>>, "");
 static_assert(!Buffer::is_pod_like_v<std::shared_ptr<int>>, "");

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -384,6 +384,13 @@ inline Timestamp ByteStream::read<Timestamp>() {
 }
 
 template <>
+inline LongDecimal ByteStream::read<LongDecimal>() {
+  LongDecimal value;
+  readBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));
+  return value;
+}
+
+template <>
 inline Date ByteStream::read<Date>() {
   Date value;
   readBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -53,6 +53,14 @@ void generateJsonTyped(
     } else if constexpr (
         std::is_same_v<T, Date> || std::is_same_v<T, Timestamp>) {
       result.append(std::to_string(value));
+    } else if constexpr (std::is_same_v<T, ShortDecimal>) {
+      // ShortDecimal doesn't include precision and scale information
+      // to serialize into JSON.
+      VELOX_UNSUPPORTED();
+    } else if constexpr (std::is_same_v<T, LongDecimal>) {
+      // LongDecimal doesn't include precision and scale information
+      // to serialize into JSON.
+      VELOX_UNSUPPORTED();
     } else {
       folly::toAppend<std::string, T>(value, &result);
     }

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -107,6 +107,10 @@ std::string typeToEncodingName(const TypePtr& type) {
       return "LONG_ARRAY";
     case TypeKind::DATE:
       return "INT_ARRAY";
+    case TypeKind::SHORT_DECIMAL:
+      return "LONG_ARRAY";
+    case TypeKind::LONG_DECIMAL:
+      return "INT128_ARRAY";
     case TypeKind::ARRAY:
       return "ARRAY";
     case TypeKind::MAP:
@@ -606,6 +610,8 @@ void readColumns(
           {TypeKind::DOUBLE, &read<double>},
           {TypeKind::TIMESTAMP, &read<Timestamp>},
           {TypeKind::DATE, &read<Date>},
+          {TypeKind::SHORT_DECIMAL, &read<ShortDecimal>},
+          {TypeKind::LONG_DECIMAL, &read<LongDecimal>},
           {TypeKind::VARCHAR, &read<StringView>},
           {TypeKind::VARBINARY, &read<StringView>},
           {TypeKind::ARRAY, &readArrayVector},

--- a/velox/type/LongDecimal.h
+++ b/velox/type/LongDecimal.h
@@ -16,57 +16,58 @@
 #include <folly/dynamic.h>
 #include <sstream>
 #include <string>
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/StringView.h"
 
 #pragma once
 
+#define BUILD_INT128(X, Y) ((int128_t)(X) << 64 | Y)
+
 namespace facebook::velox {
 
-struct ShortDecimal {
+using int128_t = __int128_t;
+
+struct LongDecimal {
  public:
   // Default required for creating vector with NULL values.
-  ShortDecimal() = default;
-  constexpr explicit ShortDecimal(int64_t value) : unscaledValue_(value) {}
+  LongDecimal() = default;
+  constexpr explicit LongDecimal(int128_t value) : unscaledValue_(value) {}
 
-  int64_t unscaledValue() const {
+  int128_t unscaledValue() const {
     return unscaledValue_;
   }
 
-  bool operator==(const ShortDecimal& other) const {
+  bool operator==(const LongDecimal& other) const {
     return unscaledValue_ == other.unscaledValue_;
   }
 
-  bool operator!=(const ShortDecimal& other) const {
+  bool operator!=(const LongDecimal& other) const {
     return unscaledValue_ != other.unscaledValue_;
   }
 
-  bool operator<(const ShortDecimal& other) const {
+  bool operator<(const LongDecimal& other) const {
     return unscaledValue_ < other.unscaledValue_;
   }
 
-  bool operator<=(const ShortDecimal& other) const {
+  bool operator<=(const LongDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
   }
 
-  bool operator>(const ShortDecimal& other) const {
-    return unscaledValue_ > other.unscaledValue_;
-  }
-
-  bool operator>=(const ShortDecimal& other) const {
-    return unscaledValue_ >= other.unscaledValue_;
-  }
-
  private:
-  int64_t unscaledValue_;
-};
+  int128_t unscaledValue_;
+}; // struct LongDecimal
 } // namespace facebook::velox
 
 namespace folly {
 template <>
-struct hasher<::facebook::velox::ShortDecimal> {
-  size_t operator()(const ::facebook::velox::ShortDecimal& value) const {
-    return std::hash<int64_t>{}(value.unscaledValue());
+struct hasher<::facebook::velox::LongDecimal> {
+  size_t operator()(const ::facebook::velox::LongDecimal& value) const {
+    auto upperHash = folly::hasher<uint64_t>{}(
+        static_cast<uint64_t>(value.unscaledValue() >> 64));
+    auto lowerHash =
+        folly::hasher<uint64_t>{}(static_cast<uint64_t>(value.unscaledValue()));
+    return facebook::velox::bits::hashMix(upperHash, lowerHash);
   }
 };
 } // namespace folly

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -37,14 +37,13 @@
 #include "velox/common/base/ClassName.h"
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/Date.h"
+#include "velox/type/LongDecimal.h"
 #include "velox/type/ShortDecimal.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
 
 namespace facebook::velox {
-
-using int128_t = __int128_t;
 
 // Velox type system supports a small set of SQL-compatible composeable types:
 // BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, VARCHAR,
@@ -294,7 +293,7 @@ struct TypeTraits<TypeKind::SHORT_DECIMAL> {
 template <>
 struct TypeTraits<TypeKind::LONG_DECIMAL> {
   using ImplType = DecimalType<TypeKind::LONG_DECIMAL>;
-  using NativeType = int128_t;
+  using NativeType = LongDecimal;
   using DeepCopiedType = NativeType;
   static constexpr uint32_t minSubTypes = 0;
   static constexpr uint32_t maxSubTypes = 0;
@@ -1156,6 +1155,12 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
       return TEMPLATE_FUNC<::facebook::velox::TypeKind::UNKNOWN>(__VA_ARGS__); \
     } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {            \
       return TEMPLATE_FUNC<::facebook::velox::TypeKind::OPAQUE>(__VA_ARGS__);  \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL) {     \
+      return TEMPLATE_FUNC<::facebook::velox::TypeKind::SHORT_DECIMAL>(        \
+          __VA_ARGS__);                                                        \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL) {      \
+      return TEMPLATE_FUNC<::facebook::velox::TypeKind::LONG_DECIMAL>(         \
+          __VA_ARGS__);                                                        \
     } else {                                                                   \
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                               \
           TEMPLATE_FUNC, typeKind, __VA_ARGS__);                               \
@@ -1230,6 +1235,12 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
       return TEMPLATE_FUNC<::facebook::velox::TypeKind::UNKNOWN>(__VA_ARGS__); \
     } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {            \
       return TEMPLATE_FUNC<::facebook::velox::TypeKind::OPAQUE>(__VA_ARGS__);  \
+    } else if (((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL)) {   \
+      return TEMPLATE_FUNC<::facebook::velox::TypeKind::SHORT_DECIMAL>(        \
+          __VA_ARGS__);                                                        \
+    } else if (((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL)) {    \
+      return TEMPLATE_FUNC<::facebook::velox::TypeKind::LONG_DECIMAL>(         \
+          __VA_ARGS__);                                                        \
     } else {                                                                   \
       return VELOX_DYNAMIC_TYPE_DISPATCH_IMPL(                                 \
           TEMPLATE_FUNC, , typeKind, __VA_ARGS__);                             \
@@ -1627,6 +1638,16 @@ inline Timestamp to(const std::string& value) {
 }
 
 template <>
+inline ShortDecimal to(const std::string& value) {
+  VELOX_UNSUPPORTED();
+}
+
+template <>
+inline LongDecimal to(const std::string& value) {
+  VELOX_UNSUPPORTED();
+}
+
+template <>
 inline UnknownValue to(const std::string& /* value */) {
   return UnknownValue();
 }
@@ -1634,6 +1655,20 @@ inline UnknownValue to(const std::string& /* value */) {
 template <>
 inline std::string to(const Timestamp& value) {
   return value.toString();
+}
+
+template <>
+inline std::string to(const ShortDecimal& value) {
+  // ShortDecimal doesn't have precision and scale information to
+  // be serialized into string.
+  VELOX_UNSUPPORTED();
+}
+
+template <>
+inline std::string to(const LongDecimal& value) {
+  // LongDecimal doesn't have precision and scale information to
+  // be serialized into string.
+  VELOX_UNSUPPORTED();
 }
 
 template <>

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -340,6 +340,12 @@ VectorPtr BaseVector::createInternal(
           true /*isSorted*/,
           0 /*representedBytes*/);
     }
+    case TypeKind::SHORT_DECIMAL: {
+      return createEmpty<TypeKind::SHORT_DECIMAL>(size, pool, type);
+    }
+    case TypeKind::LONG_DECIMAL: {
+      return createEmpty<TypeKind::LONG_DECIMAL>(size, pool, type);
+    }
     default:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
           createEmpty, kind, size, pool, type);
@@ -554,6 +560,26 @@ VectorPtr newConstant(
       std::move(copy),
       SimpleVectorStats<T>{},
       sizeof(T) /*representedByteCount*/);
+}
+
+template <>
+VectorPtr newConstant<TypeKind::SHORT_DECIMAL>(
+    variant& value,
+    vector_size_t size,
+    velox::memory::MemoryPool* pool) {
+  // ShortDecimal variant is not supported to create
+  // constant vector.
+  VELOX_UNSUPPORTED();
+}
+
+template <>
+VectorPtr newConstant<TypeKind::LONG_DECIMAL>(
+    variant& value,
+    vector_size_t size,
+    velox::memory::MemoryPool* pool) {
+  // LongDecimal variant is not supported to create
+  // constant vector.
+  VELOX_UNSUPPORTED();
 }
 
 template <>

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 add_library(
   velox_vector
   BaseVector.cpp

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -735,6 +735,21 @@ class VectorTest : public testing::Test {
 };
 
 template <>
+ShortDecimal VectorTest::testValue<ShortDecimal>(
+    int32_t i,
+    BufferPtr& /*space*/) {
+  return ShortDecimal(i);
+}
+
+template <>
+LongDecimal VectorTest::testValue<LongDecimal>(
+    int32_t i,
+    BufferPtr& /*space*/) {
+  int128_t value = BUILD_INT128(i % 2 ? (i * -1) : i, 0xAAAAAAAAAAAAAAAA);
+  return LongDecimal(value);
+}
+
+template <>
 StringView VectorTest::testValue(int32_t n, BufferPtr& buffer) {
   if (!buffer || buffer->capacity() < 1000) {
     buffer = AlignedBuffer::allocate<char>(1000, pool_.get());
@@ -830,6 +845,11 @@ TEST_F(VectorTest, createOther) {
   testFlat<TypeKind::BOOLEAN>(BOOLEAN(), vectorSize_);
   testFlat<TypeKind::TIMESTAMP>(TIMESTAMP(), vectorSize_);
   testFlat<TypeKind::DATE>(DATE(), vectorSize_);
+}
+
+TEST_F(VectorTest, createDecimal) {
+  testFlat<TypeKind::SHORT_DECIMAL>(SHORT_DECIMAL(10, 5), vectorSize_);
+  testFlat<TypeKind::LONG_DECIMAL>(LONG_DECIMAL(30, 5), vectorSize_);
 }
 
 TEST_F(VectorTest, createOpaque) {


### PR DESCRIPTION
Add support for Long and Short Decimal FlatVector.
1. Wrapped int128_t in a new value type LongDecimal.
2. Extended ByteStream::read function for LongDecimal for de-serialization.

**Testing:**
Added VectorTest::createDecimal tests that creates FlatVectors of Short and Long decimal.
Serialization and dictionary encoding are tested as part of this test.
