### PR TITLE
Change accumulator type for max/min of REAL types

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -525,7 +525,7 @@ bool registerMinMaxAggregate(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType :
-       {"tinyint", "smallint", "integer", "bigint", "timestamp", "real"}) {
+       {"tinyint", "smallint", "integer", "bigint", "timestamp"}) {
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .returnType(inputType)
                              .intermediateType("bigint")


### PR DESCRIPTION
Summary:
Accumulator type for max/min of REAL types used to by bigint to
maintain compatibility with Presto, but this makes it harder to validate
against DuckDB queries as results are truncated (and might differe in some
cases). This diff reverts the change to use float as intermediate types.

Differential Revision: D37050565

