### PR TITLE
Pass EvalCtx and result VectorPtr by Reference

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -114,7 +114,7 @@ RowVectorPtr FilterProject::getOutput() {
   }
 
   vector_size_t size = input_->size();
-  LocalSelectivityVector localRows(operatorCtx_->execCtx(), size);
+  LocalSelectivityVector localRows(*operatorCtx_->execCtx(), size);
   auto* rows = localRows.get();
   rows->setAll();
   EvalCtx evalCtx(operatorCtx_->execCtx(), exprs_.get(), input_.get());

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -191,7 +191,7 @@ wrap(vector_size_t size, BufferPtr mapping, const RowVectorPtr& vector) {
 }
 
 void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx) {
-  LocalDecodedVector decodedHolder(&execCtx);
+  LocalDecodedVector decodedHolder(execCtx);
   LocalSelectivityVector baseRowsHolder(&execCtx);
   LocalSelectivityVector rowsHolder(&execCtx);
   SelectivityVector* rows = nullptr;

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -39,8 +39,8 @@ class CastExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   std::string toString(bool recursive = true) const override;
 
@@ -54,7 +54,7 @@ class CastExpr : public SpecialForm {
   template <typename To, typename From>
   void applyCastWithTry(
       const SelectivityVector& rows,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const DecodedVector& input,
       FlatVector<To>* resultFlatVector);
 
@@ -68,9 +68,9 @@ class CastExpr : public SpecialForm {
   void applyCast(
       const TypeKind fromType,
       const SelectivityVector& rows,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const DecodedVector& input,
-      VectorPtr* result);
+      VectorPtr& result);
 
   /// Apply the cast after generating the input vectors
   /// @param rows The list of rows being processed
@@ -82,29 +82,29 @@ class CastExpr : public SpecialForm {
   void apply(
       const SelectivityVector& rows,
       VectorPtr& input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const TypePtr& fromType,
       const TypePtr& toType,
-      VectorPtr* result);
+      VectorPtr& result);
 
   VectorPtr applyMap(
       const SelectivityVector& rows,
       const MapVector* input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const MapType& fromType,
       const MapType& toType);
 
   VectorPtr applyArray(
       const SelectivityVector& rows,
       const ArrayVector* input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const ArrayType& fromType,
       const ArrayType& toType);
 
   VectorPtr applyRow(
       const SelectivityVector& rows,
       const RowVector* input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const RowType& fromType,
       const RowType& toType);
 
@@ -129,7 +129,7 @@ class CastOperator {
   /// @param result The writable output vector of the custom type
   virtual void castTo(
       const BaseVector& input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const SelectivityVector& rows,
       bool nullOnFailure,
       BaseVector& result) const = 0;
@@ -142,7 +142,7 @@ class CastOperator {
   /// @param result The writable output vector of the destination type
   virtual void castFrom(
       const BaseVector& input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const SelectivityVector& rows,
       bool nullOnFailure,
       BaseVector& result) const = 0;

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -34,8 +34,8 @@ CoalesceExpr::CoalesceExpr(TypePtr type, std::vector<ExprPtr>&& inputs)
 
 void CoalesceExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   // Make sure to include current expression in the error message in case of an
   // exception.
   ExceptionContextSetter exceptionContext(
@@ -48,13 +48,13 @@ void CoalesceExpr::evalSpecialForm(
 
   // Fix finalSelection at "rows" unless already fixed.
   VarSetter finalSelection(
-      context->mutableFinalSelection(), &rows, context->isFinalSelection());
-  VarSetter isFinalSelection(context->mutableIsFinalSelection(), false);
+      context.mutableFinalSelection(), &rows, context.isFinalSelection());
+  VarSetter isFinalSelection(context.mutableIsFinalSelection(), false);
 
   for (int i = 0; i < inputs_.size(); i++) {
     inputs_[i]->eval(*activeRows, context, result);
 
-    const uint64_t* rawNulls = (*result)->flatRawNulls(*activeRows);
+    const uint64_t* rawNulls = result->flatRawNulls(*activeRows);
     if (!rawNulls) {
       // No nulls left.
       return;

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -27,8 +27,8 @@ class CoalesceExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   bool propagatesNulls() const override {
     return false;

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -23,14 +23,14 @@ namespace facebook::velox::exec {
 
 void ConstantExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
   if (!sharedSubexprValues_) {
     sharedSubexprValues_ =
-        BaseVector::createConstant(value_, 1, context->execCtx()->pool());
+        BaseVector::createConstant(value_, 1, context.execCtx()->pool());
   }
 
   if (needToSetIsAscii_) {
@@ -45,9 +45,9 @@ void ConstantExpr::evalSpecialForm(
 
   if (sharedSubexprValues_.unique()) {
     sharedSubexprValues_->resize(rows.end());
-    context->moveOrCopyResult(sharedSubexprValues_, rows, result);
+    context.moveOrCopyResult(sharedSubexprValues_, rows, result);
   } else {
-    context->moveOrCopyResult(
+    context.moveOrCopyResult(
         BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_),
         rows,
         result);
@@ -56,19 +56,19 @@ void ConstantExpr::evalSpecialForm(
 
 void ConstantExpr::evalSpecialFormSimplified(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
   // Simplified path should never ask us to write to a vector that was already
   // pre-allocated.
-  VELOX_CHECK(*result == nullptr);
+  VELOX_CHECK(result == nullptr);
 
   if (sharedSubexprValues_ == nullptr) {
-    *result = BaseVector::createConstant(value_, rows.end(), context->pool());
+    result = BaseVector::createConstant(value_, rows.end(), context.pool());
   } else {
-    *result = BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_);
+    result = BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_);
   }
 }
 
@@ -83,30 +83,30 @@ std::string ConstantExpr::toString(bool /*recursive*/) const {
 
 void FieldReference::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
-  if (*result) {
-    BaseVector::ensureWritable(rows, type_, context->pool(), result);
+  if (result) {
+    BaseVector::ensureWritable(rows, type_, context.pool(), &result);
   }
   const RowVector* row;
   DecodedVector decoded;
   VectorPtr input;
   bool useDecode = false;
   if (inputs_.empty()) {
-    row = context->row();
+    row = context.row();
   } else {
-    inputs_[0]->eval(rows, context, &input);
+    inputs_[0]->eval(rows, context, input);
 
     if (auto rowTry = input->as<RowVector>()) {
       // Make sure output is not copied
       if (rowTry->isCodegenOutput()) {
         auto rowType = dynamic_cast<const RowType*>(rowTry->type().get());
         index_ = rowType->getChildIdx(field_);
-        *result = std::move(rowTry->childAt(index_));
-        VELOX_CHECK(result->unique());
+        result = std::move(rowTry->childAt(index_));
+        VELOX_CHECK(result.unique());
         return;
       }
     }
@@ -127,13 +127,13 @@ void FieldReference::evalSpecialForm(
   // 'context'.  Chekc if the child is unique before taking the second
   // reference. Unique constant vectors can be resized in place, non-unique
   // must be copied to set the size.
-  bool isUniqueChild = inputs_.empty() ? context->getField(index_).unique()
+  bool isUniqueChild = inputs_.empty() ? context.getField(index_).unique()
                                        : row->childAt(index_).unique();
   VectorPtr child =
-      inputs_.empty() ? context->getField(index_) : row->childAt(index_);
-  if (result->get()) {
+      inputs_.empty() ? context.getField(index_) : row->childAt(index_);
+  if (result.get()) {
     auto indices = useDecode ? decoded.indices() : nullptr;
-    (*result)->copy(child.get(), rows, indices);
+    result->copy(child.get(), rows, indices);
   } else {
     if (child->encoding() == VectorEncoding::Simple::LAZY) {
       child = BaseVector::loadedVectorShared(child);
@@ -149,27 +149,27 @@ void FieldReference::evalSpecialForm(
         child = BaseVector::wrapInConstant(rows.size(), 0, child);
       }
     }
-    *result = useDecode ? std::move(decoded.wrap(child, *input.get(), rows))
-                        : std::move(child);
+    result = useDecode ? std::move(decoded.wrap(child, *input.get(), rows))
+                       : std::move(child);
   }
 }
 
 void FieldReference::evalSpecialFormSimplified(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
-  auto row = context->row();
-  *result = row->childAt(index(context));
-  BaseVector::flattenVector(result, rows.end());
+  auto row = context.row();
+  result = row->childAt(index(context));
+  BaseVector::flattenVector(&result, rows.end());
 }
 
 void SwitchExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
@@ -183,8 +183,8 @@ void SwitchExpr::evalSpecialForm(
 
   // SWITCH: fix finalSelection at "rows" unless already fixed
   VarSetter finalSelection(
-      context->mutableFinalSelection(), &rows, context->isFinalSelection());
-  VarSetter isFinalSelection(context->mutableIsFinalSelection(), false);
+      context.mutableFinalSelection(), &rows, context.isFinalSelection());
+  VarSetter isFinalSelection(context.mutableIsFinalSelection(), false);
 
   const bool isString = type()->kind() == TypeKind::VARCHAR;
 
@@ -194,7 +194,7 @@ void SwitchExpr::evalSpecialForm(
     }
 
     // evaluate the case condition
-    inputs_[2 * i]->eval(*remainingRows.get(), context, &condition);
+    inputs_[2 * i]->eval(*remainingRows.get(), context, condition);
 
     auto booleanMix = getFlatBool(
         condition.get(),
@@ -222,9 +222,9 @@ void SwitchExpr::evalSpecialForm(
         thenRows.get()->updateBounds();
 
         if (thenRows.get()->hasSelections()) {
-          if (*result) {
+          if (result) {
             BaseVector::ensureWritable(
-                *thenRows.get(), (*result)->type(), context->pool(), result);
+                *thenRows.get(), result->type(), context.pool(), &result);
           }
 
           inputs_[2 * i + 1]->eval(*thenRows.get(), context, result);
@@ -236,9 +236,9 @@ void SwitchExpr::evalSpecialForm(
 
   // Evaluate the "else" clause.
   if (remainingRows.get()->hasSelections()) {
-    if (*result) {
+    if (result) {
       BaseVector::ensureWritable(
-          *remainingRows.get(), (*result)->type(), context->pool(), result);
+          *remainingRows.get(), result->type(), context.pool(), &result);
     }
 
     if (hasElseClause_) {
@@ -247,7 +247,7 @@ void SwitchExpr::evalSpecialForm(
     } else {
       // fill in nulls for remainingRows
       remainingRows.get()->applyToSelected(
-          [&](auto row) { (*result)->setNull(row, true); });
+          [&](auto row) { result->setNull(row, true); });
     }
   }
 }
@@ -296,13 +296,13 @@ namespace {
 uint64_t* rowsWithError(
     const SelectivityVector& rows,
     const SelectivityVector& activeRows,
-    EvalCtx* context,
-    EvalCtx::ErrorVectorPtr* previousErrors,
+    EvalCtx& context,
+    EvalCtx::ErrorVectorPtr& previousErrors,
     LocalSelectivityVector& errorRowsHolder) {
-  auto errors = context->errors();
+  auto errors = context.errors();
   if (!errors) {
     // No new errors. Put the old errors back.
-    context->swapErrors(previousErrors);
+    context.swapErrors(previousErrors);
     return nullptr;
   }
   uint64_t* errorMask = nullptr;
@@ -320,18 +320,18 @@ uint64_t* rowsWithError(
       errors->rawNulls(),
       rows.begin(),
       std::min(errors->size(), rows.end()));
-  if (*previousErrors) {
+  if (previousErrors) {
     // Add the new errors to the previous ones and free the new errors.
     bits::forEachSetBit(
         errors->rawNulls(), rows.begin(), errors->size(), [&](int32_t row) {
-          context->addError(
+          context.addError(
               row,
               *std::static_pointer_cast<std::exception_ptr>(
                   errors->valueAt(row)),
               previousErrors);
         });
-    context->swapErrors(previousErrors);
-    *previousErrors = nullptr;
+    context.swapErrors(previousErrors);
+    previousErrors = nullptr;
   }
   return errorMask;
 }
@@ -340,15 +340,15 @@ void finalizeErrors(
     const SelectivityVector& rows,
     const SelectivityVector& activeRows,
     bool throwOnError,
-    EvalCtx* context) {
-  auto errors = context->errors();
+    EvalCtx& context) {
+  auto errors = context.errors();
   if (!errors) {
     return;
   }
   // null flag of error |= initial active & ~final active.
   int32_t numWords = bits::nwords(errors->size());
   auto errorNulls =
-      context->errors()->mutableNulls(errors->size())->asMutable<uint64_t>();
+      context.errors()->mutableNulls(errors->size())->asMutable<uint64_t>();
   for (int32_t i = 0; i < numWords; ++i) {
     errorNulls[i] &= rows.asRange().bits()[i] & activeRows.asRange().bits()[i];
     if (throwOnError && errorNulls[i]) {
@@ -365,16 +365,16 @@ void finalizeErrors(
 
 void ConjunctExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
   // TODO Revisit error handling
-  bool throwOnError = *context->mutableThrowOnError();
-  VarSetter saveError(context->mutableThrowOnError(), false);
-  BaseVector::ensureWritable(rows, type(), context->pool(), result);
-  auto flatResult = (*result)->asFlatVector<bool>();
+  bool throwOnError = *context.mutableThrowOnError();
+  VarSetter saveError(context.mutableThrowOnError(), false);
+  BaseVector::ensureWritable(rows, type(), context.pool(), &result);
+  auto flatResult = result->asFlatVector<bool>();
   // clear nulls from the result for the active rows.
   if (flatResult->mayHaveNulls()) {
     auto nulls = flatResult->mutableNulls(rows.end())->asMutable<uint64_t>();
@@ -391,11 +391,11 @@ void ConjunctExpr::evalSpecialForm(
 
   // OR: fix finalSelection at "rows" unless already fixed
   VarSetter finalSelectionOr(
-      context->mutableFinalSelection(),
+      context.mutableFinalSelection(),
       &rows,
-      !isAnd_ && context->isFinalSelection());
+      !isAnd_ && context.isFinalSelection());
   VarSetter isFinalSelectionOr(
-      context->mutableIsFinalSelection(), false, !isAnd_);
+      context.mutableIsFinalSelection(), false, !isAnd_);
 
   bool handleErrors = false;
   LocalSelectivityVector errorRows(context);
@@ -407,19 +407,19 @@ void ConjunctExpr::evalSpecialForm(
     VectorPtr inputResult;
     EvalCtx::ErrorVectorPtr errors;
     if (handleErrors) {
-      context->swapErrors(&errors);
+      context.swapErrors(errors);
     }
 
     // AND: reduce finalSelection to activeRows unless it has been fixed by IF
     // or OR above.
     VarSetter finalSelectionAnd(
-        context->mutableFinalSelection(),
+        context.mutableFinalSelection(),
         static_cast<const SelectivityVector*>(activeRows),
-        isAnd_ && context->isFinalSelection());
+        isAnd_ && context.isFinalSelection());
 
     SelectivityTimer timer(selectivity_[inputOrder_[i]], numActive);
-    inputs_[inputOrder_[i]]->eval(*activeRows, context, &inputResult);
-    if (context->errors()) {
+    inputs_[inputOrder_[i]]->eval(*activeRows, context, inputResult);
+    if (context.errors()) {
       handleErrors = true;
     }
     uint64_t* extraActive = nullptr;
@@ -427,7 +427,7 @@ void ConjunctExpr::evalSpecialForm(
       // Add rows with new errors to activeRows and merge these with
       // previous errors.
       extraActive =
-          rowsWithError(rows, *activeRows, context, &errors, errorRows);
+          rowsWithError(rows, *activeRows, context, errors, errorRows);
     }
     updateResult(inputResult.get(), context, flatResult, activeRows);
     if (extraActive) {
@@ -445,7 +445,7 @@ void ConjunctExpr::evalSpecialForm(
   // Clear errors for 'rows' that are not in 'activeRows'.
   finalizeErrors(rows, *activeRows, throwOnError, context);
   if (!reorderEnabledChecked_) {
-    reorderEnabled_ = context->execCtx()
+    reorderEnabled_ = context.execCtx()
                           ->queryCtx()
                           ->config()
                           .adaptiveFilterReorderingEnabled();
@@ -478,7 +478,7 @@ void ConjunctExpr::maybeReorderInputs() {
 
 void ConjunctExpr::updateResult(
     BaseVector* inputResult,
-    EvalCtx* context,
+    EvalCtx& context,
     FlatVector<bool>* result,
     SelectivityVector* activeRows) {
   // Set result and clear active rows for the positions that are decided.
@@ -575,7 +575,7 @@ BooleanMix refineBooleanMixNonNull(
 BooleanMix getFlatBool(
     BaseVector* vector,
     const SelectivityVector& activeRows,
-    EvalCtx* context,
+    EvalCtx& context,
     BufferPtr* tempValues,
     BufferPtr* tempNulls,
     bool mergeNullsToValues,
@@ -593,7 +593,7 @@ BooleanMix getFlatBool(
       if (nulls && mergeNullsToValues) {
         uint64_t* mergedValues;
         BaseVector::ensureBuffer<bool>(
-            size, context->pool(), tempValues, &mergedValues);
+            size, context.pool(), tempValues, &mergedValues);
 
         bits::andBits(
             mergedValues, values, nulls, activeRows.begin(), activeRows.end());
@@ -627,11 +627,11 @@ BooleanMix getFlatBool(
       uint64_t* valuesToSet = nullptr;
       if (vector->mayHaveNulls() && !mergeNullsToValues) {
         BaseVector::ensureBuffer<bool>(
-            size, context->pool(), tempNulls, &nullsToSet);
+            size, context.pool(), tempNulls, &nullsToSet);
         memset(nullsToSet, bits::kNotNullByte, bits::nbytes(size));
       }
       BaseVector::ensureBuffer<bool>(
-          size, context->pool(), tempValues, &valuesToSet);
+          size, context.pool(), tempValues, &valuesToSet);
       memset(valuesToSet, 0, bits::nbytes(size));
       DecodedVector decoded(*vector, activeRows);
       auto values = decoded.data<uint64_t>();
@@ -705,7 +705,7 @@ class ExprCallable : public Callable {
         rows.end(),
         std::move(allVectors));
     EvalCtx lambdaCtx(context->execCtx(), context->exprSet(), row.get());
-    body_->eval(rows, &lambdaCtx, result);
+    body_->eval(rows, lambdaCtx, *result);
   }
 
  private:
@@ -718,8 +718,8 @@ class ExprCallable : public Callable {
 
 void LambdaExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
@@ -729,10 +729,10 @@ void LambdaExpr::evalSpecialForm(
   std::vector<VectorPtr> values(typeWithCapture_->size());
   for (auto i = 0; i < captureChannels_.size(); ++i) {
     assert(!values.empty());
-    values[signature_->size() + i] = context->getField(captureChannels_[i]);
+    values[signature_->size() + i] = context.getField(captureChannels_[i]);
   }
   auto capture = std::make_shared<RowVector>(
-      context->pool(),
+      context.pool(),
       typeWithCapture_,
       BufferPtr(nullptr),
       rows.end(),
@@ -740,23 +740,23 @@ void LambdaExpr::evalSpecialForm(
       0);
   auto callable = std::make_shared<ExprCallable>(signature_, capture, body_);
   std::shared_ptr<FunctionVector> functions;
-  if (!*result) {
-    functions = std::make_shared<FunctionVector>(context->pool(), type_);
-    *result = functions;
+  if (!result) {
+    functions = std::make_shared<FunctionVector>(context.pool(), type_);
+    result = functions;
   } else {
-    VELOX_CHECK((*result)->encoding() == VectorEncoding::Simple::FUNCTION);
-    functions = std::static_pointer_cast<FunctionVector>(*result);
+    VELOX_CHECK(result->encoding() == VectorEncoding::Simple::FUNCTION);
+    functions = std::static_pointer_cast<FunctionVector>(result);
   }
   functions->addFunction(callable, rows);
 }
 
-void LambdaExpr::makeTypeWithCapture(EvalCtx* context) {
+void LambdaExpr::makeTypeWithCapture(EvalCtx& context) {
   // On first use, compose the type of parameters + capture and set
   // the indices of captures in the context row.
   if (capture_.empty()) {
     typeWithCapture_ = signature_;
   } else {
-    auto& contextType = context->row()->type()->as<TypeKind::ROW>();
+    auto& contextType = context.row()->type()->as<TypeKind::ROW>();
     auto parameterNames = signature_->names();
     auto parameterTypes = signature_->children();
     for (auto& reference : capture_) {
@@ -773,12 +773,12 @@ void LambdaExpr::makeTypeWithCapture(EvalCtx* context) {
 
 void TryExpr::evalSpecialForm(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
-  VarSetter throwOnError(context->mutableThrowOnError(), false);
+  VarSetter throwOnError(context.mutableThrowOnError(), false);
   // It's possible with nested TRY expressions that some rows already threw
   // exceptions in earlier expressions that haven't been handled yet. To avoid
   // incorrectly handling them here, store those errors and temporarily reset
@@ -787,8 +787,7 @@ void TryExpr::evalSpecialForm(
   // This also prevents this TRY expression from leaking exceptions to the
   // parent TRY expression, so the parent won't incorrectly null out rows that
   // threw exceptions which this expression already handled.
-  VarSetter<EvalCtx::ErrorVectorPtr> errorsSetter(
-      context->errorsPtr(), nullptr);
+  VarSetter<EvalCtx::ErrorVectorPtr> errorsSetter(context.errorsPtr(), nullptr);
   inputs_[0]->eval(rows, context, result);
 
   nullOutErrors(rows, context, result);
@@ -796,9 +795,9 @@ void TryExpr::evalSpecialForm(
 
 void TryExpr::evalSpecialFormSimplified(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
-  VarSetter throwOnError(context->mutableThrowOnError(), false);
+    EvalCtx& context,
+    VectorPtr& result) {
+  VarSetter throwOnError(context.mutableThrowOnError(), false);
   // It's possible with nested TRY expressions that some rows already threw
   // exceptions in earlier expressions that haven't been handled yet. To avoid
   // incorrectly handling them here, store those errors and temporarily reset
@@ -807,8 +806,7 @@ void TryExpr::evalSpecialFormSimplified(
   // This also prevents this TRY expression from leaking exceptions to the
   // parent TRY expression, so the parent won't incorrectly null out rows that
   // threw exceptions which this expression already handled.
-  VarSetter<EvalCtx::ErrorVectorPtr> errorsSetter(
-      context->errorsPtr(), nullptr);
+  VarSetter<EvalCtx::ErrorVectorPtr> errorsSetter(context.errorsPtr(), nullptr);
   inputs_[0]->evalSimplified(rows, context, result);
 
   nullOutErrors(rows, context, result);
@@ -816,14 +814,14 @@ void TryExpr::evalSpecialFormSimplified(
 
 void TryExpr::nullOutErrors(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
-  auto errors = context->errors();
+    EvalCtx& context,
+    VectorPtr& result) {
+  auto errors = context.errors();
   if (errors) {
-    if ((*result)->encoding() == VectorEncoding::Simple::CONSTANT) {
+    if (result->encoding() == VectorEncoding::Simple::CONSTANT) {
       // Since it's constant, if any row is NULL they're all NULL, so check row
       // 0 arbitrarily.
-      if ((*result)->isNullAt(0)) {
+      if (result->isNullAt(0)) {
         // The result is already a NULL constant, so this is a no-op.
         return;
       }
@@ -836,12 +834,12 @@ void TryExpr::nullOutErrors(
       VELOX_DCHECK(
           rows.testSelected([&](auto row) { return !errors->isNullAt(row); }));
       // Set the result to be a NULL constant.
-      *result = BaseVector::createNullConstant(
-          (*result)->type(), (*result)->size(), context->pool());
+      result = BaseVector::createNullConstant(
+          result->type(), result->size(), context.pool());
     } else {
       rows.applyToSelected([&](auto row) {
         if (row < errors->size() && !errors->isNullAt(row)) {
-          (*result)->setNull(row, true);
+          result->setNull(row, true);
         }
       });
     }

--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -50,7 +50,7 @@ enum class BooleanMix { kAllTrue, kAllFalse, kAllNull, kMixNonNull, kMix };
 BooleanMix getFlatBool(
     BaseVector* vector,
     const SelectivityVector& activeRows,
-    EvalCtx* context,
+    EvalCtx& context,
     BufferPtr* tempValues,
     BufferPtr* tempNulls,
     bool mergeNullsToValues,
@@ -84,13 +84,13 @@ class ConstantExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   void evalSpecialFormSimplified(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   const VectorPtr& value() const {
     return sharedSubexprValues_;
@@ -120,11 +120,11 @@ class FieldReference : public SpecialForm {
     return field_;
   }
 
-  int32_t index(EvalCtx* context) {
+  int32_t index(EvalCtx& context) {
     if (index_ != -1) {
       return index_;
     }
-    auto* rowType = dynamic_cast<const RowType*>(context->row()->type().get());
+    auto* rowType = dynamic_cast<const RowType*>(context.row()->type().get());
     VELOX_CHECK(rowType, "The context has no row");
     index_ = rowType->getChildIdx(field_);
     return index_;
@@ -132,13 +132,13 @@ class FieldReference : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   void evalSpecialFormSimplified(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
  protected:
   void computeMetadata() override {
@@ -192,8 +192,8 @@ class SwitchExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   bool propagatesNulls() const override;
 
@@ -223,8 +223,8 @@ class ConjunctExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   bool propagatesNulls() const override {
     return false;
@@ -242,7 +242,7 @@ class ConjunctExpr : public SpecialForm {
   void maybeReorderInputs();
   void updateResult(
       BaseVector* inputResult,
-      EvalCtx* context,
+      EvalCtx& context,
       FlatVector<bool>* result,
       SelectivityVector* activeRows);
 
@@ -288,11 +288,11 @@ class LambdaExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
  private:
-  void makeTypeWithCapture(EvalCtx* context);
+  void makeTypeWithCapture(EvalCtx& context);
 
   std::shared_ptr<const RowType> signature_;
   std::vector<std::shared_ptr<FieldReference>> capture_;
@@ -313,13 +313,13 @@ class TryExpr : public SpecialForm {
 
   void evalSpecialForm(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   void evalSpecialFormSimplified(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result) override;
+      EvalCtx& context,
+      VectorPtr& result) override;
 
   bool propagatesNulls() const override {
     return inputs_[0]->propagatesNulls();
@@ -328,7 +328,7 @@ class TryExpr : public SpecialForm {
  private:
   void nullOutErrors(
       const SelectivityVector& rows,
-      EvalCtx* context,
-      VectorPtr* result);
+      EvalCtx& context,
+      VectorPtr& result);
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/DecodedArgs.h
+++ b/velox/expression/DecodedArgs.h
@@ -35,13 +35,13 @@ class DecodedArgs {
   DecodedArgs(
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
-      exec::EvalCtx* context) {
+      exec::EvalCtx* FOLLY_NONNULL context) {
     for (auto& arg : args) {
-      holders_.emplace_back(context, *arg.get(), rows);
+      holders_.emplace_back(*context, *arg.get(), rows);
     }
   }
 
-  DecodedVector* at(int i) const {
+  DecodedVector* FOLLY_NONNULL at(int i) const {
     return const_cast<exec::LocalDecodedVector*>(&holders_[i])->get();
   }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -31,16 +31,19 @@ struct ContextSaver;
 // flags for Expr interpreter.
 class EvalCtx {
  public:
-  EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row);
+  EvalCtx(
+      core::ExecCtx* FOLLY_NONNULL execCtx,
+      ExprSet* FOLLY_NULLABLE exprSet,
+      const RowVector* FOLLY_NULLABLE row);
 
   /// For testing only.
-  explicit EvalCtx(core::ExecCtx* execCtx);
+  explicit EvalCtx(core::ExecCtx* FOLLY_NONNULL execCtx);
 
-  const RowVector* row() const {
+  const RowVector* FOLLY_NONNULL row() const {
     return row_;
   }
 
-  memory::MemoryPool* pool() const {
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
     return execCtx_->pool();
   }
 
@@ -49,7 +52,7 @@ class EvalCtx {
   // peeled off fields.
   const VectorPtr& getField(int32_t index) const;
 
-  BaseVector* getRawField(int32_t index) const;
+  BaseVector* FOLLY_NONNULL getRawField(int32_t index) const;
 
   void ensureFieldLoaded(int32_t index, const SelectivityVector& rows);
 
@@ -61,9 +64,9 @@ class EvalCtx {
   }
 
   /// Used by peelEncodings.
-  void saveAndReset(ContextSaver* saver, const SelectivityVector& rows);
+  void saveAndReset(ContextSaver& saver, const SelectivityVector& rows);
 
-  void restore(ContextSaver* saver);
+  void restore(ContextSaver& saver);
 
   // Creates or updates *result according to 'source'. The
   // 'source' position corresponding to each position in 'rows' is
@@ -71,10 +74,10 @@ class EvalCtx {
   // EvalEncoding. If '*result' existed, positions not in 'rows' are
   // not changed.
   void setWrapped(
-      Expr* expr,
+      Expr* FOLLY_NONNULL expr,
       VectorPtr source,
       const SelectivityVector& rows,
-      VectorPtr* result);
+      VectorPtr& result);
 
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);
 
@@ -109,24 +112,24 @@ class EvalCtx {
   void addError(
       vector_size_t index,
       const std::exception_ptr& exceptionPtr,
-      ErrorVectorPtr* errorsPtr) const;
+      ErrorVectorPtr& errorsPtr) const;
 
   // Returns the vector of errors or nullptr if no errors. This is
   // intentionally a raw pointer to signify that the caller may not
   // retain references to this.
-  ErrorVector* errors() const {
+  ErrorVector* FOLLY_NULLABLE errors() const {
     return errors_.get();
   }
 
-  ErrorVectorPtr* errorsPtr() {
+  ErrorVectorPtr* FOLLY_NONNULL errorsPtr() {
     return &errors_;
   }
 
-  void swapErrors(ErrorVectorPtr* other) {
-    std::swap(errors_, *other);
+  void swapErrors(ErrorVectorPtr& other) {
+    std::swap(errors_, other);
   }
 
-  bool* mutableThrowOnError() {
+  bool* FOLLY_NONNULL mutableThrowOnError() {
     return &throwOnError_;
   }
 
@@ -134,7 +137,7 @@ class EvalCtx {
     return nullsPruned_;
   }
 
-  bool* mutableNullsPruned() {
+  bool* FOLLY_NONNULL mutableNullsPruned() {
     return &nullsPruned_;
   }
 
@@ -150,23 +153,24 @@ class EvalCtx {
   // current SelectivityVector. For example, true for top level
   // projections or conjuncts of a top level AND. False for then and
   // else of an IF.
-  bool* mutableIsFinalSelection() {
+  bool* FOLLY_NONNULL mutableIsFinalSelection() {
     return &isFinalSelection_;
   }
 
-  const SelectivityVector** mutableFinalSelection() {
+  const SelectivityVector* FOLLY_NULLABLE* FOLLY_NONNULL
+  mutableFinalSelection() {
     return &finalSelection_;
   }
 
-  const SelectivityVector* finalSelection() const {
+  const SelectivityVector* FOLLY_NULLABLE finalSelection() const {
     return finalSelection_;
   }
 
-  core::ExecCtx* execCtx() const {
+  core::ExecCtx* FOLLY_NONNULL execCtx() const {
     return execCtx_;
   }
 
-  ExprSet* exprSet() const {
+  ExprSet* FOLLY_NULLABLE exprSet() const {
     return exprSet_;
   }
 
@@ -190,20 +194,26 @@ class EvalCtx {
   void moveOrCopyResult(
       const VectorPtr& localResult,
       const SelectivityVector& rows,
-      VectorPtr* result) const {
-    if (*result && !isFinalSelection() && *finalSelection() != rows) {
-      BaseVector::ensureWritable(
-          rows, (*result)->type(), (*result)->pool(), result);
-      (*result)->copy(localResult.get(), rows, nullptr);
+      VectorPtr& result) const {
+    if (result && !isFinalSelection() && *finalSelection() != rows) {
+      BaseVector::ensureWritable(rows, result->type(), result->pool(), &result);
+      result->copy(localResult.get(), rows, nullptr);
     } else {
-      *result = localResult;
+      result = localResult;
     }
   }
 
+  void moveOrCopyResult(
+      const VectorPtr& localResult,
+      const SelectivityVector& rows,
+      VectorPtr* FOLLY_NONNULL result) const {
+    moveOrCopyResult(localResult, rows, *result);
+  }
+
  private:
-  core::ExecCtx* const execCtx_;
-  ExprSet* const exprSet_;
-  const RowVector* row_;
+  core::ExecCtx* const FOLLY_NONNULL execCtx_;
+  ExprSet* FOLLY_NULLABLE const exprSet_;
+  const RowVector* FOLLY_NULLABLE row_;
 
   // Corresponds 1:1 to children of 'row_'. Set to an inner vector
   // after removing dictionary/sequence wrappers.
@@ -224,7 +234,7 @@ class EvalCtx {
 
   // If isFinalSelection_ is false, the set of rows for the upper-most IF or
   // OR. Used to determine the set of rows for loading lazy vectors.
-  const SelectivityVector* finalSelection_;
+  const SelectivityVector* FOLLY_NULLABLE finalSelection_;
 
   // Stores exception found during expression evaluation. Exceptions are stored
   // in a opaque flat vector, which will translate to a
@@ -235,15 +245,15 @@ class EvalCtx {
 struct ContextSaver {
   ~ContextSaver();
   // The context to restore. nullptr if nothing to restore.
-  EvalCtx* context = nullptr;
+  EvalCtx* FOLLY_NULLABLE context = nullptr;
   std::vector<VectorPtr> peeled;
   BufferPtr wrap;
   BufferPtr wrapNulls;
   VectorEncoding::Simple wrapEncoding;
   bool nullsPruned = false;
   // The selection of the context being saved.
-  const SelectivityVector* rows;
-  const SelectivityVector* finalSelection;
+  const SelectivityVector* FOLLY_NONNULL rows;
+  const SelectivityVector* FOLLY_NULLABLE finalSelection;
   EvalCtx::ErrorVectorPtr errors;
 };
 
@@ -251,51 +261,61 @@ class LocalSelectivityVector {
  public:
   // Grab an instance of a SelectivityVector from the pool and resize it to
   // specified size.
-  LocalSelectivityVector(EvalCtx* context, vector_size_t size)
-      : context_(context->execCtx()),
-        vector_(context_->getSelectivityVector(size)) {}
+  LocalSelectivityVector(EvalCtx& context, vector_size_t size)
+      : context_(*context.execCtx()),
+        vector_(context_.getSelectivityVector(size)) {}
 
-  explicit LocalSelectivityVector(core::ExecCtx* context)
+  explicit LocalSelectivityVector(
+      EvalCtx* FOLLY_NONNULL context,
+      vector_size_t size)
+      : LocalSelectivityVector(*context, size) {}
+
+  explicit LocalSelectivityVector(core::ExecCtx& context)
       : context_(context), vector_(nullptr) {}
+  explicit LocalSelectivityVector(core::ExecCtx* FOLLY_NONNULL context)
+      : context_(*context), vector_(nullptr) {}
 
-  explicit LocalSelectivityVector(EvalCtx* context)
-      : context_(context->execCtx()), vector_(nullptr) {}
+  explicit LocalSelectivityVector(EvalCtx& context)
+      : context_(*context.execCtx()), vector_(nullptr) {}
 
-  LocalSelectivityVector(core::ExecCtx* context, vector_size_t size)
-      : context_(context), vector_(context_->getSelectivityVector(size)) {}
+  explicit LocalSelectivityVector(EvalCtx* FOLLY_NONNULL context)
+      : LocalSelectivityVector(*context) {}
+
+  LocalSelectivityVector(core::ExecCtx& context, vector_size_t size)
+      : context_(context), vector_(context_.getSelectivityVector(size)) {}
 
   // Grab an instance of a SelectivityVector from the pool and initialize it to
   // the specified value.
-  LocalSelectivityVector(EvalCtx* context, const SelectivityVector& value)
-      : context_(context->execCtx()),
-        vector_(context_->getSelectivityVector(value.size())) {
+  LocalSelectivityVector(EvalCtx& context, const SelectivityVector& value)
+      : context_(*context.execCtx()),
+        vector_(context_.getSelectivityVector(value.size())) {
     *vector_ = value;
   }
 
   ~LocalSelectivityVector() {
     if (vector_) {
-      context_->releaseSelectivityVector(std::move(vector_));
+      context_.releaseSelectivityVector(std::move(vector_));
     }
   }
 
   void allocate(vector_size_t size) {
     if (vector_) {
-      context_->releaseSelectivityVector(std::move(vector_));
+      context_.releaseSelectivityVector(std::move(vector_));
     }
-    vector_ = context_->getSelectivityVector(size);
+    vector_ = context_.getSelectivityVector(size);
   }
 
   explicit operator SelectivityVector&() {
     return *vector_;
   }
 
-  SelectivityVector* get() {
+  SelectivityVector* FOLLY_NONNULL get() {
     return vector_.get();
   }
 
-  SelectivityVector* get(vector_size_t size) {
+  SelectivityVector* FOLLY_NONNULL get(vector_size_t size) {
     if (!vector_) {
-      vector_ = context_->getSelectivityVector(size);
+      vector_ = context_.getSelectivityVector(size);
     }
     return vector_.get();
   }
@@ -310,54 +330,62 @@ class LocalSelectivityVector {
     return *vector_;
   }
 
-  SelectivityVector* operator->() {
+  SelectivityVector* FOLLY_NULLABLE operator->() {
     VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
     return vector_.get();
   }
 
-  const SelectivityVector* operator->() const {
+  const SelectivityVector* FOLLY_NONNULL operator->() const {
     VELOX_DCHECK_NOT_NULL(vector_, "get(size) must be called.");
     return vector_.get();
   }
 
  private:
-  core::ExecCtx* const context_;
+  core::ExecCtx& context_;
   std::unique_ptr<SelectivityVector> vector_ = nullptr;
 };
 
 class LocalDecodedVector {
  public:
-  explicit LocalDecodedVector(core::ExecCtx* context) : context_(context) {}
+  explicit LocalDecodedVector(core::ExecCtx& context) : context_(context) {}
 
-  explicit LocalDecodedVector(EvalCtx* context)
-      : context_(context->execCtx()) {}
+  explicit LocalDecodedVector(core::ExecCtx* FOLLY_NONNULL context)
+      : LocalDecodedVector(*context) {}
+
+  explicit LocalDecodedVector(EvalCtx& context)
+      : context_(*context.execCtx()) {}
+
+  explicit LocalDecodedVector(EvalCtx* FOLLY_NONNULL context)
+      : LocalDecodedVector(*context) {}
 
   LocalDecodedVector(
-      EvalCtx* context,
+      const EvalCtx& context,
       const BaseVector& vector,
       const SelectivityVector& rows,
       bool loadLazy = true)
-      : context_(context->execCtx()) {
+      : context_(*context.execCtx()) {
     get()->decode(vector, rows, loadLazy);
   }
+
+  LocalDecodedVector(
+      const EvalCtx* FOLLY_NONNULL context,
+      const BaseVector& vector,
+      const SelectivityVector& rows,
+      bool loadLazy = true)
+      : LocalDecodedVector(*context, vector, rows, loadLazy) {}
 
   LocalDecodedVector(LocalDecodedVector&& other) noexcept
       : context_{other.context_}, vector_{std::move(other.vector_)} {}
 
-  void operator=(LocalDecodedVector&& other) {
-    context_ = other.context_;
-    vector_ = std::move(other.vector_);
-  }
-
   ~LocalDecodedVector() {
     if (vector_) {
-      context_->releaseDecodedVector(std::move(vector_));
+      context_.releaseDecodedVector(std::move(vector_));
     }
   }
 
-  DecodedVector* get() {
+  DecodedVector* FOLLY_NONNULL get() {
     if (!vector_) {
-      vector_ = context_->getDecodedVector();
+      vector_ = context_.getDecodedVector();
     }
     return vector_.get();
   }
@@ -373,18 +401,18 @@ class LocalDecodedVector {
     return *vector_;
   }
 
-  DecodedVector* operator->() {
+  DecodedVector* FOLLY_NONNULL operator->() {
     VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
     return vector_.get();
   }
 
-  const DecodedVector* operator->() const {
+  const DecodedVector* FOLLY_NONNULL operator->() const {
     VELOX_DCHECK_NOT_NULL(vector_, "get() must be called.");
     return vector_.get();
   }
 
  private:
-  core::ExecCtx* context_;
+  core::ExecCtx& context_;
   std::unique_ptr<DecodedVector> vector_;
 };
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -74,15 +74,15 @@ namespace {
 
 bool isMember(
     const std::vector<FieldReference*>& fields,
-    FieldReference* field) {
-  return std::find(fields.begin(), fields.end(), field) != fields.end();
+    FieldReference& field) {
+  return std::find(fields.begin(), fields.end(), &field) != fields.end();
 }
 
 void mergeFields(
     std::vector<FieldReference*>& fields,
     const std::vector<FieldReference*>& moreFields) {
   for (auto* newField : moreFields) {
-    if (!isMember(fields, newField)) {
+    if (!isMember(fields, *newField)) {
       fields.emplace_back(newField);
     }
   }
@@ -113,7 +113,7 @@ bool Expr::isSameFields(
   }
   return std::all_of(
       fields1.begin(), fields1.end(), [&fields2](const auto& field) {
-        return isMember(fields2, field);
+        return isMember(fields2, *field);
       });
 }
 
@@ -125,7 +125,7 @@ bool Expr::isSubsetOfFields(
   }
   return std::all_of(
       subset.begin(), subset.end(), [&superset](const auto& field) {
-        return isMember(superset, field);
+        return isMember(superset, *field);
       });
 }
 
@@ -184,8 +184,8 @@ bool isFlat(const BaseVector& vector) {
 
 void Expr::evalSimplified(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   LocalSelectivityVector nonNullHolder(context);
 
   // First we try to update the initial selectivity vector, setting null for
@@ -206,11 +206,11 @@ void Expr::evalSimplified(
 
 void Expr::evalSimplifiedImpl(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
-    *result = BaseVector::createNullConstant(type(), 0, context->pool());
+    result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
   }
 
@@ -226,7 +226,7 @@ void Expr::evalSimplifiedImpl(
 
   for (int32_t i = 0; i < inputs_.size(); ++i) {
     auto& inputValue = inputValues_[i];
-    inputs_[i]->evalSimplifiedImpl(remainingRows, context, &inputValue);
+    inputs_[i]->evalSimplifiedImpl(remainingRows, context, inputValue);
 
     BaseVector::flattenVector(&inputValue, rows.end());
     VELOX_CHECK_EQ(VectorEncoding::Simple::FLAT, inputValue->encoding());
@@ -243,14 +243,15 @@ void Expr::evalSimplifiedImpl(
     // All rows are null, return a null constant.
     if (!remainingRows.hasSelections()) {
       inputValues_.clear();
-      *result =
-          BaseVector::createNullConstant(type(), rows.size(), context->pool());
+      result =
+          BaseVector::createNullConstant(type(), rows.size(), context.pool());
       return;
     }
   }
 
   // Apply the actual function.
-  vectorFunction_->apply(remainingRows, inputValues_, type(), context, result);
+  vectorFunction_->apply(
+      remainingRows, inputValues_, type(), &context, &result);
 
   // Make sure the returned vector has its null bitmap properly set.
   addNulls(rows, remainingRows.asRange().bits(), context, result);
@@ -259,8 +260,8 @@ void Expr::evalSimplifiedImpl(
 
 void Expr::eval(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   // Make sure to include current expression in the error message in case of an
   // exception.
   ExceptionContextSetter exceptionContext(
@@ -268,7 +269,7 @@ void Expr::eval(
 
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
-    *result = BaseVector::createNullConstant(type(), 0, context->pool());
+    result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
   }
 
@@ -286,7 +287,7 @@ void Expr::eval(
   if (!hasConditionals_ || distinctFields_.size() == 1) {
     // Load lazy vectors if any.
     for (const auto& field : distinctFields_) {
-      context->ensureFieldLoaded(field->index(context), rows);
+      context.ensureFieldLoaded(field->index(context), rows);
     }
   }
 
@@ -303,13 +304,13 @@ void Expr::eval(
 
   evalEncodings(rows, context, result);
 
-  checkUpdateSharedSubexprValues(rows, context, *result);
+  checkUpdateSharedSubexprValues(rows, context, result);
 }
 
 bool Expr::checkGetSharedSubexprValues(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   // Common subexpression optimization and peeling off of encodings and lazy
   // vectors do not work well together. There are cases when expression
   // initially is evaluated on rows before peeling and later is evaluated on
@@ -319,7 +320,7 @@ bool Expr::checkGetSharedSubexprValues(
   // For now, disable the optimization if any encodings have been peeled off.
 
   if (!isMultiplyReferenced_ || !sharedSubexprValues_ ||
-      context->wrapEncoding() != VectorEncoding::Simple::FLAT) {
+      context.wrapEncoding() != VectorEncoding::Simple::FLAT) {
     return false;
   }
 
@@ -330,30 +331,30 @@ bool Expr::checkGetSharedSubexprValues(
 
     // Fix finalSelection at "rows" if missingRows is a strict subset to avoid
     // losing values outside of missingRows.
-    bool updateFinalSelection = context->isFinalSelection() &&
+    bool updateFinalSelection = context.isFinalSelection() &&
         (missingRows->countSelected() < rows.countSelected());
     VarSetter finalSelectionOr(
-        context->mutableFinalSelection(), &rows, updateFinalSelection);
+        context.mutableFinalSelection(), &rows, updateFinalSelection);
     VarSetter isFinalSelectionOr(
-        context->mutableIsFinalSelection(), false, updateFinalSelection);
+        context.mutableIsFinalSelection(), false, updateFinalSelection);
 
-    evalEncodings(*missingRows, context, &sharedSubexprValues_);
+    evalEncodings(*missingRows, context, sharedSubexprValues_);
   }
-  context->moveOrCopyResult(sharedSubexprValues_, rows, result);
+  context.moveOrCopyResult(sharedSubexprValues_, rows, result);
   return true;
 }
 
 void Expr::checkUpdateSharedSubexprValues(
     const SelectivityVector& rows,
-    EvalCtx* context,
+    EvalCtx& context,
     const VectorPtr& result) {
   if (!isMultiplyReferenced_ || sharedSubexprValues_ ||
-      context->wrapEncoding() != VectorEncoding::Simple::FLAT) {
+      context.wrapEncoding() != VectorEncoding::Simple::FLAT) {
     return;
   }
 
   if (!sharedSubexprRows_) {
-    sharedSubexprRows_ = context->execCtx()->getSelectivityVector(rows.size());
+    sharedSubexprRows_ = context.execCtx()->getSelectivityVector(rows.size());
   }
   *sharedSubexprRows_ = rows;
   sharedSubexprValues_ = result;
@@ -363,10 +364,10 @@ namespace {
 inline void setPeeled(
     const VectorPtr& leaf,
     int32_t fieldIndex,
-    EvalCtx* context,
+    EvalCtx& context,
     std::vector<VectorPtr>& peeled) {
   if (peeled.size() <= fieldIndex) {
-    peeled.resize(context->row()->childrenSize());
+    peeled.resize(context.row()->childrenSize());
   }
   assert(peeled.size() > fieldIndex);
   peeled[fieldIndex] = leaf;
@@ -421,29 +422,29 @@ void Expr::setDictionaryWrapping(
     DecodedVector& decoded,
     const SelectivityVector& rows,
     BaseVector& firstWrapper,
-    EvalCtx* context) {
+    EvalCtx& context) {
   if (decoded.indicesNotCopied() && decoded.nullsNotCopied()) {
-    context->setDictionaryWrap(firstWrapper.wrapInfo(), firstWrapper.nulls());
+    context.setDictionaryWrap(firstWrapper.wrapInfo(), firstWrapper.nulls());
   } else {
     auto wrap = newBuffer<vector_size_t>(
-        decoded.indices(), rows.end(), context->execCtx()->pool());
+        decoded.indices(), rows.end(), context.execCtx()->pool());
     // If nulls are added by wrapping add a null wrap.
     auto wrapNulls = decoded.hasExtraNulls()
         ? newBuffer<bool>(
-              decoded.nulls(), rows.end(), context->execCtx()->pool())
+              decoded.nulls(), rows.end(), context.execCtx()->pool())
         : BufferPtr(nullptr);
-    context->setDictionaryWrap(std::move(wrap), std::move(wrapNulls));
+    context.setDictionaryWrap(std::move(wrap), std::move(wrapNulls));
   }
 }
 
 Expr::PeelEncodingsResult Expr::peelEncodings(
-    EvalCtx* context,
-    ContextSaver* saver,
+    EvalCtx& context,
+    ContextSaver& saver,
     const SelectivityVector& rows,
     LocalDecodedVector& localDecoded,
     LocalSelectivityVector& newRowsHolder,
     LocalSelectivityVector& finalRowsHolder) {
-  if (context->wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
+  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
     return Expr::PeelEncodingsResult::empty();
   }
   std::vector<VectorPtr> peeledVectors;
@@ -452,7 +453,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
   int numLevels = 0;
   bool peeled;
   bool nonConstant = false;
-  auto numFields = context->row()->childrenSize();
+  auto numFields = context.row()->childrenSize();
   int32_t firstPeeled = -1;
   do {
     peeled = true;
@@ -461,7 +462,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
     for (const auto& field : distinctFields_) {
       auto fieldIndex = field->index(context);
       assert(fieldIndex >= 0 && fieldIndex < numFields);
-      auto leaf = peeledVectors.empty() ? context->getField(fieldIndex)
+      auto leaf = peeledVectors.empty() ? context.getField(fieldIndex)
                                         : peeledVectors[fieldIndex];
       if (!constantFields.empty() && constantFields[fieldIndex]) {
         setPeeled(leaf, fieldIndex, context, maybePeeled);
@@ -539,26 +540,26 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
   if (firstPeeled == -1) {
     // All the fields are constant across the rows of interest.
     newRows = singleRow(newRowsHolder, rows.begin());
-    context->saveAndReset(saver, rows);
-    context->setConstantWrap(rows.begin());
+    context.saveAndReset(saver, rows);
+    context.setConstantWrap(rows.begin());
   } else {
     auto decoded = localDecoded.get();
-    auto firstWrapper = context->getField(firstPeeled).get();
+    auto firstWrapper = context.getField(firstPeeled).get();
     const auto& rowsToDecode =
-        context->isFinalSelection() ? rows : *context->finalSelection();
+        context.isFinalSelection() ? rows : *context.finalSelection();
     decoded->makeIndices(*firstWrapper, rowsToDecode, numLevels);
 
     newRows = translateToInnerRows(rows, *decoded, newRowsHolder);
 
-    if (!context->isFinalSelection()) {
+    if (!context.isFinalSelection()) {
       newFinalSelection = translateToInnerRows(
-          *context->finalSelection(), *decoded, finalRowsHolder);
+          *context.finalSelection(), *decoded, finalRowsHolder);
     }
 
-    context->saveAndReset(saver, rows);
+    context.saveAndReset(saver, rows);
 
-    if (!context->isFinalSelection()) {
-      *context->mutableFinalSelection() = newFinalSelection;
+    if (!context.isFinalSelection()) {
+      *context.mutableFinalSelection() = newFinalSelection;
     }
 
     setDictionaryWrapping(*decoded, rows, *firstWrapper, context);
@@ -570,10 +571,10 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
       continue;
     }
     if (!constantFields.empty() && constantFields[i]) {
-      context->setPeeled(
+      context.setPeeled(
           i, BaseVector::wrapInConstant(rows.size(), rows.begin(), values));
     } else {
-      context->setPeeled(i, values);
+      context.setPeeled(i, values);
       ++numPeeled;
     }
   }
@@ -584,12 +585,12 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
 
 void Expr::evalEncodings(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   if (deterministic_ && !distinctFields_.empty()) {
     bool hasNonFlat = false;
     for (const auto& field : distinctFields_) {
-      if (!isFlat(*context->getField(field->index(context)))) {
+      if (!isFlat(*context.getField(field->index(context)))) {
         hasNonFlat = true;
         break;
       }
@@ -602,7 +603,7 @@ void Expr::evalEncodings(
       LocalDecodedVector decodedHolder(context);
       auto peelEncodingsResult = peelEncodings(
           context,
-          &saveContext,
+          saveContext,
           rows,
           decodedHolder,
           newRowsHolder,
@@ -615,12 +616,12 @@ void Expr::evalEncodings(
         // check for such a case.
         if (newRows->hasSelections()) {
           if (peelEncodingsResult.mayCache) {
-            evalWithMemo(*newRows, context, &peeledResult);
+            evalWithMemo(*newRows, context, peeledResult);
           } else {
-            evalWithNulls(*newRows, context, &peeledResult);
+            evalWithNulls(*newRows, context, peeledResult);
           }
         }
-        context->setWrapped(this, peeledResult, rows, result);
+        context.setWrapped(this, peeledResult, rows, result);
         return;
       }
     }
@@ -630,12 +631,12 @@ void Expr::evalEncodings(
 
 bool Expr::removeSureNulls(
     const SelectivityVector& rows,
-    EvalCtx* context,
+    EvalCtx& context,
     LocalSelectivityVector& nullHolder) {
   SelectivityVector* result = nullptr;
   for (auto* field : distinctFields_) {
     VectorPtr values;
-    field->evalSpecialForm(rows, context, &values);
+    field->evalSpecialForm(rows, context, values);
     if (values->mayHaveNulls()) {
       auto nulls = values->flatRawNulls(rows);
       if (nulls) {
@@ -658,50 +659,50 @@ bool Expr::removeSureNulls(
 void Expr::addNulls(
     const SelectivityVector& rows,
     const uint64_t* rawNulls,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   // If there's no `result` yet, return a NULL ContantVector.
-  if (!*result) {
-    *result =
-        BaseVector::createNullConstant(type(), rows.size(), context->pool());
+  if (!result) {
+    result =
+        BaseVector::createNullConstant(type(), rows.size(), context.pool());
     return;
   }
 
   // If result is already a NULL ConstantVector, do nothing.
-  if ((*result)->isConstantEncoding() && (*result)->mayHaveNulls()) {
+  if (result->isConstantEncoding() && result->mayHaveNulls()) {
     return;
   }
 
-  if (!result->unique() || !(*result)->isNullsWritable()) {
+  if (!result.unique() || !result->isNullsWritable()) {
     BaseVector::ensureWritable(
-        SelectivityVector::empty(), type(), context->pool(), result);
+        SelectivityVector::empty(), type(), context.pool(), &result);
   }
 
-  if ((*result)->size() < rows.end()) {
+  if (result->size() < rows.end()) {
     // Not all Vectors support resize.  Since we only want to append nulls,
     // we can work around that by calling setSize to resize the vector and
     // ensureNullsCapacity to resize the nulls_ bit vector.
-    (*result)->setSize(rows.end());
-    (*result)->ensureNullsCapacity(rows.end(), true);
+    result->setSize(rows.end());
+    result->ensureNullsCapacity(rows.end(), true);
   }
 
-  (*result)->addNulls(rawNulls, rows);
+  result->addNulls(rawNulls, rows);
 }
 
 void Expr::evalWithNulls(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
-    *result = BaseVector::createNullConstant(type(), 0, context->pool());
+    result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
   }
 
   if (propagatesNulls_) {
     bool mayHaveNulls = false;
     for (const auto& field : distinctFields_) {
-      if (context->getField(field->index(context))->mayHaveNulls()) {
+      if (context.getField(field->index(context))->mayHaveNulls()) {
         mayHaveNulls = true;
         break;
       }
@@ -710,7 +711,7 @@ void Expr::evalWithNulls(
     if (mayHaveNulls && !distinctFields_.empty()) {
       LocalSelectivityVector nonNullHolder(context);
       if (removeSureNulls(rows, context, nonNullHolder)) {
-        VarSetter noMoreNulls(context->mutableNullsPruned(), true);
+        VarSetter noMoreNulls(context.mutableNullsPruned(), true);
         if (nonNullHolder.get()->hasSelections()) {
           evalAll(*nonNullHolder.get(), context, result);
         }
@@ -724,8 +725,8 @@ void Expr::evalWithNulls(
 }
 
 namespace {
-void deselectErrors(EvalCtx* context, SelectivityVector& rows) {
-  auto errors = context->errors();
+void deselectErrors(EvalCtx& context, SelectivityVector& rows) {
+  auto errors = context.errors();
   if (!errors) {
     return;
   }
@@ -737,10 +738,10 @@ void deselectErrors(EvalCtx* context, SelectivityVector& rows) {
 
 void Expr::evalWithMemo(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   VectorPtr base;
-  distinctFields_[0]->evalSpecialForm(rows, context, &base);
+  distinctFields_[0]->evalSpecialForm(rows, context, base);
   ++numCachableInput_;
   if (baseDictionary_ == base) {
     ++numCacheableRepeats_;
@@ -749,8 +750,8 @@ void Expr::evalWithMemo(
       auto cached = cachedHolder.get();
       cached->intersect(*cachedDictionaryIndices_);
       if (cached->hasSelections()) {
-        BaseVector::ensureWritable(rows, type(), context->pool(), result);
-        (*result)->copy(dictionaryCache_.get(), *cached, nullptr);
+        BaseVector::ensureWritable(rows, type(), context.pool(), &result);
+        result->copy(dictionaryCache_.get(), *cached, nullptr);
       }
     }
     LocalSelectivityVector uncachedHolder(context, rows);
@@ -761,16 +762,16 @@ void Expr::evalWithMemo(
     if (uncached->hasSelections()) {
       // Fix finalSelection at "rows" if uncached rows is a strict subset to
       // avoid losing values not in uncached rows.
-      bool updateFinalSelection = context->isFinalSelection() &&
+      bool updateFinalSelection = context.isFinalSelection() &&
           (uncached->countSelected() < rows.countSelected());
       VarSetter finalSelectionMemo(
-          context->mutableFinalSelection(), &rows, updateFinalSelection);
+          context.mutableFinalSelection(), &rows, updateFinalSelection);
       VarSetter isFinalSelectionMemo(
-          context->mutableIsFinalSelection(), false, updateFinalSelection);
+          context.mutableIsFinalSelection(), false, updateFinalSelection);
 
       evalWithNulls(*uncached, context, result);
       deselectErrors(context, *uncached);
-      context->exprSet()->addToMemo(this);
+      context.exprSet()->addToMemo(this);
       auto newCacheSize = uncached->end();
 
       // dictionaryCache_ is valid only for cachedDictionaryIndices_. Hence, a
@@ -783,7 +784,7 @@ void Expr::evalWithMemo(
       allUncached.get()->setAll();
       allUncached.get()->deselect(*cachedDictionaryIndices_);
       BaseVector::ensureWritable(
-          *allUncached.get(), type(), context->pool(), &dictionaryCache_);
+          *allUncached.get(), type(), context.pool(), &dictionaryCache_);
 
       if (cachedDictionaryIndices_->size() < newCacheSize) {
         cachedDictionaryIndices_->resize(newCacheSize, false);
@@ -795,16 +796,16 @@ void Expr::evalWithMemo(
       if (dictionaryCache_->size() < uncached->end()) {
         dictionaryCache_->resize(uncached->end());
       }
-      dictionaryCache_->copy(result->get(), *uncached, nullptr);
+      dictionaryCache_->copy(result.get(), *uncached, nullptr);
     }
     return;
   }
   baseDictionary_ = base;
   evalWithNulls(rows, context, result);
-  dictionaryCache_ = *result;
+  dictionaryCache_ = result;
   if (!cachedDictionaryIndices_) {
     cachedDictionaryIndices_ =
-        context->execCtx()->getSelectivityVector(rows.end());
+        context.execCtx()->getSelectivityVector(rows.end());
   }
   *cachedDictionaryIndices_ = rows;
   deselectErrors(context, *cachedDictionaryIndices_);
@@ -812,18 +813,17 @@ void Expr::evalWithMemo(
 
 void Expr::setAllNulls(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) const {
-  if (*result) {
-    BaseVector::ensureWritable(rows, type(), context->pool(), result);
+    EvalCtx& context,
+    VectorPtr& result) const {
+  if (result) {
+    BaseVector::ensureWritable(rows, type(), context.pool(), &result);
     LocalSelectivityVector notNulls(context, rows.end());
     notNulls.get()->setAll();
     notNulls.get()->deselect(rows);
-    (*result)->addNulls(notNulls.get()->asRange().bits(), rows);
+    result->addNulls(notNulls.get()->asRange().bits(), rows);
     return;
   }
-  *result =
-      BaseVector::createNullConstant(type(), rows.size(), context->pool());
+  result = BaseVector::createNullConstant(type(), rows.size(), context.pool());
 }
 
 namespace {
@@ -908,11 +908,11 @@ inline bool isPeelable(VectorEncoding::Simple encoding) {
 
 void Expr::evalAll(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
-    *result = BaseVector::createNullConstant(type(), 0, context->pool());
+    result = BaseVector::createNullConstant(type(), 0, context.pool());
     return;
   }
   if (isSpecialForm()) {
@@ -925,7 +925,7 @@ void Expr::evalAll(
   bool defaultNulls = vectorFunction_->isDefaultNullBehavior();
   inputValues_.resize(inputs_.size());
   for (int32_t i = 0; i < inputs_.size(); ++i) {
-    inputs_[i]->eval(*remainingRows, context, &inputValues_[i]);
+    inputs_[i]->eval(*remainingRows, context, inputValues_[i]);
     tryPeelArgs = tryPeelArgs && isPeelable(inputValues_[i]->encoding());
     if (defaultNulls && inputValues_[i]->mayHaveNulls()) {
       if (remainingRows == &rows) {
@@ -950,7 +950,7 @@ void Expr::evalAll(
   // lead to undefined behavior if we try to evaluate the current function on
   // them.  It's safe to skip evaluating them since the value for this branch
   // of the expression tree will be NULL for those rows anyway.
-  if (context->errors()) {
+  if (context.errors()) {
     if (remainingRows == &rows) {
       nonNulls.allocate(rows.end());
       *nonNulls.get() = rows;
@@ -990,9 +990,9 @@ void setPeeledArg(
 bool Expr::applyFunctionWithPeeling(
     const SelectivityVector& rows,
     const SelectivityVector& applyRows,
-    EvalCtx* context,
-    VectorPtr* result) {
-  if (context->wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
+    EvalCtx& context,
+    VectorPtr& result) {
+  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
     return false;
   }
   int numLevels = 0;
@@ -1096,26 +1096,26 @@ bool Expr::applyFunctionWithPeeling(
     // All the fields are constant across the rows of interest.
     newRows = singleRow(newRowsHolder, rows.begin());
 
-    context->saveAndReset(&saver, rows);
-    context->setConstantWrap(rows.begin());
+    context.saveAndReset(saver, rows);
+    context.setConstantWrap(rows.begin());
   } else {
     auto decoded = localDecoded.get();
     decoded->makeIndices(*firstWrapper, applyRows, numLevels);
     newRows = translateToInnerRows(applyRows, *decoded, newRowsHolder);
-    context->saveAndReset(&saver, rows);
+    context.saveAndReset(saver, rows);
     setDictionaryWrapping(*decoded, rows, *firstWrapper, context);
   }
 
   VectorPtr peeledResult;
-  applyFunction(*newRows, context, &peeledResult);
-  context->setWrapped(this, peeledResult, rows, result);
+  applyFunction(*newRows, context, peeledResult);
+  context.setWrapped(this, peeledResult, rows, result);
   return true;
 }
 
 void Expr::applyFunction(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   stats_.numProcessedVectors += 1;
   stats_.numProcessedRows += rows.countSelected();
   auto timer = cpuWallTimer();
@@ -1126,29 +1126,29 @@ void Expr::applyFunction(
       : std::nullopt;
   applyVectorFunction(rows, context, result);
   if (isAscii.has_value()) {
-    (*result)->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
+    result->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
         isAscii.value(), rows);
   }
 }
 
 void Expr::applyVectorFunction(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   // Single-argument deterministic functions expect their input as a flat
   // vector. Check if input has constant wrapping and remove it.
   if (deterministic_ && inputValues_.size() == 1 &&
       inputValues_[0]->isConstantEncoding()) {
     applySingleConstArgVectorFunction(rows, context, result);
   } else {
-    vectorFunction_->apply(rows, inputValues_, type(), context, result);
+    vectorFunction_->apply(rows, inputValues_, type(), &context, &result);
   }
 }
 
 void Expr::applySingleConstArgVectorFunction(
     const SelectivityVector& rows,
-    EvalCtx* context,
-    VectorPtr* result) {
+    EvalCtx& context,
+    VectorPtr& result) {
   VELOX_CHECK_EQ(rows.countSelected(), 1);
 
   auto inputValue = inputValues_[0];
@@ -1163,7 +1163,7 @@ void Expr::applySingleConstArgVectorFunction(
   // use valueVector(). Otherwise, need to make a new flat vector.
   std::vector<VectorPtr> args;
   if (inputValue->isScalar()) {
-    auto flat = BaseVector::create(inputValue->type(), 1, context->pool());
+    auto flat = BaseVector::create(inputValue->type(), 1, context.pool());
     flat->copy(inputValue.get(), 0, 0, 1);
     args = {flat};
   } else {
@@ -1171,11 +1171,11 @@ void Expr::applySingleConstArgVectorFunction(
   }
 
   VectorPtr tempResult;
-  vectorFunction_->apply(*inputRows, args, type(), context, &tempResult);
+  vectorFunction_->apply(*inputRows, args, type(), &context, &tempResult);
 
-  if (*result && !context->isFinalSelection()) {
-    BaseVector::ensureWritable(rows, type(), context->pool(), result);
-    (*result)->copy(tempResult.get(), resultRow, inputRow, 1);
+  if (result && !context.isFinalSelection()) {
+    BaseVector::ensureWritable(rows, type(), context.pool(), &result);
+    result->copy(tempResult.get(), resultRow, inputRow, 1);
   } else {
     // TODO Move is available only for flat vectors. Check if tempResult is
     // not flat and copy if so.
@@ -1183,7 +1183,7 @@ void Expr::applySingleConstArgVectorFunction(
       tempResult->resize(resultRow + 1);
     }
     tempResult->move(inputRow, resultRow);
-    *result = std::move(tempResult);
+    result = std::move(tempResult);
   }
 }
 
@@ -1277,7 +1277,7 @@ void ExprSet::eval(
     clearSharedSubexprs();
   }
   for (int32_t i = begin; i < end; ++i) {
-    exprs_[i]->eval(rows, context, &(*result)[i]);
+    exprs_[i]->eval(rows, *context, (*result)[i]);
   }
 }
 
@@ -1306,7 +1306,7 @@ void ExprSetSimplified::eval(
     clearSharedSubexprs();
   }
   for (int32_t i = begin; i < end; ++i) {
-    exprs_[i]->evalSimplified(rows, context, &(*result)[i]);
+    exprs_[i]->evalSimplified(rows, *context, (*result)[i]);
   }
 }
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -277,7 +277,7 @@ ExprPtr tryFoldIfConstant(const ExprPtr& expr, Scope* scope) {
           execCtx, scope->exprSet, dynamic_cast<RowVector*>(row.get()));
       VectorPtr result;
       SelectivityVector rows(1);
-      expr->eval(rows, &context, &result);
+      expr->eval(rows, context, result);
       auto constantVector = BaseVector::wrapInConstant(1, 0, result);
 
       return std::make_shared<ConstantExpr>(constantVector);

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -173,7 +173,7 @@ struct AsJson {
     // Translates the selected rows of input into the corresponding rows of the
     // base of the decoded input.
     exec::LocalSelectivityVector baseRows(
-        context->execCtx(), decoded_->base()->size());
+        *context->execCtx(), decoded_->base()->size());
     baseRows->clearAll();
     context->applyToSelectedNoThrow(rows, [&](auto row) {
       baseRows->setValid(decoded_->index(row), true);
@@ -472,7 +472,7 @@ bool JsonCastOperator::isSupportedType(const TypePtr& other) const {
 ///       +- castToJson (recursive)
 void JsonCastOperator::castTo(
     const BaseVector& input,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     const SelectivityVector& rows,
     bool /*nullOnFailure*/,
     BaseVector& result) const {
@@ -482,7 +482,7 @@ void JsonCastOperator::castTo(
   // Casting from VARBINARY and OPAQUE are not supported and should have been
   // rejected by isSupportedType() in the caller.
   VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
-      castToJson, input.typeKind(), input, context, rows, *flatResult);
+      castToJson, input.typeKind(), input, &context, rows, *flatResult);
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -34,14 +34,14 @@ class JsonCastOperator : public exec::CastOperator {
 
   void castTo(
       const BaseVector& input,
-      exec::EvalCtx* context,
+      exec::EvalCtx& context,
       const SelectivityVector& rows,
       bool nullOnFailure,
       BaseVector& result) const override;
 
   void castFrom(
       const BaseVector& /*input*/,
-      exec::EvalCtx* /*context*/,
+      exec::EvalCtx& /*context*/,
       const SelectivityVector& /*rows*/,
       bool /*nullOnFailure*/,
       BaseVector& /*result*/) const override {


### PR DESCRIPTION
Passes non-optional non-const parameters by reference. This avoids
nullability specifiers required by Mac Circle CI builds. Adds
nullability declarations to pointers that need them.

The scope of tis is expressions. The function base class signatures
are not changed.