### PR TITLE
Bug fix for null setting in the MAP function

### DIFF
--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -72,7 +72,7 @@ void setValuesResultTyped(
     decoded.get()->decode(*args[i * 2 + 1], rows);
     rows.applyToSelected([&](vector_size_t row) {
       if (decoded->isNullAt(row)) {
-        valuesResult->asFlatVector<T>()->setNull(row, true);
+        valuesResult->asFlatVector<T>()->setNull(row * mapSize + i, true);
       } else {
         flatValues[row * mapSize + i] = decoded->valueAt<T>(row);
       }


### PR DESCRIPTION
Summary: This diff fix a bug in how we set nulls in the MAP function using the decoded vector.

Differential Revision: D36849552

