### PR TITLE
Fix LazyVector::ensureLoadedRows

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -255,7 +255,11 @@ void EvalCtx::ensureFieldLoaded(int32_t index, const SelectivityVector& rows) {
     auto rawField = field.get();
     LazyVector::ensureLoadedRows(field, rowsToLoad, *decoded, *baseRows);
     if (rawField != field.get()) {
-      const_cast<RowVector*>(row_)->childAt(index) = field;
+      if (peeledFields_.empty()) {
+        const_cast<RowVector*>(row_)->childAt(index) = field;
+      } else {
+        peeledFields_[index] = field;
+      }
     }
   } else {
     // This is needed in any case because wrappers must be initialized also if

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -470,6 +470,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
         continue;
       }
       if (numLevels == 0 && leaf->isConstant(rows)) {
+        context.ensureFieldLoaded(fieldIndex, rows);
         setPeeled(leaf, fieldIndex, context, maybePeeled);
         constantFields.resize(numFields);
         constantFields.at(fieldIndex) = true;

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -31,6 +31,9 @@ void assertEqualVectors(
     const VectorPtr& actual,
     const std::string& additionalContext = "");
 
+/// Verify that 'vector' is copyable, by copying all rows.
+void assertCopyableVector(const VectorPtr& vector);
+
 class VectorTestBase {
  protected:
   template <typename T>
@@ -495,6 +498,10 @@ class VectorTestBase {
   BufferPtr makeIndicesInReverse(vector_size_t size) {
     return ::facebook::velox::test::makeIndicesInReverse(size, pool());
   }
+
+  BufferPtr makeNulls(
+      vector_size_t size,
+      std::function<bool(vector_size_t /*row*/)> isNullAt);
 
   static VectorPtr
   wrapInDictionary(BufferPtr indices, vector_size_t size, VectorPtr vector);


### PR DESCRIPTION
LazyVector::ensureLoadedRows didn't preserve nulls and could produce dictionary
vectors with indices larger than the base vector size.