### PR TITLE
Support decimal type signature and type calculation using flex/bison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
     set(FLEX_INCLUDE_DIR "${BREW_FLEX_PREFIX}/include")
   endif()
 endif()
-find_package(BISON 3.7.4 REQUIRED)
+find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
 
 include_directories(SYSTEM velox)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,35 @@ if(NOT VELOX_BUILD_TEST_UTILS
   add_definitions(-DVELOX_DISABLE_GOOGLETEST)
 endif()
 
+# On macOS, search Homebrew for keg-only versions of Bison and Flex. Xcode does
+# not provide new enough versions for us to use.
+if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+  execute_process(
+    COMMAND brew --prefix bison
+    RESULT_VARIABLE BREW_BISON
+    OUTPUT_VARIABLE BREW_BISON_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(BREW_BISON EQUAL 0 AND EXISTS "${BREW_BISON_PREFIX}")
+    message(
+      STATUS "Found Bison keg installed by Homebrew at ${BREW_BISON_PREFIX}")
+    set(BISON_EXECUTABLE "${BREW_BISON_PREFIX}/bin/bison")
+  endif()
+
+  execute_process(
+    COMMAND brew --prefix flex
+    RESULT_VARIABLE BREW_FLEX
+    OUTPUT_VARIABLE BREW_FLEX_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(BREW_FLEX EQUAL 0 AND EXISTS "${BREW_FLEX_PREFIX}")
+    message(
+      STATUS "Found Flex keg installed by Homebrew at ${BREW_FLEX_PREFIX}")
+    set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
+    set(FLEX_INCLUDE_DIR "${BREW_FLEX_PREFIX}/include")
+  endif()
+endif()
+find_package(BISON 3.7.4 REQUIRED)
+find_package(FLEX 2.5.13 REQUIRED)
+
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)
 include_directories(SYSTEM velox/external/duckdb)

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -37,7 +37,7 @@ NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_DEPS="ninja cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
+MACOS_DEPS="ninja flex bison cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
 
 function run_and_time {
   time "$@"

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -15,7 +15,8 @@
 add_library(velox_expression_functions FunctionRegistry.h FunctionSignature.cpp
                                        SignatureBinder.cpp)
 
-target_link_libraries(velox_expression_functions velox_common_base)
+target_link_libraries(velox_expression_functions velox_common_base
+                      velox_type_calculation)
 
 add_library(
   velox_expression
@@ -30,6 +31,8 @@ add_library(
 
 target_link_libraries(velox_expression velox_core velox_vector
                       velox_common_base velox_expression_functions)
+
+add_subdirectory(type_calculation)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -42,7 +42,7 @@ std::string TypeSignature::toString() const {
   std::ostringstream out;
   out << baseType_;
   auto typeName = boost::algorithm::to_upper_copy(baseType_);
-  if (typeName == "DECIMAL") {
+  if (isCommonDecimalName(typeName)) {
     out << "(" << variables_[0] << ", " << variables_[1] << ")";
   }
   if (!parameters_.empty()) {
@@ -107,7 +107,7 @@ TypeSignature parseTypeSignature(const std::string& signature) {
   nestedTypes.emplace_back(parseTypeSignature(token));
 
   auto typeName = boost::algorithm::to_upper_copy(baseType);
-  if (typeName == "DECIMAL") {
+  if (isCommonDecimalName(typeName)) {
     std::vector<std::string> vars(2);
     vars[0] = nestedTypes[0].baseType();
     vars[1] = nestedTypes[1].baseType();
@@ -130,11 +130,11 @@ void validateBaseTypeAndCollectTypeParams(
       return;
     }
 
-    if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+    if (isDecimalName(typeName)) {
       VELOX_USER_FAIL("Use 'DECIMAL' in the signature.");
     }
 
-    if (typeName == "DECIMAL") {
+    if (isCommonDecimalName(typeName)) {
       return;
     }
 

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -102,6 +102,12 @@ TypeSignature parseTypeSignature(const std::string& signature) {
   boost::algorithm::trim(token);
   nestedTypes.emplace_back(parseTypeSignature(token));
 
+  if (baseType == "SHORT_DECIMAL") {
+    std::vector<std::string> vars(2);
+    vars[0] = nestedTypes[0].baseType();
+    vars[1] = nestedTypes[1].baseType();
+    return TypeSignature(baseType, {}, vars);
+  }
   return TypeSignature(baseType, std::move(nestedTypes));
 }
 
@@ -185,10 +191,25 @@ FunctionSignature::FunctionSignature(
   validate(typeVariableConstants_, returnType_, argumentTypes_);
 }
 
+FunctionSignature::FunctionSignature(
+    std::vector<TypeVariableConstraint> typeVariableConstants,
+    std::vector<TypeVariableConstraint> variables,
+    TypeSignature returnType,
+    std::vector<TypeSignature> argumentTypes,
+    bool variableArity)
+    : typeVariableConstants_{std::move(typeVariableConstants)},
+      variables_{std::move(variables)},
+      returnType_{std::move(returnType)},
+      argumentTypes_{std::move(argumentTypes)},
+      variableArity_{variableArity} {
+  validate(typeVariableConstants_, returnType_, argumentTypes_);
+}
+
 FunctionSignaturePtr FunctionSignatureBuilder::build() {
   VELOX_CHECK(returnType_.has_value());
   return std::make_shared<FunctionSignature>(
       std::move(typeVariableConstants_),
+      std::move(variables_),
       returnType_.value(),
       std::move(argumentTypes_),
       variableArity_);

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -41,6 +41,10 @@ void toAppend(
 std::string TypeSignature::toString() const {
   std::ostringstream out;
   out << baseType_;
+  auto typeName = boost::algorithm::to_upper_copy(baseType_);
+  if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+    out << "(" << variables_[0] << ", " << variables_[1] << ")";
+  }
   if (!parameters_.empty()) {
     out << "(" << folly::join(",", parameters_) << ")";
   }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -102,11 +102,12 @@ TypeSignature parseTypeSignature(const std::string& signature) {
   boost::algorithm::trim(token);
   nestedTypes.emplace_back(parseTypeSignature(token));
 
-  if (baseType == "SHORT_DECIMAL") {
+  auto typeName = boost::algorithm::to_upper_copy(baseType);
+  if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
     std::vector<std::string> vars(2);
     vars[0] = nestedTypes[0].baseType();
     vars[1] = nestedTypes[1].baseType();
-    return TypeSignature(baseType, {}, vars);
+    return TypeSignature(baseType, {}, std::move(vars));
   }
   return TypeSignature(baseType, std::move(nestedTypes));
 }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -42,7 +42,7 @@ std::string TypeSignature::toString() const {
   std::ostringstream out;
   out << baseType_;
   auto typeName = boost::algorithm::to_upper_copy(baseType_);
-  if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+  if (isDecimalType(typeName)) {
     out << "(" << variables_[0] << ", " << variables_[1] << ")";
   }
   if (!parameters_.empty()) {
@@ -107,7 +107,7 @@ TypeSignature parseTypeSignature(const std::string& signature) {
   nestedTypes.emplace_back(parseTypeSignature(token));
 
   auto typeName = boost::algorithm::to_upper_copy(baseType);
-  if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+  if (isDecimalType(typeName)) {
     std::vector<std::string> vars(2);
     vars[0] = nestedTypes[0].baseType();
     vars[1] = nestedTypes[1].baseType();

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -42,7 +42,7 @@ std::string TypeSignature::toString() const {
   std::ostringstream out;
   out << baseType_;
   auto typeName = boost::algorithm::to_upper_copy(baseType_);
-  if (isDecimalType(typeName)) {
+  if (typeName == "DECIMAL") {
     out << "(" << variables_[0] << ", " << variables_[1] << ")";
   }
   if (!parameters_.empty()) {
@@ -107,7 +107,7 @@ TypeSignature parseTypeSignature(const std::string& signature) {
   nestedTypes.emplace_back(parseTypeSignature(token));
 
   auto typeName = boost::algorithm::to_upper_copy(baseType);
-  if (isDecimalType(typeName)) {
+  if (typeName == "DECIMAL") {
     std::vector<std::string> vars(2);
     vars[0] = nestedTypes[0].baseType();
     vars[1] = nestedTypes[1].baseType();
@@ -127,6 +127,14 @@ void validateBaseTypeAndCollectTypeParams(
     if (typeName == "ANY") {
       VELOX_USER_CHECK(
           arg.parameters().empty(), "Type 'Any' cannot have parameters")
+      return;
+    }
+
+    if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+      VELOX_USER_FAIL("Use 'DECIMAL' in the signature.");
+    }
+
+    if (typeName == "DECIMAL") {
       return;
     }
 

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -25,13 +25,19 @@ namespace facebook::velox::exec {
 std::string sanitizeFunctionName(const std::string& name);
 
 // A type name (e.g. K or V in map(K, V)) and optionally constraints, e.g.
-// orderable, sortable, etc.
+// expression over the variable, etc.
 class TypeVariableConstraint {
  public:
   explicit TypeVariableConstraint(std::string name) : name_{std::move(name)} {}
+  TypeVariableConstraint(std::string name, std::string constraint)
+      : name_{std::move(name)}, constraint_{std::move(constraint)} {}
 
   const std::string& name() const {
     return name_;
+  }
+
+  const std::string& constraint() const {
+    return constraint_;
   }
 
   bool operator==(const TypeVariableConstraint& rhs) const {
@@ -40,6 +46,7 @@ class TypeVariableConstraint {
 
  private:
   const std::string name_;
+  const std::string constraint_;
 };
 
 // Base type (e.g. map) and optional parameters (e.g. K, V).
@@ -47,6 +54,13 @@ class TypeSignature {
  public:
   TypeSignature(std::string baseType, std::vector<TypeSignature> parameters)
       : baseType_{std::move(baseType)}, parameters_{std::move(parameters)} {}
+  TypeSignature(
+      std::string baseType,
+      std::vector<TypeSignature> parameters,
+      std::vector<std::string> variables)
+      : baseType_{std::move(baseType)},
+        parameters_{std::move(parameters)},
+        variables_{std::move(variables)} {}
 
   const std::string& baseType() const {
     return baseType_;
@@ -54,6 +68,10 @@ class TypeSignature {
 
   const std::vector<TypeSignature>& parameters() const {
     return parameters_;
+  }
+
+  const std::vector<std::string>& variables() const {
+    return variables_;
   }
 
   std::string toString() const;
@@ -65,6 +83,8 @@ class TypeSignature {
  private:
   const std::string baseType_;
   const std::vector<TypeSignature> parameters_;
+  // Decimals types have variables (precision, scale)
+  const std::vector<std::string> variables_;
 };
 
 class FunctionSignature {
@@ -87,8 +107,19 @@ class FunctionSignature {
       std::vector<TypeSignature> argumentTypes,
       bool variableArity);
 
+  FunctionSignature(
+      std::vector<TypeVariableConstraint> typeVariableConstants,
+      std::vector<TypeVariableConstraint> variables,
+      TypeSignature returnType,
+      std::vector<TypeSignature> argumentTypes,
+      bool variableArity);
+
   const std::vector<TypeVariableConstraint>& typeVariableConstants() const {
     return typeVariableConstants_;
+  }
+
+  const std::vector<TypeVariableConstraint>& variables() const {
+    return variables_;
   }
 
   const TypeSignature& returnType() const {
@@ -117,6 +148,7 @@ class FunctionSignature {
 
  private:
   const std::vector<TypeVariableConstraint> typeVariableConstants_;
+  const std::vector<TypeVariableConstraint> variables_;
   const TypeSignature returnType_;
   const std::vector<TypeSignature> argumentTypes_;
   const bool variableArity_;
@@ -183,6 +215,13 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
+  FunctionSignatureBuilder& variableConstraint(
+      std::string name,
+      std::string constraint) {
+    variables_.emplace_back(name, constraint);
+    return *this;
+  }
+
   FunctionSignatureBuilder& returnType(const std::string& type) {
     returnType_.emplace(parseTypeSignature(type));
     return *this;
@@ -202,6 +241,7 @@ class FunctionSignatureBuilder {
 
  private:
   std::vector<TypeVariableConstraint> typeVariableConstants_;
+  std::vector<TypeVariableConstraint> variables_;
   std::optional<TypeSignature> returnType_;
   std::vector<TypeSignature> argumentTypes_;
   bool variableArity_{false};

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -304,7 +304,8 @@ struct hash<facebook::velox::exec::TypeVariableConstraint> {
   using result_type = std::size_t;
 
   result_type operator()(const argument_type& key) const noexcept {
-    return std::hash<std::string>{}(key.name());
+    return std::hash<std::string>{}(key.name()) * 31 +
+        std::hash<std::string>{}(key.constraint());
   }
 };
 
@@ -317,6 +318,9 @@ struct hash<facebook::velox::exec::TypeSignature> {
     size_t val = std::hash<std::string>{}(key.baseType());
     for (const auto& parameter : key.parameters()) {
       val = val * 31 + this->operator()(parameter);
+    }
+    for (const auto& variable : key.variables()) {
+      val = val * 31 + std::hash<std::string>{}(variable);
     }
     return val;
   }
@@ -336,6 +340,10 @@ struct hash<facebook::velox::exec::FunctionSignature> {
     size_t val = 0;
     for (const auto& constraint : key.typeVariableConstants()) {
       val = val * 31 + typeVariableConstraintHasher(constraint);
+    }
+
+    for (const auto& variable : key.variables()) {
+      val = val * 31 + typeVariableConstraintHasher(variable);
     }
 
     val = val * 31 + typeSignatureHasher(key.returnType());

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -24,6 +24,10 @@ namespace facebook::velox::exec {
 
 std::string sanitizeFunctionName(const std::string& name);
 
+inline bool isCommonDecimalName(const std::string& typeName) {
+  return (typeName == "DECIMAL");
+}
+
 // A type name (e.g. K or V in map(K, V)) and optionally constraints, e.g.
 // expression over the variable, etc.
 class TypeVariableConstraint {

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -120,7 +120,7 @@ TypePtr SignatureBinder::tryResolveType(
 std::string buildCalculation(
     const std::string& variable,
     const std::string& calculation) {
-  return fmt::format("{}={}\n", variable, calculation);
+  return fmt::format("{}={}", variable, calculation);
 }
 
 // static

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -71,10 +71,10 @@ bool SignatureBinder::tryBind(
   if (it == bindings_.end()) {
     // concrete type
     auto typeName = boost::algorithm::to_upper_copy(typeSignature.baseType());
-    if (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL") {
+    if (isDecimalName(typeName)) {
       VELOX_USER_FAIL("Use 'DECIMAL' in the signature.");
     }
-    if (isDecimalKind(actualType->kind()) && typeName == "DECIMAL") {
+    if (isDecimalKind(actualType->kind()) && isCommonDecimalName(typeName)) {
       const auto& variables = typeSignature.variables();
       VELOX_CHECK_EQ(variables.size(), 2);
       int precision, scale;
@@ -149,7 +149,7 @@ TypePtr SignatureBinder::tryResolveType(
     // concrete type
     auto typeName = boost::algorithm::to_upper_copy(typeSignature.baseType());
 
-    if (typeName == "DECIMAL") {
+    if (isCommonDecimalName(typeName)) {
       const auto& precisionVar = typeSignature.variables()[0];
       const auto& scaleVar = typeSignature.variables()[1];
       // check for constraints, else set defaults.

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -35,6 +35,7 @@ void assertCannotResolve(
     const std::vector<TypePtr>& actualTypes) {
   exec::SignatureBinder binder(*signature, actualTypes);
   ASSERT_FALSE(binder.tryBind());
+}
 
 TEST(SignatureBinderTest, shortDecimals) {
   // Decimal Add/Subtract.

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -35,6 +35,25 @@ void assertCannotResolve(
     const std::vector<TypePtr>& actualTypes) {
   exec::SignatureBinder binder(*signature, actualTypes);
   ASSERT_FALSE(binder.tryBind());
+
+TEST(SignatureBinderTest, decimals) {
+  // decimal(10, 3), decimal(10, 5) -> decimal()
+
+  auto signature =
+      exec::FunctionSignatureBuilder()
+          .returnType("SHORT_DECIMAL(r_precision, r_scale)")
+          .argumentType("SHORT_DECIMAL(a_precision, a_scale)")
+          .argumentType("SHORT_DECIMAL(b_precision, b_scale)")
+          .variableConstraint(
+              "r_precision",
+              "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
+          .variableConstraint("r_scale", "max(a_scale, b_scale)")
+          .build();
+
+  testSignatureBinder(
+      signature,
+      {SHORT_DECIMAL(11, 5), SHORT_DECIMAL(10, 6)},
+      SHORT_DECIMAL(10, 6));
 }
 
 TEST(SignatureBinderTest, generics) {

--- a/velox/expression/type_calculation/CMakeLists.txt
+++ b/velox/expression/type_calculation/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bison_target(
+  TypeCalculationParser TypeCalculation.y ${CMAKE_CURRENT_BINARY_DIR}/Parser.cpp
+  DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/Parser.h)
+flex_target(TypeCalculationScanner TypeCalculation.l
+            ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp COMPILE_FLAGS "-Cf")
+add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${FLEX_INCLUDE_DIRS})
+add_library(velox_type_calculation ${BISON_TypeCalculationParser_OUTPUTS}
+                                   ${FLEX_TypeCalculationScanner_OUTPUTS})

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::expression::calculate {
+
+class Scanner : public yyFlexLexer {
+ public:
+  Scanner(
+      std::istream& arg_yyin,
+      std::ostream& arg_yyout,
+      std::unordered_map<std::string, int>& values)
+      : yyFlexLexer(arg_yyin, arg_yyout), values_(values){};
+  int lex(Parser::semantic_type* yylval);
+  void setValue(const std::string& varName, int value) {
+    values_[varName] = value;
+  }
+  int getValue(const std::string& varName) const {
+    return values_.at(varName);
+  }
+
+ private:
+  std::unordered_map<std::string, int>& values_;
+};
+
+} // namespace facebook::velox::expression::calculate

--- a/velox/expression/type_calculation/TypeCalculation.h
+++ b/velox/expression/type_calculation/TypeCalculation.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::expression::calculation {
+void evaluate(
+    const std::string& calculation,
+    std::unordered_map<std::string, int>& variables);
+}

--- a/velox/expression/type_calculation/TypeCalculation.l
+++ b/velox/expression/type_calculation/TypeCalculation.l
@@ -1,0 +1,45 @@
+%{
+#include "Parser.h"
+#include "Scanner.h"
+#define YY_DECL int facebook::velox::expression::calculate::Scanner::lex(facebook::velox::expression::calculate::Parser::semantic_type *yylval)
+%}
+ 
+%option c++ noyywrap noyylineno nodefault
+ 
+dseq            ([[:digit:]]+)
+integer         ({dseq})
+var             ([[:alpha:]][[:alnum:]_]*)
+ 
+%%
+ 
+"+"             return Parser::token::PLUS;
+"-"             return Parser::token::MINUS;
+"*"             return Parser::token::MULTIPLY;
+"/"             return Parser::token::DIVIDE;
+"%"             return Parser::token::MODULO;
+"("             return Parser::token::LPAREN;
+")"             return Parser::token::RPAREN;
+","             return Parser::token::COMMA;
+"="             return Parser::token::ASSIGN;
+"min"           return Parser::token::MIN;
+"max"           return Parser::token::MAX;
+{integer}       yylval->emplace<long long>(strtoll(YYText(), nullptr, 10)); return Parser::token::INT;
+{var}           yylval->emplace<std::string>(YYText()); return Parser::token::VAR;
+\n              return Parser::token::EOL;
+<<EOF>>         return Parser::token::YYEOF;
+.               /* no action on unmatched input */
+ 
+%%
+ 
+int yyFlexLexer::yylex() {
+    throw std::runtime_error("Bad call to yyFlexLexer::yylex()");
+}
+
+#include "velox/expression/type_calculation/TypeCalculation.h"
+
+void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, int>& variables) {
+    std::istringstream is(calculation);
+    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables };
+    facebook::velox::expression::calculate::Parser parser{ &scanner };
+    parser.parse();
+}

--- a/velox/expression/type_calculation/TypeCalculation.l
+++ b/velox/expression/type_calculation/TypeCalculation.l
@@ -5,9 +5,8 @@
 %}
  
 %option c++ noyywrap noyylineno nodefault
- 
-dseq            ([[:digit:]]+)
-integer         ({dseq})
+
+integer         ([[:digit:]]+)
 var             ([[:alpha:]][[:alnum:]_]*)
  
 %%
@@ -25,7 +24,6 @@ var             ([[:alpha:]][[:alnum:]_]*)
 "max"           return Parser::token::MAX;
 {integer}       yylval->build<long long>(strtoll(YYText(), nullptr, 10)); return Parser::token::INT;
 {var}           yylval->build<std::string>(YYText()); return Parser::token::VAR;
-\n              return Parser::token::EOL;
 <<EOF>>         return Parser::token::YYEOF;
 .               /* no action on unmatched input */
  

--- a/velox/expression/type_calculation/TypeCalculation.l
+++ b/velox/expression/type_calculation/TypeCalculation.l
@@ -23,8 +23,8 @@ var             ([[:alpha:]][[:alnum:]_]*)
 "="             return Parser::token::ASSIGN;
 "min"           return Parser::token::MIN;
 "max"           return Parser::token::MAX;
-{integer}       yylval->emplace<long long>(strtoll(YYText(), nullptr, 10)); return Parser::token::INT;
-{var}           yylval->emplace<std::string>(YYText()); return Parser::token::VAR;
+{integer}       yylval->build<long long>(strtoll(YYText(), nullptr, 10)); return Parser::token::INT;
+{var}           yylval->build<std::string>(YYText()); return Parser::token::VAR;
 \n              return Parser::token::EOL;
 <<EOF>>         return Parser::token::YYEOF;
 .               /* no action on unmatched input */

--- a/velox/expression/type_calculation/TypeCalculation.y
+++ b/velox/expression/type_calculation/TypeCalculation.y
@@ -24,7 +24,7 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               EOL LPAREN RPAREN COMMA MIN MAX
+%token               LPAREN RPAREN COMMA MIN MAX
 %token <long long>   INT
 %token <std::string> VAR
 %token YYEOF         0
@@ -38,13 +38,8 @@
  
 %%
  
-lines   : %empty
-        | lines line
-        ;
- 
-line    : EOL                       { std::cerr << "Read an empty line.\n"; }
-        | VAR ASSIGN iexp EOL       { scanner->setValue($1, $3); }
-        | error EOL                 { yyerrok; }
+calc    : VAR ASSIGN iexp           { scanner->setValue($1, $3); }
+        | error                     { yyerrok; }
         ;
  
 iexp    : INT                       { $$ = $1; }

--- a/velox/expression/type_calculation/TypeCalculation.y
+++ b/velox/expression/type_calculation/TypeCalculation.y
@@ -2,14 +2,14 @@
 #include <FlexLexer.h>
 #include <velox/common/base/Exceptions.h>
 %}
-%require "3.7.4"
+%require "3.0.4"
 %language "C++"
  
-%define api.parser.class {Parser}
+%define parser_class_name {Parser}
 %define api.namespace {facebook::velox::expression::calculate}
 %define api.value.type variant
 %parse-param {Scanner* scanner}
-%define parse.error detailed
+%define parse.error verbose
  
 %code requires
 {
@@ -24,9 +24,10 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token              EOL LPAREN RPAREN COMMA MIN MAX
-%token <long long>  INT
+%token               EOL LPAREN RPAREN COMMA MIN MAX
+%token <long long>   INT
 %token <std::string> VAR
+%token YYEOF         0
 
 %nterm <long long>  iexp
  

--- a/velox/expression/type_calculation/TypeCalculation.y
+++ b/velox/expression/type_calculation/TypeCalculation.y
@@ -1,0 +1,66 @@
+%{
+#include <FlexLexer.h>
+#include <velox/common/base/Exceptions.h>
+%}
+%require "3.7.4"
+%language "C++"
+ 
+%define api.parser.class {Parser}
+%define api.namespace {facebook::velox::expression::calculate}
+%define api.value.type variant
+%parse-param {Scanner* scanner}
+%define parse.error detailed
+ 
+%code requires
+{
+    namespace facebook::velox::expression::calculate {
+        class Scanner;
+    } // namespace facebook::velox::expression::calculate
+} // %code requires
+ 
+%code
+{
+    #include "Scanner.h"
+    #define yylex(x) scanner->lex(x)
+}
+
+%token              EOL LPAREN RPAREN COMMA MIN MAX
+%token <long long>  INT
+%token <std::string> VAR
+
+%nterm <long long>  iexp
+ 
+%nonassoc           ASSIGN
+%left               PLUS MINUS
+%left               MULTIPLY DIVIDE MODULO
+%precedence         UMINUS
+ 
+%%
+ 
+lines   : %empty
+        | lines line
+        ;
+ 
+line    : EOL                       { std::cerr << "Read an empty line.\n"; }
+        | VAR ASSIGN iexp EOL       { scanner->setValue($1, $3); }
+        | error EOL                 { yyerrok; }
+        ;
+ 
+iexp    : INT                       { $$ = $1; }
+        | iexp PLUS iexp            { $$ = $1 + $3; }
+        | iexp MINUS iexp           { $$ = $1 - $3; }
+        | iexp MULTIPLY iexp        { $$ = $1 * $3; }
+        | iexp DIVIDE iexp          { $$ = $1 / $3; }
+        | iexp MODULO iexp          { $$ = $1 % $3; }
+        | MINUS iexp %prec UMINUS   { $$ = -$2; }
+        | LPAREN iexp RPAREN        { $$ = $2; }
+        | MAX LPAREN iexp COMMA iexp RPAREN { $$ = std::max($3, $5); }
+        | MIN LPAREN iexp COMMA iexp RPAREN { $$ = std::min($3, $5); }
+        | VAR                       { $$ = scanner->getValue($1); }
+        ;
+ 
+%%
+ 
+void facebook::velox::expression::calculate::Parser::error(const std::string& msg) {
+    VELOX_FAIL(msg);
+}

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -121,12 +121,6 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   return found->second;
 }
 
-bool isDecimalKind(TypeKind typeKind) {
-  return (
-      typeKind == TypeKind::SHORT_DECIMAL ||
-      typeKind == TypeKind::LONG_DECIMAL);
-}
-
 void getDecimalPrecisionScale(const Type& type, int& precision, int& scale) {
   VELOX_CHECK(isDecimalKind(type.kind()));
   if (type.kind() == TypeKind::SHORT_DECIMAL) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -121,18 +121,14 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   return found->second;
 }
 
-bool isDecimalType(TypeKind typeKind) {
+bool isDecimalKind(TypeKind typeKind) {
   return (
       typeKind == TypeKind::SHORT_DECIMAL ||
       typeKind == TypeKind::LONG_DECIMAL);
 }
 
-bool isDecimalType(const std::string& typeName) {
-  return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
-}
-
 void getDecimalPrecisionScale(const Type& type, int& precision, int& scale) {
-  VELOX_CHECK(isDecimalType(type.kind()));
+  VELOX_CHECK(isDecimalKind(type.kind()));
   if (type.kind() == TypeKind::SHORT_DECIMAL) {
     const ShortDecimalType* decimalType =
         static_cast<const ShortDecimalType*>(&type);

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -121,6 +121,31 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   return found->second;
 }
 
+bool isDecimalType(TypeKind typeKind) {
+  return (
+      typeKind == TypeKind::SHORT_DECIMAL ||
+      typeKind == TypeKind::LONG_DECIMAL);
+}
+
+bool isDecimalType(const std::string& typeName) {
+  return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
+}
+
+void getDecimalPrecisionScale(const Type& type, int& precision, int& scale) {
+  VELOX_CHECK(isDecimalType(type.kind()));
+  if (type.kind() == TypeKind::SHORT_DECIMAL) {
+    const ShortDecimalType* decimalType =
+        static_cast<const ShortDecimalType*>(&type);
+    precision = decimalType->precision();
+    scale = decimalType->scale();
+  } else {
+    const LongDecimalType* decimalType =
+        static_cast<const LongDecimalType*>(&type);
+    precision = decimalType->precision();
+    scale = decimalType->scale();
+  }
+}
+
 namespace {
 struct OpaqueSerdeRegistry {
   struct Entry {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -667,9 +667,7 @@ class DecimalType : public ScalarType<KIND> {
 using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
 using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
 
-bool isDecimalType(TypeKind typeKind);
-
-bool isDecimalType(const std::string& typeName);
+bool isDecimalKind(TypeKind typeKind);
 
 void getDecimalPrecisionScale(const Type& type, int& precision, int& scale);
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -667,7 +667,15 @@ class DecimalType : public ScalarType<KIND> {
 using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
 using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
 
-bool isDecimalKind(TypeKind typeKind);
+inline bool isDecimalKind(TypeKind typeKind) {
+  return (
+      typeKind == TypeKind::SHORT_DECIMAL ||
+      typeKind == TypeKind::LONG_DECIMAL);
+}
+
+inline bool isDecimalName(const std::string& typeName) {
+  return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
+}
 
 void getDecimalPrecisionScale(const Type& type, int& precision, int& scale);
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -667,6 +667,12 @@ class DecimalType : public ScalarType<KIND> {
 using ShortDecimalType = DecimalType<TypeKind::SHORT_DECIMAL>;
 using LongDecimalType = DecimalType<TypeKind::LONG_DECIMAL>;
 
+bool isDecimalType(TypeKind typeKind);
+
+bool isDecimalType(const std::string& typeName);
+
+void getDecimalPrecisionScale(const Type& type, int& precision, int& scale);
+
 class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
  public:
   UnknownType() = default;


### PR DESCRIPTION
Add support for decimal signature and type calculation.
Example:
```
auto signature =
      exec::FunctionSignatureBuilder()
          .returnType("DECIMAL(r_precision, r_scale)")
          .argumentType("DECIMAL(a_precision, a_scale)")
          .argumentType("DECIMAL(b_precision, b_scale)")
          .variableConstraint(
              "r_precision",
              "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
          .variableConstraint("r_scale", "max(a_scale, b_scale)")
          .build();

  testSignatureBinder(
      signature,
      {DECIMAL(11, 5), DECIMAL(10, 6)}, DECIMAL(10, 6));
```

Type calculator uses flex/bison to parse and evaluate the calculation.
flex/bison are used to generate the scanner/parser code at CMake time.
The generated code is built with Velox. There are no external dependencies at build time.