### PR TITLE
Refactor SeekableInputStream::loadIndices()

### DIFF
--- a/velox/dwio/dwrf/common/ByteRLE.cpp
+++ b/velox/dwio/dwrf/common/ByteRLE.cpp
@@ -388,6 +388,11 @@ void ByteRleDecoder::skip(uint64_t numValues) {
   }
 }
 
+void ByteRleDecoder::skipPositions(PositionProvider& pp) {
+  inputStream->skipPositions(pp);
+  pp.next();
+}
+
 void ByteRleDecoder::next(
     char* data,
     uint64_t numValues,
@@ -493,6 +498,11 @@ void BooleanRleDecoder::skip(uint64_t numValues) {
       remainingBits = 8 - bitsToSkip;
     }
   }
+}
+
+void BooleanRleDecoder::skipPositions(PositionProvider& pp) {
+  ByteRleDecoder::skipPositions(pp);
+  pp.next();
 }
 
 void BooleanRleDecoder::next(

--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -113,6 +113,8 @@ class ByteRleDecoder {
    */
   virtual void skip(uint64_t numValues);
 
+  virtual void skipPositions(PositionProvider& pp);
+
   /**
    * Read a number of values into the batch.
    * @param data the array to read into
@@ -121,15 +123,6 @@ class ByteRleDecoder {
    *    pointer is not null, positions that are true are skipped.
    */
   virtual void next(char* data, uint64_t numValues, const uint64_t* nulls);
-
-  /**
-   * Load the RowIndex values for the stream this is reading.
-   */
-  virtual size_t loadIndices(
-      const proto::RowIndex& rowIndex,
-      size_t startIndex) {
-    return inputStream->loadIndices(rowIndex, startIndex) + 1;
-  }
 
   void skipBytes(size_t bytes);
 
@@ -262,12 +255,9 @@ class BooleanRleDecoder : public ByteRleDecoder {
 
   void skip(uint64_t numValues) override;
 
-  void next(char* data, uint64_t numValues, const uint64_t* nulls) override;
+  void skipPositions(PositionProvider& pp) override;
 
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override {
-    return ByteRleDecoder::loadIndices(rowIndex, startIndex) + 1;
-  }
+  void next(char* data, uint64_t numValues, const uint64_t* nulls) override;
 
   // Advances 'dataPosition' by 'numValue' non-nulls, where 'current'
   // is the position in 'nulls'.

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -96,15 +96,13 @@ void CacheInputStream::seekToPosition(PositionProvider& seekPosition) {
   position_ = seekPosition.next();
 }
 
-std::string CacheInputStream::getName() const {
-  return fmt::format("CacheInputStream {} of {}", position_, region_.length);
+void CacheInputStream::skipPositions(PositionProvider& position) {
+  // not compressed, so only need to skip 1 value (uncompressed position)
+  position.next();
 }
 
-size_t CacheInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value (uncompressed position)
-  return startIndex + 1;
+std::string CacheInputStream::getName() const {
+  return fmt::format("CacheInputStream {} of {}", position_, region_.length);
 }
 
 namespace {

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -44,9 +44,8 @@ class CacheInputStream : public SeekableInputStream {
   bool Skip(int count) override;
   google::protobuf::int64 ByteCount() const override;
   void seekToPosition(PositionProvider& position) override;
+  void skipPositions(PositionProvider& position) override;
   std::string getName() const override;
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
 
  private:
   // Ensures that the current position is covered by 'pin_'.

--- a/velox/dwio/dwrf/common/InputStream.cpp
+++ b/velox/dwio/dwrf/common/InputStream.cpp
@@ -173,16 +173,14 @@ void SeekableArrayInputStream::seekToPosition(PositionProvider& position) {
   this->position = position.next();
 }
 
+void SeekableArrayInputStream::skipPositions(PositionProvider& pp) {
+  // not compressed, so only need to skip 1 value (uncompressed position)
+  pp.next();
+}
+
 std::string SeekableArrayInputStream::getName() const {
   return folly::to<std::string>(
       "SeekableArrayInputStream ", position, " of ", length);
-}
-
-size_t SeekableArrayInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value (uncompressed position)
-  return startIndex + 1;
 }
 
 static uint64_t computeBlock(uint64_t request, uint64_t length) {
@@ -255,16 +253,14 @@ void SeekableFileInputStream::seekToPosition(PositionProvider& location) {
   pushBack = 0;
 }
 
+void SeekableFileInputStream::skipPositions(PositionProvider& pp) {
+  // not compressed, so only need to skip 1 value: uncompressed position
+  pp.next();
+}
+
 std::string SeekableFileInputStream::getName() const {
   return folly::to<std::string>(
       input.getName(), " from ", start, " for ", length);
-}
-
-size_t SeekableFileInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value: uncompressed position
-  return startIndex + 1;
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/InputStream.h
+++ b/velox/dwio/dwrf/common/InputStream.h
@@ -52,11 +52,12 @@ class SeekableInputStream : public google::protobuf::io::ZeroCopyInputStream {
 
   virtual void seekToPosition(PositionProvider& position) = 0;
 
-  virtual std::string getName() const = 0;
+  // The number of positions in the PositionProvider that are used to identify
+  // an ORC/DWRF input stream address could be 1 or 2. This function just skips
+  // that number of positions in the PositionProvider parameter.
+  virtual void skipPositions(PositionProvider& position) = 0;
 
-  virtual size_t loadIndices(
-      const proto::RowIndex& rowIndex,
-      size_t startIndex) = 0;
+  virtual std::string getName() const = 0;
 
   void readFully(char* buffer, size_t bufferSize);
 };
@@ -100,9 +101,8 @@ class SeekableArrayInputStream : public SeekableInputStream {
   virtual bool Skip(int32_t count) override;
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
+  virtual void skipPositions(PositionProvider& position) override;
   virtual std::string getName() const override;
-  virtual size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
 };
 
 /**
@@ -135,9 +135,8 @@ class SeekableFileInputStream : public SeekableInputStream {
   virtual bool Skip(int32_t count) override;
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
+  virtual void skipPositions(PositionProvider& position) override;
   virtual std::string getName() const override;
-  virtual size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/IntDecoder.h
+++ b/velox/dwio/dwrf/common/IntDecoder.h
@@ -98,9 +98,9 @@ class IntDecoder {
    * Load RowIndex values for the stream being read.
    * @return updated start index after this stream's index values.
    */
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex) {
-    size_t updatedStartIndex = inputStream->loadIndices(rowIndex, startIndex);
-    return updatedStartIndex + 1;
+  void skipPositions(PositionProvider& pp) {
+    inputStream->skipPositions(pp);
+    pp.next();
   }
 
   /**

--- a/velox/dwio/dwrf/common/PagedInputStream.h
+++ b/velox/dwio/dwrf/common/PagedInputStream.h
@@ -59,10 +59,10 @@ class PagedInputStream : public SeekableInputStream {
         ")");
   }
 
-  size_t loadIndices(const proto::RowIndex& /* unused */, size_t startIndex)
-      override {
+  void skipPositions(PositionProvider& position) override {
     // need to skip 2 values: compressed position + uncompressed position
-    return startIndex + 2;
+    position.next();
+    position.next();
   }
 
  protected:

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -98,8 +98,6 @@ class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
   FlatVectorPtr<StringView> dictionaryValues_;
 
   int64_t lastStrideIndex_;
-  size_t positionOffset_;
-  size_t strideDictSizeOffset_;
 
   const StrideIndexProvider& provider_;
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -246,8 +246,6 @@ TEST(StripeStream, zeroLength) {
     const void* buf = nullptr;
     int32_t size = 1;
     EXPECT_FALSE(stream->Next(&buf, &size));
-    proto::RowIndex rowIndex;
-    EXPECT_EQ(stream->loadIndices(rowIndex, 0), 2);
   }
 }
 


### PR DESCRIPTION
loadIndices() in SeekableInputStream returns the the positions array
index for the next stream in the current column for DWRF, relative to
the startIndex parameter. It was used in
SelectiveStringDictionaryColumnReader to lazily load the stride
dictionary for DWRF. To prepare for the upcoming refactoring that
moves this class and its subclasses to dwio::common, we need to decouple
the DWRF related concept from it. This commit changed loadIndices() to
skipPositions() which takes a PositionProvider parameter, and would
skip the number of positions needed by this stream to identify any
stream address.