### PR TITLE
Introduce AssertQueryBuilder

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTableScanTest.cpp
@@ -112,9 +112,8 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   std::shared_ptr<connector::hive::HiveConnectorSplit> makeSplit(
       const std::string& filePath) {
-    auto split = makeHiveConnectorSplit(filePath);
-    split->fileFormat = dwio::common::FileFormat::PARQUET;
-    return split;
+    return makeHiveConnectorSplits(
+        filePath, 1, dwio::common::FileFormat::PARQUET)[0];
   }
 
  private:

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+class AssertQueryBuilderTest : public HiveConnectorTestBase {};
+
+TEST_F(AssertQueryBuilderTest, basic) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  AssertQueryBuilder(
+      PlanBuilder().values({data}).planNode(), duckDbQueryRunner_)
+      .assertResults("VALUES (1), (2), (3)");
+
+  AssertQueryBuilder(PlanBuilder().values({data}).planNode())
+      .assertResults(data);
+}
+
+TEST_F(AssertQueryBuilderTest, orderedResults) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  AssertQueryBuilder(
+      PlanBuilder().values({data}).orderBy({"c0 DESC"}, true).planNode(),
+      duckDbQueryRunner_)
+      .assertResults("VALUES (3), (2), (1)", {{0}});
+}
+
+TEST_F(AssertQueryBuilderTest, concurrency) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  AssertQueryBuilder(
+      PlanBuilder().values({data}, true).planNode(), duckDbQueryRunner_)
+      .maxDrivers(3)
+      .assertResults("VALUES (1), (2), (3), (1), (2), (3), (1), (2), (3)");
+
+  AssertQueryBuilder(PlanBuilder().values({data}, true).planNode())
+      .maxDrivers(3)
+      .assertResults({data, data, data});
+}
+
+TEST_F(AssertQueryBuilderTest, config) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  AssertQueryBuilder(
+      PlanBuilder().values({data}).project({"c0 * 2"}).planNode(),
+      duckDbQueryRunner_)
+      .config(core::QueryConfig::kExprEvalSimplified, "true")
+      .assertResults("VALUES (2), (4), (6)");
+}
+
+TEST_F(AssertQueryBuilderTest, hiveSplits) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+
+  auto file = TempFilePath::create();
+  writeToFile(file->path, {data});
+
+  // Single leaf node.
+  AssertQueryBuilder(
+      PlanBuilder().tableScan(asRowType(data->type())).planNode(),
+      duckDbQueryRunner_)
+      .split(makeHiveSplit(file->path))
+      .assertResults("VALUES (1), (2), (3)");
+
+  // Split with partition key.
+  ColumnHandleMap assignments = {
+      {"ds", partitionKey("ds", VARCHAR())},
+      {"c0", regularColumn("c0", BIGINT())}};
+
+  AssertQueryBuilder(
+      PlanBuilder()
+          .tableScan(
+              ROW({"c0", "ds"}, {INTEGER(), VARCHAR()}),
+              makeTableHandle(),
+              assignments)
+          .planNode(),
+      duckDbQueryRunner_)
+      .split(makeHiveConnectorSplit(file->path, {{"ds", "2022-05-10"}}))
+      .assertResults(
+          "VALUES (1, '2022-05-10'), (2, '2022-05-10'), (3, '2022-05-10')");
+
+  // Two leaf nodes.
+  auto buildData = makeRowVector({makeFlatVector<int32_t>({2, 3})});
+  auto buildFile = TempFilePath::create();
+  writeToFile(buildFile->path, {buildData});
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  auto joinPlan = PlanBuilder(planNodeIdGenerator)
+                      .tableScan(asRowType(data->type()))
+                      .capturePlanNodeId(probeScanId)
+                      .hashJoin(
+                          {"c0"},
+                          {"b_c0"},
+                          PlanBuilder(planNodeIdGenerator)
+                              .tableScan(asRowType(data->type()))
+                              .capturePlanNodeId(buildScanId)
+                              .project({"c0 as b_c0"})
+                              .planNode(),
+                          "",
+                          {"c0", "b_c0"})
+                      .singleAggregation({}, {"count(1)"})
+                      .planNode();
+
+  AssertQueryBuilder(joinPlan, duckDbQueryRunner_)
+      .split(probeScanId, makeHiveSplit(file->path))
+      .split(buildScanId, makeHiveSplit(buildFile->path))
+      .assertResults("SELECT 2");
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(utils)
 
 add_executable(
   velox_exec_test
+  AssertQueryBuilderTest.cpp
   CrossJoinTest.cpp
   CustomJoinTest.cpp
   DriverTest.cpp

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -88,7 +88,7 @@ TEST_F(LimitTest, limitOverLocalExchange) {
           .planNode();
 
   TaskCursor cursor(params);
-  addSplit(cursor.task().get(), scanNodeId, makeHiveSplit(file->path));
+  cursor.task()->addSplit(scanNodeId, makeHiveSplit(file->path));
 
   int32_t numRead = 0;
   while (cursor.moveNext()) {

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -473,7 +473,7 @@ TEST_F(MultiFragmentTest, limit) {
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   Task::start(leafTask, 1);
 
-  addSplit(leafTask.get(), "0", makeHiveSplit(file->path));
+  leafTask.get()->addSplit("0", makeHiveSplit(file->path));
 
   // Make final task: Exchange -> FinalLimit(1).
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -24,10 +24,6 @@ class StreamingAggregationTest : public OperatorTestBase {
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = core::QueryCtx::createForTest();
-    queryCtx->setConfigOverridesUnsafe(
-        {{core::QueryConfig::kCreateEmptyFiles, "true"}});
-
     CursorParameters params;
     params.planNode = planNode;
     params.queryCtx = core::QueryCtx::createForTest();

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+namespace {
+/// Returns the plan node ID of the only leaf plan node. Throws if 'root' has
+/// multiple leaf nodes.
+core::PlanNodeId getOnlyLeafPlanNodeId(const core::PlanNodePtr& root) {
+  const auto& sources = root->sources();
+  if (sources.empty()) {
+    return root->id();
+  }
+
+  VELOX_CHECK_EQ(1, sources.size());
+  return getOnlyLeafPlanNodeId(sources[0]);
+}
+} // namespace
+
+AssertQueryBuilder::AssertQueryBuilder(
+    const core::PlanNodePtr& plan,
+    DuckDbQueryRunner& duckDbQueryRunner)
+    : duckDbQueryRunner_{&duckDbQueryRunner} {
+  params_.planNode = plan;
+}
+
+AssertQueryBuilder::AssertQueryBuilder(DuckDbQueryRunner& duckDbQueryRunner)
+    : duckDbQueryRunner_{&duckDbQueryRunner} {}
+
+AssertQueryBuilder::AssertQueryBuilder(const core::PlanNodePtr& plan) {
+  params_.planNode = plan;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::plan(const core::PlanNodePtr& plan) {
+  params_.planNode = plan;
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::maxDrivers(int32_t maxDrivers) {
+  params_.maxDrivers = maxDrivers;
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::config(
+    const std::string& key,
+    const std::string& value) {
+  configs_[key] = value;
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::split(Split split) {
+  this->split(getOnlyLeafPlanNodeId(params_.planNode), std::move(split));
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::split(
+    const core::PlanNodeId& planNodeId,
+    Split split) {
+  splits_[planNodeId].emplace_back(std::move(split));
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::splits(std::vector<Split> splits) {
+  this->splits(getOnlyLeafPlanNodeId(params_.planNode), std::move(splits));
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::splits(
+    const core::PlanNodeId& planNodeId,
+    std::vector<Split> splits) {
+  splits_[planNodeId] = std::move(splits);
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::split(
+    const std::shared_ptr<connector::ConnectorSplit>& connectorSplit) {
+  split(getOnlyLeafPlanNodeId(params_.planNode), connectorSplit);
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::split(
+    const core::PlanNodeId& planNodeId,
+    const std::shared_ptr<connector::ConnectorSplit>& connectorSplit) {
+  splits_[planNodeId].emplace_back(
+      exec::Split(folly::copy(connectorSplit), -1));
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::splits(
+    const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+        connectorSplits) {
+  splits(getOnlyLeafPlanNodeId(params_.planNode), connectorSplits);
+  return *this;
+}
+
+AssertQueryBuilder& AssertQueryBuilder::splits(
+    const core::PlanNodeId& planNodeId,
+    const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+        connectorSplits) {
+  std::vector<Split> splits;
+  for (auto& connectorSplit : connectorSplits) {
+    splits.emplace_back(exec::Split(folly::copy(connectorSplit), -1));
+  }
+  splits_[planNodeId] = std::move(splits);
+  return *this;
+}
+
+std::shared_ptr<Task> AssertQueryBuilder::assertResults(
+    const std::string& duckDbSql,
+    const std::optional<std::vector<uint32_t>>& sortingKeys) {
+  VELOX_CHECK_NOT_NULL(duckDbQueryRunner_);
+
+  auto [cursor, results] = readCursor();
+  if (results.empty()) {
+    test::assertResults(results, ROW({}, {}), duckDbSql, *duckDbQueryRunner_);
+  } else if (sortingKeys.has_value()) {
+    test::assertResultsOrdered(
+        results,
+        asRowType(results[0]->type()),
+        duckDbSql,
+        *duckDbQueryRunner_,
+        sortingKeys.value());
+  } else {
+    test::assertResults(
+        results, asRowType(results[0]->type()), duckDbSql, *duckDbQueryRunner_);
+  }
+  return cursor->task();
+}
+
+std::shared_ptr<Task> AssertQueryBuilder::assertResults(
+    const RowVectorPtr& expected) {
+  return assertResults(std::vector<RowVectorPtr>{expected});
+}
+
+std::shared_ptr<Task> AssertQueryBuilder::assertResults(
+    const std::vector<RowVectorPtr>& expected) {
+  auto [cursor, results] = readCursor();
+
+  assertEqualResults(expected, results);
+  return cursor->task();
+}
+
+std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+AssertQueryBuilder::readCursor() {
+  VELOX_CHECK_NOT_NULL(params_.planNode);
+
+  if (!configs_.empty()) {
+    params_.queryCtx = core::QueryCtx::createForTest();
+    params_.queryCtx->setConfigOverridesUnsafe(std::move(configs_));
+  }
+
+  bool noMoreSplits = false;
+  return test::readCursor(params_, [&](Task* task) {
+    if (noMoreSplits) {
+      return;
+    }
+    for (auto& [nodeId, nodeSplits] : splits_) {
+      for (auto& split : nodeSplits) {
+        task->addSplit(nodeId, std::move(split));
+      }
+      task->noMoreSplits(nodeId);
+    }
+    noMoreSplits = true;
+  });
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/tests/utils/QueryAssertions.h"
+
+namespace facebook::velox::exec::test {
+
+class AssertQueryBuilder {
+ public:
+  AssertQueryBuilder(
+      const core::PlanNodePtr& plan,
+      DuckDbQueryRunner& duckDbQueryRunner);
+
+  explicit AssertQueryBuilder(DuckDbQueryRunner& duckDbQueryRunner);
+
+  explicit AssertQueryBuilder(const core::PlanNodePtr& plan);
+
+  /// Set the plan.
+  AssertQueryBuilder& plan(const core::PlanNodePtr& plan);
+
+  /// Change requested number of drivers. Default is 1.
+  AssertQueryBuilder& maxDrivers(int32_t maxDrivers);
+
+  /// Set configuration property. May be called multiple times to set multiple
+  /// properties.
+  AssertQueryBuilder& config(const std::string& key, const std::string& value);
+
+  // Methods to add splits.
+
+  /// Add a single split for the specified plan node.
+  AssertQueryBuilder& split(const core::PlanNodeId& planNodeId, Split split);
+
+  /// Add a single split to the only leaf plan node. Throws if there are
+  /// multiple leaf nodes.
+  AssertQueryBuilder& split(Split split);
+
+  /// Add multiple splits for the specified plan node.
+  AssertQueryBuilder& splits(
+      const core::PlanNodeId& planNodeId,
+      std::vector<Split> splits);
+
+  /// Add multiple splits to the only leaf plan node. Throws if there are
+  /// multiple leaf nodes.
+  AssertQueryBuilder& splits(std::vector<Split> splits);
+
+  /// Add a single connector split to the only leaf plan node. Throws if there
+  /// are multiple leaf nodes.
+  AssertQueryBuilder& split(
+      const std::shared_ptr<connector::ConnectorSplit>& connectorSplit);
+
+  /// Add a single connector split for the specified plan node.
+  AssertQueryBuilder& split(
+      const core::PlanNodeId& planNodeId,
+      const std::shared_ptr<connector::ConnectorSplit>& connectorSplit);
+
+  /// Add multiple connector splits for the specified plan node.
+  AssertQueryBuilder& splits(
+      const core::PlanNodeId& planNodeId,
+      const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+          connectorSplits);
+
+  /// Add multiple connector splits to the only leaf plan node. Throws if there
+  /// are multiple leaf nodes.
+  AssertQueryBuilder& splits(
+      const std::vector<std::shared_ptr<connector::ConnectorSplit>>&
+          connectorSplits);
+
+  // Methods to run the query and verify the results.
+
+  /// Run the query and verify results against DuckDB. Requires
+  /// duckDbQueryRunner to be provided in the constructor.
+  std::shared_ptr<Task> assertResults(
+      const std::string& duckDbSql,
+      const std::optional<std::vector<uint32_t>>& sortingKeys = std::nullopt);
+
+  /// Run the query and compare results with 'expected'.
+  std::shared_ptr<Task> assertResults(const RowVectorPtr& expected);
+
+  /// Run the query and compare results with 'expected'.
+  std::shared_ptr<Task> assertResults(
+      const std::vector<RowVectorPtr>& expected);
+
+ private:
+  std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+  readCursor();
+
+  CursorParameters params_;
+  std::unordered_map<std::string, std::string> configs_;
+  std::unordered_map<core::PlanNodeId, std::vector<Split>> splits_;
+  DuckDbQueryRunner* duckDbQueryRunner_;
+};
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -18,8 +18,13 @@ target_link_libraries(velox_temp_path velox_exception)
 
 add_library(
   velox_exec_test_util
-  Cursor.cpp HiveConnectorTestBase.cpp OperatorTestBase.cpp PlanBuilder.cpp
-  QueryAssertions.cpp TpchQueryBuilder.cpp)
+  AssertQueryBuilder.cpp
+  Cursor.cpp
+  HiveConnectorTestBase.cpp
+  OperatorTestBase.cpp
+  PlanBuilder.cpp
+  QueryAssertions.cpp
+  TpchQueryBuilder.cpp)
 
 target_link_libraries(
   velox_exec_test_util

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -107,22 +107,6 @@ std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
       plan, makeHiveSplits(filePaths), duckDbSql);
 }
 
-std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
-    const core::PlanNodePtr& plan,
-    const std::unordered_map<
-        core::PlanNodeId,
-        std::vector<std::shared_ptr<TempFilePath>>>& filePaths,
-    const std::string& duckDbSql) {
-  std::unordered_map<core::PlanNodeId, std::vector<Split>> splits;
-  for (const auto& [nodeId, nodePaths] : filePaths) {
-    for (const auto& path : nodePaths) {
-      splits[nodeId].emplace_back(makeHiveSplit(path->path));
-    }
-  }
-
-  return OperatorTestBase::assertQuery(plan, std::move(splits), duckDbSql);
-}
-
 std::vector<std::shared_ptr<TempFilePath>> HiveConnectorTestBase::makeFilePaths(
     int count) {
   std::vector<std::shared_ptr<TempFilePath>> filePaths;
@@ -163,7 +147,7 @@ HiveConnectorTestBase::makeHiveSplits(
   return splits;
 }
 
-std::shared_ptr<connector::hive::HiveConnectorSplit>
+std::shared_ptr<connector::ConnectorSplit>
 HiveConnectorTestBase::makeHiveConnectorSplit(
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
@@ -221,13 +205,6 @@ HiveConnectorTestBase::partitionKey(
     const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
       name, connector::hive::HiveColumnHandle::ColumnType::kPartitionKey, type);
-}
-
-void HiveConnectorTestBase::addSplit(
-    Task* task,
-    const core::PlanNodeId& planNodeId,
-    exec::Split&& split) {
-  task->addSplit(planNodeId, std::move(split));
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -60,20 +60,12 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
       const std::string& duckDbSql);
 
-  std::shared_ptr<exec::Task> assertQuery(
-      const core::PlanNodePtr& plan,
-      const std::unordered_map<
-          core::PlanNodeId,
-          std::vector<std::shared_ptr<TempFilePath>>>& filePaths,
-      const std::string& duckDbSql);
-
   static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);
 
   static std::vector<std::shared_ptr<connector::ConnectorSplit>> makeHiveSplits(
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths);
 
-  static std::shared_ptr<connector::hive::HiveConnectorSplit>
-  makeHiveConnectorSplit(
+  static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
       const std::string& filePath,
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max()) {
@@ -87,8 +79,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
       uint32_t splitCount,
       dwio::common::FileFormat format);
 
-  static std::shared_ptr<connector::hive::HiveConnectorSplit>
-  makeHiveConnectorSplit(
+  static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
       const std::string& filePath,
       const std::unordered_map<std::string, std::optional<std::string>>&
           partitionKeys,
@@ -105,7 +96,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
       int32_t groupId);
 
   static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
-      common::test::SubfieldFilters subfieldFilters,
+      common::test::SubfieldFilters subfieldFilters = {},
       const std::shared_ptr<const core::ITypedExpr>& remainingFilter = nullptr,
       const std::string& tableName = "hive_table") {
     return std::make_shared<connector::hive::HiveTableHandle>(
@@ -133,9 +124,6 @@ class HiveConnectorTestBase : public OperatorTestBase {
     }
     return assignments;
   }
-
-  static void
-  addSplit(Task* task, const core::PlanNodeId& planNodeId, exec::Split&& split);
 
   memory::MappedMemory* mappedMemory() {
     return memory::MappedMemory::getInstance();

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -40,10 +40,6 @@ class ExprStatsTest : public testing::Test, public VectorTestBase {
     });
   }
 
-  static RowTypePtr asRowType(const TypePtr& type) {
-    return std::dynamic_pointer_cast<const RowType>(type);
-  }
-
   std::shared_ptr<const core::ITypedExpr> parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -16,7 +16,9 @@
 
 #include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 
+using facebook::velox::exec::test::AssertQueryBuilder;
 using facebook::velox::exec::test::CursorParameters;
 using facebook::velox::exec::test::PlanBuilder;
 
@@ -122,9 +124,10 @@ void AggregationTestBase::testAggregations(
     }
 
     if constexpr (UseDuckDB) {
-      assertQuery(builder.planNode(), duckDbSql);
+      AssertQueryBuilder(builder.planNode(), duckDbQueryRunner_)
+          .assertResults(duckDbSql);
     } else {
-      exec::test::assertQuery(builder.planNode(), expectedResult);
+      AssertQueryBuilder(builder.planNode()).assertResults(expectedResult);
     }
   }
 
@@ -140,9 +143,10 @@ void AggregationTestBase::testAggregations(
     }
 
     if constexpr (UseDuckDB) {
-      assertQuery(builder.planNode(), duckDbSql);
+      AssertQueryBuilder(builder.planNode(), duckDbQueryRunner_)
+          .assertResults(duckDbSql);
     } else {
-      exec::test::assertQuery(builder.planNode(), expectedResult);
+      AssertQueryBuilder(builder.planNode()).assertResults(expectedResult);
     }
   }
 
@@ -164,13 +168,14 @@ void AggregationTestBase::testAggregations(
       builder.project(postAggregationProjections);
     }
 
-    CursorParameters params;
-    params.planNode = builder.planNode();
-    params.maxDrivers = 2;
     if constexpr (UseDuckDB) {
-      assertQuery(params, duckDbSql);
+      AssertQueryBuilder(builder.planNode(), duckDbQueryRunner_)
+          .maxDrivers(2)
+          .assertResults(duckDbSql);
     } else {
-      exec::test::assertQuery(params, expectedResult);
+      AssertQueryBuilder(builder.planNode())
+          .maxDrivers(2)
+          .assertResults(expectedResult);
     }
   }
 
@@ -203,13 +208,14 @@ void AggregationTestBase::testAggregations(
       builder.project(postAggregationProjections);
     }
 
-    CursorParameters params;
-    params.planNode = builder.planNode();
-    params.maxDrivers = 2;
     if constexpr (UseDuckDB) {
-      assertQuery(params, duckDbSql);
+      AssertQueryBuilder(builder.planNode(), duckDbQueryRunner_)
+          .maxDrivers(2)
+          .assertResults(duckDbSql);
     } else {
-      exec::test::assertQuery(params, expectedResult);
+      AssertQueryBuilder(builder.planNode())
+          .maxDrivers(2)
+          .assertResults(expectedResult);
     }
   }
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -805,6 +805,10 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
 using RowTypePtr = std::shared_ptr<const RowType>;
 
+inline RowTypePtr asRowType(const TypePtr& type) {
+  return std::dynamic_pointer_cast<const RowType>(type);
+}
+
 // Represents a lambda function. The children are the argument types
 // followed by the return value type.
 class FunctionType : public TypeBase<TypeKind::FUNCTION> {


### PR DESCRIPTION
There is a proliferation of assertQuery methods in HiveConnectorTestBase and
OperatorTestBase serving different use cases: Plan vs. CursorParameters, splits
or no splits, splits for the only leaf node or for multiple leaves, results are
expected to be ordered or not, results to be compared to DuckDB or to specified
expected values.

We introduce AssertQueryBiulder to allow for specifying different query 
execution and verification parameters separately from each other.

A basic usage of the new builder is to run a query and verify results using DuckDB:

```
AssertQueryBuilder(plan, duckDbQueryRunner_)
  .assertResults("SELECT ...");
```

To run multi-threaded, set maxDrivers:

```
AssertQueryBuilder(plan, duckDbQueryRunner_)
  .maxDrivers(5)
  .assertResults("SELECT ...");
```

To compare with expected values:

```
RowVectorPtr expectedValues = ...;

AssertQueryBuilder(plan)
  .assertResults(expectedValues);
```

To run with custom configuration values:

```
AssertQueryBuilder(plan, duckDbQueryRunner_)
  .config(core::QueryConfig::kXxx, "yyy")
  .assertResults("SELECT ...");
```

To run with splits for a single leaf node:

```
AssertQueryBuilder(plan, duckDbQueryRunner_)
  .split(makeHiveSplit(filePath))
  .assertResults("SELECT ...");
```

To run with splits for multiple leaf nodes:

```
AssertQueryBuilder(plan, duckDbQueryRunner_)
  .split(probeScanId, makeHiveSplit(probeFilePath))
  .split(buildScanId, makeHiveSplit(buildFilePath))
  .assertResults("SELECT ...");
```