### PR TITLE
json_extract_scalar() should always throw when path is invalid

### DIFF
--- a/velox/functions/prestosql/json/JsonExtractor.h
+++ b/velox/functions/prestosql/json/JsonExtractor.h
@@ -23,8 +23,6 @@
 
 namespace facebook::velox::functions {
 
-using JsonVector = std::vector<const folly::dynamic*>;
-
 /**
  * Extract a json object from path
  * @param json: A json object
@@ -72,20 +70,5 @@ folly::Optional<folly::dynamic> jsonExtract(
 folly::Optional<std::string> jsonExtractScalar(
     const std::string& json,
     const std::string& path);
-
-class JsonExtractor {
- public:
-  explicit JsonExtractor(const std::string& path);
-
-  folly::Optional<folly::dynamic> extract(const folly::dynamic* json);
-
- private:
-  void tokenize();
-
- private:
-  bool isValid_;
-  std::string path_;
-  std::vector<std::string> tokens_;
-};
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -415,13 +415,13 @@ TEST(JsonExtractorTest, fullJsonValueTest) {
 }
 
 TEST(JsonExtractorTest, invalidJsonPathTest) {
-  EXPECT_JSON_VALUE_NULL(""s, ""s);
+  EXPECT_THROW_INVALID_ARGUMENT(""s, ""s);
   EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$.bar[2][-1]"s);
   EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$.fuu..bar"s);
   EXPECT_THROW_INVALID_ARGUMENT("{}"s, "$."s);
-  EXPECT_JSON_VALUE_NULL(""s, "$$"s);
-  EXPECT_JSON_VALUE_NULL(""s, " "s);
-  EXPECT_JSON_VALUE_NULL(""s, "."s);
+  EXPECT_THROW_INVALID_ARGUMENT(""s, "$$"s);
+  EXPECT_THROW_INVALID_ARGUMENT(""s, " "s);
+  EXPECT_THROW_INVALID_ARGUMENT(""s, "."s);
   EXPECT_THROW_INVALID_ARGUMENT(
       "{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }"s,
       "$.store.book["s);

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -145,6 +145,7 @@ TEST_F(JsonExtractScalarTest, invalidPath) {
   EXPECT_THROW(json_extract_scalar(R"({"k1":"v1"})", "$k1"), VeloxUserError);
   EXPECT_THROW(json_extract_scalar(R"({"k1":"v1"})", "$.k1."), VeloxUserError);
   EXPECT_THROW(json_extract_scalar(R"({"k1":"v1"})", "$.k1]"), VeloxUserError);
+  EXPECT_THROW(json_extract_scalar(R"({"k1":"v1)", "$.k1]"), VeloxUserError);
 }
 
 // TODO: Folly tries to convert scalar integers, and in case they are large


### PR DESCRIPTION
Summary:
To follow the exact semantic in Presto, json_extract_scalar() should
always throw if the path provided is invalid. The previous code used to return
null in case the json was invalid.
Also refactoring the code to encapsulate more code into JsonExtractor and
remove it from the header, since it doesn't need to be part of the API.

Reviewed By: kagamiori

Differential Revision: D36394476

