### PR TITLE
Reset StringViews in FlatVector::prepareForReuse

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -362,24 +362,6 @@ void FlatVector<T>::prepareForReuse() {
     values_ = nullptr;
     rawValues_ = nullptr;
   }
-
-  // Check string buffers. Keep at most one singly-referenced buffer if it is
-  // not too large.
-  if (!stringBuffers_.empty()) {
-    auto& firstBuffer = stringBuffers_.front();
-    if (firstBuffer->unique() && firstBuffer->isMutable() &&
-        firstBuffer->capacity() <= kMaxStringSizeForReuse) {
-      firstBuffer->setSize(0);
-      stringBuffers_.resize(1);
-    } else {
-      stringBuffers_.clear();
-    }
-  }
-
-  // Clear ASCII-ness.
-  if constexpr (std::is_same_v<T, StringView>) {
-    SimpleVector<StringView>::invalidateIsAscii();
-  }
 }
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -402,6 +402,9 @@ void FlatVector<bool>::copyValuesAndNulls(
 template <>
 Buffer* FlatVector<StringView>::getBufferWithSpace(vector_size_t size);
 
+template <>
+void FlatVector<StringView>::prepareForReuse();
+
 template <typename T>
 using FlatVectorPtr = std::shared_ptr<FlatVector<T>>;
 

--- a/velox/vector/tests/VectorPrepareForReuseTest.cpp
+++ b/velox/vector/tests/VectorPrepareForReuseTest.cpp
@@ -76,6 +76,11 @@ TEST_F(VectorPrepareForReuseTest, strings) {
     ASSERT_EQ(originalVector, vector.get());
     ASSERT_EQ(originalBytes, vector->retainedSize());
 
+    // Verify that StringViews are reset to empty strings.
+    for (auto i = 0; i < vector->size(); i++) {
+      ASSERT_EQ("", vector->asFlatVector<StringView>()->valueAt(i).str());
+    }
+
     for (auto i = 0; i < vector->size(); i++) {
       vector->asFlatVector<StringView>()->set(i, stringAt(i));
     }


### PR DESCRIPTION
FlatVector::prepareForReuse deallocates all but one string buffer leaving
StringViews referencing freed memory. Reset the StringViews to avoid
referencing freed memory.

Also, moved StringView-specific implementation of FlatVector::prepareForReuse 
to .cpp file to speed up incremental builds.