### PR TITLE
Fix stats builder bugs

### DIFF
--- a/velox/dwio/dwrf/test/TestColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestColumnStatistics.cpp
@@ -298,9 +298,7 @@ TEST(StatisticsBuilder, doubleNaN) {
   target.addValues(std::numeric_limits<double>::infinity());
   target.addValues(-std::numeric_limits<double>::infinity());
   stats = as<DoubleColumnStatistics>(target.build());
-  EXPECT_EQ(stats->getMaximum(), std::numeric_limits<double>::infinity());
-  EXPECT_EQ(stats->getMinimum(), -std::numeric_limits<double>::infinity());
-  EXPECT_FALSE(stats->getSum().has_value());
+  EXPECT_EQ(stats, nullptr);
 
   target.reset();
   DoubleStatisticsBuilder builder{options};
@@ -308,9 +306,7 @@ TEST(StatisticsBuilder, doubleNaN) {
   builder.addValues(-std::numeric_limits<double>::infinity());
   target.merge(*builder.build());
   stats = as<DoubleColumnStatistics>(target.build());
-  EXPECT_EQ(stats->getMaximum(), std::numeric_limits<double>::infinity());
-  EXPECT_EQ(stats->getMinimum(), -std::numeric_limits<double>::infinity());
-  EXPECT_FALSE(stats->getSum().has_value());
+  EXPECT_EQ(stats, nullptr);
 }
 
 TEST(StatisticsBuilder, string) {
@@ -445,7 +441,7 @@ TEST(StatisticsBuilder, stringLengthOverflow) {
   target.addValues("foo");
   EXPECT_TRUE(target.getTotalLength().has_value());
   stats = as<StringColumnStatistics>(target.build());
-  EXPECT_FALSE(stats->getTotalLength().has_value());
+  EXPECT_EQ(stats, nullptr);
 
   // merge causing overflow
   target.reset();
@@ -453,7 +449,7 @@ TEST(StatisticsBuilder, stringLengthOverflow) {
   target.merge(*buildColumnStatisticsFromProto(proto, context));
   EXPECT_TRUE(target.getTotalLength().has_value());
   stats = as<StringColumnStatistics>(target.build());
-  EXPECT_FALSE(stats->getTotalLength().has_value());
+  EXPECT_EQ(stats, nullptr);
 }
 
 TEST(StatisticsBuilder, boolean) {

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -220,8 +220,9 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
   void addValues(double value, uint64_t count = 1) {
     increaseValueCount(count);
     // min/max/sum is defined only when none of the values added is NaN
-    if (std::isnan(value)) {
+    if (hasNaN_ || std::isnan(value)) {
       clear();
+      hasNaN_ = true;
       return;
     }
 
@@ -238,7 +239,8 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
         sum_.value() += value;
       }
       if (std::isnan(sum_.value())) {
-        sum_.reset();
+        clear();
+        hasNaN_ = true;
       }
     }
   }
@@ -257,6 +259,7 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
     min_ = std::numeric_limits<double>::infinity();
     max_ = -std::numeric_limits<double>::infinity();
     sum_ = 0;
+    hasNaN_ = false;
   }
 
   void clear() {
@@ -264,6 +267,10 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
     max_.reset();
     sum_.reset();
   }
+
+  // Might not be necessary if we always properly deal with
+  // nullability but is more readable.
+  bool hasNaN_{false};
 };
 
 class StringStatisticsBuilder : public StatisticsBuilder,


### PR DESCRIPTION
Summary:
Fix the issues in handling stats integrity:
1) only set max and min when both are valid
2) correctly coupling the nullity of double statistics when dealing NaNs. Also make tracking of hasNaN more readable

Differential Revision: D36741660

