### PR TITLE
Add AssertQueryBuilder::copyResults(pool) method

### DIFF
--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/tpch/TpchConnector.h"
 #include <folly/init/Init.h>
 #include "gtest/gtest.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -48,6 +49,14 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
 
   exec::Split makeTpchSplit() const {
     return exec::Split(std::make_shared<TpchConnectorSplit>(kTpchConnectorId));
+  }
+
+  RowVectorPtr getResults(
+      const core::PlanNodePtr& planNode,
+      std::vector<exec::Split>&& splits) {
+    return exec::test::AssertQueryBuilder(planNode)
+        .splits(std::move(splits))
+        .copyResults(pool());
   }
 
   void runScaleFactorTest(size_t scaleFactor);
@@ -169,7 +178,6 @@ TEST_F(TpchConnectorTest, unknownColumn) {
       },
       VeloxUserError);
 }
-
 } // namespace
 
 int main(int argc, char** argv) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -94,6 +94,10 @@ class AssertQueryBuilder {
   std::shared_ptr<Task> assertResults(
       const std::vector<RowVectorPtr>& expected);
 
+  /// Run the query and collect all results into a single vector. Throws if
+  /// query returns empty result.
+  RowVectorPtr copyResults(memory::MemoryPool* pool);
+
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -110,28 +110,9 @@ class OperatorTestBase : public testing::Test,
       const std::string& duckDbSql,
       std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
 
-  RowVectorPtr getResults(const core::PlanNodePtr& planNode);
-
-  /// Assumes plan has a single leaf node. All splits are added to that node.
-  RowVectorPtr getResults(
-      const core::PlanNodePtr& planNode,
-      std::vector<exec::Split>&& splits);
-
-  RowVectorPtr getResults(
-      const core::PlanNodePtr& planNode,
-      std::unordered_map<core::PlanNodeId, std::vector<exec::Split>>&& splits);
-
-  RowVectorPtr getResults(const CursorParameters& params);
-
-  /// Assumes plan has a single leaf node. All splits are added to that node.
-  RowVectorPtr getResults(
-      const CursorParameters& params,
-      std::function<void(exec::Task*)> addSplits);
-
-  static RowTypePtr makeRowType(
-      std::vector<std::shared_ptr<const Type>>&& types) {
+  static RowTypePtr makeRowType(std::vector<TypePtr>&& types) {
     return velox::test::VectorMaker::rowType(
-        std::forward<std::vector<std::shared_ptr<const Type>>&&>(types));
+        std::forward<std::vector<TypePtr>&&>(types));
   }
 
   static std::shared_ptr<core::FieldAccessTypedExpr> toFieldExpr(

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -710,12 +710,15 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     std::function<void(exec::Task*)> addSplits) {
   std::vector<RowVectorPtr> result;
   auto cursor = std::make_unique<TaskCursor>(params);
-  addSplits(cursor->task().get());
+  auto* task = cursor->task().get();
+  addSplits(task);
 
   while (cursor->moveNext()) {
     result.push_back(cursor->current());
-    addSplits(cursor->task().get());
+    addSplits(task);
   }
+
+  EXPECT_TRUE(waitForTaskCompletion(task));
   return {std::move(cursor), std::move(result)};
 }
 


### PR DESCRIPTION
Add AssertQueryBuilder::copyResults(pool) method to execute the query and copy
the results into a single vector allocated from the specified memory pool.
Remove OperatorTestBase::getResult() methods in favor of the new method.

Also, fix the logic of copying results into a single vector. Previous version
worked only if query returned a single vector. If there were multiple vectors
of results, the returned vector contained the data from the last result vector
only.