### PR TITLE
Add sanity checks for dictionary indices

### DIFF
--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -79,7 +79,7 @@ class InTest : public SparkFunctionBaseTest {
       VectorPtr rhsArrayVector =
           vectorMaker_.arrayVectorNullable<T>({std::optional(rhs)});
       if (asDictionary) {
-        auto indices = makeIndices(rhs.size(), [](auto row) { return row; });
+        auto indices = makeIndices(rhs.size(), [](auto /*row*/) { return 0; });
         rhsArrayVector = wrapInDictionary(indices, rhs.size(), rhsArrayVector);
       }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -147,6 +147,9 @@ class DictionaryVector : public SimpleVector<T> {
   }
 
   BaseVector* loadedVector() override {
+    if (initialized_) {
+      return this;
+    }
     dictionaryValues_ = BaseVector::loadedVectorShared(dictionaryValues_);
     setInternalState();
     return this;
@@ -196,6 +199,7 @@ class DictionaryVector : public SimpleVector<T> {
 
   void setDictionaryValues(VectorPtr dictionaryValues) {
     dictionaryValues_ = dictionaryValues;
+    initialized_ = false;
     setInternalState();
   }
 

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -418,7 +418,7 @@ TEST_F(ArrowBridgeArrayExportTest, unsupported) {
   EXPECT_THROW(exportToArrow(vector, arrowArray, pool_.get()), VeloxException);
 
   // Dictionary encoding.
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(3, pool_.get());
+  BufferPtr indices = allocateIndices(3, pool_.get());
   vector = BaseVector::wrapInDictionary(
       BufferPtr(), indices, 3, vectorMaker_.flatVector<int64_t>({1, 2, 3}));
   EXPECT_THROW(exportToArrow(vector, arrowArray, pool_.get()), VeloxException);

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -115,7 +115,7 @@ TEST_F(LazyVectorTest, lazyInDoubleDictionary) {
     lazy = std::make_shared<LazyVector>(
         pool_.get(),
         INTEGER(),
-        kInnerSize,
+        kOuterSize,
         std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
           loadEnd = rows.back() + 1;
           return makeFlatVector<int32_t>(loadEnd, [](auto row) { return row; });


### PR DESCRIPTION
Add debug-only checks for dictionary indices for non-null positions. These
indices must be greater than or equal to zero and less than base vector's size.

Fix tests which used to create invalid dictionaries.

Fixed logic in EvalCtx::wrapped that used to create invalid dictionaries (caught by the Fuzzer).