### PR TITLE
Install fbthrift

### DIFF
--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -94,4 +94,14 @@ cmake_install fmt -DFMT_TEST=OFF
 cmake_install folly
 # cmake_install ranges-v3
 
+(
+  git clone https://github.com/facebook/fbthrift &&
+  cd fbthrift &&
+  git checkout $FB_OS_VERSION &&
+  cd build &&
+  cmake -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DBUILD_TESTS=OFF .. &&
+  make "-j$(nproc)" &&
+  make install
+)
+
 dnf clean all

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -37,7 +37,7 @@ NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_DEPS="ninja cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
+MACOS_DEPS="ninja cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1 fizz wangle"
 
 function run_and_time {
   time "$@"
@@ -93,6 +93,18 @@ function install_double_conversion {
   cmake_install -DBUILD_TESTING=OFF
 }
 
+function install_fbthrift {
+  github_checkout facebook/fbthrift "${FB_OS_VERSION}"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF
+}
+
+function install_fizz {
+  github_checkout facebookincubator/fizz "${FB_OS_VERSION}"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF -S fizz
+}
+
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
   OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
@@ -109,6 +121,12 @@ function install_re2 {
   cmake_install -DRE2_BUILD_TESTING=OFF
 }
 
+function install_wangle {
+  github_checkout facebook/wangle "${FB_OS_VERSION}"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF -S wangle
+}
+
 function install_velox_deps {
   if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
     run_and_time install_build_prerequisites
@@ -118,6 +136,9 @@ function install_velox_deps {
   run_and_time install_double_conversion
   run_and_time install_folly
   run_and_time install_re2
+  run_and_time install_fizz
+  run_and_time install_wangle
+  run_and_time install_fbthrift
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -76,6 +76,11 @@ function install_fmt {
   cmake_install -DFMT_TEST=OFF
 }
 
+function install_fbthrift {
+  github_checkout facebook/fbthrift "${FB_OS_VERSION}"
+  cmake_install -DBUILD_TESTS=OFF
+}
+
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
   cmake_install -DBUILD_TESTS=OFF
@@ -84,6 +89,7 @@ function install_folly {
 function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_folly
+  run_and_time install_fbthrift
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -86,3 +86,13 @@ wait
 # Folly fails to build in release-mode due
 # AtomicUtil-inl.h:202: Error: operand type mismatch for `bts'
 cmake_install folly
+
+(
+  git clone https://github.com/facebook/fbthrift &&
+  cd fbthrift &&
+  git checkout $FB_OS_VERSION &&
+  cd build &&
+  cmake -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS" -DBUILD_TESTS=OFF .. &&
+  make "-j$(nproc)" &&
+  make install
+)


### PR DESCRIPTION
Thrift library is required for the new native Parquet reader. This
commit installs fbthrift for Velox.