### PR TITLE
Fix Scanner.h to support 2.5.* flex versions

### DIFF
--- a/velox/expression/type_calculation/CMakeLists.txt
+++ b/velox/expression/type_calculation/CMakeLists.txt
@@ -17,8 +17,9 @@ bison_target(
   ${CMAKE_CURRENT_BINARY_DIR}/Parser.cpp
   DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/Parser.h)
 
-flex_target(TypeCalculationScanner TypeCalculation.ll
-            ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp COMPILE_FLAGS "-Cf")
+flex_target(
+  TypeCalculationScanner TypeCalculation.ll
+  ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp COMPILE_FLAGS "-Cf --prefix=veloxtc")
 
 add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
 

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -29,7 +29,7 @@ class Scanner : public yyFlexLexer {
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
       std::unordered_map<std::string, int>& values)
-      : yyFlexLexer(arg_yyin, arg_yyout), values_(values){};
+      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
   int lex(Parser::semantic_type* yylval);
   void setValue(const std::string& varName, int value) {
     values_[varName] = value;


### PR DESCRIPTION
`Scanner.h` has been fixed to use API that is available in older Flex 2.5.* versions.
`--prefix=veloxtc` flag is added to flex code generation of TypeCalculator.
 `veloxtc` is added as a prefix for all globally-visible variables and function names.
 This option allows linking together multiple flex programs into the same executable.