### PR TITLE
Move OutputStream to dwio::common

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   ColumnSelector.cpp
   Common.cpp
   DataBuffer.cpp
+  DataBufferHolder.cpp
   DataSink.cpp
   DecoderUtil.cpp
   DwioMetricsLog.cpp
@@ -34,6 +35,7 @@ add_library(
   IoStatistics.cpp
   MemoryInputStream.cpp
   Options.cpp
+  OutputStream.cpp
   ReaderFactory.cpp
   ScanSpec.cpp
   SeekableInputStream.cpp

--- a/velox/dwio/common/DataBufferHolder.cpp
+++ b/velox/dwio/common/DataBufferHolder.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
+#include "velox/dwio/common/DataBufferHolder.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 bool DataBufferHolder::tryResize(
-    dwio::common::DataBuffer<char>& buffer,
+    DataBuffer<char>& buffer,
     uint64_t headerSize,
     uint64_t increment) const {
   auto size = buffer.size();
@@ -53,4 +53,4 @@ bool DataBufferHolder::tryResize(
   return true;
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DataBufferHolder.h
+++ b/velox/dwio/common/DataBufferHolder.h
@@ -19,7 +19,7 @@
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/DataSink.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 constexpr float DEFAULT_PAGE_GROW_RATIO = 2.0f;
 constexpr float MIN_PAGE_GROW_RATIO = 1.2f;
@@ -34,7 +34,7 @@ class DataBufferHolder {
       uint64_t maxSize,
       uint64_t initialSize = 0,
       float growRatio = DEFAULT_PAGE_GROW_RATIO,
-      dwio::common::DataSink* sink = nullptr)
+      DataSink* sink = nullptr)
       : pool_{pool},
         sink_{sink},
         maxSize_{maxSize},
@@ -54,7 +54,7 @@ class DataBufferHolder {
       totalSize += buf.size();
     }
     if (totalSize > 0) {
-      dwio::common::DataBuffer<char> buf(pool_, totalSize);
+      DataBuffer<char> buf(pool_, totalSize);
       auto data = buf.data();
       for (auto& buffer : buffers) {
         auto size = buffer.size();
@@ -76,7 +76,7 @@ class DataBufferHolder {
     take(std::vector<folly::StringPiece>{buffer});
   }
 
-  void take(const dwio::common::DataBuffer<char>& buffer) {
+  void take(const DataBuffer<char>& buffer) {
     take(folly::StringPiece{buffer.data(), buffer.size()});
   }
 
@@ -144,7 +144,7 @@ class DataBufferHolder {
   // - size() increases by grow ratio until increment fits or exceeds max size
   // Return true when buffer size is increased
   bool tryResize(
-      dwio::common::DataBuffer<char>& buffer,
+      DataBuffer<char>& buffer,
       uint64_t headerSize = 0,
       uint64_t increment = 1) const;
 
@@ -159,7 +159,7 @@ class DataBufferHolder {
 
   memory::MemoryPool& pool_;
   std::vector<dwio::common::DataBuffer<char>> buffers_;
-  dwio::common::DataSink* sink_;
+  DataSink* sink_;
 
   // state
   bool suppressed_{false};
@@ -171,4 +171,4 @@ class DataBufferHolder {
   float growRatio_;
 };
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/OutputStream.cpp
+++ b/velox/dwio/common/OutputStream.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/OutputStream.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 bool BufferedOutputStream::Next(
     void** buffer,
@@ -74,4 +74,4 @@ uint64_t AppendOnlyBufferedStream::flush() {
   return outStream_->flush();
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/OutputStream.h
+++ b/velox/dwio/common/OutputStream.h
@@ -16,11 +16,10 @@
 
 #pragma once
 
+#include "velox/dwio/common/DataBufferHolder.h"
 #include "velox/dwio/common/wrap/zero-copy-stream-wrapper.h"
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
-#include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 /**
  * Record write position for creating index stream
@@ -91,7 +90,7 @@ class BufferedOutputStream : public google::protobuf::io::ZeroCopyOutputStream {
 
  protected:
   DataBufferHolder& bufferHolder_;
-  dwio::common::DataBuffer<char> buffer_;
+  DataBuffer<char> buffer_;
 
   // try increase buffer size, and then assign to output buffer/size. Returns
   // false if buffer size remained the same
@@ -163,4 +162,4 @@ class AppendOnlyBufferedStream {
   }
 };
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   TestBufferedInput.cpp
   TestColumnSelector.cpp
   TypeTests.cpp)
+
 add_test(velox_dwio_common_test velox_dwio_common_test)
 target_link_libraries(
   velox_dwio_common_test

--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -17,12 +17,13 @@
 #pragma once
 
 #include <memory>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Nulls.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
-#include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/Range.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/vector/TypeAliases.h"
@@ -86,7 +87,7 @@ class ByteRleEncoder {
    * @param strideIndex the index of the stride to backfill
    */
   virtual void recordPosition(
-      PositionRecorder& recorder,
+      dwio::common::PositionRecorder& recorder,
       int32_t strideIndex = -1) const = 0;
 };
 
@@ -230,14 +231,14 @@ class ByteRleDecoder {
  * @param output the output stream to write to
  */
 std::unique_ptr<ByteRleEncoder> createByteRleEncoder(
-    std::unique_ptr<BufferedOutputStream> output);
+    std::unique_ptr<dwio::common::BufferedOutputStream> output);
 
 /**
  * Create a boolean RLE encoder.
  * @param output the output stream to write to
  */
 std::unique_ptr<ByteRleEncoder> createBooleanRleEncoder(
-    std::unique_ptr<BufferedOutputStream> output);
+    std::unique_ptr<dwio::common::BufferedOutputStream> output);
 
 /**
  * Create a byte RLE decoder.

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -18,14 +18,12 @@ add_library(
   Common.cpp
   Compression.cpp
   Config.cpp
-  DataBufferHolder.cpp
   Decryption.cpp
   DirectDecoder.cpp
   Encryption.cpp
   EncryptionSpecification.cpp
   IntDecoder.cpp
   IntEncoder.cpp
-  OutputStream.cpp
   PagedInputStream.cpp
   PagedOutputStream.cpp
   RLEv1.cpp

--- a/velox/dwio/dwrf/common/Compression.cpp
+++ b/velox/dwio/dwrf/common/Compression.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/dwio/dwrf/common/Compression.h"
-
 #include "velox/dwio/common/Common.h"
 #include "velox/dwio/common/compression/LzoDecompressor.h"
 #include "velox/dwio/common/exception/Exception.h"
@@ -433,17 +432,18 @@ bool ZlibDecompressionStream::Next(const void** data, int32_t* size) {
 
 } // namespace
 
-std::unique_ptr<BufferedOutputStream> createCompressor(
+std::unique_ptr<dwio::common::BufferedOutputStream> createCompressor(
     dwio::common::CompressionKind kind,
     CompressionBufferPool& bufferPool,
-    DataBufferHolder& bufferHolder,
+    dwio::common::DataBufferHolder& bufferHolder,
     const Config& config,
     const Encrypter* encrypter) {
   std::unique_ptr<Compressor> compressor;
   switch (static_cast<int64_t>(kind)) {
     case dwio::common::CompressionKind_NONE:
       if (!encrypter) {
-        return std::make_unique<BufferedOutputStream>(bufferHolder);
+        return std::make_unique<dwio::common::BufferedOutputStream>(
+            bufferHolder);
       }
       // compressor remain as nullptr
       break;

--- a/velox/dwio/dwrf/common/Compression.h
+++ b/velox/dwio/dwrf/common/Compression.h
@@ -17,13 +17,13 @@
 #pragma once
 
 #include "velox/dwio/common/Common.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/CompressionBufferPool.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/dwio/dwrf/common/Decryption.h"
 #include "velox/dwio/dwrf/common/Encryption.h"
-#include "velox/dwio/dwrf/common/OutputStream.h"
 
 namespace facebook::velox::dwrf {
 
@@ -88,10 +88,10 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
  * collection
  * @param level compression level
  */
-std::unique_ptr<BufferedOutputStream> createCompressor(
+std::unique_ptr<dwio::common::BufferedOutputStream> createCompressor(
     dwio::common::CompressionKind kind,
     CompressionBufferPool& bufferPool,
-    DataBufferHolder& bufferHolder,
+    dwio::common::DataBufferHolder& bufferHolder,
     const Config& config,
     const dwio::common::encryption::Encrypter* encrypter = nullptr);
 

--- a/velox/dwio/dwrf/common/IntEncoder.cpp
+++ b/velox/dwio/dwrf/common/IntEncoder.cpp
@@ -33,7 +33,7 @@ template uint64_t IntEncoder<false>::flush();
 template <bool isSigned>
 std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createRle(
     RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes) {
   switch (static_cast<int64_t>(version)) {
@@ -49,18 +49,18 @@ std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createRle(
 
 template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createRle(
     RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes);
 template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createRle(
     RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes);
 
 template <bool isSigned>
 std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes) {
   return std::make_unique<IntEncoder<isSigned>>(
@@ -68,11 +68,11 @@ std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createDirect(
 }
 
 template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes);
 template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
+    std::unique_ptr<dwio::common::BufferedOutputStream> output,
     bool useVInts,
     uint32_t numBytes);
 

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -17,12 +17,12 @@
 #pragma once
 
 #include <folly/Varint.h>
+#include "dwio/common/OutputStream.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
-#include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/Range.h"
 
 namespace facebook::velox::dwrf {
@@ -31,7 +31,7 @@ template <bool isSigned>
 class IntEncoder {
  public:
   IntEncoder(
-      std::unique_ptr<BufferedOutputStream> output,
+      std::unique_ptr<dwio::common::BufferedOutputStream> output,
       bool useVInts,
       uint32_t numBytes)
       : output_{std::move(output)},
@@ -123,7 +123,7 @@ class IntEncoder {
    * @param strideIndex the index of the stride to backfill
    */
   virtual void recordPosition(
-      PositionRecorder& recorder,
+      dwio::common::PositionRecorder& recorder,
       int32_t strideIndex = -1) const {
     output_->recordPosition(
         recorder, bufferLength_, bufferPosition_, strideIndex);
@@ -138,7 +138,7 @@ class IntEncoder {
    */
   static std::unique_ptr<IntEncoder<isSigned>> createRle(
       RleVersion version,
-      std::unique_ptr<BufferedOutputStream> output,
+      std::unique_ptr<dwio::common::BufferedOutputStream> output,
       bool useVInts,
       uint32_t numBytes);
 
@@ -146,12 +146,12 @@ class IntEncoder {
    * Create a direct encoder
    */
   static std::unique_ptr<IntEncoder<isSigned>> createDirect(
-      std::unique_ptr<BufferedOutputStream> output,
+      std::unique_ptr<dwio::common::BufferedOutputStream> output,
       bool useVInts,
       uint32_t numBytes);
 
  protected:
-  std::unique_ptr<BufferedOutputStream> output_;
+  std::unique_ptr<dwio::common::BufferedOutputStream> output_;
   const bool useVInts_;
   const uint32_t numBytes_;
 

--- a/velox/dwio/dwrf/common/PagedOutputStream.cpp
+++ b/velox/dwio/dwrf/common/PagedOutputStream.cpp
@@ -116,7 +116,7 @@ bool PagedOutputStream::Next(void** data, int32_t* size, uint64_t increment) {
 }
 
 void PagedOutputStream::recordPosition(
-    PositionRecorder& recorder,
+    dwio::common::PositionRecorder& recorder,
     int32_t bufferLength,
     int32_t bufferOffset,
     int32_t strideOffset) const {

--- a/velox/dwio/dwrf/common/PagedOutputStream.h
+++ b/velox/dwio/dwrf/common/PagedOutputStream.h
@@ -20,11 +20,11 @@
 
 namespace facebook::velox::dwrf {
 
-class PagedOutputStream : public BufferedOutputStream {
+class PagedOutputStream : public dwio::common::BufferedOutputStream {
  public:
   PagedOutputStream(
       CompressionBufferPool& pool,
-      DataBufferHolder& bufferHolder,
+      dwio::common::DataBufferHolder& bufferHolder,
       const Config& config,
       std::unique_ptr<Compressor> compressor,
       const dwio::common::encryption::Encrypter* encrypter)
@@ -52,7 +52,7 @@ class PagedOutputStream : public BufferedOutputStream {
   }
 
   void recordPosition(
-      PositionRecorder& recorder,
+      dwio::common::PositionRecorder& recorder,
       int32_t bufferLength,
       int32_t bufferOffset,
       int32_t strideOffset = -1) const override;

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -31,7 +31,7 @@ template <bool isSigned>
 class RleEncoderV1 : public IntEncoder<isSigned> {
  public:
   RleEncoderV1(
-      std::unique_ptr<BufferedOutputStream> outStream,
+      std::unique_ptr<dwio::common::BufferedOutputStream> outStream,
       bool useVInts,
       uint32_t numBytes)
       : IntEncoder<isSigned>{std::move(outStream), useVInts, numBytes},
@@ -82,8 +82,9 @@ class RleEncoderV1 : public IntEncoder<isSigned> {
     return IntEncoder<isSigned>::flush();
   }
 
-  void recordPosition(PositionRecorder& recorder, int32_t strideIndex = -1)
-      const override {
+  void recordPosition(
+      dwio::common::PositionRecorder& recorder,
+      int32_t strideIndex = -1) const override {
     IntEncoder<isSigned>::recordPosition(recorder, strideIndex);
     recorder.add(static_cast<uint64_t>(numLiterals), strideIndex);
   }

--- a/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
+++ b/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
@@ -15,10 +15,9 @@
  */
 
 #include <gtest/gtest.h>
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
+#include "velox/dwio/common/DataBufferHolder.h"
 
 using namespace facebook::velox::dwio::common;
-using namespace facebook::velox::dwrf;
 using namespace facebook::velox::memory;
 
 TEST(DataBufferHolderTests, InputCheck) {

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -18,7 +18,7 @@
 #include <folly/Varint.h>
 #include <folly/init/Init.h>
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
+#include "velox/dwio/common/DataBufferHolder.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 #include "velox/dwio/dwrf/common/Range.h"
 

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/dwrf/writer/LayoutPlanner.h"
 
 namespace facebook::velox::dwrf {
@@ -34,7 +36,7 @@ TEST(LayoutPlannerTests, Basic) {
       [&](uint32_t node, uint32_t seq, StreamKind kind, uint32_t size) {
         auto streamId = DwrfStreamIdentifier{node, seq, 0, kind};
         streams.push_back(streamId);
-        AppendOnlyBufferedStream out{context.newStream(streamId)};
+        dwio::common::AppendOnlyBufferedStream out{context.newStream(streamId)};
         out.write(data.data(), size);
         out.flush();
       };

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -182,7 +182,7 @@ inline BufferPtr sequence(MemoryPool* pool, int64_t begin, int64_t end) {
   return buffer;
 }
 
-class TestPositionRecorder : public PositionRecorder {
+class TestPositionRecorder : public dwio::common::PositionRecorder {
  public:
   explicit TestPositionRecorder() {
     addEntry();

--- a/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
+++ b/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/OutputStream.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
 

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -16,6 +16,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "velox/dwio/dwrf/proto/dwrf_proto.pb.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
 
 using namespace testing;

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -17,10 +17,10 @@
 #pragma once
 
 #include "velox/common/base/GTestMacros.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 #include "velox/dwio/dwrf/writer/WriterContext.h"
@@ -66,7 +66,8 @@ class ColumnWriter {
     encoding.set_sequence(sequence_);
   }
 
-  std::unique_ptr<BufferedOutputStream> newStream(StreamKind kind) {
+  std::unique_ptr<dwio::common::BufferedOutputStream> newStream(
+      StreamKind kind) {
     return context_.newStream(DwrfStreamIdentifier{id_, sequence_, 0, kind});
   }
 

--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/common/OutputStream.h"
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
@@ -30,9 +30,9 @@ constexpr int32_t PRESENT_STREAM_INDEX_ENTRIES_PAGED =
 
 } // namespace
 
-class IndexBuilder : public PositionRecorder {
+class IndexBuilder : public dwio::common::PositionRecorder {
  public:
-  IndexBuilder(std::unique_ptr<BufferedOutputStream> out)
+  IndexBuilder(std::unique_ptr<dwio::common::BufferedOutputStream> out)
       : out_{std::move(out)} {}
 
   virtual ~IndexBuilder() = default;
@@ -84,7 +84,7 @@ class IndexBuilder : public PositionRecorder {
  private:
   friend class IndexBuilderTest;
 
-  std::unique_ptr<BufferedOutputStream> out_;
+  std::unique_ptr<dwio::common::BufferedOutputStream> out_;
   proto::RowIndex index_;
   proto::RowIndexEntry entry_;
   std::optional<int32_t> presentStreamOffset_;

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -32,7 +32,8 @@ LayoutPlanner::LayoutPlanner(StreamList streams)
     : streams_{std::move(streams)} {}
 
 void LayoutPlanner::iterateIndexStreams(
-    std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+    std::function<
+        void(const DwrfStreamIdentifier&, dwio::common::DataBufferHolder&)>
         consumer) {
   for (auto iter = streams_.begin(), end = iter + indexCount_; iter != end;
        ++iter) {
@@ -41,7 +42,8 @@ void LayoutPlanner::iterateIndexStreams(
 }
 
 void LayoutPlanner::iterateDataStreams(
-    std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
+    std::function<
+        void(const DwrfStreamIdentifier&, dwio::common::DataBufferHolder&)>
         consumer) {
   for (auto iter = streams_.begin() + indexCount_; iter != streams_.end();
        ++iter) {

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -21,8 +21,8 @@
 #include "velox/dwio/dwrf/writer/WriterContext.h"
 
 namespace facebook::velox::dwrf {
-using StreamList =
-    std::vector<std::pair<const DwrfStreamIdentifier*, DataBufferHolder*>>;
+using StreamList = std::vector<
+    std::pair<const DwrfStreamIdentifier*, dwio::common::DataBufferHolder*>>;
 
 StreamList getStreamList(WriterContext& context);
 
@@ -31,13 +31,13 @@ class LayoutPlanner {
   explicit LayoutPlanner(StreamList streamList);
   virtual ~LayoutPlanner() = default;
 
-  void iterateIndexStreams(
-      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
-          consumer);
+  void iterateIndexStreams(std::function<void(
+                               const DwrfStreamIdentifier&,
+                               dwio::common::DataBufferHolder&)> consumer);
 
-  void iterateDataStreams(
-      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
-          consumer);
+  void iterateDataStreams(std::function<void(
+                              const DwrfStreamIdentifier&,
+                              dwio::common::DataBufferHolder&)> consumer);
 
   virtual void plan();
 

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -35,7 +35,7 @@ void WriterContext::validateConfigs() const {
       compressionBlockSize, getConfig(Config::COMPRESSION_BLOCK_SIZE_MIN));
   DWIO_ENSURE_GE(
       getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO),
-      MIN_PAGE_GROW_RATIO);
+      dwio::common::MIN_PAGE_GROW_RATIO);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterSink.h
+++ b/velox/dwio/dwrf/writer/WriterSink.h
@@ -18,9 +18,9 @@
 
 #include <folly/container/Array.h>
 
+#include "velox/dwio/common/DataBufferHolder.h"
 #include "velox/dwio/dwrf/common/Checksum.h"
 #include "velox/dwio/dwrf/common/Config.h"
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
 
 namespace facebook::velox::dwrf {
 
@@ -78,7 +78,7 @@ class WriterSink {
 
   void addBuffer(dwio::common::DataBuffer<char> buffer);
 
-  void addBuffers(DataBufferHolder& holder) {
+  void addBuffers(dwio::common::DataBufferHolder& holder) {
     auto& other = holder.getBuffers();
     for (auto& buf : other) {
       addBuffer(std::move(buf));
@@ -139,7 +139,7 @@ class WriterSink {
 
   // members used by stripe metadata cache
   uint32_t maxCacheSize_;
-  DataBufferHolder cacheHolder_;
+  dwio::common::DataBufferHolder cacheHolder_;
   dwio::common::DataBuffer<char> cacheBuffer_;
   std::vector<uint32_t> offsets_;
   bool exceedsLimit_;


### PR DESCRIPTION
The decoders need to be moved to dwio::common for the new Parquet reader,
and the decoders need to call the OutputStream. This commit moves the
OutputStream related classes to dwio::common.