### PR TITLE
Add support for NegatedValues filters to dwio/dwrf/reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <velox/type/Filter.h>
 #include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
@@ -182,6 +183,10 @@ void SelectiveByteRleColumnReader::processFilter(
       break;
     case FilterKind::kBigintValuesUsingBitmask:
       readHelper<common::BigintValuesUsingBitmask, isDense>(
+          filter, rows, extractValues);
+      break;
+    case FilterKind::kNegatedBigintValuesUsingBitmask:
+      readHelper<common::NegatedBigintValuesUsingBitmask, isDense>(
           filter, rows, extractValues);
       break;
     default:

--- a/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
@@ -140,6 +140,14 @@ void SelectiveIntegerColumnReader::processFilter(
       readHelper<Reader, common::BigintValuesUsingBitmask, isDense>(
           filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBigintValuesUsingHashTable:
+      readHelper<Reader, common::NegatedBigintValuesUsingHashTable, isDense>(
+          filter, rows, extractValues);
+      break;
+    case common::FilterKind::kNegatedBigintValuesUsingBitmask:
+      readHelper<Reader, common::NegatedBigintValuesUsingBitmask, isDense>(
+          filter, rows, extractValues);
+      break;
     default:
       readHelper<Reader, common::Filter, isDense>(filter, rows, extractValues);
       break;

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -88,5 +88,4 @@ void SelectiveIntegerDirectColumnReader::readWithVisitor(
   }
   readOffset_ += numRows;
 }
-
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.h
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.h
@@ -231,10 +231,14 @@ class ColumnStats : public AbstractColumnStats {
     int32_t upperIndex;
     T lower = valueAtPct(startPct, &lowerIndex);
     T upper = valueAtPct(startPct + selectPct, &upperIndex);
-    if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 < 3) {
+    if (upperIndex - lowerIndex < 1000 && ++counter_ % 10 <= 3) {
       std::vector<int64_t> in;
       for (auto i = lowerIndex; i <= upperIndex; ++i) {
         in.push_back(values_[i]);
+      }
+      // make sure we don't accidentally generate an AlwaysFalse filter
+      if (counter_ % 2 == 1 && selectPct < 100.0) {
+        return velox::common::createNegatedBigintValues(in, true);
       }
       return velox::common::createBigintValues(in, true);
     }

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -258,6 +258,12 @@ inline std::unique_ptr<common::Filter> in(
   return common::createBigintValues(values, nullAllowed);
 }
 
+inline std::unique_ptr<common::Filter> notIn(
+    const std::vector<int64_t>& values,
+    bool nullAllowed = false) {
+  return common::createNegatedBigintValues(values, nullAllowed);
+}
+
 inline std::unique_ptr<common::BytesValues> in(
     const std::vector<std::string>& values,
     bool nullAllowed = false) {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -28,7 +28,9 @@
 #include "velox/common/base/SimdUtil.h"
 #include "velox/type/StringView.h"
 
-namespace facebook ::velox::common {
+namespace facebook::velox::common {
+
+static constexpr int64_t kEmptyMarker = 0xdeadbeefbadefeedL;
 
 enum class FilterKind {
   kAlwaysFalse,
@@ -698,7 +700,6 @@ class BigintValuesUsingHashTable final : public Filter {
   std::unique_ptr<Filter>
   mergeWith(int64_t min, int64_t max, const Filter* other) const;
 
-  static constexpr int64_t kEmptyMarker = 0xdeadbeefbadefeedL;
   // from Murmur hash
   static constexpr uint64_t M = 0xc6a4a7935bd1e995L;
 

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1148,6 +1148,16 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(in({1, 2, 3, 67, 10'134}));
   filters.push_back(in({1, 2, 3, 67, 10'134}, true));
 
+  // NOT IN-list.
+  filters.push_back(notIn({1, 2, 3, 67'000'000'000, 134}));
+  filters.push_back(notIn({1, 2, 3, 67'000'000'000, 134}, true));
+  filters.push_back(notIn({1, 3, 5, 7, 67'000'000'000, 122}));
+  filters.push_back(notIn({1, 3, 5, 7, 67'000'000'000, 122}, true));
+  filters.push_back(notIn({-4, -3, -2, -1, 0, 1, 2}));
+  filters.push_back(notIn({-4, -3, -2, -1, 0, 1, 2}, true));
+  filters.push_back(notIn({122, 150, 151, 210, 213, 251}));
+  filters.push_back(notIn({122, 150, 151, 210, 213, 251}, true));
+
   for (const auto& left : filters) {
     for (const auto& right : filters) {
       testMergeWithBigint(left.get(), right.get());
@@ -1236,6 +1246,24 @@ TEST(FilterTest, mergeWithBigintMultiRange) {
   // IN-list using hash table.
   filters.push_back(in({1, 2, 3, 67, 10'134}));
   filters.push_back(in({1, 2, 3, 67, 10'134}, true));
+
+  // NOT IN-list using bitmask.
+  filters.push_back(notIn({0, 3, 5, 20, 32, 210}));
+  filters.push_back(notIn({0, 3, 5, 20, 32, 210}, true));
+  filters.push_back(notIn({3, 7, 9, 45, 46, 47, 48}));
+  filters.push_back(notIn({3, 7, 9, 45, 46, 47, 48}, true));
+
+  filters.push_back(notIn({12, 18}));
+  std::vector<int64_t> rejectionRange;
+  rejectionRange.push_back(12);
+  for (int i = 25; i <= 47; ++i) {
+    rejectionRange.push_back(i);
+  }
+  filters.push_back(notIn(rejectionRange));
+
+  // NOT IN-list using hash table.
+  filters.push_back(notIn({0, 3, 5, 20, 32, 15'210}));
+  filters.push_back(notIn({0, 3, 5, 20, 32, 15'210}, true));
 
   for (const auto& left : filters) {
     for (const auto& right : filters) {


### PR DESCRIPTION
Summary:
Extended the dwrf reader to support the `NegatedBigintValuesUsingBitmask` and `NegatedBigintValuesUsingHashTable` classes of filters when reading data from a file. To do so, changes were made to `SelectiveIntegerDirectColumnReader.h`, `SelectiveIntegerDictionaryColumnReader.h`, and `SelectiveByteRleColumnReader.h` to support the new types of filters in the `processFilter` method. While the changes are not consequential along the current execution path, passing the information regarding the filter type to the `ReadHelper` template could be useful in future code changes.

The existing unit tests in `E2EFilterTest.cpp` were also modified to include NegatedValues test cases by modifying the `makeRangeFilter` method in `FilterGenerator.h`, which causes NegatedValues filters to be randomly generated sometimes.

Differential Revision: D37133348

