### PR TITLE
Fix Unsaferow deserializer failure when the nested struct is null.

### DIFF
--- a/velox/row/UnsafeRowBatchDeserializer.h
+++ b/velox/row/UnsafeRowBatchDeserializer.h
@@ -212,14 +212,15 @@ struct UnsafeRowStructBatchIterator : UnsafeRowDataBatchIterator {
         idx_ * UnsafeRow::kFieldWidthBytes;
 
     for (int32_t i = 0; i < numRows_; ++i) {
-      const char* rawData = data_[i]->data();
-      const char* fieldData = rawData + fieldOffset;
-
       // if null
-      if (bits::isBitSet(rawData, idx_)) {
+      if (!data_[i] || bits::isBitSet(data_[i].value().data(), idx_)) {
         columnData_[i] = std::nullopt;
         continue;
       }
+
+      const char* rawData = data_[i]->data();
+      const char* fieldData = rawData + fieldOffset;
+
       // Fixed length field
       if (cppSizeInBytes) {
         columnData_[i] = std::string_view(fieldData, cppSizeInBytes);

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_row_test UnsafeRowSerializerTest.cpp
-                              UnsafeRowDeserializerTest.cpp)
+add_executable(
+  velox_row_test UnsafeRowSerializerTest.cpp UnsafeRowDeserializerTest.cpp
+                 UnsafeRowFuzzTests.cpp)
 
 add_test(velox_row_test velox_row_test)
 


### PR DESCRIPTION
Reviewed By: syscl

Differential Revision: D36620530

