### PR TITLE
Fix Unsaferow Serializer failure in Fuzzer test.

### DIFF
--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -1002,13 +1002,13 @@ TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
   for (int i = 0; i < 100; ++i) {
     auto seed = i; // TODO: Switch to folly::Random::rand32().
     fuzzer.reSeed(seed);
-    const TypePtr type = fuzzer.randRowType();
+    const auto type = fuzzer.randRowType();
     LOG(INFO) << "i=" << i << " seed=" << seed << " type=" << type->toString();
-    const VectorPtr input = fuzzer.fuzz(type);
+    const VectorPtr input = fuzzer.fuzzRow(type);
     std::vector<std::string_view> rowData;
     char* data = &buffer[0];
-    for (int i = 0; i < input->size(); ++i) {
-      auto size = UnsafeRowDynamicSerializer::serialize(type, input, data, i);
+    for (int j = 0; j < input->size(); ++j) {
+      auto size = UnsafeRowDynamicSerializer::serialize(type, input, data, j);
       ASSERT_TRUE(size);
       rowData.emplace_back(data, *size);
       data += *size;


### PR DESCRIPTION
Summary: switching to call the fuzzer from `fuzz.fuzzRow` instead `fuzz.fuzz` to ensure the row is not null.

Reviewed By: zzhao0

Differential Revision: D36635754

