### PR TITLE
[Substrait to Velox] Add validation support

### DIFF
--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -41,7 +41,7 @@ add_custom_command(
 add_custom_target(substrait_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})
 add_dependencies(substrait_proto protobuf::libprotobuf)
 
-set(SRCS ${PROTO_SRCS} SubstraitUtils.cpp SubstraitToVeloxExpr.cpp
+set(SRCS ${PROTO_SRCS} SubstraitParser.cpp SubstraitToVeloxExpr.cpp
          SubstraitToVeloxPlan.cpp TypeUtils.cpp)
 add_library(velox_substrait_plan_converter ${SRCS})
 target_include_directories(velox_substrait_plan_converter

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -41,8 +41,9 @@ add_custom_command(
 add_custom_target(substrait_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})
 add_dependencies(substrait_proto protobuf::libprotobuf)
 
-set(SRCS ${PROTO_SRCS} SubstraitParser.cpp SubstraitToVeloxExpr.cpp
-         SubstraitToVeloxPlan.cpp TypeUtils.cpp)
+set(SRCS
+    ${PROTO_SRCS} SubstraitParser.cpp SubstraitToVeloxExpr.cpp
+    SubstraitToVeloxPlan.cpp SubstraitToVeloxPlanValidator.cpp TypeUtils.cpp)
 add_library(velox_substrait_plan_converter ${SRCS})
 target_include_directories(velox_substrait_plan_converter
                            PUBLIC ${PROTO_OUTPUT_DIR})

--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -42,17 +42,21 @@ class SubstraitParser {
       const ::substrait::NamedStruct& namedStruct);
 
   /// Used to parse Substrait Type.
-  std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& sType);
+  std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& substraitType);
 
   /// Used to parse Substrait ReferenceSegment.
   int32_t parseReferenceSegment(
-      const ::substrait::Expression::ReferenceSegment& sRef);
+      const ::substrait::Expression::ReferenceSegment& refSegment);
 
   /// Used to make names in the format of {prefix}_{index}.
   std::vector<std::string> makeNames(const std::string& prefix, int size);
 
   /// Used to make node name in the format of n{nodeId}_{colIdx}.
   std::string makeNodeName(int nodeId, int colIdx);
+
+  /// Used to get the column index from a node name in the format of
+  /// n{nodeId}_{colIdx}.
+  int getIdxFromNodeName(const std::string& nodeName);
 
   /// Used to find the Substrait function name according to the function id
   /// from a pre-constructed function map. The function specification can be
@@ -69,6 +73,11 @@ class SubstraitParser {
   /// When the input is a simple name, it will be returned.
   std::string getSubFunctionName(const std::string& subFuncSpec) const;
 
+  /// This function is used get the types from the compound name.
+  void getSubFunctionTypes(
+      const std::string& subFuncSpec,
+      std::vector<std::string>& types) const;
+
   /// Used to find the Velox function name according to the function id
   /// from a pre-constructed function map.
   std::string findVeloxFunction(
@@ -83,7 +92,9 @@ class SubstraitParser {
   /// words. Key: the Substrait function key word, Value: the Velox function key
   /// word. For those functions with different names in Substrait and Velox,
   /// a mapping relation should be added here.
-  std::unordered_map<std::string, std::string> substraitVeloxFunctionMap;
+  std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_ = {
+      {"add", "plus"},
+      {"subtract", "minus"}};
 };
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/core/Expressions.h"
-#include "velox/substrait/SubstraitUtils.h"
+#include "velox/substrait/SubstraitParser.h"
 
 namespace facebook::velox::substrait {
 
@@ -29,9 +29,8 @@ class SubstraitVeloxExprConverter {
   /// into recognizable representations. functionMap: A pre-constructed map
   /// storing the relations between the function id and the function name.
   SubstraitVeloxExprConverter(
-      const std::shared_ptr<SubstraitParser>& subParser,
       const std::unordered_map<uint64_t, std::string>& functionMap)
-      : subParser_(subParser), functionMap_(functionMap) {}
+      : functionMap_(functionMap) {}
 
   /// Used to convert Substrait Field into Velox Field Expression.
   std::shared_ptr<const core::FieldAccessTypedExpr> toVeloxExpr(
@@ -60,7 +59,8 @@ class SubstraitVeloxExprConverter {
  private:
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.
-  std::shared_ptr<SubstraitParser> subParser_;
+  std::shared_ptr<SubstraitParser> subParser_ =
+      std::make_shared<SubstraitParser>();
 
   /// The map storing the relations between the function id and the function
   /// name.

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -73,6 +73,23 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::Plan& substraitPlan,
       memory::MemoryPool* pool);
 
+  /// Multiple conditions are connected to a binary tree structure with
+  /// the relation key words, including AND, OR, and etc. Currently, only
+  /// AND is supported. This function is used to extract all the Substrait
+  /// conditions in the binary tree structure into a vector.
+  void flattenConditions(
+      const ::substrait::Expression& sFilter,
+      std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions);
+
+  /// Construct the function map between the index and the Substrait function
+  /// name.
+  void constructFuncMap(const ::substrait::Plan& sPlan);
+
+  /// Return the function map used by this plan converter.
+  const std::unordered_map<uint64_t, std::string>& getFunctionMap() {
+    return functionMap_;
+  }
+
   /// Return the index of Partition to be scanned.
   u_int32_t getPartitionIndex() {
     return partitionIndex_;
@@ -93,7 +110,30 @@ class SubstraitVeloxPlanConverter {
     return lengths_;
   }
 
+  /// Used to find the function specification in the constructed function map.
+  std::string findFuncSpec(uint64_t id);
+
  private:
+  /// A function returning current function id and adding the plan node id by
+  /// one once called.
+  std::string nextPlanNodeId();
+
+  /// Used to convert Substrait Filter into Velox SubfieldFilters which will
+  /// be used in TableScan.
+  connector::hive::SubfieldFilters toVeloxFilter(
+      const std::vector<std::string>& inputNameList,
+      const std::vector<TypePtr>& inputTypeList,
+      const ::substrait::Expression& sFilter);
+
+  /// The Substrait parser used to convert Substrait representations into
+  /// recognizable representations.
+  std::shared_ptr<SubstraitParser> subParser_{
+      std::make_shared<SubstraitParser>()};
+
+  /// The Expression converter used to convert Substrait representations into
+  /// Velox expressions.
+  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+
   /// The Partition index.
   u_int32_t partitionIndex_;
 
@@ -112,34 +152,6 @@ class SubstraitVeloxPlanConverter {
   /// The map storing the relations between the function id and the function
   /// name. Will be constructed based on the Substrait representation.
   std::unordered_map<uint64_t, std::string> functionMap_;
-
-  /// The Substrait parser used to convert Substrait representations into
-  /// recognizable representations.
-  std::shared_ptr<SubstraitParser> subParser_{
-      std::make_shared<SubstraitParser>()};
-
-  /// The Expression converter used to convert Substrait representations into
-  /// Velox expressions.
-  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
-
-  /// A function returning current function id and adding the plan node id by
-  /// one once called.
-  std::string nextPlanNodeId();
-
-  /// Used to convert Substrait Filter into Velox SubfieldFilters which will
-  /// be used in TableScan.
-  connector::hive::SubfieldFilters toVeloxFilter(
-      const std::vector<std::string>& inputNameList,
-      const std::vector<TypePtr>& inputTypeList,
-      const ::substrait::Expression& sFilter);
-
-  /// Multiple conditions are connected to a binary tree structure with
-  /// the relation key words, including AND, OR, and etc. Currently, only
-  /// AND is supported. This function is used to extract all the Substrait
-  /// conditions in the binary tree structure into a vector.
-  void flattenConditions(
-      const ::substrait::Expression& sFilter,
-      std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions);
 };
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/substrait/SubstraitToVeloxPlanValidator.h"
+#include "TypeUtils.h"
+
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::substrait {
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::Type& substraitType) {
+  switch (substraitType.kind_case()) {
+    case ::substrait::Type::KindCase::kBool:
+    case ::substrait::Type::KindCase::kI32:
+    case ::substrait::Type::KindCase::kI64:
+    case ::substrait::Type::KindCase::kFp64:
+    case ::substrait::Type::KindCase::kString:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool SubstraitToVeloxPlanValidator::validateInputTypes(
+    const ::substrait::extensions::AdvancedExtension& extension,
+    std::vector<TypePtr>& types) {
+  // The input type is wrapped in enhancement.
+  if (!extension.has_enhancement()) {
+    return false;
+  }
+  const auto& enhancement = extension.enhancement();
+  ::substrait::Type inputType;
+  if (!enhancement.UnpackTo(&inputType)) {
+    return false;
+  }
+  if (!inputType.has_struct_()) {
+    return false;
+  }
+
+  // Get the input types.
+  const auto& substraitTypes = inputType.struct_().types();
+  for (const auto& substraitType : substraitTypes) {
+    try {
+      types.emplace_back(
+          toVeloxType(subParser_->parseType(substraitType)->type));
+    } catch (const VeloxException& err) {
+      VLOG(0) << "Type is not supported in ProjectRel due to:" << err.message();
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::ProjectRel& projectRel) {
+  if (projectRel.has_input() && !validate(projectRel.input())) {
+    return false;
+  }
+
+  // Get and validate the input types from extension.
+  if (!projectRel.has_advanced_extension()) {
+    VLOG(0) << "Input types are expected in ProjectRel.";
+    return false;
+  }
+  const auto& extension = projectRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    VLOG(0) << "Validation failed for input types in ProjectRel";
+    return false;
+  }
+
+  int32_t inputPlanNodeId = 0;
+  // Create the fake input names to be used in row type.
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (uint32_t colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  // Validate the project expressions.
+  const auto& projectExprs = projectRel.expressions();
+  std::vector<std::shared_ptr<const core::ITypedExpr>> expressions;
+  expressions.reserve(projectExprs.size());
+  try {
+    for (const auto& expr : projectExprs) {
+      expressions.emplace_back(exprConverter_->toVeloxExpr(expr, rowType));
+    }
+    // Try to compile the expressions. If there is any unregistred funciton or
+    // mismatched type, exception will be thrown.
+    exec::ExprSet exprSet(std::move(expressions), execCtx_);
+  } catch (const VeloxException& err) {
+    VLOG(0) << "Validation failed for expression in ProjectRel due to:"
+            << err.message();
+    return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::FilterRel& filterRel) {
+  // Not verified the Filter and fallback it currently.
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::AggregateRel& aggRel) {
+  if (aggRel.has_input() && !validate(aggRel.input())) {
+    return false;
+  }
+
+  // Validate input types.
+  if (aggRel.has_advanced_extension()) {
+    const auto& extension = aggRel.advanced_extension();
+    std::vector<TypePtr> types;
+    if (!validateInputTypes(extension, types)) {
+      VLOG(0) << "Validation failed for input types in AggregateRel";
+      return false;
+    }
+  }
+
+  // Validate groupings.
+  for (const auto& grouping : aggRel.groupings()) {
+    for (const auto& groupingExpr : grouping.grouping_expressions()) {
+      const auto& typeCase = groupingExpr.rex_type_case();
+      switch (typeCase) {
+        case ::substrait::Expression::RexTypeCase::kSelection:
+          break;
+        default:
+          VLOG(0) << "Only field is supported in groupings.";
+          return false;
+      }
+    }
+  }
+
+  // Validate aggregate functions.
+  std::vector<std::string> funcSpecs;
+  funcSpecs.reserve(aggRel.measures().size());
+  for (const auto& smea : aggRel.measures()) {
+    try {
+      const auto& aggFunction = smea.measure();
+      funcSpecs.emplace_back(
+          planConverter_->findFuncSpec(aggFunction.function_reference()));
+      toVeloxType(subParser_->parseType(aggFunction.output_type())->type);
+      for (const auto& arg : aggFunction.args()) {
+        auto typeCase = arg.rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection:
+            break;
+          default:
+            VLOG(0) << "Only field is supported in aggregate functions.";
+            return false;
+        }
+      }
+    } catch (const VeloxException& err) {
+      VLOG(0) << "Validation failed for aggregate function due to: "
+              << err.message();
+      return false;
+    }
+  }
+
+  std::unordered_set<std::string> supportedFuncs = {"sum", "count", "avg"};
+  for (const auto& funcSpec : funcSpecs) {
+    auto funcName = subParser_->getSubFunctionName(funcSpec);
+    if (supportedFuncs.find(funcName) == supportedFuncs.end()) {
+      VLOG(0) << "Validation failed due to " << funcName
+              << " was not supported in AggregateRel.";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::ReadRel& readRel) {
+  if (!readRel.has_base_schema()) {
+    VLOG(0) << "Validation failed due to schema was not found in ReadRel.";
+    return false;
+  }
+  const auto& substraitTypes = readRel.base_schema().struct_().types();
+  for (const auto& substraitType : substraitTypes) {
+    if (!validate(substraitType)) {
+      VLOG(0) << "Validation failed due to type was not supported in ReadRel.";
+      return false;
+    }
+  }
+  std::vector<::substrait::Expression_ScalarFunction> scalarFunctions;
+  if (readRel.has_filter()) {
+    try {
+      planConverter_->flattenConditions(readRel.filter(), scalarFunctions);
+    } catch (const VeloxException& err) {
+      VLOG(0)
+          << "Validation failed due to flattening conditions failed in ReadRel due to:"
+          << err.message();
+      return false;
+    }
+  }
+  // Get and validate the filter functions.
+  std::vector<std::string> funcSpecs;
+  funcSpecs.reserve(scalarFunctions.size());
+  for (const auto& scalarFunction : scalarFunctions) {
+    try {
+      funcSpecs.emplace_back(
+          planConverter_->findFuncSpec(scalarFunction.function_reference()));
+    } catch (const VeloxException& err) {
+      VLOG(0) << "Validation failed in ReadRel due to:" << err.message();
+      return false;
+    }
+
+    if (scalarFunction.args().size() == 1) {
+      // Field is expected.
+      for (const auto& param : scalarFunction.args()) {
+        auto typeCase = param.rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection:
+            break;
+          default:
+            VLOG(0) << "Field is Expected.";
+            return false;
+        }
+      }
+    } else if (scalarFunction.args().size() == 2) {
+      // Expect there being two args. One is field and the other is literal.
+      bool fieldExists = false;
+      bool litExists = false;
+      for (const auto& param : scalarFunction.args()) {
+        auto typeCase = param.rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection: {
+            fieldExists = true;
+            break;
+          }
+          case ::substrait::Expression::RexTypeCase::kLiteral: {
+            litExists = true;
+            break;
+          }
+          default:
+            VLOG(0) << "Type case: " << typeCase
+                    << " is not supported in ReadRel.";
+            return false;
+        }
+      }
+      if (!fieldExists || !litExists) {
+        VLOG(0) << "Only the case of Field and Literal is supported.";
+        return false;
+      }
+    } else {
+      VLOG(0) << "More than two args is not supported in ReadRel.";
+      return false;
+    }
+  }
+  std::unordered_set<std::string> supportedFilters = {
+      "is_not_null", "gte", "gt", "lte", "lt"};
+  std::unordered_set<std::string> supportedTypes = {"opt", "req", "fp64"};
+  for (const auto& funcSpec : funcSpecs) {
+    // Validate the functions.
+    auto funcName = subParser_->getSubFunctionName(funcSpec);
+    if (supportedFilters.find(funcName) == supportedFilters.end()) {
+      VLOG(0) << "Validation failed due to " << funcName
+              << " was not supported in ReadRel.";
+      return false;
+    }
+
+    // Validate the types.
+    std::vector<std::string> funcTypes;
+    subParser_->getSubFunctionTypes(funcSpec, funcTypes);
+    for (const auto& funcType : funcTypes) {
+      if (supportedTypes.find(funcType) == supportedTypes.end()) {
+        VLOG(0) << "Validation failed due to " << funcType
+                << " was not supported in ReadRel.";
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::Rel& substraitRel) {
+  if (substraitRel.has_aggregate()) {
+    return validate(substraitRel.aggregate());
+  }
+  if (substraitRel.has_project()) {
+    return validate(substraitRel.project());
+  }
+  if (substraitRel.has_filter()) {
+    return validate(substraitRel.filter());
+  }
+  if (substraitRel.has_read()) {
+    return validate(substraitRel.read());
+  }
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::RelRoot& root) {
+  if (root.has_input()) {
+    const auto& substraitRel = root.input();
+    return validate(substraitRel);
+  }
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(
+    const ::substrait::Plan& substraitPlan) {
+  functions::prestosql::registerAllScalarFunctions();
+  // Create plan converter and expression converter to help the validation.
+  planConverter_->constructFuncMap(substraitPlan);
+  exprConverter_ = std::make_shared<SubstraitVeloxExprConverter>(
+      planConverter_->getFunctionMap());
+
+  for (const auto& substraitRel : substraitPlan.relations()) {
+    if (substraitRel.has_root()) {
+      return validate(substraitRel.root());
+    }
+    if (substraitRel.has_rel()) {
+      return validate(substraitRel.rel());
+    }
+  }
+  return false;
+}
+
+} // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/substrait/SubstraitToVeloxPlan.h"
+
+namespace facebook::velox::substrait {
+
+/// This class is used to validate whether the computing of
+/// a Substrait plan is supported in Velox.
+class SubstraitToVeloxPlanValidator {
+ public:
+  SubstraitToVeloxPlanValidator(core::ExecCtx* execCtx) : execCtx_(execCtx) {}
+
+  /// Validate the Type.
+  bool validate(const ::substrait::Type& substraitType);
+
+  /// Validate the Aggregation.
+  bool validate(const ::substrait::AggregateRel& aggRel);
+
+  /// Validate the Project.
+  bool validate(const ::substrait::ProjectRel& sProject);
+
+  /// Validate the Filter.
+  bool validate(const ::substrait::FilterRel& filterRel);
+
+  /// Validate the Read.
+  bool validate(const ::substrait::ReadRel& readRel);
+
+  /// Validate the Rel.
+  bool validate(const ::substrait::Rel& rel);
+
+  /// Validate the RelRoot.
+  bool validate(const ::substrait::RelRoot& root);
+
+  /// Validate the Plan.
+  bool validate(const ::substrait::Plan& substraitPlan);
+
+ private:
+  /// Used to get types from advanced extension and validate them.
+  bool validateInputTypes(
+      const ::substrait::extensions::AdvancedExtension& extension,
+      std::vector<TypePtr>& types);
+
+  /// An execution context used for function validation.
+  core::ExecCtx* execCtx_;
+
+  /// A converter used to convert Substrait plan into Velox's plan node.
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>();
+
+  /// A parser used to convert Substrait plan into recognizable representations.
+  std::shared_ptr<SubstraitParser> subParser_ =
+      std::make_shared<SubstraitParser>();
+
+  /// An expression converter used to convert Substrait representations into
+  /// Velox expressions.
+  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+};
+
+} // namespace facebook::velox::substrait

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 add_executable(
-  velox_plan_conversion_test PlanConversionTest.cpp
-                             Substrait2VeloxValuesNodeConversionTest.cpp)
+  velox_plan_conversion_test
+  PlanConversionTest.cpp Substrait2VeloxValuesNodeConversionTest.cpp TestUtils.cpp)
 
 add_dependencies(velox_plan_conversion_test velox_substrait_plan_converter)
 

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_executable(
   velox_plan_conversion_test
-  PlanConversionTest.cpp Substrait2VeloxValuesNodeConversionTest.cpp TestUtils.cpp)
+  PlanConversionTest.cpp Substrait2VeloxValuesNodeConversionTest.cpp
+  PlanValidationTest.cpp TestUtils.cpp)
 
 add_dependencies(velox_plan_conversion_test velox_substrait_plan_converter)
 

--- a/velox/substrait/tests/PlanValidationTest.cpp
+++ b/velox/substrait/tests/PlanValidationTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TestUtils.h"
+
+#include "velox/common/base/tests/Fs.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/dwrf/test/utils/DataFiles.h"
+#include "velox/substrait/SubstraitToVeloxPlanValidator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+namespace vestrait = facebook::velox::substrait;
+
+class PlanValidationTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<core::QueryCtx> queryCtx_ = core::QueryCtx::createForTest();
+
+  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
+      memory::getDefaultScopedMemoryPool();
+
+  std::shared_ptr<TestUtils> testUtils_ = std::make_shared<TestUtils>();
+};
+
+// This test will validate the Substrait plan of Read.
+TEST_F(PlanValidationTest, read) {
+  core::ExecCtx execCtx{pool_.get(), queryCtx_.get()};
+  auto planValidator =
+      std::make_shared<vestrait::SubstraitToVeloxPlanValidator>(&execCtx);
+  std::string subPlanPath =
+      getDataFilePath("velox/substrait/tests", "data/read_validation.json");
+  ::substrait::Plan subPlan;
+  testUtils_->getMsg(subPlanPath, subPlan);
+  bool validated = planValidator->validate(subPlan);
+  ASSERT_EQ(validated, true);
+}
+
+// This test will validate the Substrait plan of Project.
+TEST_F(PlanValidationTest, project) {
+  core::ExecCtx execCtx{pool_.get(), queryCtx_.get()};
+  auto planValidator =
+      std::make_shared<vestrait::SubstraitToVeloxPlanValidator>(&execCtx);
+  std::string subPlanPath =
+      getDataFilePath("velox/substrait/tests", "data/project_validation.json");
+  ::substrait::Plan subPlan;
+  testUtils_->getMsg(subPlanPath, subPlan);
+  bool validated = planValidator->validate(subPlan);
+  ASSERT_EQ(validated, true);
+}
+
+// This test will validate the Substrait plan of Aggregate.
+TEST_F(PlanValidationTest, aggregate) {
+  core::ExecCtx execCtx{pool_.get(), queryCtx_.get()};
+  auto planValidator =
+      std::make_shared<vestrait::SubstraitToVeloxPlanValidator>(&execCtx);
+  std::string subPlanPath =
+      getDataFilePath("velox/substrait/tests", "data/agg_validation.json");
+  ::substrait::Plan subPlan;
+  testUtils_->getMsg(subPlanPath, subPlan);
+  bool validated = planValidator->validate(subPlan);
+  ASSERT_EQ(validated, true);
+}

--- a/velox/substrait/tests/TestUtils.cpp
+++ b/velox/substrait/tests/TestUtils.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TestUtils.h"
+#include <fstream>
+#include <sstream>
+
+void TestUtils::getMsg(
+    const std::string& msgPath,
+    google::protobuf::Message& msg) {
+  // Read json file and resume the Substrait plan.
+  std::ifstream subJson(msgPath);
+  std::stringstream buffer;
+  buffer << subJson.rdbuf();
+  std::string msgData = buffer.str();
+  google::protobuf::util::JsonStringToMessage(msgData, &msg);
+}

--- a/velox/substrait/tests/TestUtils.h
+++ b/velox/substrait/tests/TestUtils.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <google/protobuf/util/json_util.h>
+
+class TestUtils {
+ public:
+  /// This method will resume the Substrait plan from Json file.
+  void getMsg(const std::string& msgPath, google::protobuf::Message& msg);
+};

--- a/velox/substrait/tests/data/agg_validation.json
+++ b/velox/substrait/tests/data/agg_validation.json
@@ -1,0 +1,528 @@
+{
+ "extension_uris": [],
+ "extensions": [
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 3,
+    "name": "sum:opt_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 0,
+    "name": "subtract:opt_fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 2,
+    "name": "add:opt_fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 4,
+    "name": "avg:opt_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 1,
+    "name": "multiply:opt_fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 5,
+    "name": "count:opt_i32"
+   }
+  }
+ ],
+ "relations": [
+  {
+   "root": {
+    "input": {
+     "aggregate": {
+      "common": {
+       "direct": {}
+      },
+      "input": {
+       "project": {
+        "common": {
+         "direct": {}
+        },
+        "expressions": [
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 4
+            }
+           }
+          }
+         },
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 5
+            }
+           }
+          }
+         },
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 0
+            }
+           }
+          }
+         },
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 1
+            }
+           }
+          }
+         },
+         {
+          "scalar_function": {
+           "function_reference": 1,
+           "args": [
+            {
+             "selection": {
+              "direct_reference": {
+               "struct_field": {
+                "field": 1
+               }
+              }
+             }
+            },
+            {
+             "scalar_function": {
+              "function_reference": 0,
+              "args": [
+               {
+                "literal": {
+                 "nullable": false,
+                 "fp64": 1
+                }
+               },
+               {
+                "selection": {
+                 "direct_reference": {
+                  "struct_field": {
+                   "field": 2
+                  }
+                 }
+                }
+               }
+              ],
+              "output_type": {
+               "fp64": {
+                "type_variation_reference": 0,
+                "nullability": "NULLABILITY_NULLABLE"
+               }
+              }
+             }
+            }
+           ],
+           "output_type": {
+            "fp64": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           }
+          }
+         },
+         {
+          "scalar_function": {
+           "function_reference": 1,
+           "args": [
+            {
+             "scalar_function": {
+              "function_reference": 1,
+              "args": [
+               {
+                "selection": {
+                 "direct_reference": {
+                  "struct_field": {
+                   "field": 1
+                  }
+                 }
+                }
+               },
+               {
+                "scalar_function": {
+                 "function_reference": 0,
+                 "args": [
+                  {
+                   "literal": {
+                    "nullable": false,
+                    "fp64": 1
+                   }
+                  },
+                  {
+                   "selection": {
+                    "direct_reference": {
+                     "struct_field": {
+                      "field": 2
+                     }
+                    }
+                   }
+                  }
+                 ],
+                 "output_type": {
+                  "fp64": {
+                   "type_variation_reference": 0,
+                   "nullability": "NULLABILITY_NULLABLE"
+                  }
+                 }
+                }
+               }
+              ],
+              "output_type": {
+               "fp64": {
+                "type_variation_reference": 0,
+                "nullability": "NULLABILITY_NULLABLE"
+               }
+              }
+             }
+            },
+            {
+             "scalar_function": {
+              "function_reference": 2,
+              "args": [
+               {
+                "literal": {
+                 "nullable": false,
+                 "fp64": 1
+                }
+               },
+               {
+                "selection": {
+                 "direct_reference": {
+                  "struct_field": {
+                   "field": 3
+                  }
+                 }
+                }
+               }
+              ],
+              "output_type": {
+               "fp64": {
+                "type_variation_reference": 0,
+                "nullability": "NULLABILITY_NULLABLE"
+               }
+              }
+             }
+            }
+           ],
+           "output_type": {
+            "fp64": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           }
+          }
+         },
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 2
+            }
+           }
+          }
+         },
+         {
+          "literal": {
+           "nullable": false,
+           "i32": 1
+          }
+         }
+        ],
+        "advanced_extension": {
+         "enhancement": {
+          "@type": "type.googleapis.com/substrait.Type",
+          "struct": {
+           "types": [
+            {
+             "fp64": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            },
+            {
+             "fp64": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            },
+            {
+             "fp64": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            },
+            {
+             "fp64": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            },
+            {
+             "string": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            },
+            {
+             "string": {
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_NULLABLE"
+             }
+            }
+           ],
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_UNSPECIFIED"
+          }
+         }
+        }
+       }
+      },
+      "groupings": [
+       {
+        "grouping_expressions": [
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 0
+            }
+           }
+          }
+         },
+         {
+          "selection": {
+           "direct_reference": {
+            "struct_field": {
+             "field": 1
+            }
+           }
+          }
+         }
+        ]
+       }
+      ],
+      "measures": [
+       {
+        "measure": {
+         "function_reference": 3,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 2
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 3,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 3
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 3,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 4
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 3,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 5
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 4,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 2
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 4,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 3
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 4,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 6
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       },
+       {
+        "measure": {
+         "function_reference": 5,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 7
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "i64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_REQUIRED"
+          }
+         }
+        }
+       }
+      ]
+     }
+    },
+    "names": []
+   }
+  }
+ ],
+ "expected_type_urls": []
+}

--- a/velox/substrait/tests/data/project_validation.json
+++ b/velox/substrait/tests/data/project_validation.json
@@ -1,0 +1,128 @@
+{
+ "extension_uris": [],
+ "extensions": [],
+ "relations": [
+  {
+   "root": {
+    "input": {
+     "project": {
+      "common": {
+       "direct": {}
+      },
+      "expressions": [
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 0
+          }
+         }
+        }
+       },
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 1
+          }
+         }
+        }
+       },
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 2
+          }
+         }
+        }
+       },
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 3
+          }
+         }
+        }
+       },
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 4
+          }
+         }
+        }
+       },
+       {
+        "selection": {
+         "direct_reference": {
+          "struct_field": {
+           "field": 5
+          }
+         }
+        }
+       }
+      ],
+      "advanced_extension": {
+       "enhancement": {
+        "@type": "type.googleapis.com/substrait.Type",
+        "struct": {
+         "types": [
+          {
+           "fp64": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "fp64": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "fp64": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "fp64": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "string": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "string": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_NULLABLE"
+           }
+          },
+          {
+           "fp64": {
+            "type_variation_reference": 0,
+            "nullability": "NULLABILITY_REQUIRED"
+           }
+          }
+         ],
+         "type_variation_reference": 0,
+         "nullability": "NULLABILITY_UNSPECIFIED"
+        }
+       }
+      }
+     }
+    },
+    "names": []
+   }
+  }
+ ],
+ "expected_type_urls": []
+}

--- a/velox/substrait/tests/data/read_validation.json
+++ b/velox/substrait/tests/data/read_validation.json
@@ -1,0 +1,163 @@
+{
+ "extension_uris": [],
+ "extensions": [
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 1,
+    "name": "lte:fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 0,
+    "name": "is_not_null:fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 2,
+    "name": "and:bool_bool"
+   }
+  }
+ ],
+ "relations": [
+  {
+   "root": {
+    "input": {
+     "read": {
+      "common": {
+       "direct": {}
+      },
+      "base_schema": {
+       "names": [
+        "l_quantity",
+        "l_extendedprice",
+        "l_discount",
+        "l_tax",
+        "l_returnflag",
+        "l_linestatus",
+        "l_shipdate_new"
+       ],
+       "struct": {
+        "types": [
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "string": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "string": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         },
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        ],
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_UNSPECIFIED"
+       }
+      },
+      "filter": {
+       "scalar_function": {
+        "function_reference": 2,
+        "args": [
+         {
+          "scalar_function": {
+           "function_reference": 0,
+           "args": [
+            {
+             "selection": {
+              "direct_reference": {
+               "struct_field": {
+                "field": 6
+               }
+              }
+             }
+            }
+           ],
+           "output_type": {
+            "bool": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           }
+          }
+         },
+         {
+          "scalar_function": {
+           "function_reference": 1,
+           "args": [
+            {
+             "selection": {
+              "direct_reference": {
+               "struct_field": {
+                "field": 6
+               }
+              }
+             }
+            },
+            {
+             "literal": {
+              "nullable": false,
+              "fp64": 10471
+             }
+            }
+           ],
+           "output_type": {
+            "bool": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           }
+          }
+         }
+        ],
+        "output_type": {
+         "bool": {
+          "type_variation_reference": 0,
+          "nullability": "NULLABILITY_NULLABLE"
+         }
+        }
+       }
+      }
+     }
+    },
+    "names": []
+   }
+  }
+ ],
+ "expected_type_urls": []
+}


### PR DESCRIPTION
Supported Substrait plan validations based on current supported cases, including:

- validations for TableScan (with Filter pushdown), Project, Aggregate.

https://github.com/facebookincubator/velox/issues/1573.