### PR TITLE
DuckDB to Velox Decimal Conversion

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -96,8 +96,12 @@ TypePtr toVeloxType(LogicalType type) {
       return BIGINT();
     case LogicalTypeId::FLOAT:
       return REAL();
-    case LogicalTypeId::HUGEINT:
     case LogicalTypeId::DECIMAL:
+      uint8_t width;
+      uint8_t scale;
+      type.GetDecimalProperties(width, scale);
+      return DECIMAL(width, scale);
+    case LogicalTypeId::HUGEINT:
     case LogicalTypeId::DOUBLE:
       return DOUBLE();
     case LogicalTypeId::VARCHAR:

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -87,7 +87,37 @@ struct DuckStringConversion {
   }
 };
 
-struct DuckShortDecimalConversion {
+struct DuckInt16DecimalConversion {
+  typedef int16_t DUCK_TYPE;
+  typedef ShortDecimal VELOX_TYPE;
+
+  static int16_t toDuck(
+      const ShortDecimal& input,
+      ::duckdb::Vector& /* unused */) {
+    return input.unscaledValue();
+  }
+
+  static ShortDecimal toVelox(const int16_t input) {
+    return ShortDecimal(static_cast<int64_t>(input));
+  }
+};
+
+struct DuckInt32DecimalConversion {
+  typedef int32_t DUCK_TYPE;
+  typedef ShortDecimal VELOX_TYPE;
+
+  static int32_t toDuck(
+      const ShortDecimal& input,
+      ::duckdb::Vector& /* unused */) {
+    return input.unscaledValue();
+  }
+
+  static ShortDecimal toVelox(const int32_t input) {
+    return ShortDecimal(static_cast<int64_t>(input));
+  }
+};
+
+struct DuckInt64DecimalConversion {
   typedef int64_t DUCK_TYPE;
   typedef ShortDecimal VELOX_TYPE;
 
@@ -97,8 +127,7 @@ struct DuckShortDecimalConversion {
     return input.unscaledValue();
   }
 
-  template <typename T>
-  static ShortDecimal toVelox(const T input) {
+  static ShortDecimal toVelox(const int64_t input) {
     return ShortDecimal(input);
   }
 };
@@ -107,14 +136,16 @@ struct DuckLongDecimalConversion {
   typedef ::duckdb::hugeint_t DUCK_TYPE;
   typedef LongDecimal VELOX_TYPE;
 
-  static int64_t toDuck(
-      const ShortDecimal& input,
+  static ::duckdb::hugeint_t toDuck(
+      const LongDecimal& input,
       ::duckdb::Vector& /* unused */) {
-    return input.unscaledValue();
+    ::duckdb::hugeint_t duckValue;
+    duckValue.upper = (input.unscaledValue() >> 64);
+    duckValue.lower = input.unscaledValue();
+    return duckValue;
   }
 
-  template <typename T>
-  static LongDecimal toVelox(const T input) {
+  static LongDecimal toVelox(const ::duckdb::hugeint_t input) {
     return LongDecimal(buildInt128(input.upper, input.lower));
   }
 };

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -87,6 +87,38 @@ struct DuckStringConversion {
   }
 };
 
+struct DuckShortDecimalConversion {
+  typedef int64_t DUCK_TYPE;
+  typedef ShortDecimal VELOX_TYPE;
+
+  static int64_t toDuck(
+      const ShortDecimal& input,
+      ::duckdb::Vector& /* unused */) {
+    return input.unscaledValue();
+  }
+
+  template <typename T>
+  static ShortDecimal toVelox(const T input) {
+    return ShortDecimal(input);
+  }
+};
+
+struct DuckLongDecimalConversion {
+  typedef ::duckdb::hugeint_t DUCK_TYPE;
+  typedef LongDecimal VELOX_TYPE;
+
+  static int64_t toDuck(
+      const ShortDecimal& input,
+      ::duckdb::Vector& /* unused */) {
+    return input.unscaledValue();
+  }
+
+  template <typename T>
+  static LongDecimal toVelox(const T input) {
+    return LongDecimal(buildInt128(input.upper, input.lower));
+  }
+};
+
 struct DuckTimestampConversion {
   typedef ::duckdb::timestamp_t DUCK_TYPE;
   typedef Timestamp VELOX_TYPE;

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -589,9 +589,19 @@ VectorPtr newConstant<TypeKind::LONG_DECIMAL>(
     variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
-  // LongDecimal variant is not supported to create
-  // constant vector.
-  VELOX_UNSUPPORTED();
+  if (value.isNull()) {
+    // NULL literals.
+    return std::make_shared<ConstantVector<LongDecimal>>(
+        pool,
+        size,
+        true,
+        DECIMAL(DecimalType<TypeKind::LONG_DECIMAL>::kMaxPrecision, 0),
+        LongDecimal(),
+        SimpleVectorStats<LongDecimal>{},
+        sizeof(LongDecimal));
+  }
+  VELOX_UNSUPPORTED(
+      "Decimal variant is not supported to create a ConstantVector");
 }
 
 template <>
@@ -629,6 +639,7 @@ std::shared_ptr<BaseVector> BaseVector::createNullConstant(
     return std::make_shared<ConstantVector<ComplexType>>(
         pool, size, true, type, ComplexType());
   }
+
   return BaseVector::createConstant(variant(type->kind()), size, pool);
 }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -589,19 +589,9 @@ VectorPtr newConstant<TypeKind::LONG_DECIMAL>(
     variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
-  if (value.isNull()) {
-    // NULL literals.
-    return std::make_shared<ConstantVector<LongDecimal>>(
-        pool,
-        size,
-        true,
-        DECIMAL(DecimalType<TypeKind::LONG_DECIMAL>::kMaxPrecision, 0),
-        LongDecimal(),
-        SimpleVectorStats<LongDecimal>{},
-        sizeof(LongDecimal));
-  }
-  VELOX_UNSUPPORTED(
-      "Decimal variant is not supported to create a ConstantVector");
+  // LongDecimal variant is not supported to create
+  // constant vector.
+  VELOX_UNSUPPORTED();
 }
 
 template <>
@@ -639,7 +629,6 @@ std::shared_ptr<BaseVector> BaseVector::createNullConstant(
     return std::make_shared<ConstantVector<ComplexType>>(
         pool, size, true, type, ComplexType());
   }
-
   return BaseVector::createConstant(variant(type->kind()), size, pool);
 }
 


### PR DESCRIPTION
The DuckDB decimal type vectors are currently interpreted as Velox double type vectors.
We now use the Velox decimal type for DuckDB decimal type.

The internal representation (`PhysicalType`) of DuckDB decimal types depends on the
width (precision) and uses `INT16, INT32, INT64 `and `INT128` physical types to 
represent decimal vectors. Velox decimal type uses `INT64` and `INT128` as physical types.
For DuckDB decimals smaller than `INT64`, zero-copy conversion to Velox vectors
 is not possible.


Testing:
Added tests for ShortDecimal and longDecimal conversion.