### PR TITLE
Refactor integer readers to share boilerplate

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
+
+namespace facebook::velox::dwrf {
+
+// Abstract class for format and encoding-independent parts of reading ingeger
+// columns.
+class SelectiveIntegerColumnReader : public SelectiveColumnReader {
+ public:
+  SelectiveIntegerColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      StripeStreams& stripe,
+      common::ScanSpec* scanSpec,
+      const TypePtr& type)
+      : SelectiveColumnReader(
+            std::move(requestedType),
+            stripe,
+            scanSpec,
+            type) {}
+
+  void getValues(RowSet rows, VectorPtr* result) override {
+    getIntValues(rows, nodeType_->type.get(), result);
+  }
+
+ protected:
+  // Switches based on filter type between different readHelper instantiations.
+  template <typename Reader, bool isDense, typename ExtractValues>
+  void processFilter(
+      common::Filter* filter,
+      ExtractValues extractValues,
+      RowSet rows);
+
+  // Switches based on the type of ValueHook between different readWithVisitor
+  // instantiations.
+  template <typename Reader, bool isDence>
+  void processValueHook(RowSet rows, ValueHook* hook);
+
+  // Instantiates a Visitor based on type, isDense, value processing.
+  template <
+      typename Reader,
+      typename TFilter,
+      bool isDense,
+      typename ExtractValues>
+  void
+  readHelper(common::Filter* filter, RowSet rows, ExtractValues extractValues);
+
+  // The common part of integer reading. calls the appropriate
+  // instantiation of processValueHook or processFilter based on
+  // possible value hook, filter and denseness.
+  template <typename Reader>
+  void readCommon(RowSet rows);
+};
+
+template <
+    typename Reader,
+    typename TFilter,
+    bool isDense,
+    typename ExtractValues>
+void SelectiveIntegerColumnReader::readHelper(
+    common::Filter* filter,
+    RowSet rows,
+    ExtractValues extractValues) {
+  switch (valueSize_) {
+    case 2:
+      reinterpret_cast<Reader*>(this)->Reader::readWithVisitor(
+          rows,
+          ColumnVisitor<int16_t, TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+      break;
+
+    case 4:
+      reinterpret_cast<Reader*>(this)->Reader::readWithVisitor(
+          rows,
+          ColumnVisitor<int32_t, TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+
+      break;
+
+    case 8:
+      reinterpret_cast<Reader*>(this)->Reader::readWithVisitor(
+          rows,
+          ColumnVisitor<int64_t, TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+      break;
+    default:
+      VELOX_FAIL("Unsupported valueSize_ {}", valueSize_);
+  }
+}
+
+template <typename Reader, bool isDense, typename ExtractValues>
+void SelectiveIntegerColumnReader::processFilter(
+    common::Filter* filter,
+    ExtractValues extractValues,
+    RowSet rows) {
+  switch (filter ? filter->kind() : common::FilterKind::kAlwaysTrue) {
+    case common::FilterKind::kAlwaysTrue:
+      readHelper<Reader, common::AlwaysTrue, isDense>(
+          filter, rows, extractValues);
+      break;
+    case common::FilterKind::kIsNull:
+      filterNulls<int64_t>(
+          rows,
+          true,
+          !std::is_same<decltype(extractValues), DropValues>::value);
+      break;
+    case common::FilterKind::kIsNotNull:
+      if (std::is_same<decltype(extractValues), DropValues>::value) {
+        filterNulls<int64_t>(rows, false, false);
+      } else {
+        readHelper<Reader, common::IsNotNull, isDense>(
+            filter, rows, extractValues);
+      }
+      break;
+    case common::FilterKind::kBigintRange:
+      readHelper<Reader, common::BigintRange, isDense>(
+          filter, rows, extractValues);
+      break;
+    case common::FilterKind::kBigintValuesUsingHashTable:
+      readHelper<Reader, common::BigintValuesUsingHashTable, isDense>(
+          filter, rows, extractValues);
+      break;
+    case common::FilterKind::kBigintValuesUsingBitmask:
+      readHelper<Reader, common::BigintValuesUsingBitmask, isDense>(
+          filter, rows, extractValues);
+      break;
+    default:
+      readHelper<Reader, common::Filter, isDense>(filter, rows, extractValues);
+      break;
+  }
+}
+
+template <typename Reader, bool isDense>
+void SelectiveIntegerColumnReader::processValueHook(
+    RowSet rows,
+    ValueHook* hook) {
+  switch (hook->kind()) {
+    case aggregate::AggregationHook::kSumBigintToBigint:
+      readHelper<Reader, common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::SumHook<int64_t, int64_t>>(hook));
+      break;
+    case aggregate::AggregationHook::kBigintMax:
+      readHelper<Reader, common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::MinMaxHook<int64_t, false>>(hook));
+      break;
+    case aggregate::AggregationHook::kBigintMin:
+      readHelper<Reader, common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::MinMaxHook<int64_t, true>>(hook));
+      break;
+    default:
+      readHelper<Reader, common::AlwaysTrue, isDense>(
+          &alwaysTrue(), rows, ExtractToGenericHook(hook));
+  }
+}
+
+template <typename Reader>
+void SelectiveIntegerColumnReader::readCommon(RowSet rows) {
+  bool isDense = rows.back() == rows.size() - 1;
+  common::Filter* filter =
+      scanSpec_->filter() ? scanSpec_->filter() : &alwaysTrue();
+  if (scanSpec_->keepValues()) {
+    if (scanSpec_->valueHook()) {
+      if (isDense) {
+        processValueHook<Reader, true>(rows, scanSpec_->valueHook());
+      } else {
+        processValueHook<Reader, false>(rows, scanSpec_->valueHook());
+      }
+      return;
+    }
+    if (isDense) {
+      processFilter<Reader, true>(filter, ExtractToReader(this), rows);
+    } else {
+      processFilter<Reader, false>(filter, ExtractToReader(this), rows);
+    }
+  } else {
+    if (isDense) {
+      processFilter<Reader, true>(filter, DropValues(), rows);
+    } else {
+      processFilter<Reader, false>(filter, DropValues(), rows);
+    }
+  }
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -25,7 +25,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
     StripeStreams& stripe,
     common::ScanSpec* scanSpec,
     uint32_t numBytes)
-    : SelectiveColumnReader(
+    : SelectiveIntegerColumnReader(
           std::move(requestedType),
           stripe,
           scanSpec,
@@ -96,30 +96,7 @@ void SelectiveIntegerDictionaryColumnReader::read(
 
   // lazy load dictionary only when it's needed
   ensureInitialized();
-
-  bool isDense = rows.back() == rows.size() - 1;
-  common::Filter* filter = scanSpec_->filter();
-  if (scanSpec_->keepValues()) {
-    if (scanSpec_->valueHook()) {
-      if (isDense) {
-        processValueHook<true>(rows, scanSpec_->valueHook());
-      } else {
-        processValueHook<false>(rows, scanSpec_->valueHook());
-      }
-      return;
-    }
-    if (isDense) {
-      processFilter<true>(filter, ExtractToReader(this), rows);
-    } else {
-      processFilter<false>(filter, ExtractToReader(this), rows);
-    }
-  } else {
-    if (isDense) {
-      processFilter<true>(filter, DropValues(), rows);
-    } else {
-      processFilter<false>(filter, DropValues(), rows);
-    }
-  }
+  readCommon<SelectiveIntegerDictionaryColumnReader>(rows);
 }
 
 void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -16,11 +16,12 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveIntegerDictionaryColumnReader : public SelectiveColumnReader {
+class SelectiveIntegerDictionaryColumnReader
+    : public SelectiveIntegerColumnReader {
  public:
   using ValueType = int64_t;
 
@@ -55,27 +56,10 @@ class SelectiveIntegerDictionaryColumnReader : public SelectiveColumnReader {
   void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
       override;
 
-  void getValues(RowSet rows, VectorPtr* result) override {
-    getIntValues(rows, nodeType_->type.get(), result);
-  }
-
- private:
   template <typename ColumnVisitor>
   void readWithVisitor(RowSet rows, ColumnVisitor visitor);
 
-  template <bool isDense, typename ExtractValues>
-  void processFilter(
-      common::Filter* filter,
-      ExtractValues extractValues,
-      RowSet rows);
-
-  template <bool isDence>
-  void processValueHook(RowSet rows, ValueHook* hook);
-
-  template <typename TFilter, bool isDense, typename ExtractValues>
-  void
-  readHelper(common::Filter* filter, RowSet rows, ExtractValues extractValues);
-
+ private:
   void ensureInitialized();
 
   std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
@@ -92,100 +76,14 @@ void SelectiveIntegerDictionaryColumnReader::readWithVisitor(
     ColumnVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
   VELOX_CHECK_EQ(rleVersion_, RleVersion_1);
+  auto dictVisitor = visitor.toDictionaryColumnVisitor();
   auto reader = reinterpret_cast<RleDecoderV1<false>*>(dataReader_.get());
   if (nullsInReadRange_) {
-    reader->readWithVisitor<true>(nullsInReadRange_->as<uint64_t>(), visitor);
+    reader->readWithVisitor<true>(
+        nullsInReadRange_->as<uint64_t>(), dictVisitor);
   } else {
-    reader->readWithVisitor<false>(nullptr, visitor);
+    reader->readWithVisitor<false>(nullptr, dictVisitor);
   }
   readOffset_ += numRows;
 }
-
-template <typename TFilter, bool isDense, typename ExtractValues>
-void SelectiveIntegerDictionaryColumnReader::readHelper(
-    common::Filter* filter,
-    RowSet rows,
-    ExtractValues extractValues) {
-  switch (valueSize_) {
-    case 2:
-      readWithVisitor(
-          rows,
-          DictionaryColumnVisitor<int16_t, TFilter, ExtractValues, isDense>(
-              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
-      break;
-    case 4:
-      readWithVisitor(
-          rows,
-          DictionaryColumnVisitor<int32_t, TFilter, ExtractValues, isDense>(
-              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
-      break;
-
-    case 8:
-      readWithVisitor(
-          rows,
-          DictionaryColumnVisitor<int64_t, TFilter, ExtractValues, isDense>(
-              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
-      break;
-
-    default:
-      VELOX_FAIL("Unsupported valueSize_ {}", valueSize_);
-  }
-}
-
-template <bool isDense, typename ExtractValues>
-void SelectiveIntegerDictionaryColumnReader::processFilter(
-    common::Filter* filter,
-    ExtractValues extractValues,
-    RowSet rows) {
-  switch (filter ? filter->kind() : common::FilterKind::kAlwaysTrue) {
-    case common::FilterKind::kAlwaysTrue:
-      readHelper<common::AlwaysTrue, isDense>(filter, rows, extractValues);
-      break;
-    case common::FilterKind::kIsNull:
-      filterNulls<int64_t>(
-          rows,
-          true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
-      break;
-    case common::FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
-        filterNulls<int64_t>(rows, false, false);
-      } else {
-        readHelper<common::IsNotNull, isDense>(filter, rows, extractValues);
-      }
-      break;
-    case common::FilterKind::kBigintRange:
-      readHelper<common::BigintRange, isDense>(filter, rows, extractValues);
-      break;
-    case common::FilterKind::kBigintValuesUsingHashTable:
-      readHelper<common::BigintValuesUsingHashTable, isDense>(
-          filter, rows, extractValues);
-      break;
-    case common::FilterKind::kBigintValuesUsingBitmask:
-      readHelper<common::BigintValuesUsingBitmask, isDense>(
-          filter, rows, extractValues);
-      break;
-    default:
-      readHelper<common::Filter, isDense>(filter, rows, extractValues);
-      break;
-  }
-}
-
-template <bool isDense>
-void SelectiveIntegerDictionaryColumnReader::processValueHook(
-    RowSet rows,
-    ValueHook* hook) {
-  switch (hook->kind()) {
-    case aggregate::AggregationHook::kSumBigintToBigint:
-      readHelper<common::AlwaysTrue, isDense>(
-          &alwaysTrue(),
-          rows,
-          ExtractToHook<aggregate::SumHook<int64_t, int64_t>>(hook));
-      break;
-    default:
-      readHelper<common::AlwaysTrue, isDense>(
-          &alwaysTrue(), rows, ExtractToGenericHook(hook));
-  }
-}
-
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -30,30 +30,7 @@ void SelectiveIntegerDirectColumnReader::read(
     const uint64_t* incomingNulls) {
   VELOX_WIDTH_DISPATCH(
       sizeOfIntKind(type_->kind()), prepareRead, offset, rows, incomingNulls);
-  bool isDense = rows.back() == rows.size() - 1;
-  common::Filter* filter =
-      scanSpec_->filter() ? scanSpec_->filter() : &alwaysTrue();
-  if (scanSpec_->keepValues()) {
-    if (scanSpec_->valueHook()) {
-      if (isDense) {
-        processValueHook<true>(rows, scanSpec_->valueHook());
-      } else {
-        processValueHook<false>(rows, scanSpec_->valueHook());
-      }
-      return;
-    }
-    if (isDense) {
-      processFilter<true>(filter, ExtractToReader(this), rows);
-    } else {
-      processFilter<false>(filter, ExtractToReader(this), rows);
-    }
-  } else {
-    if (isDense) {
-      processFilter<true>(filter, DropValues(), rows);
-    } else {
-      processFilter<false>(filter, DropValues(), rows);
-    }
-  }
+  readCommon<SelectiveIntegerDirectColumnReader>(rows);
 }
 
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
The template instantiation logic for direct and dictionary integer
readers is the same. The difference is at the top of read() where we
seek different streams and at the bottom where we call different
decoders on different visitors.

Adds a conversion from direct to dictionary visitor. This supports
switching between encodings in mid-stripe.

This allows directly inheriting the integer logic for Parquet and Alpha.