### PR TITLE
Ensuring evalSimplified() has consistent null semantic

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -79,10 +79,6 @@ int main(int argc, char** argv) {
       // called prior to constant folding so this case is not caught up.
       // TODO: T117753276
       "date_parse",
-      // 'distinct_from' with seed 4009637301 causes fuzzer failure: Only
-      // simplified path threw exception.
-      // TODO: T120528837
-      "distinct_from",
   };
   return FuzzerRunner::run(FLAGS_only, FLAGS_steps, FLAGS_seed, skipFunctions);
 }


### PR DESCRIPTION
Summary:
Ensure evalSimplified() follows the exact null semantic as evalAll(),
so that they throw exception in the same cases. The difference was
evalSimplified() was only considering and merging null inputs from the top
level expression, and not doing it recursively like evalAll(). This can be
reproduced by the Fuzzer with the command line below:

Reviewed By: spershin

Differential Revision: D36392050

