### PR TITLE
Fix approx_percentile accuracy

### DIFF
--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -27,9 +27,9 @@ namespace detail {
 
 constexpr uint8_t kMaxLevel = 60;
 
-uint32_t computeTotalCapacity(uint16_t k, uint8_t numLevels);
+uint32_t computeTotalCapacity(uint32_t k, uint8_t numLevels);
 
-uint16_t levelCapacity(uint16_t k, uint8_t numLevels, uint8_t height);
+uint32_t levelCapacity(uint32_t k, uint8_t numLevels, uint8_t height);
 
 // Collect elements in odd or even positions to first half of buf.
 template <typename T, typename RandomBit>
@@ -131,7 +131,7 @@ struct CompressResult {
  */
 template <typename T, typename C, typename RandomBit>
 CompressResult generalCompress(
-    uint16_t k,
+    uint32_t k,
     uint8_t numLevelsIn,
     T* items,
     uint32_t* inLevels,
@@ -250,7 +250,7 @@ void readRange(const char* data, size_t& offset, folly::Range<const T*>& out) {
 } // namespace detail
 
 template <typename T, typename A, typename C>
-KllSketch<T, A, C>::KllSketch(uint16_t k, const A& allocator, uint32_t seed)
+KllSketch<T, A, C>::KllSketch(uint32_t k, const A& allocator, uint32_t seed)
     : k_(k),
       allocator_(allocator),
       randomBit_(seed),
@@ -267,7 +267,7 @@ KllSketch<T, A, C>::KllSketch(const A& allocator, uint32_t seed)
       levels_(AllocU32(allocator)) {}
 
 template <typename T, typename A, typename C>
-void KllSketch<T, A, C>::setK(uint16_t k) {
+void KllSketch<T, A, C>::setK(uint32_t k) {
   if (k_ == k) {
     return;
   }
@@ -700,7 +700,7 @@ template <typename T, typename A, typename C>
 KllSketch<T, A, C> KllSketch<T, A, C>::fromRepeatedValue(
     T value,
     size_t count,
-    uint16_t k,
+    uint32_t k,
     const A& allocator,
     uint32_t seed) {
   int numLevels = 0;

--- a/velox/functions/lib/KllSketch.cpp
+++ b/velox/functions/lib/KllSketch.cpp
@@ -18,7 +18,7 @@
 
 namespace facebook::velox::functions::kll {
 
-uint16_t kFromEpsilon(double eps) {
+uint32_t kFromEpsilon(double eps) {
   return ceil(exp(1.0285 * log(2.296 / eps)));
 }
 
@@ -41,7 +41,7 @@ double powerOfTwoThirds(int n) {
 
 } // namespace
 
-uint32_t computeTotalCapacity(uint16_t k, uint8_t numLevels) {
+uint32_t computeTotalCapacity(uint32_t k, uint8_t numLevels) {
   uint32_t total = 0;
   for (uint8_t h = 0; h < numLevels; ++h) {
     total += levelCapacity(k, numLevels, h);
@@ -49,10 +49,10 @@ uint32_t computeTotalCapacity(uint16_t k, uint8_t numLevels) {
   return total;
 }
 
-uint16_t levelCapacity(uint16_t k, uint8_t numLevels, uint8_t height) {
+uint32_t levelCapacity(uint32_t k, uint8_t numLevels, uint8_t height) {
   VELOX_DCHECK_LT(height, numLevels);
   VELOX_DCHECK_LE(numLevels, kMaxLevel);
-  return std::max<uint16_t>(
+  return std::max<uint32_t>(
       kMinBufferWidth, k * powerOfTwoThirds(numLevels - height - 1));
 }
 

--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -24,10 +24,10 @@
 
 namespace facebook::velox::functions::kll {
 
-constexpr uint16_t kDefaultK = 200;
+constexpr uint32_t kDefaultK = 200;
 
 /// Estimate the proper k value to ensure the error bound epsilon.
-uint16_t kFromEpsilon(double epsilon);
+uint32_t kFromEpsilon(double epsilon);
 
 /// Implementation of KLL sketch that can achieve nearly optimal
 /// accuracy per retained item.
@@ -50,12 +50,12 @@ template <
     typename Compare = std::less<T>>
 struct KllSketch {
   KllSketch(
-      uint16_t k = kll::kDefaultK,
+      uint32_t k = kll::kDefaultK,
       const Allocator& = Allocator(),
       uint32_t seed = folly::Random::rand32());
 
   /// Cannot be called after insert().
-  void setK(uint16_t k);
+  void setK(uint32_t k);
 
   /// Add one new value to the sketch.
   void insert(T value);
@@ -108,7 +108,7 @@ struct KllSketch {
   static KllSketch<T, Allocator, Compare> fromRepeatedValue(
       T value,
       size_t count,
-      uint16_t k = kll::kDefaultK,
+      uint32_t k = kll::kDefaultK,
       const Allocator& = Allocator(),
       uint32_t seed = folly::Random::rand32());
 
@@ -145,7 +145,7 @@ struct KllSketch {
   }
 
   struct View {
-    uint16_t k;
+    uint32_t k;
     size_t n;
     T minValue;
     T maxValue;
@@ -171,7 +171,7 @@ struct KllSketch {
   using AllocU32 = typename std::allocator_traits<
       Allocator>::template rebind_alloc<uint32_t>;
 
-  uint16_t k_;
+  uint32_t k_;
   Allocator allocator_;
 
   // Cannot use sfmt19937 here because the object cannot be guaranteed


### PR DESCRIPTION
Summary:
The accuracy parameter is not passed to final aggregation properly;
thus final aggregation was always using the default accuracy of 1.33%.  Also
change the type of K to allow larger values.

Differential Revision: D36863128

