### PR TITLE
Add -fvisibility=default compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ message("Setting CMAKE_CXX_FLAGS=${SCRIPT_CXX_FLAGS}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D USE_VELOX_COMMON_BASE")
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D HAS_UNCAUGHT_EXCEPTIONS")
 
 # Under Ninja, we are able to designate certain targets large enough to require


### PR DESCRIPTION
Stop the flood of compiler warnings on Mac:

```
ld: warning: direct access in function 'fmt::v7::appender fmt::v7::detail::write<char, fmt::v7::appender, unsigned long long, 0>(fmt::v7::appender, unsigned long long, fmt::v7::basic_format_specs<char> const&, fmt::v7::detail::locale_ref)' from file '/usr/local/lib/libfmt.a(format.cc.o)' to global weak symbol 'fmt::v7::detail::basic_data<void>::left_padding_shifts' from file '/usr/local/lib/libfolly.a(Singleton.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

See https://stackoverflow.com/questions/9894961/strange-warnings-from-the-linker-ld and https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/CppRuntimeEnv/Articles/SymbolVisibility.html