### PR TITLE
Add NegatedValues filter classes for integers

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "velox/type/Filter.h"
+#include <velox/common/base/Exceptions.h>
+#include <cstdint>
+#include <limits>
+#include <memory>
 
 namespace facebook::velox::common {
 
@@ -42,6 +46,12 @@ std::string Filter::toString() const {
       strKind = "BigintValuesUsingHashTable";
       break;
     case FilterKind::kBigintValuesUsingBitmask:
+      strKind = "BigintValuesUsingBitmask";
+      break;
+    case FilterKind::kNegatedBigintValuesUsingHashTable:
+      strKind = "NegatedBigintValuesUsingHashTable";
+      break;
+    case FilterKind::kNegatedBigintValuesUsingBitmask:
       strKind = "BigintValuesUsingBitmask";
       break;
     case FilterKind::kDoubleRange:
@@ -276,6 +286,95 @@ bool BigintValuesUsingHashTable::testInt64Range(
   return max >= *it;
 }
 
+NegatedBigintValuesUsingBitmask::NegatedBigintValuesUsingBitmask(
+    int64_t min,
+    int64_t max,
+    const std::vector<int64_t>& values,
+    bool nullAllowed)
+    : Filter(true, nullAllowed, FilterKind::kNegatedBigintValuesUsingBitmask),
+      min_(min),
+      max_(max) {
+  VELOX_CHECK(min <= max, "min must be no greater than max");
+
+  nonNegated_ = std::make_unique<BigintValuesUsingBitmask>(
+      min, max, values, !nullAllowed);
+}
+
+bool NegatedBigintValuesUsingBitmask::testInt64Range(
+    int64_t min,
+    int64_t max,
+    bool hasNull) const {
+  if (hasNull && nullAllowed_) {
+    return true;
+  }
+
+  if (min == max) {
+    return testInt64(min);
+  }
+
+  // boundary checks: if max < min_ then min < min_ as well and vice versa
+  // since part of the range is outside the bitmask, the endpoint is accepted
+  if (min < min_ || max > max_) {
+    return true;
+  }
+
+  // check the range manually
+  for (int i = min; i <= max; ++i) {
+    if (!nonNegated_->testInt64(i)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+NegatedBigintValuesUsingHashTable::NegatedBigintValuesUsingHashTable(
+    int64_t min,
+    int64_t max,
+    const std::vector<int64_t>& values,
+    bool nullAllowed)
+    : Filter(
+          true,
+          nullAllowed,
+          FilterKind::kNegatedBigintValuesUsingHashTable) {
+  nonNegated_ = std::make_unique<BigintValuesUsingHashTable>(
+      min, max, values, !nullAllowed);
+}
+
+bool NegatedBigintValuesUsingHashTable::testInt64Range(
+    int64_t min,
+    int64_t max,
+    bool hasNull) const {
+  if (hasNull && nullAllowed_) {
+    return true;
+  }
+
+  if (min == max) {
+    return testInt64(min);
+  }
+
+  if (min > nonNegated_->max() || max < nonNegated_->min()) {
+    return true;
+  }
+
+  auto lo = std::lower_bound(
+      nonNegated_->values().begin(), nonNegated_->values().end(), min);
+  auto hi = std::lower_bound(
+      nonNegated_->values().begin(), nonNegated_->values().end(), max);
+  assert(
+      lo !=
+      nonNegated_->values().end()); // min is already tested to be <= max_.
+  if (min != *lo || max != *hi) {
+    // at least one of the endpoints of the range succeeds
+    return true;
+  }
+  // Check if all values in this range are in values_ by counting the number
+  // of things between min and max
+  // if distance is any less, then we are missing an element => something
+  // in the range is accepted
+  return (std::distance(lo, hi) != max - min);
+}
+
 namespace {
 std::unique_ptr<Filter> nullOrFalse(bool nullAllowed) {
   if (nullAllowed) {
@@ -283,16 +382,22 @@ std::unique_ptr<Filter> nullOrFalse(bool nullAllowed) {
   }
   return std::make_unique<AlwaysFalse>();
 }
-} // namespace
 
-std::unique_ptr<Filter> createBigintValues(
+std::unique_ptr<Filter> createBigintValueFilter(
     const std::vector<int64_t>& values,
-    bool nullAllowed) {
+    bool nullAllowed,
+    bool negated) {
   if (values.empty()) {
-    return nullOrFalse(nullAllowed);
+    if (!negated) {
+      return nullOrFalse(nullAllowed);
+    }
+    if (nullAllowed) {
+      return std::make_unique<AlwaysTrue>();
+    }
+    return std::make_unique<IsNotNull>();
   }
-
-  if (values.size() == 1) {
+  // single-value filter aka ==, the != filter is handled below
+  if (values.size() == 1 && !negated) {
     return std::make_unique<BigintRange>(
         values.front(), values.front(), nullAllowed);
   }
@@ -311,17 +416,60 @@ std::unique_ptr<Filter> createBigintValues(
   int64_t range;
   bool overflow = __builtin_sub_overflow(max, min, &range);
   if (LIKELY(!overflow)) {
+    // all accepted/rejected values form one contiguous block
     if (range + 1 == values.size()) {
-      return std::make_unique<BigintRange>(min, max, nullAllowed);
+      if (!negated) {
+        return std::make_unique<BigintRange>(min, max, nullAllowed);
+      }
+      std::vector<std::unique_ptr<BigintRange>> ranges;
+      // add inclusive ranges for above and below the desired range of values
+      if (min != std::numeric_limits<int64_t>::min()) {
+        ranges.emplace_back(std::make_unique<BigintRange>(
+            std::numeric_limits<int64_t>::min(), min - 1, nullAllowed));
+      }
+      if (max != std::numeric_limits<int64_t>::max()) {
+        ranges.emplace_back(std::make_unique<BigintRange>(
+            max + 1, std::numeric_limits<int64_t>::max(), nullAllowed));
+      }
+      // all values are rejected
+      if (ranges.size() == 0) {
+        return nullOrFalse(nullAllowed);
+      }
+      // range above or range below does not exist
+      if (ranges.size() == 1) {
+        return std::move(ranges[0]);
+      }
+      return std::make_unique<BigintMultiRange>(std::move(ranges), nullAllowed);
     }
 
     if (range < 32 * 64 || range < values.size() * 4 * 64) {
+      if (negated) {
+        return std::make_unique<NegatedBigintValuesUsingBitmask>(
+            min, max, values, nullAllowed);
+      }
       return std::make_unique<BigintValuesUsingBitmask>(
           min, max, values, nullAllowed);
     }
   }
+  if (negated) {
+    return std::make_unique<NegatedBigintValuesUsingHashTable>(
+        min, max, values, nullAllowed);
+  }
   return std::make_unique<BigintValuesUsingHashTable>(
       min, max, values, nullAllowed);
+}
+} // namespace
+
+std::unique_ptr<Filter> createBigintValues(
+    const std::vector<int64_t>& values,
+    bool nullAllowed) {
+  return createBigintValueFilter(values, nullAllowed, false);
+}
+
+std::unique_ptr<Filter> createNegatedBigintValues(
+    const std::vector<int64_t>& values,
+    bool nullAllowed) {
+  return createBigintValueFilter(values, nullAllowed, true);
 }
 
 BigintMultiRange::BigintMultiRange(
@@ -925,6 +1073,19 @@ std::unique_ptr<Filter> BigintValuesUsingBitmask::mergeWith(
     default:
       VELOX_UNREACHABLE();
   }
+}
+
+std::unique_ptr<Filter> NegatedBigintValuesUsingHashTable::mergeWith(
+    const Filter* other) const {
+  // TODO: Add this method to merge with null and other integer filters
+  // and update other mergeWith methods to match
+  VELOX_NYI("Negated-values merge is not supported yet");
+}
+
+std::unique_ptr<Filter> NegatedBigintValuesUsingBitmask::mergeWith(
+    const Filter* other) const {
+  // TODO: Add this method to merge with null and other integer filters
+  VELOX_NYI("Negated-values merge is not supported yet");
 }
 
 std::unique_ptr<Filter> BigintValuesUsingBitmask::mergeWith(

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -39,6 +39,8 @@ enum class FilterKind {
   kBigintRange,
   kBigintValuesUsingHashTable,
   kBigintValuesUsingBitmask,
+  kNegatedBigintValuesUsingHashTable,
+  kNegatedBigintValuesUsingBitmask,
   kDoubleRange,
   kFloatRange,
   kBytesRange,
@@ -758,6 +760,138 @@ class BigintValuesUsingBitmask final : public Filter {
   const int64_t max_;
 };
 
+// NOT IN-list filter for integral data types. Implemented as a hash table. Good
+// for large number of rejected values that do not fit within a small range.
+class NegatedBigintValuesUsingHashTable final : public Filter {
+ public:
+  /// @param min Minimum REJECTED value.
+  /// @param max Maximum REJECTED value.
+  /// @param values A list of unique values that fail the filter. Must contain
+  /// at least two entries.
+  /// @param nullAllowed Null values are passing the filter if true.
+  NegatedBigintValuesUsingHashTable(
+      int64_t min,
+      int64_t max,
+      const std::vector<int64_t>& values,
+      bool nullAllowed);
+
+  NegatedBigintValuesUsingHashTable(
+      const NegatedBigintValuesUsingHashTable& other,
+      bool nullAllowed)
+      : Filter(true, nullAllowed, other.kind()),
+        nonNegated_(dynamic_cast<BigintValuesUsingHashTable*>(
+            other.nonNegated_->clone(!nullAllowed).release())) {}
+
+  std::unique_ptr<Filter> clone(
+      std::optional<bool> nullAllowed = std::nullopt) const final {
+    if (nullAllowed) {
+      return std::make_unique<NegatedBigintValuesUsingHashTable>(
+          *this, nullAllowed.value());
+    } else {
+      return std::make_unique<NegatedBigintValuesUsingHashTable>(
+          *this, nullAllowed_);
+    }
+  }
+
+  bool testInt64(int64_t value) const final {
+    return !nonNegated_->testInt64(value);
+  }
+  xsimd::batch_bool<int64_t> testValues(xsimd::batch<int64_t> x) const final {
+    return ~nonNegated_->testValues(x);
+  }
+  xsimd::batch_bool<int32_t> testValues(xsimd::batch<int32_t> x) const final {
+    return ~nonNegated_->testValues(x);
+  }
+  xsimd::batch_bool<int16_t> testValues(xsimd::batch<int16_t> x) const final {
+    return Filter::testValues(x);
+  }
+  bool testInt64Range(int64_t min, int64_t max, bool hashNull) const final;
+
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
+
+  int64_t min() const {
+    return nonNegated_->min();
+  }
+
+  int64_t max() const {
+    return nonNegated_->max();
+  }
+
+  const std::vector<int64_t>& values() const {
+    return nonNegated_->values();
+  }
+
+  std::string toString() const final {
+    return fmt::format(
+        "NegatedBigintValuesUsingHashTable: [{}, {}] {}",
+        nonNegated_->min(),
+        nonNegated_->max(),
+        nullAllowed_ ? "with nulls" : "no nulls");
+  }
+
+ private:
+  std::unique_ptr<Filter>
+  mergeWith(int64_t min, int64_t max, const Filter* other) const;
+
+  std::unique_ptr<BigintValuesUsingHashTable> nonNegated_;
+};
+
+/// NOT IN-list filter for integral data types. Implemented as a bitmask. Offers
+/// better performance than the hash table when the range of values is small.
+class NegatedBigintValuesUsingBitmask final : public Filter {
+ public:
+  /// @param min Minimum REJECTED value.
+  /// @param max Maximum REJECTED value.
+  /// @param values A list of unique values that pass the filter. Must contain
+  /// at least two entries.
+  /// @param nullAllowed Null values are passing the filter if true.
+  NegatedBigintValuesUsingBitmask(
+      int64_t min,
+      int64_t max,
+      const std::vector<int64_t>& values,
+      bool nullAllowed);
+
+  NegatedBigintValuesUsingBitmask(
+      const NegatedBigintValuesUsingBitmask& other,
+      bool nullAllowed)
+      : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBitmask),
+        min_(other.min_),
+        max_(other.max_),
+        nonNegated_(dynamic_cast<BigintValuesUsingBitmask*>(
+            other.nonNegated_->clone(!nullAllowed).release())) {}
+
+  std::unique_ptr<Filter> clone(
+      std::optional<bool> nullAllowed = std::nullopt) const final {
+    if (nullAllowed) {
+      return std::make_unique<NegatedBigintValuesUsingBitmask>(
+          *this, nullAllowed.value());
+    } else {
+      return std::make_unique<NegatedBigintValuesUsingBitmask>(
+          *this, nullAllowed_);
+    }
+  }
+
+  std::vector<int64_t> values() const {
+    return nonNegated_->values();
+  }
+
+  bool testInt64(int64_t value) const final {
+    return !nonNegated_->testInt64(value);
+  }
+
+  bool testInt64Range(int64_t min, int64_t max, bool hasNull) const final;
+
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
+
+ private:
+  std::unique_ptr<Filter>
+  mergeWith(int64_t min, int64_t max, const Filter* other) const;
+
+  int min_;
+  int max_;
+  std::unique_ptr<BigintValuesUsingBitmask> nonNegated_;
+};
+
 /// Base class for range filters on floating point and string data types.
 class AbstractRange : public Filter {
  public:
@@ -1356,6 +1490,11 @@ static inline bool applyFilter(TFilter& filter, StringView value) {
 
 // Creates a hash or bitmap based IN filter depending on value distribution.
 std::unique_ptr<Filter> createBigintValues(
+    const std::vector<int64_t>& values,
+    bool nullAllowed);
+
+// Creates a hash or bitmap based NOT IN filter depending on value distribution.
+std::unique_ptr<Filter> createNegatedBigintValues(
     const std::vector<int64_t>& values,
     bool nullAllowed);
 

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -50,3 +50,18 @@ target_link_libraries(
   gtest_main
   ${gflags_LIBRARIES}
   glog::glog)
+
+add_executable(velox_negated_values_filter_benchmark
+               NegatedValuesFilterBenchmark.cpp)
+
+target_link_libraries(
+  velox_negated_values_filter_benchmark
+  velox_type
+  velox_serialization
+  ${FOLLY}
+  ${FOLLY_BENCHMARK}
+  ${DOUBLE_CONVERSION}
+  gtest
+  gtest_main
+  ${gflags_LIBRARIES}
+  glog::glog)

--- a/velox/type/tests/NegatedValuesFilterBenchmark.cpp
+++ b/velox/type/tests/NegatedValuesFilterBenchmark.cpp
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include "folly/Benchmark.h"
+#include "folly/Portability.h"
+#include "folly/Random.h"
+#include "folly/Varint.h"
+#include "folly/init/Init.h"
+#include "folly/lang/Bits.h"
+#include "velox/dwio/common/exception/Exception.h"
+
+#include "velox/type/Filter.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+
+std::vector<int64_t> verySparseValues;
+std::vector<int64_t> sparseValues;
+std::vector<int64_t> mediumValues;
+std::vector<int64_t> denseValues;
+std::vector<int64_t> veryDenseValues;
+std::vector<int64_t> extremelyDenseValues; // used for testing != only
+std::vector<int64_t> randomValues;
+std::vector<std::unique_ptr<Filter>> newFilters;
+std::vector<std::unique_ptr<Filter>> oldFilters;
+
+int32_t filterOld(int filterNum, const std::vector<int64_t>& data) {
+  int32_t count = 0;
+  for (auto i = 0; i < data.size(); ++i) {
+    if (oldFilters[filterNum]->testInt64(data[i]))
+      ++count;
+  }
+  return count;
+}
+
+int32_t filterNew(int filterNum, const std::vector<int64_t>& data) {
+  int32_t count = 0;
+  for (auto i = 0; i < data.size(); ++i) {
+    if (newFilters[filterNum]->testInt64(data[i]))
+      ++count;
+  }
+  return count;
+}
+
+BENCHMARK(verySparseOldNotEqual) {
+  // expect to remove about 1 out of every 1,000,000 values
+  folly::doNotOptimizeAway(filterOld(0, verySparseValues));
+}
+
+BENCHMARK_RELATIVE(verySparseNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, verySparseValues));
+}
+
+BENCHMARK(sparseOldNotEqual) {
+  // expect to remove about 1 out of every 100,000 values
+  folly::doNotOptimizeAway(filterOld(0, sparseValues));
+}
+
+BENCHMARK_RELATIVE(sparseNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, sparseValues));
+}
+
+BENCHMARK(mediumOldNotEqual) {
+  // expect to remove about 1 out of every 15,000 values (< 0.1%)
+  folly::doNotOptimizeAway(filterOld(0, mediumValues));
+}
+
+BENCHMARK_RELATIVE(mediumNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, mediumValues));
+}
+
+BENCHMARK(denseOldNotEqual) {
+  // expect to remove about 1 out of every 3,000 values
+  folly::doNotOptimizeAway(filterOld(0, denseValues));
+}
+
+BENCHMARK_RELATIVE(denseNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, denseValues));
+}
+
+BENCHMARK(veryDenseOldNotEqual) {
+  // expect to remove about 1 out of every 1,050 values
+  folly::doNotOptimizeAway(filterOld(0, veryDenseValues));
+}
+
+BENCHMARK_RELATIVE(veryDenseNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, veryDenseValues));
+}
+
+BENCHMARK(extremelyDenseOldNotEqual) {
+  // expect to remove about 1 out of every 20 values (5%)
+  folly::doNotOptimizeAway(filterOld(0, extremelyDenseValues));
+}
+
+BENCHMARK_RELATIVE(extremelyDenseNewNotEqual) {
+  folly::doNotOptimizeAway(filterNew(0, extremelyDenseValues));
+}
+
+BENCHMARK(verySparseOld10) {
+  // expect to remove about 1 out of every 100,000 values
+  folly::doNotOptimizeAway(filterOld(1, verySparseValues));
+}
+
+BENCHMARK_RELATIVE(verySparseNew10) {
+  folly::doNotOptimizeAway(filterNew(1, verySparseValues));
+}
+
+BENCHMARK(sparseOld10) {
+  // expect to remove about 1 out of every 10,000 values
+  folly::doNotOptimizeAway(filterOld(1, sparseValues));
+}
+
+BENCHMARK_RELATIVE(sparseNew10) {
+  folly::doNotOptimizeAway(filterNew(1, sparseValues));
+}
+
+BENCHMARK(mediumOld10) {
+  // expect to remove about 1 out of every 1,500 values
+  folly::doNotOptimizeAway(filterOld(1, mediumValues));
+}
+
+BENCHMARK_RELATIVE(mediumNew10) {
+  folly::doNotOptimizeAway(filterNew(1, mediumValues));
+}
+
+BENCHMARK(denseOld10) {
+  // expect to remove about 1 out of every 300 values
+  folly::doNotOptimizeAway(filterOld(1, denseValues));
+}
+
+BENCHMARK_RELATIVE(denseNew10) {
+  folly::doNotOptimizeAway(filterNew(1, denseValues));
+}
+
+BENCHMARK(veryDenseOld10) {
+  // expect to remove about 1 out of every 105 values or about 1%
+  folly::doNotOptimizeAway(filterOld(1, veryDenseValues));
+}
+
+BENCHMARK_RELATIVE(veryDenseNew10) {
+  folly::doNotOptimizeAway(filterNew(1, veryDenseValues));
+}
+
+BENCHMARK(extremelyDenseOld10) {
+  // expect to remove about half the values (50%)
+  folly::doNotOptimizeAway(filterOld(1, extremelyDenseValues));
+}
+
+BENCHMARK_RELATIVE(extremelyDenseNew10) {
+  folly::doNotOptimizeAway(filterNew(1, extremelyDenseValues));
+}
+
+BENCHMARK(verySparseOld100) {
+  // expect to remove about 1 out of every 10,000 values
+  folly::doNotOptimizeAway(filterOld(2, verySparseValues));
+}
+
+BENCHMARK_RELATIVE(verySparseNew100) {
+  folly::doNotOptimizeAway(filterNew(2, verySparseValues));
+}
+
+BENCHMARK(sparseOld100) {
+  // expect to remove about 1 out of every 1,000 values
+  folly::doNotOptimizeAway(filterOld(2, sparseValues));
+}
+
+BENCHMARK_RELATIVE(sparseNew100) {
+  folly::doNotOptimizeAway(filterNew(2, sparseValues));
+}
+
+BENCHMARK(mediumOld100) {
+  // expect to remove about 1 out of every 150 values
+  folly::doNotOptimizeAway(filterOld(2, mediumValues));
+}
+
+BENCHMARK_RELATIVE(mediumNew100) {
+  folly::doNotOptimizeAway(filterNew(2, mediumValues));
+}
+
+BENCHMARK(denseOld100) {
+  // expect to remove about 1 out of every 30 values (3%)
+  folly::doNotOptimizeAway(filterOld(2, denseValues));
+}
+
+BENCHMARK_RELATIVE(denseNew100) {
+  folly::doNotOptimizeAway(filterNew(2, denseValues));
+}
+
+BENCHMARK(veryDenseOld100) {
+  // expect to remove about 1 out of every 10.5 values (9%)
+  folly::doNotOptimizeAway(filterOld(2, veryDenseValues));
+}
+
+BENCHMARK_RELATIVE(veryDenseNew100) {
+  folly::doNotOptimizeAway(filterNew(2, veryDenseValues));
+}
+
+BENCHMARK(verySparseOld1000) {
+  // expect to remove about 1 out of every 1,000 values
+  folly::doNotOptimizeAway(filterOld(3, verySparseValues));
+}
+
+BENCHMARK_RELATIVE(verySparseNew1000) {
+  folly::doNotOptimizeAway(filterNew(3, verySparseValues));
+}
+
+BENCHMARK(sparseOld1000) {
+  // expect to remove about 1 out of every 100 values (1%)
+  folly::doNotOptimizeAway(filterOld(3, sparseValues));
+}
+
+BENCHMARK_RELATIVE(sparseNew1000) {
+  folly::doNotOptimizeAway(filterNew(3, sparseValues));
+}
+
+BENCHMARK(mediumOld1000) {
+  // expect to remove about 1 out of every 15 values (7%)
+  folly::doNotOptimizeAway(filterOld(3, mediumValues));
+}
+
+BENCHMARK_RELATIVE(mediumNew1000) {
+  folly::doNotOptimizeAway(filterNew(3, mediumValues));
+}
+
+BENCHMARK(denseOld1000) {
+  // expect to remove about 1 out of every 3 values (33%)
+  folly::doNotOptimizeAway(filterOld(3, denseValues));
+}
+
+BENCHMARK_RELATIVE(denseNew1000) {
+  folly::doNotOptimizeAway(filterNew(3, denseValues));
+}
+
+BENCHMARK(veryDenseOld1000) {
+  // expect to remove about 1 out of every 1.05 values (95%)
+  folly::doNotOptimizeAway(filterOld(3, veryDenseValues));
+}
+
+BENCHMARK_RELATIVE(veryDenseNew1000) {
+  folly::doNotOptimizeAway(filterNew(3, veryDenseValues));
+}
+
+BENCHMARK(verySparseOld10000) {
+  // expect to remove about 1 out of every 100 values
+  folly::doNotOptimizeAway(filterOld(4, verySparseValues));
+}
+
+BENCHMARK_RELATIVE(verySparseNew10000) {
+  folly::doNotOptimizeAway(filterNew(4, verySparseValues));
+}
+
+BENCHMARK(sparseOld10000) {
+  // expect to remove about 1 out of every 10 values (10%)
+  folly::doNotOptimizeAway(filterOld(4, sparseValues));
+}
+
+BENCHMARK_RELATIVE(sparseNew10000) {
+  folly::doNotOptimizeAway(filterNew(4, sparseValues));
+}
+
+BENCHMARK(mediumOld10000) {
+  // expect to remove about two-thirds of the values (66%)
+  folly::doNotOptimizeAway(filterOld(4, mediumValues));
+}
+
+BENCHMARK_RELATIVE(mediumNew10000) {
+  folly::doNotOptimizeAway(filterNew(4, mediumValues));
+}
+
+BENCHMARK(denseOld10000) {
+  // removes all the values
+  folly::doNotOptimizeAway(filterOld(4, denseValues));
+}
+
+BENCHMARK_RELATIVE(denseNew10000) {
+  folly::doNotOptimizeAway(filterNew(4, denseValues));
+}
+
+// various tests to see if other factors impact the tests
+
+BENCHMARK(greaterSpreadOld) {
+  // removes about 10% of the values, but they're spread apart more
+  // checking to see if a greater spread in the ranges affects anything
+  folly::doNotOptimizeAway(filterOld(5, sparseValues));
+}
+
+BENCHMARK_RELATIVE(greaterSpreadNew) {
+  folly::doNotOptimizeAway(filterNew(5, sparseValues));
+}
+
+BENCHMARK(bitmaskOld) {
+  // removes about 10% of the values
+  folly::doNotOptimizeAway(filterOld(6, veryDenseValues));
+}
+
+BENCHMARK_RELATIVE(bitmaskNew) {
+  folly::doNotOptimizeAway(filterNew(6, veryDenseValues));
+}
+
+BENCHMARK(randomOld3Val) {
+  // removes about 3 out of a million values
+  folly::doNotOptimizeAway(filterOld(7, randomValues));
+}
+
+BENCHMARK_RELATIVE(randomNew3Val) {
+  folly::doNotOptimizeAway(filterNew(7, randomValues));
+}
+
+BENCHMARK(randomOld10Val) {
+  // removes about 10 out of a million values
+  folly::doNotOptimizeAway(filterOld(8, randomValues));
+}
+
+BENCHMARK_RELATIVE(randomNew10Val) {
+  folly::doNotOptimizeAway(filterNew(8, randomValues));
+}
+
+BENCHMARK(randomOld100Val) {
+  // removes about 100 out of a million values
+  folly::doNotOptimizeAway(filterOld(9, randomValues));
+}
+
+BENCHMARK_RELATIVE(randomNew100Val) {
+  folly::doNotOptimizeAway(filterNew(9, randomValues));
+}
+
+BENCHMARK(randomOld1000Val) {
+  // removes about 1000 out of a million values
+  folly::doNotOptimizeAway(filterOld(10, randomValues));
+}
+
+BENCHMARK_RELATIVE(randomNew1000Val) {
+  folly::doNotOptimizeAway(filterNew(10, randomValues));
+}
+
+BENCHMARK(randomOld10000Val) {
+  // removes about 1% of the million values (10,000)
+  folly::doNotOptimizeAway(filterOld(11, randomValues));
+}
+
+BENCHMARK_RELATIVE(randomNew10000Val) {
+  folly::doNotOptimizeAway(filterNew(11, randomValues));
+}
+
+int32_t main(int32_t argc, char* argv[]) {
+  constexpr int32_t kNumValues = 1000000;
+  // first one represents a != filter, the rest are "NOT IN" filters
+  std::vector<int32_t> kFilterSizes = {1, 5, 100, 1000, 10000, 10, 100};
+  std::vector<int32_t> kFilterIntervals = {
+      1000, 1000, 1000, 1000, 1000, 10000, 10};
+  folly::init(&argc, &argv);
+
+  for (auto j = 0; j < kFilterSizes.size(); ++j) {
+    std::vector<int64_t> filterValues;
+    std::vector<std::unique_ptr<common::BigintRange>> subfilters;
+    filterValues.reserve(kFilterSizes[j]);
+    subfilters.reserve(kFilterSizes[j]);
+    int64_t start = std::numeric_limits<int64_t>::min();
+    for (auto i = 0; i < kFilterSizes[j]; ++i) {
+      filterValues.emplace_back(i * kFilterIntervals[j]);
+      subfilters.emplace_back(std::make_unique<common::BigintRange>(
+          start, i * kFilterIntervals[j] - 1, false));
+      start = i * kFilterIntervals[j] + 1;
+    }
+    subfilters.emplace_back(std::make_unique<common::BigintRange>(
+        start, std::numeric_limits<int64_t>::max(), false));
+    newFilters.emplace_back(createNegatedBigintValues(filterValues, false));
+    oldFilters.emplace_back(std::make_unique<common::BigintMultiRange>(
+        std::move(subfilters), false));
+  }
+
+  std::vector<int32_t> kRandSizes = {3, 10, 100, 1000, 10000};
+  // generate some random filters of numbers between 1 and 1,000,000
+  for (auto size : kRandSizes) {
+    std::unordered_set<int64_t> rejects;
+    while (rejects.size() < size) {
+      rejects.insert(folly::Random::rand64() % 1000000);
+    }
+    std::vector<int64_t> rejectedValues;
+    rejectedValues.reserve(rejects.size());
+    for (auto it = rejects.begin(); it != rejects.end(); ++it) {
+      rejectedValues.emplace_back(*it);
+    }
+    sort(rejectedValues.begin(), rejectedValues.end());
+    newFilters.emplace_back(createNegatedBigintValues(rejectedValues, false));
+    std::vector<std::unique_ptr<common::BigintRange>> subfilters;
+    int64_t start = std::numeric_limits<int64_t>::min();
+
+    for (auto i = 0; i < size; ++i) {
+      if (rejectedValues[i] != start) {
+        subfilters.emplace_back(std::make_unique<common::BigintRange>(
+            start, rejectedValues[i] - 1, false));
+      }
+      start = rejectedValues[i] + 1;
+    }
+    subfilters.emplace_back(std::make_unique<common::BigintRange>(
+        start, std::numeric_limits<int64_t>::max(), false));
+    oldFilters.emplace_back(std::make_unique<common::BigintMultiRange>(
+        std::move(subfilters), false));
+  }
+
+  veryDenseValues.resize(kNumValues);
+  denseValues.resize(kNumValues);
+  mediumValues.resize(kNumValues);
+  sparseValues.resize(kNumValues);
+  verySparseValues.resize(kNumValues);
+  extremelyDenseValues.resize(kNumValues);
+  randomValues.resize(kNumValues);
+
+  for (auto i = 0; i < kNumValues; ++i) {
+    extremelyDenseValues[i] = (folly::Random::rand32() % 20) * 1000;
+    veryDenseValues[i] = (folly::Random::rand32() % 1050) * 1000;
+    denseValues[i] = (folly::Random::rand32() % 3000) * 1000;
+    mediumValues[i] = (folly::Random::rand32() % 15000) * 1000;
+    sparseValues[i] = (folly::Random::rand32() % 100000) * 1000;
+    verySparseValues[i] = (folly::Random::rand32() % 1000000) * 1000;
+    randomValues[i] = (folly::Random::rand32() % 1000000);
+  }
+
+  // comment out this section to speed up testing + skip verifying correctness
+
+  VELOX_CHECK_EQ(
+      filterOld(0, extremelyDenseValues), filterNew(0, extremelyDenseValues));
+  for (int i = 0; i < newFilters.size(); ++i) {
+    VELOX_CHECK_EQ(
+        filterOld(i, verySparseValues), filterNew(i, verySparseValues));
+    VELOX_CHECK_EQ(filterOld(i, sparseValues), filterNew(i, sparseValues));
+    VELOX_CHECK_EQ(filterOld(i, mediumValues), filterNew(i, mediumValues));
+    VELOX_CHECK_EQ(filterOld(i, denseValues), filterNew(i, denseValues));
+    VELOX_CHECK_EQ(
+        filterOld(i, veryDenseValues), filterNew(i, veryDenseValues));
+    VELOX_CHECK_EQ(filterOld(i, randomValues), filterNew(i, randomValues));
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
This diff adds the `NegatedBigintValuesUsingBitmask` and `NegatedBigintValuesUsingHashTable` classes to `Filter.h`. These classes are meant to be used with filters in the form `NOT IN [list]` and `!= <value>`.

Implementations for the relevant `testInt64` and `testInt64Range` methods, as well as constructors methods have been added to `Filter.cpp`. Additionally, the `createNegatedBigintValues` function has been added to the `common` namespace, which takes a vector of values rejected by the filter and creates either a bitmask or hash-table NegatedValues filter as is appropriate for the given data set. These methods are similar to the corresponding ones for the `BigintValues` filters that are already implemented. The next thing to implement is the `mergeWith` methods, which will be created in a future diff.

Tests were also added to `FilterTest.cpp` for all of the newly-implemented classes.

Differential Revision: D36974472

