### PR TITLE
evalExprSetAsync and evalExprAsyn

### DIFF
--- a/velox/experimental/AsynExpression/AsyncExprEval.cpp
+++ b/velox/experimental/AsynExpression/AsyncExprEval.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/experimental/coro/Collect.h>
+
+#include "velox/experimental/AsynExpression/AsyncExprEval.h"
+#include "velox/experimental/AsynExpression/AsyncVectorFunction.h"
+namespace facebook::velox::exec {
+
+folly::coro::Task<void> AsyncExprEval::evalExprAsyncIntenral(
+    Expr& expr,
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  if (!rows.hasSelections()) {
+    // Empty input, return an empty vector of the right type.ß
+    result = BaseVector::createNullConstant(expr.type(), 0, context.pool());
+    co_return;
+  }
+
+  if (auto fieldReference = dynamic_cast<FieldReference*>(&expr)) {
+    fieldReference->evalSpecialForm(rows, context, result);
+    co_return;
+  } else if (auto constantExpr = dynamic_cast<ConstantExpr*>(&expr)) {
+    fieldReference->evalSpecialForm(rows, context, result);
+    co_return;
+  }
+
+  // Expression is vector function.
+  expr.inputValues_.resize(expr.inputs_.size());
+
+  std::vector<folly::coro::Task<void>> tasks;
+  for (auto i = 0; i < expr.inputs_.size(); i++) {
+    tasks.push_back(evalExprAsyncIntenral(
+        *expr.inputs_[i], rows, context, expr.inputValues_[i]));
+  }
+  co_await folly::coro::collectAllRange(std::move(tasks));
+
+  if (auto asyncFunction = std::dynamic_pointer_cast<AsyncVectorFunction>(
+          expr.vectorFunction_)) {
+    co_await asyncFunction->applyAsync(
+        rows, expr.inputValues_, expr.type(), &context, &result);
+  } else {
+    expr.vectorFunction_->apply(
+        rows, expr.inputValues_, expr.type(), &context, &result);
+  }
+
+  expr.inputValues_.clear();
+  co_return;
+}
+} // namespace facebook::velox::exec

--- a/velox/experimental/AsynExpression/AsyncExprEval.h
+++ b/velox/experimental/AsynExpression/AsyncExprEval.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <folly/experimental/coro/Collect.h>
+#include <folly/experimental/coro/Task.h>
+
+#include "velox/experimental/AsynExpression/AsyncVectorFunction.h"
+#include "velox/expression/ControlExpr.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::exec {
+
+class AsyncExprEval {
+ public:
+  // Async path to execute an expression that is composed of supported async
+  // expressions. For now only AsyncVectorFunctions.
+  static folly::coro::Task<void> evalExprAsync(
+      Expr& expression_,
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result) {
+    VELOX_CHECK(
+        isSupportedAsyncExpression(expression_),
+        "expression is not supported in asyncEval")
+
+    co_return co_await evalExprAsyncIntenral(
+        expression_, rows, context, result);
+  }
+
+  // Async path to execute an expression that is composed of supported async
+  // expressions. For now only AsyncVectorFunctions.
+  static folly::coro::Task<void> evalExprSetAsync(
+      ExprSet& exprSet,
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      std::vector<VectorPtr>& result) {
+    result.resize(exprSet.exprs_.size());
+
+    std::vector<folly::coro::Task<void>> tasks;
+
+    for (int32_t i = 0; i < exprSet.exprs_.size(); ++i) {
+      tasks.push_back(
+          evalExprAsync(*exprSet.exprs_[i], rows, context, result[i]));
+    }
+    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_return;
+  }
+
+ private:
+  static folly::coro::Task<void> evalExprAsyncIntenral(
+      Expr& expr,
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result);
+
+  static bool isSupportedAsyncExpression(const Expr& expr) {
+    if (expr.isSpecialForm() && !isFieldReference(expr) && !isConstant(expr)) {
+      return false;
+    }
+    bool result = true;
+    for (auto& input : expr.inputs()) {
+      result = result && isSupportedAsyncExpression(*input);
+    }
+    return result;
+  }
+
+  static bool isFieldReference(const Expr& expr) {
+    return dynamic_cast<const FieldReference*>(&expr) != nullptr;
+  }
+
+  static bool isConstant(const Expr& expr) {
+    return dynamic_cast<const ConstantExpr*>(&expr) != nullptr;
+  }
+};
+
+} // namespace facebook::velox::exec

--- a/velox/experimental/AsynExpression/AsyncVectorFunction.h
+++ b/velox/experimental/AsynExpression/AsyncVectorFunction.h
@@ -18,6 +18,7 @@
 
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/experimental/coro/Task.h>
+#include <iostream>
 
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/Type.h"

--- a/velox/experimental/AsynExpression/AsyncVectorFunction.h
+++ b/velox/experimental/AsynExpression/AsyncVectorFunction.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/experimental/coro/BlockingWait.h>
+#include <folly/experimental/coro/Task.h>
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+class AsyncVectorFunction : public VectorFunction {
+ public:
+  virtual folly::coro::Task<void> applyAsync(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      EvalCtx* context,
+      VectorPtr* result) const = 0;
+
+  // Calls `applyAsyn` and block.
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      EvalCtx* context,
+      VectorPtr* result) const override {
+    folly::coro::blockingWait(
+        applyAsync(rows, args, outputType, context, result));
+  }
+
+  virtual bool threadSafe() {
+    return false;
+  }
+};
+
+} // namespace facebook::velox::exec

--- a/velox/experimental/AsynExpression/tests/AsyncExprEvalTest.cpp
+++ b/velox/experimental/AsynExpression/tests/AsyncExprEvalTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Executor.h>
+#include <folly/experimental/coro/Collect.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+
+#include <folly/experimental/coro/Task.h>
+#include <velox/vector/BaseVector.h>
+#include <velox/vector/FlatVector.h>
+#include <velox/vector/SelectivityVector.h>
+#include <velox/vector/TypeAliases.h>
+#include "velox/experimental/AsynExpression/AsyncExprEval.h"
+#include "velox/experimental/AsynExpression/AsyncVectorFunction.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/Type.h"
+
+// #define PRINT_INFO
+namespace facebook::velox::exec::test {
+
+namespace {
+// For every row, the execution will async sleep input[row]ms, and then result
+// will be the number of rows that were completed before the execution of the
+// row starts.
+// This is used to make sure all rows from multiple functions start
+// before any complete. Hence guarantee no blocking.
+class RecordPreStartCompletedWork : public AsyncVectorFunction {
+ public:
+  folly::coro::Task<void> applyAsync(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      EvalCtx* context,
+      VectorPtr* result) const override {
+    BaseVector::ensureWritable(rows, INTEGER(), context->pool(), result);
+
+    auto flatArg = args[0]->asFlatVector<int32_t>();
+    std::vector<folly::coro::Task<bool>> tasks;
+    rows.applyToSelected([&](vector_size_t row) {
+      tasks.push_back(perRowWork(
+          row, flatArg->valueAt(row), (*result)->asFlatVector<int32_t>()));
+    });
+
+    // we can use collect windowed.
+    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_return;
+  }
+  static int32_t finishedItems;
+
+  bool isDeterministic() const override {
+    return false;
+  }
+
+ private:
+  // The results record the number of finished items at the time right
+  // before the work per row started.
+  folly::coro::Task<bool> perRowWork(
+      vector_size_t row,
+      int32_t input,
+      FlatVector<int32_t>* result) const {
+    int32_t rowResult = finishedItems;
+
+#ifdef PRINT_INFO
+    std::cout << "start function for row:" << row << "\n";
+#endif
+    co_await folly::futures::sleep(std::chrono::milliseconds{input});
+
+#ifdef PRINT_INFO
+    std::cout << "finish function for row:" << row << "\n";
+#endif
+
+    finishedItems++;
+    result->set(row, rowResult);
+    co_return true;
+  }
+};
+
+int32_t RecordPreStartCompletedWork::finishedItems = 0;
+} // namespace
+
+class AsyncExprEvalTest : public functions::test::FunctionBaseTest {
+ public:
+  AsyncExprEvalTest() : FunctionBaseTest() {
+    facebook::velox::exec::registerVectorFunction(
+        "async_call",
+        {exec::FunctionSignatureBuilder()
+             .returnType("integer")
+             .argumentType("integer")
+             .build()},
+        std::make_unique<RecordPreStartCompletedWork>());
+  }
+
+  exec::ExprSet compileExpression(
+      const std::string& text,
+      const TypePtr& rowType) {
+    auto untyped = parse::parseExpr(text);
+    auto typed =
+        core::Expressions::inferTypes(untyped, rowType, execCtx_.pool());
+    return exec::ExprSet({typed}, &execCtx_);
+  }
+};
+
+TEST_F(AsyncExprEvalTest, test) {
+  auto input =
+      vectorMaker_.rowVector({makeFlatVector<int32_t>({10, 100, 200})});
+  auto exprSet =
+      compileExpression("async_call(c0) + async_call(c0)", input->type());
+
+  SelectivityVector rows(3);
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, input.get());
+  std::vector<VectorPtr> results(1);
+
+  // The output shall be 0+0, 0+0, 0+0 when we ran evalAsync.
+  // Since  All will start before any finishes.
+  // start function for row:0
+  // start function for row:1
+  // start function for row:2
+  // start function for row:0
+  // start function for row:1
+  // start function for row:2
+  // finish function for row:0
+  // finish function for row:0
+  // finish function for row:1
+  // finish function for row:1
+  // finish function for row:2
+  // finish function for row:2
+  folly::coro::blockingWait(
+      AsyncExprEval::evalExprSetAsync(exprSet, rows, evalCtx, results));
+
+  auto flatResultAsync = results[0]->asFlatVector<int32_t>();
+  VELOX_CHECK_EQ(flatResultAsync->valueAt(0), 0);
+  VELOX_CHECK_EQ(flatResultAsync->valueAt(1), 0);
+  VELOX_CHECK_EQ(flatResultAsync->valueAt(2), 0);
+  VELOX_CHECK_EQ(RecordPreStartCompletedWork::finishedItems, 6);
+  // Run in non-async mode.
+
+  // Rows will run async within an async vector function, then in the apply
+  // function call will block, so two inputs of + are not running
+  // concurrently.
+
+  // Output will be 3, 3, 3. The first vector function will finish then the
+  // second. For each row starting in the second function, it will see 3
+  // finished rows.
+
+  // start function for row:0
+  // start function for row:1
+  // start function for row:2
+  // finish function for row:0
+  // finish function for row:1
+  // finish function for row:2
+  // start function for row:0
+  // start function for row:1
+  // start function for row:2
+  // finish function for row:0
+  // finish function for row:1
+  // finish function for row:2
+  RecordPreStartCompletedWork::finishedItems = 0;
+  exprSet.eval(rows, &evalCtx, &results);
+  auto flatResultSync = results[0]->asFlatVector<int32_t>();
+  VELOX_CHECK_EQ(flatResultSync->valueAt(0), 3);
+  VELOX_CHECK_EQ(flatResultSync->valueAt(1), 3);
+  VELOX_CHECK_EQ(flatResultSync->valueAt(2), 3);
+  VELOX_CHECK_EQ(RecordPreStartCompletedWork::finishedItems, 6);
+}
+} // namespace facebook::velox::exec::test

--- a/velox/experimental/AsynExpression/tests/AsyncVectorFunctionTest.cpp
+++ b/velox/experimental/AsynExpression/tests/AsyncVectorFunctionTest.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Executor.h>
+#include <folly/experimental/coro/Collect.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+
+#include <velox/vector/BaseVector.h>
+#include <velox/vector/FlatVector.h>
+#include <velox/vector/SelectivityVector.h>
+#include <velox/vector/TypeAliases.h>
+#include "velox/experimental/AsynExpression/AsyncVectorFunction.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+// For every row, it will sleep input[i] ms, and the result will be the order
+// at which execution of the row is completed. Hence we expect that to match
+// the sleep durations order.
+class RecordWakeUpOrder : public AsyncVectorFunction {
+ public:
+  // Such expansion of the work shall be done through the
+  // AsyncFunctionAdapter eventually.
+  folly::coro::Task<void> applyAsync(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      EvalCtx* context,
+      VectorPtr* result) const override {
+    // TODO: if we want to allow threadSafe()-> true, we need to make sure this
+    // is thread-safe.
+    BaseVector::ensureWritable(rows, INTEGER(), context->pool(), result);
+
+    auto flatArg = args[0]->asFlatVector<int32_t>();
+    std::vector<folly::coro::Task<bool>> tasks;
+    int32_t counter = 0;
+    rows.applyToSelected([&](vector_size_t row) {
+      tasks.push_back(perRowWork(
+          row,
+          flatArg->valueAt(row),
+          (*result)->asFlatVector<int32_t>(),
+          counter));
+    });
+
+    // we can use collect windowed.
+    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_return;
+  }
+
+ private:
+  // The results record the order at which rows execution finished.
+  // Not thread-safe but ok since collectAllRange run all tasks on the same
+  // thread.
+  folly::coro::Task<bool> perRowWork(
+      vector_size_t row,
+      int32_t input,
+      FlatVector<int32_t>* result,
+      int32_t& counter) const {
+    co_await folly::futures::sleep(std::chrono::milliseconds{input});
+    // record the order in which rows finished.
+    result->set(row, counter++);
+    co_return true;
+  }
+};
+
+class AsyncVectorFunctionTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(AsyncVectorFunctionTest, testRowsRunAsync) {
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  ExprSet exprSet({}, &execCtx_);
+  auto inputs = makeRowVector({});
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputs.get());
+
+  RecordWakeUpOrder function;
+  VectorPtr result;
+  SelectivityVector rows(3);
+  {
+    auto input = makeFlatVector<int32_t>({10, 200, 1000});
+    std::vector<VectorPtr> inputsVector = {input};
+    function.apply(rows, inputsVector, INTEGER(), &evalCtx, &result);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(0), 0);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(1), 1);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(2), 2);
+  }
+
+  {
+    auto input = makeFlatVector<int32_t>({1000, 10, 500});
+    std::vector<VectorPtr> inputsVector = {input};
+    function.apply(rows, inputsVector, INTEGER(), &evalCtx, &result);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(0), 2);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(1), 0);
+    ASSERT_EQ(result->asFlatVector<int32_t>()->valueAt(2), 1);
+  }
+}
+
+// For every row, it will sleep input[i] ms, and the result will be the rows
+// completed before the execution of the row starts. We use this to make sure
+// all rows from multiple functions start before any complete. Hence
+// guarantee no blocking.
+class RecordPreStartCompletedWork : public AsyncVectorFunction {
+ public:
+  folly::coro::Task<void> applyAsync(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      EvalCtx* context,
+      VectorPtr* result) const override {
+    BaseVector::ensureWritable(rows, INTEGER(), context->pool(), result);
+
+    auto flatArg = args[0]->asFlatVector<int32_t>();
+    std::vector<folly::coro::Task<bool>> tasks;
+    rows.applyToSelected([&](vector_size_t row) {
+      tasks.push_back(perRowWork(
+          row, flatArg->valueAt(row), (*result)->asFlatVector<int32_t>()));
+    });
+
+    // we can use collect windowed.
+    co_await folly::coro::collectAllRange(std::move(tasks));
+    co_return;
+  }
+
+ private:
+  // The results record the number of finished items at the time right
+  // before the work per row started.
+  folly::coro::Task<bool> perRowWork(
+      vector_size_t row,
+      int32_t input,
+      FlatVector<int32_t>* result) const {
+    static int32_t finishedItems = 0;
+    int32_t rowResult = finishedItems;
+    co_await folly::futures::sleep(std::chrono::milliseconds{input});
+    finishedItems++;
+    result->set(row, rowResult);
+    co_return true;
+  }
+};
+
+TEST_F(AsyncVectorFunctionTest, testVectorsRunAsync) {
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  ExprSet exprSet({}, &execCtx_);
+  auto inputs = makeRowVector({});
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputs.get());
+
+  RecordPreStartCompletedWork function;
+  auto input = makeFlatVector<int32_t>({100, 200, 1000});
+  std::vector<VectorPtr> inputsVector = {input};
+
+  VectorPtr result1, result2;
+  SelectivityVector rows(3);
+
+  auto task1 =
+      function.applyAsync(rows, inputsVector, INTEGER(), &evalCtx, &result1);
+  auto task2 =
+      function.applyAsync(rows, inputsVector, INTEGER(), &evalCtx, &result2);
+  folly::coro::blockingWait(
+      folly::coro::collectAll(std::move(task1), std::move(task2)));
+
+  auto assertAllZeros = [&](auto& vector) {
+    for (auto i = 0; i < vector->size(); i++) {
+      ASSERT_EQ(vector->template asFlatVector<int32_t>()->valueAt(i), 0);
+    }
+  };
+  assertAllZeros(result1);
+  assertAllZeros(result2);
+}
+} // namespace facebook::velox::exec

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -292,6 +292,8 @@ void Expr::eval(
   }
 
   if (inputs_.empty()) {
+    // If the function does not have inputs and is not constant folded, then it
+    // must be non-detetministic so we do not run peeling or cse opts.
     evalAll(rows, context, result);
     return;
   }
@@ -319,7 +321,7 @@ bool Expr::checkGetSharedSubexprValues(
   //
   // For now, disable the optimization if any encodings have been peeled off.
 
-  if (!isMultiplyReferenced_ || !sharedSubexprValues_ ||
+  if (!deterministic_ || !isMultiplyReferenced_ || !sharedSubexprValues_ ||
       context.wrapEncoding() != VectorEncoding::Simple::FLAT) {
     return false;
   }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -362,6 +362,8 @@ class Expr {
 
   /// Runtime statistics. CPU time, wall time and number of processed rows.
   ExprStats stats_;
+
+  friend class AsyncExprEval;
 };
 
 using ExprPtr = std::shared_ptr<Expr>;
@@ -438,6 +440,7 @@ class ExprSet {
   // Exprs which retain memoized state, e.g. from running over dictionaries.
   std::unordered_set<Expr*> memoizingExprs_;
   core::ExecCtx* FOLLY_NONNULL const execCtx_;
+  friend class AsyncExprEval;
 };
 
 class ExprSetSimplified : public ExprSet {

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -839,4 +839,55 @@ TEST_F(SimpleFunctionTest, mapStringOut) {
   }
 }
 
+template <typename T>
+struct NonDeterministicFunc {
+  static constexpr bool is_deterministic = false;
+
+  void call(int64_t& out) {
+    static size_t counter = 0;
+    out = counter++;
+  }
+};
+
+// Test that non-deterministic functions do not participate in CSE
+// optimization, or constant folding.
+TEST_F(SimpleFunctionTest, cseDisabled) {
+  registerFunction<NonDeterministicFunc, int64_t>({"new_value"});
+
+  auto input = vectorMaker_.flatVector<int64_t>({1, 2, 3, 4});
+  auto result = evaluate("new_value() + new_value()", makeRowVector({input}));
+  auto* flatResult = result->asFlatVector<int64_t>();
+  ASSERT_EQ(flatResult->valueAt(0), 4);
+  ASSERT_EQ(flatResult->valueAt(1), 6);
+  ASSERT_EQ(flatResult->valueAt(2), 8);
+  ASSERT_EQ(flatResult->valueAt(3), 10);
+}
+
+template <typename T>
+struct NonDeterministicFuncWithInput {
+  static constexpr bool is_deterministic = false;
+
+  void call(int64_t& out, const int64_t& input) {
+    static size_t counter = 0;
+    out = input + counter++;
+  }
+};
+
+TEST_F(SimpleFunctionTest, cseDisabledFuncWithInput) {
+  registerFunction<NonDeterministicFuncWithInput, int64_t, int64_t>(
+      {"new_value_with_input"});
+
+  auto input = vectorMaker_.flatVector<int64_t>({1, 2, 3, 4});
+  {
+    auto result = evaluate(
+        "new_value_with_input(c0) + new_value_with_input(c0)",
+        makeRowVector({input}));
+    auto* flatResult = result->asFlatVector<int64_t>();
+    ASSERT_EQ(flatResult->valueAt(0), 6);
+    ASSERT_EQ(flatResult->valueAt(1), 10);
+    ASSERT_EQ(flatResult->valueAt(2), 14);
+    ASSERT_EQ(flatResult->valueAt(3), 18);
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
prototype for async expression evaluation that supports input fields, constants 
and async vector functions. 
For vector functions, all inputs are evaluated first asynchronously, if an input is an async vector function, then its evaluation will yield until its execution is finished if it's waiting otherwise, it runs through apply.

The test shows that for async(c0)+ async(c0). All calls for all rows are started concurrently, then finished when running evalAsync:
  // start function for row:0
  // start function for row:1
  // start function for row:2
  // start function for row:0
  // start function for row:1
  // start function for row:2
  // finish function for row:0
  // finish function for row:0
  // finish function for row:1
  // finish function for row:1
  // finish function for row:2
  // finish function for row:2

When running in the normal eval, the apply function will call applyAsync and block. 
hence we have a concurrency of 3 instead of 6.

  // start function for row:0
  // start function for row:1
  // start function for row:2
  // finish function for row:0
  // finish function for row:1
  // finish function for row:2
  // start function for row:0
  // start function for row:1
  // start function for row:2
  // finish function for row:0
  // finish function for row:1
  // finish function for row:2

Differential Revision: D36634715

