### PR TITLE
Avoid wrapping constant vector in a dictionary

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -160,13 +160,6 @@ VectorPtr wrapChild(
     return child;
   }
 
-  if (child->encoding() == VectorEncoding::Simple::CONSTANT && !nulls) {
-    if (size == child->size()) {
-      return child;
-    }
-    return BaseVector::wrapInConstant(size, 0, child);
-  }
-
   return BaseVector::wrapInDictionary(nulls, mapping, size, child);
 }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -129,6 +129,15 @@ VectorPtr BaseVector::wrapInDictionary(
     BufferPtr indices,
     vector_size_t size,
     VectorPtr vector) {
+  // Dictionary that doesn't add nulls over constant is same as constant. Just
+  // make sure to adjust the size.
+  if (vector->encoding() == VectorEncoding::Simple::CONSTANT && !nulls) {
+    if (size == vector->size()) {
+      return vector;
+    }
+    return BaseVector::wrapInConstant(size, 0, vector);
+  }
+
   auto kind = vector->typeKind();
   return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
       addDictionary, kind, nulls, indices, size, std::move(vector));


### PR DESCRIPTION
wrapChild helper function in OperatorUtils had logic to avoid wrapping constant
in a dictionary that doesn't add nulls. This logic is generally useful and
therefore belongs to BaseVector::wrapInDictionary. Moved accordingly.