### PR TITLE
[Substrait to Velox] Add conversion for hash join

### DIFF
--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -31,35 +31,35 @@ namespace facebook::velox::substrait {
 /// components, and convert them into recognizable representations.
 class SubstraitParser {
  public:
-  /// Used to store the type name and nullability.
+  /// Stores the type name and nullability.
   struct SubstraitType {
     std::string type;
     bool nullable;
   };
 
-  /// Used to parse Substrait NamedStruct.
+  /// Parse Substrait NamedStruct.
   std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> parseNamedStruct(
       const ::substrait::NamedStruct& namedStruct);
 
-  /// Used to parse Substrait Type.
+  /// Parse Substrait Type.
   std::shared_ptr<SubstraitType> parseType(
       const ::substrait::Type& substraitType);
 
-  /// Used to parse Substrait ReferenceSegment.
+  /// Parse Substrait ReferenceSegment.
   int32_t parseReferenceSegment(
       const ::substrait::Expression::ReferenceSegment& refSegment);
 
-  /// Used to make names in the format of {prefix}_{index}.
+  /// Make names in the format of {prefix}_{index}.
   std::vector<std::string> makeNames(const std::string& prefix, int size);
 
-  /// Used to make node name in the format of n{nodeId}_{colIdx}.
+  /// Make node name in the format of n{nodeId}_{colIdx}.
   std::string makeNodeName(int nodeId, int colIdx);
 
-  /// Used to get the column index from a node name in the format of
+  /// Get the column index from a node name in the format of
   /// n{nodeId}_{colIdx}.
   int getIdxFromNodeName(const std::string& nodeName);
 
-  /// Used to find the Substrait function name according to the function id
+  /// Find the Substrait function name according to the function id
   /// from a pre-constructed function map. The function specification can be
   /// a simple name or a compound name. The compound name format is:
   /// <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>.
@@ -72,11 +72,11 @@ class SubstraitParser {
 
   /// Extracts the function name for a function from specified compound name.
   /// When the input is a simple name, it will be returned.
-  std::string getFunctionName(const std::string& subFuncSpec) const;
+  std::string getFunctionName(const std::string& functionSpec) const;
 
   /// Extracts argument types for a function from specified compound name.
   void getFunctionTypes(
-      const std::string& subFuncSpec,
+      const std::string& functionSpec,
       std::vector<std::string>& types) const;
 
   /// Find the Velox function name according to the function id
@@ -86,12 +86,12 @@ class SubstraitParser {
       uint64_t id) const;
 
   /// Map the Substrait function key word into Velox function key word.
-  std::string mapToVeloxFunction(const std::string& subFunc) const;
+  std::string mapToVeloxFunction(const std::string& substraitFunction) const;
 
  private:
-  /// Used for mapping Substrait function key words into Velox functions' key
-  /// words. Key: the Substrait function key word, Value: the Velox function key
-  /// word. For those functions with different names in Substrait and Velox,
+  /// A map used for mapping Substrait function key words into Velox functions'
+  /// key words. Key: the Substrait function key word, Value: the Velox function
+  /// key word. For those functions with different names in Substrait and Velox,
   /// a mapping relation should be added here.
   std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_ = {
       {"add", "plus"},

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -21,21 +21,21 @@ namespace facebook::velox::substrait {
 
 std::shared_ptr<const core::FieldAccessTypedExpr>
 SubstraitVeloxExprConverter::toVeloxExpr(
-    const ::substrait::Expression::FieldReference& sField,
+    const ::substrait::Expression::FieldReference& substraitField,
     const RowTypePtr& inputType) {
-  auto typeCase = sField.reference_type_case();
+  auto typeCase = substraitField.reference_type_case();
   switch (typeCase) {
     case ::substrait::Expression::FieldReference::ReferenceTypeCase::
         kDirectReference: {
-      auto dRef = sField.direct_reference();
-      int32_t colIdx = substraitParser_.parseReferenceSegment(dRef);
+      const auto& directRef = substraitField.direct_reference();
+      int32_t colIdx = substraitParser_.parseReferenceSegment(directRef);
 
       const auto& inputTypes = inputType->children();
       const auto& inputNames = inputType->names();
       const int64_t inputSize = inputNames.size();
 
       if (colIdx <= inputSize) {
-        // convert type to row
+        // Convert type to row.
         return std::make_shared<core::FieldAccessTypedExpr>(
             inputTypes[colIdx],
             std::make_shared<core::InputTypedExpr>(inputTypes[colIdx]),
@@ -52,39 +52,48 @@ SubstraitVeloxExprConverter::toVeloxExpr(
 
 std::shared_ptr<const core::ITypedExpr>
 SubstraitVeloxExprConverter::toVeloxExpr(
-    const ::substrait::Expression::ScalarFunction& sFunc,
+    const ::substrait::Expression::ScalarFunction& substraitFunc,
     const RowTypePtr& inputType) {
   std::vector<std::shared_ptr<const core::ITypedExpr>> params;
-  params.reserve(sFunc.args().size());
-  for (const auto& sArg : sFunc.args()) {
+  params.reserve(substraitFunc.args().size());
+  for (const auto& sArg : substraitFunc.args()) {
     params.emplace_back(toVeloxExpr(sArg, inputType));
   }
-  auto functionId = sFunc.function_reference();
-  auto veloxFunction =
-      substraitParser_.findVeloxFunction(functionMap_, functionId);
-  auto substraitType = substraitParser_.parseType(sFunc.output_type());
-  auto veloxType = toVeloxType(substraitType->type);
+  const auto& veloxFunction = substraitParser_.findVeloxFunction(
+      functionMap_, substraitFunc.function_reference());
+  const auto& veloxType = toVeloxType(
+      substraitParser_.parseType(substraitFunc.output_type())->type);
+
+  // Omit alias because name change is not needed.
+  if (veloxFunction == "alias") {
+    VELOX_CHECK(params.size() == 1, "Alias expects one parameter.");
+    return params[0];
+  }
+
   return std::make_shared<const core::CallTypedExpr>(
       veloxType, std::move(params), veloxFunction);
 }
 
 std::shared_ptr<const core::ConstantTypedExpr>
 SubstraitVeloxExprConverter::toVeloxExpr(
-    const ::substrait::Expression::Literal& sLit) {
-  auto typeCase = sLit.literal_type_case();
+    const ::substrait::Expression::Literal& substraitLit) {
+  auto typeCase = substraitLit.literal_type_case();
   switch (typeCase) {
     case ::substrait::Expression_Literal::LiteralTypeCase::kBoolean:
-      return std::make_shared<core::ConstantTypedExpr>(variant(sLit.boolean()));
+      return std::make_shared<core::ConstantTypedExpr>(
+          variant(substraitLit.boolean()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI32:
-      return std::make_shared<core::ConstantTypedExpr>(variant(sLit.i32()));
+      return std::make_shared<core::ConstantTypedExpr>(
+          variant(substraitLit.i32()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
-      return std::make_shared<core::ConstantTypedExpr>(variant(sLit.i64()));
+      return std::make_shared<core::ConstantTypedExpr>(
+          variant(substraitLit.i64()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kFp64:
-      return std::make_shared<core::ConstantTypedExpr>(variant(sLit.fp64()));
+      return std::make_shared<core::ConstantTypedExpr>(
+          variant(substraitLit.fp64()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
-      auto substraitType = substraitParser_.parseType(sLit.null());
-      auto veloxType = toVeloxType(substraitType->type);
-
+      auto veloxType =
+          toVeloxType(substraitParser_.parseType(substraitLit.null())->type);
       return std::make_shared<core::ConstantTypedExpr>(
           veloxType, variant::null(veloxType->kind()));
     }
@@ -111,19 +120,19 @@ SubstraitVeloxExprConverter::toVeloxExpr(
 
 std::shared_ptr<const core::ITypedExpr>
 SubstraitVeloxExprConverter::toVeloxExpr(
-    const ::substrait::Expression& sExpr,
+    const ::substrait::Expression& substraitExpr,
     const RowTypePtr& inputType) {
   std::shared_ptr<const core::ITypedExpr> veloxExpr;
-  auto typeCase = sExpr.rex_type_case();
+  auto typeCase = substraitExpr.rex_type_case();
   switch (typeCase) {
     case ::substrait::Expression::RexTypeCase::kLiteral:
-      return toVeloxExpr(sExpr.literal());
+      return toVeloxExpr(substraitExpr.literal());
     case ::substrait::Expression::RexTypeCase::kScalarFunction:
-      return toVeloxExpr(sExpr.scalar_function(), inputType);
+      return toVeloxExpr(substraitExpr.scalar_function(), inputType);
     case ::substrait::Expression::RexTypeCase::kSelection:
-      return toVeloxExpr(sExpr.selection(), inputType);
+      return toVeloxExpr(substraitExpr.selection(), inputType);
     case ::substrait::Expression::RexTypeCase::kCast:
-      return toVeloxExpr(sExpr.cast(), inputType);
+      return toVeloxExpr(substraitExpr.cast(), inputType);
     default:
       VELOX_NYI(
           "Substrait conversion not supported for Expression '{}'", typeCase);

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -32,14 +32,14 @@ class SubstraitVeloxExprConverter {
       const std::unordered_map<uint64_t, std::string>& functionMap)
       : functionMap_(functionMap) {}
 
-  /// Used to convert Substrait Field into Velox Field Expression.
+  /// Convert Substrait Field into Velox Field Expression.
   std::shared_ptr<const core::FieldAccessTypedExpr> toVeloxExpr(
-      const ::substrait::Expression::FieldReference& sField,
+      const ::substrait::Expression::FieldReference& substraitField,
       const RowTypePtr& inputType);
 
-  /// Used to convert Substrait ScalarFunction into Velox Expression.
+  /// Convert Substrait ScalarFunction into Velox Expression.
   std::shared_ptr<const core::ITypedExpr> toVeloxExpr(
-      const ::substrait::Expression::ScalarFunction& sFunc,
+      const ::substrait::Expression::ScalarFunction& substraitFunc,
       const RowTypePtr& inputType);
 
   /// Convert Substrait CastExpression to Velox Expression.
@@ -47,11 +47,11 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression::Cast& castExpr,
       const RowTypePtr& inputType);
 
-  /// Used to convert Substrait Literal into Velox Expression.
+  /// Convert Substrait Literal into Velox Expression.
   std::shared_ptr<const core::ConstantTypedExpr> toVeloxExpr(
-      const ::substrait::Expression::Literal& sLit);
+      const ::substrait::Expression::Literal& substraitLit);
 
-  /// Used to convert Substrait Expression into Velox Expression.
+  /// Convert Substrait Expression into Velox Expression.
   std::shared_ptr<const core::ITypedExpr> toVeloxExpr(
       const ::substrait::Expression& substraitExpr,
       const RowTypePtr& inputType);

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -228,6 +228,95 @@ SubstraitVeloxPlanConverter::toVeloxAggWithRowConstruct(
   return aggNode;
 }
 
+std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
+    const ::substrait::JoinRel& sJoin,
+    memory::MemoryPool* pool) {
+  if (!sJoin.has_left()) {
+    VELOX_FAIL("Left Rel is expected in JoinRel.");
+  }
+  if (!sJoin.has_right()) {
+    VELOX_FAIL("Right Rel is expected in JoinRel.");
+  }
+
+  auto leftNode = toVeloxPlan(sJoin.left(), pool);
+  auto rightNode = toVeloxPlan(sJoin.right(), pool);
+
+  auto outputSize =
+      leftNode->outputType()->size() + rightNode->outputType()->size();
+  std::vector<std::string> outputNames;
+  std::vector<std::shared_ptr<const Type>> outputTypes;
+  outputNames.reserve(outputSize);
+  outputTypes.reserve(outputSize);
+  for (const auto& node : {leftNode, rightNode}) {
+    const auto& names = node->outputType()->names();
+    outputNames.insert(outputNames.end(), names.begin(), names.end());
+    const auto& types = node->outputType()->children();
+    outputTypes.insert(outputTypes.end(), types.begin(), types.end());
+  }
+  auto outputRowType = std::make_shared<const RowType>(
+      std::move(outputNames), std::move(outputTypes));
+
+  // extract join keys from join expression
+  std::vector<const ::substrait::Expression::FieldReference*> leftExprs,
+      rightExprs;
+  extractJoinKeys(sJoin.expression(), leftExprs, rightExprs);
+  VELOX_CHECK_EQ(leftExprs.size(), rightExprs.size());
+  size_t numKeys = leftExprs.size();
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> leftKeys,
+      rightKeys;
+  leftKeys.reserve(numKeys);
+  rightKeys.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    leftKeys.emplace_back(
+        exprConverter_->toVeloxExpr(*leftExprs[i], outputRowType));
+    rightKeys.emplace_back(
+        exprConverter_->toVeloxExpr(*rightExprs[i], outputRowType));
+  }
+
+  std::shared_ptr<const core::ITypedExpr> filter;
+  if (sJoin.has_post_join_filter()) {
+    filter =
+        exprConverter_->toVeloxExpr(sJoin.post_join_filter(), outputRowType);
+  }
+
+  // Map join type
+  core::JoinType joinType;
+  switch (sJoin.type()) {
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_INNER:
+      joinType = core::JoinType::kInner;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_OUTER:
+      joinType = core::JoinType::kFull;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT:
+      joinType = core::JoinType::kLeft;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT:
+      joinType = core::JoinType::kRight;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_SEMI:
+      joinType = core::JoinType::kSemi;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_ANTI:
+      joinType = core::JoinType::kAnti;
+      break;
+    default:
+      VELOX_NYI("Unsupported Join type: {}", sJoin.type());
+  }
+
+  // Create join node
+  return std::make_shared<core::HashJoinNode>(
+      nextPlanNodeId(),
+      joinType,
+      leftKeys,
+      rightKeys,
+      filter,
+      leftNode,
+      rightNode,
+      outputRowType);
+}
+
 std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxAgg(
     const ::substrait::AggregateRel& aggRel,
     const std::shared_ptr<const core::PlanNode>& childNode,
@@ -521,6 +610,9 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     return toVeloxPlan(
         rel.read(), pool, partitionIndex_, paths_, starts_, lengths_);
   }
+  if (rel.has_join()) {
+    return toVeloxPlan(rel.join(), pool);
+  }
   VELOX_NYI("Substrait conversion not supported for Rel.");
 }
 
@@ -810,6 +902,40 @@ int32_t SubstraitVeloxPlanConverter::streamIsInput(
     }
   }
   return -1;
+}
+
+void SubstraitVeloxPlanConverter::extractJoinKeys(
+    const ::substrait::Expression& joinExpression,
+    std::vector<const ::substrait::Expression::FieldReference*>& leftExprs,
+    std::vector<const ::substrait::Expression::FieldReference*>& rightExprs) {
+  std::vector<const ::substrait::Expression*> expressions;
+  expressions.push_back(&joinExpression);
+  while (!expressions.empty()) {
+    auto visited = expressions.back();
+    expressions.pop_back();
+    if (visited->rex_type_case() ==
+        ::substrait::Expression::RexTypeCase::kScalarFunction) {
+      auto functionSpec = substraitParser_->findFunctionSpec(
+          functionMap_, visited->scalar_function().function_reference());
+      auto functionName = substraitParser_->getFunctionName(functionSpec);
+      const auto& args = visited->scalar_function().args();
+      if (functionName == "and") {
+        expressions.push_back(&args[0]);
+        expressions.push_back(&args[1]);
+      } else if (functionName == "equal") {
+        VELOX_CHECK(std::all_of(
+            args.cbegin(), args.cend(), [](const ::substrait::Expression& arg) {
+              return arg.has_selection();
+            }));
+        leftExprs.push_back(&args[0].selection());
+        rightExprs.push_back(&args[1].selection());
+      }
+    } else {
+      VELOX_FAIL(
+          "Unable to parse from join expression: {}",
+          joinExpression.DebugString());
+    }
+  }
 }
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -22,6 +22,9 @@
 
 namespace facebook::velox::substrait {
 
+static const std::string kAnd = "and";
+static const std::string kEqual = "equal";
+
 /// This class is used to convert the Substrait plan into Velox plan.
 class SubstraitVeloxPlanConverter {
  public:
@@ -40,7 +43,7 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::FilterRel& filterRel,
       memory::MemoryPool* pool);
 
-  /// Used to convert Substrait JoinRel into Velox PlanNode.
+  /// Convert Substrait JoinRel into Velox HashJoinNode.
   std::shared_ptr<const core::PlanNode> toVeloxPlan(
       const ::substrait::JoinRel& joinRel,
       memory::MemoryPool* pool);
@@ -177,6 +180,9 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::Expression& joinExpression,
       std::vector<const ::substrait::Expression::FieldReference*>& leftExprs,
       std::vector<const ::substrait::Expression::FieldReference*>& rightExprs);
+
+  /// Convert Substrait join type into Velox join type.
+  core::JoinType toVeloxJoinType(::substrait::JoinRel_JoinType joinType);
 
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -40,7 +40,11 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::FilterRel& filterRel,
       memory::MemoryPool* pool);
 
-  /// Convert Substrait ReadRel into Velox PlanNode.
+  /// Used to convert Substrait JoinRel into Velox PlanNode.
+  std::shared_ptr<const core::PlanNode> toVeloxPlan(
+      const ::substrait::JoinRel& joinRel,
+      memory::MemoryPool* pool);
+
   /// Index: the index of the partition this item belongs to.
   /// Starts: the start positions in byte to read from the items.
   /// Lengths: the lengths in byte to read from the items.
@@ -163,6 +167,16 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::AggregateRel& sAgg,
       const std::shared_ptr<const core::PlanNode>& childNode,
       const core::AggregationNode::Step& aggStep);
+
+  /// Extract join keys from joinExpression.
+  /// joinExpression is a boolean condition that describes whether each record
+  /// from the left set “match” the record from the right set. The condition
+  /// must only include the following operations: AND, ==, field references.
+  /// Field references correspond to the direct output order of the data.
+  void extractJoinKeys(
+      const ::substrait::Expression& joinExpression,
+      std::vector<const ::substrait::Expression::FieldReference*>& leftExprs,
+      std::vector<const ::substrait::Expression::FieldReference*>& rightExprs);
 
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/common/base/tests/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/dwrf/test/utils/DataFiles.h"
-
 #include "velox/substrait/SubstraitToVeloxPlan.h"
 
 using namespace facebook::velox;
@@ -133,4 +132,13 @@ TEST_F(FunctionTest, constructFunctionMap) {
 
   function = planConverter_->findFunction(8);
   ASSERT_EQ(function, "count:opt_i32");
+}
+
+TEST_F(FunctionTest, streamIsInput) {
+  std::string planPath =
+      getDataFilePath("velox/substrait/tests", "data/read_second_stage.json");
+  ::substrait::Rel substraitRel;
+  JsonToProtoConverter::readFromFile(planPath, substraitRel);
+  int index = planConverter_->streamIsInput(substraitRel.read());
+  ASSERT_EQ(index, 1);
 }

--- a/velox/substrait/tests/PlanConversionTest.cpp
+++ b/velox/substrait/tests/PlanConversionTest.cpp
@@ -38,6 +38,8 @@ using namespace facebook::velox::connector::hive;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::common::test;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+namespace vestrait = facebook::velox::substrait;
 
 class PlanConversionTest : public virtual HiveConnectorTestBase,
                            public testing::WithParamInterface<bool> {
@@ -75,18 +77,16 @@ class PlanConversionTest : public virtual HiveConnectorTestBase,
             starts_(starts),
             lengths_(lengths) {
         // Construct the splits.
-        std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
-            connectorSplits;
+        std::vector<std::shared_ptr<connector::ConnectorSplit>> connectorSplits;
         connectorSplits.reserve(paths.size());
         for (int idx = 0; idx < paths.size(); idx++) {
           auto path = paths[idx];
           auto start = starts[idx];
           auto length = lengths[idx];
-          auto split = std::make_shared<
-              facebook::velox::connector::hive::HiveConnectorSplit>(
-              facebook::velox::exec::test::kHiveConnectorId,
+          auto split = std::make_shared<connector::hive::HiveConnectorSplit>(
+              exec::test::kHiveConnectorId,
               path,
-              facebook::velox::dwio::common::FileFormat::ORC,
+              dwio::common::FileFormat::ORC,
               start,
               length);
           connectorSplits.emplace_back(split);
@@ -162,8 +162,8 @@ class PlanConversionTest : public virtual HiveConnectorTestBase,
       ::substrait::Plan substraitPlan;
       JsonToProtoConverter::readFromFile(planPath, substraitPlan);
 
-      auto planConverter = std::make_shared<
-          facebook::velox::substrait::SubstraitVeloxPlanConverter>();
+      auto planConverter =
+          std::make_shared<vestrait::SubstraitVeloxPlanConverter>();
       // Convert to Velox PlanNode.
       auto planNode = planConverter->toVeloxPlan(substraitPlan, pool_.get());
 
@@ -202,14 +202,14 @@ class PlanConversionTest : public virtual HiveConnectorTestBase,
   VectorPtr createSpecificScalar(
       size_t size,
       std::vector<T> vals,
-      facebook::velox::memory::MemoryPool& pool) {
-    facebook::velox::BufferPtr values = AlignedBuffer::allocate<T>(size, &pool);
+      memory::MemoryPool& pool) {
+    BufferPtr values = AlignedBuffer::allocate<T>(size, &pool);
     auto valuesPtr = values->asMutableRange<T>();
-    facebook::velox::BufferPtr nulls = nullptr;
+    BufferPtr nulls = nullptr;
     for (size_t i = 0; i < size; ++i) {
       valuesPtr[i] = vals[i];
     }
-    return std::make_shared<facebook::velox::FlatVector<T>>(
+    return std::make_shared<FlatVector<T>>(
         &pool, nulls, size, values, std::vector<BufferPtr>{});
   }
 
@@ -218,7 +218,7 @@ class PlanConversionTest : public virtual HiveConnectorTestBase,
   VectorPtr createSpecificStringVector(
       size_t size,
       std::vector<std::string> vals,
-      facebook::velox::memory::MemoryPool& pool) {
+      memory::MemoryPool& pool) {
     auto vector = BaseVector::create(VARCHAR(), size, &pool);
     auto flatVector = vector->asFlatVector<StringView>();
 
@@ -247,242 +247,250 @@ class PlanConversionTest : public virtual HiveConnectorTestBase,
     size_t offset = 0;
     for (size_t i = 0; i < size; ++i) {
       if (!vector->isNullAt(i)) {
-        flatVector->set(
-            i, facebook::velox::StringView(bufPtr + offset, lengths[i]));
+        flatVector->set(i, StringView(bufPtr + offset, lengths[i]));
         offset += lengths[i];
       }
     }
     return vector;
   }
+
+  void genLineitemORC(const std::shared_ptr<VeloxConverter>& veloxConverter) {
+    auto type =
+        ROW({"l_orderkey",
+             "l_partkey",
+             "l_suppkey",
+             "l_linenumber",
+             "l_quantity",
+             "l_extendedprice",
+             "l_discount",
+             "l_tax",
+             "l_returnflag",
+             "l_linestatus",
+             "l_shipdate",
+             "l_commitdate",
+             "l_receiptdate",
+             "l_shipinstruct",
+             "l_shipmode",
+             "l_comment"},
+            {BIGINT(),
+             BIGINT(),
+             BIGINT(),
+             INTEGER(),
+             DOUBLE(),
+             DOUBLE(),
+             DOUBLE(),
+             DOUBLE(),
+             VARCHAR(),
+             VARCHAR(),
+             DOUBLE(),
+             DOUBLE(),
+             DOUBLE(),
+             VARCHAR(),
+             VARCHAR(),
+             VARCHAR()});
+    std::unique_ptr<memory::MemoryPool> pool{
+        memory::getDefaultScopedMemoryPool()};
+    std::vector<VectorPtr> vectors;
+    // TPC-H lineitem table has 16 columns.
+    int colNum = 16;
+    vectors.reserve(colNum);
+    std::vector<int64_t> lOrderkeyData = {
+        4636438147,
+        2012485446,
+        1635327427,
+        8374290148,
+        2972204230,
+        8001568994,
+        989963396,
+        2142695974,
+        6354246853,
+        4141748419};
+    vectors.emplace_back(
+        createSpecificScalar<int64_t>(10, lOrderkeyData, *pool));
+    std::vector<int64_t> lPartkeyData = {
+        263222018,
+        255918298,
+        143549509,
+        96877642,
+        201976875,
+        196938305,
+        100260625,
+        273511608,
+        112999357,
+        299103530};
+    vectors.emplace_back(
+        createSpecificScalar<int64_t>(10, lPartkeyData, *pool));
+    std::vector<int64_t> lSuppkeyData = {
+        2102019,
+        13998315,
+        12989528,
+        4717643,
+        9976902,
+        12618306,
+        11940632,
+        871626,
+        1639379,
+        3423588};
+    vectors.emplace_back(
+        createSpecificScalar<int64_t>(10, lSuppkeyData, *pool));
+    std::vector<int32_t> lLinenumberData = {4, 6, 1, 5, 1, 2, 1, 5, 2, 6};
+    vectors.emplace_back(
+        createSpecificScalar<int32_t>(10, lLinenumberData, *pool));
+    std::vector<double> lQuantityData = {
+        6.0, 1.0, 19.0, 4.0, 6.0, 12.0, 23.0, 11.0, 16.0, 19.0};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lQuantityData, *pool));
+    std::vector<double> lExtendedpriceData = {
+        30586.05,
+        7821.0,
+        1551.33,
+        30681.2,
+        1941.78,
+        66673.0,
+        6322.44,
+        41754.18,
+        8704.26,
+        63780.36};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lExtendedpriceData, *pool));
+    std::vector<double> lDiscountData = {
+        0.05, 0.06, 0.01, 0.07, 0.05, 0.06, 0.07, 0.05, 0.06, 0.07};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lDiscountData, *pool));
+    std::vector<double> lTaxData = {
+        0.02, 0.03, 0.01, 0.0, 0.01, 0.01, 0.03, 0.07, 0.01, 0.04};
+    vectors.emplace_back(createSpecificScalar<double>(10, lTaxData, *pool));
+    std::vector<std::string> lReturnflagData = {
+        "N", "A", "A", "R", "A", "N", "A", "A", "N", "R"};
+    vectors.emplace_back(
+        createSpecificStringVector(10, lReturnflagData, *pool));
+    std::vector<std::string> lLinestatusData = {
+        "O", "F", "F", "F", "F", "O", "F", "F", "O", "F"};
+    vectors.emplace_back(
+        createSpecificStringVector(10, lLinestatusData, *pool));
+    std::vector<double> lShipdateNewData = {
+        8953.666666666666,
+        8773.666666666666,
+        9034.666666666666,
+        8558.666666666666,
+        9072.666666666666,
+        8864.666666666666,
+        9004.666666666666,
+        8778.666666666666,
+        9013.666666666666,
+        8832.666666666666};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lShipdateNewData, *pool));
+    std::vector<double> lCommitdateNewData = {
+        10447.666666666666,
+        8953.666666666666,
+        8325.666666666666,
+        8527.666666666666,
+        8438.666666666666,
+        10049.666666666666,
+        9036.666666666666,
+        8666.666666666666,
+        9519.666666666666,
+        9138.666666666666};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lCommitdateNewData, *pool));
+    std::vector<double> lReceiptdateNewData = {
+        10456.666666666666,
+        8979.666666666666,
+        8299.666666666666,
+        8474.666666666666,
+        8525.666666666666,
+        9996.666666666666,
+        9103.666666666666,
+        8726.666666666666,
+        9593.666666666666,
+        9178.666666666666};
+    vectors.emplace_back(
+        createSpecificScalar<double>(10, lReceiptdateNewData, *pool));
+    std::vector<std::string> lShipinstructData = {
+        "COLLECT COD",
+        "NONE",
+        "TAKE BACK RETURN",
+        "NONE",
+        "TAKE BACK RETURN",
+        "NONE",
+        "DELIVER IN PERSON",
+        "DELIVER IN PERSON",
+        "TAKE BACK RETURN",
+        "NONE"};
+    vectors.emplace_back(
+        createSpecificStringVector(10, lShipinstructData, *pool));
+    std::vector<std::string> lShipmodeData = {
+        "FOB",
+        "REG AIR",
+        "MAIL",
+        "FOB",
+        "RAIL",
+        "SHIP",
+        "REG AIR",
+        "REG AIR",
+        "TRUCK",
+        "AIR"};
+    vectors.emplace_back(createSpecificStringVector(10, lShipmodeData, *pool));
+    std::vector<std::string> lCommentData = {
+        " the furiously final foxes. quickly final p",
+        "thely ironic",
+        "ate furiously. even, pending pinto bean",
+        "ackages af",
+        "odolites. slyl",
+        "ng the regular requests sleep above",
+        "lets above the slyly ironic theodolites sl",
+        "lyly regular excuses affi",
+        "lly unusual theodolites grow slyly above",
+        " the quickly ironic pains lose car"};
+    vectors.emplace_back(createSpecificStringVector(10, lCommentData, *pool));
+
+    // Batches has only one RowVector here.
+    uint64_t nullCount = 0;
+    std::vector<RowVectorPtr> batches{std::make_shared<RowVector>(
+        pool.get(), type, nullptr, 10, vectors, nullCount)};
+
+    // Writes data into an ORC file.
+    auto sink = std::make_unique<dwio::common::FileSink>(
+        veloxConverter->getTmpDirPath() + "/mock_lineitem.orc");
+    auto config = std::make_shared<dwrf::Config>();
+    const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max();
+    dwrf::WriterOptions options;
+    options.config = config;
+    options.schema = type;
+    options.memoryBudget = writerMemoryCap;
+    options.flushPolicyFactory = nullptr;
+    options.layoutPlannerFactory = nullptr;
+    auto writer = std::make_unique<dwrf::Writer>(
+        options,
+        std::move(sink),
+        memory::getProcessDefaultMemoryManager().getRoot());
+    for (size_t i = 0; i < batches.size(); ++i) {
+      writer->write(batches[i]);
+    }
+    writer->close();
+  }
 };
 
 // This test will firstly generate mock TPC-H lineitem ORC file. Then, Velox's
 // computing will be tested based on the generated ORC file.
-// Input: Json file of the Substrait plan for the below modified TPC-H Q6 query:
+// Input: Json file of the Substrait plan for the first stage of below modified
+// TPC-H Q6 query:
 //
 //  select sum(l_extendedprice*l_discount) as revenue from lineitem where
-//  l_shipdate_new >= 8766 and l_shipdate_new < 9131 and l_discount between .06
+//  l_shipdate >= 8766 and l_shipdate < 9131 and l_discount between .06
 //  - 0.01 and .06 + 0.01 and l_quantity < 24
 //
 //  Tested Velox computings include: TableScan (Filter Pushdown) + Project +
 //  Aggregate
 //  Output: the Velox computed Aggregation result
 
-TEST_P(PlanConversionTest, queryTest) {
-  // Generate the used ORC file.
-  auto type =
-      ROW({"l_orderkey",
-           "l_partkey",
-           "l_suppkey",
-           "l_linenumber",
-           "l_quantity",
-           "l_extendedprice",
-           "l_discount",
-           "l_tax",
-           "l_returnflag",
-           "l_linestatus",
-           "l_shipdate_new",
-           "l_commitdate_new",
-           "l_receiptdate_new",
-           "l_shipinstruct",
-           "l_shipmode",
-           "l_comment"},
-          {BIGINT(),
-           BIGINT(),
-           BIGINT(),
-           INTEGER(),
-           DOUBLE(),
-           DOUBLE(),
-           DOUBLE(),
-           DOUBLE(),
-           VARCHAR(),
-           VARCHAR(),
-           DOUBLE(),
-           DOUBLE(),
-           DOUBLE(),
-           VARCHAR(),
-           VARCHAR(),
-           VARCHAR()});
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
-  std::vector<VectorPtr> vectors;
-  // TPC-H lineitem table has 16 columns.
-  int colNum = 16;
-  vectors.reserve(colNum);
-  std::vector<int64_t> lOrderkeyData = {
-      4636438147,
-      2012485446,
-      1635327427,
-      8374290148,
-      2972204230,
-      8001568994,
-      989963396,
-      2142695974,
-      6354246853,
-      4141748419};
-  vectors.emplace_back(createSpecificScalar<int64_t>(10, lOrderkeyData, *pool));
-  std::vector<int64_t> lPartkeyData = {
-      263222018,
-      255918298,
-      143549509,
-      96877642,
-      201976875,
-      196938305,
-      100260625,
-      273511608,
-      112999357,
-      299103530};
-  vectors.emplace_back(createSpecificScalar<int64_t>(10, lPartkeyData, *pool));
-  std::vector<int64_t> lSuppkeyData = {
-      2102019,
-      13998315,
-      12989528,
-      4717643,
-      9976902,
-      12618306,
-      11940632,
-      871626,
-      1639379,
-      3423588};
-  vectors.emplace_back(createSpecificScalar<int64_t>(10, lSuppkeyData, *pool));
-  std::vector<int32_t> lLinenumberData = {4, 6, 1, 5, 1, 2, 1, 5, 2, 6};
-  vectors.emplace_back(
-      createSpecificScalar<int32_t>(10, lLinenumberData, *pool));
-  std::vector<double> lQuantityData = {
-      6.0, 1.0, 19.0, 4.0, 6.0, 12.0, 23.0, 11.0, 16.0, 19.0};
-  vectors.emplace_back(createSpecificScalar<double>(10, lQuantityData, *pool));
-  std::vector<double> lExtendedpriceData = {
-      30586.05,
-      7821.0,
-      1551.33,
-      30681.2,
-      1941.78,
-      66673.0,
-      6322.44,
-      41754.18,
-      8704.26,
-      63780.36};
-  vectors.emplace_back(
-      createSpecificScalar<double>(10, lExtendedpriceData, *pool));
-  std::vector<double> lDiscountData = {
-      0.05, 0.06, 0.01, 0.07, 0.05, 0.06, 0.07, 0.05, 0.06, 0.07};
-  vectors.emplace_back(createSpecificScalar<double>(10, lDiscountData, *pool));
-  std::vector<double> lTaxData = {
-      0.02, 0.03, 0.01, 0.0, 0.01, 0.01, 0.03, 0.07, 0.01, 0.04};
-  vectors.emplace_back(createSpecificScalar<double>(10, lTaxData, *pool));
-  std::vector<std::string> lReturnflagData = {
-      "N", "A", "A", "R", "A", "N", "A", "A", "N", "R"};
-  vectors.emplace_back(createSpecificStringVector(10, lReturnflagData, *pool));
-  std::vector<std::string> lLinestatusData = {
-      "O", "F", "F", "F", "F", "O", "F", "F", "O", "F"};
-  vectors.emplace_back(createSpecificStringVector(10, lLinestatusData, *pool));
-  std::vector<double> lShipdateNewData = {
-      8953.666666666666,
-      8773.666666666666,
-      9034.666666666666,
-      8558.666666666666,
-      9072.666666666666,
-      8864.666666666666,
-      9004.666666666666,
-      8778.666666666666,
-      9013.666666666666,
-      8832.666666666666};
-  vectors.emplace_back(
-      createSpecificScalar<double>(10, lShipdateNewData, *pool));
-  std::vector<double> lCommitdateNewData = {
-      10447.666666666666,
-      8953.666666666666,
-      8325.666666666666,
-      8527.666666666666,
-      8438.666666666666,
-      10049.666666666666,
-      9036.666666666666,
-      8666.666666666666,
-      9519.666666666666,
-      9138.666666666666};
-  vectors.emplace_back(
-      createSpecificScalar<double>(10, lCommitdateNewData, *pool));
-  std::vector<double> lReceiptdateNewData = {
-      10456.666666666666,
-      8979.666666666666,
-      8299.666666666666,
-      8474.666666666666,
-      8525.666666666666,
-      9996.666666666666,
-      9103.666666666666,
-      8726.666666666666,
-      9593.666666666666,
-      9178.666666666666};
-  vectors.emplace_back(
-      createSpecificScalar<double>(10, lReceiptdateNewData, *pool));
-  std::vector<std::string> lShipinstructData = {
-      "COLLECT COD",
-      "NONE",
-      "TAKE BACK RETURN",
-      "NONE",
-      "TAKE BACK RETURN",
-      "NONE",
-      "DELIVER IN PERSON",
-      "DELIVER IN PERSON",
-      "TAKE BACK RETURN",
-      "NONE"};
-  vectors.emplace_back(
-      createSpecificStringVector(10, lShipinstructData, *pool));
-  std::vector<std::string> lShipmodeData = {
-      "FOB",
-      "REG AIR",
-      "MAIL",
-      "FOB",
-      "RAIL",
-      "SHIP",
-      "REG AIR",
-      "REG AIR",
-      "TRUCK",
-      "AIR"};
-  vectors.emplace_back(createSpecificStringVector(10, lShipmodeData, *pool));
-  std::vector<std::string> lCommentData = {
-      " the furiously final foxes. quickly final p",
-      "thely ironic",
-      "ate furiously. even, pending pinto bean",
-      "ackages af",
-      "odolites. slyl",
-      "ng the regular requests sleep above",
-      "lets above the slyly ironic theodolites sl",
-      "lyly regular excuses affi",
-      "lly unusual theodolites grow slyly above",
-      " the quickly ironic pains lose car"};
-  vectors.emplace_back(createSpecificStringVector(10, lCommentData, *pool));
-
-  // Batches has only one RowVector here.
-  uint64_t nullCount = 0;
-  std::vector<RowVectorPtr> batches{std::make_shared<RowVector>(
-      pool.get(), type, nullptr, 10, vectors, nullCount)};
-
+TEST_P(PlanConversionTest, q6FirstStage) {
+  auto veloxConverter = std::make_shared<VeloxConverter>();
+  genLineitemORC(veloxConverter);
   // Find and deserialize Substrait plan json file.
   std::string planPath =
-      getDataFilePath("velox/substrait/tests", "data/sub.json");
-  auto veloxConverter = std::make_shared<VeloxConverter>();
-
-  // Writes data into an ORC file.
-  auto sink = std::make_unique<facebook::velox::dwio::common::FileSink>(
-      veloxConverter->getTmpDirPath() + "/mock_lineitem.orc");
-  auto config = std::make_shared<facebook::velox::dwrf::Config>();
-  const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max();
-  facebook::velox::dwrf::WriterOptions options;
-  options.config = config;
-  options.schema = type;
-  options.memoryBudget = writerMemoryCap;
-  options.flushPolicyFactory = nullptr;
-  options.layoutPlannerFactory = nullptr;
-  auto writer = std::make_unique<facebook::velox::dwrf::Writer>(
-      options,
-      std::move(sink),
-      facebook::velox::memory::getProcessDefaultMemoryManager().getRoot());
-  for (size_t i = 0; i < batches.size(); ++i) {
-    writer->write(batches[i]);
-  }
-  writer->close();
-
+      getDataFilePath("velox/substrait/tests", "data/q6_first_stage.json");
   auto resIter = veloxConverter->getResIter(planPath);
   while (resIter->HasNext()) {
     auto rv = resIter->Next();
@@ -490,6 +498,46 @@ TEST_P(PlanConversionTest, queryTest) {
     ASSERT_EQ(size, 1);
     std::string res = rv->toString(0);
     ASSERT_EQ(res, "{ [child at 0]: 13613.1921}");
+  }
+}
+
+// This test will firstly generate mock TPC-H lineitem ORC file. Then, Velox's
+// computing will be tested based on the generated ORC file.
+// Input: Json file of the Substrait plan for the first stage of the below
+// modified TPC-H Q1 query:
+//
+// select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty,
+// sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 -
+// l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 +
+// l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as
+// avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem
+// where l_shipdate <= 10471 group by l_returnflag, l_linestatus order by
+// l_returnflag, l_linestatus
+//
+//  Tested Velox computings include: TableScan (Filter Pushdown) + Project +
+//  Aggregate
+//  Output: the Velox computed Aggregation result
+
+TEST_P(PlanConversionTest, q1FirstStage) {
+  auto veloxConverter = std::make_shared<VeloxConverter>();
+  genLineitemORC(veloxConverter);
+  // Find and deserialize Substrait plan json file.
+  std::string planPath =
+      getDataFilePath("velox/substrait/tests", "data/q1_first_stage.json");
+  auto resIter = veloxConverter->getResIter(planPath);
+  while (resIter->HasNext()) {
+    auto rv = resIter->Next();
+    auto size = rv->size();
+    ASSERT_EQ(size, 3);
+    ASSERT_EQ(
+        rv->toString(0),
+        "{ [child at 0]: N, O, 34, 105963.31, 99911.3719, 101201.05309399999, 34, 3, 105963.31, 3, 0.16999999999999998, 3, 3}");
+    ASSERT_EQ(
+        rv->toString(1),
+        "{ [child at 1]: A, F, 60, 59390.729999999996, 56278.5879, 59485.994223, 60, 5, 59390.729999999996, 5, 0.24, 5, 5}");
+    ASSERT_EQ(
+        rv->toString(2),
+        "{ [child at 2]: R, F, 23, 94461.56, 87849.2508, 90221.880192, 23, 2, 94461.56, 2, 0.14, 2, 2}");
   }
 }
 

--- a/velox/substrait/tests/data/q6_first_stage.json
+++ b/velox/substrait/tests/data/q6_first_stage.json
@@ -1,0 +1,523 @@
+{
+ "extension_uris": [],
+ "extensions": [
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 4,
+    "name": "lte:fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 6,
+    "name": "sum:opt_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 3,
+    "name": "lt:fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 0,
+    "name": "is_not_null:fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 1,
+    "name": "and:bool_bool"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 2,
+    "name": "gte:fp64_fp64"
+   }
+  },
+  {
+   "extension_function": {
+    "extension_uri_reference": 0,
+    "function_anchor": 5,
+    "name": "multiply:opt_fp64_fp64"
+   }
+  }
+ ],
+ "relations": [
+  {
+   "root": {
+    "input": {
+     "aggregate": {
+      "common": {
+       "direct": {}
+      },
+      "input": {
+       "project": {
+        "common": {
+         "direct": {}
+        },
+        "input": {
+         "project": {
+          "common": {
+           "direct": {}
+          },
+          "input": {
+           "read": {
+            "common": {
+             "direct": {}
+            },
+            "base_schema": {
+             "names": [
+              "l_quantity",
+              "l_extendedprice",
+              "l_discount",
+              "l_shipdate"
+             ],
+             "struct": {
+              "types": [
+               {
+                "fp64": {
+                 "type_variation_reference": 0,
+                 "nullability": "NULLABILITY_NULLABLE"
+                }
+               },
+               {
+                "fp64": {
+                 "type_variation_reference": 0,
+                 "nullability": "NULLABILITY_NULLABLE"
+                }
+               },
+               {
+                "fp64": {
+                 "type_variation_reference": 0,
+                 "nullability": "NULLABILITY_NULLABLE"
+                }
+               },
+               {
+                "fp64": {
+                 "type_variation_reference": 0,
+                 "nullability": "NULLABILITY_NULLABLE"
+                }
+               }
+              ],
+              "type_variation_reference": 0,
+              "nullability": "NULLABILITY_UNSPECIFIED"
+             }
+            },
+            "filter": {
+             "scalar_function": {
+              "function_reference": 1,
+              "args": [
+               {
+                "scalar_function": {
+                 "function_reference": 1,
+                 "args": [
+                  {
+                   "scalar_function": {
+                    "function_reference": 1,
+                    "args": [
+                     {
+                      "scalar_function": {
+                       "function_reference": 1,
+                       "args": [
+                        {
+                         "scalar_function": {
+                          "function_reference": 1,
+                          "args": [
+                           {
+                            "scalar_function": {
+                             "function_reference": 1,
+                             "args": [
+                              {
+                               "scalar_function": {
+                                "function_reference": 1,
+                                "args": [
+                                 {
+                                  "scalar_function": {
+                                   "function_reference": 0,
+                                   "args": [
+                                    {
+                                     "selection": {
+                                      "direct_reference": {
+                                       "struct_field": {
+                                        "field": 3
+                                       }
+                                      }
+                                     }
+                                    }
+                                   ],
+                                   "output_type": {
+                                    "bool": {
+                                     "type_variation_reference": 0,
+                                     "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                   }
+                                  }
+                                 },
+                                 {
+                                  "scalar_function": {
+                                   "function_reference": 0,
+                                   "args": [
+                                    {
+                                     "selection": {
+                                      "direct_reference": {
+                                       "struct_field": {
+                                        "field": 2
+                                       }
+                                      }
+                                     }
+                                    }
+                                   ],
+                                   "output_type": {
+                                    "bool": {
+                                     "type_variation_reference": 0,
+                                     "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                   }
+                                  }
+                                 }
+                                ],
+                                "output_type": {
+                                 "bool": {
+                                  "type_variation_reference": 0,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                 }
+                                }
+                               }
+                              },
+                              {
+                               "scalar_function": {
+                                "function_reference": 0,
+                                "args": [
+                                 {
+                                  "selection": {
+                                   "direct_reference": {
+                                    "struct_field": {
+                                     "field": 0
+                                    }
+                                   }
+                                  }
+                                 }
+                                ],
+                                "output_type": {
+                                 "bool": {
+                                  "type_variation_reference": 0,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                 }
+                                }
+                               }
+                              }
+                             ],
+                             "output_type": {
+                              "bool": {
+                               "type_variation_reference": 0,
+                               "nullability": "NULLABILITY_NULLABLE"
+                              }
+                             }
+                            }
+                           },
+                           {
+                            "scalar_function": {
+                             "function_reference": 2,
+                             "args": [
+                              {
+                               "selection": {
+                                "direct_reference": {
+                                 "struct_field": {
+                                  "field": 3
+                                 }
+                                }
+                               }
+                              },
+                              {
+                               "literal": {
+                                "nullable": false,
+                                "fp64": 8766
+                               }
+                              }
+                             ],
+                             "output_type": {
+                              "bool": {
+                               "type_variation_reference": 0,
+                               "nullability": "NULLABILITY_NULLABLE"
+                              }
+                             }
+                            }
+                           }
+                          ],
+                          "output_type": {
+                           "bool": {
+                            "type_variation_reference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                           }
+                          }
+                         }
+                        },
+                        {
+                         "scalar_function": {
+                          "function_reference": 3,
+                          "args": [
+                           {
+                            "selection": {
+                             "direct_reference": {
+                              "struct_field": {
+                               "field": 3
+                              }
+                             }
+                            }
+                           },
+                           {
+                            "literal": {
+                             "nullable": false,
+                             "fp64": 9131
+                            }
+                           }
+                          ],
+                          "output_type": {
+                           "bool": {
+                            "type_variation_reference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                           }
+                          }
+                         }
+                        }
+                       ],
+                       "output_type": {
+                        "bool": {
+                         "type_variation_reference": 0,
+                         "nullability": "NULLABILITY_NULLABLE"
+                        }
+                       }
+                      }
+                     },
+                     {
+                      "scalar_function": {
+                       "function_reference": 2,
+                       "args": [
+                        {
+                         "selection": {
+                          "direct_reference": {
+                           "struct_field": {
+                            "field": 2
+                           }
+                          }
+                         }
+                        },
+                        {
+                         "literal": {
+                          "nullable": false,
+                          "fp64": 0.05
+                         }
+                        }
+                       ],
+                       "output_type": {
+                        "bool": {
+                         "type_variation_reference": 0,
+                         "nullability": "NULLABILITY_NULLABLE"
+                        }
+                       }
+                      }
+                     }
+                    ],
+                    "output_type": {
+                     "bool": {
+                      "type_variation_reference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                     }
+                    }
+                   }
+                  },
+                  {
+                   "scalar_function": {
+                    "function_reference": 4,
+                    "args": [
+                     {
+                      "selection": {
+                       "direct_reference": {
+                        "struct_field": {
+                         "field": 2
+                        }
+                       }
+                      }
+                     },
+                     {
+                      "literal": {
+                       "nullable": false,
+                       "fp64": 0.07
+                      }
+                     }
+                    ],
+                    "output_type": {
+                     "bool": {
+                      "type_variation_reference": 0,
+                      "nullability": "NULLABILITY_NULLABLE"
+                     }
+                    }
+                   }
+                  }
+                 ],
+                 "output_type": {
+                  "bool": {
+                   "type_variation_reference": 0,
+                   "nullability": "NULLABILITY_NULLABLE"
+                  }
+                 }
+                }
+               },
+               {
+                "scalar_function": {
+                 "function_reference": 3,
+                 "args": [
+                  {
+                   "selection": {
+                    "direct_reference": {
+                     "struct_field": {
+                      "field": 0
+                     }
+                    }
+                   }
+                  },
+                  {
+                   "literal": {
+                    "nullable": false,
+                    "fp64": 24
+                   }
+                  }
+                 ],
+                 "output_type": {
+                  "bool": {
+                   "type_variation_reference": 0,
+                   "nullability": "NULLABILITY_NULLABLE"
+                  }
+                 }
+                }
+               }
+              ],
+              "output_type": {
+               "bool": {
+                "type_variation_reference": 0,
+                "nullability": "NULLABILITY_NULLABLE"
+               }
+              }
+             }
+            },
+            "local_files": {
+             "items": [
+              {
+               "format": "FILE_FORMAT_UNSPECIFIED",
+               "partition_index": "0",
+               "start": "0",
+               "length": "3719",
+               "uri_file": "/mock_lineitem.orc"
+              }
+             ]
+            }
+           }
+          },
+          "expressions": [
+           {
+            "selection": {
+             "direct_reference": {
+              "struct_field": {
+               "field": 1
+              }
+             }
+            }
+           },
+           {
+            "selection": {
+             "direct_reference": {
+              "struct_field": {
+               "field": 2
+              }
+             }
+            }
+           }
+          ]
+         }
+        },
+        "expressions": [
+         {
+          "scalar_function": {
+           "function_reference": 5,
+           "args": [
+            {
+             "selection": {
+              "direct_reference": {
+               "struct_field": {
+                "field": 0
+               }
+              }
+             }
+            },
+            {
+             "selection": {
+              "direct_reference": {
+               "struct_field": {
+                "field": 1
+               }
+              }
+             }
+            }
+           ],
+           "output_type": {
+            "fp64": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           }
+          }
+         }
+        ]
+       }
+      },
+      "groupings": [
+       {
+        "grouping_expressions": []
+       }
+      ],
+      "measures": [
+       {
+        "measure": {
+         "function_reference": 6,
+         "args": [
+          {
+           "selection": {
+            "direct_reference": {
+             "struct_field": {
+              "field": 0
+             }
+            }
+           }
+          }
+         ],
+         "sorts": [],
+         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+         "output_type": {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        }
+       }
+      ]
+     }
+    },
+    "names": [
+     "real_arrow_output",
+     "sum"
+    ]
+   }
+  }
+ ],
+ "expected_type_urls": []
+}

--- a/velox/substrait/tests/data/read_second_stage.json
+++ b/velox/substrait/tests/data/read_second_stage.json
@@ -1,0 +1,119 @@
+{
+"read": {
+   "common": {
+    "direct": {}
+   },
+   "base_schema": {
+    "names": [
+     "l_returnflag",
+     "l_linestatus",
+     "sum",
+     "sum",
+     "sum",
+     "sum",
+     "sum",
+     "count",
+     "sum",
+     "count",
+     "sum",
+     "count",
+     "count"
+    ],
+    "struct": {
+     "types": [
+      {
+       "string": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "string": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "i64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "i64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "fp64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "i64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      {
+       "i64": {
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_REQUIRED"
+       }
+      }
+     ],
+     "type_variation_reference": 0,
+     "nullability": "NULLABILITY_UNSPECIFIED"
+    }
+   },
+   "local_files": {
+    "items": [
+     {
+      "format": "FILE_FORMAT_UNSPECIFIED",
+      "partition_index": "0",
+      "start": "0",
+      "length": "0",
+      "uri_file": "iterator:1"
+     }
+    ]
+   }
+  }
+}


### PR DESCRIPTION
Add substrait-to-velox conversion for JoinRel. Since substrait doesn't distinguish between different kinds of physical join types, we'll convert JoinRel to hash join by default.

This PR depends on https://github.com/facebookincubator/velox/pull/1554. Will rebase after https://github.com/facebookincubator/velox/pull/1554 gets merged.