### PR TITLE
[WIP] Fix Ninja error on type_calculation

### DIFF
--- a/velox/expression/type_calculation/CMakeLists.txt
+++ b/velox/expression/type_calculation/CMakeLists.txt
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 bison_target(
-  TypeCalculationParser TypeCalculation.y ${CMAKE_CURRENT_BINARY_DIR}/Parser.cpp
+  TypeCalculationParser TypeCalculation.yy
+  ${CMAKE_CURRENT_BINARY_DIR}/Parser.cpp
   DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/Parser.h)
-flex_target(TypeCalculationScanner TypeCalculation.l
+flex_target(TypeCalculationScanner TypeCalculation.ll
             ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp COMPILE_FLAGS "-Cf")
 add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
 


### PR DESCRIPTION
make failed with error message "ninja: error:
'velox/expression/type_calculation/TypeCalculation.y', needed by
'velox/expression/type_calculation/Parser.cpp', missing and no known
rule to make it". This was introduced by eb79237 "Support decimal type
signature and type calculation using flex/bison (#1693)". This commit
fixes the issue by correcting the TypeCalculation files' names.