### PR TITLE
Optimize for constant aggregation mask

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -544,6 +544,76 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
   return ss.str();
 }
 
+/// Plan node used to implement aggregations over grouping sets. Duplicates the
+/// aggregation input for each set of grouping keys. The output contains one
+/// column for each grouping key, followed by aggregation inputs, followed by a
+/// column containing grouping set ID. For a given grouping set, only a subset
+/// of the grouping key columns corresponding to the grouping set is populated.
+/// The rest of the grouping key columns are filled in with nulls.
+class GroupIdNode : public PlanNode {
+ public:
+  /// @param id Plan node ID.
+  /// @param groupingSets A list of grouping key sets. Grouping keys within the
+  /// set must be unique, but grouping keys across sets may repeat.
+  /// @param outputGroupingKeyNames Output names for the grouping keys.
+  /// @param aggregationInputs Columns that contain inputs to the aggregate
+  /// functions.
+  /// @param groupIdName Name of the column that will contain the grouping set
+  /// ID (a zero based integer).
+  /// @param source Input plan node.
+  GroupIdNode(
+      PlanNodeId id,
+      std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
+      std::map<std::string, FieldAccessTypedExprPtr> outputGroupingKeyNames,
+      std::vector<FieldAccessTypedExprPtr> aggregationInputs,
+      std::string groupIdName,
+      PlanNodePtr source);
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  const std::vector<std::vector<FieldAccessTypedExprPtr>>& groupingSets()
+      const {
+    return groupingSets_;
+  }
+
+  const std::map<std::string, FieldAccessTypedExprPtr>& outputGroupingKeyNames()
+      const {
+    return outputGroupingKeyNames_;
+  }
+
+  const std::vector<FieldAccessTypedExprPtr>& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  const std::string& groupIdName() {
+    return groupIdName_;
+  }
+
+  int32_t numGroupingKeys() const {
+    return outputType_->size() - aggregationInputs_.size() - 1;
+  }
+
+  std::string_view name() const override {
+    return "GroupId";
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  const std::vector<PlanNodePtr> sources_;
+  const RowTypePtr outputType_;
+  const std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets_;
+  const std::map<std::string, FieldAccessTypedExprPtr> outputGroupingKeyNames_;
+  const std::vector<FieldAccessTypedExprPtr> aggregationInputs_;
+  const std::string groupIdName_;
+};
+
 class ExchangeNode : public PlanNode {
  public:
   ExchangeNode(const PlanNodeId& id, RowTypePtr type)

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -35,6 +35,7 @@ TableScanNode               TableScan                                        Y
 FilterNode                  FilterProject
 ProjectNode                 FilterProject
 AggregationNode             HashAggregation or StreamingAggregation
+GroupIdNode                 GroupId
 HashJoinNode                HashProbe and HashBuild
 MergeJoinNode               MergeJoin
 CrossJoinNode               CrossJoinProbe and CrossJoinBuild
@@ -138,6 +139,26 @@ each measure for each combination of the grouping keys.
      - For each measure, an optional boolean input column that is used to mask out rows for this particular measure.
    * - ignoreNullKeys
      - A boolean flag indicating whether the aggregation should drop rows with nulls in any of the grouping keys. Used to avoid unnecessary processing for an aggregation followed by an inner join on the grouping keys.
+
+GroupIdNode
+~~~~~~~~~~~
+
+Duplicates the input for each of the specified grouping key sets. Used to
+implement aggregations over grouping sets.
+
+.. list-table::
+   :widths: 10 30
+   :align: left
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - groupingSets
+     - List of grouping key sets. Keys within each set must be unique, but keys can repeat across the sets.
+   * - aggregationInputs
+     - Input columns to duplicate.
+   * - groupIdName
+     - The name for the group-id column that identifies the grouping set. Zero-based integer corresponding to the position of the grouping set in the 'groupingSets' list.
 
 HashJoinNode and MergeJoinNode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/velox/exec/AggregationMasks.cpp
+++ b/velox/exec/AggregationMasks.cpp
@@ -40,12 +40,20 @@ void AggregationMasks::addInput(
 
     // Get decoded vector and update the masked selectivity vector.
     decodedMask_.decode(*maskVector, rows);
-    rows.applyToSelected([&](vector_size_t i) {
-      if (maskVector->isNullAt(i) || !decodedMask_.valueAt<bool>(i)) {
-        maskedRows.setValid(i, false);
+    if (decodedMask_.isConstantMapping()) {
+      if (decodedMask_.isNullAt(rows.begin()) ||
+          !decodedMask_.valueAt<bool>(rows.begin())) {
+        maskedRows.setValidRange(rows.begin(), rows.end(), false);
+        maskedRows.updateBounds();
       }
-    });
-    maskedRows.updateBounds();
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedMask_.isNullAt(i) || !decodedMask_.valueAt<bool>(i)) {
+          maskedRows.setValid(i, false);
+        }
+      });
+      maskedRows.updateBounds();
+    }
   }
 }
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   EnforceSingleRow.cpp
   Exchange.cpp
   FilterProject.cpp
+  GroupId.cpp
   GroupingSet.cpp
   HashAggregation.cpp
   HashBuild.cpp

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/GroupId.h"
+
+namespace facebook::velox::exec {
+
+GroupId::GroupId(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::GroupIdNode>& groupIdNode)
+    : Operator(
+          driverCtx,
+          groupIdNode->outputType(),
+          operatorId,
+          groupIdNode->id(),
+          "GroupId") {
+  const auto& inputType = groupIdNode->sources()[0]->outputType();
+
+  std::unordered_map<std::string, ChannelIndex> inputToOutputGroupingKeyMapping;
+  for (const auto& [output, input] : groupIdNode->outputGroupingKeyNames()) {
+    inputToOutputGroupingKeyMapping[input->name()] =
+        outputType_->getChildIdx(output);
+  }
+
+  auto numGroupingSets = groupIdNode->groupingSets().size();
+  groupingKeyMappings_.reserve(numGroupingSets);
+
+  auto numGroupingKeys = groupIdNode->numGroupingKeys();
+
+  for (const auto& groupingSet : groupIdNode->groupingSets()) {
+    std::vector<ChannelIndex> mappings(numGroupingKeys, kMissingGroupingKey);
+    for (const auto& groupingKey : groupingSet) {
+      auto outputChannel =
+          inputToOutputGroupingKeyMapping.at(groupingKey->name());
+      auto inputChannel = inputType->getChildIdx(groupingKey->name());
+      mappings[outputChannel] = inputChannel;
+    }
+
+    groupingKeyMappings_.emplace_back(std::move(mappings));
+  }
+
+  const auto& aggregationInputs = groupIdNode->aggregationInputs();
+  aggregationInputs_.reserve(aggregationInputs.size());
+  for (auto i = 0; i < aggregationInputs.size(); ++i) {
+    const auto& input = aggregationInputs[i];
+    aggregationInputs_.push_back(inputType->getChildIdx(input->name()));
+  }
+}
+
+bool GroupId::needsInput() const {
+  return !noMoreInput_ && input_ == nullptr;
+}
+
+void GroupId::addInput(RowVectorPtr input) {
+  // Load Lazy vectors.
+  for (auto& child : input->children()) {
+    child->loadedVector();
+  }
+
+  input_ = std::move(input);
+}
+
+RowVectorPtr GroupId::getOutput() {
+  if (!input_) {
+    return nullptr;
+  }
+
+  // Make a copy of input for the grouping set at 'groupingSetIndex_'.
+  auto numInput = input_->size();
+
+  std::vector<VectorPtr> outputColumns(outputType_->size());
+
+  const auto& mapping = groupingKeyMappings_[groupingSetIndex_];
+  auto numGroupingKeys = mapping.size();
+
+  // Fill in grouping keys.
+  for (auto i = 0; i < numGroupingKeys; ++i) {
+    if (mapping[i] == kMissingGroupingKey) {
+      // Add null column.
+      outputColumns[i] = BaseVector::createNullConstant(
+          outputType_->childAt(i), numInput, pool());
+    } else {
+      outputColumns[i] = input_->childAt(mapping[i]);
+    }
+  }
+
+  // Fill in aggregation inputs.
+  for (auto i = 0; i < aggregationInputs_.size(); ++i) {
+    outputColumns[numGroupingKeys + i] = input_->childAt(aggregationInputs_[i]);
+  }
+
+  // Add groupId column.
+  outputColumns[outputType_->size() - 1] =
+      BaseVector::createConstant((int64_t)groupingSetIndex_, numInput, pool());
+
+  ++groupingSetIndex_;
+  if (groupingSetIndex_ == groupingKeyMappings_.size()) {
+    groupingSetIndex_ = 0;
+    input_ = nullptr;
+  }
+
+  return std::make_shared<RowVector>(
+      pool(), outputType_, nullptr, numInput, std::move(outputColumns));
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/GroupId.h
+++ b/velox/exec/GroupId.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class GroupId : public Operator {
+ public:
+  GroupId(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::GroupIdNode>& groupIdNode);
+
+  bool needsInput() const override;
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return finished_ || (noMoreInput_ && input_ == nullptr);
+  }
+
+ private:
+  static constexpr ChannelIndex kMissingGroupingKey =
+      std::numeric_limits<ChannelIndex>::max();
+
+  bool finished_{false};
+
+  /// A grouping set contains a subset of all the grouping keys. This list
+  /// contains one entry per grouping set and identifies the grouping keys that
+  /// are part of the set as indices of the input columns. The position in the
+  /// list identifies the grouping key column in the output. Positions with
+  /// kMissingGroupingKey correspond to grouping keys which are not included in
+  /// the set.
+  std::vector<std::vector<ChannelIndex>> groupingKeyMappings_;
+
+  /// A list of input column indices corresponding to aggregation inputs. The
+  /// position in the list identifies the column in the output.
+  std::vector<ChannelIndex> aggregationInputs_;
+
+  /// 'getOutput()' returns 'input_' for one grouping set at a time.
+  /// 'groupingSetIndex_' contains the index of the grouping set to output in
+  /// the next 'getOutput' call. This index is used to generate groupId column
+  /// and lookup the input-to-output column mappings in the
+  /// groupingKeyMappings_.
+  int32_t groupingSetIndex_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/EnforceSingleRow.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/FilterProject.h"
+#include "velox/exec/GroupId.h"
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/HashProbe.h"
@@ -350,6 +351,11 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         operators.push_back(
             std::make_unique<HashAggregation>(id, ctx.get(), aggregationNode));
       }
+    } else if (
+        auto groupIdNode =
+            std::dynamic_pointer_cast<const core::GroupIdNode>(planNode)) {
+      operators.push_back(
+          std::make_unique<GroupId>(id, ctx.get(), groupIdNode));
     } else if (
         auto topNNode =
             std::dynamic_pointer_cast<const core::TopNNode>(planNode)) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -824,6 +824,32 @@ TEST_F(AggregationTest, groupingSets) {
       plan,
       "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY GROUPING SETS ((k1), (k2))");
 
+  // Compute a subset of aggregates per grouping set by using masks based on
+  // group_id column.
+  plan = PlanBuilder()
+             .values({data})
+             .groupId({{"k1"}, {"k2"}}, {"a", "b"})
+             .project(
+                 {"k1",
+                  "k2",
+                  "group_id",
+                  "a",
+                  "b",
+                  "group_id = 0 as mask_a",
+                  "group_id = 1 as mask_b"})
+             .singleAggregation(
+                 {"k1", "k2", "group_id"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"},
+                 {"", "mask_a", "mask_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, null, count(1), sum(a), null FROM tmp GROUP BY k1 "
+      "UNION ALL "
+      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");
+
   // Cube.
   plan = PlanBuilder()
              .values({data})

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -795,5 +795,63 @@ TEST_F(AggregationTest, memoryAllocations) {
   ASSERT_EQ(5, planStats.at(aggNodeId).numMemoryAllocations);
 }
 
+TEST_F(AggregationTest, groupingSets) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector(
+      {"k1", "k2", "a", "b"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row % 11; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row % 17; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<StringView>(
+              size,
+              [](auto row) { return StringView(std::string(row % 12, 'x')); }),
+      });
+
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .groupId({{"k1"}, {"k2"}}, {"a", "b"})
+          .singleAggregation(
+              {"k1", "k2", "group_id"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY GROUPING SETS ((k1), (k2))");
+
+  // Cube.
+  plan = PlanBuilder()
+             .values({data})
+             .groupId({{"k1", "k2"}, {"k1"}, {"k2"}, {}}, {"a", "b"})
+             .singleAggregation(
+                 {"k1", "k2", "group_id"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY CUBE (k1, k2)");
+
+  // Rollup.
+  plan = PlanBuilder()
+             .values({data})
+             .groupId({{"k1", "k2"}, {"k1"}, {}}, {"a", "b"})
+             .singleAggregation(
+                 {"k1", "k2", "group_id"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1016,6 +1016,33 @@ PlanBuilder& PlanBuilder::streamingAggregation(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::groupId(
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregationInputs,
+    std::string groupIdName) {
+  std::vector<std::vector<core::FieldAccessTypedExprPtr>> groupingSetExprs;
+  for (const auto& groupingSet : groupingSets) {
+    groupingSetExprs.push_back(fields(groupingSet));
+  }
+
+  std::map<std::string, core::FieldAccessTypedExprPtr> outputGroupingKeyNames;
+  for (const auto& groupingSet : groupingSetExprs) {
+    for (const auto& groupingKey : groupingSet) {
+      outputGroupingKeyNames[groupingKey->name()] = groupingKey;
+    }
+  }
+
+  planNode_ = std::make_shared<core::GroupIdNode>(
+      nextPlanNodeId(),
+      groupingSetExprs,
+      std::move(outputGroupingKeyNames),
+      fields(aggregationInputs),
+      std::move(groupIdName),
+      planNode_);
+
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::localMerge(
     const std::vector<std::string>& keys,
     std::vector<std::shared_ptr<const core::PlanNode>> sources) {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -343,12 +343,13 @@ class PlanBuilder {
   /// types of aggregate expressions.
   PlanBuilder& singleAggregation(
       const std::vector<std::string>& groupingKeys,
-      const std::vector<std::string>& aggregates) {
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks = {}) {
     return aggregation(
         groupingKeys,
         {},
         aggregates,
-        {},
+        masks,
         core::AggregationNode::Step::kSingle,
         false);
   }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -437,6 +437,13 @@ class PlanBuilder {
       bool ignoreNullKeys,
       const std::vector<TypePtr>& resultTypes = {});
 
+  /// Add a GroupIdNode using the specified grouping sets, aggregation inputs
+  /// and a groupId column name.
+  PlanBuilder& groupId(
+      const std::vector<std::vector<std::string>>& groupingSets,
+      const std::vector<std::string>& aggregationInputs,
+      std::string groupIdName = "group_id");
+
   /// Add a LocalMergeNode using specified ORDER BY clauses.
   ///
   /// For example,


### PR DESCRIPTION
When aggregation mask uses group-id column to disable aggregate for a given
grouping set, mask column is constant. Optimize for this case.