### PR TITLE
Add nullable specifier to Memory.h/cpp (#765)

### DIFF
--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -179,6 +179,14 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       data_ = nullptr;
     }
 
+    ContiguousAllocation(ContiguousAllocation&& other) noexcept {
+      mappedMemory_ = other.mappedMemory_;
+      data_ = other.data_;
+      size_ = other.size_;
+      other.data_ = nullptr;
+      other.size_ = 0;
+    }
+
     MappedMemory* FOLLY_NULLABLE mappedMemory() const {
       return mappedMemory_;
     }
@@ -213,11 +221,15 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   // Stats on memory allocated by allocateBytes().
   struct AllocateBytesCounters {
     // Total size of small allocations.
-    uint64_t totalSmall;
+    uint64_t totalSmallAllocateBytes;
     // Total size of allocations from some size class.
-    uint64_t totalInSizeClasses;
+    uint64_t totalSizeClassAllocateBytes;
     // Total in standalone large allocations via allocateContiguous().
-    uint64_t totalLarge;
+    uint64_t totalLargeAllocateBytes;
+
+    uint64_t numSmallAllocations;
+    uint64_t numSizeClassAllocations;
+    uint64_t numLargeAllocations;
   };
 
   MappedMemory() {}
@@ -277,15 +289,15 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
-  // Allocates 'size'contiguous bytes and returns the pointer to the
-  // first byte. If 'size' is less than 'maxMallocSize', delegates the
-  // allocation to malloc. If the size is above that and below the
-  // largest size class, allocates one element of the next size
-  // class. If 'size' is greater than the largest size class, calls
-  // allocateContiguous(). Returns nullptr if there is no space. The
-  // amount to allocate is subject to the size limit of 'this'. This
-  // function is not virtual but calls the virtual functions allocate
-  // and allocateContiguous, which can track sizes and enforce caps etc.
+  // Allocates 'bytes' contiguous bytes and returns the pointer to the first
+  // byte. If 'bytes' is less than 'maxMallocSize', delegates the allocation to
+  // malloc. If the size is above that and below the largest size classes' size,
+  // allocates one element of the next size classes' size. If 'size' is greater
+  // than the largest size classes' size, calls allocateContiguous(). Returns
+  // nullptr if there is no space. The amount to allocate is subject to the size
+  // limit of 'this'. This function is not virtual but calls the virtual
+  // functions allocate and allocateContiguous, which can track sizes and
+  // enforce caps etc.
   void* FOLLY_NULLABLE
   allocateBytes(uint64_t bytes, uint64_t maxMallocSize = kMaxMallocBytes);
 
@@ -322,7 +334,10 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     return {
         totalSmallAllocateBytes_,
         totalSizeClassAllocateBytes_,
-        totalLargeAllocateBytes_};
+        totalLargeAllocateBytes_,
+        numSmallAllocations_,
+        numSizeClassAllocations_,
+        numLargeAllocations_};
   }
 
   virtual std::string toString() const;
@@ -369,6 +384,12 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   static std::atomic<uint64_t> totalSmallAllocateBytes_;
   static std::atomic<uint64_t> totalSizeClassAllocateBytes_;
   static std::atomic<uint64_t> totalLargeAllocateBytes_;
+
+  static std::atomic<uint64_t> numSmallAllocations_;
+  static std::atomic<uint64_t> numSizeClassAllocations_;
+  static std::atomic<uint64_t> numLargeAllocations_;
+
+  static std::atomic<uint64_t> numLargeAllocationsIncrementOnly_;
 };
 
 // Wrapper around MappedMemory for scoped tracking of activity. We

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -24,6 +24,8 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <folly/Synchronized.h>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "folly/CPortability.h"
@@ -32,6 +34,7 @@
 #include "folly/SharedMutex.h"
 #include "folly/experimental/FunctionScheduler.h"
 #include "velox/common/base/GTestMacros.h"
+#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
@@ -65,10 +68,12 @@ class ScopedMemoryPool;
 class AbstractMemoryPool {
  public:
   virtual ~AbstractMemoryPool() {}
-  virtual void* allocate(int64_t size) = 0;
-  virtual void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) = 0;
-  virtual void* reallocate(void* p, int64_t size, int64_t newSize) = 0;
-  virtual void free(void* p, int64_t size) = 0;
+  virtual void* FOLLY_NULLABLE allocate(int64_t size) = 0;
+  virtual void* FOLLY_NULLABLE
+  allocateZeroFilled(int64_t numMembers, int64_t sizeEach) = 0;
+  virtual void* FOLLY_NULLABLE
+  reallocate(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) = 0;
+  virtual void free(void* FOLLY_NULLABLE p, int64_t size) = 0;
   virtual size_t getPreferredSize(size_t size) = 0;
 };
 
@@ -113,7 +118,7 @@ class MemoryPool : public AbstractMemoryPool {
   virtual MemoryPool& getChildByName(const std::string& name) = 0;
   virtual uint64_t getChildCount() const = 0;
   virtual void visitChildren(
-      std::function<void(MemoryPool*)> visitor) const = 0;
+      std::function<void(MemoryPool* FOLLY_NONNULL)> visitor) const = 0;
 
   virtual std::shared_ptr<MemoryPool> genChild(
       std::weak_ptr<MemoryPool> parent,
@@ -125,7 +130,7 @@ class MemoryPool : public AbstractMemoryPool {
   virtual std::unique_ptr<ScopedMemoryPool> addScopedChild(
       const std::string& name,
       int64_t cap = kMaxMemory) = 0;
-  virtual void dropChild(const MemoryPool* child) = 0;
+  virtual void dropChild(const MemoryPool* FOLLY_NONNULL child) = 0;
 
   // Used to explicitly remove self when a user is done with the node, since
   // nodes are owned by parents and users only get object references. Any
@@ -171,15 +176,16 @@ class ScopedMemoryPool final : public MemoryPool {
     return pool_.getMemoryUsageTracker();
   }
 
-  void* allocate(int64_t size) override {
+  void* FOLLY_NULLABLE allocate(int64_t size) override {
     return pool_.allocate(size);
   }
 
-  void* reallocate(void* p, int64_t size, int64_t newSize) override {
+  void* FOLLY_NULLABLE
+  reallocate(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override {
     return pool_.reallocate(p, size, newSize);
   }
 
-  void free(void* p, int64_t size) override {
+  void free(void* FOLLY_NULLABLE p, int64_t size) override {
     return pool_.free(p, size);
   }
 
@@ -193,61 +199,80 @@ class ScopedMemoryPool final : public MemoryPool {
   int64_t updateSubtreeMemoryUsage(int64_t size) override {
     return pool_.updateSubtreeMemoryUsage(size);
   }
-  void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
+
+  void* FOLLY_NULLABLE
+  allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
     return pool_.allocateZeroFilled(numMembers, sizeEach);
   }
+
   int64_t getCap() const override {
     return pool_.getCap();
   }
+
   uint16_t getAlignment() const override {
     return pool_.getAlignment();
   }
+
   void capMemoryAllocation() override {
     pool_.capMemoryAllocation();
   }
+
   void uncapMemoryAllocation() override {
     pool_.uncapMemoryAllocation();
   }
   bool isMemoryCapped() const override {
     return pool_.isMemoryCapped();
   }
+
   const std::string& getName() const override {
     return pool_.getName();
   }
+
   std::weak_ptr<MemoryPool> getWeakPtr() override {
     VELOX_NYI();
   }
+
   MemoryPool& getChildByName(const std::string& name) override {
     return pool_.getChildByName(name);
   }
+
   uint64_t getChildCount() const override {
     return pool_.getChildCount();
   }
+
   std::shared_ptr<MemoryPool> genChild(
       std::weak_ptr<MemoryPool> parent,
       const std::string& name,
       int64_t cap) override {
     return pool_.genChild(parent, name, cap);
   }
+
   MemoryPool& addChild(const std::string& name, int64_t cap = kMaxMemory)
       override {
     return pool_.addChild(name, cap);
   }
+
   std::unique_ptr<memory::ScopedMemoryPool> addScopedChild(
       const std::string& name,
       int64_t cap = kMaxMemory) override {
     return pool_.addScopedChild(name, cap);
   }
+
   void removeSelf() override {
     VELOX_NYI();
   }
+
   void visitChildren(
-      std::function<void(velox::memory::MemoryPool*)> visitor) const override {
+      std::function<void(velox::memory::MemoryPool* FOLLY_NONNULL)> visitor)
+      const override {
     pool_.visitChildren(visitor);
   }
-  void dropChild(const velox::memory::MemoryPool* child) override {
+
+  void dropChild(
+      const velox::memory::MemoryPool* FOLLY_NONNULL child) override {
     pool_.dropChild(child);
   }
+
   void setSubtreeMemoryUsage(int64_t size) override {
     pool_.setSubtreeMemoryUsage(size);
   }
@@ -265,17 +290,55 @@ class ScopedMemoryPool final : public MemoryPool {
 // node tree.
 class MemoryAllocator {
  public:
-  // TODO: move to factory pattern with type trait.
   static std::shared_ptr<MemoryAllocator> createDefaultAllocator();
 
-  void* alloc(int64_t size);
-  void* allocZeroFilled(int64_t numMembers, int64_t sizeEach);
+  virtual ~MemoryAllocator() {}
+
+  virtual void* FOLLY_NULLABLE alloc(int64_t size);
+  virtual void* FOLLY_NULLABLE
+  allocZeroFilled(int64_t numMembers, int64_t sizeEach);
   // TODO: might be able to collapse this with templated class
-  void* allocAligned(uint16_t alignment, int64_t size);
-  void* realloc(void* p, int64_t size, int64_t newSize);
-  void*
-  reallocAligned(void* p, uint16_t alignment, int64_t size, int64_t newSize);
-  void free(void* p, int64_t size);
+  virtual void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size);
+  virtual void* FOLLY_NULLABLE
+  realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize);
+  virtual void* FOLLY_NULLABLE reallocAligned(
+      void* FOLLY_NULLABLE p,
+      uint16_t alignment,
+      int64_t size,
+      int64_t newSize);
+  virtual void free(void* FOLLY_NULLABLE p, int64_t size);
+};
+
+// An allocator that uses memory::MappedMemory to allocate memory. We leverage
+// MappedMemory for relatively small allocations. Allocations less than 3/4 of
+// smallest size class and larger than largest size class are delegated to
+// jemalloc still.
+class MmapMemoryAllocator : public MemoryAllocator {
+ public:
+  static std::shared_ptr<MmapMemoryAllocator> createDefaultAllocator();
+
+  MmapMemoryAllocator() : mappedMemory_(MappedMemory::getInstance()) {}
+  ~MmapMemoryAllocator() override {}
+
+  void* FOLLY_NULLABLE alloc(int64_t size) override;
+  void* FOLLY_NULLABLE
+  allocZeroFilled(int64_t numMembers, int64_t sizeEach) override;
+  void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size) override;
+  void* FOLLY_NULLABLE
+  realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override;
+  void* FOLLY_NULLABLE reallocAligned(
+      void* FOLLY_NULLABLE p,
+      uint16_t alignment,
+      int64_t size,
+      int64_t newSize) override;
+  void free(void* FOLLY_NULLABLE p, int64_t size) override;
+
+  MappedMemory* FOLLY_NONNULL mappedMemory() {
+    return mappedMemory_;
+  }
+
+ private:
+  MappedMemory* FOLLY_NONNULL mappedMemory_;
 };
 
 class MemoryPoolBase : public std::enable_shared_from_this<MemoryPoolBase>,
@@ -290,7 +353,8 @@ class MemoryPoolBase : public std::enable_shared_from_this<MemoryPoolBase>,
   std::weak_ptr<MemoryPool> getWeakPtr() override;
   MemoryPool& getChildByName(const std::string& name) override;
   uint64_t getChildCount() const override;
-  void visitChildren(std::function<void(MemoryPool*)> visitor) const override;
+  void visitChildren(
+      std::function<void(MemoryPool* FOLLY_NONNULL)> visitor) const override;
 
   MemoryPool& addChild(const std::string& name, int64_t cap = kMaxMemory)
       override;
@@ -299,7 +363,7 @@ class MemoryPoolBase : public std::enable_shared_from_this<MemoryPoolBase>,
       int64_t cap = kMaxMemory) override;
   // Drops child (and implicitly the entire subtree) to reclaim memory.
   // Derived classes can override this behavior. e.g. append only semantics.
-  void dropChild(const MemoryPool* child) override;
+  void dropChild(const MemoryPool* FOLLY_NONNULL child) override;
   // Used to explicitly remove self when a user is done with the node, since
   // nodes are owned by parents and users only get object references. Any
   // reference to self would be invalid after this call. This will also drop the
@@ -344,12 +408,14 @@ class MemoryPoolImpl : public MemoryPoolBase {
   // memory cap accordingly. Since MemoryManager walks the MemoryPoolImpl
   // tree periodically, this is slightly stale and we have to reserve our own
   // overhead.
-  void* allocate(int64_t size) override;
-  void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override;
+  void* FOLLY_NULLABLE allocate(int64_t size) override;
+  void* FOLLY_NULLABLE
+  allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override;
 
   // No-op for attempts to shrink buffer.
-  void* reallocate(void* p, int64_t size, int64_t newSize) override;
-  void free(void* p, int64_t size) override;
+  void* FOLLY_NULLABLE
+  reallocate(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override;
+  void free(void* FOLLY_NULLABLE p, int64_t size) override;
 
   //////////////////// Memory Management methods /////////////////////
   // Library checks for low memory mode on a push model. The respective root,
@@ -422,28 +488,29 @@ class MemoryPoolImpl : public MemoryPoolBase {
   }
 
   template <uint16_t A, typename = std::enable_if_t<A != kNoAlignment>>
-  void* allocAligned(ALIGNER<A> /* unused */, int64_t size) {
+  void* FOLLY_NULLABLE allocAligned(ALIGNER<A> /* unused */, int64_t size) {
     return allocator_.allocAligned(A, size);
   }
 
   template <uint16_t A>
-  void* allocAligned(ALIGNER<kNoAlignment> /* unused */, int64_t size) {
+  void* FOLLY_NULLABLE
+  allocAligned(ALIGNER<kNoAlignment> /* unused */, int64_t size) {
     return allocator_.alloc(size);
   }
 
   template <uint16_t A, typename = std::enable_if_t<A != kNoAlignment>>
-  void* reallocAligned(
+  void* FOLLY_NULLABLE reallocAligned(
       ALIGNER<A> /* unused */,
-      void* p,
+      void* FOLLY_NULLABLE p,
       int64_t size,
       int64_t newSize) {
     return allocator_.reallocAligned(p, A, size, newSize);
   }
 
   template <uint16_t A>
-  void* reallocAligned(
+  void* FOLLY_NULLABLE reallocAligned(
       ALIGNER<kNoAlignment> /* unused */,
-      void* p,
+      void* FOLLY_NULLABLE p,
       int64_t size,
       int64_t newSize) {
     return allocator_.realloc(p, size, newSize);
@@ -577,7 +644,8 @@ MemoryPoolImpl<Allocator, ALIGNMENT>::MemoryPoolImpl(
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>
-void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
+void* FOLLY_NULLABLE
+MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
   if (this->isMemoryCapped()) {
     VELOX_MEM_MANUAL_CAP();
   }
@@ -587,7 +655,7 @@ void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>
-void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
+void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
     int64_t numMembers,
     int64_t sizeEach) {
   VELOX_USER_CHECK_EQ(sizeEach, 1);
@@ -600,8 +668,8 @@ void* MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>
-void* MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
-    void* p,
+void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
+    void* FOLLY_NULLABLE p,
     int64_t size,
     int64_t newSize) {
   auto alignedSize = sizeAlign<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, size);
@@ -625,7 +693,9 @@ void* MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::free(void* p, int64_t size) {
+void MemoryPoolImpl<Allocator, ALIGNMENT>::free(
+    void* FOLLY_NULLABLE p,
+    int64_t size) {
   auto alignedSize = sizeAlign<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, size);
   allocator_.free(p, alignedSize);
   release(alignedSize);
@@ -877,6 +947,7 @@ IMemoryManager& getProcessDefaultMemoryManager();
 std::unique_ptr<ScopedMemoryPool> getDefaultScopedMemoryPool(
     int64_t cap = kMaxMemory);
 
+// Allocator that uses passed in memory pool to allocate memory.
 template <typename T>
 class Allocator {
  public:
@@ -888,11 +959,11 @@ class Allocator {
   template <typename U>
   /* implicit */ Allocator(const Allocator<U>& a) : pool{a.pool} {}
 
-  T* allocate(size_t n) {
+  T* FOLLY_NULLABLE allocate(size_t n) {
     return static_cast<T*>(pool.allocate(n * sizeof(T)));
   }
 
-  void deallocate(T* p, size_t n) {
+  void deallocate(T* FOLLY_NULLABLE p, size_t n) {
     pool.free(p, n * sizeof(T));
   }
 

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -19,6 +19,11 @@
 
 #include <sys/mman.h>
 
+DEFINE_bool(
+    use_large_pool,
+    true,
+    "Keep separate pool for allocations over max size class");
+
 namespace facebook::velox::memory {
 
 MmapAllocator::MmapAllocator(const MmapAllocatorOptions& options)
@@ -32,6 +37,7 @@ MmapAllocator::MmapAllocator(const MmapAllocatorOptions& options)
   for (int size : sizeClassSizes_) {
     sizeClasses_.push_back(std::make_unique<SizeClass>(capacity_ / size, size));
   }
+  arena_ = std::make_unique<Arena>(capacity_ * kPageSize);
 }
 
 bool MmapAllocator::allocate(
@@ -157,9 +163,14 @@ bool MmapAllocator::allocateContiguous(
   }
   int64_t numLargeCollateralPages = allocation.numPages();
   if (numLargeCollateralPages) {
-    if (munmap(allocation.data(), allocation.size()) < 0) {
-      LOG(ERROR) << "munmap got " << errno << "for " << allocation.data()
-                 << ", " << allocation.size();
+    if (FLAGS_use_large_pool) {
+      std::lock_guard<std::mutex> l(arenaMutex_);
+      arena_->free(allocation.data(), allocation.size());
+    } else {
+      if (munmap(allocation.data(), allocation.size()) < 0) {
+        LOG(ERROR) << "munmap got " << errno << "for " << allocation.data()
+                   << ", " << allocation.size();
+      }
     }
     allocation.reset(nullptr, nullptr, 0);
   }
@@ -229,13 +240,18 @@ bool MmapAllocator::allocateContiguous(
     injectedFailure_ = Failure::kNone;
     data = nullptr;
   } else {
-    data = mmap(
-        nullptr,
-        numPages * kPageSize,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS,
-        -1,
-        0);
+    if (FLAGS_use_large_pool) {
+      std::lock_guard<std::mutex> l(arenaMutex_);
+      data = arena_->allocate(allocation.size());
+    } else {
+      data = mmap(
+          nullptr,
+          numPages * kPageSize,
+          PROT_READ | PROT_WRITE,
+          MAP_PRIVATE | MAP_ANONYMOUS,
+          -1,
+          0);
+    }
   }
   if (!data) {
     // If the mmap failed, we have unmapped former 'allocation' and
@@ -250,14 +266,19 @@ bool MmapAllocator::allocateContiguous(
 
 void MmapAllocator::freeContiguous(ContiguousAllocation& allocation) {
   if (allocation.data() && allocation.size()) {
-    if (munmap(allocation.data(), allocation.size()) < 0) {
-      LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
-                 << ", " << allocation.size();
+    if (FLAGS_use_large_pool) {
+      std::lock_guard<std::mutex> l(arenaMutex_);
+      arena_->free(allocation.data(), allocation.size());
+    } else {
+      if (munmap(allocation.data(), allocation.size()) < 0) {
+        LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
+                   << ", " << allocation.size();
+      }
+      numMapped_ -= allocation.numPages();
+      numExternalMapped_ -= allocation.numPages();
+      numAllocated_ -= allocation.numPages();
+      allocation.reset(nullptr, nullptr, 0);
     }
-    numMapped_ -= allocation.numPages();
-    numExternalMapped_ -= allocation.numPages();
-    numAllocated_ -= allocation.numPages();
-    allocation.reset(nullptr, nullptr, 0);
   }
 }
 
@@ -608,6 +629,160 @@ std::string MmapAllocator::toString() const {
   }
   out << "]" << std::endl;
   return out.str();
+}
+
+uint64_t Arena::roundBytes(uint64_t bytes) {
+  uint64_t nextPowTwo = bits::nextPowerOfTwo(bytes);
+  return bytes;
+}
+
+Arena::Arena(size_t capacityBytes) : byteSize_(capacityBytes) {
+  VELOX_CHECK(
+      byteSize_ % kMinGrainSizeBytes == 0,
+      "Arena must have a multiple of ",
+      kMinGrainSizeBytes,
+      " bytes capacity.");
+  void* ptr = mmap(
+      nullptr,
+      capacityBytes,
+      PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS,
+      -1,
+      0);
+  if (ptr == MAP_FAILED || !ptr) {
+    VELOX_FAIL(
+        "Could not allocate working memory"
+        "mmap failed with errno {}",
+        errno);
+  }
+  address_ = reinterpret_cast<uint8_t*>(ptr);
+  addFreeBlock(reinterpret_cast<uint64_t>(address_), byteSize_);
+}
+
+Arena::~Arena() {
+  munmap(address_, byteSize_);
+}
+
+void* Arena::allocate(uint64_t bytes) {
+  bytes = roundBytes(bytes);
+
+  // First match in the list that can give this many bytes
+  auto lookupItr = freeLookup_.lower_bound(bytes);
+  auto address = *(lookupItr->second.begin());
+  auto freeBytes = lookupItr->first;
+  void* result = reinterpret_cast<void*>(address);
+  if (freeBytes == bytes) {
+    removeFreeBlock(address, freeBytes);
+    return result;
+  }
+  addFreeBlock(address + bytes, freeBytes - bytes);
+  removeFreeBlock(address, freeBytes);
+  return result;
+}
+
+void Arena::free(void* address, uint64_t bytes) {
+  bytes = roundBytes(bytes);
+
+  madvise(address, bytes, MADV_DONTNEED);
+  auto curAddr = reinterpret_cast<uint64_t>(address);
+
+  bool mergePrev = false;
+  bool mergeNext = false;
+
+  auto curItr = addFreeBlock(curAddr, bytes);
+  auto prevItr = freeList_.end();
+  uint64_t prevAddr;
+  uint64_t prevBytes;
+  if (curItr != freeList_.begin()) {
+    prevItr = std::prev(curItr);
+    prevAddr = prevItr->first;
+    prevBytes = prevItr->second;
+    auto prevEndAddr = prevAddr + prevBytes;
+    VELOX_CHECK_LE(
+        prevEndAddr,
+        curAddr,
+        "New free node (addr:{} size:{}) overlaps with previous free node (addr:{} size:{}) in free list",
+        curAddr,
+        bytes,
+        prevAddr,
+        prevBytes);
+    mergePrev = prevEndAddr == curAddr;
+  }
+
+  auto nextItr = std::next(curItr);
+  uint64_t nextAddr;
+  uint64_t nextBytes;
+  if (nextItr != freeList_.end()) {
+    nextAddr = nextItr->first;
+    nextBytes = nextItr->second;
+    auto curEndAddr = curAddr + bytes;
+    VELOX_CHECK_LE(
+        curEndAddr,
+        nextAddr,
+        "New free node (addr:{} size:{}) overlaps with next free node (addr:{} size:{}) in free list",
+        curAddr,
+        bytes,
+        nextAddr,
+        nextBytes);
+    mergeNext = curEndAddr == nextAddr;
+  }
+
+  if (!mergePrev && !mergeNext) {
+    return;
+  }
+  if (mergePrev) {
+    removeFreeBlock(curItr);
+    if (mergeNext) {
+      removeFromLookup(prevAddr, prevBytes);
+      prevItr->second = nextAddr - prevAddr + nextBytes;
+      freeLookup_[prevItr->second].emplace(prevAddr);
+      removeFreeBlock(nextItr);
+      return;
+    }
+    removeFromLookup(prevAddr, prevBytes);
+    prevItr->second = curAddr - prevAddr + bytes;
+    freeLookup_[prevItr->second].emplace(prevAddr);
+    return;
+  }
+  if (mergeNext) {
+    removeFreeBlock(nextItr);
+    removeFromLookup(curAddr, bytes);
+    curItr->second = nextAddr - curAddr + nextBytes;
+    freeLookup_[curItr->second].emplace(curAddr);
+  }
+}
+
+void Arena::removeFromLookup(uint64_t addr, uint64_t bytes) {
+  freeLookup_[bytes].erase(addr);
+  if (freeLookup_[bytes].empty()) {
+    freeLookup_.erase(bytes);
+  }
+}
+
+std::map<uint64_t, uint64_t>::iterator Arena::addFreeBlock(
+    uint64_t address,
+    uint64_t bytes) {
+  auto insertResult = freeList_.emplace(address, bytes);
+  VELOX_CHECK(
+      insertResult.second,
+      "Trying to free a memory space that is already freed. Already in free list address {} size {}. Attempted to free address {} size {}",
+      address,
+      freeList_[address],
+      address,
+      bytes);
+  freeLookup_[bytes].emplace(address);
+  return insertResult.first;
+}
+
+void Arena::removeFreeBlock(uint64_t addr, uint64_t bytes) {
+  freeList_.erase(addr);
+  removeFromLookup(addr, bytes);
+}
+
+void Arena::removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& itr) {
+  auto bytes = itr->second;
+  removeFromLookup(itr->first, bytes);
+  freeList_.erase(itr);
 }
 
 } // namespace facebook::velox::memory


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto_cpp/pull/765

MemoryPool currently uses Jemalloc to allocate memory. The idea is to let MemoryPool to move away from Jemalloc and instead use MmapAllocator to allocate memory. The allocation scenarios can be largely devided to the following:
1. Tiny allocations:
   For allocation size that is less than 3/4 of the smallest size class in mapped memory, we delegate the job
   to Jemalloc to minimize memory inefficiency. Consider smallest size to be 4096 bytes and user only needs 1024 bytes of memory. In this case if we still try to use mapped memory we will waste 3072 bytes of memory, having memory utilization efficiency of only 25%.
2. Small allocations:
   For allocation size that is larger than smallest size class but less than or equal to biggest size class, we use mapped memory to allocate memory. The allocated size will be rounded up to the closest size class. The allocated memory will, of course, be a contiguous chunk of memory equaling to the size class. This will likely create memory utilization inefficiency but we can overcome it by adding more size classes in between based on actual memory usage.
3. Large allocations:
   For allocation size that is larger than largest size class, we use contiguous allocation from mapped memory to allocate memory. There will not be memory utilization inefficiency in this case because an exact sized memory chunk will be mmaped instead of any rounding like in small allocation scenario.

Pull Request resolved: https://github.com/facebookincubator/velox/pull/1251

Differential Revision: D37131739

Pulled By: tanjialiang

