### PR TITLE
Add Connector::canAddDynamicFilter API

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -59,8 +59,19 @@ class ColumnHandle {
 
 class ConnectorTableHandle {
  public:
+  explicit ConnectorTableHandle(std::string connectorId)
+      : connectorId_(std::move(connectorId)) {}
+
   virtual ~ConnectorTableHandle() = default;
+
   virtual std::string toString() const = 0;
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+ private:
+  const std::string connectorId_;
 };
 
 /**
@@ -217,6 +228,12 @@ class Connector {
 
   const std::shared_ptr<const Config>& connectorProperties() const {
     return properties_;
+  }
+
+  // Returns true if this connector would accept a filter dynamically generated
+  // during query execution.
+  virtual bool canAddDynamicFilter() const {
+    return false;
   }
 
   // TODO Generalize to specify TableHandle/Layout and ColumnHandles.

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -41,11 +41,13 @@ static const char* kBucket = "$bucket";
 } // namespace
 
 HiveTableHandle::HiveTableHandle(
+    std::string connectorId,
     const std::string& tableName,
     bool filterPushdownEnabled,
     SubfieldFilters subfieldFilters,
-    const std::shared_ptr<const core::ITypedExpr>& remainingFilter)
-    : tableName_(tableName),
+    const core::TypedExprPtr& remainingFilter)
+    : ConnectorTableHandle(std::move(connectorId)),
+      tableName_(tableName),
       filterPushdownEnabled_(filterPushdownEnabled),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter) {}

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -62,10 +62,11 @@ using SubfieldFilters =
 class HiveTableHandle : public ConnectorTableHandle {
  public:
   HiveTableHandle(
+      std::string connectorId,
       const std::string& tableName,
       bool filterPushdownEnabled,
       SubfieldFilters subfieldFilters,
-      const std::shared_ptr<const core::ITypedExpr>& remainingFilter);
+      const core::TypedExprPtr& remainingFilter);
 
   ~HiveTableHandle() override;
 
@@ -77,7 +78,7 @@ class HiveTableHandle : public ConnectorTableHandle {
     return subfieldFilters_;
   }
 
-  const std::shared_ptr<const core::ITypedExpr>& remainingFilter() const {
+  const core::TypedExprPtr& remainingFilter() const {
     return remainingFilter_;
   }
 
@@ -87,7 +88,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const std::string tableName_;
   const bool filterPushdownEnabled_;
   const SubfieldFilters subfieldFilters_;
-  const std::shared_ptr<const core::ITypedExpr> remainingFilter_;
+  const core::TypedExprPtr remainingFilter_;
 };
 
 /**
@@ -226,6 +227,10 @@ class HiveConnector final : public Connector {
       const std::string& id,
       std::shared_ptr<const Config> properties,
       folly::Executor* FOLLY_NULLABLE executor);
+
+  bool canAddDynamicFilter() const override {
+    return true;
+  }
 
   std::shared_ptr<DataSource> createDataSource(
       const std::shared_ptr<const RowType>& outputType,

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -40,8 +40,13 @@ class TpchColumnHandle : public ColumnHandle {
 // TPC-H table handle uses the underlying enum to describe the target table.
 class TpchTableHandle : public ConnectorTableHandle {
  public:
-  explicit TpchTableHandle(velox::tpch::Table table, size_t scaleFactor = 1)
-      : table_(table), scaleFactor_(scaleFactor) {}
+  explicit TpchTableHandle(
+      std::string connectorId,
+      velox::tpch::Table table,
+      size_t scaleFactor = 1)
+      : ConnectorTableHandle(std::move(connectorId)),
+        table_(table),
+        scaleFactor_(scaleFactor) {}
 
   ~TpchTableHandle() override {}
 

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -115,7 +115,8 @@ TEST_F(TpchConnectorTest, singleColumnWithAlias) {
       PlanBuilder()
           .tableScan(
               outputType,
-              std::make_shared<TpchTableHandle>(Table::TBL_NATION),
+              std::make_shared<TpchTableHandle>(
+                  kTpchConnectorId, Table::TBL_NATION),
               {
                   {aliasedName, std::make_shared<TpchColumnHandle>("n_name")},
                   {"other_name", std::make_shared<TpchColumnHandle>("n_name")},
@@ -140,7 +141,7 @@ void TpchConnectorTest::runScaleFactorTest(size_t scaleFactor) {
                   .tableScan(
                       ROW({}, {}),
                       std::make_shared<TpchTableHandle>(
-                          Table::TBL_SUPPLIER, scaleFactor),
+                          kTpchConnectorId, Table::TBL_SUPPLIER, scaleFactor),
                       {})
                   .singleAggregation({}, {"count(1)"})
                   .planNode();
@@ -168,6 +169,45 @@ TEST_F(TpchConnectorTest, unknownColumn) {
             .planNode();
       },
       VeloxUserError);
+}
+
+// Join nation and region.
+TEST_F(TpchConnectorTest, join) {
+  auto planNodeIdGenerator =
+      std::make_shared<exec::test::PlanNodeIdGenerator>();
+  core::PlanNodeId nationScanId;
+  core::PlanNodeId regionScanId;
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              tpch::Table::TBL_NATION, {"n_regionkey"}, 1 /*scaleFactor*/)
+          .capturePlanNodeId(nationScanId)
+          .hashJoin(
+              {"n_regionkey"},
+              {"r_regionkey"},
+              PlanBuilder(planNodeIdGenerator)
+                  .tableScan(
+                      tpch::Table::TBL_REGION,
+                      {"r_regionkey", "r_name"},
+                      1 /*scaleFactor*/)
+                  .capturePlanNodeId(regionScanId)
+                  .planNode(),
+              "", // extra filter
+              {"r_name"})
+          .singleAggregation({"r_name"}, {"count(1) as nation_cnt"})
+          .orderBy({"r_name"}, false)
+          .planNode();
+
+  auto output = getResults(
+      plan,
+      {{nationScanId, {makeTpchSplit()}}, {regionScanId, {makeTpchSplit()}}});
+
+  auto expected = makeRowVector({
+      makeFlatVector<StringView>(
+          {"AFRICA", "AMERICA", "ASIA", "EUROPE", "MIDDLE EAST"}),
+      makeConstant<int64_t>(5, 5),
+  });
+  test::assertEqualVectors(expected, output);
 }
 
 } // namespace

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -40,9 +40,7 @@ class TableScan : public SourceOperator {
   bool isFinished() override;
 
   bool canAddDynamicFilter() const override {
-    // TODO Consult with the connector. Return true only if connector can accept
-    // dynamic filters.
-    return true;
+    return connector_->canAddDynamicFilter();
   }
 
   void addDynamicFilter(

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -79,7 +79,11 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table") {
     return std::make_shared<connector::hive::HiveTableHandle>(
-        tableName, true, std::move(subfieldFilters), remainingFilter);
+        kHiveConnectorId,
+        tableName,
+        true,
+        std::move(subfieldFilters),
+        remainingFilter);
   }
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -33,6 +33,10 @@ namespace facebook::velox::exec::test {
 
 namespace {
 
+// TODO Avoid duplication.
+static const std::string kHiveConnectorId = "test-hive";
+static const std::string kTpchConnectorId = "test-tpch";
+
 std::shared_ptr<const core::ITypedExpr> parseExpr(
     const std::string& text,
     const RowTypePtr& rowType,
@@ -416,7 +420,11 @@ PlanBuilder& PlanBuilder::tableScan(
   }
 
   auto tableHandle = std::make_shared<HiveTableHandle>(
-      tableName, true, std::move(filters), remainingFilterExpr);
+      kHiveConnectorId,
+      tableName,
+      true,
+      std::move(filters),
+      remainingFilterExpr);
   return tableScan(outputType, tableHandle, assignments);
 }
 
@@ -451,7 +459,8 @@ PlanBuilder& PlanBuilder::tableScan(
   auto rowType = ROW(std::move(columnNames), std::move(outputTypes));
   return tableScan(
       rowType,
-      std::make_shared<connector::tpch::TpchTableHandle>(table, scaleFactor),
+      std::make_shared<connector::tpch::TpchTableHandle>(
+          kTpchConnectorId, table, scaleFactor),
       assignmentsMap);
 }
 


### PR DESCRIPTION
The new API allows TableScan operator to find out whether the connectors support
dynamic filter pushdown or not. Hive connector supports dynamic filter
pushdown, but TPC-H connector doesn't. 

Also, modified ConnectorTableHandle to add connectorId field. This is necessary
to allow TableScan operator to lookup the connector and find out whether it
supports dynamic filter pushdown in time to respond to the same question from the 
Driver.