### PR TITLE
Remove deferred copy logic from string writer.

### DIFF
--- a/velox/expression/StringWriter.h
+++ b/velox/expression/StringWriter.h
@@ -29,20 +29,9 @@ class StringWriter;
 template <>
 class StringWriter<false /*reuseInput*/> : public UDFOutputString {
  public:
-  StringWriter() : vector_(nullptr), offset_(-1) {}
-
   // Used to initialize top-level strings and allow zero-copy writes.
   StringWriter(FlatVector<StringView>* vector, int32_t offset)
       : vector_(vector), offset_(offset) {}
-
-  // Used to initialize nested strings and requires a copy on write.
-  /* implicit */ StringWriter(StringView value)
-      : vector_(nullptr), offset_(-1), value_{value.str()} {}
-
-  // Returns true if initialized for zero-copy write. False, otherwise.
-  bool initialized() const {
-    return offset_ >= 0;
-  }
 
   // If not initialized for zero-copy write, returns a string to copy into the
   // target vector on commit.
@@ -57,12 +46,10 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
     }
 
     auto* newDataBuffer = vector_->getBufferWithSpace(newCapacity);
-    // If the new allocated space is on the same buffer no need to copy content
-    // or reassign start address
-    if (dataBuffer_ == newDataBuffer) {
-      setCapacity(newCapacity);
-      return;
-    }
+    auto actualCapacity = newDataBuffer->capacity() - newDataBuffer->size();
+
+    // Impossible to be the same due to the way the capacity is computed.
+    DCHECK(dataBuffer_ != newDataBuffer);
 
     auto newStartAddress =
         newDataBuffer->asMutable<char>() + newDataBuffer->size();
@@ -71,21 +58,31 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
       std::memcpy(newStartAddress, data(), size());
     }
 
-    setCapacity(newCapacity);
+    setCapacity(actualCapacity);
     setData(newStartAddress);
     dataBuffer_ = newDataBuffer;
   }
 
   /// Not called by the UDF Implementation. Should be called at the end to
-  /// finalize the allocation and the string writing
+  /// finalize the allocation and the string writing.
   void finalize() {
     if (!finalized_) {
-      VELOX_CHECK(size() == 0 || data());
-      if (dataBuffer_) {
+      VELOX_DCHECK(size() == 0 || data());
+      if LIKELY (size()) {
+        DCHECK(dataBuffer_);
         dataBuffer_->setSize(dataBuffer_->size() + size());
       }
       vector_->setNoCopy(offset_, StringView(data(), size()));
     }
+  }
+
+  void prepareForReuse(bool isSet) {
+    if (isSet) {
+      setCapacity(capacity() - size());
+      setData(data() + size());
+    }
+    resize(0);
+    finalized_ = false;
   }
 
   void setEmpty() {
@@ -126,7 +123,6 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
 
   template <typename T>
   void copy_from(const T& input) {
-    VELOX_DCHECK(initialized());
     append(input);
   }
 
@@ -135,6 +131,8 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
   }
 
  private:
+  StringWriter() = default;
+
   bool finalized_{false};
 
   /// The buffer that the output string uses for its allocation set during
@@ -146,6 +144,9 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
   int32_t offset_;
 
   std::string value_;
+
+  template <typename A, typename B>
+  friend struct VectorWriter;
 };
 
 // A string writer with UDFOutputString semantics that utilizes a pre-allocated
@@ -179,7 +180,7 @@ class StringWriter<true /*reuseInput*/> : public UDFOutputString {
   /// Not called by the UDF Implementation. Should be called at the end to
   /// finalize the allocation and the string writing
   void finalize() {
-    VELOX_CHECK(size() == 0 || data());
+    VELOX_DCHECK(size() == 0 || data());
     vector_->setNoCopy(offset_, StringView(data(), size()));
   }
 

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -354,58 +354,45 @@ struct VectorWriter<
   using exec_out_t = StringWriter<>;
 
   void init(vector_t& vector) {
-    vector_ = &vector;
+    proxy_.vector_ = &vector;
   }
 
   void finish() {}
 
   void ensureSize(size_t size) {
-    if (size > vector_->size()) {
-      vector_->resize(size, /*setNotNull*/ false);
+    if (size > proxy_.vector_->size()) {
+      proxy_.vector_->resize(size, /*setNotNull*/ false);
     }
   }
 
   VectorWriter() {}
 
   exec_out_t& current() {
-    proxy_ = exec_out_t(vector_, offset_);
     return proxy_;
   }
 
-  void copyCommit(const exec_out_t& data) {
-    // If not initialized for zero-copy writes, copy the value into the vector.
-    if (!proxy_.initialized()) {
-      vector_->set(offset_, StringView(data.value()));
-    } else {
-      // Not really copying.
-      proxy_.finalize();
-    }
-  }
-
   void commitNull() {
-    vector_->setNull(offset_, true);
+    proxy_.vector_->setNull(proxy_.offset_, true);
   }
 
   void commit(bool isSet) {
     // this code path is called when the slice is top-level
     if (isSet) {
-      copyCommit(proxy_);
+      proxy_.finalize();
     } else {
       commitNull();
     }
+    proxy_.prepareForReuse(isSet);
   }
 
   void setOffset(int32_t offset) {
-    offset_ = offset;
+    proxy_.offset_ = offset;
   }
 
   vector_t& vector() {
-    return *vector_;
+    return *proxy_.vector_;
   }
-
   exec_out_t proxy_;
-  vector_t* vector_;
-  size_t offset_ = 0;
 };
 
 template <typename T>

--- a/velox/functions/UDFOutputString.h
+++ b/velox/functions/UDFOutputString.h
@@ -42,20 +42,12 @@ class UDFOutputString {
 
   /// Has the semantics as std::string, except that it does not fill the
   /// space[size(), newSize] with 0 but rather leaves it as is
-  virtual void resize(size_t newSize) {
-    if (newSize <= size_) {
-      // shrinking
-      size_ = newSize;
-      return;
-    }
-
-    // newSize > size
-    if (newSize <= capacity_) {
-      size_ = newSize;
-    } else {
+  void resize(size_t newSize) {
+    if (newSize > capacity_) {
       reserve(newSize);
-      resize(newSize);
     }
+    size_ = newSize;
+    return;
   }
 
   /// Reserve a sequential space for the string with at least size bytes.

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -472,7 +472,7 @@ struct TestFunction {
       out_type<Varchar>& out,
       const arg_type<Varchar>&,
       const arg_type<Varchar>&) {
-    out = "1"_sv;
+    out.copy_from("1"_sv);
   }
 
   void call(int32_t& out, const arg_type<Variadic<Varchar>>&) {


### PR DESCRIPTION
Summary:
Deferred copy logic was needed for nested strings in slow writers. 
With the new writer interface, everything should be written 
during the function execution, and hence, we always call setNoCopy.

Differential Revision: D36354037

