### PR TITLE
Adding unit tests for HivePartitionFunction and VectorHasher.

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -119,7 +119,7 @@ HivePartitionFunction::HivePartitionFunction(
     int numBuckets,
     std::vector<int> bucketToPartition,
     std::vector<ChannelIndex> keyChannels,
-    const std::vector<std::shared_ptr<BaseVector>>& constValues)
+    const std::vector<VectorPtr>& constValues)
     : numBuckets_{numBuckets},
       bucketToPartition_{bucketToPartition},
       keyChannels_{std::move(keyChannels)} {

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -26,7 +26,7 @@ class HivePartitionFunction : public core::PartitionFunction {
       int numBuckets,
       std::vector<int> bucketToPartition,
       std::vector<ChannelIndex> keyChannels,
-      const std::vector<std::shared_ptr<BaseVector>>& constValues = {});
+      const std::vector<VectorPtr>& constValues = {});
 
   ~HivePartitionFunction() override = default;
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -120,19 +120,19 @@ void addKeys(
     std::stringstream& stream,
     const std::vector<std::shared_ptr<const ITypedExpr>>& keys) {
   for (auto i = 0; i < keys.size(); ++i) {
+    const auto& expr = keys[i];
     if (i > 0) {
       stream << ", ";
     }
     if (auto field =
-            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-                keys[i])) {
+            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expr)) {
       stream << field->name();
     } else if (
         auto constant =
-            std::dynamic_pointer_cast<const core::ConstantTypedExpr>(keys[i])) {
-      stream << "<constexpr>";
+            std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr)) {
+      stream << constant->toString();
     } else {
-      stream << "<unknown>";
+      stream << expr->toString();
     }
   }
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -854,7 +854,7 @@ class PartitionedOutputNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   const std::vector<PlanNodePtr> sources_;
-  const std::vector<std::shared_ptr<const ITypedExpr>> keys_;
+  const std::vector<TypedExprPtr> keys_;
   const int numPartitions_;
   const bool broadcast_;
   const bool replicateNullsAndAny_;

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -21,7 +21,7 @@ HashPartitionFunction::HashPartitionFunction(
     int numPartitions,
     const RowTypePtr& inputType,
     const std::vector<ChannelIndex>& keyChannels,
-    const std::vector<std::shared_ptr<BaseVector>>& constValues)
+    const std::vector<VectorPtr>& constValues)
     : numPartitions_{numPartitions} {
   hashers_.reserve(keyChannels.size());
   size_t constChannel{0};

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -26,7 +26,7 @@ class HashPartitionFunction : public core::PartitionFunction {
       int numPartitions,
       const RowTypePtr& inputType,
       const std::vector<ChannelIndex>& keyChannels,
-      const std::vector<std::shared_ptr<BaseVector>>& constValues = {});
+      const std::vector<VectorPtr>& constValues = {});
 
   ~HashPartitionFunction() override = default;
 

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -476,7 +476,7 @@ void VectorHasher::hashPrecomputed(
 
 void VectorHasher::precompute(const BaseVector& value) {
   if (value.isNullAt(0)) {
-    precomputedHash_ = 0;
+    precomputedHash_ = kNullHash;
     return;
   }
 


### PR DESCRIPTION
Summary:
Adding unit tests for HivePartitionFunction and VectorHasher.
Using typedef fomr some shared pointers.
Fixing bug in VectorHasher, when we used zero for precomputed hash for null values, should use 'kNullHash'.

Differential Revision: D36335387

