### PR TITLE
VectorMaker mapVector taking key & value vectors

### DIFF
--- a/velox/vector/tests/VectorMaker.h
+++ b/velox/vector/tests/VectorMaker.h
@@ -640,6 +640,20 @@ class VectorMaker {
       const VectorPtr& elements,
       const std::vector<vector_size_t>& nulls = {});
 
+  /// Create a MapVector from a vector of offsets and key and value vectors.
+  /// The size of the maps is computed from the difference of offsets.
+  /// The sizes of the key and value vectors must be equal.
+  /// An optional vector of nulls can be passed to specify null rows.
+  /// The offset for a null value must match previous offset
+  /// i.e size computed should be zero.
+  /// E.g map({0, 2 ,2}, keys, values, {1}) creates a map vector
+  /// with map at index 1 as null.
+  MapVectorPtr mapVector(
+      const std::vector<vector_size_t>& offsets,
+      const VectorPtr& keys,
+      const VectorPtr& values,
+      const std::vector<vector_size_t>& nulls = {});
+
  private:
   vector_size_t createOffsetsAndSizes(
       vector_size_t size,

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -592,6 +592,77 @@ TEST_F(VectorMakerTest, arrayVectorUsingBaseVector) {
   EXPECT_EQ(arrayVectorWithNull->sizeAt(3), 0);
 }
 
+TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsNoNulls) {
+  auto keys = maker_.flatVector<int32_t>({1, 2, 3, 4, 5, 6});
+  auto values = maker_.flatVector<int64_t>({7, 8, 9, 10, 11, 12});
+
+  // Create a map vector with 2 entries per map.
+  auto mapVector = maker_.mapVector({0, 2, 4}, keys, values);
+
+  EXPECT_EQ(mapVector->size(), 3);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(mapVector->sizeAt(i), 2);
+    EXPECT_EQ(mapVector->isNullAt(i), false);
+  }
+
+  auto rawMapKeys = mapVector->mapKeys()->values()->as<int32_t>();
+  auto baseKeys = keys->values()->as<int32_t>();
+  EXPECT_EQ(memcmp(rawMapKeys, baseKeys, keys->size() * sizeof(int32_t)), 0);
+
+  auto rawMapValues = mapVector->mapValues()->values()->as<int64_t>();
+  auto baseValues = values->values()->as<int64_t>();
+  EXPECT_EQ(
+      memcmp(rawMapValues, baseValues, values->size() * sizeof(int64_t)), 0);
+}
+
+TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsSomeNulls) {
+  auto keys = maker_.flatVector<int32_t>({1, 2, 3, 4, 5, 6});
+  auto values = maker_.flatVector<int64_t>({7, 8, 9, 10, 11, 12});
+
+  // Create map vector with last map as null.
+  auto mapVectorWithLastNull =
+      maker_.mapVector({0, 2, 4, 6}, keys, values, {3});
+  EXPECT_EQ(mapVectorWithLastNull->isNullAt(3), true);
+  EXPECT_EQ(mapVectorWithLastNull->sizeAt(3), 0);
+
+  // Create map vector with middle map as null.
+  auto mapVectorWithMiddleNull =
+      maker_.mapVector({0, 2, 2, 4, 6}, keys, values, {1});
+  EXPECT_EQ(mapVectorWithMiddleNull->isNullAt(1), true);
+  EXPECT_EQ(mapVectorWithMiddleNull->sizeAt(1), 0);
+}
+
+TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsAllNulls) {
+  auto keys = maker_.flatVector<int32_t>({});
+  auto values = maker_.flatVector<int64_t>({});
+
+  // Create map vector with last map as null.
+  auto mapVector = maker_.mapVector({0, 0, 0}, keys, values, {0, 1, 2});
+
+  EXPECT_EQ(mapVector->size(), 3);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(mapVector->sizeAt(i), 0);
+    EXPECT_EQ(mapVector->isNullAt(i), true);
+  }
+}
+
+TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsUnevenKeysValues) {
+  auto keys = maker_.flatVector<int32_t>({1, 2, 3, 4, 5, 6});
+  // Create map vector with uneven keys and values, should fail.
+  auto values = maker_.flatVector<int64_t>({7, 8, 9});
+  EXPECT_THROW(maker_.mapVector({0, 2, 4}, keys, values), VeloxRuntimeError);
+}
+
+TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsNullsInvalidIndices) {
+  auto keys = maker_.flatVector<int32_t>({0, 1, 2, 3, 4, 5});
+  auto values = maker_.flatVector<int64_t>({6, 7, 8, 9, 10, 11});
+
+  // The middle map is NULL, but according to the offsets it has size 2, this
+  // should fail.
+  EXPECT_THROW(
+      maker_.mapVector({0, 2, 4}, keys, values, {1}), VeloxRuntimeError);
+}
+
 TEST_F(VectorMakerTest, biasVector) {
   std::vector<std::optional<int64_t>> data = {10, 13, std::nullopt, 15, 12, 11};
   auto biasVector = maker_.biasVector(data);

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -458,6 +458,27 @@ class VectorTestBase {
         [&](vector_size_t idx) { return nullValues[idx]; });
   }
 
+  // Convenience function to create vector from vectors of keys and values.
+  // The size of the maps is computed from the difference of offsets.
+  // The sizes of the key and value vectors must be equal.
+  // An optional vector of nulls can be passed to specify null rows.
+  // The offset for a null value must match previous offset
+  // i.e size computed should be zero.
+  // Example:
+  //   auto mapVector = makeMapVector({0, 2 ,2}, keyVector, valueVector, {1});
+  //
+  //   creates a map vector with map at index 1 as null.
+  // You can make higher order MapVectors (i.e maps with maps as values etc),
+  // by repeatedly calling this function and passing in resultant MapVector
+  // and appropriate offsets.
+  MapVectorPtr makeMapVector(
+      const std::vector<vector_size_t>& offsets,
+      const VectorPtr& keyVector,
+      const VectorPtr& valueVector,
+      const std::vector<vector_size_t>& nulls = {}) {
+    return vectorMaker_.mapVector(offsets, keyVector, valueVector, nulls);
+  }
+
   template <typename T>
   VectorPtr makeConstant(T value, vector_size_t size) {
     return BaseVector::createConstant(value, size, pool());


### PR DESCRIPTION
Summary:
This diff adds a function to VectorMaker which constructs a MapVector given Vectors of keys and values, along with an std::vector of offsets for where each map begins, and optionally a std::vector of indices for which maps are null.

There is an analogous arrayVector function that takes the elements as a Vector, this heavily borrows from that with the additional condition that the key and value Vectors must be the same size.

Differential Revision: D36682357

