### PR TITLE
Introduce SelectivityVector::clearNulls

### DIFF
--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -374,8 +374,8 @@ void ConjunctExpr::evalSpecialForm(
   auto flatResult = result->asFlatVector<bool>();
   // clear nulls from the result for the active rows.
   if (flatResult->mayHaveNulls()) {
-    auto nulls = flatResult->mutableNulls(rows.end())->asMutable<uint64_t>();
-    bits::orBits(nulls, rows.asRange().bits(), rows.begin(), rows.end());
+    auto nulls = flatResult->mutableNulls(rows.end());
+    rows.clearNulls(nulls);
   }
   // Initialize result to all true for AND and all false for OR.
   auto values = flatResult->mutableValues(rows.end())->asMutable<uint64_t>();
@@ -497,11 +497,7 @@ void ConjunctExpr::updateResult(
       if (isAnd_) {
         // Clear the nulls and values for all active rows.
         if (result->mayHaveNulls()) {
-          bits::orBits(
-              result->mutableRawNulls(),
-              activeRows->asRange().bits(),
-              activeRows->begin(),
-              activeRows->end());
+          activeRows->clearNulls(result->mutableRawNulls());
         }
         bits::andWithNegatedBits(
             result->mutableRawValues<uint64_t>(),

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -83,11 +83,7 @@ void EvalCtx::setWrapped(
       // with all nulls.
       nulls = AlignedBuffer::allocate<bool>(rows.size(), pool(), bits::kNull);
       // Set the active rows to non-null.
-      bits::orBits(
-          nulls->asMutable<uint64_t>(),
-          rows.asRange().bits(),
-          rows.begin(),
-          rows.end());
+      rows.clearNulls(nulls);
       if (wrapNulls_) {
         // Add the nulls from the wrapping.
         bits::andBits(

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -195,9 +195,7 @@ void FlatVector<T>::copyValuesAndNulls(
     auto constant = source->asUnchecked<ConstantVector<T>>();
     T value = constant->valueAt(0);
     rows.applyToSelected([&](int32_t row) { rawValues_[row] = value; });
-    if (rawNulls) {
-      bits::orBits(rawNulls, rows.asRange().bits(), rows.begin(), rows.end());
-    }
+    rows.clearNulls(rawNulls);
   } else {
     auto sourceVector = source->typeKind() != TypeKind::UNKNOWN
         ? source->asUnchecked<SimpleVector<T>>()

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -112,9 +112,7 @@ void FlatVector<bool>::copyValuesAndNulls(
       bits::andWithNegatedBits(
           rawValues, range.bits(), range.begin(), range.end());
     }
-    if (rawNulls) {
-      bits::orBits(rawNulls, rows.asRange().bits(), rows.begin(), rows.end());
-    }
+    rows.clearNulls(rawNulls);
   } else {
     auto sourceVector = source->asUnchecked<SimpleVector<bool>>();
     rows.applyToSelected([&](auto row) {

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <vector>
 
+#include "velox/buffer/Buffer.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Range.h"
@@ -229,6 +230,19 @@ class SelectivityVector {
         std::max<int32_t>(begin_, begin),
         std::min<int32_t>(end_, end));
     updateBounds();
+  }
+
+  /// Clear null bits in 'nulls' for active rows.
+  void clearNulls(BufferPtr& nulls) const {
+    if (nulls) {
+      bits::orBits(nulls->asMutable<uint64_t>(), bits_.data(), begin_, end_);
+    }
+  }
+
+  void clearNulls(uint64_t* rawNulls) const {
+    if (rawNulls) {
+      bits::orBits(rawNulls, bits_.data(), begin_, end_);
+    }
   }
 
   /**

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -19,5 +19,5 @@ target_link_libraries(velox_vector_hash_all_benchmark velox_vector
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)
 
-target_link_libraries(velox_vector_selectivity_vector_benchmark velox_exception
+target_link_libraries(velox_vector_selectivity_vector_benchmark velox_vector
                       ${FOLLY_WITH_DEPENDENCIES} ${FOLLY_BENCHMARK})


### PR DESCRIPTION
Introduce SelectivityVector::clearNulls to simplify code like

```
bits::orBits(
   nulls->asMutable<uint64_t>(),
   rows.asRange().bits(),
   rows.begin(),
   rows.end());
```

to

```
rows.clearNulls(nulls);
```
