### PR TITLE
Refactor EvalCtx::setWrapped to use moveOrCopyResult

### DIFF
--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -698,6 +698,10 @@ class ExprCallable : public Callable {
         rows.end(),
         std::move(allVectors));
     EvalCtx lambdaCtx(context->execCtx(), context->exprSet(), row.get());
+    if (!context->isFinalSelection()) {
+      *lambdaCtx.mutableIsFinalSelection() = false;
+      *lambdaCtx.mutableFinalSelection() = context->finalSelection();
+    }
     body_->eval(rows, lambdaCtx, *result);
   }
 


### PR DESCRIPTION
EvalCtx::setWrapped takes a result of evaluating an expression on the base
vector and wraps it using original wrapping (constant or dictionary). This
method has separate code paths for dictionary and constant wrappings and for
case when 'result' has some row filled out vs. result is empty. 

The two code paths for dictionary should be logically equivalent. The two code
paths for constant should be logically equivalent as well. However, there are a
few (presumably unintentional) discrepancies. To avoid divergence and reduce
copy-paste, I'm replacing the code path for non-empty result with
moveOrCopyResult.