### PR TITLE
Ensure TPC-H DBGEN speed advances seeds

### DIFF
--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -83,6 +83,32 @@ DBGenIterator DBGenIterator::create(size_t scaleFactor) {
   return DBGenIterator(dbGenLease->getLease(scaleFactor));
 }
 
+void DBGenIterator::initNation(size_t offset) {
+  sd_nation(NATION, offset);
+}
+
+void DBGenIterator::initRegion(size_t offset) {
+  sd_region(REGION, offset);
+}
+
+void DBGenIterator::initOrder(size_t offset) {
+  sd_order(ORDER, offset);
+  sd_line(LINE, offset);
+}
+
+void DBGenIterator::initSupplier(size_t offset) {
+  sd_supp(SUPP, offset);
+}
+
+void DBGenIterator::initPart(size_t offset) {
+  sd_part(PART, offset);
+  sd_psupp(PSUPP, offset);
+}
+
+void DBGenIterator::initCustomer(size_t offset) {
+  sd_cust(CUST, offset);
+}
+
 void DBGenIterator::genNation(size_t index, code_t& code) {
   row_start(NATION);
   mk_nation(index, &code);

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -40,6 +40,16 @@ class DBGenIterator {
   // internal lock).
   static DBGenIterator create(size_t scaleFactor);
 
+  // Before generating records using the gen*() functions below, call the
+  // appropriate init*() function to correctly initialize the seed given the
+  // offset to be generated.
+  void initNation(size_t offset);
+  void initRegion(size_t offset);
+  void initOrder(size_t offset);
+  void initSupplier(size_t offset);
+  void initPart(size_t offset);
+  void initCustomer(size_t offset);
+
   // Generate different types of records.
   void genNation(size_t index, code_t& code);
   void genRegion(size_t index, code_t& code);

--- a/velox/tpch/gen/TpchGen.cpp
+++ b/velox/tpch/gen/TpchGen.cpp
@@ -347,6 +347,7 @@ RowVectorPtr genTpchOrders(
   auto commentVector = children[8]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initOrder(offset);
   order_t order;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it
@@ -404,6 +405,7 @@ RowVectorPtr genTpchLineItem(
   auto commentVector = children[15]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initOrder(ordersOffset);
   order_t order;
 
   // Dbgen can't generate lineItem one row at a time; instead, it generates
@@ -483,6 +485,7 @@ RowVectorPtr genTpchPart(
   auto commentVector = children[8]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initPart(offset);
   part_t part;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it
@@ -524,6 +527,7 @@ RowVectorPtr genTpchSupplier(
   auto commentVector = children[6]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initSupplier(offset);
   supplier_t supp;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it
@@ -574,6 +578,8 @@ RowVectorPtr genTpchPartSupp(
   size_t partIdx = offset / SUPP_PER_PART;
   size_t partSuppIdx = offset % SUPP_PER_PART;
   size_t partSuppCount = 0;
+
+  dbgenIt.initPart(partIdx);
 
   do {
     dbgenIt.genPart(partIdx + 1, part);
@@ -626,6 +632,7 @@ RowVectorPtr genTpchCustomer(
   auto commentVector = children[7]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initCustomer(offset);
   customer_t cust;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it
@@ -668,6 +675,7 @@ RowVectorPtr genTpchNation(
   auto commentVector = children[3]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initNation(offset);
   code_t code;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it
@@ -700,6 +708,7 @@ RowVectorPtr genTpchRegion(
   auto commentVector = children[2]->asFlatVector<StringView>();
 
   auto dbgenIt = DBGenIterator::create(scaleFactor);
+  dbgenIt.initRegion(offset);
   code_t code;
 
   // Dbgen generates the dataset one row at a time, so we need to transpose it

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -110,6 +110,15 @@ TEST(TpchGenTestNation, reproducible) {
   for (size_t i = 0; i < rowVector4->size(); ++i) {
     ASSERT_TRUE(rowVector4->equalValueAt(rowVector5.get(), i, i));
   }
+
+  // Ensure it's also reproducible if we generate batches starting in
+  // different offsets.
+  auto rowVector6 = genTpchNation(100, 0);
+  auto rowVector7 = genTpchNation(90, 10);
+
+  for (size_t i = 0; i < rowVector7->size(); ++i) {
+    ASSERT_TRUE(rowVector7->equalValueAt(rowVector6.get(), i, i + 10));
+  }
 }
 
 // Region.
@@ -157,6 +166,13 @@ TEST(TpchGenTestRegion, reproducible) {
     ASSERT_TRUE(rowVector1->equalValueAt(rowVector2.get(), i, i));
     ASSERT_TRUE(rowVector1->equalValueAt(rowVector3.get(), i, i));
   }
+
+  auto rowVector4 = genTpchRegion(100, 0);
+  auto rowVector5 = genTpchRegion(98, 2);
+
+  for (size_t i = 0; i < rowVector5->size(); ++i) {
+    ASSERT_TRUE(rowVector5->equalValueAt(rowVector4.get(), i, i + 2));
+  }
 }
 
 // Orders tests.
@@ -188,11 +204,11 @@ TEST(TpchGenTestOrders, batches) {
   orderDate = rowVector2->childAt(4)->asFlatVector<StringView>();
 
   EXPECT_EQ(40001, orderKey->valueAt(0));
-  EXPECT_EQ("1996-01-02"_sv, orderDate->valueAt(0));
+  EXPECT_EQ("1995-02-25"_sv, orderDate->valueAt(0));
   LOG(INFO) << rowVector2->toString(0);
 
   EXPECT_EQ(80000, orderKey->valueAt(9999));
-  EXPECT_EQ("1995-01-30"_sv, orderDate->valueAt(9999));
+  EXPECT_EQ("1995-12-15"_sv, orderDate->valueAt(9999));
   LOG(INFO) << rowVector2->toString(9999);
 }
 
@@ -227,6 +243,16 @@ TEST(TpchGenTestOrders, reproducible) {
     for (size_t i = 0; i < rowVector1->size(); ++i) {
       ASSERT_TRUE(rowVector1->equalValueAt(rowVector2.get(), i, i));
       ASSERT_TRUE(rowVector1->equalValueAt(rowVector3.get(), i, i));
+    }
+  }
+
+  // Ensure it's reproducible if we generate from different offsets.
+  {
+    auto rowVector1 = genTpchOrders(1000, 0);
+    auto rowVector2 = genTpchOrders(990, 10);
+
+    for (size_t i = 0; i < rowVector2->size(); ++i) {
+      ASSERT_TRUE(rowVector2->equalValueAt(rowVector1.get(), i, i + 10));
     }
   }
 
@@ -276,12 +302,12 @@ TEST(TpchGenTestLineItem, batches) {
   shipDate = rowVector2->childAt(10)->asFlatVector<StringView>();
 
   EXPECT_EQ(389, orderKey->valueAt(0));
-  EXPECT_EQ("1996-03-13"_sv, shipDate->valueAt(0));
+  EXPECT_EQ("1994-04-13"_sv, shipDate->valueAt(0));
   LOG(INFO) << rowVector2->toString(0);
 
   lastRow = rowVector2->size() - 1;
   EXPECT_EQ(800, orderKey->valueAt(lastRow));
-  EXPECT_EQ("1992-12-24"_sv, shipDate->valueAt(lastRow));
+  EXPECT_EQ("1998-07-23"_sv, shipDate->valueAt(lastRow));
   LOG(INFO) << rowVector2->toString(lastRow);
 }
 
@@ -318,6 +344,18 @@ TEST(TpchGenTestLineItem, reproducible) {
     for (size_t i = 0; i < rowVector1->size(); ++i) {
       ASSERT_TRUE(rowVector1->equalValueAt(rowVector2.get(), i, i));
       ASSERT_TRUE(rowVector1->equalValueAt(rowVector3.get(), i, i));
+    }
+  }
+
+  // Ensure it's reproducible if we generate from different offsets.
+  {
+    auto rowVector1 = genTpchLineItem(1000);
+    auto rowVector2 = genTpchLineItem(998, 2);
+
+    // The offset for comparisons is 7, since the first generated order has 6
+    // lineitems, and the second has 1.
+    for (size_t i = 0; i < rowVector2->size(); ++i) {
+      ASSERT_TRUE(rowVector2->equalValueAt(rowVector1.get(), i, i + 7));
     }
   }
 
@@ -365,13 +403,13 @@ TEST(TpchGenTestSupplier, batches) {
   phone = rowVector2->childAt(4)->asFlatVector<StringView>();
 
   EXPECT_EQ(1'001, suppKey->valueAt(0));
-  EXPECT_EQ(17, nationKey->valueAt(0));
-  EXPECT_EQ("27-918-335-1736"_sv, phone->valueAt(0));
+  EXPECT_EQ(9, nationKey->valueAt(0));
+  EXPECT_EQ("19-393-671-5272"_sv, phone->valueAt(0));
   LOG(INFO) << rowVector2->toString(0);
 
   EXPECT_EQ(2'000, suppKey->valueAt(999));
-  EXPECT_EQ(17, nationKey->valueAt(999));
-  EXPECT_EQ("27-971-649-2792"_sv, phone->valueAt(999));
+  EXPECT_EQ(11, nationKey->valueAt(999));
+  EXPECT_EQ("21-860-645-7227"_sv, phone->valueAt(999));
   LOG(INFO) << rowVector2->toString(999);
 }
 
@@ -406,6 +444,14 @@ TEST(TpchGenTestSupplier, reproducible) {
   for (size_t i = 0; i < rowVector4->size(); ++i) {
     ASSERT_TRUE(rowVector4->equalValueAt(rowVector5.get(), i, i));
   }
+
+  // Ensure it's also reproducible if we generate from different offsets.
+  auto rowVector6 = genTpchSupplier(100, 0);
+  auto rowVector7 = genTpchSupplier(90, 10);
+
+  for (size_t i = 0; i < rowVector7->size(); ++i) {
+    ASSERT_TRUE(rowVector7->equalValueAt(rowVector6.get(), i, i + 10));
+  }
 }
 
 // Part.
@@ -436,11 +482,11 @@ TEST(TpchGenTestPart, batches) {
   mfgr = rowVector2->childAt(2)->asFlatVector<StringView>();
 
   EXPECT_EQ(1'001, partKey->valueAt(0));
-  EXPECT_EQ("Manufacturer#1"_sv, mfgr->valueAt(0));
+  EXPECT_EQ("Manufacturer#5"_sv, mfgr->valueAt(0));
   LOG(INFO) << rowVector2->toString(0);
 
   EXPECT_EQ(2'000, partKey->valueAt(999));
-  EXPECT_EQ("Manufacturer#2"_sv, mfgr->valueAt(999));
+  EXPECT_EQ("Manufacturer#1"_sv, mfgr->valueAt(999));
   LOG(INFO) << rowVector2->toString(999);
 }
 
@@ -474,6 +520,14 @@ TEST(TpchGenTestPart, reproducible) {
 
   for (size_t i = 0; i < rowVector4->size(); ++i) {
     ASSERT_TRUE(rowVector4->equalValueAt(rowVector5.get(), i, i));
+  }
+
+  // Ensure it's also reproducible if we add different offsets.
+  auto rowVector6 = genTpchPart(100, 0);
+  auto rowVector7 = genTpchPart(90, 10);
+
+  for (size_t i = 0; i < rowVector7->size(); ++i) {
+    ASSERT_TRUE(rowVector7->equalValueAt(rowVector6.get(), i, i + 10));
   }
 }
 
@@ -594,6 +648,7 @@ TEST(TpchGenTestPartSupp, reproducible) {
     ASSERT_TRUE(rowVector1->equalValueAt(rowVector2.get(), i, i));
     ASSERT_TRUE(rowVector1->equalValueAt(rowVector3.get(), i, i));
   }
+
   // Ensure it's also reproducible if we add an offset.
   auto rowVector4 = genTpchPartSupp(100, 10);
   auto rowVector5 = genTpchPartSupp(100, 10);
@@ -601,6 +656,14 @@ TEST(TpchGenTestPartSupp, reproducible) {
 
   for (size_t i = 0; i < rowVector4->size(); ++i) {
     ASSERT_TRUE(rowVector4->equalValueAt(rowVector5.get(), i, i));
+  }
+
+  // Ensure it's also reproducible if we add different offsets.
+  auto rowVector6 = genTpchPartSupp(100, 0);
+  auto rowVector7 = genTpchPartSupp(91, 9);
+
+  for (size_t i = 0; i < rowVector7->size(); ++i) {
+    ASSERT_TRUE(rowVector7->equalValueAt(rowVector6.get(), i, i + 9));
   }
 }
 
@@ -632,11 +695,11 @@ TEST(TpchGenTestCustomer, batches) {
   mktSegment = rowVector2->childAt(6)->asFlatVector<StringView>();
 
   EXPECT_EQ(1'001, custKey->valueAt(0));
-  EXPECT_EQ("BUILDING"_sv, mktSegment->valueAt(0));
+  EXPECT_EQ("MACHINERY"_sv, mktSegment->valueAt(0));
   LOG(INFO) << rowVector2->toString(0);
 
   EXPECT_EQ(2'000, custKey->valueAt(999));
-  EXPECT_EQ("BUILDING"_sv, mktSegment->valueAt(999));
+  EXPECT_EQ("AUTOMOBILE"_sv, mktSegment->valueAt(999));
   LOG(INFO) << rowVector2->toString(999);
 }
 
@@ -670,6 +733,14 @@ TEST(TpchGenTestCustomer, reproducible) {
 
   for (size_t i = 0; i < rowVector4->size(); ++i) {
     ASSERT_TRUE(rowVector4->equalValueAt(rowVector5.get(), i, i));
+  }
+
+  // Ensure it's also reproducible if we add different offsets.
+  auto rowVector6 = genTpchCustomer(100, 0);
+  auto rowVector7 = genTpchCustomer(90, 10);
+
+  for (size_t i = 0; i < rowVector7->size(); ++i) {
+    ASSERT_TRUE(rowVector7->equalValueAt(rowVector6.get(), i, i + 10));
   }
 }
 


### PR DESCRIPTION
Summary:
In order to make DBGEN dataset generations deterministic when starting
at a certain offset, the inner seed used need to be set to the correct offset
point.

Differential Revision: D36940446

