### PR TITLE
Refactor SeekableInputStream::loadIndices()

### DIFF
--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -125,10 +125,8 @@ class ByteRleDecoder {
   /**
    * Load the RowIndex values for the stream this is reading.
    */
-  virtual size_t loadIndices(
-      const proto::RowIndex& rowIndex,
-      size_t startIndex) {
-    return inputStream->loadIndices(rowIndex, startIndex) + 1;
+  virtual size_t loadIndices(size_t startIndex) {
+    return inputStream->positionSize() + startIndex + 1;
   }
 
   void skipBytes(size_t bytes);
@@ -264,9 +262,8 @@ class BooleanRleDecoder : public ByteRleDecoder {
 
   void next(char* data, uint64_t numValues, const uint64_t* nulls) override;
 
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override {
-    return ByteRleDecoder::loadIndices(rowIndex, startIndex) + 1;
+  size_t loadIndices(size_t startIndex) override {
+    return ByteRleDecoder::loadIndices(startIndex) + 1;
   }
 
   // Advances 'dataPosition' by 'numValue' non-nulls, where 'current'

--- a/velox/dwio/dwrf/common/CacheInputStream.cpp
+++ b/velox/dwio/dwrf/common/CacheInputStream.cpp
@@ -100,11 +100,9 @@ std::string CacheInputStream::getName() const {
   return fmt::format("CacheInputStream {} of {}", position_, region_.length);
 }
 
-size_t CacheInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value (uncompressed position)
-  return startIndex + 1;
+size_t CacheInputStream::positionSize() {
+  // not compressed, so only need 1 position (uncompressed position)
+  return 1;
 }
 
 namespace {

--- a/velox/dwio/dwrf/common/CacheInputStream.h
+++ b/velox/dwio/dwrf/common/CacheInputStream.h
@@ -45,8 +45,7 @@ class CacheInputStream : public SeekableInputStream {
   google::protobuf::int64 ByteCount() const override;
   void seekToPosition(PositionProvider& position) override;
   std::string getName() const override;
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
+  size_t positionSize() override;
 
  private:
   // Ensures that the current position is covered by 'pin_'.

--- a/velox/dwio/dwrf/common/InputStream.cpp
+++ b/velox/dwio/dwrf/common/InputStream.cpp
@@ -178,11 +178,9 @@ std::string SeekableArrayInputStream::getName() const {
       "SeekableArrayInputStream ", position, " of ", length);
 }
 
-size_t SeekableArrayInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value (uncompressed position)
-  return startIndex + 1;
+size_t SeekableArrayInputStream::positionSize() {
+  // not compressed, so only need 1 position (uncompressed position)
+  return 1;
 }
 
 static uint64_t computeBlock(uint64_t request, uint64_t length) {
@@ -260,11 +258,9 @@ std::string SeekableFileInputStream::getName() const {
       input.getName(), " from ", start, " for ", length);
 }
 
-size_t SeekableFileInputStream::loadIndices(
-    const proto::RowIndex& /*rowIndex*/,
-    size_t startIndex) {
-  // not compressed, so only need to skip 1 value: uncompressed position
-  return startIndex + 1;
+size_t SeekableFileInputStream::positionSize() {
+  // not compressed, so only need 1 position (uncompressed position)
+  return 1;
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/InputStream.h
+++ b/velox/dwio/dwrf/common/InputStream.h
@@ -54,9 +54,9 @@ class SeekableInputStream : public google::protobuf::io::ZeroCopyInputStream {
 
   virtual std::string getName() const = 0;
 
-  virtual size_t loadIndices(
-      const proto::RowIndex& rowIndex,
-      size_t startIndex) = 0;
+  // Returns the number of position values this input stream uses to identify an
+  // ORC/DWRF stream address.
+  virtual size_t positionSize() = 0;
 
   void readFully(char* buffer, size_t bufferSize);
 };
@@ -101,8 +101,7 @@ class SeekableArrayInputStream : public SeekableInputStream {
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
-  virtual size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
+  virtual size_t positionSize() override;
 };
 
 /**
@@ -136,8 +135,7 @@ class SeekableFileInputStream : public SeekableInputStream {
   virtual google::protobuf::int64 ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
-  virtual size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex)
-      override;
+  virtual size_t positionSize() override;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/IntDecoder.h
+++ b/velox/dwio/dwrf/common/IntDecoder.h
@@ -98,9 +98,8 @@ class IntDecoder {
    * Load RowIndex values for the stream being read.
    * @return updated start index after this stream's index values.
    */
-  size_t loadIndices(const proto::RowIndex& rowIndex, size_t startIndex) {
-    size_t updatedStartIndex = inputStream->loadIndices(rowIndex, startIndex);
-    return updatedStartIndex + 1;
+  size_t loadIndices(size_t startIndex) {
+    return inputStream->positionSize() + startIndex + 1;
   }
 
   /**

--- a/velox/dwio/dwrf/common/PagedInputStream.h
+++ b/velox/dwio/dwrf/common/PagedInputStream.h
@@ -59,10 +59,10 @@ class PagedInputStream : public SeekableInputStream {
         ")");
   }
 
-  size_t loadIndices(const proto::RowIndex& /* unused */, size_t startIndex)
-      override {
-    // need to skip 2 values: compressed position + uncompressed position
-    return startIndex + 2;
+  size_t positionSize() override {
+    // not compressed, so need 2 positions (compressed position + uncompressed
+    // position)
+    return 2;
   }
 
  protected:

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1349,14 +1349,13 @@ void StringDictionaryColumnReader::ensureInitialized() {
     // load stride dictionary offsets
     rowIndex_ = ProtoUtils::readProto<proto::RowIndex>(std::move(indexStream_));
     auto indexStartOffset = flatMapContext_.inMapDecoder
-        ? flatMapContext_.inMapDecoder->loadIndices(*rowIndex_, 0)
+        ? flatMapContext_.inMapDecoder->loadIndices(0)
         : 0;
     positionOffset = notNullDecoder_
-        ? notNullDecoder_->loadIndices(*rowIndex_, indexStartOffset)
+        ? notNullDecoder_->loadIndices(indexStartOffset)
         : indexStartOffset;
-    auto offset = strideDictStream->loadIndices(*rowIndex_, positionOffset);
-    strideDictSizeOffset =
-        strideDictLengthDecoder->loadIndices(*rowIndex_, offset);
+    size_t offset = strideDictStream->positionSize() + positionOffset;
+    strideDictSizeOffset = strideDictLengthDecoder->loadIndices(offset);
   }
   initialized_ = true;
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -299,14 +299,13 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
     ensureRowGroupIndex();
     // load stride dictionary offsets
     auto indexStartOffset = flatMapContext_.inMapDecoder
-        ? flatMapContext_.inMapDecoder->loadIndices(*index_, 0)
+        ? flatMapContext_.inMapDecoder->loadIndices(0)
         : 0;
     positionOffset_ = notNullDecoder_
-        ? notNullDecoder_->loadIndices(*index_, indexStartOffset)
+        ? notNullDecoder_->loadIndices(indexStartOffset)
         : indexStartOffset;
-    size_t offset = strideDictStream_->loadIndices(*index_, positionOffset_);
-    strideDictSizeOffset_ =
-        strideDictLengthDecoder_->loadIndices(*index_, offset);
+    size_t offset = strideDictStream_->positionSize() + positionOffset_;
+    strideDictSizeOffset_ = strideDictLengthDecoder_->loadIndices(offset);
   }
   scanState_.updateRawState();
   initialized_ = true;

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -247,7 +247,7 @@ TEST(StripeStream, zeroLength) {
     int32_t size = 1;
     EXPECT_FALSE(stream->Next(&buf, &size));
     proto::RowIndex rowIndex;
-    EXPECT_EQ(stream->loadIndices(rowIndex, 0), 2);
+    EXPECT_EQ(stream->positionSize(), 2);
   }
 }
 


### PR DESCRIPTION
loadIndices() in SeekableInputStream returns the the positions array
index for the next stream in the current column for DWRF, relative to
the startIndex parameter. It was used in
SelectiveStringDictionaryColumnReader to lazily load the stride
dictionary for DWRF. To prepare for the upcoming refactoring that
moves this class and its subclasses to dwio::common, we need to decouple
the DWRF related concept from it. This commit changes loadIndices() to
positionSize() which returns the number of position values this input
stream uses to identify an ORC/DWRF stream address.