### PR TITLE
Improve infer type for MAP

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -509,14 +509,22 @@ class variant {
   std::shared_ptr<const Type> inferType() const {
     switch (kind_) {
       case TypeKind::MAP: {
+        TypePtr keyType;
+        TypePtr valueType;
         auto& m = map();
         for (auto& pair : m) {
-          if (!pair.first.isNull() && !pair.second.isNull()) {
-            return MAP(pair.first.inferType(), pair.second.inferType());
+          if (keyType == nullptr && !pair.first.isNull()) {
+            keyType = pair.first.inferType();
+          }
+          if (valueType == nullptr && !pair.second.isNull()) {
+            valueType = pair.second.inferType();
+          }
+          if (keyType && valueType) {
+            break;
           }
         }
-        throw std::invalid_argument{
-            "map is empty or contains null values: cannot infer type"};
+        return MAP(
+            keyType ? keyType : UNKNOWN(), valueType ? valueType : UNKNOWN());
       }
       case TypeKind::ROW: {
         auto& r = row();

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/type/Variant.h"
 #include <gtest/gtest.h>
+#include <velox/type/Type.h>
 
 using namespace facebook::velox;
 
@@ -31,6 +32,22 @@ TEST(Variant, arrayInferType) {
       *ARRAY(ARRAY(DOUBLE())),
       *variant::array({variant::array({variant(TypeKind::DOUBLE)})})
            .inferType());
+}
+
+TEST(Variant, mapInferType) {
+  EXPECT_EQ(*variant::map({{1LL, 1LL}}).inferType(), *MAP(BIGINT(), BIGINT()));
+  EXPECT_EQ(*variant::map({}).inferType(), *MAP(UNKNOWN(), UNKNOWN()));
+
+  const variant nullBigint = variant::null(TypeKind::BIGINT);
+  const variant nullReal = variant::null(TypeKind::REAL);
+  EXPECT_EQ(
+      *variant::map({{nullBigint, nullReal}, {1LL, 1.0f}}).inferType(),
+      *MAP(BIGINT(), REAL()));
+  EXPECT_EQ(
+      *variant::map({{nullBigint, 1.0f}, {1LL, nullReal}}).inferType(),
+      *MAP(BIGINT(), REAL()));
+  EXPECT_EQ(
+      *variant::map({{nullBigint, 1.0f}}).inferType(), *MAP(UNKNOWN(), REAL()));
 }
 
 struct Foo {};


### PR DESCRIPTION
Summary:
# Problem
`variant::inferType()` threw an exception if MAP could not infer types for key and value. Which is an inconsistent behavior to ARRAY type, that returns `ARRAY(UNKNOWN())` instead. I'd like to keep it consistent.

# Solution
Infer logic iterates for each element and get the type of the first not-null entry. I updated the logic to get key and value type separately, and if it can't it would use `UNKNOWN()` instead of throwing an exception.

I added some test cases to confirm the behavior. I hope this makes sense.

Differential Revision: D37313760

