### PR TITLE
Change BaseVector::encoding() to a non-getter

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -32,6 +32,7 @@ namespace velox {
 BaseVector::BaseVector(
     velox::memory::MemoryPool* pool,
     std::shared_ptr<const Type> type,
+    VectorEncoding::Simple encoding,
     BufferPtr nulls,
     size_t length,
     std::optional<vector_size_t> distinctValueCount,
@@ -40,6 +41,7 @@ BaseVector::BaseVector(
     std::optional<ByteCount> storageByteCount)
     : type_(std::move(type)),
       typeKind_(type_->kind()),
+      encoding_(encoding),
       nulls_(std::move(nulls)),
       rawNulls_(nulls_.get() ? nulls_->as<uint64_t>() : nullptr),
       pool_(pool),

--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -46,6 +46,7 @@ BiasVector<T>::BiasVector(
     std::optional<ByteCount> storageByteCount)
     : SimpleVector<T>(
           pool,
+          VectorEncoding::Simple::BIASED,
           nulls,
           length,
           stats,

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -112,10 +112,6 @@ class BiasVector : public SimpleVector<T> {
 
   ~BiasVector() override {}
 
-  inline VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::BIASED;
-  }
-
   const T valueAtFast(vector_size_t idx) const;
 
   const T valueAt(vector_size_t idx) const override {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -44,7 +44,15 @@ class RowVector : public BaseVector {
       size_t length,
       std::vector<VectorPtr> children,
       std::optional<vector_size_t> nullCount = std::nullopt)
-      : BaseVector(pool, type, nulls, length, std::nullopt, nullCount, 1),
+      : BaseVector(
+            pool,
+            type,
+            VectorEncoding::Simple::ROW,
+            nulls,
+            length,
+            std::nullopt,
+            nullCount,
+            1),
         childrenSize_(children.size()),
         children_(std::move(children)) {
     // Some columns may not be projected out
@@ -71,10 +79,6 @@ class RowVector : public BaseVector {
       velox::memory::MemoryPool* pool);
 
   virtual ~RowVector() override {}
-
-  VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::ROW;
-  }
 
   std::optional<int32_t> compare(
       const BaseVector* other,
@@ -205,6 +209,7 @@ class ArrayVector : public BaseVector {
       : BaseVector(
             pool,
             type,
+            VectorEncoding::Simple::ARRAY,
             nulls,
             length,
             std::nullopt /*distinctValueCount*/,
@@ -269,10 +274,6 @@ class ArrayVector : public BaseVector {
   }
 
   virtual ~ArrayVector() override {}
-
-  VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::ARRAY;
-  }
 
   std::optional<int32_t> compare(
       const BaseVector* other,
@@ -404,6 +405,7 @@ class MapVector : public BaseVector {
       : BaseVector(
             pool,
             type,
+            VectorEncoding::Simple::MAP,
             nulls,
             length,
             std::nullopt /*distinctValueCount*/,
@@ -436,10 +438,6 @@ class MapVector : public BaseVector {
   }
 
   virtual ~MapVector() override {}
-
-  VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::MAP;
-  }
 
   std::optional<int32_t> compare(
       const BaseVector* other,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -70,6 +70,7 @@ class ConstantVector final : public SimpleVector<T> {
       : SimpleVector<T>(
             pool,
             type,
+            VectorEncoding::Simple::CONSTANT,
             BufferPtr(nullptr),
             length,
             stats,
@@ -116,6 +117,7 @@ class ConstantVector final : public SimpleVector<T> {
       : SimpleVector<T>(
             pool,
             base->type(),
+            VectorEncoding::Simple::CONSTANT,
             BufferPtr(nullptr),
             length,
             stats,
@@ -130,21 +132,17 @@ class ConstantVector final : public SimpleVector<T> {
         valueVector_(base),
         index_(index) {
     VELOX_CHECK_NE(
-        base->encoding(),
+        base->BaseVector::encoding(),
         VectorEncoding::Simple::CONSTANT,
         "Constant vector cannot wrap Constant vector");
     VELOX_CHECK_NE(
-        base->encoding(),
+        base->BaseVector::encoding(),
         VectorEncoding::Simple::DICTIONARY,
         "Constant vector cannot wrap Dictionary vector");
     setInternalState();
   }
 
   virtual ~ConstantVector() override = default;
-
-  inline VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::CONSTANT;
-  }
 
   bool isNullAt(vector_size_t /*idx*/) const override {
     VELOX_DCHECK(initialized_);
@@ -327,8 +325,8 @@ class ConstantVector final : public SimpleVector<T> {
 
   std::string toString() const override {
     std::stringstream out;
-    out << "[" << encoding() << " " << this->type()->toString() << ": "
-        << toString(index_) << " value, " << this->size() << " size]";
+    out << "[" << BaseVector::encoding() << " " << this->type()->toString()
+        << ": " << toString(index_) << " value, " << this->size() << " size]";
     return out.str();
   }
 

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -64,6 +64,7 @@ DictionaryVector<T>::DictionaryVector(
     : SimpleVector<T>(
           pool,
           dictionaryValues->type(),
+          VectorEncoding::Simple::DICTIONARY,
           nulls,
           length,
           stats,

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -64,10 +64,6 @@ class DictionaryVector : public SimpleVector<T> {
 
   virtual ~DictionaryVector() override = default;
 
-  inline VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::DICTIONARY;
-  }
-
   bool mayHaveNulls() const override {
     VELOX_DCHECK(initialized_);
     return BaseVector::nulls() || dictionaryValues_->mayHaveNulls();

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -93,6 +93,7 @@ class FlatVector final : public SimpleVector<T> {
       : SimpleVector<T>(
             pool,
             type,
+            VectorEncoding::Simple::FLAT,
             std::move(nulls),
             length,
             stats,
@@ -128,10 +129,6 @@ class FlatVector final : public SimpleVector<T> {
 
   virtual ~FlatVector() override = default;
 
-  inline VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::FLAT;
-  }
-
   const T valueAtFast(vector_size_t idx) const;
 
   const T valueAt(vector_size_t idx) const override {
@@ -149,7 +146,7 @@ class FlatVector final : public SimpleVector<T> {
    */
   xsimd::batch<T> loadSIMDValueBufferAt(size_t index) const;
 
-  // dictionary vector makes internal use here for SIMD functions
+  // dictionary vector makes internal usehere for SIMD functions
   template <typename X>
   friend class DictionaryVector;
 
@@ -190,6 +187,11 @@ class FlatVector final : public SimpleVector<T> {
 
   const void* valuesAsVoid() const override {
     return rawValues_;
+  }
+
+  bool isRecyclable() const final {
+    return (!BaseVector::nulls_ || BaseVector::nulls_->unique()) &&
+        (values_ && values_->unique());
   }
 
   template <typename As>

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -101,11 +101,12 @@ class FunctionVector : public BaseVector {
   };
 
   FunctionVector(velox::memory::MemoryPool* pool, TypePtr type)
-      : BaseVector(pool, type, BufferPtr(nullptr), 0) {}
-
-  VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::FUNCTION;
-  }
+      : BaseVector(
+            pool,
+            type,
+            VectorEncoding::Simple::FUNCTION,
+            BufferPtr(nullptr),
+            0) {}
 
   // Implements evaluation of the lambda function literal special
   // form. This assigns a function to a specified set of rows. This

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -129,12 +129,13 @@ class LazyVector : public BaseVector {
       TypePtr type,
       vector_size_t size,
       std::unique_ptr<VectorLoader>&& loader)
-      : BaseVector(pool, std::move(type), BufferPtr(nullptr), size),
+      : BaseVector(
+            pool,
+            std::move(type),
+            VectorEncoding::Simple::LAZY,
+            BufferPtr(nullptr),
+            size),
         loader_(std::move(loader)) {}
-
-  VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::LAZY;
-  }
 
   void reset(std::unique_ptr<VectorLoader>&& loader, vector_size_t size) {
     BaseVector::length_ = size;

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -36,6 +36,7 @@ SequenceVector<T>::SequenceVector(
     : SimpleVector<T>(
           pool,
           sequenceValues->type(),
+          VectorEncoding::Simple::SEQUENCE,
           BufferPtr(nullptr),
           length,
           stats,

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -54,10 +54,6 @@ class SequenceVector : public SimpleVector<T> {
  public:
   ~SequenceVector() override = default;
 
-  inline VectorEncoding::Simple encoding() const override {
-    return VectorEncoding::Simple::SEQUENCE;
-  }
-
   bool mayHaveNulls() const override {
     return sequenceValues_->mayHaveNulls();
   }

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -59,6 +59,7 @@ class SimpleVector : public BaseVector {
   SimpleVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,
+      VectorEncoding::Simple encoding,
       BufferPtr nulls,
       size_t length,
       const SimpleVectorStats<T>& stats,
@@ -70,6 +71,7 @@ class SimpleVector : public BaseVector {
       : BaseVector(
             pool,
             std::move(type),
+            encoding,
             std::move(nulls),
             length,
             distinctValueCount,
@@ -83,6 +85,7 @@ class SimpleVector : public BaseVector {
   // Constructs SimpleVector inferring the type from T.
   SimpleVector(
       velox::memory::MemoryPool* pool,
+      VectorEncoding::Simple encoding,
       BufferPtr nulls,
       size_t length,
       const SimpleVectorStats<T>& stats,
@@ -94,6 +97,7 @@ class SimpleVector : public BaseVector {
       : SimpleVector(
             pool,
             CppToType<T>::create(),
+            encoding,
             std::move(nulls),
             length,
             stats,


### PR DESCRIPTION
Encoding of vectors is accessed all the time. A virtual function
returning a constant is 5-6 instructions. A non-virtual getter is 1
instruction. Changes encoding to be a data member in BaseVector.