### PR TITLE
Fix FlatVector<StringView>::set

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -346,7 +346,10 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
     rowsToCopy.applyToSelected(
         [&](vector_size_t row) { rawNewValues[row] = rawValues_[row]; });
 
-    // string buffers are append only, hence, safe to share
+    // Keep the string buffers even if multiply referenced. These are
+    // append-only and are written to in FlatVector::set which calls
+    // getBufferWithSpace which allocates a new buffer if existing buffers
+    // are multiply-referenced.
 
     // TODO Optimization: check and remove string buffers not referenced by
     // rowsToCopy

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -197,11 +197,15 @@ void FlatVector<bool>::copyValuesAndNulls(
 
 template <>
 Buffer* FlatVector<StringView>::getBufferWithSpace(vector_size_t size) {
+  // Check if the last buffer is uniquely referenced and has enough space.
   Buffer* buffer =
       stringBuffers_.empty() ? nullptr : stringBuffers_.back().get();
-  if (buffer && buffer->size() + size <= buffer->capacity()) {
+  if (buffer && buffer->unique() &&
+      buffer->size() + size <= buffer->capacity()) {
     return buffer;
   }
+
+  // Allocate a new buffer.
   int32_t newSize = std::max(kInitialStringSize, size);
   BufferPtr newBuffer = AlignedBuffer::allocate<char>(newSize, pool());
   newBuffer->setSize(0);


### PR DESCRIPTION
It is possible to have two FlatVectors in two threads share string buffers. In
this case, calling FlatVector::set from two threads at the same time creates a
race condition:

- [t1] FlatVector<StringView>::set(i, "longish string")
- [t2] FlatVector<StringView>::set(i, "longish string")
- [t1] FlatVector<StringView>::getBufferWithSpace(14): buffer size is 10, capacity 32 -> enough space, use that buffer
- [t2] FlatVector<StringView>::getBufferWithSpace(14): buffer size is 10, capacity 32 -> enough space, use that buffer
- [t1] append "longish string" to the buffer making buffer size 10 + 14 = 24
- [t1] try to append "longish string" to the buffer that now holds 24 bytes with 12 bytes available - FAILURE: size <= capacity_ (34 vs. 32)

To fix this, modify getBufferWithSpace to check that buffer has enough space and
is uniquely referenced. Otherwise, make a new buffer.

Before modifying a vector, the caller is expected to call
BaseVector::ensureWritable which checks if the vector and buffers are uniquely
referenced and if not allocates new vector and buffers. However, ensureWritable
doesn't check that string buffers are uniquely referenced. An alternative fix
would be to modify ensureWritable to check string buffers and make a copy if
these are not uniquely referenced.

The reason for making a change in FlatVector::set instead is because often
strings are written by copying StringViews and referencing the buffers, not by
writing the strings into the buffers. Hence, aggressively copying string
buffers in ensureWritable will perform costly copying unnecessarily.

```
template <>
void FlatVector<StringView>::copy(
    const BaseVector* source,
    const SelectivityVector& rows,
    const vector_size_t* toSourceRow) {
  ...

  auto leaf = source->wrappedVector()->asUnchecked<SimpleVector<StringView>>();

  if (pool_ == leaf->pool()) {
    // We copy referencing the storage of 'source'.
    copyValuesAndNulls(source, rows, toSourceRow);
    acquireSharedStringBuffers(source);
  } else {
    rows.applyToSelected([&](vector_size_t row) {
      auto sourceRow = toSourceRow ? toSourceRow[row] : row;
      if (source->isNullAt(sourceRow)) {
        setNull(row, true);
      } else {
        set(row, leaf->valueAt(source->wrappedIndex(sourceRow)));
      }
    });
  }
  ...
}
```