### PR TITLE
Improve 'Field not found' error message

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -31,3 +31,13 @@
 #else
 #define VELOX_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
 #endif
+
+#define VELOX_ASSERT_THROW(expression, errorMessage)                 \
+  try {                                                              \
+    (expression);                                                    \
+    FAIL() << "Expected an exception";                               \
+  } catch (const VeloxException& e) {                                \
+    ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos) \
+        << "Expected error message to contain '" << errorMessage     \
+        << "', but received '" << e.message() << "'.";               \
+  }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -14,20 +14,11 @@
  * limitations under the License.
  */
 #include "velox/exec/Task.h"
-#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/vector/tests/VectorTestBase.h"
-
-#define VELOX_ASSERT_THROW(expression, errorMessage)                  \
-  try {                                                               \
-    (expression);                                                     \
-    VELOX_FAIL("Expected an exception");                              \
-  } catch (const VeloxException& e) {                                 \
-    ASSERT_TRUE(e.isUserError());                                     \
-    ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos); \
-  }
 
 using namespace facebook::velox;
 

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -314,16 +314,16 @@ TEST_F(ArrayDistinctTest, invalidTypes) {
   EXPECT_THROW(
       testExpr(expected, "array_distinct(1)", {array}), std::invalid_argument);
   EXPECT_THROW(
-      testExpr(expected, "array_distinct(C0, CO)", {array, array}),
+      testExpr(expected, "array_distinct(c0, c0)", {array, array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_distinct(ARRAY[1], 1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_distinct(ARRAY[ARRAY[1]])", {array}),
-      facebook::velox::VeloxUserError);
+      VeloxUserError);
   EXPECT_THROW(
       testExpr(expected, "array_distinct()", {array}), std::invalid_argument);
 
-  EXPECT_NO_THROW(testExpr(expected, "array_distinct(C0)", {array}));
+  EXPECT_NO_THROW(testExpr(expected, "array_distinct(c0)", {array}));
 }

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -184,18 +184,18 @@ TEST_F(ArrayDuplicatesTest, invalidTypes) {
       testExpr(expected, "array_duplicates(1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
-      testExpr(expected, "array_duplicates(C0, CO)", {array, array}),
+      testExpr(expected, "array_duplicates(c0, c0)", {array, array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates(ARRAY[1], 1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates(ARRAY[ARRAY[1]])", {array}),
-      facebook::velox::VeloxUserError);
+      VeloxUserError);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates()", {array}), std::invalid_argument);
 
-  EXPECT_NO_THROW(testExpr(expected, "array_duplicates(C0)", {array}));
+  EXPECT_NO_THROW(testExpr(expected, "array_duplicates(c0)", {array}));
 }
 
 TEST_F(ArrayDuplicatesTest, invalidBooleanElementType) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "velox/type/Type.h"
-#include <gtest/gtest.h>
 #include <sstream>
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook;
 using namespace facebook::velox;
@@ -272,7 +272,8 @@ TEST(TypeTest, row) {
   EXPECT_THROW(row0->nameOf(4), std::out_of_range);
   EXPECT_THROW(row0->findChild("not_exist"), VeloxUserError);
   // todo: expected case behavior?:
-  EXPECT_THROW(row0->findChild("A"), VeloxUserError);
+  VELOX_ASSERT_THROW(
+      row0->findChild("A"), "Field not found: A. Available fields are: a, b.");
   EXPECT_EQ(row0->childAt(1)->toString(), "ROW<a:BIGINT>");
   EXPECT_EQ(row0->findChild("b")->toString(), "ROW<a:BIGINT>");
   EXPECT_EQ(row0->findChild("b")->asRow().findChild("a")->toString(), "BIGINT");


### PR DESCRIPTION
Enhance 'Field not found'  error message thrown when looking up a sub-type of a
RowType by name by adding the list of available names. This error happens often 
during unit test development and better error message can help developers fix the 
problem quicker.

Before: `Field not found: a`
After: `Field not found: a. Available fields are: c0.`