### PR TITLE
Refactor EvalCtx::setWrapped to use moveOrCopyResult

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -165,7 +165,7 @@ class HiveDataSource : public DataSource {
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
   // passed. Populates filterEvalCtx_.selectedIndices and selectedBits if only
-  // some rows passed the filter. If no or all rows passed
+  // some rows passed the filter. If none or all rows passed
   // filterEvalCtx_.selectedIndices and selectedBits are not updated.
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1610,6 +1610,55 @@ TEST_F(TableScanTest, remainingFilter) {
       "SELECT c1, c2 FROM tmp WHERE c1 > c0");
 }
 
+/// Test the handling of constant remaining filter results which occur when
+/// filter input is a dictionary vector with all indices being the same (i.e.
+/// DictionaryVector::isConstant() == true).
+TEST_F(TableScanTest, remainingFilterConstantResult) {
+  /// Make 2 batches of 10K rows each. 10K is the default batch size in
+  /// TableScan. Use a pushed down and a remaining filter. Make it so that
+  /// pushed down filter passes only for a subset of rows from each batch, e.g.
+  /// pass for the first 100 rows in the first batch and for the first 5 rows
+  /// in the second batch. Then, use remaining filter that passes for a subset
+  /// of rows that passed the pushed down filter in the first batch and all rows
+  /// in the second batch. Make sure that remaining filter doesn't pass on the
+  /// first 5 rows in the first batch, e.g. passing row numbers for the first
+  /// batch start with 11. Also, make sure that remaining filter inputs for the
+  /// second batch are dictionary encoded and constant. This makes it so that
+  /// first batch is producing results using dictionary encoding with indices
+  /// starting at 11 and second batch cannot re-use these indices as they point
+  /// past the vector size (5).
+  vector_size_t size = 10'000;
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<StringView>(
+              size,
+              [](auto row) { return StringView(fmt::format("{}", row % 23)); }),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>(
+              size, [](auto row) { return row < 5 ? row : 1000; }),
+          makeFlatVector<StringView>(size, [](auto row) { return "15"_sv; }),
+      }),
+  };
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, data);
+  createDuckDbTable(data);
+
+  auto rowType = asRowType(data[0]->type());
+
+  auto plan =
+      PlanBuilder()
+          .tableScan(rowType, {"c0 < 100"}, "cast(c1 as bigint) % 23 > 10")
+          .planNode();
+
+  assertQuery(
+      plan,
+      {filePath},
+      "SELECT * FROM tmp WHERE c0 < 100 AND c1::bigint % 23 > 10");
+}
+
 TEST_F(TableScanTest, aggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/expression/ControlExpr.cpp
+++ b/velox/expression/ControlExpr.cpp
@@ -698,6 +698,10 @@ class ExprCallable : public Callable {
         rows.end(),
         std::move(allVectors));
     EvalCtx lambdaCtx(context->execCtx(), context->exprSet(), row.get());
+    if (!context->isFinalSelection()) {
+      *lambdaCtx.mutableIsFinalSelection() = false;
+      *lambdaCtx.mutableFinalSelection() = context->finalSelection();
+    }
     body_->eval(rows, lambdaCtx, *result);
   }
 


### PR DESCRIPTION
EvalCtx::setWrapped takes a result of evaluating an expression on the base
vector and wraps it using original wrapping (constant or dictionary). This
method has separate code paths for dictionary and constant wrappings and for
case when 'result' has some row filled out vs. result is empty.

The two code paths for dictionary should be logically equivalent. The two code
paths for constant should be logically equivalent as well. However, there are a
few (presumably unintentional) discrepancies. To avoid divergence and reduce
copy-paste, I'm replacing the code path for non-empty result with
moveOrCopyResult.

With this change expression evaluation produces constant and dictionary-encoded
results more often. This exposes 2 pre-existing bugs in lambda functions and
Hive connector. Fixes for these bugs are included.

- HiveConnector::next didn't handle correctly constant-encoded results of evaluating the remaining filter.
- Lambda functions didn't propagate the is-final-selection flag.
