### PR TITLE
Publish task_id in task completion event.

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1170,7 +1170,8 @@ uint64_t Task::timeSinceEndMs() const {
 void Task::onTaskCompletion() {
   listeners().withRLock([&](auto& listeners) {
     for (auto& listener : listeners) {
-      listener->onTaskCompletion(uuid_, state_, exception_, taskStats_);
+      listener->onTaskCompletion(
+          uuid_, taskId_, state_, exception_, taskStats_);
     }
   });
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -706,6 +706,7 @@ class TaskListener {
   /// failure as well as runtime statistics about task execution.
   virtual void onTaskCompletion(
       const std::string& taskUuid,
+      const std::string& taskId,
       TaskState state,
       std::exception_ptr error,
       TaskStats stats) = 0;

--- a/velox/exec/tests/TaskListenerTest.cpp
+++ b/velox/exec/tests/TaskListenerTest.cpp
@@ -47,6 +47,7 @@ class TestTaskListener : public exec::TaskListener {
 
   void onTaskCompletion(
       const std::string& taskUuid,
+      const std::string& taskId,
       exec::TaskState state,
       std::exception_ptr error,
       exec::TaskStats stats) override {


### PR DESCRIPTION
Summary: Task id is application specific and does not necessarily be unique. We publish the task id in completion event as well, so that caller can log application specific task id.

Differential Revision: D36997358

