### PR TITLE
Change way we calculate output channels for LocalPartition.

### DIFF
--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -189,13 +189,15 @@ class LocalPartition : public Operator {
 
  private:
   BlockingReason
-  enqueue(int32_t source, RowVectorPtr data, ContinueFuture* future);
+  enqueue(int32_t partition, RowVectorPtr data, ContinueFuture* future);
 
   const std::vector<std::shared_ptr<LocalExchangeQueue>> queues_;
   const size_t numPartitions_;
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
-  // Empty if column order in the output is exactly the same as in input.
-  const std::vector<ChannelIndex> outputChannels_;
+  /// Mapping of sources' output columns to our output columns.
+  /// One for all sources.
+  /// Empty if column order in the output is exactly the same as in input.
+  std::vector<ChannelIndex> sourceOutputChannels_;
 
   uint32_t numBlockedPartitions_{0};
   std::vector<BlockingReason> blockingReasons_;

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -600,3 +600,33 @@ TEST_F(LocalPartitionTest, producerError) {
   // blocked forever.
   assertTaskReferenceCount(task, 1);
 }
+
+TEST_F(LocalPartitionTest, unionAll) {
+  auto data1 = makeRowVector(
+      {"d0", "d1"},
+      {makeFlatVector<int32_t>({10, 11}),
+       makeFlatVector<StringView>({"x", "y"})});
+  auto data2 = makeRowVector(
+      {"e0", "e1"},
+      {makeFlatVector<int32_t>({20, 21}),
+       makeFlatVector<StringView>({"z", "w"})});
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  // For the partition node, use the 1st source's names to define the output
+  // layout and rename the output columns to be different from the sources'.
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localPartition(
+              {},
+              {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+               PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+              {"d0", "d1"},
+              {"c0", "c1"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "WITH T1 AS (VALUES (10, 'x'), (11, 'y')), "
+      "T2 AS (VALUES (20, 'z'), (21, 'w')) "
+      "SELECT * FROM T1 UNION ALL SELECT * FROM T2; ");
+}

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -543,10 +543,13 @@ class PlanBuilder {
   /// the input. Output columns may appear in different order from the input,
   /// some input columns may be missing in the output, some columns may be
   /// duplicated in the output.
+  /// @param outputRenamedLayout Optional output layout used to change the
+  /// column names in the node's output.
   PlanBuilder& localPartition(
       const std::vector<std::string>& keys,
       const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      const std::vector<std::string>& outputRenamedLayout = {});
 
   /// Add a LocalPartitionNode to partition the input using row-wise
   /// round-robin. Number of partitions is determined at runtime based on
@@ -557,9 +560,12 @@ class PlanBuilder {
   /// the input. Output columns may appear in different order from the input,
   /// some input columns may be missing in the output, some columns may be
   /// duplicated in the output.
+  /// @param outputRenamedLayout Optional output layout used to change the
+  /// column names in the node's output.
   PlanBuilder& localPartitionRoundRobin(
       const std::vector<std::shared_ptr<const core::PlanNode>>& sources,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      const std::vector<std::string>& outputRenamedLayout = {});
 
   /// Add a HashJoinNode to join two inputs using one or more join keys and an
   /// optional filter.


### PR DESCRIPTION
Summary:
Presto Exchange node has 'inputs' field, which dictates the field/column order for each Exchange's source as it is required by the Exchange node itself.
Together with the each source's output layout, it provides the mapping between columns coming from each source to the columns Exchange is expecting.
We need to use that for mapping of the columns from the sources to the columns we output from the Exchange.
Before we used the 1st source output and Exchange's output for this mapping, but the column names aren't guaranteed to match, so mapping fails.

The example query, which fails:
**WITH dw_usage AS (VALUES ('2022-05-09')), mc_usage AS (VALUES ('2022-05-07')) SELECT * FROM mc_usage UNION ALL SELECT * FROM dw_usage;**

In this change we add "inputTypeFromSource" field to the LocalPartitionNode and use that and the source output layout for creating column mapping.

Note that the column mapping would be the same for all sources, so we use only the 1st source for the column mapping.

Differential Revision: D36438832

