### PR TITLE
Convert function names to lower case at function registration and resolution

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -442,6 +442,13 @@ For example,
 creates a final aggregation using an approx_percentile aggregate function with
 DOUBLE result type.
 
+Function names
+------------
+
+Same as scalar functions, aggregate function names are case insensitive. The names
+are converted to lower case automatically when the functions are registered and
+when they are resolved for a given expression.
+
 Documentation
 -------------
 
@@ -482,4 +489,3 @@ To confirm that aggregate function works end to end as part of query, update tes
 .. code-block:: java
 
     assertQuery("SELECT orderkey, array_agg(linenumber) FROM lineitem GROUP BY 1");
-

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1218,6 +1218,13 @@ result. Here is an example of a test for simple function “sqrt”:
       EXPECT_TRUE(std::isnan(sqrt(kNan).value_or(-1)));
     }
 
+Function names
+------------
+
+For both simple and vector functions, their names are case insensitive. Function
+names are converted to lower case automatically when the functions are
+registered and when they are resolved for a given expression.
+
 Benchmarking
 ------------
 

--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -37,8 +37,10 @@ AggregateFunctionMap& aggregateFunctions() {
 namespace {
 std::optional<const AggregateFunctionEntry*> getAggregateFunctionEntry(
     const std::string& name) {
+  auto sanitizedName = sanitizeFunctionName(name);
+
   auto& functionsMap = aggregateFunctions();
-  auto it = functionsMap.find(name);
+  auto it = functionsMap.find(sanitizedName);
   if (it != functionsMap.end()) {
     return &it->second;
   }
@@ -51,7 +53,10 @@ bool registerAggregateFunction(
     const std::string& name,
     std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures,
     AggregateFunctionFactory factory) {
-  aggregateFunctions()[name] = {std::move(signatures), std::move(factory)};
+  auto sanitizedName = sanitizeFunctionName(name);
+
+  aggregateFunctions()[sanitizedName] = {
+      std::move(signatures), std::move(factory)};
   return true;
 }
 

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -119,6 +119,7 @@ class FunctionRegistryTest : public testing::Test {
  public:
   FunctionRegistryTest() {
     registerAggregateFunc("aggregate_func");
+    registerAggregateFunc("Aggregate_Func_Alias");
   }
 
   void checkEqual(const TypePtr& actual, const TypePtr& expected) {
@@ -165,6 +166,13 @@ TEST_F(FunctionRegistryTest, hasAggregateFunctionSignatureWrongArgType) {
   testResolveAggregateFunction("aggregate_func", {BIGINT()}, nullptr, nullptr);
   testResolveAggregateFunction(
       "aggregate_func", {BIGINT(), BIGINT(), BIGINT()}, nullptr, nullptr);
+}
+
+TEST_F(FunctionRegistryTest, functionNameInMixedCase) {
+  testResolveAggregateFunction(
+      "aggregatE_funC", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
+  testResolveAggregateFunction(
+      "aggregatE_funC_aliaS", {DOUBLE(), DOUBLE()}, DOUBLE(), ARRAY(DOUBLE()));
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -129,18 +129,23 @@ class FunctionRegistry {
       const std::shared_ptr<const Metadata>& metadata,
       typename FunctionEntry<Function, Metadata>::FunctionFactory factory) {
     for (const auto& name : names) {
-      if (registeredFunctions_.find(name) == registeredFunctions_.end()) {
-        registeredFunctions_[name] = SignatureMap{};
+      auto sanitizedName = sanitizeFunctionName(name);
+
+      if (registeredFunctions_.find(sanitizedName) ==
+          registeredFunctions_.end()) {
+        registeredFunctions_[sanitizedName] = SignatureMap{};
       }
 
-      registeredFunctions_[name][*metadata->signature()] =
+      registeredFunctions_[sanitizedName][*metadata->signature()] =
           std::make_unique<const FunctionEntry<Function, Metadata>>(
               metadata, std::move(factory));
     }
   }
 
   SignatureMap* getSignatureMap(const std::string& name) {
-    auto it = registeredFunctions_.find(name);
+    auto sanitizedName = sanitizeFunctionName(name);
+
+    auto it = registeredFunctions_.find(sanitizedName);
     if (it != registeredFunctions_.end()) {
       return &it->second;
     }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -21,6 +21,17 @@
 
 namespace facebook::velox::exec {
 
+std::string sanitizeFunctionName(const std::string& name) {
+  std::string sanitizedName;
+  sanitizedName.resize(name.size());
+  std::transform(
+      name.begin(), name.end(), sanitizedName.begin(), [](unsigned char c) {
+        return std::tolower(c);
+      });
+
+  return sanitizedName;
+}
+
 void toAppend(
     const facebook::velox::exec::TypeSignature& signature,
     std::string* result) {

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -22,6 +22,8 @@
 
 namespace facebook::velox::exec {
 
+std::string sanitizeFunctionName(const std::string& name);
+
 // A type name (e.g. K or V in map(K, V)) and optionally constraints, e.g.
 // orderable, sortable, etc.
 class TypeVariableConstraint {

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -199,7 +199,7 @@ VELOX_DECLARE_VECTOR_FUNCTION(
 
 inline void registerTestFunctions() {
   // If no alias is specified, ensure it will fallback to the struct name.
-  registerFunction<FuncOne, Varchar, Varchar>({"func_one"});
+  registerFunction<FuncOne, Varchar, Varchar>({"func_one", "Func_One_Alias"});
 
   // func_two has two signatures.
   registerFunction<FuncTwo, int64_t, int64_t, int32_t>({"func_two"});
@@ -213,9 +213,11 @@ inline void registerTestFunctions() {
   registerFunction<FuncFour, Varchar, Varchar>({"func_five"});
   registerFunction<FuncFive, int64_t, int64_t>({"func_four"});
 
-  registerFunction<VariadicFunc, Varchar, Variadic<Varchar>>({"variadic_func"});
+  registerFunction<VariadicFunc, Varchar, Variadic<Varchar>>(
+      {"variadic_func", "Variadic_Func_Alias"});
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_one, "vector_func_one");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_one, "Vector_Func_One_Alias");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_two, "vector_func_two");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_three, "vector_func_three");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_vector_func_four, "vector_func_four");
@@ -247,7 +249,7 @@ class FunctionRegistryTest : public ::testing::Test {
 
 TEST_F(FunctionRegistryTest, getFunctionSignatures) {
   auto functionSignatures = getFunctionSignatures();
-  ASSERT_EQ(functionSignatures.size(), 11);
+  ASSERT_EQ(functionSignatures.size(), 14);
 
   ASSERT_EQ(functionSignatures.count("func_one"), 1);
   ASSERT_EQ(functionSignatures.count("func_two"), 1);
@@ -445,6 +447,21 @@ TEST_F(FunctionRegistryTest, registerFunctionTwice) {
   // The function should only be registered once, despite the multiple calls to
   // registerFunction.
   ASSERT_EQ(signatures.size(), 1);
+}
+
+TEST_F(FunctionRegistryTest, functionNameInMixedCase) {
+  auto result = resolveFunction("funC_onE", {VARCHAR()});
+  ASSERT_EQ(*result, *VARCHAR());
+  result = resolveFunction("funC_onE_aliaS", {VARCHAR()});
+  ASSERT_EQ(*result, *VARCHAR());
+
+  testResolveVectorFunction("vectoR_funC_onE_aliaS", {VARCHAR()}, BIGINT());
+  testResolveVectorFunction("vectoR_funC_onE", {VARCHAR()}, BIGINT());
+
+  result = resolveFunction("variadiC_funC_aliaS", {VARCHAR(), VARCHAR()});
+  ASSERT_EQ(*result, *VARCHAR());
+  result = resolveFunction("variadiC_funC", {});
+  ASSERT_EQ(*result, *VARCHAR());
 }
 
 template <typename T>


### PR DESCRIPTION
Summary: Since SQL is case agnostic, we convert function names to lower case when registering and resolving the functions. This allows UDFs to be registered with mixed-case names. Engines that use Velox should convert function names in expressions into lower case before giving them to Velox.

Differential Revision: D36380252

