### PR TITLE
Fix replace function when input is reusable but inplace is not triggered

### DIFF
--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -421,17 +421,15 @@ class Replace : public exec::VectorFunction {
         (searchArgValue.value().size() >= replaceArgValue.value().size()) &&
         (args.at(0)->encoding() == VectorEncoding::Simple::FLAT);
 
-    bool inputVectorMoved =
-        prepareFlatResultsVector(result, rows, context, args.at(0));
-
-    bool inPlace = tryInplace && inputVectorMoved;
-
-    if (inPlace) {
-      auto* resultFlatVector = (*result)->as<FlatVector<StringView>>();
-      applyInPlace(
-          stringReader, searchReader, replaceReader, rows, resultFlatVector);
-      return;
+    if (tryInplace) {
+      if (prepareFlatResultsVector(result, rows, context, args.at(0))) {
+        auto* resultFlatVector = (*result)->as<FlatVector<StringView>>();
+        applyInPlace(
+            stringReader, searchReader, replaceReader, rows, resultFlatVector);
+        return;
+      }
     }
+
     // Not in place path
     VectorPtr emptyVectorPtr;
     prepareFlatResultsVector(result, rows, context, emptyVectorPtr);


### PR DESCRIPTION
Summary: When input is reusable, the result and input will share the same underlying data, and if the data for result is reallocated later, it will cause heap-use-after-free when reading from the input, which still points to the old data.

Differential Revision: D36495362

