### PR TITLE
Add check for duplicate subfield in PlanBuilder::tableScan

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -31,3 +31,13 @@
 #else
 #define VELOX_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
 #endif
+
+#define VELOX_ASSERT_THROW(expression, errorMessage)                 \
+  try {                                                              \
+    (expression);                                                    \
+    FAIL() << "Expected an exception";                               \
+  } catch (const VeloxException& e) {                                \
+    ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos) \
+        << "Expected error message to contain '" << errorMessage     \
+        << "', but received '" << e.message() << "'.";               \
+  }

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   MergeTest.cpp
   MergeJoinTest.cpp
   HashJoinTest.cpp
+  PlanBuilderTest.cpp
   PlanNodeToStringTest.cpp
   FunctionSignatureBuilderTest.cpp
   SimpleFunctionResolutionTest.cpp

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+
+class PlanBuilderTest : public testing::Test,
+                        public velox::test::VectorTestBase {
+ public:
+  PlanBuilderTest() {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+};
+
+TEST_F(PlanBuilderTest, duplicateSubfield) {
+  VELOX_ASSERT_THROW(
+      PlanBuilder()
+          .tableScan(
+              ROW({"a", "b"}, {BIGINT(), BIGINT()}),
+              {"a < 5", "b = 7", "a > 0"},
+              "a + b < 100")
+          .planNode(),
+      "Duplicate subfield: a");
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -14,20 +14,11 @@
  * limitations under the License.
  */
 #include "velox/exec/Task.h"
-#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/vector/tests/VectorTestBase.h"
-
-#define VELOX_ASSERT_THROW(expression, errorMessage)                  \
-  try {                                                               \
-    (expression);                                                     \
-    VELOX_FAIL("Expected an exception");                              \
-  } catch (const VeloxException& e) {                                 \
-    ASSERT_TRUE(e.isUserError());                                     \
-    ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos); \
-  }
 
 using namespace facebook::velox;
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -400,6 +400,12 @@ PlanBuilder& PlanBuilder::tableScan(
       subfield = common::Subfield(it->second);
     }
 
+    VELOX_CHECK_EQ(
+        filters.count(subfield),
+        0,
+        "Duplicate subfield: {}",
+        subfield.toString());
+
     filters[std::move(subfield)] = std::move(subfieldFilter);
   }
 

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -314,16 +314,16 @@ TEST_F(ArrayDistinctTest, invalidTypes) {
   EXPECT_THROW(
       testExpr(expected, "array_distinct(1)", {array}), std::invalid_argument);
   EXPECT_THROW(
-      testExpr(expected, "array_distinct(C0, CO)", {array, array}),
+      testExpr(expected, "array_distinct(c0, c0)", {array, array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_distinct(ARRAY[1], 1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_distinct(ARRAY[ARRAY[1]])", {array}),
-      facebook::velox::VeloxUserError);
+      VeloxUserError);
   EXPECT_THROW(
       testExpr(expected, "array_distinct()", {array}), std::invalid_argument);
 
-  EXPECT_NO_THROW(testExpr(expected, "array_distinct(C0)", {array}));
+  EXPECT_NO_THROW(testExpr(expected, "array_distinct(c0)", {array}));
 }

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -184,18 +184,18 @@ TEST_F(ArrayDuplicatesTest, invalidTypes) {
       testExpr(expected, "array_duplicates(1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
-      testExpr(expected, "array_duplicates(C0, CO)", {array, array}),
+      testExpr(expected, "array_duplicates(c0, c0)", {array, array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates(ARRAY[1], 1)", {array}),
       std::invalid_argument);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates(ARRAY[ARRAY[1]])", {array}),
-      facebook::velox::VeloxUserError);
+      VeloxUserError);
   EXPECT_THROW(
       testExpr(expected, "array_duplicates()", {array}), std::invalid_argument);
 
-  EXPECT_NO_THROW(testExpr(expected, "array_duplicates(C0)", {array}));
+  EXPECT_NO_THROW(testExpr(expected, "array_duplicates(c0)", {array}));
 }
 
 TEST_F(ArrayDuplicatesTest, invalidBooleanElementType) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "velox/type/Type.h"
-#include <gtest/gtest.h>
 #include <sstream>
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook;
 using namespace facebook::velox;
@@ -272,7 +272,8 @@ TEST(TypeTest, row) {
   EXPECT_THROW(row0->nameOf(4), std::out_of_range);
   EXPECT_THROW(row0->findChild("not_exist"), VeloxUserError);
   // todo: expected case behavior?:
-  EXPECT_THROW(row0->findChild("A"), VeloxUserError);
+  VELOX_ASSERT_THROW(
+      row0->findChild("A"), "Field not found: A. Available fields are: a, b.");
   EXPECT_EQ(row0->childAt(1)->toString(), "ROW<a:BIGINT>");
   EXPECT_EQ(row0->findChild("b")->toString(), "ROW<a:BIGINT>");
   EXPECT_EQ(row0->findChild("b")->asRow().findChild("a")->toString(), "BIGINT");


### PR DESCRIPTION
PlanBuilder::tableScan() takes a list a SQL expressions representing range
filters on individual columns. These filters are pushed down into DWRF reader.
Before this change, if there were multiple expressions using same column, all
but last one were ignored. This change is to throw an error if there are
multiple expressions using same column.