### PR TITLE
Allow null values to be generated for nested structs

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -130,7 +130,11 @@ class VectorFuzzer {
 
   VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
 
-  VectorPtr fuzzRow(const RowTypePtr& rowType, vector_size_t size);
+  VectorPtr
+  fuzzRow(const RowTypePtr& rowType, vector_size_t size, bool mayHaveNulls);
+
+  // Generate a random null vector.
+  BufferPtr fuzzNulls(vector_size_t size);
 
   VectorFuzzer::Options opts_;
 


### PR DESCRIPTION
Summary: Existing logic always creates non-null rows. This is true for the root row, but may not be for nested ones. Adding the logic so we can get better coverage.

Differential Revision: D36564148

