### PR TITLE
Fix ColumnLoader to pass correct parameter to ExceptionContextSetter

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnLoader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnLoader.cpp
@@ -55,7 +55,7 @@ void ColumnLoader::loadInternal(
          return static_cast<SelectiveStructColumnReader*>(reader)
              ->debugString();
        },
-       this});
+       structReader_});
 
   if (rows.size() == outputRows.size()) {
     // All the rows planned at creation are accessed.


### PR DESCRIPTION
Summary: ColumnLoader used to pass "this" (of type ColumnLoader*) to arg in ExceptionContextSetter but later tried to cast it to SelectiveStructColumnReader* which caused crashes when exceptions are thrown.

Differential Revision: D36424980

