### PR TITLE
Fix return-local-addr warning from ApproxPercentileAggregate.cpp

### DIFF
--- a/velox/common/base/Macros.h
+++ b/velox/common/base/Macros.h
@@ -22,11 +22,8 @@
   _Pragma("clang diagnostic push");        \
   _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #define VELOX_UNSUPPRESS_DEPRECATION_WARNING _Pragma("clang diagnostic pop");
-#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING \
-  _Pragma("clang diagnostic push");              \
-  _Pragma("clang diagnostic ignored \"-Wreturn-local-addr\"")
-#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING \
-  _Pragma("clang diagnostic pop");
+#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING
+#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING
 #else
 #define VELOX_SUPPRESS_DEPRECATION_WARNING
 #define VELOX_UNSUPPRESS_DEPRECATION_WARNING

--- a/velox/common/base/Macros.h
+++ b/velox/common/base/Macros.h
@@ -22,7 +22,17 @@
   _Pragma("clang diagnostic push");        \
   _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #define VELOX_UNSUPPRESS_DEPRECATION_WARNING _Pragma("clang diagnostic pop");
+#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+  _Pragma("clang diagnostic push");              \
+  _Pragma("clang diagnostic ignored \"-Wreturn-local-addr\"")
+#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+  _Pragma("clang diagnostic pop");
 #else
 #define VELOX_SUPPRESS_DEPRECATION_WARNING
 #define VELOX_UNSUPPRESS_DEPRECATION_WARNING
+#define VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+  _Pragma("GCC diagnostic push");                \
+  _Pragma("GCC diagnostic ignored \"-Wreturn-local-addr\"")
+#define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING \
+  _Pragma("GCC diagnostic pop");
 #endif

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/Macros.h"
 #include "velox/common/base/RandomUtil.h"
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/Aggregate.h"
@@ -438,7 +439,14 @@ class ApproxPercentileAggregate : public exec::Aggregate {
         accuracy != kMissingNormalizedValue) {
       checkSetAccuracy(accuracy);
     }
+    // If 'data' is inline, this function will return a local
+    // address. Assert data is not inline.
+    assert(!data.isInline());
+    // Some compilers cannot deduce that the StringView cannot be inline from
+    // the assert above. Suppress warning.
+    VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING
     return data.data() + stream.offset();
+    VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING
   }
 
   static constexpr double kMissingNormalizedValue = -1;

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -441,7 +441,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     }
     // If 'data' is inline, this function will return a local
     // address. Assert data is not inline.
-    assert(!data.isInline());
+    VELOX_DCHECK(!data.isInline());
     // Some compilers cannot deduce that the StringView cannot be inline from
     // the assert above. Suppress warning.
     VELOX_SUPPRESS_RETURN_LOCAL_ADDR_WARNING


### PR DESCRIPTION
The warning below from GCC 11 is resolved.

```
ApproxPercentileAggregate.cpp: In member function 'const char* facebook::velox::aggregate::{anonymous}::ApproxPercentileAggregate<T>::getDeserializedDigest(facebook::velox::vector_size_t) [with T = int]':
/presto_cpp_repo/velox/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp:441:40: error: function may return address of local variable [-Werror=return-local-addr]
  441 |     return data.data() + stream.offset();
      |                                        ^
```

Resolves https://github.com/facebookincubator/velox/issues/1836