### PR TITLE
Fix LocalPartition to return proper output type in output vectors.

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -278,7 +278,8 @@ LocalPartition::LocalPartition(
               : planNode->partitionFunctionFactory()(numPartitions_)),
       sourceOutputChannels_{calculateOutputChannels(
           planNode->sources()[0]->outputType(),
-          planNode->inputTypeFromSource())},
+          planNode->inputTypeFromSource(),
+          planNode->outputType())},
       blockingReasons_{numPartitions_} {
   VELOX_CHECK(numPartitions_ == 1 || partitionFunction_ != nullptr);
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -244,19 +244,23 @@ ChannelIndex exprToChannel(const core::ITypedExpr* expr, const TypePtr& type) {
 }
 
 std::vector<ChannelIndex> calculateOutputChannels(
-    const RowTypePtr& inputType,
-    const RowTypePtr& outputType) {
-  // Note that outputType may have more columns than inputType as some columns
-  // can be duplicated.
-
-  bool identicalProjection = inputType->size() == outputType->size();
-  const auto& outputNames = outputType->names();
+    const RowTypePtr& sourceOutputType,
+    const RowTypePtr& targetInputType,
+    const RowTypePtr& targetOutputType) {
+  // Note that targetInputType may have more columns than sourceOutputType as
+  // some columns can be duplicated.
+  bool identicalProjection =
+      sourceOutputType->size() == targetInputType->size();
+  const auto& outputNames = targetInputType->names();
 
   std::vector<ChannelIndex> outputChannels;
   outputChannels.resize(outputNames.size());
   for (auto i = 0; i < outputNames.size(); i++) {
-    outputChannels[i] = inputType->getChildIdx(outputNames[i]);
+    outputChannels[i] = sourceOutputType->getChildIdx(outputNames[i]);
     if (outputChannels[i] != i) {
+      identicalProjection = false;
+    }
+    if (outputNames[i] != targetOutputType->nameOf(i)) {
       identicalProjection = false;
     }
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -422,12 +422,14 @@ std::vector<ChannelIndex> toChannels(
 
 ChannelIndex exprToChannel(const core::ITypedExpr* expr, const TypePtr& type);
 
-/// Given an input type and output type that contains a subset of the input type
-/// columns possibly in different order returns the indices of the output
-/// columns in the input type.
+/// Given a source output type and target input type we return the indices of
+/// the target input columns in the source output type.
+/// The target output type is used to determine if the projection is identity.
+/// An empty indices vector is returned when projection is identity.
 std::vector<ChannelIndex> calculateOutputChannels(
-    const RowTypePtr& inputType,
-    const RowTypePtr& outputType);
+    const RowTypePtr& sourceOutputType,
+    const RowTypePtr& targetInputType,
+    const RowTypePtr& targetOutputType);
 
 // A first operator in a Driver, e.g. table scan or exchange client.
 class SourceOperator : public Operator {

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -146,6 +146,7 @@ class PartitionedOutput : public Operator {
                 : planNode->partitionFunctionFactory()(numDestinations_)),
         outputChannels_(calculateOutputChannels(
             planNode->inputType(),
+            planNode->outputType(),
             planNode->outputType())),
         future_(false),
         bufferManager_(PartitionedOutputBufferManager::getInstance()),


### PR DESCRIPTION
Summary:
"Field not found" error has been triggered for certain queries with "union all".
In such queries LacalPartition was retuning output vectors (data for the next operator) with not the output type, but the type which was set by the source (to LocalPartiton) operator.
This change makes sure we use proper output type in the returned output vector.

Differential Revision: D36654248

