### PR TITLE
Fixes to map_agg

### DIFF
--- a/velox/docs/functions/aggregate.rst
+++ b/velox/docs/functions/aggregate.rst
@@ -104,6 +104,12 @@ Map Aggregate Functions
 
     Returns a map created from the input ``key`` / ``value`` pairs.
 
+.. function:: map_union(map(K,V)) -> map(K,V)
+
+    Returns the union of all the input ``maps``.
+    If a ``key`` is found in multiple input ``maps``,
+    that ``key’s`` ``value`` in the resulting ``map`` comes from an arbitrary input ``map``.
+
 Approximate Aggregate Functions
 -------------------------------
 

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -37,6 +37,7 @@ const char* const kCovarSamp = "covar_samp";
 const char* const kEvery = "every";
 const char* const kHistogram = "histogram";
 const char* const kMapAgg = "map_agg";
+const char* const kMapUnion = "map_union";
 const char* const kMax = "max";
 const char* const kMaxBy = "max_by";
 const char* const kMerge = "merge";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(
   ChecksumAggregate.cpp
   HistogramAggregate.cpp
   MapAggAggregate.cpp
+  MapAggregateBase.h
+  MapAggregateBase.cpp
+  MapUnionAggregate.cpp
   MinMaxAggregates.cpp
   MinMaxByAggregates.cpp
   CountAggregate.cpp

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
+#include <velox/common/base/Exceptions.h>
+
+namespace facebook::velox::aggregate {
+
+void MapAggregateBase::extractValues(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  auto mapVector = (*result)->as<MapVector>();
+  VELOX_CHECK(mapVector);
+  mapVector->resize(numGroups);
+  auto mapKeys = mapVector->mapKeys();
+  auto mapValues = mapVector->mapValues();
+  auto numElements = countElements(groups, numGroups);
+  mapKeys->resize(numElements);
+  mapValues->resize(numElements);
+
+  auto* rawNulls = getRawNulls(mapVector);
+  vector_size_t offset = 0;
+
+  for (int32_t i = 0; i < numGroups; ++i) {
+    char* group = groups[i];
+    clearNull(rawNulls, i);
+
+    auto accumulator = value<MapAccumulator>(group);
+    auto mapSize = accumulator->keys.size();
+    if (mapSize) {
+      ValueListReader keysReader(accumulator->keys);
+      ValueListReader valuesReader(accumulator->values);
+      for (auto index = 0; index < mapSize; ++index) {
+        keysReader.next(*mapKeys, offset + index);
+        valuesReader.next(*mapValues, offset + index);
+      }
+      mapVector->setOffsetAndSize(i, offset, mapSize);
+      offset += mapSize;
+    } else {
+      mapVector->setOffsetAndSize(i, offset, 0);
+    }
+  }
+
+  // Canonicalize requires a singly referenced MapVector. std::move
+  // inside the cast does not clear *result, so we clear this
+  // manually.
+  auto mapVectorPtr = std::static_pointer_cast<MapVector>(std::move(*result));
+  *result = nullptr;
+  *result = removeDuplicates(mapVectorPtr);
+}
+
+VectorPtr MapAggregateBase::removeDuplicates(MapVectorPtr& mapVector) const {
+  MapVector::canonicalize(mapVector);
+
+  auto offsets = mapVector->rawOffsets();
+  auto sizes = mapVector->rawSizes();
+  auto mapKeys = mapVector->mapKeys();
+
+  auto numRows = mapVector->size();
+  auto numElements = mapKeys->size();
+
+  BufferPtr newSizes;
+  vector_size_t* rawNewSizes = nullptr;
+
+  BufferPtr elementIndices;
+  vector_size_t* rawElementIndices = nullptr;
+
+  // Check for duplicate keys.
+  for (vector_size_t row = 0; row < numRows; row++) {
+    auto offset = offsets[row];
+    auto size = sizes[row];
+    auto duplicateCnt = 0;
+    for (vector_size_t i = 1; i < size; i++) {
+      if (mapKeys->equalValueAt(mapKeys.get(), offset + i, offset + i - 1)) {
+        // Duplicate key found.
+        duplicateCnt++;
+        if (!rawNewSizes) {
+          newSizes = allocateSizes(numElements, mapVector->pool());
+          rawNewSizes = newSizes->asMutable<vector_size_t>();
+
+          elementIndices = allocateIndices(numElements, mapVector->pool());
+          rawElementIndices = elementIndices->asMutable<vector_size_t>();
+
+          memcpy(rawNewSizes, sizes, row * sizeof(vector_size_t));
+          std::iota(rawElementIndices, rawElementIndices + numElements, 0);
+        }
+      } else if (rawNewSizes) {
+        rawElementIndices[offset + i - duplicateCnt] = offset + i;
+      }
+    }
+    if (rawNewSizes) {
+      rawNewSizes[row] = size - duplicateCnt;
+    }
+  };
+
+  if (rawNewSizes) {
+    return std::make_shared<MapVector>(
+        mapVector->pool(),
+        mapVector->type(),
+        mapVector->nulls(),
+        mapVector->size(),
+        mapVector->offsets(),
+        newSizes,
+        BaseVector::wrapInDictionary(
+            BufferPtr(nullptr), elementIndices, numElements, mapKeys),
+        BaseVector::wrapInDictionary(
+            BufferPtr(nullptr),
+            elementIndices,
+            numElements,
+            mapVector->mapValues()));
+  } else {
+    return mapVector;
+  }
+}
+
+void MapAggregateBase::addMapInputToAccumulator(
+    char** groups,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool /*mayPushdown*/) {
+  decodedMaps_.decode(*args[0], rows);
+  auto mapVector = decodedMaps_.base()->as<MapVector>();
+
+  VELOX_CHECK_NOT_NULL(mapVector);
+  auto& mapKeys = mapVector->mapKeys();
+  auto& mapValues = mapVector->mapValues();
+  rows.applyToSelected([&](vector_size_t row) {
+    auto group = groups[row];
+    auto accumulator = value<MapAccumulator>(group);
+
+    auto decodedRow = decodedMaps_.index(row);
+    auto offset = mapVector->offsetAt(decodedRow);
+    auto size = mapVector->sizeAt(decodedRow);
+    auto tracker = trackRowSize(group);
+    accumulator->keys.appendRange(mapKeys, offset, size, allocator_);
+    accumulator->values.appendRange(mapValues, offset, size, allocator_);
+  });
+}
+
+void MapAggregateBase::addSingleGroupMapInputToAccumulator(
+    char* group,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool /*mayPushdown*/) {
+  decodedMaps_.decode(*args[0], rows);
+  auto mapVector = decodedMaps_.base()->as<MapVector>();
+
+  auto accumulator = value<MapAccumulator>(group);
+  auto& keys = accumulator->keys;
+  auto& values = accumulator->values;
+
+  VELOX_CHECK_NOT_NULL(mapVector);
+  auto& mapKeys = mapVector->mapKeys();
+  auto& mapValues = mapVector->mapValues();
+  rows.applyToSelected([&](vector_size_t row) {
+    auto decodedRow = decodedMaps_.index(row);
+    auto offset = mapVector->offsetAt(decodedRow);
+    auto size = mapVector->sizeAt(decodedRow);
+    keys.appendRange(mapKeys, offset, size, allocator_);
+    values.appendRange(mapValues, offset, size, allocator_);
+  });
+}
+} // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/ContainerRowSerde.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/ValueList.h"
+
+namespace facebook::velox::aggregate {
+struct MapAccumulator {
+  ValueList keys;
+  ValueList values;
+};
+
+class MapAggregateBase : public exec::Aggregate {
+ public:
+  explicit MapAggregateBase(TypePtr resultType) : Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(MapAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_) MapAccumulator();
+    }
+  }
+
+  void finalize(char** groups, int32_t numGroups) override {
+    for (auto i = 0; i < numGroups; i++) {
+      value<MapAccumulator>(groups[i])->keys.finalize(allocator_);
+      value<MapAccumulator>(groups[i])->values.finalize(allocator_);
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override;
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addMapInputToAccumulator(groups, rows, args, false);
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addSingleGroupMapInputToAccumulator(group, rows, args, false);
+  }
+
+  void destroy(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      auto accumulator = value<MapAccumulator>(group);
+      accumulator->keys.free(allocator_);
+      accumulator->values.free(allocator_);
+    }
+  }
+
+ protected:
+  vector_size_t countElements(char** groups, int32_t numGroups) const {
+    vector_size_t size = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      size += value<MapAccumulator>(groups[i])->keys.size();
+    }
+    return size;
+  }
+
+  VectorPtr removeDuplicates(MapVectorPtr& mapVector) const;
+
+  void addMapInputToAccumulator(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown);
+
+  void addSingleGroupMapInputToAccumulator(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown);
+
+  DecodedVector decodedKeys_;
+  DecodedVector decodedValues_;
+  DecodedVector decodedMaps_;
+};
+} // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   PrestoHasherTest.cpp
   SumTest.cpp
   MapAggTest.cpp
+  MapUnionAggregationTest.cpp
   ValueListTest.cpp
   VarianceAggregationTest.cpp)
 

--- a/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class MapUnionTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    // Tests only single batches of input.
+    disableSpill();
+  }
+};
+
+/**
+ * This test checks single, partial, intermediate, final aggregates
+ * with and without local exchange when
+ * there are no duplicates in the keys of the map.
+ *
+ * Takes as input a table that contains 2 columns.
+ * First column: five 0's followed by five 1's.
+ * Second column: A map of size one which contains
+ * consecutive numbers, where the key is NULL for
+ * every 4th entry (num % 4 == 0) and the value is NULL
+ * for every 7th entry (num % 7 == 0).
+ *
+ * The expected output is to GROUP BY the first column
+ * and the map size is to be of size 3 for the first row
+ * while of size 4 for the second row, where each map
+ * has a list of consecutive numbers and the value of the
+ * map is NULL for every 7th entry (num % 7 == 0).
+ */
+TEST_F(MapUnionTest, groupByWithoutDuplicates) {
+  auto inputVectors = {makeRowVector(
+      {makeFlatVector<int32_t>(10, [](vector_size_t row) { return row / 5; }),
+       makeMapVector<int32_t, double>(
+           10,
+           [&](vector_size_t /*row*/) { return 1; },
+           [&](vector_size_t row) { return row; },
+           [&](vector_size_t row) { return row + 0.05; },
+           nullEvery(4),
+           nullEvery(7))})};
+
+  auto expectedResult = {makeRowVector(
+      {makeFlatVector<int32_t>({0, 1}),
+       makeMapVector<int32_t, double>(
+           2,
+           [&](vector_size_t row) { return row == 0 ? 3 : 4; },
+           [&](vector_size_t row) { return row; },
+           [&](vector_size_t row) { return row + 0.05; },
+           nullptr,
+           nullEvery(7))})};
+
+  testAggregations(inputVectors, {"c0"}, {"map_union(c1)"}, expectedResult);
+}
+
+/**
+ * This test checks single, partial, intermediate, final aggregates
+ * with and without local exchange when
+ * there are duplicates in the keys of the map.
+ *
+ * Takes as input a table that contains 2 columns.
+ * First column: five 0's followed by five 1's
+ * Second column: A map of size one which contains
+ * (Key, Value) as (1, 1.05).
+ *
+ * The expected output is to GROUP BY the first column
+ * and for each row, the map size is to be of size 1 which
+ * contains (Key, Value) as (1, 1.05).
+ */
+TEST_F(MapUnionTest, groupByWithDuplicates) {
+  auto inputVectors = {makeRowVector(
+      {makeFlatVector<int32_t>(10, [](vector_size_t row) { return row / 5; }),
+       makeMapVector<int32_t, double>(
+           10,
+           [&](vector_size_t /*row*/) { return 1; },
+           [&](vector_size_t /*row*/) { return 1; },
+           [&](vector_size_t /*row*/) { return 1.05; })})};
+  auto expectedResult = {makeRowVector(
+      {makeFlatVector<int32_t>({0, 1}),
+       makeMapVector<int32_t, double>(
+           2,
+           [&](vector_size_t /*row*/) { return 1; },
+           [&](vector_size_t /*row*/) { return 1; },
+           [&](vector_size_t /*row*/) { return 1.05; })})};
+
+  testAggregations(inputVectors, {"c0"}, {"map_union(c1)"}, expectedResult);
+}
+
+/**
+ * This test checks single, partial, intermediate, final aggregates
+ * with and without local exchange when input is empty.
+ */
+TEST_F(MapUnionTest, groupByNoData) {
+  auto inputVectors = {makeRowVector(
+      {makeFlatVector<int32_t>({}), makeMapVector<int32_t, double>({})})};
+  auto expectedResult = inputVectors;
+
+  testAggregations(inputVectors, {"c0"}, {"map_union(c1)"}, expectedResult);
+}
+
+/**
+ * This test checks global aggregate when
+ * with and without local exchange when
+ * there are no duplicates in the keys of the map.
+ *
+ * Takes as input a table that contains 1 column i.e.
+ * a map of size one which contains consecutive numbers,
+ * where the key is NULL for every 4th entry
+ * (num % 4 == 0) and the value is NULL
+ * for every 7th entry (num % 7 == 0).
+ *
+ * The expected output is a map of all the non-NULL keys.
+ */
+TEST_F(MapUnionTest, globalWithoutDuplicates) {
+  auto inputVectors = {makeRowVector({makeMapVector<int32_t, double>(
+      10,
+      [&](vector_size_t /*row*/) { return 1; },
+      [&](vector_size_t row) { return row; },
+      [&](vector_size_t row) { return row + 0.05; },
+      nullEvery(4),
+      nullEvery(7))})};
+  auto expectedResult = {makeRowVector({makeMapVector<int32_t, double>(
+      1,
+      [&](vector_size_t /*row*/) { return 7; },
+      [&](vector_size_t row) { return row; },
+      [&](vector_size_t row) { return row + 0.05; },
+      nullptr,
+      nullEvery(7))})};
+
+  testAggregations(inputVectors, {}, {"map_union(c0)"}, expectedResult);
+}
+
+/**
+ * This test checks global aggregate when
+ * with and without local exchange when
+ * there are duplicates in the keys of the map.
+ *
+ * Takes as input a table that contains 1 column i.e.
+ * a map of size one which contains
+ * (Key, Value) as (1, 1.05).
+ *
+ * The expected output a map which
+ * contains (Key, Value) as (1, 1.05).
+ */
+TEST_F(MapUnionTest, globalWithDuplicates) {
+  auto inputVectors = {makeRowVector({makeMapVector<int32_t, double>(
+      10,
+      [&](vector_size_t /*row*/) { return 1; },
+      [&](vector_size_t /*row*/) { return 1; },
+      [&](vector_size_t /*row*/) { return 1.05; })})};
+  auto expectedResult = {makeRowVector({makeMapVector<int32_t, double>(
+      1,
+      [&](vector_size_t /*row*/) { return 1; },
+      [&](vector_size_t /*row*/) { return 1; },
+      [&](vector_size_t /*row*/) { return 1.05; })})};
+
+  testAggregations(inputVectors, {}, {"map_union(c0)"}, expectedResult);
+}
+
+/**
+ * This test checks global aggregate when
+ * the input is empty.
+ */
+TEST_F(MapUnionTest, globalNoData) {
+  auto inputVectors = {makeRowVector({makeMapVector<int32_t, double>(
+      1,
+      [&](vector_size_t /*row*/) { return 0; },
+      [&](vector_size_t /*row*/) { return 0; },
+      [&](vector_size_t /*row*/) { return 0; })})};
+  auto expectedResult = inputVectors;
+
+  testAggregations(inputVectors, {}, {"map_union(c0)"}, expectedResult);
+}
+} // namespace
+} // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
## Summary of changes
- Fixed an issue with the function `removeDuplicates` that initializes the values of `rawElementIndices` from `0` to the `number of total keys`
- Added more test cases for more coverage
- Replaced testing function `assertQuery()` with `testAggregates()` which also provides better test coverage

Differential Revision: D37185013

