### PR TITLE
Simplify calling toString() methods on vectors

### DIFF
--- a/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
@@ -519,7 +519,7 @@ TEST_F(UnsafeRowBatchDeserializerTest, NestedMap) {
   ASSERT_EQ(1, outerMapVectorPtr->size());
   EXPECT_EQ(
       outerMapVectorPtr->toString(0),
-      "2 elements starting at 0 {1 = 2 elements starting at 0 {2 = 3,\n 4 = null},\n 6 = 1 elements starting at 2 {7 = 8}}");
+      "2 elements starting at 0 {1 => 2 elements starting at 0 {2 => 3, 4 => null}, 6 => 1 elements starting at 2 {7 => 8}}");
   ASSERT_TRUE(checkVectorMetadata(
       outerMapVectorPtr,
       outerMapSize,
@@ -629,11 +629,11 @@ TEST_F(UnsafeRowBatchDeserializerTest, RowVector) {
 
   EXPECT_EQ(
       rowVectorPtr->toString(0),
-      "{ [child at 0]: 72340172838076673, null, 11259375, 1234, null, \
+      "{72340172838076673, null, 11259375, 1234, null, \
 Make time for civilization, for civilization wont make time.}");
   EXPECT_EQ(
       rowVectorPtr->toString(1),
-      "{ [child at 1]: 72340172838076673, null, 11259375, 1234, null, \
+      "{72340172838076673, null, 11259375, 1234, null, \
 Im a string with 30 characters}");
 }
 

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -888,11 +888,11 @@ TYPED_TEST(UnsafeRowVectorDeserializerTest, RowVector) {
 
   EXPECT_EQ(
       rowVectorPtr->toString(0),
-      "{ [child at 0]: 72340172838076673, null, 11259375, 1234, null, \
+      "{72340172838076673, null, 11259375, 1234, null, \
 Make time for civilization, for civilization wont make time.}");
   EXPECT_EQ(
       rowVectorPtr->toString(1),
-      "{ [child at 1]: 72340172838076673, null, 11259375, 1234, null, \
+      "{72340172838076673, null, 11259375, 1234, null, \
 Im a string with 30 characters}");
 }
 

--- a/velox/substrait/tests/PlanConversionTest.cpp
+++ b/velox/substrait/tests/PlanConversionTest.cpp
@@ -489,7 +489,7 @@ TEST_P(PlanConversionTest, queryTest) {
     auto size = rv->size();
     ASSERT_EQ(size, 1);
     std::string res = rv->toString(0);
-    ASSERT_EQ(res, "{ [child at 0]: 13613.1921}");
+    ASSERT_EQ(res, "{13613.1921}");
   }
 }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -449,12 +449,23 @@ std::string BaseVector::toString(vector_size_t index) const {
   return out.str();
 }
 
-std::string BaseVector::toString(vector_size_t from, vector_size_t to) const {
+std::string BaseVector::toString(
+    vector_size_t from,
+    vector_size_t to,
+    const std::string& delimiter,
+    bool includeRowNumbers) const {
+  const auto start = std::max(0, std::min<int32_t>(from, length_));
+  const auto end = std::max(0, std::min<int32_t>(to, length_));
+
   std::stringstream out;
-  for (auto i = std::min<int32_t>(from, length_);
-       i < std::min<int32_t>(to, length_);
-       ++i) {
-    out << i << ": " << toString(i) << std::endl;
+  for (auto i = start; i < end; ++i) {
+    if (i > start) {
+      out << delimiter;
+    }
+    if (includeRowNumbers) {
+      out << i << ": ";
+    }
+    out << toString(i);
   }
   return out.str();
 }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -659,7 +659,11 @@ class BaseVector {
 
   virtual std::string toString(vector_size_t index) const;
 
-  std::string toString(vector_size_t from, vector_size_t to) const;
+  std::string toString(
+      vector_size_t from,
+      vector_size_t to,
+      const std::string& delimiter = "\n",
+      bool includeRowNumbers = true) const;
 
   void setCodegenOutput() {
     isCodegenOutput_ = true;

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -143,6 +143,8 @@ class RowVector : public BaseVector {
 
   uint64_t estimateFlatSize() const override;
 
+  using BaseVector::toString;
+
   std::string toString(vector_size_t index) const override;
 
   void ensureWritable(const SelectivityVector& rows) override;
@@ -367,6 +369,8 @@ class ArrayVector : public BaseVector {
 
   uint64_t estimateFlatSize() const override;
 
+  using BaseVector::toString;
+
   std::string toString(vector_size_t index) const override;
 
   void ensureWritable(const SelectivityVector& rows) override;
@@ -542,6 +546,8 @@ class MapVector : public BaseVector {
   }
 
   uint64_t estimateFlatSize() const override;
+
+  using BaseVector::toString;
 
   std::string toString(vector_size_t index) const override;
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -172,6 +172,8 @@ class SimpleVector : public BaseVector {
     return false;
   }
 
+  using BaseVector::toString;
+
   std::string toString(vector_size_t index) const override {
     std::stringstream out;
     if (isNullAt(index)) {

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   VectorCompareTest.cpp
   VectorMakerTest.cpp
   VectorTest.cpp
+  VectorToStringTest.cpp
   VectorEstimateFlatSizeTest.cpp
   VectorPrepareForReuseTest.cpp
   DecodedVectorTest.cpp

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/tests/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+class VectorToStringTest : public testing::Test, public VectorTestBase {};
+
+TEST_F(VectorToStringTest, flatIntegers) {
+  // No nulls.
+  auto flat = makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  ASSERT_EQ(flat->toString(), "[FLAT INTEGER: 10 elements, no nulls]");
+  ASSERT_EQ(flat->toString(1), "2");
+  ASSERT_EQ(flat->toString(3, 8, ", ", false), "4, 5, 6, 7, 8");
+
+  // With nulls.
+  flat = makeFlatVector<int32_t>(
+      100, [](auto row) { return row; }, nullEvery(3));
+  ASSERT_EQ(flat->toString(), "[FLAT INTEGER: 100 elements, 34 nulls]");
+  ASSERT_EQ(flat->toString(1), "1");
+  ASSERT_EQ(flat->toString(33), "null");
+  ASSERT_EQ(flat->toString(0, 7, ", ", false), "null, 1, 2, null, 4, 5, null");
+}
+
+TEST_F(VectorToStringTest, arrayOfIntegers) {
+  // No nulls.
+  auto arr = makeArrayVector<int64_t>(
+      {{0}, {1, 2}, {3, 4, 5}, {6}, {}, {8, 9, 10, 11}});
+  ASSERT_EQ(arr->toString(), "[ARRAY ARRAY<BIGINT>: 6 elements, no nulls]");
+  ASSERT_EQ(arr->toString(3), "1 elements starting at 6 {6}");
+  ASSERT_EQ(
+      arr->toString(2, 6),
+      "2: 3 elements starting at 3 {3, 4, 5}\n"
+      "3: 1 elements starting at 6 {6}\n"
+      "4: <empty>\n"
+      "5: 4 elements starting at 7 {8, 9, 10, 11}");
+
+  // With nulls.
+  arr = makeNullableArrayVector<int64_t>(
+      {{0}, {1, 2}, {3, 4, 5}, {6}, {}, {std::nullopt, 5}, {8, 9, 10, 11}});
+  ASSERT_EQ(arr->toString(), "[ARRAY ARRAY<BIGINT>: 7 elements, 0 nulls]");
+  ASSERT_EQ(arr->toString(4), "<empty>");
+  ASSERT_EQ(
+      arr->toString(2, 6),
+      "2: 3 elements starting at 3 {3, 4, 5}\n"
+      "3: 1 elements starting at 6 {6}\n"
+      "4: <empty>\n"
+      "5: 2 elements starting at 7 {null, 5}");
+}
+
+TEST_F(VectorToStringTest, mapOfIntegerToDouble) {
+  auto map = makeMapVector<int32_t, double>(
+      {{{1, 0.1}, {2, 0.2}, {3, 0.3}}, {}, {{4, 0.4}, {5, 0.5}}});
+  ASSERT_EQ(map->toString(), "[MAP MAP<INTEGER,DOUBLE>: 3 elements, no nulls]");
+  ASSERT_EQ(
+      map->toString(0),
+      "3 elements starting at 0 {1 => 0.1, 2 => 0.2, 3 => 0.3}");
+  ASSERT_EQ(
+      map->toString(2, 6), "2: 2 elements starting at 3 {4 => 0.4, 5 => 0.5}");
+}
+
+TEST_F(VectorToStringTest, row) {
+  auto row = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<float>({10.1, 2.3, 444.56}),
+      makeConstant(true, 3),
+  });
+  ASSERT_EQ(
+      row->toString(),
+      "[ROW ROW<c0:INTEGER,c1:REAL,c2:BOOLEAN>: 3 elements, no nulls]");
+  ASSERT_EQ(row->toString(2), "{3, 444.55999755859375, 1}");
+  ASSERT_EQ(
+      row->toString(0, 10),
+      "0: {1, 10.100000381469727, 1}\n"
+      "1: {2, 2.299999952316284, 1}\n"
+      "2: {3, 444.55999755859375, 1}");
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Enable vector->toString(), vector->toString(row), vector->toString(from , to)
for all kinds of vector. Before this change, developers needed to use
vector->BaseVector::toString() and vector->BaseVector::toString(from, to). Add
some basic tests.