### PR TITLE
Add degrees, e, and sha512 Presto functions

### DIFF
--- a/velox/docs/functions/binary.rst
+++ b/velox/docs/functions/binary.rst
@@ -14,6 +14,10 @@ Binary Functions
 
     Computes the SHA-256 hash of ``binary``.
 
+.. function:: sha512(binary) -> varbinary
+
+    Computes the SHA-512 hash of ``binary``.
+
 .. function:: to_base64(binary) -> varchar
 
     Encodes ``binary`` into a base64 string representation.

--- a/velox/docs/functions/math.rst
+++ b/velox/docs/functions/math.rst
@@ -23,6 +23,10 @@ Mathematical Functions
     Returns ``low`` if ``x`` is less than ``low``. Returns ``high`` if ``x`` is greater than ``high``.
     Returns ``x`` otherwise. ``low`` must be less than or equal to ``high``.
 
+.. function:: degrees(x) -> double
+
+    Converts angle x in radians to degrees.
+
 .. function:: divide(x, y) -> [same as x]
 
     Returns the results of dividing x by y. The types of x and y must be the same.
@@ -30,6 +34,10 @@ Mathematical Functions
     division by zero results in an error. For floating point types,  division by
     zero returns positive infinity if x is greater than zero, negative infinity if
     x if less than zero and NaN if x is equal to zero.
+
+.. function:: e() -> double
+
+    Returns the value of Euler's Constant.
 
 .. function:: exp(x) -> double
 

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -286,6 +286,16 @@ FOLLY_ALWAYS_INLINE bool sha256(TOutString& output, const TInString& input) {
   return true;
 }
 
+/// Compute the SHA512 Hash.
+template <typename TOutString, typename TInString>
+FOLLY_ALWAYS_INLINE bool sha512(TOutString& output, const TInString& input) {
+  output.resize(64);
+  folly::ssl::OpenSSLHash::sha512(
+      folly::MutableByteRange((uint8_t*)output.data(), output.size()),
+      folly::ByteRange((const uint8_t*)input.data(), input.size()));
+  return true;
+}
+
 template <typename TOutString, typename TInString>
 FOLLY_ALWAYS_INLINE bool toHex(TOutString& output, const TInString& input) {
   static const char* const kHexTable =

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -288,12 +288,11 @@ FOLLY_ALWAYS_INLINE bool sha256(TOutString& output, const TInString& input) {
 
 /// Compute the SHA512 Hash.
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool sha512(TOutString& output, const TInString& input) {
+FOLLY_ALWAYS_INLINE void sha512(TOutString& output, const TInString& input) {
   output.resize(64);
   folly::ssl::OpenSSLHash::sha512(
       folly::MutableByteRange((uint8_t*)output.data(), output.size()),
       folly::ByteRange((const uint8_t*)input.data(), input.size()));
-  return true;
 }
 
 template <typename TOutString, typename TInString>

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -332,6 +332,13 @@ struct RadiansFunction {
 };
 
 template <typename T>
+struct DegreesFunction {
+  FOLLY_ALWAYS_INLINE void call(double& result, double a) {
+    result = a * (180 / M_PI);
+  }
+};
+
+template <typename T>
 struct SignFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, const TInput& a) {
@@ -464,6 +471,13 @@ template <typename T>
 struct PiFunction {
   FOLLY_ALWAYS_INLINE void call(double& result) {
     result = M_PI;
+  }
+};
+
+template <typename T>
+struct EulerConstantFunction {
+  FOLLY_ALWAYS_INLINE void call(double& result) {
+    result = M_E;
   }
 };
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -93,6 +93,17 @@ struct Sha256Function {
   }
 };
 
+/// sha512(varbinary) -> varbinary
+template <typename T>
+struct Sha512Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TTo, typename TFrom>
+  FOLLY_ALWAYS_INLINE bool call(TTo& result, const TFrom& input) {
+    return stringImpl::sha512(result, input);
+  }
+};
+
 template <typename T>
 struct ToHexFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -99,8 +99,8 @@ struct Sha512Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   template <typename TTo, typename TFrom>
-  FOLLY_ALWAYS_INLINE bool call(TTo& result, const TFrom& input) {
-    return stringImpl::sha512(result, input);
+  FOLLY_ALWAYS_INLINE void call(TTo& result, const TFrom& input) {
+    stringImpl::sha512(result, input);
   }
 };
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -33,6 +33,7 @@ void registerSimpleFunctions() {
   registerUnaryNumeric<AbsFunction>({"abs"});
   registerUnaryFloatingPoint<NegateFunction>({"negate"});
   registerFunction<RadiansFunction, double, double>({"radians"});
+  registerFunction<DegreesFunction, double, double>({"degrees"});
   registerUnaryNumeric<RoundFunction>({"round"});
   registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
   registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});
@@ -84,6 +85,7 @@ void registerSimpleFunctions() {
   registerFunction<FromBaseFunction, int64_t, Varchar, int64_t>({"from_base"});
   registerFunction<ToBaseFunction, Varchar, int64_t, int64_t>({"to_base"});
   registerFunction<PiFunction, double>({"pi"});
+  registerFunction<EulerConstantFunction, double>({"e"});
 }
 
 } // namespace

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -59,6 +59,7 @@ void registerSimpleFunctions() {
   registerFunction<XxHash64Function, Varbinary, Varbinary>({"xxhash64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});
+  registerFunction<Sha256Function, Varbinary, Varbinary>({"sha512"});
 
   registerFunction<ToHexFunction, Varchar, Varbinary>({"to_hex"});
   registerFunction<FromHexFunction, Varbinary, Varchar>({"from_hex"});

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -59,7 +59,7 @@ void registerSimpleFunctions() {
   registerFunction<XxHash64Function, Varbinary, Varbinary>({"xxhash64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});
-  registerFunction<Sha256Function, Varbinary, Varbinary>({"sha512"});
+  registerFunction<Sha512Function, Varbinary, Varbinary>({"sha512"});
 
   registerFunction<ToHexFunction, Varchar, Varbinary>({"to_hex"});
   registerFunction<FromHexFunction, Varbinary, Varchar>({"from_hex"});

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -412,7 +412,8 @@ TEST_F(ArithmeticTest, degrees) {
   EXPECT_DOUBLE_EQ(-57.295779513082323, degrees(-1).value());
   EXPECT_DOUBLE_EQ(-179.90874767107849, degrees(-3.14).value());
   EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
-  EXPECT_DOUBLE_EQ(1.2748734119735194e-306,
+  EXPECT_DOUBLE_EQ(
+      1.2748734119735194e-306,
       degrees(std::numeric_limits<double>::min()).value());
   EXPECT_DOUBLE_EQ(kInf, degrees(std::numeric_limits<double>::max()).value());
 }

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -405,12 +405,12 @@ TEST_F(ArithmeticTest, degrees) {
   };
 
   EXPECT_EQ(std::nullopt, degrees(std::nullopt));
-  EXPECT_DOUBLE_EQ(57.2957795130823229, degrees(1).value());
-  EXPECT_DOUBLE_EQ(0.9994930426171028, degrees(3.14).value());
+  EXPECT_DOUBLE_EQ(57.295779513082323, degrees(1).value());
+  EXPECT_DOUBLE_EQ(179.90874767107849, degrees(3.14).value());
   EXPECT_DOUBLE_EQ(kInf, degrees(kInf).value());
   EXPECT_DOUBLE_EQ(0, degrees(0).value());
-  EXPECT_DOUBLE_EQ(57.2957795130823229, degrees(-1).value());
-  EXPECT_DOUBLE_EQ(0.9994930426171028, degrees(-3.14).value());
+  EXPECT_DOUBLE_EQ(-57.295779513082323, degrees(-1).value());
+  EXPECT_DOUBLE_EQ(-179.90874767107849, degrees(-3.14).value());
   EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
 }
 

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -412,7 +412,9 @@ TEST_F(ArithmeticTest, degrees) {
   EXPECT_DOUBLE_EQ(-57.295779513082323, degrees(-1).value());
   EXPECT_DOUBLE_EQ(-179.90874767107849, degrees(-3.14).value());
   EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
-  EXPECT_DOUBLE_EQ(1.2748734119735194e-306, degrees(std::numeric_limits<double>::min()).value());
+  EXPECT_DOUBLE_EQ(
+      1.2748734119735194e-306, 
+      degrees(std::numeric_limits<double>::min()).value());
   EXPECT_DOUBLE_EQ(kInf, degrees(std::numeric_limits<double>::max()).value());
 }
 

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -412,6 +412,8 @@ TEST_F(ArithmeticTest, degrees) {
   EXPECT_DOUBLE_EQ(-57.295779513082323, degrees(-1).value());
   EXPECT_DOUBLE_EQ(-179.90874767107849, degrees(-3.14).value());
   EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
+  EXPECT_DOUBLE_EQ(1.2748734119735194e-306, degrees(std::numeric_limits<double>::min()).value());
+  EXPECT_DOUBLE_EQ(kInf, degrees(std::numeric_limits<double>::max()).value());
 }
 
 TEST_F(ArithmeticTest, signFloatingPoint) {

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -412,8 +412,7 @@ TEST_F(ArithmeticTest, degrees) {
   EXPECT_DOUBLE_EQ(-57.295779513082323, degrees(-1).value());
   EXPECT_DOUBLE_EQ(-179.90874767107849, degrees(-3.14).value());
   EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
-  EXPECT_DOUBLE_EQ(
-      1.2748734119735194e-306, 
+  EXPECT_DOUBLE_EQ(1.2748734119735194e-306,
       degrees(std::numeric_limits<double>::min()).value());
   EXPECT_DOUBLE_EQ(kInf, degrees(std::numeric_limits<double>::max()).value());
 }

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -399,6 +399,21 @@ TEST_F(ArithmeticTest, radians) {
   EXPECT_DOUBLE_EQ(-1.0000736613927508, radians(-57.3).value());
 }
 
+TEST_F(ArithmeticTest, degrees) {
+  const auto degrees = [&](std::optional<double> a) {
+    return evaluateOnce<double>("degrees(c0)", a);
+  };
+
+  EXPECT_EQ(std::nullopt, degrees(std::nullopt));
+  EXPECT_DOUBLE_EQ(57.2957795130823229, degrees(1).value());
+  EXPECT_DOUBLE_EQ(0.9994930426171028, degrees(3.14).value());
+  EXPECT_DOUBLE_EQ(kInf, degrees(kInf).value());
+  EXPECT_DOUBLE_EQ(0, degrees(0).value());
+  EXPECT_DOUBLE_EQ(57.2957795130823229, degrees(-1).value());
+  EXPECT_DOUBLE_EQ(0.9994930426171028, degrees(-3.14).value());
+  EXPECT_DOUBLE_EQ(-kInf, degrees(-kInf).value());
+}
+
 TEST_F(ArithmeticTest, signFloatingPoint) {
   const auto sign = [&](std::optional<double> a) {
     return evaluateOnce<double>("sign(c0)", a);
@@ -570,6 +585,14 @@ TEST_F(ArithmeticTest, pi) {
   };
 
   EXPECT_EQ(piValue(), M_PI);
+}
+
+TEST_F(ArithmeticTest, e) {
+  const auto eulerConstantValue = [&]() {
+    return evaluateOnce<double>("e()", makeRowVector(ROW({}), 1));
+  };
+
+  EXPECT_EQ(eulerConstantValue(), M_E);
 }
 
 TEST_F(ArithmeticTest, clamp) {

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1031,13 +1031,16 @@ TEST_F(StringFunctionsTest, sha512) {
   };
 
   EXPECT_EQ(
-      hexToDec("1f6b05823a0453c1ec55009555087e8226d774c7c49d099784317b8460a0623ddaa083334f9218dda8075e0a0dc8319f89199f04e6b8f3980a73556866b388ae"),
+      hexToDec(
+          "1f6b05823a0453c1ec55009555087e8226d774c7c49d099784317b8460a0623ddaa083334f9218dda8075e0a0dc8319f89199f04e6b8f3980a73556866b388ae"),
       sha512("prestodb"));
   EXPECT_EQ(
-      hexToDec("04f0823aefeb6e61866bdb47322ce033adb0a81684bf21fbc6e4f8513e798996e4732d28b15c631d1d6b0ca1e300c97fbadf62ea608d7d69930ddfd98f3e3a0e"),
+      hexToDec(
+          "7de872ed1c41ce3901bb7f12f20b0c0106331fe5b5ecc5fbbcf3ce6c79df4da595ebb7e221ab8b7fc5d918583eac6890ade1c26436335d3835828011204b7679"),
       sha512("Infinity"));
   EXPECT_EQ(
-      hexToDec("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+      hexToDec(
+          "30163935c002fc4e1200906c3d30a9c4956b4af9f6dcaef1eb4b1fcb8fba69e7a7acdc491ea5b1f2864ea8c01b01580ef09defc3b11b3f183cb21d236f7f1a6b"),
       sha512("hash"));
 
   EXPECT_EQ(std::nullopt, sha512(std::nullopt));

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1024,6 +1024,28 @@ TEST_F(StringFunctionsTest, sha256) {
   EXPECT_EQ(std::nullopt, sha256(std::nullopt));
 }
 
+TEST_F(StringFunctionsTest, sha512) {
+  const auto sha512 = [&](std::optional<std::string> arg) {
+    return evaluateOnce<std::string, std::string>(
+        "sha512(c0)", {arg}, {VARBINARY()});
+  };
+
+  EXPECT_EQ(
+      hexToDec(
+          "05b41d06db66a1c9f3b86a4033f920c25a59624dcad4118544f32147f7d04bcdd2627710e487958da69176b6a3884d13fa85f99ccfd44f97f81877bb8c103453"),
+      sha512("prestodb"));
+  EXPECT_EQ(
+      hexToDec(
+          "7de872ed1c41ce3901bb7f12f20b0c0106331fe5b5ecc5fbbcf3ce6c79df4da595ebb7e221ab8b7fc5d918583eac6890ade1c26436335d3835828011204b7679"),
+      sha512("Infinity"));
+  EXPECT_EQ(
+      hexToDec(
+          "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+      sha512(""));
+
+  EXPECT_EQ(std::nullopt, sha512(std::nullopt));
+}
+
 void StringFunctionsTest::testReplaceInPlace(
     const std::vector<std::pair<std::string, std::string>>& tests,
     const std::string& search,

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1042,7 +1042,10 @@ TEST_F(StringFunctionsTest, sha512) {
       hexToDec(
           "30163935c002fc4e1200906c3d30a9c4956b4af9f6dcaef1eb4b1fcb8fba69e7a7acdc491ea5b1f2864ea8c01b01580ef09defc3b11b3f183cb21d236f7f1a6b"),
       sha512("hash"));
-
+  EXPECT_EQ(
+      hexToDec(
+          "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+      sha512(""));
   EXPECT_EQ(std::nullopt, sha512(std::nullopt));
 }
 

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1031,17 +1031,14 @@ TEST_F(StringFunctionsTest, sha512) {
   };
 
   EXPECT_EQ(
-      hexToDec(
-          "05b41d06db66a1c9f3b86a4033f920c25a59624dcad4118544f32147f7d04bcdd2627710e487958da69176b6a3884d13fa85f99ccfd44f97f81877bb8c103453"),
+      hexToDec("1f6b05823a0453c1ec55009555087e8226d774c7c49d099784317b8460a0623ddaa083334f9218dda8075e0a0dc8319f89199f04e6b8f3980a73556866b388ae"),
       sha512("prestodb"));
   EXPECT_EQ(
-      hexToDec(
-          "7de872ed1c41ce3901bb7f12f20b0c0106331fe5b5ecc5fbbcf3ce6c79df4da595ebb7e221ab8b7fc5d918583eac6890ade1c26436335d3835828011204b7679"),
+      hexToDec("04f0823aefeb6e61866bdb47322ce033adb0a81684bf21fbc6e4f8513e798996e4732d28b15c631d1d6b0ca1e300c97fbadf62ea608d7d69930ddfd98f3e3a0e"),
       sha512("Infinity"));
   EXPECT_EQ(
-      hexToDec(
-          "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
-      sha512(""));
+      hexToDec("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"),
+      sha512("hash"));
 
   EXPECT_EQ(std::nullopt, sha512(std::nullopt));
 }


### PR DESCRIPTION
Add three Presto math functions:
degrees(x) → double (https://prestodb.io/docs/current/functions/math.html#degrees)
Converts angle x in radians to degrees.
e() → double (https://prestodb.io/docs/current/functions/math.html#e)
Returns the constant Euler’s number.
sha512(binary) → varbinary (https://prestodb.io/docs/current/functions/binary.html?highlight=sha#sha512)
Computes the sha512 hash of binary.

#1697 