### PR TITLE
Updated DateTimeFormatter so year 0 is BC not AD for ERA token

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -149,7 +149,7 @@ std::string DateTimeFormatter::format(
     } else {
       switch (token.pattern.specifier) {
         case DateTimeFormatSpecifier::ERA:
-          result += static_cast<signed>(calDate.year()) >= 0 ? "AD" : "BC";
+          result += static_cast<signed>(calDate.year()) > 0 ? "AD" : "BC";
           break;
 
         case DateTimeFormatSpecifier::CENTURY_OF_ERA: {


### PR DESCRIPTION
Summary: See title

Reviewed By: tanjialiang

Differential Revision: D37290263

