### PR TITLE
Remove duplicate DecodedVector::values method

### DIFF
--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -130,7 +130,7 @@ class MapResolverVectorFunction : public exec::VectorFunction {
     // because valueAt() will end up copying the shared_ptrs, and that's a
     // little expensive.
     const std::shared_ptr<UserDefinedMap>* opaqueRawVector =
-        opaqueVector->values<std::shared_ptr<UserDefinedMap>>();
+        opaqueVector->data<std::shared_ptr<UserDefinedMap>>();
 
     // Ensure we have an output vector where we can write the output opaqued
     // values.

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -180,7 +180,7 @@ template <typename T>
 bool VectorHasher::makeValueIdsFlatNoNulls(
     const SelectivityVector& rows,
     uint64_t* result) {
-  const auto* values = decoded_.values<T>();
+  const auto* values = decoded_.data<T>();
   if (isRange_ && tryMapToRange(values, rows, result)) {
     return true;
   }
@@ -210,7 +210,7 @@ template <typename T>
 bool VectorHasher::makeValueIdsFlatWithNulls(
     const SelectivityVector& rows,
     uint64_t* result) {
-  const auto* values = decoded_.values<T>();
+  const auto* values = decoded_.data<T>();
   const auto* nulls = decoded_.nulls();
 
   bool success = true;
@@ -247,7 +247,7 @@ bool VectorHasher::makeValueIdsDecoded(
   std::fill(cachedHashes_.begin(), cachedHashes_.end(), 0);
 
   auto indices = decoded_.indices();
-  auto values = decoded_.values<T>();
+  auto values = decoded_.data<T>();
 
   bool success = true;
   rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
@@ -288,7 +288,7 @@ bool VectorHasher::makeValueIdsDecoded<bool, true>(
     const SelectivityVector& rows,
     uint64_t* result) {
   auto indices = decoded_.indices();
-  auto values = decoded_.values<uint64_t>();
+  auto values = decoded_.data<uint64_t>();
 
   rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
     if (decoded_.isNullAt(row)) {
@@ -310,7 +310,7 @@ bool VectorHasher::makeValueIdsDecoded<bool, false>(
     const SelectivityVector& rows,
     uint64_t* result) {
   auto indices = decoded_.indices();
-  auto values = decoded_.values<uint64_t>();
+  auto values = decoded_.data<uint64_t>();
 
   rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
     bool value = bits::isBitSet(values, indices[row]);

--- a/velox/functions/prestosql/ArrayContains.cpp
+++ b/velox/functions/prestosql/ArrayContains.cpp
@@ -37,7 +37,7 @@ void applyTyped(
 
   if (!isBoolType && elementsDecoded.isIdentityMapping() &&
       !elementsDecoded.mayHaveNulls() && searchDecoded.isConstantMapping()) {
-    auto rawElements = elementsDecoded.values<T>();
+    auto rawElements = elementsDecoded.data<T>();
     auto search = searchDecoded.valueAt<T>(0);
 
     rows.applyToSelected([&](auto row) {

--- a/velox/functions/prestosql/ArrayMinMax.cpp
+++ b/velox/functions/prestosql/ArrayMinMax.cpp
@@ -41,7 +41,7 @@ VectorPtr applyTyped(
 
   if (elementsDecoded.isIdentityMapping() && !elementsDecoded.mayHaveNulls()) {
     if constexpr (std::is_same_v<bool, T>) {
-      auto rawElements = elementsDecoded.values<uint64_t>();
+      auto rawElements = elementsDecoded.data<uint64_t>();
       rows.applyToSelected([&](auto row) {
         auto size = rawSizes[row];
         if (size == 0) {
@@ -60,7 +60,7 @@ VectorPtr applyTyped(
         }
       });
     } else {
-      auto rawElements = elementsDecoded.values<T>();
+      auto rawElements = elementsDecoded.data<T>();
       rows.applyToSelected([&](auto row) {
         auto size = rawSizes[row];
         if (size == 0) {

--- a/velox/functions/prestosql/ArrayPosition.cpp
+++ b/velox/functions/prestosql/ArrayPosition.cpp
@@ -43,9 +43,9 @@ void applyTypedFirstMatch(
       searchDecoded.isConstantMapping()) {
     // Fast path for array vector of boolean.
     if constexpr (std::is_same_v<bool, T>) {
-      auto rawElements = elementsDecoded.values<uint64_t>();
+      auto rawElements = elementsDecoded.data<uint64_t>();
 
-      auto search = bits::isBitSet(searchDecoded.values<uint64_t>(), 0);
+      auto search = bits::isBitSet(searchDecoded.data<uint64_t>(), 0);
 
       rows.applyToSelected([&](auto row) {
         auto size = rawSizes[indices[row]];
@@ -66,7 +66,7 @@ void applyTypedFirstMatch(
     }
 
     // Fast path for array vector of types other than boolean.
-    auto rawElements = elementsDecoded.values<T>();
+    auto rawElements = elementsDecoded.data<T>();
 
     auto search = searchDecoded.valueAt<T>(0);
 
@@ -198,9 +198,9 @@ void applyTypedWithInstance(
 
     // Fast path for array vector of boolean.
     if constexpr (std::is_same_v<bool, T>) {
-      auto rawElements = elementsDecoded.values<uint64_t>();
+      auto rawElements = elementsDecoded.data<uint64_t>();
 
-      auto search = bits::isBitSet(searchDecoded.values<uint64_t>(), 0);
+      auto search = bits::isBitSet(searchDecoded.data<uint64_t>(), 0);
 
       rows.applyToSelected([&](auto row) {
         auto offset = rawOffsets[indices[row]];
@@ -225,7 +225,7 @@ void applyTypedWithInstance(
     }
 
     // Fast path for array vector of types other than boolean.
-    auto rawElements = elementsDecoded.values<T>();
+    auto rawElements = elementsDecoded.data<T>();
 
     auto search = searchDecoded.valueAt<T>(0);
 

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -141,11 +141,6 @@ class DecodedVector {
     return size_;
   }
 
-  template <typename T>
-  const T* values() const {
-    return reinterpret_cast<const T*>(data_);
-  }
-
   const BaseVector* base() const {
     return baseVector_;
   }


### PR DESCRIPTION
DecodedVector::values method is a duplicate of DecodedVector::data method. The
name 'values' is better as it matches valueAt method name, but there are a lot
of usage of the 'data' method and very few of 'values'.