### PR TITLE
Use folly::Unit instead of bool for Driver continue future

### DIFF
--- a/velox/common/future/VeloxPromise.h
+++ b/velox/common/future/VeloxPromise.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/Unit.h>
 #include <folly/futures/Future.h>
 
 namespace facebook::velox {
@@ -60,15 +61,15 @@ class VeloxPromise : public folly::Promise<T> {
   std::string context_;
 };
 
+using ContinuePromise = VeloxPromise<folly::Unit>;
+using ContinueFuture = folly::SemiFuture<folly::Unit>;
+
 /// Equivalent of folly's makePromiseContract for VeloxPromise.
-template <class T>
-std::pair<VeloxPromise<T>, folly::SemiFuture<T>> makeVeloxPromiseContract(
-    const std::string& promiseContext = "") {
-  auto p = VeloxPromise<T>(promiseContext);
+static inline std::pair<ContinuePromise, ContinueFuture>
+makeVeloxContinuePromiseContract(const std::string& promiseContext = "") {
+  auto p = ContinuePromise(promiseContext);
   auto f = p.getSemiFuture();
   return std::make_pair(std::move(p), std::move(f));
 }
-
-using ContinuePromise = VeloxPromise<bool>;
 
 } // namespace facebook::velox

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
       readPlanFragment,
       /*destination=*/0,
       core::QueryCtx::createForTest(),
-      [](RowVectorPtr vector, exec::ContinueFuture*) {
+      [](RowVectorPtr vector, facebook::velox::ContinueFuture*) {
         if (vector) {
           LOG(INFO) << "Vector available after processing (scan + sort):";
           for (size_t i = 0; i < vector->size(); ++i) {

--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -27,7 +27,6 @@ class CallbackSink : public Operator {
       DriverCtx* driverCtx,
       std::function<BlockingReason(RowVectorPtr, ContinueFuture*)> callback)
       : Operator(driverCtx, nullptr, operatorId, "N/A", "N/A"),
-        future_(false),
         callback_{callback} {}
 
   void addInput(RowVectorPtr input) override {

--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -95,7 +95,7 @@ void CrossJoinBuild::noMoreInput() {
   // the last to finish) can continue from the barrier and finish.
   peers.clear();
   for (auto& promise : promises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 
   operatorCtx_->task()

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -72,7 +72,7 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
   auto& exec = folly::QueuedImmediateExecutor::instance();
   std::move(state->future_)
       .via(&exec)
-      .thenValue([state](bool /* unused */) {
+      .thenValue([state](auto&& /* unused */) {
         state->operator_->recordBlockingTime(state->sinceMicros_);
         auto driver = state->driver_;
         auto task = driver->task();
@@ -292,7 +292,7 @@ StopReason Driver::runInternal(
 
   try {
     int32_t numOperators = operators_.size();
-    ContinueFuture future(false);
+    ContinueFuture future;
 
     for (;;) {
       for (int32_t i = numOperators - 1; i >= 0; --i) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -129,8 +129,6 @@ enum class BlockingReason {
 
 std::string blockingReasonToString(BlockingReason reason);
 
-using ContinueFuture = folly::SemiFuture<bool>;
-
 class BlockingState {
  public:
   BlockingState(

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -267,7 +267,7 @@ BlockingReason Exchange::isBlocked(ContinueFuture* future) {
     getSplits(&splitFuture_);
   }
 
-  ContinueFuture dataFuture{false};
+  ContinueFuture dataFuture;
   currentPage_ = exchangeClient_->next(&atEnd_, &dataFuture);
   if (currentPage_ || atEnd_) {
     if (atEnd_ && noMoreSplits_) {
@@ -284,8 +284,7 @@ BlockingReason Exchange::isBlocked(ContinueFuture* future) {
     futures.push_back(std::move(splitFuture_));
     futures.push_back(std::move(dataFuture));
 
-    *future = folly::collectAny(futures).deferValue(
-        [](auto /*unused*/) { return true; });
+    *future = folly::collectAny(futures).unit();
   } else {
     // Block until data becomes available.
     *future = std::move(dataFuture);

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -94,7 +94,7 @@ class ExchangeQueue {
     queue_.push_back(std::move(page));
     if (!promises_.empty()) {
       // Resume one of the waiting drivers.
-      promises_.back().setValue(true);
+      promises_.back().setValue();
       promises_.pop_back();
     }
   }
@@ -166,7 +166,7 @@ class ExchangeQueue {
 
   void clearAllPromises() {
     for (auto& promise : promises_) {
-      promise.setValue(true);
+      promise.setValue();
     }
     promises_.clear();
   }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -223,7 +223,7 @@ void HashBuild::noMoreInput() {
   // the last to finish) can continue from the barrier and finish.
   peers.clear();
   for (auto& promise : promises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 
   if (antiJoinHasNullKeys_) {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -622,7 +622,7 @@ void HashProbe::noMoreInput() {
     std::vector<std::shared_ptr<Driver>> peers;
     // The last Driver to hit HashProbe::finish is responsible for producing
     // non-matching build-side rows for the right join.
-    ContinueFuture future{false};
+    ContinueFuture future;
     if (!operatorCtx_->task()->allPeersFinished(
             planNodeId(), operatorCtx_->driver(), &future, promises, peers)) {
       return;

--- a/velox/exec/JoinBridge.cpp
+++ b/velox/exec/JoinBridge.cpp
@@ -16,11 +16,10 @@
 #include "velox/exec/JoinBridge.h"
 
 namespace facebook::velox::exec {
-
 // static
 void JoinBridge::notify(std::vector<ContinuePromise> promises) {
   for (auto& promise : promises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 }
 

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::exec {
 namespace {
 void notify(std::vector<ContinuePromise>& promises) {
   for (auto& promise : promises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 }
 } // namespace
@@ -289,7 +289,7 @@ LocalPartition::LocalPartition(
 
   futures_.reserve(numPartitions_);
   for (auto i = 0; i < numPartitions_; i++) {
-    futures_.emplace_back(false);
+    futures_.emplace_back();
   }
 }
 
@@ -391,7 +391,7 @@ void LocalPartition::addInput(RowVectorPtr input) {
       auto partitionData =
           wrapChildren(input_, partitionSize, std::move(indexBuffers[i]));
 
-      ContinueFuture future{false};
+      ContinueFuture future;
       auto reason = enqueue(i, partitionData, &future);
       if (reason != BlockingReason::kNotBlocked) {
         blockingReasons_[numBlockedPartitions_] = reason;

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -145,7 +145,7 @@ class LocalExchange : public SourceOperator {
  private:
   const int partition_;
   const std::shared_ptr<LocalExchangeQueue> queue_{nullptr};
-  ContinueFuture future_{false};
+  ContinueFuture future_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
 };
 

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -109,7 +109,7 @@ RowVectorPtr Merge::getOutput() {
 
   // No merging is needed if there is only one source.
   if (sources_.size() == 1) {
-    ContinueFuture future{false};
+    ContinueFuture future;
     RowVectorPtr data;
     auto reason = sources_[0]->next(data, &future);
     if (reason != BlockingReason::kNotBlocked) {
@@ -222,7 +222,7 @@ void SourceStream::copyToOutput(RowVectorPtr& output) {
 }
 
 bool SourceStream::fetchMoreData(std::vector<ContinueFuture>& futures) {
-  ContinueFuture future{false};
+  ContinueFuture future;
   auto reason = source_->next(data_, &future);
   if (reason != BlockingReason::kNotBlocked) {
     needData_ = true;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -90,14 +90,14 @@ class LocalMergeSource : public MergeSource {
    private:
     void notifyConsumers() {
       for (auto& promise : consumerPromises_) {
-        promise.setValue(true);
+        promise.setValue();
       }
       consumerPromises_.clear();
     }
 
     void notifyProducers() {
       for (auto& promise : producerPromises_) {
-        promise.setValue(true);
+        promise.setValue();
       }
       producerPromises_.clear();
     }
@@ -194,7 +194,7 @@ std::shared_ptr<MergeSource> MergeSource::createMergeExchangeSource(
 namespace {
 void notify(std::optional<ContinuePromise>& promise) {
   if (promise) {
-    promise->setValue(true);
+    promise->setValue();
     promise.reset();
   }
 }

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -148,7 +148,6 @@ class PartitionedOutput : public Operator {
             planNode->inputType(),
             planNode->outputType(),
             planNode->outputType())),
-        future_(false),
         bufferManager_(PartitionedOutputBufferManager::getInstance()),
         maxBufferedBytes_(
             ctx->task->queryCtx()->config().maxPartitionedOutputBufferSize()),

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -143,7 +143,7 @@ void releaseAfterAcknowledge(
     std::vector<ContinuePromise>& promises) {
   freed.clear();
   for (auto& promise : promises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 }
 } // namespace
@@ -429,7 +429,7 @@ void PartitionedOutputBuffer::terminate() {
     outstandingPromises.swap(promises_);
   }
   for (auto& promise : outstandingPromises) {
-    promise.setValue(true);
+    promise.setValue();
   }
 }
 

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -32,8 +32,7 @@ TableScan::TableScan(
           "TableScan"),
       tableHandle_(tableScanNode->tableHandle()),
       columnHandles_(tableScanNode->assignments()),
-      driverCtx_(driverCtx),
-      blockingFuture_(false) {
+      driverCtx_(driverCtx) {
   connector_ = connector::getConnector(tableHandle_->connectorId());
 }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -58,7 +58,7 @@ class TableScan : public SourceOperator {
       unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
           columnHandles_;
   DriverCtx* driverCtx_;
-  ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
+  ContinueFuture blockingFuture_;
   bool needNewSplit_ = true;
   std::shared_ptr<connector::Connector> connector_;
   std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;

--- a/velox/exec/tests/CustomJoinTest.cpp
+++ b/velox/exec/tests/CustomJoinTest.cpp
@@ -128,7 +128,7 @@ class CustomJoinBuild : public Operator {
     // the last to finish) can continue from the barrier and finish.
     peers.clear();
     for (auto& promise : promises) {
-      promise.setValue(true);
+      promise.setValue();
     }
 
     auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -86,7 +86,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       int destination,
       std::shared_ptr<const RowType> rowType,
       vector_size_t size) {
-    ContinueFuture future(false);
+    ContinueFuture future;
     auto blockingReason = bufferManager_->enqueue(
         taskId, destination, makeSerializedPage(rowType, size), &future);
     ASSERT_EQ(blockingReason, BlockingReason::kNotBlocked);
@@ -365,7 +365,7 @@ TEST_F(PartitionedOutputBufferManagerTest, errorInQueue) {
     std::lock_guard<std::mutex> l(queue->mutex());
     queue->setErrorLocked("error");
   }
-  ContinueFuture future(false);
+  ContinueFuture future;
   bool atEnd = false;
   EXPECT_THROW(auto page = queue->dequeue(&atEnd, &future), std::runtime_error);
 }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -174,7 +174,7 @@ class TestSkewedJoinBridge : public exec::JoinBridge {
     notify(std::move(promises));
   }
 
-  std::optional<bool> buildFinishedOrFuture(exec::ContinueFuture* future) {
+  std::optional<bool> buildFinishedOrFuture(ContinueFuture* future) {
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");
     if (buildFinished_.has_value()) {
@@ -238,7 +238,7 @@ class TestSkewedJoinBuild : public exec::Operator {
     VELOX_FAIL("Last driver should not finish successfully.");
   }
 
-  exec::BlockingReason isBlocked(exec::ContinueFuture* future) override {
+  exec::BlockingReason isBlocked(ContinueFuture* future) override {
     if (!future_.valid()) {
       return exec::BlockingReason::kNotBlocked;
     }
@@ -251,7 +251,7 @@ class TestSkewedJoinBuild : public exec::Operator {
   }
 
  private:
-  exec::ContinueFuture future_{exec::ContinueFuture::makeEmpty()};
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
   int64_t slowJoinBuildDelaySeconds_;
 };
 
@@ -280,7 +280,7 @@ class TestSkewedJoinProbe : public exec::Operator {
     return nullptr;
   }
 
-  exec::BlockingReason isBlocked(exec::ContinueFuture* future) override {
+  exec::BlockingReason isBlocked(ContinueFuture* future) override {
     auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
         operatorCtx_->driverCtx()->splitGroupId, planNodeId());
     auto buildFinished =

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -20,13 +20,13 @@ namespace facebook::velox::exec::test {
 
 exec::BlockingReason TaskQueue::enqueue(
     RowVectorPtr vector,
-    exec::ContinueFuture* future) {
+    velox::ContinueFuture* future) {
   if (!vector) {
     std::lock_guard<std::mutex> l(mutex_);
     ++producersFinished_;
     if (consumerBlocked_) {
       consumerBlocked_ = false;
-      consumerPromise_.setValue(true);
+      consumerPromise_.setValue();
     }
     return exec::BlockingReason::kNotBlocked;
   }
@@ -43,10 +43,10 @@ exec::BlockingReason TaskQueue::enqueue(
   totalBytes_ += bytes;
   if (consumerBlocked_) {
     consumerBlocked_ = false;
-    consumerPromise_.setValue(true);
+    consumerPromise_.setValue();
   }
   if (totalBytes_ > maxBytes_) {
-    auto [unblockPromise, unblockFuture] = makeVeloxPromiseContract<bool>();
+    auto [unblockPromise, unblockFuture] = makeVeloxContinuePromiseContract();
     producerUnblockPromises_.emplace_back(std::move(unblockPromise));
     *future = std::move(unblockFuture);
     return exec::BlockingReason::kWaitForConsumer;
@@ -80,7 +80,7 @@ RowVectorPtr TaskQueue::dequeue() {
     }
     // outside of 'mutex_'
     for (auto& promise : mayContinue) {
-      promise.setValue(true);
+      promise.setValue();
     }
     if (vector) {
       return vector;
@@ -93,7 +93,7 @@ void TaskQueue::close() {
   std::lock_guard<std::mutex> l(mutex_);
   closed_ = true;
   for (auto& promise : producerUnblockPromises_) {
-    promise.setValue(true);
+    promise.setValue();
   }
   producerUnblockPromises_.clear();
 }
@@ -127,7 +127,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
       params.destination,
       std::move(queryCtx),
       // consumer
-      [queue](RowVectorPtr vector, exec::ContinueFuture* future) {
+      [queue](RowVectorPtr vector, velox::ContinueFuture* future) {
         if (!vector) {
           return queue->enqueue(nullptr, future);
         }

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <velox/exec/Driver.h>
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
 
@@ -54,9 +55,7 @@ class TaskQueue {
   };
 
   explicit TaskQueue(uint64_t maxBytes)
-      : pool_(memory::getDefaultScopedMemoryPool()),
-        maxBytes_(maxBytes),
-        consumerFuture_(false) {}
+      : pool_(memory::getDefaultScopedMemoryPool()), maxBytes_(maxBytes) {}
 
   void setNumProducers(int32_t n) {
     numProducers_ = n;
@@ -68,7 +67,7 @@ class TaskQueue {
   // realized when the producer may continue.
   exec::BlockingReason enqueue(
       RowVectorPtr vector,
-      exec::ContinueFuture* future);
+      velox::ContinueFuture* future);
 
   // Returns nullptr when all producers are at end. Otherwise blocks.
   RowVectorPtr dequeue();
@@ -95,7 +94,7 @@ class TaskQueue {
   std::vector<ContinuePromise> producerUnblockPromises_;
   bool consumerBlocked_ = false;
   ContinuePromise consumerPromise_;
-  folly::Future<bool> consumerFuture_;
+  ContinueFuture consumerFuture_;
   bool closed_ = false;
 };
 


### PR DESCRIPTION
Summary:
A continue future can be used to suspend a driver and resume it once fulfilled,
right now a future<bool> is used, however, the bool value is
never read anywhere for any of the operators and never used.

Furthermore, it is a bit confusing as the user wont know if he shall set true or false,
the proper and official way of implementing a void future is by using future<unit>.

Reviewed By: mbasmanova

Differential Revision: D37194084

