### PR TITLE
Make type checking in RowVector constructor debug-only

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -60,10 +60,11 @@ class RowVector : public BaseVector {
     const auto* rowType = dynamic_cast<const RowType*>(type.get());
 
     // Check child vector types.
+    // This can be an expensive operation, so it's only done at debug time.
     for (auto i = 0; i < children_.size(); i++) {
       const auto& child = children_[i];
       if (child) {
-        VELOX_CHECK(
+        VELOX_DCHECK(
             child->type()->kindEquals(type->childAt(i)),
             "Got type {} for field `{}` at position {}, but expected {}.",
             child->type()->toString(),


### PR DESCRIPTION
Summary:
The constructor for RowVector checks that the Types of the children Vectors match the
children Types of the RowType passed in.

For very wide Rows with complex children this can become a significant performance
bottleneck.  Since it is not a critical check and mostly used for debugging, I'm limiting it to
a debug-only check so it doesn't impact production.

(Thanks Masha for the suggestion)

Differential Revision: D37196122

