### PR TITLE
Refactor PlanNode.h/cpp

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -212,6 +212,8 @@ class CallTypedExpr : public ITypedExpr {
   const std::string name_;
 };
 
+using CallTypedExprPtr = std::shared_ptr<const CallTypedExpr>;
+
 /// Represents one of two things:
 ///     - a leaf in an expression tree specifying input column by name;
 ///     - a dereference expression which selects a subfield in a struct by name.
@@ -279,6 +281,8 @@ class FieldAccessTypedExpr : public ITypedExpr {
  private:
   const std::string name_;
 };
+
+using FieldAccessTypedExprPtr = std::shared_ptr<const FieldAccessTypedExpr>;
 
 /*
  * Evaluates a list of expressions to produce a row.

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -25,18 +25,17 @@ const SortOrder kDescNullsLast(false, false);
 namespace {
 const std::vector<PlanNodePtr> kEmptySources;
 
-std::shared_ptr<RowType> getAggregationOutputType(
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-        groupingKeys,
+RowTypePtr getAggregationOutputType(
+    const std::vector<FieldAccessTypedExprPtr>& groupingKeys,
     const std::vector<std::string>& aggregateNames,
-    const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates) {
+    const std::vector<CallTypedExprPtr>& aggregates) {
   VELOX_CHECK_EQ(
       aggregateNames.size(),
       aggregates.size(),
       "Number of aggregate names must be equal to number of aggregates");
 
   std::vector<std::string> names;
-  std::vector<std::shared_ptr<const Type>> types;
+  std::vector<TypePtr> types;
 
   for (auto& key : groupingKeys) {
     auto field =
@@ -58,14 +57,11 @@ std::shared_ptr<RowType> getAggregationOutputType(
 AggregationNode::AggregationNode(
     const PlanNodeId& id,
     Step step,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-        groupingKeys,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-        preGroupedKeys,
+    const std::vector<FieldAccessTypedExprPtr>& groupingKeys,
+    const std::vector<FieldAccessTypedExprPtr>& preGroupedKeys,
     const std::vector<std::string>& aggregateNames,
-    const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-        aggregateMasks,
+    const std::vector<CallTypedExprPtr>& aggregates,
+    const std::vector<FieldAccessTypedExprPtr>& aggregateMasks,
     bool ignoreNullKeys,
     PlanNodePtr source)
     : PlanNode(id),
@@ -107,7 +103,7 @@ AggregationNode::AggregationNode(
 namespace {
 void addFields(
     std::stringstream& stream,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& keys) {
+    const std::vector<FieldAccessTypedExprPtr>& keys) {
   for (auto i = 0; i < keys.size(); ++i) {
     if (i > 0) {
       stream << ", ";
@@ -116,9 +112,7 @@ void addFields(
   }
 }
 
-void addKeys(
-    std::stringstream& stream,
-    const std::vector<std::shared_ptr<const ITypedExpr>>& keys) {
+void addKeys(std::stringstream& stream, const std::vector<TypedExprPtr>& keys) {
   for (auto i = 0; i < keys.size(); ++i) {
     const auto& expr = keys[i];
     if (i > 0) {
@@ -197,8 +191,8 @@ void ExchangeNode::addDetails(std::stringstream& /* stream */) const {
 
 UnnestNode::UnnestNode(
     const PlanNodeId& id,
-    std::vector<std::shared_ptr<const FieldAccessTypedExpr>> replicateVariables,
-    std::vector<std::shared_ptr<const FieldAccessTypedExpr>> unnestVariables,
+    std::vector<FieldAccessTypedExprPtr> replicateVariables,
+    std::vector<FieldAccessTypedExprPtr> unnestVariables,
     const std::vector<std::string>& unnestNames,
     const std::optional<std::string>& ordinalityName,
     const PlanNodePtr& source)
@@ -251,8 +245,8 @@ void UnnestNode::addDetails(std::stringstream& stream) const {
 AbstractJoinNode::AbstractJoinNode(
     const PlanNodeId& id,
     JoinType joinType,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& rightKeys,
+    const std::vector<FieldAccessTypedExprPtr>& leftKeys,
+    const std::vector<FieldAccessTypedExprPtr>& rightKeys,
     TypedExprPtr filter,
     PlanNodePtr left,
     PlanNodePtr right,
@@ -362,7 +356,7 @@ void AssignUniqueIdNode::addDetails(std::stringstream& /* stream */) const {
 namespace {
 void addSortingKeys(
     std::stringstream& stream,
-    const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& sortingKeys,
+    const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
     const std::vector<SortOrder>& sortingOrders) {
   for (auto i = 0; i < sortingKeys.size(); ++i) {
     if (i > 0) {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -297,7 +297,7 @@ class ProjectNode : public PlanNode {
   static RowTypePtr makeOutputType(
       const std::vector<std::string>& names,
       const std::vector<TypedExprPtr>& projections) {
-    std::vector<std::shared_ptr<const Type>> types;
+    std::vector<TypePtr> types;
     for (auto& projection : projections) {
       types.push_back(projection->type());
     }
@@ -458,14 +458,11 @@ class AggregationNode : public PlanNode {
   AggregationNode(
       const PlanNodeId& id,
       Step step,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          groupingKeys,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          preGroupedKeys,
+      const std::vector<FieldAccessTypedExprPtr>& groupingKeys,
+      const std::vector<FieldAccessTypedExprPtr>& preGroupedKeys,
       const std::vector<std::string>& aggregateNames,
-      const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          aggregateMasks,
+      const std::vector<CallTypedExprPtr>& aggregates,
+      const std::vector<FieldAccessTypedExprPtr>& aggregateMasks,
       bool ignoreNullKeys,
       PlanNodePtr source);
 
@@ -481,13 +478,11 @@ class AggregationNode : public PlanNode {
     return step_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& groupingKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& groupingKeys() const {
     return groupingKeys_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-  preGroupedKeys() const {
+  const std::vector<FieldAccessTypedExprPtr>& preGroupedKeys() const {
     return preGroupedKeys_;
   }
 
@@ -495,12 +490,11 @@ class AggregationNode : public PlanNode {
     return aggregateNames_;
   }
 
-  const std::vector<std::shared_ptr<const CallTypedExpr>>& aggregates() const {
+  const std::vector<CallTypedExprPtr>& aggregates() const {
     return aggregates_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-  aggregateMasks() const {
+  const std::vector<FieldAccessTypedExprPtr>& aggregateMasks() const {
     return aggregateMasks_;
   }
 
@@ -516,15 +510,13 @@ class AggregationNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   const Step step_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> groupingKeys_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
-      preGroupedKeys_;
+  const std::vector<FieldAccessTypedExprPtr> groupingKeys_;
+  const std::vector<FieldAccessTypedExprPtr> preGroupedKeys_;
   const std::vector<std::string> aggregateNames_;
-  const std::vector<std::shared_ptr<const CallTypedExpr>> aggregates_;
+  const std::vector<CallTypedExprPtr> aggregates_;
   // Keeps mask/'no mask' for every aggregation. Mask, if given, is a reference
   // to a boolean projection column, used to mask out rows for the aggregation.
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
-      aggregateMasks_;
+  const std::vector<FieldAccessTypedExprPtr> aggregateMasks_;
   const bool ignoreNullKeys_;
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
@@ -582,15 +574,13 @@ class MergeExchangeNode : public ExchangeNode {
   explicit MergeExchangeNode(
       const PlanNodeId& id,
       const RowTypePtr& type,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          sortingKeys,
+      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
       const std::vector<SortOrder>& sortingOrders)
       : ExchangeNode(id, type),
         sortingKeys_(sortingKeys),
         sortingOrders_(sortingOrders) {}
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& sortingKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
     return sortingKeys_;
   }
 
@@ -605,7 +595,7 @@ class MergeExchangeNode : public ExchangeNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> sortingKeys_;
+  const std::vector<FieldAccessTypedExprPtr> sortingKeys_;
   const std::vector<SortOrder> sortingOrders_;
 };
 
@@ -613,7 +603,7 @@ class LocalMergeNode : public PlanNode {
  public:
   LocalMergeNode(
       const PlanNodeId& id,
-      std::vector<std::shared_ptr<const FieldAccessTypedExpr>> sortingKeys,
+      std::vector<FieldAccessTypedExprPtr> sortingKeys,
       std::vector<SortOrder> sortingOrders,
       std::vector<PlanNodePtr> sources)
       : PlanNode(id),
@@ -629,8 +619,7 @@ class LocalMergeNode : public PlanNode {
     return sources_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& sortingKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
     return sortingKeys_;
   }
 
@@ -646,7 +635,7 @@ class LocalMergeNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   const std::vector<PlanNodePtr> sources_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> sortingKeys_;
+  const std::vector<FieldAccessTypedExprPtr> sortingKeys_;
   const std::vector<SortOrder> sortingOrders_;
 };
 
@@ -757,7 +746,7 @@ class PartitionedOutputNode : public PlanNode {
  public:
   PartitionedOutputNode(
       const PlanNodeId& id,
-      const std::vector<std::shared_ptr<const ITypedExpr>>& keys,
+      const std::vector<TypedExprPtr>& keys,
       int numPartitions,
       bool broadcast,
       bool replicateNullsAndAny,
@@ -790,7 +779,7 @@ class PartitionedOutputNode : public PlanNode {
       int numPartitions,
       RowTypePtr outputType,
       PlanNodePtr source) {
-    std::vector<std::shared_ptr<const core::ITypedExpr>> noKeys;
+    std::vector<TypedExprPtr> noKeys;
     return std::make_shared<PartitionedOutputNode>(
         id,
         noKeys,
@@ -806,7 +795,7 @@ class PartitionedOutputNode : public PlanNode {
 
   static std::shared_ptr<PartitionedOutputNode>
   single(const PlanNodeId& id, RowTypePtr outputType, PlanNodePtr source) {
-    std::vector<std::shared_ptr<const core::ITypedExpr>> noKeys;
+    std::vector<TypedExprPtr> noKeys;
     return std::make_shared<PartitionedOutputNode>(
         id,
         noKeys,
@@ -832,7 +821,7 @@ class PartitionedOutputNode : public PlanNode {
     return sources_[0]->outputType();
   }
 
-  const std::vector<std::shared_ptr<const ITypedExpr>>& keys() const {
+  const std::vector<TypedExprPtr>& keys() const {
     return keys_;
   }
 
@@ -923,8 +912,8 @@ class AbstractJoinNode : public PlanNode {
   AbstractJoinNode(
       const PlanNodeId& id,
       JoinType joinType,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& rightKeys,
+      const std::vector<FieldAccessTypedExprPtr>& leftKeys,
+      const std::vector<FieldAccessTypedExprPtr>& rightKeys,
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
@@ -966,13 +955,11 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kAnti;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {
     return leftKeys_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& rightKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& rightKeys() const {
     return rightKeys_;
   }
 
@@ -984,8 +971,8 @@ class AbstractJoinNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   const JoinType joinType_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> leftKeys_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> rightKeys_;
+  const std::vector<FieldAccessTypedExprPtr> leftKeys_;
+  const std::vector<FieldAccessTypedExprPtr> rightKeys_;
   // Optional join filter, nullptr if absent. This is applied to
   // join hits and if this is false, the hit turns into a miss, which
   // has a special meaning for outer joins. For inner joins, this is
@@ -1003,8 +990,8 @@ class HashJoinNode : public AbstractJoinNode {
   HashJoinNode(
       const PlanNodeId& id,
       JoinType joinType,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& rightKeys,
+      const std::vector<FieldAccessTypedExprPtr>& leftKeys,
+      const std::vector<FieldAccessTypedExprPtr>& rightKeys,
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
@@ -1034,8 +1021,8 @@ class MergeJoinNode : public AbstractJoinNode {
   MergeJoinNode(
       const PlanNodeId& id,
       JoinType joinType,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& leftKeys,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& rightKeys,
+      const std::vector<FieldAccessTypedExprPtr>& leftKeys,
+      const std::vector<FieldAccessTypedExprPtr>& rightKeys,
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
@@ -1088,8 +1075,7 @@ class OrderByNode : public PlanNode {
  public:
   OrderByNode(
       const PlanNodeId& id,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          sortingKeys,
+      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
       const std::vector<SortOrder>& sortingOrders,
       bool isPartial,
       const PlanNodePtr& source)
@@ -1105,8 +1091,7 @@ class OrderByNode : public PlanNode {
         "Number of sorting keys and sorting orders in OrderBy must be the same");
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& sortingKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
     return sortingKeys_;
   }
 
@@ -1136,7 +1121,7 @@ class OrderByNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> sortingKeys_;
+  const std::vector<FieldAccessTypedExprPtr> sortingKeys_;
   const std::vector<SortOrder> sortingOrders_;
   const bool isPartial_;
   const std::vector<PlanNodePtr> sources_;
@@ -1146,8 +1131,7 @@ class TopNNode : public PlanNode {
  public:
   TopNNode(
       const PlanNodeId& id,
-      const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-          sortingKeys,
+      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
       const std::vector<SortOrder>& sortingOrders,
       int32_t count,
       bool isPartial,
@@ -1167,8 +1151,7 @@ class TopNNode : public PlanNode {
         "TopN must specify greater than zero number of rows to keep");
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>& sortingKeys()
-      const {
+  const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
     return sortingKeys_;
   }
 
@@ -1199,7 +1182,7 @@ class TopNNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>> sortingKeys_;
+  const std::vector<FieldAccessTypedExprPtr> sortingKeys_;
   const std::vector<SortOrder> sortingOrders_;
   const int32_t count_;
   const bool isPartial_;
@@ -1278,9 +1261,8 @@ class UnnestNode : public PlanNode {
   /// present, ordinality column is not produced.
   UnnestNode(
       const PlanNodeId& id,
-      std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
-          replicateVariables,
-      std::vector<std::shared_ptr<const FieldAccessTypedExpr>> unnestVariables,
+      std::vector<FieldAccessTypedExprPtr> replicateVariables,
+      std::vector<FieldAccessTypedExprPtr> unnestVariables,
       const std::vector<std::string>& unnestNames,
       const std::optional<std::string>& ordinalityName,
       const PlanNodePtr& source);
@@ -1296,13 +1278,11 @@ class UnnestNode : public PlanNode {
     return sources_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-  replicateVariables() const {
+  const std::vector<FieldAccessTypedExprPtr>& replicateVariables() const {
     return replicateVariables_;
   }
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>&
-  unnestVariables() const {
+  const std::vector<FieldAccessTypedExprPtr>& unnestVariables() const {
     return unnestVariables_;
   }
 
@@ -1317,10 +1297,8 @@ class UnnestNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
-      replicateVariables_;
-  const std::vector<std::shared_ptr<const FieldAccessTypedExpr>>
-      unnestVariables_;
+  const std::vector<FieldAccessTypedExprPtr> replicateVariables_;
+  const std::vector<FieldAccessTypedExprPtr> unnestVariables_;
   const bool withOrdinality_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;


### PR DESCRIPTION
Introduce CallTypedExprPtr and FieldAccessTypedExprPtr and refactor PlanNode.*
to use these as well as TypePtr, RowTypePtr, TypedExprPtr, and PlanNodePtr.