### PR TITLE
Add recycling of intermediate result vectors

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -153,7 +153,9 @@ class SimpleArithmeticBenchmark
 
     size_t count = 0;
     for (auto i = 0; i < times * 1'000; i++) {
-      count += evaluate(exprSet, input)->size();
+      auto result = evaluate(exprSet, input);
+      count += result->size();
+      execCtx_.releaseVector(result);
     }
     return count;
   }

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -22,6 +22,8 @@
 #include "velox/core/Context.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/VectorPool.h"
 
 namespace facebook::velox::core {
 
@@ -211,6 +213,27 @@ class ExecCtx : public Context {
     decodedVectorPool_.push_back(std::move(vector));
   }
 
+  VectorPool& vectorPool() {
+    return vectorPool_;
+  }
+
+  // Gets a possibly recycled vector of 'type and 'size'. Allocates from 'pool_'
+  // if no preallocated vector.
+  VectorPtr getVector(const TypePtr& type, vector_size_t size) {
+    return vectorPool_.get(type, size, *pool_);
+  }
+
+  // Moves 'vector' to reusable pool if it is suitable, else leaves it in place.
+  void releaseVector(VectorPtr& vector) {
+    vectorPool_.release(vector);
+  }
+
+  // Moves elements of 'vectors' to reusable pool if suitable, else leaves them
+  // in place.
+  void releaseVectors(std::vector<VectorPtr>& vectors) {
+    vectorPool_.release(vectors);
+  }
+
  private:
   // Pool for all Buffers for this thread
   memory::MemoryPool* FOLLY_NONNULL pool_;
@@ -220,6 +243,8 @@ class ExecCtx : public Context {
   // A pool of preallocated SelectivityVectors for use by expressions
   // and operators.
   std::vector<std::unique_ptr<SelectivityVector>> selectivityVectorPool_;
+
+  VectorPool vectorPool_;
 };
 
 } // namespace facebook::velox::core

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -89,7 +89,7 @@ void FieldReference::evalSpecialForm(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
   if (result) {
-    BaseVector::ensureWritable(rows, type_, context.pool(), &result);
+    context.ensureWritable(rows, type_, result);
   }
   const RowVector* row;
   DecodedVector decoded;
@@ -223,8 +223,7 @@ void SwitchExpr::evalSpecialForm(
 
         if (thenRows.get()->hasSelections()) {
           if (result) {
-            BaseVector::ensureWritable(
-                *thenRows.get(), result->type(), context.pool(), &result);
+            context.ensureWritable(*thenRows.get(), result->type(), result);
           }
 
           inputs_[2 * i + 1]->eval(*thenRows.get(), context, result);
@@ -237,8 +236,7 @@ void SwitchExpr::evalSpecialForm(
   // Evaluate the "else" clause.
   if (remainingRows.get()->hasSelections()) {
     if (result) {
-      BaseVector::ensureWritable(
-          *remainingRows.get(), result->type(), context.pool(), &result);
+      context.ensureWritable(*remainingRows.get(), result->type(), result);
     }
 
     if (hasElseClause_) {
@@ -372,7 +370,7 @@ void ConjunctExpr::evalSpecialForm(
   // TODO Revisit error handling
   bool throwOnError = *context.mutableThrowOnError();
   VarSetter saveError(context.mutableThrowOnError(), false);
-  BaseVector::ensureWritable(rows, type(), context.pool(), &result);
+  context.ensureWritable(rows, type(), result);
   auto flatResult = result->asFlatVector<bool>();
   // clear nulls from the result for the active rows.
   if (flatResult->mayHaveNulls()) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -208,6 +208,32 @@ class EvalCtx {
     moveOrCopyResult(localResult, rows, *result);
   }
 
+  VectorPool& vectorPool() const {
+    return execCtx_->vectorPool();
+  }
+
+  VectorPtr getVector(const TypePtr& type, vector_size_t size) {
+    return execCtx_->getVector(type, size);
+  }
+
+  void releaseVector(VectorPtr& vector) {
+    execCtx_->releaseVector(vector);
+  }
+
+  void releaseVectors(std::vector<VectorPtr>& vectors) {
+    execCtx_->releaseVectors(vectors);
+  }
+
+  // Makes 'result' writable for 'rows'. Allocates or reuses a vector from the
+  // pool of 'execCtx_' if needed.
+  void ensureWritable(
+      const SelectivityVector& rows,
+      const TypePtr& type,
+      VectorPtr& result) {
+    BaseVector::ensureWritable(
+        rows, type, execCtx_->pool(), &result, &execCtx_->vectorPool());
+  }
+
  private:
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
   ExprSet* FOLLY_NULLABLE const exprSet_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -942,6 +942,7 @@ void Expr::evalAll(
           remainingRows->begin(),
           remainingRows->end());
       if (!remainingRows->hasSelections()) {
+        context.releaseVectors(inputValues_);
         inputValues_.clear();
         setAllNulls(rows, context, result);
         return;
@@ -962,6 +963,7 @@ void Expr::evalAll(
     }
     deselectErrors(context, *nonNulls.get());
     if (!remainingRows->hasSelections()) {
+      context.releaseVectors(inputValues_);
       inputValues_.clear();
       setAllNulls(rows, context, result);
       return;
@@ -975,6 +977,7 @@ void Expr::evalAll(
   if (remainingRows != &rows) {
     addNulls(rows, remainingRows->asRange().bits(), context, result);
   }
+  context.releaseVectors(inputValues_);
   inputValues_.clear();
 }
 

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -85,7 +85,7 @@ class SimpleFunctionAdapter : public VectorFunction {
       // is unique, as is nulls.  We also know the size of the vector is
       // at least as large as the size of rows.
       if (!isResultReused) {
-        BaseVector::ensureWritable(*rows, outputType, context->pool(), _result);
+        context->ensureWritable(*rows, outputType, *_result);
       }
       result = reinterpret_cast<result_vector_t*>((*_result).get());
       resultWriter.init(*result);

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -24,6 +24,7 @@
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SequenceVector.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/VectorPool.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook {
@@ -488,13 +489,19 @@ void BaseVector::ensureWritable(
     const SelectivityVector& rows,
     const TypePtr& type,
     velox::memory::MemoryPool* pool,
-    VectorPtr* result) {
+    VectorPtr* result,
+    VectorPool* vectorPool) {
   if (!*result) {
-    *result = BaseVector::create(type, rows.size(), pool);
+    if (vectorPool) {
+      *result = vectorPool->get(type, rows.size(), *pool);
+    } else {
+      *result = BaseVector::create(type, rows.size(), pool);
+    }
     return;
   }
   auto resultType = (*result)->type();
   bool isUnknownType = resultType->containsUnknown();
+  const auto& createType = isUnknownType ? type : resultType;
   if ((*result)->encoding() == VectorEncoding::Simple::LAZY) {
     // TODO Figure out how to allow memory reuse for a newly loaded vector.
     // LazyVector holds a reference to loaded vector, hence, unique() check
@@ -520,8 +527,8 @@ void BaseVector::ensureWritable(
   // vector.
   auto targetSize = std::max<vector_size_t>(rows.size(), (*result)->size());
 
-  auto copy =
-      BaseVector::create(isUnknownType ? type : resultType, targetSize, pool);
+  auto copy = vectorPool ? vectorPool->get(createType, targetSize, *pool)
+                         : BaseVector::create(createType, targetSize, pool);
   SelectivityVector copyRows(
       std::min<vector_size_t>(targetSize, (*result)->size()));
   copyRows.deselect(rows);
@@ -632,8 +639,8 @@ bool isLazyNotLoaded(const BaseVector& vector) {
 
 // static
 bool BaseVector::isReusableFlatVector(const VectorPtr& vector) {
-  // If the main shared_ptr has more than one references, or if it's not a flat
-  // vector, can't reuse.
+  // If the main shared_ptr has more than one references, or if it's not a
+  // flat vector, can't reuse.
   if (!vector.unique() || !isFlat(vector->encoding())) {
     return false;
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -49,6 +49,8 @@ class SimpleVector;
 template <typename T>
 class FlatVector;
 
+class VectorPool;
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -472,7 +474,8 @@ class BaseVector {
       const SelectivityVector& rows,
       const TypePtr& type,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<BaseVector>* result);
+      std::shared_ptr<BaseVector>* result,
+      VectorPool* vectorPool = nullptr);
 
   virtual void ensureWritable(const SelectivityVector& rows);
 

--- a/velox/vector/VectorPool.h
+++ b/velox/vector/VectorPool.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox {
+
+// A thread-level cache of preallocated flat vectors of different types.
+class VectorPool {
+ public:
+  VectorPtr
+  get(const TypePtr& type, vector_size_t size, memory::MemoryPool& pool) {
+    auto kind = static_cast<int32_t>(type->kind());
+    if (kind < kNumCachedVectorTypes && size <= kMaxRecycleSize) {
+      return vectors_[kind].pop(type, size, pool);
+    }
+    return BaseVector::create(type, size, &pool);
+  }
+
+  // Moves vector into 'this' if it is flat, recursively singly referenced and
+  // there is space.
+  void release(VectorPtr& vector) {
+    if (!vector.unique() || vector->size() > kMaxRecycleSize) {
+      return;
+    }
+    auto kind = static_cast<int32_t>(vector->typeKind());
+    if (kind < kNumCachedVectorTypes) {
+      vectors_[kind].maybe_push_back(vector);
+    }
+  }
+
+  void release(std::vector<VectorPtr>& vectors) {
+    for (auto& vector : vectors) {
+      release(vector);
+    }
+  }
+
+ private:
+  static constexpr int32_t kNumCachedVectorTypes =
+      static_cast<int32_t>(TypeKind::ARRAY);
+  // Max number of elements for a vector to be recyclable. The larger
+  // the batch the less the win from recycling.
+  static constexpr vector_size_t kMaxRecycleSize = 64 * 1024;
+  static constexpr int32_t kNumPerType = 10;
+  struct TypePool {
+    int32_t size{0};
+    std::array<VectorPtr, kNumPerType> vectors;
+
+    void maybe_push_back(VectorPtr& vector) {
+      if (!vector->isRecyclable()) {
+        return;
+      }
+      if (size < kNumPerType) {
+        vector->prepareForReuse();
+        vectors[size++] = std::move(vector);
+      }
+    }
+
+    VectorPtr pop(
+        const TypePtr& type,
+        vector_size_t vectorSize,
+        memory::MemoryPool& pool) {
+      if (size) {
+        auto result = std::move(vectors[--size]);
+        if (UNLIKELY(result->rawNulls() != nullptr)) {
+          // This is a recyclable vector, no need to check uniqueness.
+          simd::memset(
+              const_cast<uint64_t*>(result->rawNulls()),
+              bits::kNotNullByte,
+              bits::roundUp(std::min<int32_t>(vectorSize, result->size()), 64) /
+                  8);
+        }
+        if (UNLIKELY(
+                result->typeKind() == TypeKind::VARCHAR ||
+                result->typeKind() == TypeKind::VARBINARY)) {
+          simd::memset(
+              const_cast<void*>(result->valuesAsVoid()),
+              0,
+              std::min<int32_t>(vectorSize, result->size()) *
+                  sizeof(StringView));
+        }
+        if (result->size() != vectorSize) {
+          result->resize(vectorSize);
+        }
+        return result;
+      }
+      return BaseVector::create(type, vectorSize, &pool);
+    }
+  };
+
+  // Caches of preallocated vectors indexed by typeKind.
+  std::array<TypePool, kNumCachedVectorTypes> vectors_;
+};
+
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   VectorTest.cpp
   VectorToStringTest.cpp
   VectorEstimateFlatSizeTest.cpp
+  VectorPoolTest.cpp
   VectorPrepareForReuseTest.cpp
   DecodedVectorTest.cpp
   SelectivityVectorTest.cpp

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/vector/VectorPool.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class VectorPoolTest : public testing::Test, public VectorTestBase {
+ protected:
+  // Makes 'size' strings of ''stringSize' characters.  If 'hasNulls' is true,
+  // sets 1/5 of the strings to null. If 'overwriteNulls' is true, there are
+  // null flags but no null values.
+  FlatVectorPtr<StringView> makeStrings(
+      vector_size_t size,
+      int32_t stringSize,
+      bool hasNulls,
+      bool overwriteNulls = false) {
+    std::string content;
+    content.resize(stringSize);
+    auto vector = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), size, pool_.get());
+    for (auto i = 0; i < size; ++i) {
+      bool isNull = hasNulls && (i % 5) == 1;
+      if (isNull) {
+        vector->setNull(i, true);
+      }
+      if (!isNull || overwriteNulls) {
+        std::fill(content.begin(), content.end(), static_cast<char>(i));
+        vector->set(i, StringView(content));
+      }
+    }
+    return vector;
+  }
+
+  VectorPool vectorPool_;
+};
+
+TEST_F(VectorPoolTest, strings) {
+  std::vector<VectorPtr> vectors;
+  std::vector<VectorPtr> secondReferences;
+  std::vector<BufferPtr> buffers;
+  // Element 0: recyclable
+  vectors.push_back(makeStrings(10000, 100, false));
+  // Element 1 - non-unique
+  vectors.push_back(makeStrings(10000, 100, false));
+  secondReferences.push_back(vectors.back());
+  // Element 2 - recyclable with nulls
+  vectors.push_back(makeStrings(10000, 100, true));
+  // Element 3 - recyclable with nulls array but no nulls
+  vectors.push_back(makeStrings(10000, 100, true, true));
+
+  // Element 4 - Not recyclable because buffers not uique
+  vectors.push_back(makeStrings(200000, 10, true));
+  buffers.push_back(vectors.back()->as<FlatVector<StringView>>()->values());
+  // Element 5: Recyclable but no recycle of string buffers
+  vectors.push_back(makeStrings(10, 2000000, false));
+  std::vector<BaseVector*> rawPointers;
+  for (auto& vector : vectors) {
+    rawPointers.push_back(vector.get());
+  }
+  vectorPool_.release(vectors);
+  EXPECT_TRUE(!vectors[0]);
+  EXPECT_FALSE(!vectors[1]);
+  EXPECT_TRUE(!vectors[2]);
+  EXPECT_TRUE(!vectors[3]);
+  EXPECT_FALSE(!vectors[4]);
+  EXPECT_TRUE(!vectors[5]);
+
+  vectors[5] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[5].get(), rawPointers[5]);
+  // Strings zeroed out.
+  EXPECT_EQ(0, vectors[5]->as<FlatVector<StringView>>()->valueAt(1).size());
+  // No buffers, the past ones were too large.
+  EXPECT_TRUE(
+      vectors[5]->as<FlatVector<StringView>>()->stringBuffers().empty());
+
+  vectors[3] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[3].get(), rawPointers[3]);
+  // No nulls array.
+  EXPECT_TRUE(!vectors[3]->rawNulls());
+
+  vectors[2] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_FALSE(!vectors[2]->rawNulls());
+  EXPECT_EQ(
+      0, BaseVector::countNulls(vectors[2]->nulls(), 0, vectors[2]->size()));
+
+  vectors[0] = vectorPool_.get(VARCHAR(), 100, *pool_);
+  EXPECT_EQ(vectors[0].get(), rawPointers[0]);
+  // No nulls buffer.
+  EXPECT_TRUE(!vectors[0]->rawNulls());
+}


### PR DESCRIPTION
Adds a thread level pool for intermediate result vectors.

- Allow use of recycled vectors in Expr::evalAll, ensureWritable and
  selected special forms.

- ToDO: Use EvalCtx::ensureWritable in more functions.