### PR TITLE
Optimize like function for exact, prefix and suffix patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ min_debug:				#: Minimal build with debugging symbols
 	$(MAKE) build BUILD_DIR=debug
 
 benchmarks-basic-build:
-	$(MAKE) release EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_MINIMAL=ON -DVELOX_ENABLE_BENCHMARKS_BASIC=ON"
+	$(MAKE) release EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_MINIMAL=OFF -DVELOX_ENABLE_BENCHMARKS_BASIC=ON"
 
 benchmarks-basic-run:
 	$(MAKE) benchmarks-basic-build

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -57,3 +57,7 @@ target_link_libraries(velox_benchmark_feature_normalization
 add_executable(velox_benchmark_basic_preproc Preproc.cpp)
 target_link_libraries(velox_benchmark_basic_preproc ${velox_benchmark_deps}
                       velox_functions_prestosql velox_vector_test_lib)
+
+add_executable(velox_like_functions_benchmark LikeFunctionsBenchmark.cpp)
+target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
+                      velox_functions_lib velox_tpch_gen velox_vector_test_lib)

--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -29,9 +29,20 @@ using namespace facebook::velox::functions;
 using namespace facebook::velox::functions::test;
 
 DEFINE_int32(vector_size, 10000, "Vector size");
+DEFINE_int32(num_runs, 10000, "Number of runs");
 DEFINE_int32(num_rows, 10000, "Number of rows");
 
 namespace {
+
+enum class TpchBenchmarkCase {
+  TpchQuery2,
+  TpchQuery9,
+  TpchQuery13,
+  TpchQuery14,
+  TpchQuery16Part,
+  TpchQuery16Supplier,
+  TpchQuery20,
+};
 
 class LikeFunctionsBenchmark : public FunctionBaseTest,
                                public FunctionBenchmarkBase {
@@ -39,21 +50,18 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
   explicit LikeFunctionsBenchmark() {
     exec::registerStatefulVectorFunction("like", likeSignatures(), makeLike);
 
-    folly::BenchmarkSuspender kSuspender;
     VectorFuzzer::Options opts;
     opts.vectorSize = FLAGS_vector_size;
     VectorFuzzer fuzzer(opts, FunctionBenchmarkBase::pool());
     inputFuzzer_ = fuzzer.fuzzFlat(VARCHAR());
-    kSuspender.dismiss();
   }
 
   // Generate random string using characters from characterSet.
   std::string generateRandomString(const char* characterSet) {
-    vector_size_t characterSetLength = strlen(characterSet);
-    vector_size_t outputStringLength;
-    vector_size_t minimumLength = 1;
-    vector_size_t maximumLength = 10;
-    outputStringLength = rand() % maximumLength + minimumLength;
+    auto characterSetLength = strlen(characterSet);
+    auto minimumLength = 1;
+    auto maximumLength = 10;
+    auto outputStringLength = rand() % maximumLength + minimumLength;
     std::string output;
 
     for (int i = 0; i < outputStringLength; i++) {
@@ -87,27 +95,70 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
     }
   }
 
-  size_t run(VectorPtr input, const StringView patternString) {
+  const VectorPtr getTpchData(const TpchBenchmarkCase tpchCase) {
+    switch (tpchCase) {
+      case TpchBenchmarkCase::TpchQuery2:
+      case TpchBenchmarkCase::TpchQuery14:
+      case TpchBenchmarkCase::TpchQuery16Part: {
+        auto tpchPart = genTpchPart(FLAGS_num_rows);
+        return tpchPart->childAt(4);
+      }
+      case TpchBenchmarkCase::TpchQuery9:
+      case TpchBenchmarkCase::TpchQuery20: {
+        auto tpchPart = genTpchPart(FLAGS_num_rows);
+        return tpchPart->childAt(1);
+      }
+      case TpchBenchmarkCase::TpchQuery13: {
+        auto tpchOrders = genTpchOrders(FLAGS_num_rows);
+        return tpchOrders->childAt(8);
+      }
+      case TpchBenchmarkCase::TpchQuery16Supplier: {
+        auto tpchSupplier = genTpchSupplier(FLAGS_num_rows);
+        return tpchSupplier->childAt(6);
+      }
+      default:
+        VELOX_FAIL(fmt::format(
+            "Tpch data generation for case {} is not supported", tpchCase));
+    }
+  }
+
+  size_t run(const TpchBenchmarkCase tpchCase, const StringView patternString) {
+    folly::BenchmarkSuspender kSuspender;
+    const auto input = getTpchData(tpchCase);
     const auto data = makeRowVector({input});
+    auto likeExpression = fmt::format("like(c0, '{}')", patternString);
+    auto rowType = std::dynamic_pointer_cast<const RowType>(data->type());
+    exec::ExprSet exprSet =
+        FunctionBenchmarkBase::compileExpression(likeExpression, rowType);
+    kSuspender.dismiss();
+
     size_t cnt = 0;
-    auto result = FunctionBaseTest::evaluate<SimpleVector<bool>>(
-        fmt::format("like(c0, '{}')", patternString), data);
-    cnt += result->size();
+    for (auto i = 0; i < FLAGS_num_runs; i++) {
+      auto result = FunctionBenchmarkBase::evaluate(exprSet, data);
+      cnt += result->size();
+    }
     folly::doNotOptimizeAway(cnt);
 
     return cnt;
   }
 
   size_t run(PatternKind patternKind) {
+    folly::BenchmarkSuspender kSuspender;
     const auto input = inputFuzzer_->values()->as<StringView>();
     auto patternString = generatePattern(patternKind, input[0].str());
     std::vector<std::string> patternVector(FLAGS_vector_size, patternString);
     const auto data = makeRowVector({inputFuzzer_});
-    size_t cnt = 0;
+    auto likeExpression = fmt::format("like(c0, '{}')", patternString);
+    auto rowType = std::dynamic_pointer_cast<const RowType>(data->type());
+    exec::ExprSet exprSet =
+        FunctionBenchmarkBase::compileExpression(likeExpression, rowType);
+    kSuspender.dismiss();
 
-    auto result = FunctionBaseTest::evaluate<SimpleVector<bool>>(
-        fmt::format("like(c0, '{}')", patternString), data);
-    cnt += result->size();
+    size_t cnt = 0;
+    for (auto i = 0; i < FLAGS_num_runs; i++) {
+      auto result = FunctionBenchmarkBase::evaluate(exprSet, data);
+      cnt += result->size();
+    }
     folly::doNotOptimizeAway(cnt);
 
     return cnt;
@@ -127,7 +178,7 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
 std::unique_ptr<LikeFunctionsBenchmark> benchmark;
 
 BENCHMARK_MULTI(wildcardExactlyN) {
-  return benchmark->run(facebook::velox::functions::PatternKind::kExactlyN);
+  return benchmark->run(PatternKind::kExactlyN);
 }
 
 BENCHMARK_MULTI(wildcardAtLeastN) {
@@ -149,45 +200,32 @@ BENCHMARK_MULTI(suffixPattern) {
 BENCHMARK_DRAW_LINE();
 
 BENCHMARK_MULTI(tpchQuery2) {
-  auto tpchPart = genTpchPart(FLAGS_num_rows);
-  auto partTypeVector = tpchPart->childAt(4);
-  return benchmark->run(partTypeVector, "%BRASS");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery2, "%BRASS");
 }
 
 BENCHMARK_MULTI(tpchQuery9) {
-  auto tpchPart = genTpchPart(FLAGS_num_rows);
-  auto partNameVector = tpchPart->childAt(1);
-  return benchmark->run(partNameVector, "%green%");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery9, "%green%");
 }
 
 BENCHMARK_MULTI(tpchQuery13) {
-  auto tpchOrders = genTpchOrders(FLAGS_num_rows);
-  auto orderCommentVector = tpchOrders->childAt(8);
-  return benchmark->run(orderCommentVector, "%special%requests%");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery13, "%special%requests%");
 }
 
 BENCHMARK_MULTI(tpchQuery14) {
-  auto tpchPart = genTpchPart(FLAGS_num_rows);
-  auto partTypeVector = tpchPart->childAt(4);
-  return benchmark->run(partTypeVector, "PROMO%");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery14, "PROMO%");
 }
 
 BENCHMARK_MULTI(tpchQuery16Part) {
-  auto tpchPart = genTpchPart(FLAGS_num_rows);
-  auto partTypeVector = tpchPart->childAt(4);
-  return benchmark->run(partTypeVector, "MEDIUM POLISHED%");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery16Part, "MEDIUM POLISHED%");
 }
 
 BENCHMARK_MULTI(tpchQuery16Supplier) {
-  auto tpchSupplier = genTpchSupplier(FLAGS_num_rows);
-  auto supplierCommentVector = tpchSupplier->childAt(6);
-  return benchmark->run(supplierCommentVector, "%Customer%Complaints%");
+  return benchmark->run(
+      TpchBenchmarkCase::TpchQuery16Supplier, "%Customer%Complaints%");
 }
 
 BENCHMARK_MULTI(tpchQuery20) {
-  auto tpchPart = genTpchPart(FLAGS_num_rows);
-  auto partNameVector = tpchPart->childAt(1);
-  return benchmark->run(partNameVector, "forest%");
+  return benchmark->run(TpchBenchmarkCase::TpchQuery20, "forest%");
 }
 
 } // namespace

--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "vector/fuzzer/VectorFuzzer.h"
+#include "velox/functions/lib/Re2Functions.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/tpch/gen/TpchGen.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::tpch;
+using namespace facebook::velox::functions;
+using namespace facebook::velox::functions::test;
+
+DEFINE_int32(vector_size, 10000, "Vector size");
+DEFINE_int32(num_rows, 10000, "Number of rows");
+
+namespace {
+
+class LikeFunctionsBenchmark : public FunctionBaseTest,
+                               public FunctionBenchmarkBase {
+ public:
+  explicit LikeFunctionsBenchmark() {
+    exec::registerStatefulVectorFunction("like", likeSignatures(), makeLike);
+
+    folly::BenchmarkSuspender kSuspender;
+    VectorFuzzer::Options opts;
+    opts.vectorSize = FLAGS_vector_size;
+    VectorFuzzer fuzzer(opts, FunctionBenchmarkBase::pool());
+    inputFuzzer_ = fuzzer.fuzzFlat(VARCHAR());
+    kSuspender.dismiss();
+  }
+
+  // Generate random string using characters from characterSet.
+  std::string generateRandomString(const char* characterSet) {
+    vector_size_t characterSetLength = strlen(characterSet);
+    vector_size_t outputStringLength;
+    vector_size_t minimumLength = 1;
+    vector_size_t maximumLength = 10;
+    outputStringLength = rand() % maximumLength + minimumLength;
+    std::string output;
+
+    for (int i = 0; i < outputStringLength; i++) {
+      output += characterSet[rand() % characterSetLength];
+    }
+    return output;
+  }
+
+  std::string generatePattern(
+      PatternKind patternKind,
+      const std::string& inputString) {
+    switch (patternKind) {
+      case PatternKind::kExactlyN:
+        return std::string(inputString.size(), '_');
+      case PatternKind::kAtLeastN:
+        return generateRandomString(kWildcardCharacterSet);
+      case PatternKind::kPrefix: {
+        auto fixedPatternLength =
+            std::min(vector_size_t(inputString.size()), 10);
+        auto fixedPatternString = inputString.substr(0, fixedPatternLength);
+        return fixedPatternString + generateRandomString(kAnyWildcardCharacter);
+      }
+      case PatternKind::kSuffix: {
+        auto fixedPatternStartIdx =
+            std::max(vector_size_t(inputString.size() - 10), 0);
+        auto fixedPatternString = inputString.substr(fixedPatternStartIdx, 10);
+        return generateRandomString(kAnyWildcardCharacter) + fixedPatternString;
+      }
+      default:
+        return inputString;
+    }
+  }
+
+  size_t run(VectorPtr input, const StringView patternString) {
+    const auto data = makeRowVector({input});
+    size_t cnt = 0;
+    auto result = FunctionBaseTest::evaluate<SimpleVector<bool>>(
+        fmt::format("like(c0, '{}')", patternString), data);
+    cnt += result->size();
+    folly::doNotOptimizeAway(cnt);
+
+    return cnt;
+  }
+
+  size_t run(PatternKind patternKind) {
+    const auto input = inputFuzzer_->values()->as<StringView>();
+    auto patternString = generatePattern(patternKind, input[0].str());
+    std::vector<std::string> patternVector(FLAGS_vector_size, patternString);
+    const auto data = makeRowVector({inputFuzzer_});
+    size_t cnt = 0;
+
+    auto result = FunctionBaseTest::evaluate<SimpleVector<bool>>(
+        fmt::format("like(c0, '{}')", patternString), data);
+    cnt += result->size();
+    folly::doNotOptimizeAway(cnt);
+
+    return cnt;
+  }
+
+  // We inherit from FunctionBaseTest so that we can get access to the helpers
+  // it defines, but since it is supposed to be a test fixture TestBody() is
+  // declared pure virtual.  We must provide an implementation here.
+  void TestBody() override {}
+
+ private:
+  static constexpr const char* kWildcardCharacterSet = "%_";
+  static constexpr const char* kAnyWildcardCharacter = "%";
+  VectorPtr inputFuzzer_;
+};
+
+std::unique_ptr<LikeFunctionsBenchmark> benchmark;
+
+BENCHMARK_MULTI(wildcardExactlyN) {
+  return benchmark->run(facebook::velox::functions::PatternKind::kExactlyN);
+}
+
+BENCHMARK_MULTI(wildcardAtLeastN) {
+  return benchmark->run(PatternKind::kAtLeastN);
+}
+
+BENCHMARK_MULTI(fixedPattern) {
+  return benchmark->run(PatternKind::kFixed);
+}
+
+BENCHMARK_MULTI(prefixPattern) {
+  return benchmark->run(PatternKind::kPrefix);
+}
+
+BENCHMARK_MULTI(suffixPattern) {
+  return benchmark->run(PatternKind::kSuffix);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_MULTI(tpchQuery2) {
+  auto tpchPart = genTpchPart(FLAGS_num_rows);
+  auto partTypeVector = tpchPart->childAt(4);
+  return benchmark->run(partTypeVector, "%BRASS");
+}
+
+BENCHMARK_MULTI(tpchQuery9) {
+  auto tpchPart = genTpchPart(FLAGS_num_rows);
+  auto partNameVector = tpchPart->childAt(1);
+  return benchmark->run(partNameVector, "%green%");
+}
+
+BENCHMARK_MULTI(tpchQuery13) {
+  auto tpchOrders = genTpchOrders(FLAGS_num_rows);
+  auto orderCommentVector = tpchOrders->childAt(8);
+  return benchmark->run(orderCommentVector, "%special%requests%");
+}
+
+BENCHMARK_MULTI(tpchQuery14) {
+  auto tpchPart = genTpchPart(FLAGS_num_rows);
+  auto partTypeVector = tpchPart->childAt(4);
+  return benchmark->run(partTypeVector, "PROMO%");
+}
+
+BENCHMARK_MULTI(tpchQuery16Part) {
+  auto tpchPart = genTpchPart(FLAGS_num_rows);
+  auto partTypeVector = tpchPart->childAt(4);
+  return benchmark->run(partTypeVector, "MEDIUM POLISHED%");
+}
+
+BENCHMARK_MULTI(tpchQuery16Supplier) {
+  auto tpchSupplier = genTpchSupplier(FLAGS_num_rows);
+  auto supplierCommentVector = tpchSupplier->childAt(6);
+  return benchmark->run(supplierCommentVector, "%Customer%Complaints%");
+}
+
+BENCHMARK_MULTI(tpchQuery20) {
+  auto tpchPart = genTpchPart(FLAGS_num_rows);
+  auto partNameVector = tpchPart->childAt(1);
+  return benchmark->run(partNameVector, "forest%");
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv, true);
+  benchmark = std::make_unique<LikeFunctionsBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+
+  return 0;
+}

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -26,6 +26,74 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions {
+
+std::pair<PatternKind, vector_size_t> determinePatternKind(StringView pattern) {
+  vector_size_t patternLength = pattern.size();
+  vector_size_t i = 0;
+  // Index of the first % or _ character.
+  vector_size_t wildcardStart = -1;
+  // Index of the first character that is not % and not _.
+  vector_size_t fixedPatternStart = -1;
+  // Total number of % characters.
+  vector_size_t anyCharacterWildcardCount = 0;
+  // Total number of _ characters.
+  vector_size_t singleCharacterWildcardCount = 0;
+  auto patternStr = pattern.data();
+
+  while (i < patternLength) {
+    if (patternStr[i] == '%' || patternStr[i] == '_') {
+      // Ensures that pattern has a single contiguous stream of wildcard
+      // characters.
+      if (wildcardStart != -1) {
+        return std::make_pair(PatternKind::kGeneric, 0);
+      }
+      // Look till the last contiguous wildcard character, starting from this
+      // index, is found, or the end of pattern is reached.
+      wildcardStart = i;
+      while (i < patternLength &&
+             (patternStr[i] == '%' || patternStr[i] == '_')) {
+        singleCharacterWildcardCount += (patternStr[i] == '_');
+        anyCharacterWildcardCount += (patternStr[i] == '%');
+        i++;
+      }
+    } else {
+      // Ensure that pattern has a single fixed pattern.
+      if (fixedPatternStart != -1) {
+        return std::make_pair(PatternKind::kGeneric, 0);
+      }
+      // Look till the end of fixed pattern, starting from this index, is found,
+      // or the end of pattern is reached.
+      fixedPatternStart = i;
+      while (i < patternLength &&
+             (patternStr[i] != '%' && patternStr[i] != '_')) {
+        i++;
+      }
+    }
+  }
+
+  // Pattern contains wildcard characters only.
+  if (fixedPatternStart == -1) {
+    if (!anyCharacterWildcardCount) {
+      return {PatternKind::kExactlyN, singleCharacterWildcardCount};
+    }
+    return {PatternKind::kAtLeastN, singleCharacterWildcardCount};
+  }
+  // Pattern contains no wildcard characters (is a fixed pattern).
+  if (wildcardStart == -1) {
+    return {PatternKind::kFixed, patternLength};
+  }
+  // Pattern is generic if it has '_' wildcard characters and a fixed pattern.
+  if (singleCharacterWildcardCount) {
+    return {PatternKind::kGeneric, 0};
+  }
+  // Classify pattern as prefix pattern or suffix pattern based on the
+  // positions of the fixed pattern and contiguous wildcard character stream.
+  if (fixedPatternStart < wildcardStart) {
+    return {PatternKind::kPrefix, wildcardStart};
+  }
+  return {PatternKind::kSuffix, patternLength - fixedPatternStart};
+}
+
 namespace {
 
 using ::facebook::velox::exec::EvalCtx;
@@ -374,9 +442,100 @@ class Re2SearchAndExtract final : public VectorFunction {
   const bool emptyNoMatch_;
 };
 
-class LikeConstantPattern final : public VectorFunction {
+// Match string 'input' with a fixed pattern (with no wildcard characters).
+bool matchExactPattern(
+    StringView input,
+    StringView pattern,
+    vector_size_t length) {
+  return input.size() == pattern.size() &&
+      std::memcmp(input.data(), pattern.data(), length) == 0;
+}
+
+// Match the first 'length' characters of string 'input' and prefix pattern.
+bool matchPrefixPattern(
+    StringView input,
+    StringView pattern,
+    vector_size_t length) {
+  return input.size() >= length &&
+      std::memcmp(input.data(), pattern.data(), length) == 0;
+}
+
+// Match the last 'length' characters of string 'input' and suffix pattern.
+bool matchSuffixPattern(
+    StringView input,
+    StringView pattern,
+    vector_size_t length) {
+  return input.size() >= length &&
+      std::memcmp(
+          input.data() + input.size() - length,
+          pattern.data() + pattern.size() - length,
+          length) == 0;
+}
+
+template <PatternKind P>
+class OptimizedLikeWithMemcmp final : public VectorFunction {
  public:
-  LikeConstantPattern(StringView pattern, std::optional<char> escapeChar)
+  OptimizedLikeWithMemcmp(
+      StringView pattern,
+      vector_size_t reducedPatternLength) {
+    pattern_ = pattern;
+    reducedPatternLength_ = reducedPatternLength;
+  }
+
+  bool match(StringView input) const {
+    switch (P) {
+      case PatternKind::kExactlyN:
+        return input.size() == reducedPatternLength_;
+      case PatternKind::kAtLeastN:
+        return input.size() >= reducedPatternLength_;
+      case PatternKind::kFixed:
+        return matchExactPattern(input, pattern_, reducedPatternLength_);
+      case PatternKind::kPrefix:
+        return matchPrefixPattern(input, pattern_, reducedPatternLength_);
+      case PatternKind::kSuffix:
+        return matchSuffixPattern(input, pattern_, reducedPatternLength_);
+    }
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      EvalCtx& context,
+      VectorPtr& resultRef) const final {
+    VELOX_CHECK(args.size() == 2 || args.size() == 3);
+    FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto toSearch = decodedArgs.at(0);
+
+    if (toSearch->isIdentityMapping()) {
+      auto input = toSearch->data<StringView>();
+      rows.applyToSelected(
+          [&](vector_size_t i) { result.set(i, match(input[i])); });
+      return;
+    }
+    if (toSearch->isConstantMapping()) {
+      auto input = toSearch->valueAt<StringView>(0);
+      bool matchResult = match(input);
+      rows.applyToSelected(
+          [&](vector_size_t i) { result.set(i, matchResult); });
+      return;
+    }
+
+    // Since the likePattern and escapeChar (2nd and 3rd args) are both
+    // constants, so the first arg is expected to be either of flat or constant
+    // vector only. This code path is unreachable.
+    VELOX_UNREACHABLE();
+  }
+
+ private:
+  StringView pattern_;
+  vector_size_t reducedPatternLength_;
+};
+
+class LikeWithRe2 final : public VectorFunction {
+ public:
+  LikeWithRe2(StringView pattern, std::optional<char> escapeChar)
       : re_(toStringPiece(likePatternToRe2(pattern, escapeChar, validPattern_)),
             RE2::Quiet) {}
 
@@ -767,7 +926,34 @@ std::shared_ptr<exec::VectorFunction> makeLike(
       name,
       inputArgs[1].type->toString());
   auto pattern = constantPattern->as<ConstantVector<StringView>>()->valueAt(0);
-  return std::make_shared<LikeConstantPattern>(pattern, escapeChar);
+  if (!escapeChar) {
+    PatternKind patternKind;
+    vector_size_t reducedLength;
+    std::tie(patternKind, reducedLength) = determinePatternKind(pattern);
+
+    switch (patternKind) {
+      case PatternKind::kExactlyN:
+        return std::make_shared<
+            OptimizedLikeWithMemcmp<PatternKind::kExactlyN>>(
+            pattern, reducedLength);
+      case PatternKind::kAtLeastN:
+        return std::make_shared<
+            OptimizedLikeWithMemcmp<PatternKind::kAtLeastN>>(
+            pattern, reducedLength);
+      case PatternKind::kFixed:
+        return std::make_shared<OptimizedLikeWithMemcmp<PatternKind::kFixed>>(
+            pattern, reducedLength);
+      case PatternKind::kPrefix:
+        return std::make_shared<OptimizedLikeWithMemcmp<PatternKind::kPrefix>>(
+            pattern, reducedLength);
+      case PatternKind::kSuffix:
+        return std::make_shared<OptimizedLikeWithMemcmp<PatternKind::kSuffix>>(
+            pattern, reducedLength);
+      default:
+        return std::make_shared<LikeWithRe2>(pattern, escapeChar);
+    }
+  }
+  return std::make_shared<LikeWithRe2>(pattern, escapeChar);
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> likeSignatures() {


### PR DESCRIPTION
Optimize like function for the following common cases:
1) Patterns with wildcard characters only:
  a) Patterns with only '\_': Match length of input with number of '\_'
      characters.
  b) Patterns with atleast one '%': Check if input length is atleast equal to
       the number of '_' characters.
2) Constant pattern search: Simple string comparison character by
    character.
3) Pattern has constant prefix followed by one or more %: Match the prefix
     only.
4) Pattern has constant suffix preceded by one or more %: Match the suffix
     only.

These cases are most common in TPC-H queries. When an escape character is
involved in the like function, the default Re2 matcher is used. This is
currently a limitation and needs further examination.

The benchmarks obtained with the changes, for inputs generated by vector fuzzer,
and Tpch queries with patterns matching the above, are as follows:
```
| No. of rows | PatternKind / Query Number | With PR (time/row in ns) | Without PR (time/row in ns) | % Change |
|-------------|----------------------------|--------------------------|-----------------------------|----------|
|    10000    |          kExactlyN         |           0.73           |            700.93           |   99.9   |
|             |          kAtLeastN         |           0.701          |            689.71           |   99.9   |
|             |           kFixed           |           3.66           |            144.7            |   97.47  |  
|             |           kPrefix          |           3.26           |            146.39           |   97.77  | 
|             |           kSuffix          |            4.4           |            670.13           |   99.34  | 
|             |              2             |           6.43           |            436.12           |   98.53  |  
|             |             14             |           5.16           |            198.94           |   97.41  |   
|             |           16 Part          |           6.36           |            157.5            |   95.96  |
|             |             20             |            3.9           |            150.26           |   97.4   |    
|    50000    |          kExactlyN         |           0.623          |            695.33           |   99.91  |      
|             |          kAtLeastN         |           0.592          |            690.4            |   99.91  |
|             |           kFixed           |           3.62           |            144.29           |   97.49  |
|             |           kPrefix          |           3.59           |            145.88           |   97.54  |
|             |           kSuffix          |           5.06           |            671.87           |   99.25  |
|             |              2             |           6.19           |            438.01           |   98.59  |   
|             |             14             |           5.41           |            200.07           |   97.3   |    
|             |           16 Part          |           7.39           |            157.33           |   95.3   | 
|             |             20             |           4.46           |            150.76           |   97.04  |
```