### PR TITLE
Add Task::maybeReserve

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -265,13 +265,19 @@ class MemoryUsageTracker
     }
   }
 
-  int maxTotalBytes() const {
+  int64_t maxTotalBytes() const {
     return usage(maxMemory_, UsageType::kTotalMem);
   }
 
   void setGrowCallback(GrowCallback func) {
     growCallback_ = func;
   }
+
+  /// Checks if it is likely that the reservation on 'this' can be
+  /// incremented by 'increment'. Returns false if this seems
+  /// unlikely. Otherwise attempts the reservation increment and returns
+  /// true if succeeded.
+  bool maybeReserve(int64_t increment);
 
  private:
   static constexpr int64_t kMB = 1 << 20;
@@ -416,7 +422,7 @@ class MemoryUsageTracker
   //  Decrements usage in 'this' and parents.
   void decrementUsage(UsageType type, int64_t size) noexcept;
 
-  void checkNonNegativeSizes(const char* message) const {
+  void checkNonNegativeSizes(const char* FOLLY_NONNULL message) const {
     if (user(currentUsageInBytes_) < 0 || system(currentUsageInBytes_) < 0 ||
         total(currentUsageInBytes_) < 0) {
       LOG_EVERY_N(ERROR, 100)


### PR DESCRIPTION
Add MemoryUsageTracker::maybeReserve

Adds a method that tries to increase a reservation in a
MemoryUsageTracker if there seems to be space. If so, this increases
the reservation and catches an eventual error. Returns true if the
reservation was increased.

This will be extended when adding Task memory cap negotiation.



