### PR TITLE
Fix seek of PagedInputStream over uncompressed data

### DIFF
--- a/velox/dwio/dwrf/common/PagedInputStream.cpp
+++ b/velox/dwio/dwrf/common/PagedInputStream.cpp
@@ -32,9 +32,11 @@ void PagedInputStream::readBuffer(bool failOnEof) {
           reinterpret_cast<const void**>(&inputBufferPtr_), &length)) {
     DWIO_ENSURE(!failOnEof, getName(), ", read past EOF");
     state_ = State::END;
+    inputBufferStart_ = nullptr;
     inputBufferPtr_ = nullptr;
     inputBufferPtrEnd_ = nullptr;
   } else {
+    inputBufferStart_ = inputBufferPtr_;
     inputBufferPtrEnd_ = inputBufferPtr_ + length;
   }
 }
@@ -188,6 +190,16 @@ void PagedInputStream::BackUp(int32_t count) {
       outputBufferPtr_ != nullptr,
       "Backup without previous Next in ",
       getName());
+  if (state_ == State::ORIGINAL) {
+    VELOX_CHECK(
+        outputBufferPtr_ >= inputBufferStart_ &&
+        outputBufferPtr_ <= inputBufferPtrEnd_);
+    // 'outputBufferPtr_' ranges over the input buffer if there is no
+    // decompression / decryption. Check that we do not back out of
+    // the last range returned from input_->Next().
+    VELOX_CHECK_GE(
+        inputBufferPtr_ - static_cast<size_t>(count), inputBufferStart_);
+  }
   outputBufferPtr_ -= static_cast<size_t>(count);
   outputBufferLength_ += static_cast<size_t>(count);
   bytesReturned_ -= count;
@@ -224,7 +236,23 @@ void PagedInputStream::seekToPosition(PositionProvider& positionProvider) {
   auto compressedOffset = positionProvider.next();
   auto uncompressedOffset = positionProvider.next();
 
-  if (compressedOffset != lastHeaderOffset_) {
+  // If we are directly returning views into input, we can only backup
+  // to the beginning of the last view. If we are returning views into
+  // uncompressed data, we can backup to the beginning of the
+  // decompressed buffer
+  auto alreadyRead = bytesReturned_ - bytesReturnedAtLastHeaderOffset_;
+
+  // outsideOriginalWindow is true if we are returning views into
+  // the input stream's buffer and we are seeking below the start of the last
+  // window.
+  auto outsideOriginalWindow = [&]() {
+    return state_ == State::ORIGINAL && compressedOffset == lastHeaderOffset_ &&
+        uncompressedOffset < alreadyRead &&
+        inputBufferPtrEnd_ - inputBufferStart_ <
+        alreadyRead - uncompressedOffset;
+  };
+
+  if (compressedOffset != lastHeaderOffset_ || outsideOriginalWindow()) {
     std::vector<uint64_t> positions = {compressedOffset};
     auto provider = PositionProvider(positions);
     input_->seekToPosition(provider);
@@ -233,7 +261,6 @@ void PagedInputStream::seekToPosition(PositionProvider& positionProvider) {
 
     Skip(uncompressedOffset);
   } else {
-    auto alreadyRead = bytesReturned_ - bytesReturnedAtLastHeaderOffset_;
     if (uncompressedOffset < alreadyRead) {
       BackUp(alreadyRead - uncompressedOffset);
     } else {

--- a/velox/dwio/dwrf/common/PagedInputStream.h
+++ b/velox/dwio/dwrf/common/PagedInputStream.h
@@ -118,14 +118,21 @@ class PagedInputStream : public SeekableInputStream {
 
   // the start of the current output buffer
   const char* outputBufferPtr_{nullptr};
+
   // the size of the current output buffer
   size_t outputBufferLength_{0};
 
   // the size of the current chunk (in its compressed/encrypted form)
   size_t remainingLength_{0};
 
-  // the last buffer returned from the input
+  // The first byte in the range from last call to 'input_->Next()'.
+  const char* inputBufferStart_{nullptr};
+
+  // The first byte to return in Next. Not the same as inputBufferStart_ if
+  // there has been a BackUp().
   const char* inputBufferPtr_{nullptr};
+
+  // The first byte after the last range returned by 'input_->Next()'.
   const char* inputBufferPtrEnd_{nullptr};
 
   // bytes returned by this stream

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -643,6 +643,12 @@ class CompressBuffer {
     buf[2] = static_cast<char>(compressedSize >> 15);
   }
 
+  void writeUncompressedHeader(size_t compressedSize) {
+    buf[0] = static_cast<char>(compressedSize << 1) | 1;
+    buf[1] = static_cast<char>(compressedSize >> 7);
+    buf[2] = static_cast<char>(compressedSize >> 15);
+  }
+
   size_t getCompressedSize() const {
     size_t header = static_cast<unsigned char>(buf[0]);
     header |= static_cast<size_t>(static_cast<unsigned char>(buf[1])) << 8;
@@ -812,7 +818,7 @@ class TestSeek : public ::testing::Test {
     std::unique_ptr<SeekableInputStream> stream = createDecompressor(
         kind,
         std::unique_ptr<SeekableInputStream>(
-            new SeekableArrayInputStream(output, offset2, outputSize)),
+            new SeekableArrayInputStream(output, offset2, outputSize / 10)),
         outputSize,
         pool,
         "TestSeek Decompressor",
@@ -868,4 +874,46 @@ TEST_F(TestSeek, Zstd) {
 TEST_F(TestSeek, Snappy) {
   auto codec = getCodec(CodecType::SNAPPY);
   runTest(*codec, CompressionKind_SNAPPY);
+}
+
+TEST_F(TestSeek, uncompressed) {
+  constexpr int32_t kSize = 1000;
+  constexpr int32_t kHeaderSize = 3;
+  constexpr int32_t kReadSize = 100;
+  CompressBuffer data(kSize);
+  data.writeUncompressedHeader(kSize);
+  for (auto i = 0; i < kSize; ++i) {
+    data.getCompressed()[i] = static_cast<char>(i);
+  }
+  auto stream = createTestDecompressor(
+      CompressionKind_SNAPPY,
+      std::make_unique<SeekableArrayInputStream>(
+          data.getBuffer(), kSize + 3, kReadSize),
+      5 * kReadSize);
+  const void* result;
+  int32_t size;
+
+  // We expect to see the data in chunks made by the inner input stream.
+  EXPECT_TRUE(stream->Next(&result, &size));
+  EXPECT_EQ(result, data.getCompressed());
+  EXPECT_EQ(kReadSize - kHeaderSize, size);
+
+  EXPECT_TRUE(stream->Next(&result, &size));
+  EXPECT_EQ(result, data.getCompressed() + kReadSize - kHeaderSize);
+
+  // Backup is limited to the last window returned by Next().
+  EXPECT_THROW(stream->BackUp(kReadSize + 1), std::exception);
+
+  EXPECT_TRUE(stream->Next(&result, &size));
+  EXPECT_EQ(result, data.getCompressed() + 2 * kReadSize - kHeaderSize);
+
+  // We seek to a position that is not in the last window returned by
+  // the input of the PagedInputStream but is in the returned bytes of
+  // it. Compressed position is start of stream (the first compression
+  // header), the byte offset if 50 bytes from there.
+  std::vector<uint64_t> offsets{0, 50};
+  PositionProvider position(offsets);
+  stream->seekToPosition(position);
+  EXPECT_TRUE(stream->Next(&result, &size));
+  EXPECT_EQ(result, data.getCompressed() + 50);
 }


### PR DESCRIPTION
PagedInputStream decompresses a whole compression entry and returns
windows into that. If the underlying data is not compressed, it
returns the windows it gets from its input. When seeking to a
position, if the target position falls in the current compression run,
we return a window into the uncompressed data starting at the desired
offset. This offset is anywhere between the start and end of the
current uncompressed buffer.

However, the compression run may be covered by multiple consecutive
windows into the input stream buffer.  If these windows of the are
directly returned to the caller, the seek to position will only work
for positions that fall in the current window, which may not include
the start of the compression run.

We add a check that we do not backup outside of the last window if
directly returning windows into the input's buffer. When seeking to
position, we distinguish the case of returning windows into the input
directly from the case of returning windows into the uncompressed
buffer.