### PR TITLE
Add missing reference

### DIFF
--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -135,7 +135,7 @@ struct ArrayOfStringsWriterFunction {
       const arg_type<int64_t>& input) {
     const size_t size = stringArrayData[input].size();
     out.reserve(size);
-    for (const auto value : stringArrayData[input]) {
+    for (const auto& value : stringArrayData[input]) {
       out.add_item().copy_from(value);
     }
   }


### PR DESCRIPTION
The modified location does not build because of warning in gcc 11.