### PR TITLE
Fix signed integer overflow in range VectorHasher

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -249,7 +249,7 @@ void HashBuild::addRuntimeStats() {
   uint64_t asRange;
   uint64_t asDistinct;
   for (auto i = 0; i < hashers.size(); i++) {
-    hashers[i]->cardinality(asRange, asDistinct);
+    hashers[i]->cardinality(0, asRange, asDistinct);
     if (asRange != VectorHasher::kRangeTooLarge) {
       stats_.addRuntimeStat(
           fmt::format("rangeKey{}", i), RuntimeCounter(asRange));

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -363,11 +363,6 @@ class HashTable : public BaseHashTable {
 
   void setHashMode(HashMode mode, int32_t numNew) override;
 
-  /// Adds extra values for value id ranges for group by hash tables in
-  /// kArray or kNormalizedKey mode. Identity for join tables since all
-  /// keys are known at build time.
-  int64_t addReserve(int64_t count, TypeKind kind);
-
   /// Tries to use as many range hashers as can in a normalized key situation.
   void enableRangeWhereCan(
       const std::vector<uint64_t>& rangeSizes,
@@ -446,6 +441,13 @@ class HashTable : public BaseHashTable {
   // Erases the entries of rows from the hash table and its RowContainer.
   // 'hashes' must be computed according to 'hashMode_'.
   void eraseWithHashes(folly::Range<char**> rows, uint64_t* hashes);
+
+  // Returns the percentage of values to reserve for new keys in range
+  // or distinct mode VectorHashers in a group by hash table. 0 for
+  // join build sides.
+  int32_t reservePct() const {
+    return isJoinBuild_ ? 0 : 50;
+  }
 
   const std::vector<std::unique_ptr<Aggregate>>& aggregates_;
   int8_t sizeBits_;


### PR DESCRIPTION
Fix signed integer overflow in range VectorHasher


A group by VectorHasher can overflow when adding reserve padding
around a range that is close to the end of its type's range
bounds. Bounds the VectorHasher range to the range of the column
type. 

Moves the logic for padding value or id ranges to VectorHasher.cpp
from HashTable.cpp. Group by hash tables leave extra values at ends of
a range of values or ids to accommodate a certain amount of new keys
without rehashing. The amount by which the range can be extended
depends on the data types and how close the values are to the end of
the type's range, so the VectorHasher knows best.

Adds a test that verifies rounding stays within type bounds and
distinct normalized keys are produced for all combinations of nulls,
type min/max values of 8/16/32 bit types.

