### PR TITLE
Fix Aggregate::clearNull() to call bits::clearNull() instead of bits::clearBit()

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -263,7 +263,7 @@ class Aggregate {
 
   static void clearNull(uint64_t* rawNulls, vector_size_t index) {
     if (rawNulls) {
-      bits::clearBit(rawNulls, index);
+      bits::clearNull(rawNulls, index);
     }
   }
 


### PR DESCRIPTION
Partial sum aggregation used to produce too many nulls when output vector was
reused. In this case, when writing not-null value into output vector, clearNull
calls set null instead of clearing it causing non-null results for 2-nd and
subsequent batches to become null.