### PR TITLE
Extract common utils from `ColumnReader` and create `DwrfColumnReader` 

### DIFF
--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -21,6 +21,6 @@
 // Replacing it with "nothing" is okay when testing is disabled.
 #define VELOX_FRIEND_TEST(X, Y)
 #else
-#include <gtest/gtest_prod.h>
+#include "third_party/googletest/googletest/include/gtest/gtest_prod.h"
 #define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
 #endif

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -21,7 +21,7 @@
 #include "velox/common/base/Exceptions.h"
 
 #include <folly/Likely.h>
-#include <xsimd/xsimd.hpp>
+#include "third_party/xsimd/include/xsimd/xsimd.hpp"
 
 namespace facebook::velox::simd {
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -31,6 +31,7 @@
 #include "folly/Random.h"
 #include "folly/SharedMutex.h"
 #include "folly/experimental/FunctionScheduler.h"
+#include "third_party/googletest/googletest/include/gtest/gtest_prod.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"

--- a/velox/dwio/common/AbstractByteRleDecoder.h
+++ b/velox/dwio/common/AbstractByteRleDecoder.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
+
+namespace facebook::velox::dwio::common {
+
+class AbstractByteRleDecoder {
+  // TODO: inputStream or AbstractInputStream can be moved here later
+  //  std::unique_ptr<SeekableInputStream> inputStream;
+ public:
+  AbstractByteRleDecoder()
+      : remainingValues{0},
+        value{0},
+        bufferStart{nullptr},
+        bufferEnd{nullptr},
+        repeating{false} {}
+  size_t remainingValues;
+  char value;
+  const char* bufferStart;
+  const char* bufferEnd;
+  bool repeating;
+
+  /**
+   * Read a number of values into the batch.
+   * @param data the array to read into
+   * @param numValues the number of values to read
+   * @param nulls If the pointer is null, all values are read. If the
+   *    pointer is not null, positions that are true are skipped.
+   */
+  virtual void next(char* data, uint64_t numValues, const uint64_t* nulls) = 0;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_subdirectory(compression)
 add_subdirectory(encryption)
 add_subdirectory(exception)
+add_subdirectory(reader)
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
@@ -33,6 +34,7 @@ add_library(
 
 target_link_libraries(
   velox_dwio_common
+  velox_dwio_common_reader
   velox_buffer
   velox_exception
   velox_dwio_common_encryption

--- a/velox/dwio/common/reader/CMakeLists.txt
+++ b/velox/dwio/common/reader/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_dwio_common_reader ColumnReader.cpp)
+
+target_link_libraries(velox_dwio_common_reader velox_dwio_dwrf_proto)

--- a/velox/dwio/common/reader/ColumnReader.cpp
+++ b/velox/dwio/common/reader/ColumnReader.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/reader/ColumnReader.h"
+#include "velox/dwio/common/TypeUtils.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+
+// TODO: Move the IntCodecCommon.h file to velox/common/dwio
+#include "velox/dwio/dwrf/common/IntCodecCommon.h"
+
+#include <folly/String.h>
+
+namespace facebook::velox::dwio::common::reader {
+
+using dwio::common::typeutils::CompatChecker;
+using memory::MemoryPool;
+
+// Buffer size for reading length stream
+constexpr uint64_t BUFFER_SIZE = 1024;
+
+// it's possible stride dictionary only contains zero length string. In that
+// case, we still need to make batch point to a valid address
+std::array<char, 1> EMPTY_DICT;
+
+namespace detail {
+
+void fillTimestamps(
+    Timestamp* timestamps,
+    const uint64_t* nullsPtr,
+    const int64_t* secondsPtr,
+    const uint64_t* nanosPtr,
+    vector_size_t numValues) {
+  for (vector_size_t i = 0; i < numValues; i++) {
+    if (!nullsPtr || !bits::isBitNull(nullsPtr, i)) {
+      auto nanos = nanosPtr[i];
+      uint64_t zeros = nanos & 0x7;
+      nanos >>= 3;
+      if (zeros != 0) {
+        for (uint64_t j = 0; j <= zeros; ++j) {
+          nanos *= 10;
+        }
+      }
+      auto seconds = secondsPtr[i] + dwrf::EPOCH_OFFSET;
+      if (seconds < 0 && nanos != 0) {
+        seconds -= 1;
+      }
+      timestamps[i] = Timestamp(seconds, nanos);
+    }
+  }
+};
+
+} // namespace detail
+
+BufferPtr ColumnReader::readNulls(
+    vector_size_t numValues,
+    VectorPtr& result,
+    const uint64_t* incomingNulls) {
+  BufferPtr nulls;
+  readNulls(numValues, incomingNulls, &result, nulls);
+  return nulls;
+}
+
+void ColumnReader::readNulls(
+    vector_size_t numValues,
+    const uint64_t* incomingNulls,
+    VectorPtr* result,
+    BufferPtr& nulls) {
+  if (!notNullDecoder_ && !incomingNulls) {
+    nulls = nullptr;
+    if (result && *result) {
+      (*result)->resetNulls();
+    }
+    return;
+  }
+  auto numBytes = bits::nbytes(numValues);
+  if (result && *result) {
+    nulls = (*result)->mutableNulls(numValues + (simd::kPadding * 8));
+    detail::resetIfNotWritable(*result, nulls);
+  }
+  if (!nulls || nulls->capacity() < numBytes + simd::kPadding) {
+    nulls =
+        AlignedBuffer::allocate<char>(numBytes + simd::kPadding, &memoryPool_);
+  }
+  nulls->setSize(numBytes);
+  auto* nullsPtr = nulls->asMutable<uint64_t>();
+  if (!notNullDecoder_) {
+    memcpy(nullsPtr, incomingNulls, numBytes);
+    return;
+  }
+  memset(nullsPtr, bits::kNotNullByte, numBytes);
+  notNullDecoder_->next(
+      reinterpret_cast<char*>(nullsPtr), numValues, incomingNulls);
+}
+
+uint64_t ColumnReader::skip(uint64_t numValues) {
+  if (notNullDecoder_) {
+    // page through the values that we want to skip
+    // and count how many are non-null
+    std::array<char, BUFFER_SIZE> buffer;
+    constexpr auto bitCount = BUFFER_SIZE * 8;
+    uint64_t remaining = numValues;
+    while (remaining > 0) {
+      uint64_t chunkSize = std::min(remaining, bitCount);
+      notNullDecoder_->next(buffer.data(), chunkSize, nullptr);
+      remaining -= chunkSize;
+      numValues -= bits::countNulls(
+          reinterpret_cast<uint64_t*>(buffer.data()), 0, chunkSize);
+    }
+  }
+  return numValues;
+}
+} // namespace facebook::velox::dwio::common::reader

--- a/velox/dwio/common/reader/ColumnReader.h
+++ b/velox/dwio/common/reader/ColumnReader.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/ColumnSelector.h"
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/vector/BaseVector.h"
+
+#include "velox/dwio/common/AbstractByteRleDecoder.h"
+
+namespace facebook::velox::dwio::common::reader {
+/**
+ * Expand an array of bytes in place to the corresponding bigger.
+ * Has to work backwards so that they data isn't clobbered during the
+ * expansion.
+ * @param buffer the array of chars and array of longs that need to be
+ *        expanded
+ * @param numValues the number of bytes to convert to longs
+ */
+template <typename From, typename To>
+std::enable_if_t<std::is_same_v<From, bool>> expandBytes(
+    To* buffer,
+    uint64_t numValues) {
+  for (size_t i = numValues - 1; i < numValues; --i) {
+    buffer[i] = static_cast<To>(bits::isBitSet(buffer, i));
+  }
+}
+
+template <typename From, typename To>
+std::enable_if_t<std::is_same_v<From, int8_t>> expandBytes(
+    To* buffer,
+    uint64_t numValues) {
+  auto from = reinterpret_cast<int8_t*>(buffer);
+  for (size_t i = numValues - 1; i < numValues; --i) {
+    buffer[i] = static_cast<To>(from[i]);
+  }
+}
+
+
+
+
+
+/**
+ * The interface for reading ORC data types.
+ */
+class ColumnReader {
+ protected:
+  explicit ColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& type, memory::MemoryPool& memoryPool) : notNullDecoder_{}, nodeType_{type}, memoryPool_{memoryPool} {}
+  // Reads nulls, if any. Sets '*nulls' to nullptr if void
+  // the reader has no nulls and there are no incoming
+  //          nulls.Takes 'nulls' from 'result' if '*result' is non -
+  //      null.Otherwise ensures that 'nulls' has a buffer of sufficient
+  //          size and uses this.
+  virtual void readNulls(
+      vector_size_t numValues,
+      const uint64_t* incomingNulls,
+      VectorPtr* result,
+      BufferPtr& nulls);
+
+  virtual BufferPtr readNulls(
+      vector_size_t numValues,
+      VectorPtr& result,
+      const uint64_t* incomingNulls);
+
+  std::shared_ptr<AbstractByteRleDecoder> notNullDecoder_;
+
+  // We use AbstractByteRleDecoder as an interface wrapper for ByteRleDecoder so that readNulls can be put in ColumnReader
+  const std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
+  memory::MemoryPool& memoryPool_;
+
+ public:
+
+  virtual ~ColumnReader() = default;
+
+  /**
+   * Skip number of specified rows.
+   * @param numValues the number of values to skip
+   * @return the number of non-null values skipped
+   */
+  virtual uint64_t skip(uint64_t numValues);
+
+
+  /**
+   * Read the next group of values into a RowVector.
+   * @param numValues the number of values to read
+   * @param vector to read into
+   */
+  virtual void next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* nulls = nullptr) = 0;
+
+};
+
+namespace detail {
+
+template <typename T>
+inline void ensureCapacity(
+    BufferPtr& data,
+    size_t capacity,
+    velox::memory::MemoryPool* pool) {
+  if (!data || !data->unique() ||
+      data->capacity() < BaseVector::byteSize<T>(capacity)) {
+    data = AlignedBuffer::allocate<T>(capacity, pool);
+  }
+}
+
+template <typename T>
+inline T* resetIfWrongVectorType(VectorPtr& result) {
+  if (result) {
+    auto casted = result->as<T>();
+    // We only expect vector to be used by a single thread.
+    if (casted && result.use_count() == 1) {
+      return casted;
+    }
+    result.reset();
+  }
+  return nullptr;
+}
+
+template <typename... T>
+inline void resetIfNotWritable(VectorPtr& result, T&... buffer) {
+  // The result vector and the buffer both hold reference, so refCount is at
+  // least 2
+  auto resetIfShared = [](auto& buffer) {
+    const bool reset = buffer->refCount() > 2;
+    if (reset) {
+      buffer.reset();
+    }
+    return reset;
+  };
+
+  if ((... | resetIfShared(buffer))) {
+    result.reset();
+  }
+}
+
+// Helper method to build timestamps based on nulls/seconds/nanos
+void fillTimestamps(
+    Timestamp* timestamps,
+    const uint64_t* nulls,
+    const int64_t* seconds,
+    const uint64_t* nanos,
+    vector_size_t numValues);
+
+} // namespace detail
+} // namespace facebook::velox::dwio::common::reader

--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -27,6 +27,8 @@
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/vector/TypeAliases.h"
 
+#include "velox/dwio/common/AbstractByteRleDecoder.h"
+
 namespace facebook::velox::dwrf {
 
 class ByteRleEncoder {
@@ -90,15 +92,11 @@ class ByteRleEncoder {
       int32_t strideIndex = -1) const = 0;
 };
 
-class ByteRleDecoder {
+class ByteRleDecoder : public dwio::common::AbstractByteRleDecoder {
  public:
   ByteRleDecoder(std::unique_ptr<SeekableInputStream> input, EncodingKey ek)
-      : inputStream{std::move(input)},
-        remainingValues{0},
-        value{0},
-        bufferStart{nullptr},
-        bufferEnd{nullptr},
-        repeating{false},
+      : dwio::common::AbstractByteRleDecoder(),
+        inputStream{std::move(input)},
         encodingKey_{ek} {}
 
   virtual ~ByteRleDecoder() = default;
@@ -215,11 +213,7 @@ class ByteRleDecoder {
   }
 
   std::unique_ptr<SeekableInputStream> inputStream;
-  size_t remainingValues;
-  char value;
-  const char* bufferStart;
-  const char* bufferEnd;
-  bool repeating;
+
   EncodingKey encodingKey_;
 };
 

--- a/velox/dwio/dwrf/reader/CMakeLists.txt
+++ b/velox/dwio/dwrf/reader/CMakeLists.txt
@@ -15,7 +15,7 @@
 add_library(
   velox_dwio_dwrf_reader
   BinaryStreamReader.cpp
-  ColumnReader.cpp
+  DwrfColumnReader.cpp
   DwrfReader.cpp
   DwrfReaderShared.cpp
   FlatMapColumnReader.cpp

--- a/velox/dwio/dwrf/reader/ConstantColumnReader.h
+++ b/velox/dwio/dwrf/reader/ConstantColumnReader.h
@@ -16,17 +16,17 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
+#include "velox/dwio/dwrf/reader/DwrfColumnReader.h"
 #include "velox/vector/ConstantVector.h"
 
 namespace facebook::velox::dwrf {
 
-class NullColumnReader : public ColumnReader {
+class NullColumnReader : public DwrfColumnReader {
  public:
   NullColumnReader(
       const StripeStreams& stripe,
       const std::shared_ptr<const Type>& type)
-      : ColumnReader(
+      : DwrfColumnReader(
             stripe.getMemoryPool(),
             dwio::common::TypeWithId::create(type)) {}
   ~NullColumnReader() override = default;

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/ReaderFactory.h"
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
+#include "velox/dwio/dwrf/reader/DwrfColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfReaderShared.h"
 
 namespace facebook::velox::dwrf {
@@ -29,12 +29,13 @@ class DwrfRowReader : public DwrfRowReaderShared {
   }
 
   void createColumnReaderImpl(StripeStreams& stripeStreams) override {
-    columnReader_ = (columnReaderFactory_ ? columnReaderFactory_.get()
-                                          : ColumnReaderFactory::baseFactory())
-                        ->build(
-                            getColumnSelector().getSchemaWithId(),
-                            getReader().getSchemaWithId(),
-                            stripeStreams);
+    columnReader_ =
+        (columnReaderFactory_ ? columnReaderFactory_.get()
+                              : DwrfColumnReaderFactory::baseFactory())
+            ->build(
+                getColumnSelector().getSchemaWithId(),
+                getReader().getSchemaWithId(),
+                stripeStreams);
   }
 
   void seekImpl() override {
@@ -62,7 +63,7 @@ class DwrfRowReader : public DwrfRowReaderShared {
     stats.skippedStrides += skippedStrides_;
   }
 
-  ColumnReader* columnReader() {
+  DwrfColumnReader* columnReader() {
     return columnReader_.get();
   }
 
@@ -80,7 +81,7 @@ class DwrfRowReader : public DwrfRowReaderShared {
  private:
   void checkSkipStrides(const StatsContext& context, uint64_t strideSize);
 
-  std::unique_ptr<ColumnReader> columnReader_;
+  std::unique_ptr<DwrfColumnReader> columnReader_;
   std::vector<uint32_t> stridesToSkip_;
   // Record of strides to skip in each visited stripe. Used for diagnostics.
   std::unordered_map<uint32_t, std::vector<uint32_t>> stripeStridesToSkip_;

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.h
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.h
@@ -18,7 +18,7 @@
 
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
+#include "velox/dwio/dwrf/reader/DwrfColumnReader.h"
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 
@@ -43,7 +43,7 @@ class DwrfRowReaderShared : public StrideIndexProvider,
   uint64_t strideIndex_;
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
-  std::unique_ptr<ColumnReaderFactory> columnReaderFactory_;
+  std::unique_ptr<DwrfColumnReaderFactory> columnReaderFactory_;
 
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -16,10 +16,12 @@
 
 #pragma once
 
+#include "velox/dwio/dwrf/reader/DwrfColumnReader.h"
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/TypeWithId.h"
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
+
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
 #include "velox/dwio/dwrf/utils/BitIterator.h"
 
@@ -63,7 +65,7 @@ class StringKeyBuffer;
 template <typename T>
 class KeyNode {
  private:
-  std::unique_ptr<ColumnReader> reader_;
+  std::unique_ptr<DwrfColumnReader> reader_;
   std::unique_ptr<ByteRleDecoder> inMap_;
   dwio::common::DataBuffer<char> inMapData_;
   KeyValue<T> key_;
@@ -76,7 +78,7 @@ class KeyNode {
 
  public:
   KeyNode(
-      std::unique_ptr<ColumnReader> valueReader,
+      std::unique_ptr<DwrfColumnReader> valueReader,
       std::unique_ptr<ByteRleDecoder> inMapDecoder,
       const KeyValue<T>& keyValue,
       uint32_t sequence,
@@ -199,7 +201,7 @@ class KeyPredicate {
 };
 
 template <typename T>
-class FlatMapColumnReader : public ColumnReader {
+class FlatMapColumnReader : public DwrfColumnReader {
  public:
   FlatMapColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -227,7 +229,7 @@ class FlatMapColumnReader : public ColumnReader {
 };
 
 template <typename T>
-class FlatMapStructEncodingColumnReader : public ColumnReader {
+class FlatMapStructEncodingColumnReader : public DwrfColumnReader {
  public:
   FlatMapStructEncodingColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -252,7 +254,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
 
 class FlatMapColumnReaderFactory {
  public:
-  static std::unique_ptr<ColumnReader> create(
+  static std::unique_ptr<DwrfColumnReader> create(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -55,7 +55,8 @@ class SelectiveByteRleColumnReader : public SelectiveColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     if (boolRle_) {

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -61,7 +61,10 @@ SelectiveColumnReader::SelectiveColumnReader(
     // TODO: why is data type instead of requested type passed in?
     const TypePtr& type,
     FlatMapContext flatMapContext)
-    : ColumnReader(std::move(requestedType), stripe, std::move(flatMapContext)),
+    : DwrfColumnReader(
+          std::move(requestedType),
+          stripe,
+          std::move(flatMapContext)),
       scanSpec_(scanSpec),
       type_{type},
       rowsPerRowGroup_{stripe.rowsPerRowGroup()} {
@@ -79,7 +82,7 @@ std::vector<uint32_t> SelectiveColumnReader::filterRowGroups(
     uint64_t rowGroupSize,
     const StatsContext& context) const {
   if ((!index_ && !indexStream_) || !scanSpec_->filter()) {
-    return ColumnReader::filterRowGroups(rowGroupSize, context);
+    return DwrfColumnReader::filterRowGroups(rowGroupSize, context);
   }
 
   ensureRowGroupIndex();

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -20,7 +20,7 @@
 #include "velox/common/process/ProcessBase.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ScanSpec.h"
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
+#include "velox/dwio/dwrf/reader/DwrfColumnReader.h"
 #include "velox/type/Filter.h"
 
 namespace facebook::velox::dwrf {
@@ -98,7 +98,7 @@ struct ScanState {
   RawScanState rawState;
 };
 
-class SelectiveColumnReader : public ColumnReader {
+class SelectiveColumnReader : public DwrfColumnReader {
  public:
   static constexpr uint64_t kStringBufferSize = 16 * 1024;
 
@@ -478,12 +478,12 @@ inline void SelectiveColumnReader::addValue(const folly::StringPiece value) {
   addStringValue(value);
 }
 
-class SelectiveColumnReaderFactory : public ColumnReaderFactory {
+class SelectiveColumnReaderFactory : public DwrfColumnReaderFactory {
  public:
   explicit SelectiveColumnReaderFactory(
       std::shared_ptr<common::ScanSpec> scanSpec)
       : scanSpec_(scanSpec) {}
-  std::unique_ptr<ColumnReader> build(
+  std::unique_ptr<DwrfColumnReader> build(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -42,7 +42,8 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     decoder_.seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -82,7 +82,7 @@ void SelectiveIntegerDictionaryColumnReader::read(
     int32_t numFlags = (isBulk && nullsInReadRange_)
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
-    detail::ensureCapacity<uint64_t>(
+    dwio::common::reader::detail::ensureCapacity<uint64_t>(
         scanState_.inDictionary, bits::nwords(numFlags), &memoryPool_);
     // The in dict buffer may have changed. If no change in
     // dictionary, the raw state will not be updated elsewhere.

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -38,7 +38,8 @@ class SelectiveIntegerDictionaryColumnReader : public SelectiveColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     if (inDictionaryReader_) {

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -56,7 +56,8 @@ class SelectiveIntegerDirectColumnReader : public SelectiveColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     ints->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -64,8 +64,10 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     // Reads the lengths, leaves an uninitialized gap for a null
     // map/list. Reading these checks the null nask.
     length_->next(allLengths_.data(), rows.back() + 1, nulls);
-    detail::ensureCapacity<vector_size_t>(offsets_, rows.size(), &memoryPool_);
-    detail::ensureCapacity<vector_size_t>(sizes_, rows.size(), &memoryPool_);
+    dwio::common::reader::detail::ensureCapacity<vector_size_t>(
+        offsets_, rows.size(), &memoryPool_);
+    dwio::common::reader::detail::ensureCapacity<vector_size_t>(
+        sizes_, rows.size(), &memoryPool_);
     auto rawOffsets = offsets_->asMutable<vector_size_t>();
     auto rawSizes = sizes_->asMutable<vector_size_t>();
     vector_size_t nestedLength = 0;
@@ -191,7 +193,8 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     length_->seekToRowGroup(positionsProvider);
@@ -236,7 +239,8 @@ class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     length_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -101,7 +101,7 @@ void SelectiveStringDictionaryColumnReader::loadDictionary(
     IntDecoder</*isSigned*/ false>& lengthDecoder,
     DictionaryValues& values) {
   // read lengths from length reader
-  detail::ensureCapacity<StringView>(
+  dwio::common::reader::detail::ensureCapacity<StringView>(
       values.values, values.numValues, &memoryPool_);
   // The lengths are read in the low addresses of the string views array.
   int64_t* int64Values = values.values->asMutable<int64_t>();
@@ -211,7 +211,7 @@ void SelectiveStringDictionaryColumnReader::read(
     int32_t numFlags = (isBulk && nullsInReadRange_)
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
-    detail::ensureCapacity<uint64_t>(
+    dwio::common::reader::detail::ensureCapacity<uint64_t>(
         scanState_.inDictionary, bits::nwords(numFlags), &memoryPool_);
     // The in dict buffer may have changed. If no change in
     // dictionary, the raw state will not be updated elsewhere.
@@ -302,7 +302,8 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
         ? flatMapContext_.inMapDecoder->loadIndices(0)
         : 0;
     positionOffset_ = notNullDecoder_
-        ? notNullDecoder_->loadIndices(indexStartOffset)
+        ? std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+              ->loadIndices(indexStartOffset)
         : indexStartOffset;
     size_t offset = strideDictStream_->positionSize() + positionOffset_;
     strideDictSizeOffset_ = strideDictLengthDecoder_->loadIndices(offset);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -41,7 +41,8 @@ class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
     }
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     if (strideDictStream_) {

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -46,7 +46,8 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
 
 uint64_t SelectiveStringDirectColumnReader::skip(uint64_t numValues) {
   numValues = ColumnReader::skip(numValues);
-  detail::ensureCapacity<int64_t>(lengths_, numValues, &memoryPool_);
+  dwio::common::reader::detail::ensureCapacity<int64_t>(
+      lengths_, numValues, &memoryPool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), numValues);
   rawLengths_ = lengths_->as<uint32_t>();
   for (auto i = 0; i < numValues; ++i) {
@@ -418,7 +419,8 @@ void SelectiveStringDirectColumnReader::read(
   auto end = rows.back() + 1;
   auto numNulls =
       nullsInReadRange_ ? BaseVector::countNulls(nullsInReadRange_, 0, end) : 0;
-  detail::ensureCapacity<int32_t>(lengths_, end - numNulls, &memoryPool_);
+  dwio::common::reader::detail::ensureCapacity<int32_t>(
+      lengths_, end - numNulls, &memoryPool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), end - numNulls);
   rawLengths_ = lengths_->as<uint32_t>();
   lengthIndex_ = 0;

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -36,7 +36,8 @@ class SelectiveStringDirectColumnReader : public SelectiveColumnReader {
     PositionProvider positionsProvider(positions);
 
     if (notNullDecoder_) {
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
 
     blobStream_->seekToPosition(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -44,7 +44,8 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
       ensureRowGroupIndex();
       auto positions = toPositions(index_->entry(index));
       PositionProvider positionsProvider(positions);
-      notNullDecoder_->seekToRowGroup(positionsProvider);
+      std::dynamic_pointer_cast<ByteRleDecoder>(notNullDecoder_)
+          ->seekToRowGroup(positionsProvider);
     }
     // Set the read offset recursively. Do this before seeking the
     // children because list/map children will reset the offsets for

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -325,7 +325,7 @@ void testDataTypeWriter(
     TestStripeStreams streams(context, sf, rowType);
     auto typeWithId = TypeWithId::create(rowType);
     auto reqType = typeWithId->childAt(0);
-    auto reader = ColumnReader::build(
+    auto reader = DwrfColumnReader::build(
         reqType, reqType, streams, FlatMapContext{sequence, nullptr});
     VectorPtr out;
     for (auto strideI = 0; strideI < strideCount; ++strideI) {
@@ -773,7 +773,7 @@ void testMapWriter(
     auto validate = [&](bool returnFlatVector = false) {
       TestStripeStreams streams(context, sf, rowType, returnFlatVector);
       const auto reader =
-          ColumnReader::build(dataTypeWithId, dataTypeWithId, streams);
+          DwrfColumnReader::build(dataTypeWithId, dataTypeWithId, streams);
       VectorPtr out;
 
       // Read map
@@ -1690,7 +1690,7 @@ struct IntegerColumnWriterTypedTestCase {
       }
       typeWithId = TypeWithId::create(rowType);
       auto reqType = typeWithId->childAt(0);
-      auto columnReader = ColumnReader::build(reqType, reqType, streams);
+      auto columnReader = DwrfColumnReader::build(reqType, reqType, streams);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         // TODO Make reuse work
@@ -2923,7 +2923,7 @@ struct StringColumnWriterTestCase {
       }
       typeWithId = TypeWithId::create(rowType);
       auto reqType = typeWithId->childAt(0);
-      auto columnReader = ColumnReader::build(reqType, reqType, streams);
+      auto columnReader = DwrfColumnReader::build(reqType, reqType, streams);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         if (!writeDirect) {
@@ -3952,7 +3952,7 @@ struct DictColumnWriterTestCase {
         .WillRepeatedly(Return(0));
     auto rowTypeWithId = TypeWithId::create(rowType);
     auto reqType = rowTypeWithId->childAt(0);
-    auto reader = ColumnReader::build(reqType, reqType, streams);
+    auto reader = DwrfColumnReader::build(reqType, reqType, streams);
     VectorPtr out;
     reader->next(batch->size(), out);
     compareResults(batch, out);

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -862,7 +862,7 @@ TEST(TestReader, testUpcastBoolean) {
           HiveTypeParser().parse("struct<col0:int>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  std::unique_ptr<ColumnReader> reader = ColumnReader::build(
+  std::unique_ptr<DwrfColumnReader> reader = DwrfColumnReader::build(
       TypeWithId::create(reqType),
       TypeWithId::create(rowType),
       streams,
@@ -909,7 +909,7 @@ TEST(TestReader, testUpcastIntDirect) {
 
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  std::unique_ptr<ColumnReader> reader = ColumnReader::build(
+  std::unique_ptr<DwrfColumnReader> reader = DwrfColumnReader::build(
       TypeWithId::create(reqType),
       TypeWithId::create(rowType),
       streams,
@@ -973,7 +973,7 @@ TEST(TestReader, testUpcastIntDict) {
           HiveTypeParser().parse("struct<col0:bigint>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  std::unique_ptr<ColumnReader> reader = ColumnReader::build(
+  std::unique_ptr<DwrfColumnReader> reader = DwrfColumnReader::build(
       TypeWithId::create(reqType),
       TypeWithId::create(rowType),
       streams,
@@ -1025,7 +1025,7 @@ TEST(TestReader, testUpcastFloat) {
           HiveTypeParser().parse("struct<col0:double>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  std::unique_ptr<ColumnReader> reader = ColumnReader::build(
+  std::unique_ptr<DwrfColumnReader> reader = DwrfColumnReader::build(
       TypeWithId::create(reqType),
       TypeWithId::create(rowType),
       streams,


### PR DESCRIPTION
This PR resolves the first part of issue [#1620](https://github.com/facebookincubator/velox/issues/1620).

Previously, `ColumnReader` and the derived `XXXColumnReader` were Dwrf specific. However, some utils can also be applied to Parquet and `ColumnReader` should only keep the common features. So this PR decouples the `DwrfColumnReader` from `ColumnReader` and adjusted the other class structures accordiingly. 

1. `ColumnReader` is moved to dwio::common::reader as the common util for both Dwrf and Parquet
2. The previous `ColumnReader` is replaced by `DwrfColumnReader`, which still remains at the same directory and inherits `ColumnReader`.
3. All the derived `XXXColumnReader` are renamed to `XXXDwrfColumnReader` and inheriting `DwrfColumnReader`.