### PR TITLE
Add config to wrap all expressions with try

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -58,6 +58,13 @@ class QueryConfig {
   static constexpr const char* kExprTrackCpuUsage =
       "expression.track_cpu_usage";
 
+  // When this is set all top-level expressions in an ExprSet will be
+  // automatically wrapped in TRY(...), so expressions that implement exception
+  // handling return NULL instead of crashing the query. Trivial expressions,
+  // like Constants and FieldReferences, as well as Try expressions themselves
+  // will not be wrapped.
+  static constexpr const char* kExprWrapInTry = "expression.wrap_in_try";
+
   // Flags used to configure the CAST operator:
 
   // This flag makes the Row conversion to by applied
@@ -194,6 +201,10 @@ class QueryConfig {
 
   bool exprTrackCpuUsage() const {
     return get<bool>(kExprTrackCpuUsage, false);
+  }
+
+  bool exprWrapInTry() const {
+    return get<bool>(kExprWrapInTry, false);
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
This was an ask from a user.  They want all to catch all exceptions and just return NULL (the same as what TRY expression provides).  However, wrapping all of their expressions with TRY(...) made their queries unreadable.  They asked for a setting to apply the TRY automatically.

This diff adds such a setting to the QueryConfig.  When this setting is applied, the ExprCompiler wraps all expressions other than TRY itself, as well as field references, constants and lambdas, with TRY.

Differential Revision: D36686668

