### PR TITLE
Build googletest only if testing or basic benchmarking are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,11 +294,10 @@ endif()
 
 # Benchmarks and tests at some places are coupled which is not great. See
 # velox/vector/CMakeLists.txt. TODO: Decouple.
+set(VELOX_DISABLE_GOOGLETEST OFF)
 if(NOT VELOX_BUILD_TESTING AND NOT VELOX_ENABLE_BENCHMARKS_BASIC)
-  set(VELOX_ENABLE_GOOGLETEST OFF)
-else()
-  set(VELOX_ENABLE_GOOGLETEST ON)
-  add_definitions(-DVELOX_ENABLE_GOOGLETEST)
+  set(VELOX_DISABLE_GOOGLETEST ON)
+  add_definitions(-DVELOX_DISABLE_GOOGLETEST)
 endif()
 
 include_directories(SYSTEM velox)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,9 @@ endif()
 
 # Benchmarks and tests at some places are coupled which is not great. See
 # velox/vector/CMakeLists.txt. TODO: Decouple.
-set(VELOX_ENABLE_GOOGLETEST OFF)
-if(VELOX_BUILD_TESTING OR VELOX_ENABLE_BENCHMARKS_BASIC)
+if(NOT VELOX_BUILD_TESTING AND NOT VELOX_ENABLE_BENCHMARKS_BASIC)
+  set(VELOX_ENABLE_GOOGLETEST OFF)
+else()
   set(VELOX_ENABLE_GOOGLETEST ON)
   add_definitions(-DVELOX_ENABLE_GOOGLETEST)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,14 @@ if(VELOX_BUILD_TESTING AND NOT VELOX_ENABLE_DUCKDB)
   )
 endif()
 
+# Benchmarks and tests at some places are coupled which is not great. See
+# velox/vector/CMakeLists.txt. TODO: Decouple.
+set(VELOX_ENABLE_GOOGLETEST OFF)
+if(VELOX_BUILD_TESTING OR VELOX_ENABLE_BENCHMARKS_BASIC)
+  set(VELOX_ENABLE_GOOGLETEST ON)
+  add_definitions(-DVELOX_ENABLE_GOOGLETEST)
+endif()
+
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(VELOX_ENABLE_GOOGLETEST)
+if(NOT VELOX_DISABLE_GOOGLETEST)
   add_subdirectory(googletest)
 endif()
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -11,5 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(googletest)
+
+if(VELOX_ENABLE_GOOGLETEST)
+  add_subdirectory(googletest)
+endif()
+
 add_subdirectory(xsimd)

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -23,8 +23,6 @@ set(velox_benchmark_deps
     ${FOLLY}
     ${FOLLY_BENCHMARK}
     ${DOUBLE_CONVERSION}
-    gtest
-    gtest_main
     ${gflags_LIBRARIES}
     glog::glog)
 

--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -33,9 +33,6 @@ target_link_libraries(
   velox_type
   velox_caching
   velox_vector
-  velox_vector_test_lib
-  gtest
-  gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK}
   ${FMT})

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -20,7 +20,7 @@
 #include <gtest/gtest_prod.h>
 #define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
 #else
-// FRIEND_TEST macro is only used when testing is enabled.
+// VELOX_FRIEND_TEST macro is only used when testing is enabled.
 // Replacing it with "nothing" is okay when testing is disabled.
 #define VELOX_FRIEND_TEST(X, Y)
 #endif

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -18,10 +18,9 @@
 
 #ifdef VELOX_ENABLE_GOOGLETEST
 #include <gtest/gtest_prod.h>
+#define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
 #else
-#ifndef FRIEND_TEST
 // FRIEND_TEST macro is only used when testing is enabled.
 // Replacing it with "nothing" is okay when testing is disabled.
-#define FRIEND_TEST(X, Y)
-#endif
+#define VELOX_FRIEND_TEST(X, Y)
 #endif

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#ifdef VELOX_ENABLE_GOOGLETEST
-#include <gtest/gtest_prod.h>
-#define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
-#else
+#ifdef VELOX_DISABLE_GOOGLETEST
 // VELOX_FRIEND_TEST macro is only used when testing is enabled.
 // Replacing it with "nothing" is okay when testing is disabled.
 #define VELOX_FRIEND_TEST(X, Y)
+#else
+#include <gtest/gtest_prod.h>
+#define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
 #endif

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -19,7 +19,9 @@
 #ifdef VELOX_ENABLE_GOOGLETEST
 #include <gtest/gtest_prod.h>
 #else
+#ifndef FRIEND_TEST
 // FRIEND_TEST macro is only used when testing is enabled.
 // Replacing it with "nothing" is okay when testing is disabled.
 #define FRIEND_TEST(X, Y)
+#endif
 #endif

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef VELOX_ENABLE_GOOGLETEST
+#include <gtest/gtest_prod.h>
+#else
+#define FRIEND_TEST(X, Y)
+#endif

--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -19,5 +19,7 @@
 #ifdef VELOX_ENABLE_GOOGLETEST
 #include <gtest/gtest_prod.h>
 #else
+// FRIEND_TEST macro is only used when testing is enabled.
+// Replacing it with "nothing" is okay when testing is disabled.
 #define FRIEND_TEST(X, Y)
 #endif

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -30,6 +30,6 @@ add_library(
 target_link_libraries(velox_memory velox_flag_definitions velox_exception gtest
                       ${FOLLY_WITH_DEPENDENCIES})
 
-if(VELOX_ENABLE_GOOGLETEST)
+if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(velox_memory gtest)
 endif()

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -29,3 +29,7 @@ add_library(
 
 target_link_libraries(velox_memory velox_flag_definitions velox_exception gtest
                       ${FOLLY_WITH_DEPENDENCIES})
+
+if(VELOX_ENABLE_GOOGLETEST)
+  target_link_libraries(velox_memory gtest)
+endif()

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -405,7 +405,7 @@ class MemoryPoolImpl : public MemoryPoolBase {
   int64_t getSubtreeMaxBytes() const;
 
  private:
-  FRIEND_TEST(MemoryPoolTest, Ctor);
+  VELOX_FRIEND_TEST(MemoryPoolTest, Ctor);
 
   template <uint16_t A>
   struct ALIGNER {};
@@ -548,12 +548,12 @@ class MemoryManager final : public IMemoryManager {
   Allocator& getAllocator();
 
  private:
-  FRIEND_TEST(MemoryPoolImplTest, CapSubtree);
-  FRIEND_TEST(MemoryPoolImplTest, CapAllocation);
-  FRIEND_TEST(MemoryPoolImplTest, UncapMemory);
-  FRIEND_TEST(MemoryPoolImplTest, MemoryManagerGlobalCap);
-  FRIEND_TEST(MultiThreadingUncappingTest, Flat);
-  FRIEND_TEST(MultiThreadingUncappingTest, SimpleTree);
+  VELOX_FRIEND_TEST(MemoryPoolImplTest, CapSubtree);
+  VELOX_FRIEND_TEST(MemoryPoolImplTest, CapAllocation);
+  VELOX_FRIEND_TEST(MemoryPoolImplTest, UncapMemory);
+  VELOX_FRIEND_TEST(MemoryPoolImplTest, MemoryManagerGlobalCap);
+  VELOX_FRIEND_TEST(MultiThreadingUncappingTest, Flat);
+  VELOX_FRIEND_TEST(MultiThreadingUncappingTest, SimpleTree);
 
   std::shared_ptr<Allocator> allocator_;
   const int64_t memoryQuota_;

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -24,15 +24,14 @@
 #include <string>
 
 #include <fmt/format.h>
-#include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <gtest/gtest_prod.h>
 
 #include "folly/CPortability.h"
 #include "folly/Likely.h"
 #include "folly/Random.h"
 #include "folly/SharedMutex.h"
 #include "folly/experimental/FunctionScheduler.h"
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 

--- a/velox/dwio/common/ChainedBuffer.h
+++ b/velox/dwio/common/ChainedBuffer.h
@@ -202,16 +202,16 @@ class ChainedBuffer {
     return val + 1;
   }
 
-  FRIEND_TEST(ChainedBufferTests, testCreate);
-  FRIEND_TEST(ChainedBufferTests, testReserve);
-  FRIEND_TEST(ChainedBufferTests, testAppend);
-  FRIEND_TEST(ChainedBufferTests, testClear);
-  FRIEND_TEST(ChainedBufferTests, testGetPage);
-  FRIEND_TEST(ChainedBufferTests, testGetPageIndex);
-  FRIEND_TEST(ChainedBufferTests, testGetPageOffset);
-  FRIEND_TEST(ChainedBufferTests, testBitCount);
-  FRIEND_TEST(ChainedBufferTests, testTrailingZeros);
-  FRIEND_TEST(ChainedBufferTests, testPowerOf2);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testCreate);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testReserve);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testAppend);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testClear);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testGetPage);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testGetPageIndex);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testGetPageOffset);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testBitCount);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testTrailingZeros);
+  VELOX_FRIEND_TEST(ChainedBufferTests, testPowerOf2);
 };
 
 } // namespace common

--- a/velox/dwio/common/ChainedBuffer.h
+++ b/velox/dwio/common/ChainedBuffer.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
 #include <bitset>
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/DataBuffer.h"
 
 namespace facebook {

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -197,7 +197,7 @@ class IntEncoder {
   FOLLY_ALWAYS_INLINE int32_t writeVslong(int64_t value, char* buffer);
   FOLLY_ALWAYS_INLINE int32_t writeLongLE(int64_t value, char* buffer);
 
-  FRIEND_TEST(TestIntEncoder, TestVarIntEncoder);
+  VELOX_FRIEND_TEST(TestIntEncoder, TestVarIntEncoder);
 };
 
 #define WRITE_INTS(FUNC)                                       \

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <folly/Varint.h>
-#include <gtest/gtest_prod.h>
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -198,8 +198,8 @@ class RleEncoderV1 : public IntEncoder<isSigned> {
     }
   }
 
-  FRIEND_TEST(RleEncoderV1Test, encodeMinAndMax);
-  FRIEND_TEST(RleEncoderV1Test, encodeMinAndMaxint32);
+  VELOX_FRIEND_TEST(RleEncoderV1Test, encodeMinAndMax);
+  VELOX_FRIEND_TEST(RleEncoderV1Test, encodeMinAndMaxint32);
 };
 
 template <bool isSigned>

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/dwrf/common/Adaptor.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"

--- a/velox/dwio/dwrf/common/Range.h
+++ b/velox/dwio/dwrf/common/Range.h
@@ -120,8 +120,8 @@ class Ranges {
   std::vector<std::tuple<size_t, size_t>> ranges_;
   size_t size_{0};
 
-  FRIEND_TEST(RangeTests, Add);
-  FRIEND_TEST(RangeTests, Filter);
+  VELOX_FRIEND_TEST(RangeTests, Add);
+  VELOX_FRIEND_TEST(RangeTests, Filter);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/Range.h
+++ b/velox/dwio/dwrf/common/Range.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook::velox::dwrf {

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.h
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.h
@@ -58,7 +58,7 @@ class StripeDictionaryCache {
       EncodingKeyHash>
       intDictionaryFactories_;
 
-  FRIEND_TEST(TestStripeDictionaryCache, RegisterDictionary);
+  VELOX_FRIEND_TEST(TestStripeDictionaryCache, RegisterDictionary);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.h
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.h
@@ -16,10 +16,9 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
-
 #include <folly/Function.h>
 
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/vector/BaseVector.h"

--- a/velox/dwio/dwrf/test/TestWriterFlush.cpp
+++ b/velox/dwio/dwrf/test/TestWriterFlush.cpp
@@ -156,7 +156,7 @@ class DummyWriter : public velox::dwrf::WriterShared {
   MOCK_METHOD0(resetImpl, void());
 
   friend class WriterFlushTestHelper;
-  FRIEND_TEST(TestWriterFlush, CheckAgainstMemoryBudget);
+  VELOX_FRIEND_TEST(TestWriterFlush, CheckAgainstMemoryBudget);
 };
 
 // Big idea is to directly manipulate context states (num rows) + memory pool

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -225,7 +225,7 @@ class ColumnWriter {
   // in_map stream
   const std::function<void(IndexBuilder&)> onRecordPosition_;
 
-  FRIEND_TEST(ColumnWriterTests, LowMemoryModeConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTests, LowMemoryModeConfig);
   friend class ValueStatisticsBuilder;
 };
 

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include "gtest/gtest_prod.h"
-
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"

--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"

--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -275,9 +275,9 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
   }
 
  private:
-  FRIEND_TEST(TestIntegerDictionaryEncoder, Clear);
-  FRIEND_TEST(TestIntegerDictionaryEncoder, GetCount);
-  FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, Clear);
+  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, GetCount);
+  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
 
   // TODO: partially specialize for integers only.
   template <typename T>

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <folly/container/F14Set.h>
-#include <gtest/gtest_prod.h>
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 #include "velox/dwio/dwrf/writer/DictionaryEncodingUtils.h"

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -47,7 +47,7 @@ class LayoutPlanner {
     static void sort(StreamList::iterator begin, StreamList::iterator end);
   };
 
-  FRIEND_TEST(LayoutPlannerTests, Basic);
+  VELOX_FRIEND_TEST(LayoutPlannerTests, Basic);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
@@ -172,10 +172,10 @@ class StringDictionaryEncoder {
   }
 
  private:
-  FRIEND_TEST(TestStringDictionaryEncoder, GetCount);
-  FRIEND_TEST(TestStringDictionaryEncoder, GetIndex);
-  FRIEND_TEST(TestStringDictionaryEncoder, GetStride);
-  FRIEND_TEST(TestStringDictionaryEncoder, Clear);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetCount);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetIndex);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetStride);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, Clear);
 
   // Intended for testing only.
   uint32_t getIndex(folly::StringPiece sp) {

--- a/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
@@ -18,7 +18,8 @@
 
 #include <folly/container/F14Set.h>
 #include <folly/hash/Checksum.h>
-#include <gtest/gtest_prod.h>
+
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/DataBuffer.h"
 
 namespace facebook::velox::dwrf {

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -163,7 +163,7 @@ class WriterBase {
   void writeUserMetadata(uint32_t writerVersion);
 
   friend class WriterTest;
-  FRIEND_TEST(WriterBaseTest, FlushWriterSinkUponClose);
+  VELOX_FRIEND_TEST(WriterBaseTest, FlushWriterSinkUponClose);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "gtest/gtest_prod.h"
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/writer/WriterContext.h"
 #include "velox/dwio/dwrf/writer/WriterSink.h"
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -497,8 +497,8 @@ class WriterContext : public CompressionBufferPool {
   friend class IntegerColumnWriterDirectEncodingIndexTest;
   friend class StringColumnWriterDictionaryEncodingIndexTest;
   friend class StringColumnWriterDirectEncodingIndexTest;
-  FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
-  FRIEND_TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode);
+  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode);
   // TODO: remove once writer code is consolidated
   template <typename TestType>
   friend class WriterEncodingIndexTest2;

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
-
+#include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Compression.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"

--- a/velox/dwio/dwrf/writer/WriterShared.h
+++ b/velox/dwio/dwrf/writer/WriterShared.h
@@ -64,8 +64,8 @@ class EncodingIter {
 
   void next();
 
-  FRIEND_TEST(TestEncodingIter, Ctor);
-  FRIEND_TEST(TestEncodingIter, EncodingIterBeginAndEnd);
+  VELOX_FRIEND_TEST(TestEncodingIter, Ctor);
+  VELOX_FRIEND_TEST(TestEncodingIter, EncodingIterBeginAndEnd);
   bool emptyEncryptionGroups() const;
 
   const proto::StripeFooter& footer_;

--- a/velox/dwio/dwrf/writer/WriterShared.h
+++ b/velox/dwio/dwrf/writer/WriterShared.h
@@ -19,8 +19,7 @@
 #include <iterator>
 #include <limits>
 
-#include <gtest/gtest_prod.h>
-
+#include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/dwrf/common/Encryption.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/proto/dwrf_proto.pb.h"

--- a/velox/expression/benchmarks/CMakeLists.txt
+++ b/velox/expression/benchmarks/CMakeLists.txt
@@ -13,14 +13,8 @@
 # limitations under the License.
 
 set(BENCHMARK_DEPENDENCIES
-    velox_functions_test_lib
-    velox_exec
-    velox_exec_test_util
-    gtest
-    gtest_main
-    ${gflags_LIBRARIES}
-    ${FOLLY_WITH_DEPENDENCIES}
-    ${FOLLY_BENCHMARK})
+    velox_functions_test_lib velox_exec velox_exec_test_util
+    ${gflags_LIBRARIES} ${FOLLY_WITH_DEPENDENCIES} ${FOLLY_BENCHMARK})
 
 add_executable(velox_benchmark_call_null_free_no_nulls
                CallNullFreeBenchmark.cpp)

--- a/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
@@ -23,6 +23,4 @@ target_link_libraries(
   velox_dwio_common_exception
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK}
-  gtest
-  gtest_main
   ${GFLAGS_LIBRARIES})

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -13,14 +13,8 @@
 # limitations under the License.
 
 set(BENCHMARK_DEPENDENCIES_NO_FUNC
-    velox_functions_test_lib
-    velox_exec
-    velox_exec_test_util
-    gtest
-    gtest_main
-    ${gflags_LIBRARIES}
-    ${FOLLY_WITH_DEPENDENCIES}
-    ${FOLLY_BENCHMARK})
+    velox_functions_test_lib velox_exec velox_exec_test_util
+    ${gflags_LIBRARIES} ${FOLLY_WITH_DEPENDENCIES} ${FOLLY_BENCHMARK})
 
 set(BENCHMARK_DEPENDENCIES
     velox_functions_prestosql velox_functions_lib velox_vector_fuzzer


### PR DESCRIPTION
Also, adds a dummy definition for`FRIEND_TEST` when googletest is disabled.
Resolves https://github.com/facebookincubator/velox/issues/1654