### PR TITLE
Add scripts for DuckDB import

### DIFF
--- a/velox/duckdb/README.md
+++ b/velox/duckdb/README.md
@@ -3,7 +3,7 @@ used in tests as a reference in-memory database to check results of Velox
 evaluation for correctness. If you need to update it to pick up a bug fix or
 a new feature, first clone DuckDB git repository:
 
-    git clone https://github.com/cwida/duckdb.git
+    git clone https://github.com/duckdb/duckdb.git
     cd duckdb/
 
 Then generate the amalgamated .cpp and .hpp files:
@@ -15,6 +15,13 @@ Then copy the generated files to velox/external/duckdb:
 
     rsync -vrh src/amalgamation/duckdb.* <path/to/velox>/velox/external/duckdb/
     rsync -vrh src/amalgamation/parquet* <path/to/velox>/velox/external/duckdb/
+
+Then modify the include guard variables in parquet-amalgamation.hpp by prefixing them with  
+DUCKDB (This is to avoid conflicts with Thrift headers also included for the parquet reader) using the script velox/external/duckdb/modify_include_guards.sh as follows:
+
+    cd <path/to/velox>/velox/external/duckdb/
+    ./modify_include_guards.sh parquet-amalgamation.hpp
+    ./modify_include_guards.sh parquet-amalgamation.cpp
 
 We also maintain a copy of TPC-H dataset generators that need to be updated:
 

--- a/velox/external/duckdb/modify_include_guards.sh
+++ b/velox/external/duckdb/modify_include_guards.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo $1
+TAGS=$(sed -n 's/^#ifndef \(_THRIFT_[A-Z][A-Z_]*_\)/\1/p' ${1})
+PREFIX=_DUCKDB
+# Substitute each tag for the same tag with '_DUCKDB' prepended.
+for TAG in ${TAGS}
+do
+	echo "Substituting ${TAG} with ${PREFIX}${TAG} in ${1}"
+	COMMAND="s/\(${TAG}\)/${PREFIX}\1/"
+	echo $COMMAND
+	$(sed -i '' ${COMMAND} ${1})
+done
+
+# Wrap the bitwise_cast function inside of duckdb_apache::thrift namespace
+awk -f wrap_namespace.awk ${1} > tmp
+mv tmp ${1}
+

--- a/velox/external/duckdb/parquet-amalgamation.cpp
+++ b/velox/external/duckdb/parquet-amalgamation.cpp
@@ -13627,8 +13627,8 @@ parquetConstants::parquetConstants() {
  * under the License.
  */
 
-#ifndef _THRIFT_TOSTRING_H_
-#define _THRIFT_TOSTRING_H_ 1
+#ifndef _DUCKDB_THRIFT_TOSTRING_H_
+#define _DUCKDB_THRIFT_TOSTRING_H_ 1
 
 #include <cmath>
 #include <limits>
@@ -13721,7 +13721,7 @@ std::string to_string(const std::set<T>& s) {
 }
 } // duckdb_apache::thrift
 
-#endif // _THRIFT_TOSTRING_H_
+#endif // _DUCKDB_THRIFT_TOSTRING_H_
 
 
 // LICENSE_CHANGE_END

--- a/velox/external/duckdb/parquet-amalgamation.hpp
+++ b/velox/external/duckdb/parquet-amalgamation.hpp
@@ -91,8 +91,8 @@ public:
  * under the License.
  */
 
-#ifndef _THRIFT_THRIFT_H_
-#define _THRIFT_THRIFT_H_ 1
+#ifndef _DUCKDB_THRIFT_THRIFT_H_
+#define _DUCKDB_THRIFT_THRIFT_H_ 1
 
 
 
@@ -121,8 +121,8 @@ public:
 
 // clang-format off
 
-#ifndef _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
-#  define _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
+#ifndef _DUCKDB_THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
+#  define _DUCKDB_THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
 
 #ifdef _WIN32
 #ifdef _WINSOCKAPI_
@@ -236,7 +236,7 @@ public:
 #  define THRIFT_SHUT_RDWR SHUT_RDWR
 #endif
 
-#endif // _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
+#endif // _DUCKDB_THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
 
 
 // LICENSE_CHANGE_END
@@ -329,8 +329,8 @@ public:
  * under the License.
  */
 
-#ifndef _THRIFT_TLOGGING_H_
-#define _THRIFT_TLOGGING_H_ 1
+#ifndef _DUCKDB_THRIFT_TLOGGING_H_
+#define _DUCKDB_THRIFT_TLOGGING_H_ 1
 
 
 
@@ -454,7 +454,7 @@ public:
 #define T_GENERIC_PROTOCOL(template_class, generic_prot, specific_prot)
 #endif
 
-#endif // #ifndef _THRIFT_TLOGGING_H_
+#endif // #ifndef _DUCKDB_THRIFT_TLOGGING_H_
 
 
 // LICENSE_CHANGE_END
@@ -546,7 +546,7 @@ void profile_write_pprof(FILE* gen_calls_f, FILE* virtual_calls_f);
 }
 } // duckdb_apache::thrift
 
-#endif // #ifndef _THRIFT_THRIFT_H_
+#endif // #ifndef _DUCKDB_THRIFT_THRIFT_H_
 
 
 // LICENSE_CHANGE_END
@@ -576,8 +576,8 @@ void profile_write_pprof(FILE* gen_calls_f, FILE* virtual_calls_f);
  * under the License.
  */
 
-#ifndef _THRIFT_TAPPLICATIONEXCEPTION_H_
-#define _THRIFT_TAPPLICATIONEXCEPTION_H_ 1
+#ifndef _DUCKDB_THRIFT_TAPPLICATIONEXCEPTION_H_
+#define _DUCKDB_THRIFT_TAPPLICATIONEXCEPTION_H_ 1
 
 
 
@@ -671,7 +671,7 @@ protected:
 }
 } // duckdb_apache::thrift
 
-#endif // #ifndef _THRIFT_TAPPLICATIONEXCEPTION_H_
+#endif // #ifndef _DUCKDB_THRIFT_TAPPLICATIONEXCEPTION_H_
 
 
 // LICENSE_CHANGE_END
@@ -701,8 +701,8 @@ protected:
  * under the License.
  */
 
-#ifndef _THRIFT_TBASE_H_
-#define _THRIFT_TBASE_H_ 1
+#ifndef _DUCKDB_THRIFT_TBASE_H_
+#define _DUCKDB_THRIFT_TBASE_H_ 1
 
 
 
@@ -730,8 +730,8 @@ protected:
  * under the License.
  */
 
-#ifndef _THRIFT_PROTOCOL_TPROTOCOL_H_
-#define _THRIFT_PROTOCOL_TPROTOCOL_H_ 1
+#ifndef _DUCKDB_THRIFT_PROTOCOL_TPROTOCOL_H_
+#define _DUCKDB_THRIFT_PROTOCOL_TPROTOCOL_H_ 1
 
 #ifdef _WIN32
 // Need to come before any Windows.h includes
@@ -763,8 +763,8 @@ protected:
  * under the License.
  */
 
-#ifndef _THRIFT_TRANSPORT_TTRANSPORT_H_
-#define _THRIFT_TRANSPORT_TTRANSPORT_H_ 1
+#ifndef _DUCKDB_THRIFT_TRANSPORT_TTRANSPORT_H_
+#define _DUCKDB_THRIFT_TRANSPORT_TTRANSPORT_H_ 1
 
 
 
@@ -792,8 +792,8 @@ protected:
  * under the License.
  */
 
-#ifndef _THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_
-#define _THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_ 1
+#ifndef _DUCKDB_THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_
+#define _DUCKDB_THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_ 1
 
 // FUCK OFF #include <boost/numeric/conversion/cast.hpp>
 #include <string>
@@ -878,7 +878,7 @@ protected:
 }
 } // duckdb_apache::thrift::transport
 
-#endif // #ifndef _THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_
+#endif // #ifndef _DUCKDB_THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_
 
 
 // LICENSE_CHANGE_END
@@ -1129,7 +1129,7 @@ public:
 }
 } // duckdb_apache::thrift::transport
 
-#endif // #ifndef _THRIFT_TRANSPORT_TTRANSPORT_H_
+#endif // #ifndef _DUCKDB_THRIFT_TRANSPORT_TTRANSPORT_H_
 
 
 // LICENSE_CHANGE_END
@@ -1159,8 +1159,8 @@ public:
  * under the License.
  */
 
-#ifndef _THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_
-#define _THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_ 1
+#ifndef _DUCKDB_THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_
+#define _DUCKDB_THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_ 1
 
 #include <string>
 
@@ -1244,7 +1244,7 @@ protected:
 }
 } // duckdb_apache::thrift::protocol
 
-#endif // #ifndef _THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_
+#endif // #ifndef _DUCKDB_THRIFT_PROTOCOL_TPROTOCOLEXCEPTION_H_
 
 
 // LICENSE_CHANGE_END
@@ -1267,6 +1267,7 @@ protected:
 // but that doesn't work.
 // For a pretty in-depth explanation of the problem, see
 // http://cellperformance.beyond3d.com/articles/2006/06/understanding-strict-aliasing.html
+namespace duckdb_apache { namespace thrift {
 template <typename To, typename From>
 static inline To bitwise_cast(From from) {
   static_assert(sizeof(From) == sizeof(To), "sizeof(From) == sizeof(To)");
@@ -1298,6 +1299,7 @@ static inline To bitwise_cast(From from) {
   u.f = from;
   return u.t;
 }
+}} // namespace duckdb_apache::thrift
 
 
 #ifdef HAVE_SYS_PARAM_H
@@ -1983,7 +1985,7 @@ uint32_t skip(Protocol_& prot, TType type) {
 
 }}} // duckdb_apache::thrift::protocol
 
-#endif // #define _THRIFT_PROTOCOL_TPROTOCOL_H_ 1
+#endif // #define _DUCKDB_THRIFT_PROTOCOL_TPROTOCOL_H_ 1
 
 
 // LICENSE_CHANGE_END
@@ -2001,7 +2003,7 @@ public:
 }
 } // duckdb_apache::thrift
 
-#endif // #ifndef _THRIFT_TBASE_H_
+#endif // #ifndef _DUCKDB_THRIFT_TBASE_H_
 
 
 // LICENSE_CHANGE_END
@@ -4651,8 +4653,8 @@ std::ostream& operator<<(std::ostream& out, const FileCryptoMetaData& obj);
  * under the License.
  */
 
-#ifndef _THRIFT_PROTOCOL_TCOMPACTPROTOCOL_H_
-#define _THRIFT_PROTOCOL_TCOMPACTPROTOCOL_H_ 1
+#ifndef _DUCKDB_THRIFT_PROTOCOL_TCOMPACTPROTOCOL_H_
+#define _DUCKDB_THRIFT_PROTOCOL_TCOMPACTPROTOCOL_H_ 1
 
 
 
@@ -4679,8 +4681,8 @@ std::ostream& operator<<(std::ostream& out, const FileCryptoMetaData& obj);
  * under the License.
  */
 
-#ifndef _THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_
-#define _THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_ 1
+#ifndef _DUCKDB_THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_
+#define _DUCKDB_THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_ 1
 
 
 
@@ -5172,7 +5174,7 @@ protected:
 }
 } // duckdb_apache::thrift::protocol
 
-#endif // #define _THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_ 1
+#endif // #define _DUCKDB_THRIFT_PROTOCOL_TVIRTUALPROTOCOL_H_ 1
 
 
 // LICENSE_CHANGE_END
@@ -5441,8 +5443,8 @@ typedef TCompactProtocolFactoryT<TTransport> TCompactProtocolFactory;
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef _THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_
-#define _THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_ 1
+#ifndef _DUCKDB_THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_
+#define _DUCKDB_THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_ 1
 
 #include <limits>
 
@@ -6248,7 +6250,7 @@ TType TCompactProtocolT<Transport_>::getTType(int8_t type) {
 
 }}} // duckdb_apache::thrift::protocol
 
-#endif // _THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_
+#endif // _DUCKDB_THRIFT_PROTOCOL_TCOMPACTPROTOCOL_TCC_
 
 
 // LICENSE_CHANGE_END
@@ -6284,8 +6286,8 @@ TType TCompactProtocolT<Transport_>::getTType(int8_t type) {
  * under the License.
  */
 
-#ifndef _THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_
-#define _THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_ 1
+#ifndef _DUCKDB_THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_
+#define _DUCKDB_THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_ 1
 
 #include <cstdlib>
 #include <cstddef>
@@ -6319,8 +6321,8 @@ TType TCompactProtocolT<Transport_>::getTType(int8_t type) {
  * under the License.
  */
 
-#ifndef _THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_
-#define _THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_ 1
+#ifndef _DUCKDB_THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_
+#define _DUCKDB_THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_ 1
 
 
 
@@ -6439,7 +6441,7 @@ protected:
 }
 } // duckdb_apache::thrift::transport
 
-#endif // #ifndef _THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_
+#endif // #ifndef _DUCKDB_THRIFT_TRANSPORT_TVIRTUALTRANSPORT_H_
 
 
 // LICENSE_CHANGE_END
@@ -6902,7 +6904,7 @@ protected:
 }
 } // duckdb_apache::thrift::transport
 
-#endif // #ifndef _THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_
+#endif // #ifndef _DUCKDB_THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_
 
 
 // LICENSE_CHANGE_END

--- a/velox/external/duckdb/wrap_namespace.awk
+++ b/velox/external/duckdb/wrap_namespace.awk
@@ -1,0 +1,6 @@
+/^static inline To bitwise_cast(From from) {/
+{if (prev == "template <typename To, typename From>") {f=1; print "namespace duckdb_apache { namespace thrift {"}}
+NR>1{print prev}
+{if (prev == "}" && f) {print "}} // namespace duckdb_apache::thrift"; f=0}}
+{prev=$0}
+END{print prev}


### PR DESCRIPTION
This adds scripts which must be run on duckdb files when imported. They find and replace include guard variables with ones prepended with _DUCKDB as there is a conflict with importing Thrift otherwise. They also find the 'bitwise_cast' function and wrap it in the duckdb_apache::thrift namespace.