### PR TITLE
Optimize VectorWriter<Varchar> for up to 2X faster for some string functions

### DIFF
--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -372,16 +372,6 @@ struct VectorWriter<
     return proxy_;
   }
 
-  void copyCommit(const exec_out_t& data) {
-    // If not initialized for zero-copy writes, copy the value into the vector.
-    if (!proxy_.initialized()) {
-      vector_->set(offset_, StringView(data.value()));
-    } else {
-      // Not really copying.
-      proxy_.finalize();
-    }
-  }
-
   void commitNull() {
     vector_->setNull(offset_, true);
   }
@@ -389,7 +379,8 @@ struct VectorWriter<
   void commit(bool isSet) {
     // this code path is called when the slice is top-level
     if (isSet) {
-      copyCommit(proxy_);
+      proxy_.finalize();
+
     } else {
       commitNull();
     }

--- a/velox/functions/UDFOutputString.h
+++ b/velox/functions/UDFOutputString.h
@@ -42,20 +42,16 @@ class UDFOutputString {
 
   /// Has the semantics as std::string, except that it does not fill the
   /// space[size(), newSize] with 0 but rather leaves it as is
-  virtual void resize(size_t newSize) {
-    if (newSize <= size_) {
+  void resize(size_t newSize) {
+    if (newSize <= capacity_) {
       // shrinking
       size_ = newSize;
       return;
     }
 
-    // newSize > size
-    if (newSize <= capacity_) {
-      size_ = newSize;
-    } else {
-      reserve(newSize);
-      resize(newSize);
-    }
+    reserve(newSize);
+    size_ = newSize;
+    return;
   }
 
   /// Reserve a sequential space for the string with at least size bytes.

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -124,3 +124,8 @@ add_executable(velox_functions_benchmarks_row_writer_no_nulls
                RowWriterBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_row_writer_no_nulls
                       ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+
+add_executable(velox_functions_benchmarks_string_writer_no_nulls
+               StringWriterBenchmark.cpp)
+target_link_libraries(velox_functions_benchmarks_string_writer_no_nulls
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -119,3 +119,8 @@ target_link_libraries(velox_benchmark_map_writer_no_nulls
                       ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 target_compile_definitions(velox_benchmark_map_writer_no_nulls
                            PUBLIC WITH_NULLS=false)
+
+add_executable(velox_functions_benchmarks_row_writer_no_nulls
+               RowWriterBenchmark.cpp)
+target_link_libraries(velox_functions_benchmarks_row_writer_no_nulls
+                      ${BENCHMARK_DEPENDENCIES_NO_FUNC})

--- a/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+#include <tuple>
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/type/StringView.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+class VectorFunctionImpl : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
+
+    // Prepare results.
+    BaseVector::ensureWritable(
+        rows, ROW({BIGINT(), BIGINT()}), context->pool(), result);
+
+    auto rowVector = (*result)->as<RowVector>();
+    rowVector->childAt(0)->resize(rows.size());
+    rowVector->childAt(1)->resize(rows.size());
+    auto flat1 = rowVector->childAt(0)->asFlatVector<int64_t>();
+    auto flat2 = rowVector->childAt(1)->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      rowVector->setNull(row, false);
+      auto n = decoded_->valueAt<int64_t>(row);
+      flat1->set(row, n);
+      flat2->set(row, n + 1);
+    });
+  }
+};
+
+template <typename T>
+struct RowOfPairGeneralFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    out.template get_writer_at<0>() = n;
+    out.template get_writer_at<1>() = n + 1;
+  }
+};
+
+template <typename T>
+struct RowOfPairTupleAssignFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    out = std::make_tuple(n, n + 1);
+  }
+};
+
+template <typename T>
+struct ArrayOfRowsFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    for (int i = 0; i < 20; i++) {
+      auto& row = out.add_item();
+      row.template get_writer_at<0>() = n;
+      row.template get_writer_at<1>() = n + 1;
+    }
+  }
+};
+
+template <typename T>
+struct ComplexRowFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    auto& array = out.template get_writer_at<0>();
+    for (auto i = 0; i < n % 100; i++) {
+      array.push_back(i);
+    }
+    out.template get_writer_at<1>() = n;
+
+    out.template get_writer_at<2>().append("aaa");
+    out.template get_writer_at<2>().append(std::to_string(n));
+
+    auto& map = out.template get_writer_at<3>();
+    for (auto i = 0; i < n % 100; i++) {
+      map.emplace(i, i * 100);
+    }
+  }
+};
+
+class RowWriterBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  RowWriterBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<RowOfPairGeneralFunc, Row<int64_t, int64_t>, int64_t>(
+        {"basic_row_simple_general"});
+    registerFunction<RowOfPairTupleAssignFunc, Row<int64_t, int64_t>, int64_t>(
+        {"basic_row_simple_tuple_assign"});
+
+    registerFunction<ArrayOfRowsFunc, Array<Row<int64_t, int64_t>>, int64_t>(
+        {"array_of_rows"});
+
+    registerFunction<
+        ComplexRowFunc,
+        Row<Array<int64_t>, int64_t, Varchar, Map<int64_t, int64_t>>,
+        int64_t>({"complex_row"});
+
+    facebook::velox::exec::registerVectorFunction(
+        "basic_row_vector",
+        {exec::FunctionSignatureBuilder()
+             .returnType("row(bigint, bigint)")
+             .argumentType("bigint")
+             .build()},
+        std::make_unique<VectorFunctionImpl>());
+  }
+
+  vector_size_t size = 1000;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  size_t run(const std::string& functionName, size_t n) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+    return doRun(exprSet, input, n);
+  }
+
+  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t n) {
+    int cnt = 0;
+    for (auto i = 0; i < n; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  bool
+  hasSameResults(ExprSet& expr1, ExprSet& expr2, const RowVectorPtr& input) {
+    auto result1 = evaluate(expr1, input);
+    auto result2 = evaluate(expr2, input);
+    auto str1 = result2->toString();
+    if (result1->size() != result2->size()) {
+      return false;
+    }
+
+    for (auto i = 0; i < result1->size(); i++) {
+      if (!result1->equalValueAt(result2.get(), i, i)) {
+        VELOX_UNREACHABLE(fmt::format("testing failed at function {}", str1));
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void test() {
+    auto input = makeInput();
+    auto exprSetRef = compileExpression("basic_row_vector(c0)", input->type());
+    std::vector<std::string> functions = {
+        "basic_row_simple_tuple_assign",
+        "basic_row_simple_general",
+    };
+
+    for (const auto& name : functions) {
+      auto other =
+          compileExpression(fmt::format("{}(c0)", name), input->type());
+      if (!hasSameResults(exprSetRef, other, input)) {
+        VELOX_UNREACHABLE(fmt::format("testing failed at function {}", name));
+      }
+    }
+  }
+};
+
+BENCHMARK_MULTI(basic_row_vector) {
+  RowWriterBenchmark benchmark;
+  return benchmark.run("basic_row_vector", 100);
+}
+
+BENCHMARK_MULTI(basic_row_simple_tuple_assign) {
+  RowWriterBenchmark benchmark;
+  return benchmark.run("basic_row_simple_tuple_assign", 100);
+}
+
+BENCHMARK_MULTI(basic_row_simple_general) {
+  RowWriterBenchmark benchmark;
+  return benchmark.run("basic_row_simple_general", 100);
+}
+
+BENCHMARK_MULTI(array_of_rows) {
+  RowWriterBenchmark benchmark;
+  return benchmark.run("array_of_rows", 100);
+}
+
+BENCHMARK_MULTI(complex_row) {
+  RowWriterBenchmark benchmark;
+  return benchmark.run("complex_row", 100);
+}
+
+} // namespace
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::RowWriterBenchmark benchmark;
+  benchmark.test();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/expression/VectorReaders.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/type/StringView.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+template <typename T>
+struct NotInlineStringFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    out.append("Welcome to Velox 2022!");
+    out.append(std::to_string(n));
+  }
+};
+
+template <typename T>
+struct InlineStringFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    out.append(std::to_string(n));
+  }
+};
+
+template <typename T>
+struct ArrayOfStringFunc {
+  template <typename OutT>
+  void call(OutT& out, const int64_t& n) {
+    for (auto i = 0; i < n % 30; i++) {
+      auto& item = out.add_item();
+      item.append("welcome to the Velox!!");
+    }
+  }
+};
+
+class StringWriterBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  StringWriterBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<NotInlineStringFunc, Varchar, int64_t>(
+        {"not_inline_string"});
+
+    registerFunction<InlineStringFunc, Varchar, int64_t>({"inline_string"});
+
+    registerFunction<ArrayOfStringFunc, Array<Varchar>, int64_t>(
+        {"array_of_string"});
+  }
+
+  vector_size_t size = 1000;
+
+  auto makeInput() {
+    std::vector<int64_t> inputData(size, 0);
+    for (auto i = 0; i < size; i++) {
+      inputData[i] = i;
+    }
+
+    auto input = vectorMaker_.rowVector({vectorMaker_.flatVector(inputData)});
+    return input;
+  }
+
+  size_t run(const std::string& functionName, size_t n) {
+    folly::BenchmarkSuspender suspender;
+    auto input = makeInput();
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", functionName), input->type());
+    suspender.dismiss();
+    return doRun(exprSet, input, n);
+  }
+
+  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t n) {
+    int cnt = 0;
+    for (auto i = 0; i < n; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  void test() {
+    auto input = makeInput();
+
+    // test not_inline_string
+    {
+      auto exprSet = compileExpression("not_inline_string(c0)", input->type());
+      auto result = evaluate(exprSet, input);
+      if (result->size() != input->size()) {
+        VELOX_UNREACHABLE("size test failed");
+      }
+
+      auto* flatResult = result->asFlatVector<StringView>();
+      for (auto i = 0; i < input->size(); i++) {
+        std::string expected = "Welcome to Velox 2022!" + std::to_string(i);
+        if (flatResult->valueAt(i) != StringView(expected)) {
+          VELOX_UNREACHABLE("test failed");
+        }
+      }
+    }
+
+    // test inline_string
+    {
+      auto exprSet = compileExpression("inline_string(c0)", input->type());
+      auto result = evaluate(exprSet, input);
+      if (result->size() != input->size()) {
+        VELOX_UNREACHABLE("size test failed");
+      }
+
+      auto* flatResult = result->asFlatVector<StringView>();
+      for (auto i = 0; i < input->size(); i++) {
+        std::string expected = std::to_string(i);
+        if (flatResult->valueAt(i) != StringView(expected)) {
+          VELOX_UNREACHABLE("test failed");
+        }
+      }
+    }
+
+    // test array_of_string
+    {
+      auto exprSet = compileExpression("array_of_string(c0)", input->type());
+      auto result = evaluate(exprSet, input);
+      if (result->size() != input->size()) {
+        VELOX_UNREACHABLE("size test failed");
+      }
+
+      DecodedVector decoded;
+      SelectivityVector rows(result->size());
+      decoded.decode(*result.get(), rows);
+
+      exec::VectorReader<Array<Varchar>> reader(&decoded);
+
+      for (auto i = 0; i < input->size(); i++) {
+        auto arrayView = reader.readNullFree(i);
+        if (arrayView.size() != i % 30) {
+          VELOX_UNREACHABLE("array size test failed");
+        }
+
+        for (auto j = 0; j < i % 30; j++) {
+          if (arrayView[j] != "welcome to the Velox!!"_sv) {
+            VELOX_UNREACHABLE("test failed");
+          }
+        }
+      }
+    }
+  }
+};
+
+BENCHMARK_MULTI(not_inline_string) {
+  StringWriterBenchmark benchmark;
+  return benchmark.run("not_inline_string", 100);
+}
+
+BENCHMARK_MULTI(inline_string) {
+  StringWriterBenchmark benchmark;
+  return benchmark.run("inline_string", 100);
+}
+
+BENCHMARK_MULTI(array_of_string) {
+  StringWriterBenchmark benchmark;
+  return benchmark.run("array_of_string", 100);
+}
+
+} // namespace
+} // namespace facebook::velox::exec
+
+int main(int /*argc*/, char** /*argv*/) {
+  facebook::velox::exec::StringWriterBenchmark benchmark;
+  benchmark.test();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -455,7 +455,7 @@ struct TestFunction {
       out_type<Varchar>& out,
       const arg_type<Varchar>&,
       const arg_type<Varchar>&) {
-    out = "1"_sv;
+    out.copy_from("1"_sv);
   }
 
   void call(int32_t& out, const arg_type<Variadic<Varchar>>&) {


### PR DESCRIPTION
Summary:
- This mostly affects simple functions that write strings:
- substring and array_of_strings are 2X faster after this change.

- A follow-up diff will change vector functions that use the
StringWriter to use  VectorWriter<Varchar> in the vector function to
gain the same benefits.
```
From StringWriterBenchmark.cpp
not_inline_string
 58.50ns  -> 28.53ns

inline_string
 46.00ns ->  28.53ns

array_of_string 12.58ms
618.39ns  -> 238.68ns

From StringAsciiUTFFunctionBenchmarks.cpp
(opts.stringLength = 100, opts.vectorSize = 1000):

asciiSubStr
23.63ms -> 12.61ms (2X)

asciiRPad
  5.01ms -> 3.06ms

aciiLPad
 4.66ms -> 2.94 ms
```

- The main optimization is avoiding reconstructing the proxy and
recomputing the buffer, capacity and locations to write to for the
every row, but instead utilizes previous state.

Differential Revision: D36356103

