### PR TITLE
Remove dependency on RLEv1 and v2 from IntDecoder and IntEncoder 

### DIFF
--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/common/DirectDecoder.h"
+#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/dwrf/common/RLEv1.h"
+#include "velox/dwio/dwrf/common/RLEv2.h"
+
+namespace facebook::velox::dwrf {
+/**
+ * Create an RLE decoder.
+ * @param input the input stream to read from
+ * @param version version of RLE decoding to do
+ * @param pool memory pool to use for allocation
+ */
+template <bool isSigned>
+std::unique_ptr<IntDecoder<isSigned>> createRleDecoder(
+    std::unique_ptr<dwio::common::SeekableInputStream> input,
+    RleVersion version,
+    memory::MemoryPool& pool,
+    bool useVInts,
+    uint32_t numBytes) {
+  switch (version) {
+    case RleVersion::RleVersion_1:
+      return std::make_unique<RleDecoderV1<isSigned>>(
+          std::move(input), useVInts, numBytes);
+    case RleVersion::RleVersion_2:
+      return std::make_unique<RleDecoderV2<isSigned>>(std::move(input), pool);
+    default:
+      DWIO_RAISE("RleVersion not supported");
+      return {};
+  }
+}
+
+/**
+ * Create a direct decoder
+ */
+template <bool isSigned>
+std::unique_ptr<IntDecoder<isSigned>> createDirectDecoder(
+    std::unique_ptr<dwio::common::SeekableInputStream> input,
+    bool useVInts,
+    uint32_t numBytes) {
+  return std::make_unique<DirectDecoder<isSigned>>(
+      std::move(input), useVInts, numBytes);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/EncoderUtil.h
+++ b/velox/dwio/dwrf/common/EncoderUtil.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/common/IntEncoder.h"
+#include "velox/dwio/dwrf/common/RLEv1.h"
+
+namespace facebook::velox::dwrf {
+
+/**
+ * Create an RLE encoder.
+ * @param version version of RLE encoding to do
+ * @param output the output stream to write to
+ * @param useVInts whether varint encoding will be used
+ * @param numBytes number of bytes the encoder will write for an integer
+ */
+template <bool isSigned>
+std::unique_ptr<IntEncoder<isSigned>> createRleEncoder(
+    RleVersion version,
+    std::unique_ptr<BufferedOutputStream> output,
+    bool useVInts,
+    uint32_t numBytes) {
+  switch (version) {
+    case RleVersion::RleVersion_1:
+      return std::make_unique<RleEncoderV1<isSigned>>(
+          std::move(output), useVInts, numBytes);
+    case RleVersion::RleVersion_2:
+    default:
+      DWIO_RAISE("RleVersion not supported");
+      return {};
+  }
+}
+
+template <bool isSigned>
+std::unique_ptr<IntEncoder<isSigned>> createDirectEncoder(
+    std::unique_ptr<BufferedOutputStream> output,
+    bool useVInts,
+    uint32_t numBytes) {
+  return std::make_unique<IntEncoder<isSigned>>(
+      std::move(output), useVInts, numBytes);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/IntDecoder.cpp
+++ b/velox/dwio/dwrf/common/IntDecoder.cpp
@@ -15,10 +15,9 @@
  */
 
 #include "velox/dwio/dwrf/common/IntDecoder.h"
+
 #include "velox/common/base/SimdUtil.h"
 #include "velox/dwio/dwrf/common/DirectDecoder.h"
-#include "velox/dwio/dwrf/common/RLEv1.h"
-#include "velox/dwio/dwrf/common/RLEv2.h"
 
 namespace facebook::velox::dwrf {
 
@@ -2406,56 +2405,6 @@ template void IntDecoder<false>::bulkReadRows(
     RowSet rows,
     int16_t* result,
     int32_t initialRow);
-
-template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> IntDecoder<isSigned>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes) {
-  switch (static_cast<int64_t>(version)) {
-    case RleVersion_1:
-      return std::make_unique<RleDecoderV1<isSigned>>(
-          std::move(input), useVInts, numBytes);
-    case RleVersion_2:
-      return std::make_unique<RleDecoderV2<isSigned>>(std::move(input), pool);
-    default:
-      DWIO_ENSURE(false, "not supported");
-      return {};
-  }
-}
-
-template std::unique_ptr<IntDecoder<true>> IntDecoder<true>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntDecoder<false>> IntDecoder<false>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes);
-
-template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> IntDecoder<isSigned>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes) {
-  return std::make_unique<DirectDecoder<isSigned>>(
-      std::move(input), useVInts, numBytes);
-}
-
-template std::unique_ptr<IntDecoder<true>> IntDecoder<true>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntDecoder<false>> IntDecoder<false>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes);
 
 #ifdef CODEGEN_BULK_VARINTS
 // Codegen for vint bulk decode. This is to document how varintSwitch

--- a/velox/dwio/dwrf/common/IntDecoder.h
+++ b/velox/dwio/dwrf/common/IntDecoder.h
@@ -16,14 +16,15 @@
 
 #pragma once
 
-#include <folly/Likely.h>
-#include <folly/Range.h>
-#include <folly/Varint.h>
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/StreamUtil.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
+
+#include <folly/Likely.h>
+#include <folly/Range.h>
+#include <folly/Varint.h>
 
 namespace facebook::velox::dwrf {
 
@@ -102,27 +103,6 @@ class IntDecoder {
   size_t loadIndices(size_t startIndex) {
     return inputStream->positionSize() + startIndex + 1;
   }
-
-  /**
-   * Create an RLE decoder.
-   * @param input the input stream to read from
-   * @param version version of RLE decoding to do
-   * @param pool memory pool to use for allocation
-   */
-  static std::unique_ptr<IntDecoder<isSigned>> createRle(
-      std::unique_ptr<dwio::common::SeekableInputStream> input,
-      RleVersion version,
-      memory::MemoryPool& pool,
-      bool useVInts,
-      uint32_t numBytes);
-
-  /**
-   * Create a direct decoder
-   */
-  static std::unique_ptr<IntDecoder<isSigned>> createDirect(
-      std::unique_ptr<dwio::common::SeekableInputStream> input,
-      bool useVInts,
-      uint32_t numBytes);
 
   void skipLongs(uint64_t numValues);
 

--- a/velox/dwio/dwrf/common/IntEncoder.cpp
+++ b/velox/dwio/dwrf/common/IntEncoder.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/RLEv1.h"
 
 namespace facebook::velox::dwrf {
 
@@ -29,51 +28,5 @@ uint64_t IntEncoder<isSigned>::flush() {
 
 template uint64_t IntEncoder<true>::flush();
 template uint64_t IntEncoder<false>::flush();
-
-template <bool isSigned>
-std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes) {
-  switch (static_cast<int64_t>(version)) {
-    case RleVersion_1:
-      return std::make_unique<RleEncoderV1<isSigned>>(
-          std::move(output), useVInts, numBytes);
-    case RleVersion_2:
-    default:
-      DWIO_ENSURE(false, "not supported");
-      return {};
-  }
-}
-
-template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-
-template <bool isSigned>
-std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes) {
-  return std::make_unique<IntEncoder<isSigned>>(
-      std::move(output), useVInts, numBytes);
-}
-
-template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
+
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exceptions.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
@@ -362,12 +364,12 @@ IntegerDirectColumnReader<ReqT>::IntegerDirectColumnReader(
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
   if (stripe.getFormat() == dwio::common::FileFormat::DWRF) {
-    ints = IntDecoder</*isSigned*/ true>::createDirect(
+    ints = createDirectDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), dataVInts, numBytes);
   } else {
     auto encoding = stripe.getEncoding(encodingKey);
     RleVersion vers = convertRleVersion(encoding.kind());
-    ints = IntDecoder</*isSigned*/ true>::createRle(
+    ints = createRleDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), vers, memoryPool_, dataVInts, numBytes);
   }
 }
@@ -495,7 +497,7 @@ IntegerDictionaryColumnReader<ReqT>::IntegerDictionaryColumnReader(
   RleVersion vers = convertRleVersion(encoding.kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
-  dataReader = IntDecoder</* isSigned = */ false>::createRle(
+  dataReader = createRleDecoder</* isSigned = */ false>(
       stripe.getStream(data, true), vers, memoryPool_, dataVInts, numBytes);
 
   // make a lazy dictionary initializer
@@ -608,11 +610,11 @@ TimestampColumnReader::TimestampColumnReader(
   RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
-  seconds = IntDecoder</*isSigned*/ true>::createRle(
+  seconds = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
   bool nanoVInts = stripe.getUseVInts(nanoData);
-  nano = IntDecoder</*isSigned*/ false>::createRle(
+  nano = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(nanoData, true),
       vers,
       memoryPool_,
@@ -922,7 +924,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
   const auto dataId = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dictVInts = stripe.getUseVInts(dataId);
-  dictIndex = IntDecoder</*isSigned*/ false>::createRle(
+  dictIndex = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, true),
       rleVersion,
       memoryPool_,
@@ -931,7 +933,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, false),
       rleVersion,
       memoryPool_,
@@ -961,7 +963,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
     const auto strideDictLenId =
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH);
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
-    strideDictLengthDecoder = IntDecoder</*isSigned*/ false>::createRle(
+    strideDictLengthDecoder = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, true),
         rleVersion,
         memoryPool_,
@@ -1403,7 +1405,7 @@ StringDirectColumnReader::StringDirectColumnReader(
       convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true),
       rleVersion,
       memoryPool_,
@@ -1687,7 +1689,7 @@ ListColumnReader::ListColumnReader(
 
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();
@@ -1845,7 +1847,7 @@ MapColumnReader::MapColumnReader(
 
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 using namespace dwio::common;
 
@@ -36,7 +38,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
   rleVersion_ = convertRleVersion(encoding.kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
-  dataReader_ = IntDecoder</* isSigned = */ false>::createRle(
+  dataReader_ = createRleDecoder</* isSigned = */ false>(
       stripe.getStream(data, true),
       rleVersion_,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h"
 
 namespace facebook::velox::dwrf {
@@ -38,7 +39,7 @@ class SelectiveIntegerDirectColumnReader : public SelectiveIntegerColumnReader {
     EncodingKey encodingKey{nodeType_->id, flatMapContext_.sequence};
     auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
     bool dataVInts = stripe.getUseVInts(data);
-    auto decoder = IntDecoder</*isSigned*/ true>::createDirect(
+    auto decoder = createDirectDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), dataVInts, numBytes);
     auto rawDecoder = decoder.release();
     auto directDecoder = dynamic_cast<DirectDecoder<true>*>(rawDecoder);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
@@ -48,7 +49,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     auto rleVersion = convertRleVersion(stripe.getEncoding(encodingKey).kind());
     auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
     bool lenVints = stripe.getUseVInts(lenId);
-    length_ = IntDecoder</*isSigned*/ false>::createRle(
+    length_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(lenId, true),
         rleVersion,
         memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 using namespace dwio::common;
@@ -41,7 +43,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
 
   const auto dataId = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dictVInts = stripe.getUseVInts(dataId);
-  dictIndex_ = IntDecoder</*isSigned*/ false>::createRle(
+  dictIndex_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, true),
       rleVersion,
       memoryPool_,
@@ -50,7 +52,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, false),
       rleVersion,
       memoryPool_,
@@ -77,7 +79,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
     const auto strideDictLenId =
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH);
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
-    strideDictLengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+    strideDictLengthDecoder_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, true),
         rleVersion,
         memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
@@ -34,7 +36,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
       convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true),
       rleVersion,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 using namespace dwio::common;
@@ -35,11 +37,11 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
   RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
-  seconds_ = IntDecoder</*isSigned*/ true>::createRle(
+  seconds_ = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
   bool nanoVInts = stripe.getUseVInts(nanoData);
-  nano_ = IntDecoder</*isSigned*/ false>::createRle(
+  nano_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(nanoData, true),
       vers,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-#include <folly/ScopeGuard.h>
+#include "velox/dwio/dwrf/reader/StripeStream.h"
 
 #include "velox/common/base/BitSet.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/wrap/coded-stream-wrapper.h"
-#include "velox/dwio/dwrf/reader/StripeStream.h"
+
+#include <folly/ScopeGuard.h>
 
 namespace facebook::velox::dwrf {
 
@@ -121,7 +123,7 @@ StripeStreamsBase::getIntDictionaryInitializerForNode(
   DWIO_ENSURE(dataStream.get());
   stripeDictionaryCache_->registerIntDictionary(
       localEk,
-      [dictReader = IntDecoder</* isSigned = */ true>::createDirect(
+      [dictReader = createDirectDecoder</* isSigned = */ true>(
            std::move(dataStream), dictVInts, elementWidth),
        dictionaryWidth,
        dictionarySize](velox::memory::MemoryPool* pool) mutable {

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-#include <folly/Random.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <algorithm>
-#include <optional>
-#include <vector>
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
@@ -31,6 +26,14 @@
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/type/Type.h"
 #include "velox/vector/DictionaryVector.h"
+
+#include <folly/Random.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <optional>
+#include <vector>
+
 using namespace ::testing;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::dwrf;
@@ -3739,7 +3742,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
   auto stream = streams.getStream(si, true);
 
   // read it as long
-  auto decoder = IntDecoder<false>::createRle(
+  auto decoder = createRleDecoder<false>(
       std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
@@ -3785,7 +3788,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
   auto stream = streams.getStream(si, true);
 
   // read it as long
-  auto decoder = IntDecoder<false>::createRle(
+  auto decoder = createRleDecoder<false>(
       std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/dwrf/common/DataBufferHolder.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
+#include "velox/dwio/dwrf/common/IntEncoder.h"
+#include "velox/dwio/dwrf/common/Range.h"
+
 #include <folly/Benchmark.h>
 #include <folly/Varint.h>
 #include <folly/init/Init.h>
-#include "velox/common/memory/Memory.h"
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
-#include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/Range.h"
 
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox;
@@ -33,7 +35,7 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
   DataBufferHolder holder{*scopedPool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<true>::createDirect(std::move(output), true, sizeof(int64_t));
+      createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));
 
   for (int64_t i = 0; i < count; i++) {
     encoder->writeValue(startId + i);
@@ -47,7 +49,7 @@ static size_t generateAutoId2(int64_t startId, int64_t count) {
   DataBufferHolder holder{*scopedPool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<true>::createDirect(std::move(output), true, sizeof(int64_t));
+      createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));
 
   int64_t buffer[1024];
   int64_t currentId = startId;

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -45,7 +46,7 @@ void testInts(std::function<T()> generator) {
   DataBufferHolder holder{pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<isSigned>::createDirect(std::move(output), vInt, sizeof(T));
+      createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));
 
   encoder->add(buffer.data(), Ranges::of(0, count), nulls.data());
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -19,6 +19,7 @@
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Compression.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
 #include "velox/dwio/dwrf/writer/RatioTracker.h"
@@ -145,7 +146,7 @@ class WriterContext : public CompressionBufferPool {
               dictionaryPool,
               generalPool,
               getConfig(Config::DICTIONARY_SORT_KEYS),
-              IntEncoder</* isSigned = */ true>::createDirect(
+              createDirectEncoder</* isSigned */ true>(
                   newStream(
                       {ek.node,
                        ek.sequence,


### PR DESCRIPTION
IntDecoder will be moved to dwio::common, but its member functions createRle and createDirect need to reference RLEv1 and RLEv2. This PR moves the decoder creation from IntDecoder to the new DecoderUtil.h to prepare for the upcoming moves. In addition, the encoder creation from IntEncoder was moved out to EncoderUtil.h to keep the encoder creation in the same manner..