### PR TITLE
Min/max(REAL) aggregations should have REAL intermediate type.

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -525,7 +525,7 @@ bool registerMinMaxAggregate(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType :
-       {"tinyint", "smallint", "integer", "bigint", "timestamp", "real"}) {
+       {"tinyint", "smallint", "integer", "bigint", "timestamp"}) {
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .returnType(inputType)
                              .intermediateType("bigint")


### PR DESCRIPTION
Summary:
Because of the weird case of Presto having BIGINT intermediate type for min/max(REAL) we had it too.
Now this changes and for Prestissimo we will have proper type support.
Removing min/max(REAL) -> BIGINT -> REAL.
This, actually, does not prevent from running Presto's aggregation with BIGINT intermediate type, so no errors will be at the moment.
As https://github.com/prestodb/presto/pull/17857 is incorporated into the Presto build we use for coordinator, we will have proper min/max(REAL) -> REAL -> REAL execution.

Differential Revision: D37050583

