### PR TITLE
Collect number of input and output batches statistics for operators

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -335,6 +335,7 @@ StopReason Driver::runInternal(
               CpuWallTimer timer(op->stats().getOutputTiming);
               result = op->getOutput();
               if (result) {
+                op->stats().outputVectors += 1;
                 op->stats().outputPositions += result->size();
                 resultBytes = result->estimateFlatSize();
                 op->stats().outputBytes += resultBytes;
@@ -343,6 +344,7 @@ StopReason Driver::runInternal(
             pushdownFilters(i);
             if (result) {
               CpuWallTimer timer(nextOp->stats().addInputTiming);
+              nextOp->stats().inputVectors += 1;
               nextOp->stats().inputPositions += result->size();
               nextOp->stats().inputBytes += resultBytes;
               nextOp->addInput(result);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -275,10 +275,12 @@ void OperatorStats::add(const OperatorStats& other) {
   addInputTiming.add(other.addInputTiming);
   inputBytes += other.inputBytes;
   inputPositions += other.inputPositions;
+  inputVectors += other.inputVectors;
 
   getOutputTiming.add(other.getOutputTiming);
   outputBytes += other.outputBytes;
   outputPositions += other.outputPositions;
+  outputVectors += other.outputVectors;
 
   physicalWrittenBytes += other.physicalWrittenBytes;
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -79,31 +79,42 @@ struct MemoryStats {
 };
 
 struct OperatorStats {
-  // Initial ordinal position in the operator's pipeline.
+  /// Initial ordinal position in the operator's pipeline.
   int32_t operatorId = 0;
   int32_t pipelineId = 0;
   core::PlanNodeId planNodeId;
-  // Name for reporting. We use Presto compatible names set at
-  // construction of the Operator where applicable.
+
+  /// Name for reporting. We use Presto compatible names set at
+  /// construction of the Operator where applicable.
   std::string operatorType;
 
-  // Number of splits (or chunks of work). Split can be a part of data file to
-  // read.
+  /// Number of splits (or chunks of work). Split can be a part of data file to
+  /// read.
   int64_t numSplits{0};
 
-  // Bytes read from raw source, e.g. compressed file or network connection.
+  /// Bytes read from raw source, e.g. compressed file or network connection.
   uint64_t rawInputBytes = 0;
   uint64_t rawInputPositions = 0;
 
   CpuWallTiming addInputTiming;
-  // Bytes of input in terms of retained size of input vectors.
+
+  /// Bytes of input in terms of retained size of input vectors.
   uint64_t inputBytes = 0;
   uint64_t inputPositions = 0;
 
+  /// Number of input batches / vectors. Allows to compute an average batch
+  /// size.
+  uint64_t inputVectors = 0;
+
   CpuWallTiming getOutputTiming;
-  // Bytes of output in terms of retained size of vectors.
+
+  /// Bytes of output in terms of retained size of vectors.
   uint64_t outputBytes = 0;
   uint64_t outputPositions = 0;
+
+  /// Number of output batches / vectors. Allows to compute an average batch
+  /// size.
+  uint64_t outputVectors = 0;
 
   uint64_t physicalWrittenBytes = 0;
 

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -34,12 +34,14 @@ void PlanNodeStats::add(const OperatorStats& stats) {
 void PlanNodeStats::addTotals(const OperatorStats& stats) {
   inputRows += stats.inputPositions;
   inputBytes += stats.inputBytes;
+  inputVectors += stats.inputVectors;
 
   rawInputRows += stats.rawInputPositions;
   rawInputBytes += stats.rawInputBytes;
 
   outputRows += stats.outputPositions;
   outputBytes += stats.outputBytes;
+  outputVectors += stats.outputVectors;
 
   cpuWallTiming.add(stats.addInputTiming);
   cpuWallTiming.add(stats.getOutputTiming);
@@ -74,14 +76,14 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
   std::stringstream out;
   if (includeInputStats) {
     out << "Input: " << inputRows << " rows (" << succinctBytes(inputBytes)
-        << "), ";
+        << ", " << inputVectors << " batches), ";
     if ((rawInputRows > 0) && (rawInputRows != inputRows)) {
       out << "Raw Input: " << rawInputRows << " rows ("
           << succinctBytes(rawInputBytes) << "), ";
     }
   }
   out << "Output: " << outputRows << " rows (" << succinctBytes(outputBytes)
-      << ")"
+      << ", " << outputVectors << " batches)"
       << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes)

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -47,6 +47,9 @@ struct PlanNodeStats {
   /// leaf plan nodes or plan nodes that correspond to a single operator type.
   vector_size_t inputRows{0};
 
+  /// Sum of input batches for all corresponding operators.
+  vector_size_t inputVectors{0};
+
   /// Sum of input bytes for all corresponding operators.
   uint64_t inputBytes{0};
 
@@ -62,6 +65,9 @@ struct PlanNodeStats {
   /// plan node corresponds to multiple operator types, operators of only one of
   /// these types report non-zero output rows.
   vector_size_t outputRows{0};
+
+  /// Sum of output batches for all corresponding operators.
+  vector_size_t outputVectors{0};
 
   /// Sum of output bytes for all corresponding operators.
   uint64_t outputBytes{0};


### PR DESCRIPTION
It is useful to know the average batch / vector size used in query processing.
We already collect total number of input and output rows. This change is to
start collecting total number of batches / vectors. This allows to compute the
average batch size as total rows / total batches.

Here is a sample output of printPlanWithStats showing number of in/output 
batches per node:

```
-- Project[expressions: (c0:INTEGER, ROW["c0"]), (p1:BIGINT, plus(ROW["c1"],1)), (p2:BIGINT, plus(ROW["c1"],ROW["u_c1"]))] -> c0:INTEGER, p1:BIGINT, p2:BIGINT
   Output: 2000 rows (154.98KB, 20 batches), Cpu time: 2.74ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 44, Threads: 1
  -- HashJoin[INNER c0=u_c0] -> c0:INTEGER, c1:BIGINT, u_c1:BIGINT
     Output: 2000 rows (136.88KB, 20 batches), Cpu time: 1.17ms, Blocked wall time: 367.00us, Peak memory: 2.00MB, Memory allocations: 27
     HashBuild: Input: 100 rows (1.31KB, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 338.65us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2, Threads: 1
     HashProbe: Input: 2000 rows (118.12KB, 20 batches), Output: 2000 rows (136.88KB, 20 batches), Cpu time: 834.92us, Blocked wall time: 367.00us, Peak memory: 1.00MB, Memory allocations: 25, Threads: 1
    -- TableScan[table: hive_table] -> c0:INTEGER, c1:BIGINT
       Input: 2000 rows (118.12KB, 0 batches), Raw Input: 20480 rows (72.31KB), Output: 2000 rows (118.12KB, 20 batches), Cpu time: 14.88ms, Blocked wall time: 12.00us, Peak memory: 1.00MB, Memory allocations: 122, Threads: 1, Splits: 20
    -- Project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:BIGINT, ROW["c1"])] -> u_c0:INTEGER, u_c1:BIGINT
       Output: 100 rows (1.31KB, 1 batches), Cpu time: 58.00us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
      -- Values[100 rows in 1 vectors] -> c0:INTEGER, c1:BIGINT
         Input: 0 rows (0B, 0 batches), Output: 100 rows (1.31KB, 1 batches), Cpu time: 6.47us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
```