### PR TITLE
Do not hold reference to input in HashAggregation

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -83,7 +83,8 @@ void FilterProject::addInput(RowVectorPtr input) {
   if (!resultProjections_.empty()) {
     results_.resize(resultProjections_.back().inputChannel + 1);
     for (auto& result : results_) {
-      if (result && result.unique()) {
+      if (result && result.unique() &&
+          result->encoding() == VectorEncoding::Simple::FLAT) {
         BaseVector::prepareForReuse(result, 0);
       } else {
         result.reset();

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -113,7 +113,7 @@ HashAggregation::HashAggregation(
   }
 
   if (isDistinct_) {
-    for (ChannelIndex i = 0; i < hashers.size(); ++i) {
+    for (auto i = 0; i < hashers.size(); ++i) {
       identityProjections_.emplace_back(hashers[i]->channel(), i);
     }
   }
@@ -131,17 +131,25 @@ HashAggregation::HashAggregation(
 }
 
 void HashAggregation::addInput(RowVectorPtr input) {
-  input_ = input;
   if (!pushdownChecked_) {
     mayPushdown_ = operatorCtx_->driver()->mayPushdownAggregation(this);
     pushdownChecked_ = true;
   }
-  groupingSet_->addInput(input_, mayPushdown_);
+
+  groupingSet_->addInput(input, mayPushdown_);
   if (isPartialOutput_ &&
       groupingSet_->allocatedBytes() > maxPartialAggregationMemoryUsage_) {
     partialFull_ = true;
   }
-  newDistincts_ = isDistinct_ && !groupingSet_->hashLookup().newGroups.empty();
+
+  if (isDistinct_) {
+    newDistincts_ = !groupingSet_->hashLookup().newGroups.empty();
+
+    if (newDistincts_) {
+      // Save input to use for output in getOutput().
+      input_ = input;
+    }
+  }
 }
 
 void HashAggregation::prepareOutput(vector_size_t size) {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -318,7 +318,7 @@ TEST_F(HashJoinTest, memory) {
   auto tracker = memory::MemoryUsageTracker::create();
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});
-  EXPECT_GT(2500, tracker->getNumAllocs());
+  EXPECT_GT(3'500, tracker->getNumAllocs());
   EXPECT_GT(7'500'000, tracker->getCumulativeBytes());
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -191,7 +191,7 @@ class EvalCtx {
       const VectorPtr& localResult,
       const SelectivityVector& rows,
       VectorPtr* result) const {
-    if (*result && !isFinalSelection()) {
+    if (*result && !isFinalSelection() && *finalSelection() != rows) {
       BaseVector::ensureWritable(
           rows, (*result)->type(), (*result)->pool(), result);
       (*result)->copy(localResult.get(), rows, nullptr);


### PR DESCRIPTION
This change comes as a result of investigating a tricky error raised by
approx_percentile aggregate function: 

```
decodedPercentile_.isConstantMapping() Percentile argument must be constant for all input rows
```

A combination of a particular plan structure, logic in HashAggregation, EvalCtx
and FilterProject resulted in constant expression for percentile parameter to
be evaluated into a flat vector. Since approx_percentile expects a constant
vector, an error occurred.

This change updates (1) HashAggregation to not hold a reference to input
vectors (it used to hold a reference in case when partial aggregation ran out
of memory); (2) EvalCtx::moveOrCopyResult to not copy the result if the final
and current sets of rows are the same; (3) FilterProject to not call
BaseVector::prepareForReuse for a non-flat vector.

HashAggregation operator doesn't need to hold a reference to input vectors as it
copies all necessary data into the hash table and accumulators except for the
case of distinct aggregation where input is used for output. In this case, the
output vector is created by wrapping input vector in a dictionary with indices
pointing to new distinct values. 

EvalCtx::moveOrCopyResult doesn't need to copy the result if the set of rows in
final selection is the same as in current selection because there are no rows
to preserve.

FilterProject operator doesn't need to call BaseVector::prepareForReuse for 
non-flat vectors since reuse is possible only for flat vectors.

We'd like to note that the original problem is fixed by applying any of the 3
changes. It is not necessary to have all 3 changes to fix that particular problem.

### Changes to HashJoinTest::memory

The new changes caused a failure in HashJoinTest::memory test because number 
of memory allocations increased:

```
Expected: (2500) > (tracker->getNumAllocs()), actual: 2500 vs 2816
```

The changes in FilterProject prevent HashProbe from reusing indices buffer for
wrapping probe-side columns. HashProbe returns t_k0 as a dictionary vector.
FilterProject passes it to expression evaluation which evaluates `t_k0 % 1000`
expression on the inner vector and wraps the results using the original indices
buffer incrementing ref-count in HashProbe::rowNumberMapping_. On the next
batch, HashProbe cannot reuse rowNumberMapping_ and allocates a new one. 

This may appear as a regression, but it is not. The original code re-used single
HashProbe::rowNumberMapping_ buffer for all batches, but it caused expression
evaluation to copy the results of evaluating `t_k0 % 1000` on inner vector
instead of wrapping in a dictionary. See EvalCtx::setWrapped in
velox/expression/EvalCtx.cpp.

Hence, we are trading copying and duplicating potentially multiple columns for 
allocating a single indices buffer.

### Details of the original problem

Here goes the detailed explanation of the bug that motivated these change. The
new ApproxPercentileTest::partialFull test reproduces the conditions for the
bug and can be used to get a deeper understanding of the problem.

The query plan called for the inputs to approx_percentile to come from a Project operator:

```
- Aggregate(PARTIAL)[expr_9] => [expr_9:varchar, approx_percentile_50:varbinary, count_49:bigint, approx_percentile_51:varbinary]
            approx_percentile_50 := "presto.default.approx_percentile"((expr_10,expr_28,expr_29,expr_30)) (1:33)
            
        - Project[projectLocality = LOCAL] => [expr_10:bigint, expr_11:bigint, expr_30:double, expr_28:bigint, expr_9:varchar, expr_29:double]
                expr_10 := (date_diff(VARCHAR'day', min, TIMESTAMP'2022-05-10 00:00:00.000')) * (IF(bool_or, approx_distinct, null)) (1:751)
                expr_30 := DOUBLE'0.001'
                expr_28 := BIGINT'1'
                expr_29 := DOUBLE'0.9995'
```

The percentile argument value was produced by evaluating ConstantExpression
`DOUBLE'0.9995'`. This expression stores a ConstantVector representing the
constant value. It returns the stored vector if it is singly-referenced or a
copy if it is multi-referenced. Also, ConstantExpression returns a flat copy of
the vector if 'result' is not null. See ConstantExpr::evalSpecialForm in 
velox/expression/ControlExpr.cpp.

FilterProject operator receives the results from the ConstantExpression, stores
it in results_ member variable and passes it on to HashAggregation operator.
FilterProject checks if results_ are uniquely referenced and if so calls
BaseVector::prepareToReuse and passes the result to expression evaluation as
a 'result' to reuse. See FilterProject::addInput in velox/exec/FilterProject.cpp.

FilterProject operator receives one of the following:
- multiply-referenced ConstantVector if ConstantExpression returns the stored
  vector (1 reference is kept in ConstantExpression, one is returned); 
- singly-referenced ConstantVector if ConstantExpression returns a copy (in case 
  stored vector is multiply-referenced);
- flat vector if it passes a non-null 'result'.

The code path where FilterProject receives a flat vector for 'percentile'
argument leads to an error in approx_percentile aggregate function.

HashAggregation operator used to keep a reference to input vectors in some
cases. Specifically, it would keep a reference if partial aggregation ran out
of memory (HashAggregation::partialFull_ == true). 

The sequence of events leading to FilterProject receiving a flat vector for
constant expression was:

- ConstantExpression returns stored vector (use_count = 2);
- FilterProject stores the vector in results_ and passes it to HashAggregation (use_count = 2);
- HashAggregation keeps a reference (use_count = 3);
- FilterProject sees that results_ is multiply-referenced, drops it and passes null 
  result to expression evaluation (use_count = 2);
- ConstantExpression returns a copy of the stored vector (use_count = 1);
- FilterProject stores singly-referenced copy in results_ and passes it to HashAggregation;
- HashAggregation doesn't keep a reference; FilterProject::results_ has the only copy;
- FilterProject decides to re-use singly-referenced result and calls BaseVector::prepareForReuse 
  which makes a new vector since the one provided is not flat (it is a constant vector); FilterProject
  calls expression evaluation with a non-null result;
- ConstantExpression returns a flat copy of the stored vector.
- approx_percentile receives a flat vector for 'percentile' argument and throws an error.