### PR TITLE
Introduce HiveConnectorSplitBuilder

### DIFF
--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -74,7 +74,7 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
   AssertQueryBuilder(
       PlanBuilder().tableScan(asRowType(data->type())).planNode(),
       duckDbQueryRunner_)
-      .split(makeHiveSplit(file->path))
+      .split(makeHiveConnectorSplit(file->path))
       .assertResults("VALUES (1), (2), (3)");
 
   // Split with partition key.
@@ -90,7 +90,9 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
               assignments)
           .planNode(),
       duckDbQueryRunner_)
-      .split(makeHiveConnectorSplit(file->path, {{"ds", "2022-05-10"}}))
+      .split(HiveConnectorSplitBuilder(file->path)
+                 .partitionKey("ds", "2022-05-10")
+                 .build())
       .assertResults(
           "VALUES (1, '2022-05-10'), (2, '2022-05-10'), (3, '2022-05-10')");
 
@@ -119,8 +121,8 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
                       .planNode();
 
   AssertQueryBuilder(joinPlan, duckDbQueryRunner_)
-      .split(probeScanId, makeHiveSplit(file->path))
-      .split(buildScanId, makeHiveSplit(buildFile->path))
+      .split(probeScanId, makeHiveConnectorSplit(file->path))
+      .split(buildScanId, makeHiveConnectorSplit(buildFile->path))
       .assertResults("SELECT 2");
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -366,8 +366,8 @@ TEST_F(HashJoinTest, lazyVectors) {
                 .planNode();
 
   AssertQueryBuilder(op, duckDbQueryRunner_)
-      .split(rightScanId, makeHiveSplit(rightFile->path))
-      .split(leftScanId, makeHiveSplit(leftFile->path))
+      .split(rightScanId, makeHiveConnectorSplit(rightFile->path))
+      .split(leftScanId, makeHiveConnectorSplit(leftFile->path))
       .assertResults("SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
 
   planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
@@ -391,8 +391,8 @@ TEST_F(HashJoinTest, lazyVectors) {
            .planNode();
 
   AssertQueryBuilder(op, duckDbQueryRunner_)
-      .split(rightScanId, makeHiveSplit(rightFile->path))
-      .split(leftScanId, makeHiveSplit(leftFile->path))
+      .split(rightScanId, makeHiveConnectorSplit(rightFile->path))
+      .split(leftScanId, makeHiveConnectorSplit(leftFile->path))
       .assertResults(
           "SELECT t.c1 + 1, U.c1, length(t.c3) FROM t, u "
           "WHERE t.c0 = u.c0 and t.c2 < 29 and (t.c1 + u.c1) % 33 < 27");
@@ -669,7 +669,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -693,7 +693,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c0, t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u)");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -724,7 +724,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -745,7 +745,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -767,7 +767,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults("SELECT t.c0, t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -787,7 +787,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(probeScanId, makeHiveSplits(leftFiles))
+            .splits(probeScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults("SELECT t.c0 FROM t JOIN u ON (t.c0 = u.c0)");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(1, getFiltersAccepted(task, 0).sum);
@@ -807,7 +807,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 500");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -831,7 +831,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0 AND t.c0 < 200");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -850,7 +850,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults(
                 "SELECT t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u) AND t.c0 < 200");
     EXPECT_EQ(1, getFiltersProduced(task, 1).sum);
@@ -887,7 +887,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     auto task =
         AssertQueryBuilder(op, duckDbQueryRunner_)
-            .splits(leftScanId, makeHiveSplits(leftFiles))
+            .splits(leftScanId, makeHiveConnectorSplits(leftFiles))
             .assertResults("SELECT t.c1 + 1 FROM t, u WHERE (t.c0 + 1) = u.c0");
     EXPECT_EQ(0, getFiltersProduced(task, 1).sum);
     EXPECT_EQ(0, getFiltersAccepted(task, 0).sum);

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -88,7 +88,8 @@ TEST_F(LimitTest, limitOverLocalExchange) {
           .planNode();
 
   TaskCursor cursor(params);
-  cursor.task()->addSplit(scanNodeId, makeHiveSplit(file->path));
+  cursor.task()->addSplit(
+      scanNodeId, exec::Split(makeHiveConnectorSplit(file->path)));
 
   int32_t numRead = 0;
   while (cursor.moveNext()) {

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -135,7 +135,8 @@ TEST_F(LocalPartitionTest, gather) {
 
   AssertQueryBuilder queryBuilder(op, duckDbQueryRunner_);
   for (auto i = 0; i < filePaths.size(); ++i) {
-    queryBuilder.split(scanNodeIds[i], makeHiveSplit(filePaths[i]->path));
+    queryBuilder.split(
+        scanNodeIds[i], makeHiveConnectorSplit(filePaths[i]->path));
   }
 
   task = queryBuilder.assertResults("SELECT 300, -71, 152");
@@ -180,7 +181,8 @@ TEST_F(LocalPartitionTest, partition) {
   AssertQueryBuilder queryBuilder(op, duckDbQueryRunner_);
   queryBuilder.maxDrivers(2);
   for (auto i = 0; i < filePaths.size(); ++i) {
-    queryBuilder.split(scanNodeIds[i], makeHiveSplit(filePaths[i]->path));
+    queryBuilder.split(
+        scanNodeIds[i], makeHiveConnectorSplit(filePaths[i]->path));
   }
 
   auto task =
@@ -259,7 +261,8 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
   AssertQueryBuilder queryBuilder(op, duckDbQueryRunner_);
   queryBuilder.maxDrivers(2);
   for (auto i = 0; i < filePaths.size(); ++i) {
-    queryBuilder.split(scanNodeIds[i % 3], makeHiveSplit(filePaths[i]->path));
+    queryBuilder.split(
+        scanNodeIds[i % 3], makeHiveConnectorSplit(filePaths[i]->path));
   }
 
   // Set an artificially low buffer size limit to trigger blocking behavior.
@@ -481,7 +484,8 @@ TEST_F(LocalPartitionTest, multipleExchanges) {
 
   AssertQueryBuilder queryBuilder(op, duckDbQueryRunner_);
   for (auto i = 0; i < filePaths.size(); ++i) {
-    queryBuilder.split(scanNodeIds[i], makeHiveSplit(filePaths[i]->path));
+    queryBuilder.split(
+        scanNodeIds[i], makeHiveConnectorSplit(filePaths[i]->path));
   }
 
   queryBuilder.maxDrivers(2).assertResults(

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -494,8 +494,8 @@ TEST_F(MergeJoinTest, lazyVectors) {
                 .planNode();
 
   AssertQueryBuilder(op, duckDbQueryRunner_)
-      .split(rightScanId, makeHiveSplit(rightFile->path))
-      .split(leftScanId, makeHiveSplit(leftFile->path))
+      .split(rightScanId, makeHiveConnectorSplit(rightFile->path))
+      .split(leftScanId, makeHiveConnectorSplit(leftFile->path))
       .assertResults(
           "SELECT c0, rc0, c1, rc1, c2, c3  FROM t, u WHERE t.c0 = u.rc0 and c1 + rc1 < 30");
 }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -473,7 +473,8 @@ TEST_F(MultiFragmentTest, limit) {
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   Task::start(leafTask, 1);
 
-  leafTask.get()->addSplit("0", makeHiveSplit(file->path));
+  leafTask.get()->addSplit(
+      "0", exec::Split(makeHiveConnectorSplit(file->path)));
 
   // Make final task: Exchange -> FinalLimit(1).
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -48,11 +48,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
       int32_t numVectors,
       int32_t rowsPerVector);
 
-  std::shared_ptr<exec::Task> assertQuery(
-      const core::PlanNodePtr& plan,
-      const std::string& duckDbSql) {
-    return OperatorTestBase::assertQuery(plan, duckDbSql);
-  }
+  using OperatorTestBase::assertQuery;
 
   /// Assumes plan has a single TableScan node.
   std::shared_ptr<exec::Task> assertQuery(
@@ -62,15 +58,14 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);
 
-  static std::vector<std::shared_ptr<connector::ConnectorSplit>> makeHiveSplits(
+  static std::vector<std::shared_ptr<connector::ConnectorSplit>>
+  makeHiveConnectorSplits(
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths);
 
   static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
       const std::string& filePath,
       uint64_t start = 0,
-      uint64_t length = std::numeric_limits<uint64_t>::max()) {
-    return makeHiveConnectorSplit(filePath, {}, start, length);
-  }
+      uint64_t length = std::numeric_limits<uint64_t>::max());
 
   /// Split file at path 'filePath' into 'splitCount' splits.
   static std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
@@ -79,25 +74,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
       uint32_t splitCount,
       dwio::common::FileFormat format);
 
-  static std::shared_ptr<connector::ConnectorSplit> makeHiveConnectorSplit(
-      const std::string& filePath,
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          partitionKeys,
-      uint64_t start = 0,
-      uint64_t length = std::numeric_limits<uint64_t>::max());
-
-  static exec::Split makeHiveSplit(
-      const std::string& filePath,
-      uint64_t start = 0,
-      uint64_t length = std::numeric_limits<uint64_t>::max());
-
-  static exec::Split makeHiveSplitWithGroup(
-      const std::string& filePath,
-      int32_t groupId);
-
   static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
       common::test::SubfieldFilters subfieldFilters = {},
-      const std::shared_ptr<const core::ITypedExpr>& remainingFilter = nullptr,
+      const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table") {
     return std::make_shared<connector::hive::HiveTableHandle>(
         tableName, true, std::move(subfieldFilters), remainingFilter);
@@ -131,6 +110,58 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   SimpleLRUDataCache* dataCache;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+};
+
+class HiveConnectorSplitBuilder {
+ public:
+  HiveConnectorSplitBuilder(std::string filePath)
+      : filePath_{std::move(filePath)} {}
+
+  HiveConnectorSplitBuilder& start(uint64_t start) {
+    start_ = start;
+    return *this;
+  }
+
+  HiveConnectorSplitBuilder& length(uint64_t length) {
+    length_ = length;
+    return *this;
+  }
+
+  HiveConnectorSplitBuilder& fileFormat(dwio::common::FileFormat format) {
+    fileFormat_ = format;
+    return *this;
+  }
+
+  HiveConnectorSplitBuilder& partitionKey(
+      std::string name,
+      std::optional<std::string> value) {
+    partitionKeys_.emplace(std::move(name), std::move(value));
+    return *this;
+  }
+
+  HiveConnectorSplitBuilder& tableBucketNumber(int32_t bucket) {
+    tableBucketNumber_ = bucket;
+    return *this;
+  }
+
+  std::shared_ptr<connector::hive::HiveConnectorSplit> build() const {
+    return std::make_shared<connector::hive::HiveConnectorSplit>(
+        kHiveConnectorId,
+        "file:" + filePath_,
+        fileFormat_,
+        start_,
+        length_,
+        partitionKeys_,
+        tableBucketNumber_);
+  }
+
+ private:
+  const std::string filePath_;
+  dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::ORC};
+  uint64_t start_{0};
+  uint64_t length_{std::numeric_limits<uint64_t>::max()};
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys_;
+  std::optional<int32_t> tableBucketNumber_;
 };
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Add HiveConnectorSplitBuilder class to help modularize HiveConnectorTestBase.

Refactor HiveConnectorTestBase:
- Remove makeHiveSplits, makeHiveSplit, makeHiveSplitWithGroup methods. 
- Remove makeHiveConnectorSplit method that took partition keys.

The remaining methods in HiveConnectorTestBase to create hive splits are:
    - makeHiveConnectorSplit(path, start = 0, length = max)
    - makeHiveConnectorSplit(paths)
    - makeHiveConnectorSplit(path, splitCount, format)

Examples of usage of the new builder:

```
HiveConnectorSplitBuilder(filePaths[i]->path)
      .tableBucketNumber(bucket)
      .build();

  HiveConnectorSplitBuilder(filePath)
      .fileFormat(format)
      .start(i * splitSize)
      .length(splitSize)
      .build();

  HiveConnectorSplitBuilder(filePath).start(start).length(length).build();

  HiveConnectorSplitBuilder(file->path)
      .partitionKey("ds", "2022-05-10")
      .build();
```
