### PR TITLE
Optimize KLL sketch memory usage for small groups

### DIFF
--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -125,6 +125,7 @@ struct KllSketch {
 
  private:
   KllSketch(const Allocator&, uint32_t seed);
+  void doInsert(T);
   uint32_t insertPosition();
   int findLevelToCompact() const;
   void addEmptyTopLevelToCompletelyFullSketch();
@@ -174,10 +175,10 @@ struct KllSketch {
   uint32_t k_;
   Allocator allocator_;
 
-  // Cannot use sfmt19937 here because the object cannot be guaranteed
-  // to be placed on 16 bytes aligned memory (e.g. in
-  // HashStringAllocator).
-  std::independent_bits_engine<std::mt19937, 1, uint32_t> randomBit_;
+  // mt19937 uses too much memory (up to 5000 bytes), we choose to use
+  // default_random_engine here to sacrifice some randomness for memory.
+  std::independent_bits_engine<std::default_random_engine, 1, uint32_t>
+      randomBit_;
 
   size_t n_;
   T minValue_;

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   velox_functions_test_lib
   velox_exec_test_util
   velox_expression
+  velox_memory
   gtest
   gtest_main
   gmock


### PR DESCRIPTION
Summary:
When the sketch is created, currently we allocate the memory depending
on the K passed in.  When the actual number of elements being tracked is much
smaller than K (often happening with group by aggregation), the unused memory is
wasted.  We optimize for this case by allowing the actual retained elements to
grow from empty instead of an initial size of K.

Differential Revision: D37182402

