### PR TITLE
Refactor dwrf::StreamIdentifier

### DIFF
--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -36,6 +36,8 @@ class TrackingId {
 
   TrackingId() : id_(-1) {}
 
+  TrackingId(int32_t id) : id_(id) {}
+
   TrackingId(int32_t node, int8_t kind) : id_((node << kNodeShift) | kind) {
     VELOX_CHECK_LT(kind, (1 << kNodeShift), "Tracker kind out of range");
   }

--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -32,15 +32,9 @@ namespace facebook::velox::cache {
 // number in the file schema tree, i.e. the column.
 class TrackingId {
  public:
-  static constexpr int32_t kNodeShift = 5;
-
   TrackingId() : id_(-1) {}
 
   TrackingId(int32_t id) : id_(id) {}
-
-  TrackingId(int32_t node, int8_t kind) : id_((node << kNodeShift) | kind) {
-    VELOX_CHECK_LT(kind, (1 << kNodeShift), "Tracker kind out of range");
-  }
 
   size_t hash() const {
     return std::hash<int32_t>()(id_);
@@ -56,10 +50,6 @@ class TrackingId {
 
   int32_t id() const {
     return id_;
-  }
-
-  int32_t columnId() const {
-    return id_ >> kNodeShift;
   }
 
  private:

--- a/velox/dwio/common/Common.h
+++ b/velox/dwio/common/Common.h
@@ -16,6 +16,11 @@
 
 #pragma once
 
+#include <fmt/core.h>
+#include <cstdint>
+#include <limits>
+#include <string>
+
 namespace facebook::velox::dwio::common {
 
 constexpr uint32_t MAX_UINT32 = std::numeric_limits<uint32_t>::max();

--- a/velox/dwio/common/Common.h
+++ b/velox/dwio/common/Common.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::dwio::common {
+
+constexpr uint32_t MAX_UINT32 = std::numeric_limits<uint32_t>::max();
+
+class StreamIdentifier {
+ public:
+  StreamIdentifier() : id_(MAX_UINT32) {}
+
+  StreamIdentifier(int32_t id) : id_(id) {}
+
+  virtual ~StreamIdentifier() = default;
+
+  virtual int32_t getId() const {
+    return id_;
+  }
+
+  virtual bool operator==(const StreamIdentifier& other) const {
+    return id_ == other.id_;
+  }
+
+  virtual std::size_t hash() const {
+    return std::hash<uint32_t>()(id_);
+  }
+
+  virtual std::string toString() const {
+    return fmt::format("[id_={}}]", id_);
+  }
+
+  int32_t id_;
+};
+
+struct StreamIdentifierHash {
+  std::size_t operator()(const StreamIdentifier& si) const {
+    return si.hash();
+  }
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/common/BufferedInput.cpp
+++ b/velox/dwio/dwrf/common/BufferedInput.cpp
@@ -78,7 +78,7 @@ void BufferedInput::load(const LogType logType) {
 
 std::unique_ptr<SeekableInputStream> BufferedInput::enqueue(
     Region region,
-    const StreamIdentifier* /*si*/) {
+    const dwio::common::StreamIdentifier* /*si*/) {
   if (region.length == 0) {
     return std::make_unique<SeekableArrayInputStream>(
         static_cast<const char*>(nullptr), 0);

--- a/velox/dwio/dwrf/common/BufferedInput.h
+++ b/velox/dwio/dwrf/common/BufferedInput.h
@@ -47,7 +47,7 @@ class BufferedInput {
   // read-ahead and caching for BufferedInput implementations supporting these.
   virtual std::unique_ptr<SeekableInputStream> enqueue(
       dwio::common::Region region,
-      const StreamIdentifier* FOLLY_NULLABLE si = nullptr);
+      const dwio::common::StreamIdentifier* FOLLY_NULLABLE si = nullptr);
 
   // load all regions to be read in an optimized way (IO efficiency)
   virtual void load(const dwio::common::LogType);

--- a/velox/dwio/dwrf/common/CachedBufferedInput.cpp
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.cpp
@@ -36,7 +36,7 @@ using memory::MappedMemory;
 
 std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
     dwio::common::Region region,
-    const StreamIdentifier* si = nullptr) {
+    const dwio::common::StreamIdentifier* si = nullptr) {
   if (region.length == 0) {
     return std::make_unique<SeekableArrayInputStream>(
         static_cast<const char*>(nullptr), 0);
@@ -44,7 +44,7 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
 
   TrackingId id;
   if (si) {
-    id = TrackingId(si->node, si->kind);
+    id = TrackingId(si->getId());
   }
   VELOX_CHECK_LE(region.offset + region.length, fileSize_);
   requests_.emplace_back(

--- a/velox/dwio/dwrf/common/CachedBufferedInput.h
+++ b/velox/dwio/dwrf/common/CachedBufferedInput.h
@@ -107,7 +107,7 @@ class CachedBufferedInput : public BufferedInput {
 
   std::unique_ptr<SeekableInputStream> enqueue(
       dwio::common::Region region,
-      const StreamIdentifier* FOLLY_NULLABLE si) override;
+      const dwio::common::StreamIdentifier* FOLLY_NULLABLE si) override;
 
   void load(const dwio::common::LogType) override;
 

--- a/velox/dwio/dwrf/common/Common.cpp
+++ b/velox/dwio/dwrf/common/Common.cpp
@@ -96,8 +96,8 @@ std::string columnEncodingKindToString(ColumnEncodingKind kind) {
   return folly::to<std::string>("unknown - ", kind);
 }
 
-StreamIdentifier EncodingKey::forKind(const proto::Stream_Kind kind) const {
-  return StreamIdentifier(node, sequence, 0, kind);
+DwrfStreamIdentifier EncodingKey::forKind(const proto::Stream_Kind kind) const {
+  return DwrfStreamIdentifier(node, sequence, 0, kind);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/BinaryStreamReader.cpp
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.cpp
@@ -68,7 +68,7 @@ std::vector<proto::ColumnEncoding> BinaryStripeStreams::getEncodings(
   return encodings;
 }
 
-std::vector<StreamIdentifier> BinaryStripeStreams::getStreamIdentifiers(
+std::vector<DwrfStreamIdentifier> BinaryStripeStreams::getStreamIdentifiers(
     const uint32_t nodeId) const {
   if (nodeToStreamIdMap_.count(nodeId) == 0) {
     return {};

--- a/velox/dwio/dwrf/reader/BinaryStreamReader.h
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.h
@@ -32,7 +32,7 @@ class BinaryStripeStreams {
 
   std::vector<proto::ColumnEncoding> getEncodings(uint32_t nodeId) const;
 
-  std::vector<StreamIdentifier> getStreamIdentifiers(uint32_t nodeId) const;
+  std::vector<DwrfStreamIdentifier> getStreamIdentifiers(uint32_t nodeId) const;
 
   std::unique_ptr<proto::RowIndex> getRowGroupIndex(
       const EncodingKey ek) const {
@@ -41,11 +41,11 @@ class BinaryStripeStreams {
   }
 
   std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si) const {
+      const DwrfStreamIdentifier& si) const {
     return stripeStreams_.getCompressedStream(si);
   }
 
-  uint64_t getStreamLength(const StreamIdentifier& si) const {
+  uint64_t getStreamLength(const DwrfStreamIdentifier& si) const {
     return stripeStreams_.getStreamLength(si);
   }
 
@@ -59,7 +59,7 @@ class BinaryStripeStreams {
   dwio::common::RowReaderOptions options_;
   StripeStreamsImpl stripeStreams_;
   std::unordered_map<uint32_t, std::vector<uint32_t>> encodingKeys_;
-  std::unordered_map<uint32_t, std::vector<StreamIdentifier>>
+  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
       nodeToStreamIdMap_;
 };
 

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -212,11 +212,11 @@ void StripeStreamsImpl::loadStreams() {
 }
 
 std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getCompressedStream(
-    const StreamIdentifier& si) const {
+    const DwrfStreamIdentifier& si) const {
   const auto& info = getStreamInfo(si);
 
   std::unique_ptr<SeekableInputStream> streamRead;
-  if (si.kind == StreamKind::StreamKind_ROW_INDEX) {
+  if (si.kind_ == StreamKind::StreamKind_ROW_INDEX) {
     streamRead = getIndexStreamFromCache(info);
   }
 
@@ -245,19 +245,20 @@ StripeStreamsImpl::getEncodingKeys() const {
   return encodingKeys;
 }
 
-std::unordered_map<uint32_t, std::vector<StreamIdentifier>>
+std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
 StripeStreamsImpl::getStreamIdentifiers() const {
-  std::unordered_map<uint32_t, std::vector<StreamIdentifier>> nodeToStreamIdMap;
+  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
+      nodeToStreamIdMap;
 
   for (const auto& kv : streams_) {
-    nodeToStreamIdMap[kv.first.node].push_back(kv.first);
+    nodeToStreamIdMap[kv.first.encodingKey_.node].push_back(kv.first);
   }
 
   return nodeToStreamIdMap;
 }
 
 std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getStream(
-    const StreamIdentifier& si,
+    const DwrfStreamIdentifier& si,
     bool /* throwIfNotFound*/) const {
   // if not found, return an empty {}
   const auto& info = getStreamInfo(si, false /* throwIfNotFound */);
@@ -266,7 +267,7 @@ std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getStream(
   }
 
   std::unique_ptr<SeekableInputStream> streamRead;
-  if (si.kind == StreamKind::StreamKind_ROW_INDEX) {
+  if (si.kind_ == StreamKind::StreamKind_ROW_INDEX) {
     streamRead = getIndexStreamFromCache(info);
   }
 
@@ -282,7 +283,9 @@ std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getStream(
   auto streamDebugInfo =
       fmt::format("Stripe {} Stream {}", stripeIndex_, si.toString());
   return reader_.getReader().createDecompressedStream(
-      std::move(streamRead), streamDebugInfo, getDecrypter(si.node));
+      std::move(streamRead),
+      streamDebugInfo,
+      getDecrypter(si.encodingKey_.node));
 }
 
 uint32_t StripeStreamsImpl::visitStreamsOfNode(
@@ -290,7 +293,7 @@ uint32_t StripeStreamsImpl::visitStreamsOfNode(
     std::function<void(const StreamInformation&)> visitor) const {
   uint32_t count = 0;
   for (auto& item : streams_) {
-    if (item.first.node == node) {
+    if (item.first.encodingKey_.node == node) {
       visitor(item.second);
       ++count;
     }
@@ -299,7 +302,7 @@ uint32_t StripeStreamsImpl::visitStreamsOfNode(
   return count;
 }
 
-bool StripeStreamsImpl::getUseVInts(const StreamIdentifier& si) const {
+bool StripeStreamsImpl::getUseVInts(const DwrfStreamIdentifier& si) const {
   const auto& info = getStreamInfo(si, false);
   if (!info.valid()) {
     return true;

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -216,7 +216,7 @@ std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getCompressedStream(
   const auto& info = getStreamInfo(si);
 
   std::unique_ptr<SeekableInputStream> streamRead;
-  if (si.kind_ == StreamKind::StreamKind_ROW_INDEX) {
+  if (si.kind() == StreamKind::StreamKind_ROW_INDEX) {
     streamRead = getIndexStreamFromCache(info);
   }
 
@@ -251,7 +251,7 @@ StripeStreamsImpl::getStreamIdentifiers() const {
       nodeToStreamIdMap;
 
   for (const auto& kv : streams_) {
-    nodeToStreamIdMap[kv.first.encodingKey_.node].push_back(kv.first);
+    nodeToStreamIdMap[kv.first.encodingKey().node].push_back(kv.first);
   }
 
   return nodeToStreamIdMap;
@@ -267,7 +267,7 @@ std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getStream(
   }
 
   std::unique_ptr<SeekableInputStream> streamRead;
-  if (si.kind_ == StreamKind::StreamKind_ROW_INDEX) {
+  if (si.kind() == StreamKind::StreamKind_ROW_INDEX) {
     streamRead = getIndexStreamFromCache(info);
   }
 
@@ -285,7 +285,7 @@ std::unique_ptr<SeekableInputStream> StripeStreamsImpl::getStream(
   return reader_.getReader().createDecompressedStream(
       std::move(streamRead),
       streamDebugInfo,
-      getDecrypter(si.encodingKey_.node));
+      getDecrypter(si.encodingKey().node));
 }
 
 uint32_t StripeStreamsImpl::visitStreamsOfNode(
@@ -293,7 +293,7 @@ uint32_t StripeStreamsImpl::visitStreamsOfNode(
     std::function<void(const StreamInformation&)> visitor) const {
   uint32_t count = 0;
   for (auto& item : streams_) {
-    if (item.first.encodingKey_.node == node) {
+    if (item.first.encodingKey().node == node) {
       visitor(item.second);
       ++count;
     }

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -36,7 +36,7 @@ class StrideIndexProvider {
  */
 class StreamInformationImpl : public StreamInformation {
  private:
-  StreamIdentifier streamId_;
+  DwrfStreamIdentifier streamId_;
   uint64_t offset_;
   uint64_t length_;
   bool useVInts_;
@@ -47,7 +47,7 @@ class StreamInformationImpl : public StreamInformation {
     return NOT_FOUND;
   }
 
-  StreamInformationImpl() : streamId_{StreamIdentifier::getInvalid()} {}
+  StreamInformationImpl() : streamId_{DwrfStreamIdentifier::getInvalid()} {}
   StreamInformationImpl(uint64_t offset, const proto::Stream& stream)
       : streamId_(stream),
         offset_(offset),
@@ -59,15 +59,15 @@ class StreamInformationImpl : public StreamInformation {
   ~StreamInformationImpl() override = default;
 
   StreamKind getKind() const override {
-    return streamId_.kind;
+    return streamId_.kind_;
   }
 
   uint32_t getNode() const override {
-    return streamId_.node;
+    return streamId_.encodingKey_.node;
   }
 
   uint32_t getSequence() const override {
-    return streamId_.sequence;
+    return streamId_.encodingKey_.sequence;
   }
 
   uint64_t getOffset() const override {
@@ -83,7 +83,7 @@ class StreamInformationImpl : public StreamInformation {
   }
 
   bool valid() const override {
-    return streamId_.valid();
+    return streamId_.encodingKey_.valid();
   }
 };
 
@@ -113,7 +113,7 @@ class StripeStreams {
    * @return the new stream
    */
   virtual std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const = 0;
 
   /// Get the integer dictionary data for the given node and sequence.
@@ -142,7 +142,7 @@ class StripeStreams {
    * Defaults to true.
    * @param streamId stream identifier
    */
-  virtual bool getUseVInts(const StreamIdentifier& streamId) const = 0;
+  virtual bool getUseVInts(const DwrfStreamIdentifier& streamId) const = 0;
 
   /**
    * Get the memory pool for this reader.
@@ -202,7 +202,7 @@ class StripeStreamsImpl : public StripeStreamsBase {
 
   // map of stream id -> stream information
   std::unordered_map<
-      StreamIdentifier,
+      DwrfStreamIdentifier,
       StreamInformationImpl,
       StreamIdentifierHash>
       streams_;
@@ -257,26 +257,26 @@ class StripeStreamsImpl : public StripeStreamsBase {
   void loadReadPlan();
 
   std::unique_ptr<SeekableInputStream> getCompressedStream(
-      const StreamIdentifier& si) const;
+      const DwrfStreamIdentifier& si) const;
 
-  uint64_t getStreamLength(const StreamIdentifier& si) const {
+  uint64_t getStreamLength(const DwrfStreamIdentifier& si) const {
     return getStreamInfo(si).getLength();
   }
 
   std::unordered_map<uint32_t, std::vector<uint32_t>> getEncodingKeys() const;
 
-  std::unordered_map<uint32_t, std::vector<StreamIdentifier>>
+  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
   getStreamIdentifiers() const;
 
   std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override;
 
   uint32_t visitStreamsOfNode(
       uint32_t node,
       std::function<void(const StreamInformation&)> visitor) const override;
 
-  bool getUseVInts(const StreamIdentifier& si) const override;
+  bool getUseVInts(const DwrfStreamIdentifier& si) const override;
 
   const StrideIndexProvider& getStrideIndexProvider() const override {
     return provider_;
@@ -288,7 +288,7 @@ class StripeStreamsImpl : public StripeStreamsBase {
 
  private:
   const StreamInformation& getStreamInfo(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       const bool throwIfNotFound = true) const {
     auto index = streams_.find(si);
     if (index == streams_.end()) {

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -59,15 +59,15 @@ class StreamInformationImpl : public StreamInformation {
   ~StreamInformationImpl() override = default;
 
   StreamKind getKind() const override {
-    return streamId_.kind_;
+    return streamId_.kind();
   }
 
   uint32_t getNode() const override {
-    return streamId_.encodingKey_.node;
+    return streamId_.encodingKey().node;
   }
 
   uint32_t getSequence() const override {
-    return streamId_.encodingKey_.sequence;
+    return streamId_.encodingKey().sequence;
   }
 
   uint64_t getOffset() const override {
@@ -83,7 +83,7 @@ class StreamInformationImpl : public StreamInformation {
   }
 
   bool valid() const override {
-    return streamId_.encodingKey_.valid();
+    return streamId_.encodingKey().valid();
   }
 };
 
@@ -204,7 +204,7 @@ class StripeStreamsImpl : public StripeStreamsBase {
   std::unordered_map<
       DwrfStreamIdentifier,
       StreamInformationImpl,
-      StreamIdentifierHash>
+      dwio::common::StreamIdentifierHash>
       streams_;
   std::unordered_map<EncodingKey, uint32_t, EncodingKeyHash> encodings_;
   std::unordered_map<EncodingKey, proto::ColumnEncoding, EncodingKeyHash>

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -144,7 +144,7 @@ class CacheTest : public testing::Test {
         std::move(ssd));
     cache_->setVerifyHook(checkEntry);
     for (auto i = 0; i < kMaxStreams; ++i) {
-      streamIds_.push_back(std::make_unique<dwrf::StreamIdentifier>(
+      streamIds_.push_back(std::make_unique<dwrf::DwrfStreamIdentifier>(
           i, i, 0, dwrf::StreamKind_DATA));
     }
     streamStarts_.resize(kMaxStreams + 1);
@@ -449,7 +449,7 @@ class CacheTest : public testing::Test {
       memory::getDefaultScopedMemoryPool()};
 
   // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
-  std::vector<std::unique_ptr<dwrf::StreamIdentifier>> streamIds_;
+  std::vector<std::unique_ptr<dwrf::DwrfStreamIdentifier>> streamIds_;
 
   // Start offset of each simulated stream in a simulated stripe.
   std::vector<uint64_t> streamStarts_;

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -48,19 +48,19 @@ class MockStrideIndexProvider : public StrideIndexProvider {
 
 class MockStreamInformation : public StreamInformation {
  public:
-  explicit MockStreamInformation(const StreamIdentifier& streamIdentifier)
+  explicit MockStreamInformation(const DwrfStreamIdentifier& streamIdentifier)
       : streamIdentifier_{streamIdentifier} {}
 
   StreamKind getKind() const override {
-    return streamIdentifier_.kind;
+    return streamIdentifier_.kind_;
   }
 
   uint32_t getNode() const override {
-    return streamIdentifier_.node;
+    return streamIdentifier_.encodingKey_.node;
   }
 
   uint32_t getSequence() const override {
-    return streamIdentifier_.sequence;
+    return streamIdentifier_.encodingKey_.sequence;
   }
 
   MOCK_CONST_METHOD0(getOffset, uint64_t());
@@ -69,7 +69,7 @@ class MockStreamInformation : public StreamInformation {
   MOCK_CONST_METHOD0(valid, bool());
 
  private:
-  const StreamIdentifier& streamIdentifier_;
+  const DwrfStreamIdentifier& streamIdentifier_;
 };
 
 class TestStripeStreams : public StripeStreamsBase {
@@ -87,7 +87,7 @@ class TestStripeStreams : public StripeStreamsBase {
   }
 
   std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override {
     const DataBufferHolder* stream = nullptr;
     if (context_.hasStream(si)) {
@@ -97,10 +97,10 @@ class TestStripeStreams : public StripeStreamsBase {
       if (throwIfNotFound) {
         DWIO_RAISE(fmt::format(
             "stream (node = {}, seq = {}, column = {}, kind = {}) not found",
-            si.node,
-            si.sequence,
-            si.column,
-            si.kind));
+            si.encodingKey_.node,
+            si.encodingKey_.sequence,
+            si.column_,
+            si.kind_));
       } else {
         return nullptr;
       }
@@ -136,7 +136,7 @@ class TestStripeStreams : public StripeStreamsBase {
       std::function<void(const StreamInformation&)> visitor) const override {
     uint32_t count = 0;
     context_.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.node == node) {
+      if (pair.first.encodingKey_.node == node) {
         visitor(MockStreamInformation(pair.first));
         ++count;
       }
@@ -153,7 +153,7 @@ class TestStripeStreams : public StripeStreamsBase {
     return options_;
   }
 
-  bool getUseVInts(const StreamIdentifier& streamId) const override {
+  bool getUseVInts(const DwrfStreamIdentifier& streamId) const override {
     DWIO_ENSURE(
         context_.hasStream(streamId),
         fmt::format("Stream not found: {}", streamId.toString()));
@@ -808,7 +808,7 @@ void testMapWriter(
     auto valueNodeId = dataTypeWithId->childAt(1)->id;
     auto streamCount = 0;
     context.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.node == valueNodeId) {
+      if (pair.first.encodingKey_.node == valueNodeId) {
         ++streamCount;
       }
     });
@@ -819,7 +819,7 @@ void testMapWriter(
 
     streamCount = 0;
     context.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.node == valueNodeId) {
+      if (pair.first.encodingKey_.node == valueNodeId) {
         ++streamCount;
       }
     });
@@ -3735,7 +3735,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
 
   // get data stream
   TestStripeStreams streams(context, sf, ROW({"foo"}, {type}));
-  StreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
+  DwrfStreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
   auto stream = streams.getStream(si, true);
 
   // read it as long
@@ -3781,7 +3781,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
 
   // get data stream
   TestStripeStreams streams(context, sf, ROW({"foo"}, {type}));
-  StreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
+  DwrfStreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
   auto stream = streams.getStream(si, true);
 
   // read it as long
@@ -3821,7 +3821,7 @@ TEST(ColumnWriterTests, RemovePresentStream) {
 
   // get data stream
   TestStripeStreams streams(context, sf, ROW({"foo"}, {type}));
-  StreamIdentifier si{1, 0, 0, proto::Stream_Kind_PRESENT};
+  DwrfStreamIdentifier si{1, 0, 0, proto::Stream_Kind_PRESENT};
   ASSERT_EQ(streams.getStream(si, false), nullptr);
 }
 

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -52,15 +52,15 @@ class MockStreamInformation : public StreamInformation {
       : streamIdentifier_{streamIdentifier} {}
 
   StreamKind getKind() const override {
-    return streamIdentifier_.kind_;
+    return streamIdentifier_.kind();
   }
 
   uint32_t getNode() const override {
-    return streamIdentifier_.encodingKey_.node;
+    return streamIdentifier_.encodingKey().node;
   }
 
   uint32_t getSequence() const override {
-    return streamIdentifier_.encodingKey_.sequence;
+    return streamIdentifier_.encodingKey().sequence;
   }
 
   MOCK_CONST_METHOD0(getOffset, uint64_t());
@@ -97,10 +97,10 @@ class TestStripeStreams : public StripeStreamsBase {
       if (throwIfNotFound) {
         DWIO_RAISE(fmt::format(
             "stream (node = {}, seq = {}, column = {}, kind = {}) not found",
-            si.encodingKey_.node,
-            si.encodingKey_.sequence,
-            si.column_,
-            si.kind_));
+            si.encodingKey().node,
+            si.encodingKey().sequence,
+            si.column(),
+            si.kind()));
       } else {
         return nullptr;
       }
@@ -136,7 +136,7 @@ class TestStripeStreams : public StripeStreamsBase {
       std::function<void(const StreamInformation&)> visitor) const override {
     uint32_t count = 0;
     context_.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.encodingKey_.node == node) {
+      if (pair.first.encodingKey().node == node) {
         visitor(MockStreamInformation(pair.first));
         ++count;
       }
@@ -808,7 +808,7 @@ void testMapWriter(
     auto valueNodeId = dataTypeWithId->childAt(1)->id;
     auto streamCount = 0;
     context.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.encodingKey_.node == valueNodeId) {
+      if (pair.first.encodingKey().node == valueNodeId) {
         ++streamCount;
       }
     });
@@ -819,7 +819,7 @@ void testMapWriter(
 
     streamCount = 0;
     context.iterateUnSuppressedStreams([&](auto& pair) {
-      if (pair.first.encodingKey_.node == valueNodeId) {
+      if (pair.first.encodingKey().node == valueNodeId) {
         ++streamCount;
       }
     });

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -25,12 +25,12 @@ TEST(LayoutPlannerTests, Basic) {
   WriterContext context{
       config, facebook::velox::memory::getDefaultScopedMemoryPool()};
   // fake streams
-  std::vector<StreamIdentifier> streams;
+  std::vector<DwrfStreamIdentifier> streams;
   std::array<char, 256> data;
   std::memset(data.data(), 'a', data.size());
   auto addStream =
       [&](uint32_t node, uint32_t seq, StreamKind kind, uint32_t size) {
-        auto streamId = StreamIdentifier{node, seq, 0, kind};
+        auto streamId = DwrfStreamIdentifier{node, seq, 0, kind};
         streams.push_back(streamId);
         AppendOnlyBufferedStream out{context.newStream(streamId)};
         out.write(data.data(), size);

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -41,10 +41,12 @@ class MockStripeStreams : public StripeStreams {
   MockStripeStreams() : scopedPool_{memory::getDefaultScopedMemoryPool()} {};
   ~MockStripeStreams() = default;
   std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override {
     return std::unique_ptr<SeekableInputStream>(getStreamProxy(
-        si.node, static_cast<proto::Stream_Kind>(si.kind), throwIfNotFound));
+        si.encodingKey_.node,
+        static_cast<proto::Stream_Kind>(si.kind_),
+        throwIfNotFound));
   }
 
   std::function<BufferPtr()> getIntDictionaryInitializerForNode(
@@ -92,7 +94,7 @@ class MockStripeStreams : public StripeStreams {
     return ptr ? *ptr : options_;
   }
 
-  bool getUseVInts(const StreamIdentifier& streamId) const override {
+  bool getUseVInts(const DwrfStreamIdentifier& streamId) const override {
     return true; // current tests all expect results from using vints
   }
 

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -44,8 +44,8 @@ class MockStripeStreams : public StripeStreams {
       const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override {
     return std::unique_ptr<SeekableInputStream>(getStreamProxy(
-        si.encodingKey_.node,
-        static_cast<proto::Stream_Kind>(si.kind_),
+        si.encodingKey().node,
+        static_cast<proto::Stream_Kind>(si.kind()),
         throwIfNotFound));
   }
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -510,9 +510,9 @@ class TestStripeStreams : public StripeStreamsBase {
       const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override {
     return std::unique_ptr<SeekableInputStream>(getStreamProxy(
-        si.encodingKey_.node,
-        si.encodingKey_.sequence,
-        static_cast<proto::Stream_Kind>(si.kind_),
+        si.encodingKey().node,
+        si.encodingKey().sequence,
+        static_cast<proto::Stream_Kind>(si.kind()),
         throwIfNotFound));
   }
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -416,7 +416,7 @@ TEST(StripeStream, readEncryptedStreams) {
   for (uint32_t node = 1; node < 6; ++node) {
     EncodingKey ek{node};
     auto stream = streams.getStream(
-        StreamIdentifier{node, 0, 0, StreamKind::StreamKind_DATA}, false);
+        DwrfStreamIdentifier{node, 0, 0, StreamKind::StreamKind_DATA}, false);
     if (existed.count(node)) {
       ASSERT_EQ(streams.getEncoding(ek).dictionarysize(), node + 1);
       ASSERT_NE(stream, nullptr);
@@ -485,7 +485,7 @@ TEST(StripeStream, schemaMismatch) {
   for (uint32_t node = 3; node < 4; ++node) {
     EncodingKey ek{node};
     auto stream = streams.getStream(
-        StreamIdentifier{node, 0, 0, StreamKind::StreamKind_DATA}, false);
+        DwrfStreamIdentifier{node, 0, 0, StreamKind::StreamKind_DATA}, false);
     ASSERT_EQ(streams.getEncoding(ek).dictionarysize(), node + 1);
     ASSERT_NE(stream, nullptr);
   }
@@ -507,12 +507,12 @@ class TestStripeStreams : public StripeStreamsBase {
   }
 
   std::unique_ptr<SeekableInputStream> getStream(
-      const StreamIdentifier& si,
+      const DwrfStreamIdentifier& si,
       bool throwIfNotFound) const override {
     return std::unique_ptr<SeekableInputStream>(getStreamProxy(
-        si.node,
-        si.sequence,
-        static_cast<proto::Stream_Kind>(si.kind),
+        si.encodingKey_.node,
+        si.encodingKey_.sequence,
+        static_cast<proto::Stream_Kind>(si.kind_),
         throwIfNotFound));
   }
 
@@ -530,7 +530,7 @@ class TestStripeStreams : public StripeStreamsBase {
     VELOX_UNSUPPORTED();
   }
 
-  bool getUseVInts(const StreamIdentifier& /* unused */) const override {
+  bool getUseVInts(const DwrfStreamIdentifier& /* unused */) const override {
     return true; // current tests all expect results from using vints
   }
 

--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -64,7 +64,7 @@ class WriterTest : public Test {
   }
 
   void validateStreamSize(uint64_t streamSize) {
-    StreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
+    DwrfStreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
     writer->validateStreamSize(si, streamSize);
   }
 

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -216,7 +216,7 @@ class IntegerColumnWriter : public BaseColumnWriter {
       // Suppress the stream used to initialize dictionary encoder.
       // TODO: passing factory method into the dict encoder also works
       // around this problem but has messier code organization.
-      context_.suppressStream(StreamIdentifier{
+      context_.suppressStream(DwrfStreamIdentifier{
           id_,
           context_.shareFlatMapDictionaries ? 0 : sequence_,
           0,
@@ -352,7 +352,7 @@ class IntegerColumnWriter : public BaseColumnWriter {
     // Suppress the stream used to initialize dictionary encoder.
     // TODO: passing factory method into the dict encoder also works
     // around this problem but has messier code organization.
-    context_.suppressStream(StreamIdentifier{
+    context_.suppressStream(DwrfStreamIdentifier{
         id_,
         context_.shareFlatMapDictionaries ? 0 : sequence_,
         0,

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -67,7 +67,7 @@ class ColumnWriter {
   }
 
   std::unique_ptr<BufferedOutputStream> newStream(StreamKind kind) {
-    return context_.newStream(StreamIdentifier{id_, sequence_, 0, kind});
+    return context_.newStream(DwrfStreamIdentifier{id_, sequence_, 0, kind});
   }
 
   WriterContext& context_;
@@ -218,7 +218,7 @@ class BaseColumnWriter : public ColumnWriter {
   }
 
   void suppressStream(StreamKind kind) {
-    context_.suppressStream(StreamIdentifier{id_, sequence_, 0, kind});
+    context_.suppressStream(DwrfStreamIdentifier{id_, sequence_, 0, kind});
   }
 
   template <typename T>

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -102,10 +102,10 @@ void FlatMapColumnWriter<K>::clearNodes() {
   });
 
   context_.removeStreams([this](const DwrfStreamIdentifier& identifier) {
-    return identifier.encodingKey_.node >= valueType_.id &&
-        identifier.encodingKey_.node <= valueType_.maxId &&
-        (identifier.kind_ == StreamKind::StreamKind_DICTIONARY_DATA ||
-         identifier.encodingKey_.sequence > 0);
+    return identifier.encodingKey().node >= valueType_.id &&
+        identifier.encodingKey().node <= valueType_.maxId &&
+        (identifier.kind() == StreamKind::StreamKind_DICTIONARY_DATA ||
+         identifier.encodingKey().sequence > 0);
   });
 }
 

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -101,11 +101,11 @@ void FlatMapColumnWriter<K>::clearNodes() {
     return nodeId >= valueType_.id && nodeId <= valueType_.maxId;
   });
 
-  context_.removeStreams([this](auto& identifier) {
-    return identifier.node >= valueType_.id &&
-        identifier.node <= valueType_.maxId &&
-        (identifier.kind == StreamKind::StreamKind_DICTIONARY_DATA ||
-         identifier.sequence > 0);
+  context_.removeStreams([this](const DwrfStreamIdentifier& identifier) {
+    return identifier.encodingKey_.node >= valueType_.id &&
+        identifier.encodingKey_.node <= valueType_.maxId &&
+        (identifier.kind_ == StreamKind::StreamKind_DICTIONARY_DATA ||
+         identifier.encodingKey_.sequence > 0);
   });
 }
 

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -32,7 +32,8 @@ LayoutPlanner::LayoutPlanner(StreamList streams)
     : streams_{std::move(streams)} {}
 
 void LayoutPlanner::iterateIndexStreams(
-    std::function<void(const StreamIdentifier&, DataBufferHolder&)> consumer) {
+    std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+        consumer) {
   for (auto iter = streams_.begin(), end = iter + indexCount_; iter != end;
        ++iter) {
     consumer(*iter->first, *iter->second);
@@ -40,7 +41,8 @@ void LayoutPlanner::iterateIndexStreams(
 }
 
 void LayoutPlanner::iterateDataStreams(
-    std::function<void(const StreamIdentifier&, DataBufferHolder&)> consumer) {
+    std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+        consumer) {
   for (auto iter = streams_.begin() + indexCount_; iter != streams_.end();
        ++iter) {
     consumer(*iter->first, *iter->second);
@@ -51,7 +53,7 @@ void LayoutPlanner::plan() {
   // place index before data
   auto iter =
       std::partition(streams_.begin(), streams_.end(), [](auto& stream) {
-        return stream.first->kind == StreamKind::StreamKind_ROW_INDEX;
+        return stream.first->kind_ == StreamKind::StreamKind_ROW_INDEX;
       });
   indexCount_ = iter - streams_.begin();
 
@@ -71,8 +73,9 @@ void LayoutPlanner::NodeSizeSorter::sort(
   // 4. for same sequence, small kind first
 
   // calculate node size
-  auto getNodeKey = [](const StreamIdentifier& stream) {
-    return static_cast<uint64_t>(stream.node) << 32 | stream.sequence;
+  auto getNodeKey = [](const DwrfStreamIdentifier& stream) {
+    return static_cast<uint64_t>(stream.encodingKey_.node) << 32 |
+        stream.encodingKey_.sequence;
   };
 
   std::unordered_map<uint64_t, uint64_t> nodeSize;
@@ -96,19 +99,19 @@ void LayoutPlanner::NodeSizeSorter::sort(
     }
 
     // if size is the same, sort by node and sequence
-    auto nodeA = a.first->node;
-    auto nodeB = b.first->node;
+    auto nodeA = a.first->encodingKey_.node;
+    auto nodeB = b.first->encodingKey_.node;
     if (nodeA != nodeB) {
       return nodeA < nodeB;
     }
 
-    auto seqA = a.first->sequence;
-    auto seqB = b.first->sequence;
+    auto seqA = a.first->encodingKey_.sequence;
+    auto seqB = b.first->encodingKey_.sequence;
     if (seqA != seqB) {
       return seqA < seqB;
     }
 
-    return a.first->kind < b.first->kind;
+    return a.first->kind_ < b.first->kind_;
   });
 }
 

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -53,7 +53,7 @@ void LayoutPlanner::plan() {
   // place index before data
   auto iter =
       std::partition(streams_.begin(), streams_.end(), [](auto& stream) {
-        return stream.first->kind_ == StreamKind::StreamKind_ROW_INDEX;
+        return stream.first->kind() == StreamKind::StreamKind_ROW_INDEX;
       });
   indexCount_ = iter - streams_.begin();
 
@@ -74,8 +74,8 @@ void LayoutPlanner::NodeSizeSorter::sort(
 
   // calculate node size
   auto getNodeKey = [](const DwrfStreamIdentifier& stream) {
-    return static_cast<uint64_t>(stream.encodingKey_.node) << 32 |
-        stream.encodingKey_.sequence;
+    return static_cast<uint64_t>(stream.encodingKey().node) << 32 |
+        stream.encodingKey().sequence;
   };
 
   std::unordered_map<uint64_t, uint64_t> nodeSize;
@@ -99,19 +99,19 @@ void LayoutPlanner::NodeSizeSorter::sort(
     }
 
     // if size is the same, sort by node and sequence
-    auto nodeA = a.first->encodingKey_.node;
-    auto nodeB = b.first->encodingKey_.node;
+    auto nodeA = a.first->encodingKey().node;
+    auto nodeB = b.first->encodingKey().node;
     if (nodeA != nodeB) {
       return nodeA < nodeB;
     }
 
-    auto seqA = a.first->encodingKey_.sequence;
-    auto seqB = b.first->encodingKey_.sequence;
+    auto seqA = a.first->encodingKey().sequence;
+    auto seqB = b.first->encodingKey().sequence;
     if (seqA != seqB) {
       return seqA < seqB;
     }
 
-    return a.first->kind_ < b.first->kind_;
+    return a.first->kind() < b.first->kind();
   });
 }
 

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -21,7 +21,7 @@
 
 namespace facebook::velox::dwrf {
 using StreamList =
-    std::vector<std::pair<const StreamIdentifier*, DataBufferHolder*>>;
+    std::vector<std::pair<const DwrfStreamIdentifier*, DataBufferHolder*>>;
 
 StreamList getStreamList(WriterContext& context);
 
@@ -31,10 +31,12 @@ class LayoutPlanner {
   virtual ~LayoutPlanner() = default;
 
   void iterateIndexStreams(
-      std::function<void(const StreamIdentifier&, DataBufferHolder&)> consumer);
+      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+          consumer);
 
   void iterateDataStreams(
-      std::function<void(const StreamIdentifier&, DataBufferHolder&)> consumer);
+      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+          consumer);
 
   virtual void plan();
 

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -141,7 +141,7 @@ class WriterBase {
   }
 
   void validateStreamSize(
-      const StreamIdentifier& streamId,
+      const DwrfStreamIdentifier& streamId,
       uint64_t streamSize) {
     if (context_->isStreamSizeAboveThresholdCheckEnabled) {
       // Jolly doesn't support Streams bigger than 2GB.

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -73,15 +73,17 @@ class WriterContext : public CompressionBufferPool {
         generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }
 
-  bool hasStream(const StreamIdentifier& stream) const {
+  bool hasStream(const DwrfStreamIdentifier& stream) const {
     return streams_.find(stream) != streams_.end();
   }
 
-  const DataBufferHolder& getStream(const StreamIdentifier& stream) const {
+  const DataBufferHolder& getStream(const DwrfStreamIdentifier& stream) const {
     return streams_.at(stream);
   }
 
-  void addBuffer(const StreamIdentifier& stream, folly::StringPiece buffer) {
+  void addBuffer(
+      const DwrfStreamIdentifier& stream,
+      folly::StringPiece buffer) {
     streams_.at(stream).take(buffer);
   }
 
@@ -94,7 +96,7 @@ class WriterContext : public CompressionBufferPool {
   // capacity vs actual usage problem. However, this is ok as an upperbound for
   // flush policy evaluation and would be more accurate after flush.
   std::unique_ptr<BufferedOutputStream> newStream(
-      const StreamIdentifier& stream) {
+      const DwrfStreamIdentifier& stream) {
     DWIO_ENSURE(
         !hasStream(stream), "Stream already exists ", stream.toString());
     streams_.emplace(
@@ -106,8 +108,9 @@ class WriterContext : public CompressionBufferPool {
             getConfig(Config::COMPRESSION_BLOCK_SIZE_MIN),
             getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO)));
     auto& holder = streams_.at(stream);
-    auto encrypter = handler_->isEncrypted(stream.node)
-        ? std::addressof(handler_->getEncryptionProvider(stream.node))
+    auto encrypter = handler_->isEncrypted(stream.encodingKey_.node)
+        ? std::addressof(
+              handler_->getEncryptionProvider(stream.encodingKey_.node))
         : nullptr;
     return newStream(compression, holder, encrypter);
   }
@@ -164,7 +167,7 @@ class WriterContext : public CompressionBufferPool {
         : std::make_unique<IndexBuilder>(std::move(stream));
   }
 
-  void suppressStream(const StreamIdentifier& stream) {
+  void suppressStream(const DwrfStreamIdentifier& stream) {
     DWIO_ENSURE(hasStream(stream));
     auto& collector = streams_.at(stream);
     collector.suppress();
@@ -253,8 +256,8 @@ class WriterContext : public CompressionBufferPool {
   }
 
   void iterateUnSuppressedStreams(
-      std::function<void(std::pair<const StreamIdentifier, DataBufferHolder>&)>
-          callback) {
+      std::function<void(
+          std::pair<const DwrfStreamIdentifier, DataBufferHolder>&)> callback) {
     for (auto& pair : streams_) {
       if (!pair.second.isSuppressed()) {
         callback(pair);
@@ -278,7 +281,7 @@ class WriterContext : public CompressionBufferPool {
   }
 
   virtual void removeStreams(
-      std::function<bool(const StreamIdentifier&)> predicate) {
+      std::function<bool(const DwrfStreamIdentifier&)> predicate) {
     auto it = streams_.begin();
     while (it != streams_.end()) {
       if (predicate(it->first)) {
@@ -442,8 +445,9 @@ class WriterContext : public CompressionBufferPool {
   memory::MemoryPool& generalPool_;
   // Map needs referential stability because reference to map value is stored by
   // another class.
-  folly::F14NodeMap<StreamIdentifier, DataBufferHolder, StreamIdentifierHash>
-      streams_;
+  folly::
+      F14NodeMap<DwrfStreamIdentifier, DataBufferHolder, StreamIdentifierHash>
+          streams_;
   folly::F14FastMap<
       EncodingKey,
       std::unique_ptr<AbstractIntegerDictionaryEncoder>,

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -108,9 +108,9 @@ class WriterContext : public CompressionBufferPool {
             getConfig(Config::COMPRESSION_BLOCK_SIZE_MIN),
             getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO)));
     auto& holder = streams_.at(stream);
-    auto encrypter = handler_->isEncrypted(stream.encodingKey_.node)
+    auto encrypter = handler_->isEncrypted(stream.encodingKey().node)
         ? std::addressof(
-              handler_->getEncryptionProvider(stream.encodingKey_.node))
+              handler_->getEncryptionProvider(stream.encodingKey().node))
         : nullptr;
     return newStream(compression, holder, encrypter);
   }
@@ -445,9 +445,11 @@ class WriterContext : public CompressionBufferPool {
   memory::MemoryPool& generalPool_;
   // Map needs referential stability because reference to map value is stored by
   // another class.
-  folly::
-      F14NodeMap<DwrfStreamIdentifier, DataBufferHolder, StreamIdentifierHash>
-          streams_;
+  folly::F14NodeMap<
+      DwrfStreamIdentifier,
+      DataBufferHolder,
+      dwio::common::StreamIdentifierHash>
+      streams_;
   folly::F14FastMap<
       EncodingKey,
       std::unique_ptr<AbstractIntegerDictionaryEncoder>,

--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -348,10 +348,10 @@ void WriterShared::flushStripe(bool close) {
 
   uint32_t lastIndex = 0;
   uint64_t offset = 0;
-  auto addStream = [&](const auto& stream, const auto& out) {
+  auto addStream = [&](const DwrfStreamIdentifier& stream, const auto& out) {
     proto::Stream* s;
     uint32_t currentIndex;
-    auto nodeId = stream.node;
+    auto nodeId = stream.encodingKey_.node;
     s = encodingManager.addStreamToFooter(nodeId, currentIndex);
 
     // set offset only when needed, ie. when offset of current stream cannot be
@@ -367,10 +367,10 @@ void WriterShared::flushStripe(bool close) {
     // Jolly/Presto readers can't read streams bigger than 2GB.
     validateStreamSize(stream, out.size());
 
-    s->set_kind(static_cast<proto::Stream_Kind>(stream.kind));
+    s->set_kind(static_cast<proto::Stream_Kind>(stream.kind_));
     s->set_node(nodeId);
-    s->set_column(stream.column);
-    s->set_sequence(stream.sequence);
+    s->set_column(stream.column_);
+    s->set_sequence(stream.encodingKey_.sequence);
     s->set_length(out.size());
     s->set_usevints(context.getConfig(Config::USE_VINTS));
     offset += out.size();
@@ -386,10 +386,10 @@ void WriterShared::flushStripe(bool close) {
   planner->plan();
   planner->iterateIndexStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE_EQ(
-        streamId.kind,
+        streamId.kind_,
         StreamKind::StreamKind_ROW_INDEX,
         "unexpected stream kind ",
-        streamId.kind);
+        streamId.kind_);
     indexLength += content.size();
     addStream(streamId, content);
     sink.addBuffers(content);
@@ -399,10 +399,10 @@ void WriterShared::flushStripe(bool close) {
   sink.setMode(WriterSink::Mode::Data);
   planner->iterateDataStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE_NE(
-        streamId.kind,
+        streamId.kind_,
         StreamKind::StreamKind_ROW_INDEX,
         "unexpected stream kind ",
-        streamId.kind);
+        streamId.kind_);
     dataLength += content.size();
     addStream(streamId, content);
     sink.addBuffers(content);

--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -351,7 +351,7 @@ void WriterShared::flushStripe(bool close) {
   auto addStream = [&](const DwrfStreamIdentifier& stream, const auto& out) {
     proto::Stream* s;
     uint32_t currentIndex;
-    auto nodeId = stream.encodingKey_.node;
+    auto nodeId = stream.encodingKey().node;
     s = encodingManager.addStreamToFooter(nodeId, currentIndex);
 
     // set offset only when needed, ie. when offset of current stream cannot be
@@ -367,10 +367,10 @@ void WriterShared::flushStripe(bool close) {
     // Jolly/Presto readers can't read streams bigger than 2GB.
     validateStreamSize(stream, out.size());
 
-    s->set_kind(static_cast<proto::Stream_Kind>(stream.kind_));
+    s->set_kind(static_cast<proto::Stream_Kind>(stream.kind()));
     s->set_node(nodeId);
-    s->set_column(stream.column_);
-    s->set_sequence(stream.encodingKey_.sequence);
+    s->set_column(stream.column());
+    s->set_sequence(stream.encodingKey().sequence);
     s->set_length(out.size());
     s->set_usevints(context.getConfig(Config::USE_VINTS));
     offset += out.size();
@@ -386,10 +386,10 @@ void WriterShared::flushStripe(bool close) {
   planner->plan();
   planner->iterateIndexStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE_EQ(
-        streamId.kind_,
+        streamId.kind(),
         StreamKind::StreamKind_ROW_INDEX,
         "unexpected stream kind ",
-        streamId.kind_);
+        streamId.kind());
     indexLength += content.size();
     addStream(streamId, content);
     sink.addBuffers(content);
@@ -399,10 +399,10 @@ void WriterShared::flushStripe(bool close) {
   sink.setMode(WriterSink::Mode::Data);
   planner->iterateDataStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE_NE(
-        streamId.kind_,
+        streamId.kind(),
         StreamKind::StreamKind_ROW_INDEX,
         "unexpected stream kind ",
-        streamId.kind_);
+        streamId.kind());
     dataLength += content.size();
     addStream(streamId, content);
     sink.addBuffers(content);


### PR DESCRIPTION


    dwrf::StreamIdentifier was used as a parameter of BufferedInput::
    enqueue(), which causes circular dependency problems for future
    refactoring that will move dwrf::common::BufferedInput to dwio::common.
    This commit extracts a common interface and moves it to dwio::common::
    StreamIdentifier. dwrf::DwrfStreamIdentifier, a subclass of dwio::
    common::StreamIdentifier, is introduced for dwrf. The EncodingKey,
    which was used to identify a DWRF encoding, is now a field of
    DwrfStreamIdentifier.
