### PR TITLE
Remove extra init from SelectivityVector

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -178,9 +178,9 @@ class ExecCtx : public Context {
     return queryCtx_;
   }
 
-  /// Returns a SelectivityVector from a pool. Allocates new one if none is
-  /// available. Make sure to call 'releaseSelectivityVector' when done using
-  /// the vector to allow for reuse.
+  /// Returns an uninitialized  SelectivityVector from a pool. Allocates new one
+  /// if none is available. Make sure to call 'releaseSelectivityVector' when
+  /// done using the vector to allow for reuse.
   ///
   /// Prefer using LocalSelectivityVector which takes care of returning the
   /// vector to the pool on destruction.
@@ -191,6 +191,18 @@ class ExecCtx : public Context {
     auto vector = std::move(selectivityVectorPool_.back());
     selectivityVectorPool_.pop_back();
     vector->resize(size);
+    return vector;
+  }
+
+  // Returns an arbitrary SelectivityVector with undefined
+  // content. The caller is responsible for setting the size and
+  // assigning the contents.
+  std::unique_ptr<SelectivityVector> getSelectivityVector() {
+    if (selectivityVectorPool_.empty()) {
+      return std::make_unique<SelectivityVector>();
+    }
+    auto vector = std::move(selectivityVectorPool_.back());
+    selectivityVectorPool_.pop_back();
     return vector;
   }
 

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -36,9 +36,8 @@ void ConstantExpr::evalSpecialForm(
   if (needToSetIsAscii_) {
     auto* vector =
         sharedSubexprValues_->asUnchecked<SimpleVector<StringView>>();
-    LocalSelectivityVector singleRow(context, 1);
-    singleRow.get()->setAll();
-    bool isAscii = vector->computeAndSetIsAscii(*singleRow.get());
+    LocalSelectivityVector singleRow(context);
+    bool isAscii = vector->computeAndSetIsAscii(*singleRow.get(1, true));
     vector->setAllIsAscii(isAscii);
     needToSetIsAscii_ = false;
   }
@@ -173,10 +172,9 @@ void SwitchExpr::evalSpecialForm(
   ExceptionContextSetter exceptionContext(
       {[](auto* expr) { return static_cast<Expr*>(expr)->toString(); }, this});
 
-  LocalSelectivityVector remainingRows(context, rows.end());
-  *remainingRows.get() = rows;
+  LocalSelectivityVector remainingRows(context, rows);
 
-  LocalSelectivityVector thenRows(context, rows.end());
+  LocalSelectivityVector thenRows(context);
 
   VectorPtr condition;
   const uint64_t* values;
@@ -214,7 +212,7 @@ void SwitchExpr::evalSpecialForm(
         continue;
       default: {
         bits::andBits(
-            thenRows.get()->asMutableRange().bits(),
+            thenRows.get(rows.end(), false)->asMutableRange().bits(),
             remainingRows.get()->asRange().bits(),
             values,
             0,
@@ -308,7 +306,7 @@ uint64_t* rowsWithError(
   uint64_t* errorMask = nullptr;
   SelectivityVector* errorRows = errorRowsHolder.get();
   if (!errorRows) {
-    errorRows = errorRowsHolder.get(rows.end());
+    errorRows = errorRowsHolder.get(rows.end(), false);
   }
   errorMask = errorRows->asMutableRange().bits();
   std::fill(errorMask, errorMask + bits::nwords(rows.end()), 0);
@@ -398,10 +396,9 @@ void ConjunctExpr::evalSpecialForm(
 
   bool handleErrors = false;
   LocalSelectivityVector errorRows(context);
-  LocalSelectivityVector activeRowsHolder(context, rows.end());
+  LocalSelectivityVector activeRowsHolder(context, rows);
   auto activeRows = activeRowsHolder.get();
   assert(activeRows); // lint
-  *activeRows = rows;
   int32_t numActive = activeRows->countSelected();
   for (int32_t i = 0; i < inputs_.size(); ++i) {
     VectorPtr inputResult;

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -290,8 +290,7 @@ class LocalSelectivityVector {
   // Grab an instance of a SelectivityVector from the pool and initialize it to
   // the specified value.
   LocalSelectivityVector(EvalCtx& context, const SelectivityVector& value)
-      : context_(*context.execCtx()),
-        vector_(context_.getSelectivityVector(value.size())) {
+      : context_(*context.execCtx()), vector_(context_.getSelectivityVector()) {
     *vector_ = value;
   }
 
@@ -320,6 +319,24 @@ class LocalSelectivityVector {
     if (!vector_) {
       vector_ = context_.getSelectivityVector(size);
     }
+    return vector_.get();
+  }
+
+  // Returns a recycled SelectivityVector with 'size' bits set to 'value'.
+  SelectivityVector* FOLLY_NONNULL get(vector_size_t size, bool value) {
+    if (!vector_) {
+      vector_ = context_.getSelectivityVector();
+    }
+    vector_->resizeFill(size, value);
+    return vector_.get();
+  }
+
+  // Returns a recycled SelectivityVector initialized from 'other'.
+  SelectivityVector* FOLLY_NONNULL get(const SelectivityVector& other) {
+    if (!vector_) {
+      vector_ = context_.getSelectivityVector();
+    }
+    *vector_ = other;
     return vector_.get();
   }
 

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_expression_test
   ExprTest.cpp
+  EvalCtxTest.cpp
   ExprStatsTest.cpp
   CastExprTest.cpp
   CoalesceTest.cpp

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/EvalCtx.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+class EvalCtxTest : public testing::Test, public VectorTestBase {
+ protected:
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), nullptr)};
+};
+
+TEST_F(EvalCtxTest, selectivityVectors) {
+  EvalCtx context(execCtx_.get());
+  SelectivityVector all100(100, true);
+  SelectivityVector none100(100, false);
+
+  // Not initialized, initially nullptr.
+  LocalSelectivityVector local1(context);
+  EXPECT_TRUE(!local1.get());
+
+  // Specify initialization in get()
+  EXPECT_EQ(all100, *local1.get(100, true));
+
+  // The get() stays the same.
+  EXPECT_EQ(all100, *local1.get());
+
+  // Initialize from other in get().
+  EXPECT_EQ(none100, *local1.get(none100));
+
+  // Init from existing
+  LocalSelectivityVector local2(context, all100);
+  EXPECT_EQ(all100, *local2.get());
+}

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -410,6 +410,26 @@ TEST(SelectivityVectorTest, resize) {
   ASSERT_TRUE(larger.isAllSelected());
 }
 
+TEST(SelectivityVectorTest, fillAndCompare) {
+  SelectivityVector first(100, true);
+  SelectivityVector second(100, false);
+  first.resize(10);
+  second.resize(10);
+  second.setAll();
+  // The significant 10 bits are equal, the rest are not. Expect == to be true.
+  EXPECT_TRUE(first == second);
+  first.resizeFill(200, false);
+  second.resizeFill(300, false);
+  EXPECT_FALSE(second.isAllSelected());
+  // Vectors with nothing selected are equal even if their max size differs.
+  EXPECT_FALSE(first != second);
+  first.resizeFill(100, true);
+  EXPECT_TRUE(first.isAllSelected());
+  second.resize(100);
+  second.setAll();
+  EXPECT_TRUE(first == second);
+}
+
 TEST(SelectivityVectorTest, select) {
   SelectivityVector first(64);
   SelectivityVector other(32, false);


### PR DESCRIPTION
Remove extra calls to SelectivityVector::updateBounds()

Do not call updateBounds when the bounds are either known or will be
overwritten. Add a resizeFill method that sets the size and contents
and does not call updateBounds.

Add LocalSelectivityVector interfaces that initialize the vector from
another vector or from size and value.

Fix SelectivityVector::== to only consider bits in between begin_ and
end_.



