### PR TITLE
Fix range filters using empty string

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -354,10 +354,14 @@ int compareRanges(const char* lhs, size_t length, const std::string& rhs) {
 
 bool BytesRange::testBytes(const char* value, int32_t length) const {
   if (length == 0) {
-    // Empty string. value is null. This is the smallest possible string. It
-    // passes the filter if there is no lower bound or if it is also an empty
-    // string.
-    return lowerUnbounded_ || lower_.empty();
+    // Empty string. value is null. This is the smallest possible string.
+    // It passes the following filters: < non-empty, <= empty | non-empty, >=
+    // empty.
+    if (lowerUnbounded_) {
+      return !upper_.empty() || !upperExclusive_;
+    }
+
+    return lower_.empty() && !lowerExclusive_;
   }
 
   if (singleValue_) {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1085,7 +1085,10 @@ class BytesRange final : public AbstractRange {
         upper_(upper),
         singleValue_(
             !lowerExclusive_ && !upperExclusive_ && !lowerUnbounded_ &&
-            !upperUnbounded_ && lower_ == upper_) {}
+            !upperUnbounded_ && lower_ == upper_) {
+    // Always-true filters should be specified using AlwaysTrue.
+    VELOX_CHECK(!lowerUnbounded_ || !upperUnbounded_);
+  }
 
   BytesRange(const BytesRange& other, bool nullAllowed)
       : AbstractRange(

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -436,6 +436,7 @@ TEST(FilterTest, bytesRange) {
 
     EXPECT_FALSE(filter->testNull());
     EXPECT_FALSE(filter->testBytes("apple", 5));
+    EXPECT_FALSE(filter->testBytes(nullptr, 0));
     EXPECT_FALSE(filter->testLength(4));
 
     EXPECT_TRUE(filter->testBytesRange("abc", "abc", false));
@@ -451,6 +452,11 @@ TEST(FilterTest, bytesRange) {
     EXPECT_FALSE(filter->testBytesRange("banana", std::nullopt, false));
     EXPECT_TRUE(filter->testBytesRange("abc", std::nullopt, false));
     EXPECT_TRUE(filter->testBytesRange("a", std::nullopt, false));
+
+    // = ''
+    filter = equal("");
+    EXPECT_TRUE(filter->testBytes(nullptr, 0));
+    EXPECT_FALSE(filter->testBytes("abc", 3));
   }
 
   char const* theBestOfTimes =
@@ -538,6 +544,26 @@ TEST(FilterTest, bytesRange) {
   EXPECT_FALSE(filter->testBytes("b", 1));
   EXPECT_TRUE(filter->testBytes("c", 1));
   EXPECT_FALSE(filter->testBytes(nullptr, 0));
+
+  // < ''
+  filter = lessThan("");
+  EXPECT_FALSE(filter->testBytes(nullptr, 0));
+  EXPECT_FALSE(filter->testBytes("abc", 3));
+
+  // <= ''
+  filter = lessThanOrEqual("");
+  EXPECT_TRUE(filter->testBytes(nullptr, 0));
+  EXPECT_FALSE(filter->testBytes("abc", 3));
+
+  // > ''
+  filter = greaterThan("");
+  EXPECT_FALSE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytes("abc", 3));
+
+  // >= ''
+  filter = greaterThanOrEqual("");
+  EXPECT_TRUE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytes("abc", 3));
 }
 
 TEST(FilterTest, bytesValues) {
@@ -610,6 +636,11 @@ TEST(FilterTest, multiRange) {
   EXPECT_FALSE(filter->testFloat(1.2f));
   EXPECT_TRUE(filter->testFloat(1.3f));
   EXPECT_FALSE(filter->testFloat(std::nanf("nan")));
+
+  // != ''
+  filter = orFilter(lessThan(""), greaterThan(""));
+  EXPECT_FALSE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytes("abc", 3));
 }
 
 TEST(FilterTest, multiRangeWithNaNs) {


### PR DESCRIPTION
Fix `> ''`, `>= ''`, `< ''`, `<= ''`, `!= ''` filters.