### PR TITLE
Add max_data_size_for_stats aggregate

### DIFF
--- a/velox/docs/functions/aggregate.rst
+++ b/velox/docs/functions/aggregate.rst
@@ -88,7 +88,7 @@ General Aggregate Functions
 
 .. function:: max_data_size_for_stats(x) -> bigint
 
-    Returns the maximum size of all input values.
+    Returns the maximum in-memory size in bytes of ``x``.
 
 Bitwise Aggregate Functions
 ---------------------------

--- a/velox/docs/functions/aggregate.rst
+++ b/velox/docs/functions/aggregate.rst
@@ -86,6 +86,10 @@ General Aggregate Functions
 
     Returns the sum of all input values.
 
+.. function:: max_data_size_for_stats(x) -> bigint
+
+    Returns the maximum size of all input values.
+
 Bitwise Aggregate Functions
 ---------------------------
 

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -51,5 +51,5 @@ const char* const kSum = "sum";
 const char* const kVariance = "variance"; // Alias for var_samp.
 const char* const kVarPop = "var_pop";
 const char* const kVarSamp = "var_samp";
-const char* const kMaxSizeForStats = "$internal$max_data_size_for_stats";
+const char* const kMaxSizeForStats = "max_data_size_for_stats";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -51,5 +51,5 @@ const char* const kSum = "sum";
 const char* const kVariance = "variance"; // Alias for var_samp.
 const char* const kVarPop = "var_pop";
 const char* const kVarSamp = "var_samp";
-
+const char* const kMaxSizeForStats = "$internal$max_data_size_for_stats";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
   add_subdirectory(benchmarks)
@@ -43,7 +44,8 @@ add_library(
   SumAggregate.cpp
   SumAggregate.h
   ValueList.cpp
-  VarianceAggregates.cpp)
+  VarianceAggregates.cpp
+  MaxSizeForStatsAggregate.cpp)
 
 target_link_libraries(velox_aggregates velox_functions_hyperloglog velox_exec
-                      ${FOLLY_WITH_DEPENDENCIES})
+                      velox_presto_serializer ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -127,7 +127,7 @@ class MaxSizeForStatsAggregate
   }
 
  protected:
-  void upsertOneAccumulatorNew(
+  void updateOneAccumulator(
       char* const group,
       std::vector<vector_size_t>& rowSizes,
       vector_size_t idx) {
@@ -154,12 +154,12 @@ class MaxSizeForStatsAggregate
     if (decoded_.isConstantMapping()) {
       estimateSerializedSizes(arg, rows, 1);
       rows.applyToSelected([&](vector_size_t i) {
-        upsertOneAccumulatorNew(groups[i], elementSizes_, 0);
+        updateOneAccumulator(groups[i], elementSizes_, 0);
       });
     } else {
       estimateSerializedSizes(arg, rows, rows.countSelected());
       rows.applyToSelected([&](vector_size_t i) {
-        upsertOneAccumulatorNew(
+        updateOneAccumulator(
             groups[i], elementSizes_, selectToElementSizesIndexMap_[i]);
       });
     }
@@ -203,26 +203,19 @@ class MaxSizeForStatsAggregate
       }
       // Estimate first element because it is constant mapping.
       estimateSerializedSizes(arg, rows, 1);
-      upsertOneAccumulatorNew(group, elementSizes_, 0);
+      updateOneAccumulator(group, elementSizes_, 0);
       return;
     }
 
     estimateSerializedSizes(arg, rows, rows.countSelected());
     rows.applyToSelected([&](vector_size_t i) {
-      upsertOneAccumulatorNew(
+      updateOneAccumulator(
           group, elementSizes_, selectToElementSizesIndexMap_[i]);
     });
   }
 };
 
 bool registerMaxSizeForStatsAggregate(const std::string& name) {
-  // Types here are used by PlanBuilder to populate partial and final
-  // aggregation input and output types. E.g. intermediate results will be of
-  // type vector<intermediateType> and used to serve as the input vector type to
-  // final aggregation. argumentType is type of vector to AddRawInput
-  // intermediateType is the type of vector that extractAccumulator write to and
-  // that addIntermediateResults reads out of
-  // returnType is the type of vector that extractValues write to.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -39,7 +39,8 @@ add_executable(
   MapAggTest.cpp
   MapUnionAggregationTest.cpp
   ValueListTest.cpp
-  VarianceAggregationTest.cpp)
+  VarianceAggregationTest.cpp
+  MaxSizeForStatsTest.cpp)
 
 add_test(
   NAME velox_aggregates_test

--- a/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class MaxSizeForStatsTest : public AggregationTestBase {
+ public:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    disableSpill();
+  }
+};
+
+// Input:
+// c0(bigint)|c1(tinyint)
+// null|null
+// Query:
+// select aggr(c0),aggr(c1)
+// Output
+// null|null
+TEST_F(MaxSizeForStatsTest, nullValues) {
+  auto vectors = {makeRowVector({
+      makeNullableFlatVector(std::vector<std::optional<int64_t>>{std::nullopt}),
+      makeNullableFlatVector(std::vector<std::optional<int8_t>>{std::nullopt}),
+  })};
+
+  testAggregations(
+      vectors,
+      {},
+      {"\"$internal$max_data_size_for_stats\"(c0)",
+       "\"$internal$max_data_size_for_stats\"(c1)"},
+      "SELECT NULL, NULL");
+}
+
+// Input:
+// c0(bigint)|c1(tinyint)
+// null|null
+// 0 | 0
+// Query:
+// select aggr(c0),aggr(c1)
+// Output
+// 8|1
+TEST_F(MaxSizeForStatsTest, nullAndNonNullValues) {
+  auto vectors = {makeRowVector({
+      makeNullableFlatVector<int64_t>({std::nullopt, 0}),
+      makeNullableFlatVector<int8_t>({std::nullopt, 0}),
+  })};
+
+  testAggregations(
+      vectors,
+      {},
+      {"\"$internal$max_data_size_for_stats\"(c0)",
+       "\"$internal$max_data_size_for_stats\"(c1)"},
+      "SELECT 8, 1");
+}
+
+// Input:
+// c0(bigint)|c1(tinyint)|c2(smallint)|c3(integer)|c4(bigint)|c5(real)|c6(double)
+// 1|rand()|rand()|rand()|rand()|rand()|rand()
+// 2|rand()|rand()|rand()|rand()|rand()|rand()
+// 1|rand()|rand()|rand()|rand()|rand()|rand()
+// 2|rand()|rand()|rand()|rand()|rand()|rand()
+// Query:
+// select aggr(c1),aggr(c2),aggr(c3),aggr(c4),aggr(c5),aggr(c6) group by c0;
+// Output
+// 1|1|2|4|8|4|8
+// 2|1|2|4|8|4|8
+TEST_F(MaxSizeForStatsTest, allScalarTypes) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(std::vector<int64_t>{1, 2, 1, 2}),
+       makeFlatVector<int8_t>(4),
+       makeFlatVector<int16_t>(4),
+       makeFlatVector<int32_t>(4),
+       makeFlatVector<int64_t>(4),
+       makeFlatVector<float>(4),
+       makeFlatVector<double>(4),
+       makeFlatVector<bool>(4),
+       makeFlatVector<Date>(4),
+       makeFlatVector<Timestamp>(4)})};
+
+  // With grouping keys.
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"\"$internal$max_data_size_for_stats\"(c1)",
+       "\"$internal$max_data_size_for_stats\"(c2)",
+       "\"$internal$max_data_size_for_stats\"(c3)",
+       "\"$internal$max_data_size_for_stats\"(c4)",
+       "\"$internal$max_data_size_for_stats\"(c5)",
+       "\"$internal$max_data_size_for_stats\"(c6)",
+       "\"$internal$max_data_size_for_stats\"(c7)",
+       "\"$internal$max_data_size_for_stats\"(c8)",
+       "\"$internal$max_data_size_for_stats\"(c9)"},
+      "SELECT * FROM (VALUES (1,1,2,4,8,4,8,1,4,16),(2,1,2,4,8,4,8,1,4,16))");
+
+  // Without grouping keys.
+  testAggregations(
+      vectors,
+      {},
+      {"\"$internal$max_data_size_for_stats\"(c1)",
+       "\"$internal$max_data_size_for_stats\"(c2)",
+       "\"$internal$max_data_size_for_stats\"(c3)",
+       "\"$internal$max_data_size_for_stats\"(c4)",
+       "\"$internal$max_data_size_for_stats\"(c5)",
+       "\"$internal$max_data_size_for_stats\"(c6)",
+       "\"$internal$max_data_size_for_stats\"(c7)",
+       "\"$internal$max_data_size_for_stats\"(c8)",
+       "\"$internal$max_data_size_for_stats\"(c9)"},
+      "SELECT * FROM (VALUES (1,2,4,8,4,8,1,4,16))");
+}
+
+// Input:
+// c0(array(bigint))
+// [1,2,3,4,5]
+// []
+// [1,2,3]
+// Query:
+// select aggr(c0)
+// Output
+// 44
+TEST_F(MaxSizeForStatsTest, arrayGlobalAggregate) {
+  auto vectors = {makeRowVector({makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 5},
+      {},
+      {1, 2, 3},
+  })})};
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 44");
+}
+
+// Input:
+// c0(map(tinyint,integer))
+// map(array(1,1,1,1,1),array(1,1,1,1,1))
+// map()
+// map(array(1,1,1), array(1,1,1))
+// Query:
+// select aggr(c0)
+// Output
+// 29
+TEST_F(MaxSizeForStatsTest, mapGlobalAggregate) {
+  auto vectors = {makeRowVector({makeMapVector<int8_t, int32_t>(
+      {{{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}},
+       {},
+       {{1, 1}, {1, 1}, {1, 1}}})})};
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 29");
+}
+
+// Input:
+// c0( row(array(bigint), map(tinyint,integer))
+// row(aray[1,2,3,4,5], map(array(1,1,1,1,1),array(1,1,1,1,1)))
+// row(array[], map())
+// row(array[1,2,3], map(array(1,1,1), array(1,1,1)))
+// Query:
+// select aggr(c0)
+// Output
+// 77
+TEST_F(MaxSizeForStatsTest, rowGlobalAggregate) {
+  auto vectors = {makeRowVector({makeRowVector(
+      {makeArrayVector<int64_t>({
+           {1, 2, 3, 4, 5},
+           {},
+           {1, 2, 3},
+       }),
+       makeMapVector<int8_t, int32_t>(
+           {{{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}},
+            {},
+            {{1, 1}, {1, 1}, {1, 1}}})})})};
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 77");
+}
+
+// Input:
+// c0(varbinary)
+// "buf"
+// ""
+// "hello"
+// query:
+// select aggr(c0)
+// output:
+// 9
+TEST_F(MaxSizeForStatsTest, varbinaryGlobalAggregate) {
+  VectorPtr varbinary_vector = BaseVector::create(VARBINARY(), 3, pool());
+  auto flat_vector = varbinary_vector->asFlatVector<StringView>();
+  StringView sv1{"buf"};
+  StringView sv2{""};
+  StringView sv3{"henlo"};
+  flat_vector->set(0, sv1);
+  flat_vector->set(1, sv2);
+  flat_vector->set(2, sv3);
+
+  auto vectors = {makeRowVector({varbinary_vector})};
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 9");
+}
+
+// Input:
+// c0(varchar)
+// "{1, 2, 3, 4, 5}"
+// "{}"
+// "{1, 2, 3}"
+// query:
+// select aggr(c0)
+// output:
+// 19
+TEST_F(MaxSizeForStatsTest, varcharGlobalAggregate) {
+  auto vectors = {makeRowVector({makeFlatVector<StringView>({
+      "{1, 2, 3, 4, 5}",
+      "{}",
+      "{1, 2, 3}",
+  })})};
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 19");
+}
+
+// Input (3 rows of recursive complex data):
+// c0(row(varchar, map(tinyint, bigint)))
+// ("{1, 2, 3, 4, 5}", {1:null,})
+// ("{}", {2:[4,5,null]})
+// ("{1, 2, 3}", {null:[7,8,9]})
+// query:
+// select aggr(c0)
+// output:
+// 50 (3rd row(4), 13("{1, 2, 3}") + 5 (null) + 28([7,8,9]))
+TEST_F(MaxSizeForStatsTest, complexRecursiveGlobalAggregate) {
+  auto vectors = {makeRowVector({makeRowVector(
+      {makeFlatVector<StringView>({
+           "{1, 2, 3, 4, 5}",
+           "{}",
+           "{1, 2, 3}",
+       }),
+       createMapOfArraysVector<int8_t, int64_t>(
+           {{{1, std::nullopt}},
+            {{2, {{4, 5, std::nullopt}}}},
+            {{std::nullopt, {{7, 8, 9}}}}})})})};
+
+  testAggregations(
+      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 50");
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
@@ -26,7 +26,7 @@ class MaxSizeForStatsTest : public AggregationTestBase {
  public:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    disableSpill();
+    allowInputShuffle();
   }
 };
 
@@ -47,16 +47,16 @@ TEST_F(MaxSizeForStatsTest, nullValues) {
   testAggregations(
       vectors,
       {},
-      {"\"$internal$max_data_size_for_stats\"(c0)",
-       "\"$internal$max_data_size_for_stats\"(c1)",
-       "\"$internal$max_data_size_for_stats\"(c2)",
-       "\"$internal$max_data_size_for_stats\"(c3)",
-       "\"$internal$max_data_size_for_stats\"(c4)",
-       "\"$internal$max_data_size_for_stats\"(c5)",
-       "\"$internal$max_data_size_for_stats\"(c6)",
-       "\"$internal$max_data_size_for_stats\"(c7)",
-       "\"$internal$max_data_size_for_stats\"(c8)",
-       "\"$internal$max_data_size_for_stats\"(c9)"},
+      {"\"max_data_size_for_stats\"(c0)",
+       "\"max_data_size_for_stats\"(c1)",
+       "\"max_data_size_for_stats\"(c2)",
+       "\"max_data_size_for_stats\"(c3)",
+       "\"max_data_size_for_stats\"(c4)",
+       "\"max_data_size_for_stats\"(c5)",
+       "\"max_data_size_for_stats\"(c6)",
+       "\"max_data_size_for_stats\"(c7)",
+       "\"max_data_size_for_stats\"(c8)",
+       "\"max_data_size_for_stats\"(c9)"},
       "SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL");
 }
 
@@ -77,16 +77,16 @@ TEST_F(MaxSizeForStatsTest, nullAndNonNullValues) {
   testAggregations(
       vectors,
       {},
-      {"\"$internal$max_data_size_for_stats\"(c0)",
-       "\"$internal$max_data_size_for_stats\"(c1)",
-       "\"$internal$max_data_size_for_stats\"(c2)",
-       "\"$internal$max_data_size_for_stats\"(c3)",
-       "\"$internal$max_data_size_for_stats\"(c4)",
-       "\"$internal$max_data_size_for_stats\"(c5)",
-       "\"$internal$max_data_size_for_stats\"(c6)",
-       "\"$internal$max_data_size_for_stats\"(c7)",
-       "\"$internal$max_data_size_for_stats\"(c8)",
-       "\"$internal$max_data_size_for_stats\"(c9)"},
+      {"\"max_data_size_for_stats\"(c0)",
+       "\"max_data_size_for_stats\"(c1)",
+       "\"max_data_size_for_stats\"(c2)",
+       "\"max_data_size_for_stats\"(c3)",
+       "\"max_data_size_for_stats\"(c4)",
+       "\"max_data_size_for_stats\"(c5)",
+       "\"max_data_size_for_stats\"(c6)",
+       "\"max_data_size_for_stats\"(c7)",
+       "\"max_data_size_for_stats\"(c8)",
+       "\"max_data_size_for_stats\"(c9)"},
       "SELECT 1, 2, 4, 8, 4, 8, 1, 4, 16, 16");
 }
 
@@ -115,30 +115,30 @@ TEST_F(MaxSizeForStatsTest, allScalarTypes) {
   testAggregations(
       vectors,
       {"c0"},
-      {"\"$internal$max_data_size_for_stats\"(c1)",
-       "\"$internal$max_data_size_for_stats\"(c2)",
-       "\"$internal$max_data_size_for_stats\"(c3)",
-       "\"$internal$max_data_size_for_stats\"(c4)",
-       "\"$internal$max_data_size_for_stats\"(c5)",
-       "\"$internal$max_data_size_for_stats\"(c6)",
-       "\"$internal$max_data_size_for_stats\"(c7)",
-       "\"$internal$max_data_size_for_stats\"(c8)",
-       "\"$internal$max_data_size_for_stats\"(c9)"},
+      {"\"max_data_size_for_stats\"(c1)",
+       "\"max_data_size_for_stats\"(c2)",
+       "\"max_data_size_for_stats\"(c3)",
+       "\"max_data_size_for_stats\"(c4)",
+       "\"max_data_size_for_stats\"(c5)",
+       "\"max_data_size_for_stats\"(c6)",
+       "\"max_data_size_for_stats\"(c7)",
+       "\"max_data_size_for_stats\"(c8)",
+       "\"max_data_size_for_stats\"(c9)"},
       "VALUES (1,1,2,4,8,4,8,1,4,16),(2,1,2,4,8,4,8,1,4,16)");
 
   // Without grouping keys.
   testAggregations(
       vectors,
       {},
-      {"\"$internal$max_data_size_for_stats\"(c1)",
-       "\"$internal$max_data_size_for_stats\"(c2)",
-       "\"$internal$max_data_size_for_stats\"(c3)",
-       "\"$internal$max_data_size_for_stats\"(c4)",
-       "\"$internal$max_data_size_for_stats\"(c5)",
-       "\"$internal$max_data_size_for_stats\"(c6)",
-       "\"$internal$max_data_size_for_stats\"(c7)",
-       "\"$internal$max_data_size_for_stats\"(c8)",
-       "\"$internal$max_data_size_for_stats\"(c9)"},
+      {"\"max_data_size_for_stats\"(c1)",
+       "\"max_data_size_for_stats\"(c2)",
+       "\"max_data_size_for_stats\"(c3)",
+       "\"max_data_size_for_stats\"(c4)",
+       "\"max_data_size_for_stats\"(c5)",
+       "\"max_data_size_for_stats\"(c6)",
+       "\"max_data_size_for_stats\"(c7)",
+       "\"max_data_size_for_stats\"(c8)",
+       "\"max_data_size_for_stats\"(c9)"},
       "VALUES (1,2,4,8,4,8,1,4,16)");
 }
 
@@ -149,7 +149,7 @@ TEST_F(MaxSizeForStatsTest, arrayGlobalAggregate) {
       {1, 2, 3},
   })})};
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 44");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 44");
 }
 
 TEST_F(MaxSizeForStatsTest, mapGlobalAggregate) {
@@ -158,7 +158,7 @@ TEST_F(MaxSizeForStatsTest, mapGlobalAggregate) {
        {},
        {{1, 1}, {1, 1}, {1, 1}}})})};
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 29");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 29");
 }
 
 TEST_F(MaxSizeForStatsTest, rowGlobalAggregate) {
@@ -173,7 +173,7 @@ TEST_F(MaxSizeForStatsTest, rowGlobalAggregate) {
             {},
             {{1, 1}, {1, 1}, {1, 1}}})})})};
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 77");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 77");
 }
 
 TEST_F(MaxSizeForStatsTest, varbinaryGlobalAggregate) {
@@ -188,7 +188,7 @@ TEST_F(MaxSizeForStatsTest, varbinaryGlobalAggregate) {
 
   auto vectors = {makeRowVector({varbinaryVector})};
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 18");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 18");
 }
 
 TEST_F(MaxSizeForStatsTest, varcharGlobalAggregate) {
@@ -198,7 +198,7 @@ TEST_F(MaxSizeForStatsTest, varcharGlobalAggregate) {
       "{1, 2, 3}",
   })})};
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 19");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 19");
 }
 
 TEST_F(MaxSizeForStatsTest, complexRecursiveGlobalAggregate) {
@@ -214,11 +214,11 @@ TEST_F(MaxSizeForStatsTest, complexRecursiveGlobalAggregate) {
             {{std::nullopt, {{7, 8, 9}}}}})})})};
 
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c0)"}, "SELECT 50");
+      vectors, {}, {"\"max_data_size_for_stats\"(c0)"}, "SELECT 50");
 }
 
 TEST_F(MaxSizeForStatsTest, constantEncodingTest) {
-  auto columnOne = makeFlatVector<int64_t>({1, 2, 3});
+  auto columnOne = makeFlatVector<int64_t>({1, 2, 1});
   auto columnTwo = makeRowVector(
       {makeFlatVector<StringView>({
            "{1, 2, 3, 4, 5}",
@@ -234,17 +234,17 @@ TEST_F(MaxSizeForStatsTest, constantEncodingTest) {
   auto vectors = {makeRowVector({columnOne, columnTwoConstantEncoded})};
 
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c1)"}, "SELECT 36");
+      vectors, {}, {"\"max_data_size_for_stats\"(c1)"}, "SELECT 36");
 
   testAggregations(
       vectors,
       {"c0"},
-      {"\"$internal$max_data_size_for_stats\"(c1)"},
-      "VALUES (1,36),(2,36),(3,36)");
+      {"\"max_data_size_for_stats\"(c1)"},
+      "VALUES (1,36),(2,36)");
 }
 
 TEST_F(MaxSizeForStatsTest, dictionaryEncodingTest) {
-  auto columnOne = makeFlatVector<int64_t>({1, 2, 3});
+  auto columnOne = makeFlatVector<int64_t>({1, 2, 1});
   auto columnTwo = makeRowVector(
       {makeFlatVector<StringView>({
            "{1, 2, 3, 4, 5}",
@@ -266,13 +266,13 @@ TEST_F(MaxSizeForStatsTest, dictionaryEncodingTest) {
   auto vectors = {makeRowVector({columnOne, columnTwoDictionaryEncoded})};
 
   testAggregations(
-      vectors, {}, {"\"$internal$max_data_size_for_stats\"(c1)"}, "SELECT 50");
+      vectors, {}, {"\"max_data_size_for_stats\"(c1)"}, "SELECT 50");
 
   testAggregations(
       vectors,
       {"c0"},
-      {"\"$internal$max_data_size_for_stats\"(c1)"},
-      "VALUES (1,32),(2,36),(3,50)");
+      {"\"max_data_size_for_stats\"(c1)"},
+      "VALUES (1,50),(2,36)");
 }
 
 } // namespace


### PR DESCRIPTION
Add support for max_data_size_for_stats aggregate.

Supported types are:
BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, DOUBLE, REAL, MAP, ROW, ARRAY, DATE, TIMESTAMP, VARBINARY, VARCHAR.

For reference: https://github.com/prestodb/presto/pull/11150