### PR TITLE
Move retrieval of custom cast operator to CastExpr constructor

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -530,34 +530,23 @@ void CastExpr::apply(
         input->flatRawNulls(rows), rows.begin(), rows.end());
   }
 
-  CastOperatorPtr castOperator;
-  if ((castOperator = getCastOperator(toType->toString()))) {
-    if (!castOperator->isSupportedType(fromType)) {
-      VELOX_FAIL(
-          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
-    }
-
+  if (castToOperator_) {
     applyCustomTypeCast<true>(
         input,
         rows,
         *nonNullRows,
-        castOperator,
+        castToOperator_,
         toType,
         fromType,
         context,
         nullOnFailure_,
         result);
-  } else if ((castOperator = getCastOperator(fromType->toString()))) {
-    if (!castOperator->isSupportedType(toType)) {
-      VELOX_FAIL(
-          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
-    }
-
+  } else if (castFromOperator_) {
     applyCustomTypeCast<false>(
         input,
         rows,
         *nonNullRows,
-        castOperator,
+        castFromOperator_,
         fromType,
         toType,
         context,


### PR DESCRIPTION
Summary:
Move the look-ups of custom cast operators into CastExpr constructor because the custom cast operators do not change across batches.

This change is motivated by a previous performance study by kevinwilfong showing that getCastOperator took about 8.27% of the time for a query.

{F733005549}

Reviewed By: mbasmanova

Differential Revision: D36417719

