### PR TITLE
Add fast path to Zip when all Arrays are flat and the same size

### DIFF
--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -123,3 +123,7 @@ add_executable(velox_functions_benchmarks_string_writer_no_nulls
                StringWriterBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_string_writer_no_nulls
                       ${BENCHMARK_DEPENDENCIES_NO_FUNC})
+
+add_executable(velox_functions_prestosql_benchmarks_zip ZipBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_zip
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::functions::test {
+namespace {
+class ZipBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  ZipBenchmark() : FunctionBenchmarkBase() {
+    prestosql::registerArrayFunctions();
+  }
+
+  VectorPtr makeData(vector_size_t arraySize, bool dictionaryEncoding) {
+    constexpr vector_size_t size = 100;
+
+    std::vector<std::optional<int64_t>> values;
+    values.reserve(size * arraySize);
+    for (int i = 0; i < size * arraySize; i++) {
+      values.push_back(i);
+    }
+
+    VectorPtr valuesVector = vectorMaker_.dictionaryVector(values);
+
+    std::vector<vector_size_t> offsets;
+    offsets.reserve(size);
+    for (int i = 0; i < size; i++) {
+      offsets.push_back(i * arraySize);
+    }
+
+    VectorPtr array = vectorMaker_.arrayVector(offsets, valuesVector);
+
+    if (dictionaryEncoding) {
+      BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool());
+      auto rawIndices = indices->asMutable<vector_size_t>();
+      for (int i = 0; i < size; i++) {
+        rawIndices[i] = i;
+      }
+
+      array = BaseVector::wrapInDictionary(nullptr, indices, size, array);
+    }
+
+    return array;
+  }
+
+  size_t run(const VectorPtr& c0, const VectorPtr& c1) {
+    folly::BenchmarkSuspender suspender;
+    auto inputs = vectorMaker_.rowVector({c0, c1});
+
+    auto exprSet = compileExpression("zip(c0, c1)", inputs->type());
+    suspender.dismiss();
+
+    return doRun(exprSet, inputs);
+  }
+
+  size_t doRun(exec::ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+    return cnt;
+  }
+};
+
+BENCHMARK_MULTI(EqSizeFlatFlat) {
+  ZipBenchmark benchmark;
+  folly::BenchmarkSuspender suspender;
+  auto c0 = benchmark.makeData(5, false);
+  auto c1 = benchmark.makeData(5, false);
+  suspender.dismiss();
+
+  return benchmark.run(c0, c1);
+}
+
+BENCHMARK_MULTI(EqSizeFlatDictionary) {
+  ZipBenchmark benchmark;
+  folly::BenchmarkSuspender suspender;
+  auto c0 = benchmark.makeData(5, false);
+  auto c1 = benchmark.makeData(5, true);
+  suspender.dismiss();
+
+  return benchmark.run(c0, c1);
+}
+
+BENCHMARK_MULTI(NeqSizeFlatFlat) {
+  ZipBenchmark benchmark;
+  folly::BenchmarkSuspender suspender;
+  auto c0 = benchmark.makeData(5, false);
+  auto c1 = benchmark.makeData(3, false);
+  suspender.dismiss();
+
+  return benchmark.run(c0, c1);
+}
+} // namespace
+} // namespace facebook::velox::functions::test
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -178,4 +178,74 @@ TEST_F(ZipTest, complexTypes) {
   assertEqualVectors(expected, result);
 }
 
+/// Test if we can zip two integer arrays with dictionary encoded elements.
+TEST_F(ZipTest, dictionaryElements) {
+  auto firstIndices = makeIndices(9, [](vector_size_t row) { return row; });
+  auto firstElements = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto firstElementsDictionary =
+      wrapInDictionary(firstIndices, 9, firstElements);
+  auto firstVector = makeArrayVector({0, 3, 6}, firstElementsDictionary);
+
+  // Use different indices.
+  auto secondIndices =
+      makeIndices(9, [](vector_size_t row) { return 8 - row; });
+  auto secondElements =
+      makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17, 18});
+  auto secondElementsDictionary =
+      wrapInDictionary(secondIndices, 9, secondElements);
+  auto secondVector = makeArrayVector({0, 3, 6}, secondElementsDictionary);
+
+  auto result = evaluate<ArrayVector>(
+      "zip(c0, c1)",
+      makeRowVector({
+          firstVector,
+          secondVector,
+      }));
+
+  auto firstResult = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto secondResult =
+      makeFlatVector<int32_t>({18, 17, 16, 15, 14, 13, 12, 11, 10});
+
+  auto rowVector = makeRowVector({firstResult, secondResult});
+
+  // create the expected ArrayVector
+  auto expected = makeArrayVector({0, 3, 6}, rowVector);
+
+  assertEqualVectors(expected, result);
+}
+
+/// Test if we can zip two dictionary encoded integer arrays
+TEST_F(ZipTest, dictionaryArrays) {
+  auto firstElements = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto firstIndices = makeIndices(3, [](vector_size_t row) { return row; });
+  auto firstVector = makeArrayVector({0, 3, 6}, firstElements);
+  auto firstVectorDictionary = wrapInDictionary(firstIndices, 3, firstVector);
+
+  // Use different indices.
+  auto secondElements =
+      makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17, 18});
+  auto secondIndices =
+      makeIndices(3, [](vector_size_t row) { return 2 - row; });
+  auto secondVector = makeArrayVector({0, 3, 6}, secondElements);
+  auto secondVectorDictionary =
+      wrapInDictionary(secondIndices, 3, secondVector);
+
+  auto result = evaluate<ArrayVector>(
+      "zip(c0, c1)",
+      makeRowVector({
+          firstVectorDictionary,
+          secondVectorDictionary,
+      }));
+
+  auto firstResult = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto secondResult =
+      makeFlatVector<int32_t>({16, 17, 18, 13, 14, 15, 10, 11, 12});
+
+  auto rowVector = makeRowVector({firstResult, secondResult});
+
+  // create the expected ArrayVector
+  auto expected = makeArrayVector({0, 3, 6}, rowVector);
+
+  assertEqualVectors(expected, result);
+}
 } // namespace


### PR DESCRIPTION
Summary:
Zip pessimistically assumes that the Arrays for a given row are different sizes.  This means it allocates nulls so it can fill in shorter arrays, and it dictionary encodes the elements from the original arrays.

If all the input vectors are "flat" ArrayVectors (this is stricter than what we need which is that they all have the same encoding, this is just a common, easy to check for case) and for every row all the arrays within that row are the same length (no need to add nulls) we don't have to allocate nulls or dictionary encode the elements.

This is a performance savings, since we have to do significantly less work, and if the elements are themselves flat, we can potentially take advantage of optimizations in downstream UDFs for flat Vectors.

Differential Revision: D36914803

