### PR TITLE
Add CAST(JSON as ...) support for array and map

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -500,10 +500,11 @@ void applyCustomTypeCast(
     castOperator->castTo(
         *inputDecoded->base(), context, *baseRows, nullOnFailure, *localResult);
   } else {
-    VELOX_NYI(
-        "Casting from {} to {} is not implemented yet.",
-        thisType->toString(),
-        otherType->toString());
+    BaseVector::ensureWritable(
+        *baseRows, otherType, context.pool(), &localResult);
+
+    castOperator->castFrom(
+        *inputDecoded->base(), context, *baseRows, nullOnFailure, *localResult);
   }
 
   if (!inputDecoded->isIdentityMapping()) {

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -27,9 +27,13 @@ class CastOperator {
  public:
   virtual ~CastOperator() = default;
 
-  /// Determines whether the cast operator supports casting the custom type to
-  /// the other type or vice versa.
-  virtual bool isSupportedType(const TypePtr& other) const = 0;
+  /// Determines whether the cast operator supports casting to the custom type
+  /// from the other type.
+  virtual bool isSupportedFromType(const TypePtr& other) const = 0;
+
+  /// Determines whether the cast operator supports casting from the custom type
+  /// to the other type.
+  virtual bool isSupportedToType(const TypePtr& other) const = 0;
 
   /// Casts an input vector to the custom type.
   /// @param input The flat or constant input vector
@@ -74,13 +78,13 @@ class CastExpr : public SpecialForm {
         nullOnFailure_(nullOnFailure) {
     auto fromType = inputs_[0]->type();
     castFromOperator_ = getCastOperator(fromType->toString());
-    if (castFromOperator_ && !castFromOperator_->isSupportedType(type)) {
+    if (castFromOperator_ && !castFromOperator_->isSupportedToType(type)) {
       VELOX_FAIL(
           "Cannot cast {} to {}.", fromType->toString(), type->toString());
     }
 
     castToOperator_ = getCastOperator(type->toString());
-    if (castToOperator_ && !castToOperator_->isSupportedType(fromType)) {
+    if (castToOperator_ && !castToOperator_->isSupportedFromType(fromType)) {
       VELOX_FAIL(
           "Cannot cast {} to {}.", fromType->toString(), type->toString());
     }

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1084,48 +1084,6 @@ class GenericView {
   }
 
  private:
-  // Utility class that checks that vectorType matches T.
-  template <typename T>
-  struct CastTypeChecker {
-    static bool check(const TypePtr& vectorType) {
-      return CppToType<T>::typeKind == vectorType->kind();
-    }
-  };
-
-  template <typename T>
-  struct CastTypeChecker<Generic<T>> {
-    static bool check(const TypePtr&) {
-      return true;
-    }
-  };
-
-  template <typename T>
-  struct CastTypeChecker<Array<T>> {
-    static bool check(const TypePtr& vectorType) {
-      return TypeKind::ARRAY == vectorType->kind() &&
-          CastTypeChecker<T>::check(vectorType->childAt(0));
-    }
-  };
-
-  template <typename K, typename V>
-  struct CastTypeChecker<Map<K, V>> {
-    static bool check(const TypePtr& vectorType) {
-      return TypeKind::MAP == vectorType->kind() &&
-          CastTypeChecker<K>::check(vectorType->childAt(0)) &&
-          CastTypeChecker<V>::check(vectorType->childAt(1));
-    }
-  };
-
-  template <typename... T>
-  struct CastTypeChecker<Row<T...>> {
-    static bool check(const TypePtr& vectorType) {
-      int index = 0;
-      return TypeKind::ROW == vectorType->kind() &&
-          (CastTypeChecker<T>::check(vectorType->childAt(index++)) && ... &&
-           true);
-    }
-  };
-
   template <typename B>
   VectorReader<B>* ensureReader() const {
     static_assert(

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <tuple>
 #include <utility>
+#include <variant>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
@@ -69,10 +70,12 @@ template <typename V>
 bool constexpr provide_std_interface = CppToType<V>::isPrimitiveType &&
     !std::is_same<Varchar, V>::value && !std::is_same<Varbinary, V>::value;
 
+// Adding Any-type items requires commit, but CppToType<Any>::isPrimitiveType is
+// true, so we add an explicit condition for Any here.
 template <typename V>
-bool constexpr requires_commit =
-    !CppToType<V>::isPrimitiveType || std::is_same<Varchar, V>::value ||
-    std::is_same<bool, V>::value || std::is_same<Varbinary, V>::value;
+bool constexpr requires_commit = !CppToType<V>::isPrimitiveType ||
+    std::is_same<Varchar, V>::value || std::is_same<bool, V>::value ||
+    std::is_same<Varbinary, V>::value || std::is_same<Any, V>::value;
 
 // The object passed to the simple function interface that represent a single
 // array entry.
@@ -677,6 +680,118 @@ class RowWriter {
 
   template <size_t I, class... Types>
   friend auto get(const RowWriter<Types...>& writer);
+};
+
+// GenericWriter represents a writer of any type. It has to be casted to one
+// specific type first in order to write values to a vector. A GenericWriter
+// must be casted to the same type throughout its lifetime, or an exception will
+// throw. Right now, only casting to the types in writer_variant_t is supported.
+// Casting to unsupported types causes compilation error.
+class GenericWriter {
+ public:
+  // Make sure user do not use these.
+  GenericWriter() = delete;
+
+  GenericWriter(const GenericWriter&) = delete;
+
+  GenericWriter& operator=(const GenericWriter&) = delete;
+
+  template <typename T>
+  using writer_ptr_t = std::shared_ptr<VectorWriter<T, void>>;
+
+  using writer_variant_t = std::variant<
+      writer_ptr_t<bool>,
+      writer_ptr_t<int8_t>,
+      writer_ptr_t<int16_t>,
+      writer_ptr_t<int32_t>,
+      writer_ptr_t<int64_t>,
+      writer_ptr_t<float>,
+      writer_ptr_t<double>,
+      writer_ptr_t<Varchar>,
+      writer_ptr_t<Varbinary>,
+      writer_ptr_t<Array<Any>>,
+      writer_ptr_t<Map<Any, Any>>>;
+
+  GenericWriter(writer_variant_t& castWriter, TypePtr& castType, size_t& index)
+      : castWriter_{castWriter}, castType_{castType}, index_{index} {}
+
+  TypeKind kind() const {
+    return vector_->typeKind();
+  }
+
+  const TypePtr type() const {
+    return vector_->type();
+  }
+
+  template <typename ToType>
+  typename VectorWriter<ToType, void>::exec_out_t& castTo() {
+    VELOX_USER_CHECK(
+        CastTypeChecker<ToType>::check(type()),
+        fmt::format(
+            "castTo type is not compatible with type of vector, vector type is {}, casted to type is {}",
+            type()->toString(),
+            CppToType<ToType>::create()->toString()));
+
+    return *castToImpl<ToType>();
+  }
+
+  template <typename ToType>
+  typename VectorWriter<ToType, void>::exec_out_t* tryCastTo() {
+    if (!CastTypeChecker<ToType>::check(type())) {
+      return nullptr;
+    }
+
+    return castToImpl<ToType>();
+  }
+
+ private:
+  void initialize(BaseVector* vector) {
+    vector_ = vector;
+  }
+
+  template <typename ToType>
+  typename VectorWriter<ToType, void>::exec_out_t* castToImpl() {
+    auto& typedWriter = ensureWriter<ToType>();
+    typedWriter->setOffset(index_);
+    return &typedWriter->current();
+  }
+
+  template <typename B>
+  writer_ptr_t<B>& ensureWriter() {
+    static_assert(
+        !isGenericType<B>::value && !isVariadicType<B>::value,
+        "Cannot cast to VectorWriter of Generic or Variadic");
+
+    // TODO: optimize the mapping between template type B and requestedType.
+    // Make this mapping static since B is known at compile time and among only
+    // a limited number of supported types.
+    auto requestedType = CppToType<B>::create();
+
+    if (castType_) {
+      VELOX_USER_CHECK(
+          castType_->operator==(*requestedType),
+          fmt::format(
+              "Not allowed to cast to two different types {} and {} within the same batch.",
+              castType_->toString(),
+              requestedType->toString()));
+      return std::get<writer_ptr_t<B>>(castWriter_);
+    } else {
+      castType_ = std::move(requestedType);
+
+      castWriter_ = std::make_shared<VectorWriter<B, void>>();
+      auto& writer = std::get<writer_ptr_t<B>>(castWriter_);
+      writer->init(*vector_->as<typename TypeToFlatVector<B>::type>());
+      return writer;
+    }
+  }
+
+  BaseVector* vector_;
+  writer_variant_t& castWriter_;
+  TypePtr& castType_;
+  size_t& index_;
+
+  template <typename A, typename B>
+  friend struct VectorWriter;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -38,7 +38,8 @@ add_executable(
   GenericViewTest.cpp
   TryExprTest.cpp
   VariadicViewTest.cpp
-  VectorReaderTest.cpp)
+  VectorReaderTest.cpp
+  GenericWriterTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <velox/vector/ComplexVector.h>
+#include "velox/expression/VectorWriters.h"
+#include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox {
+namespace {
+
+class GenericWriterTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(GenericWriterTest, boolean) {
+  VectorPtr result;
+  BaseVector::ensureWritable(SelectivityVector(5), BOOLEAN(), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 5; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current();
+    current.castTo<bool>() = i % 2;
+
+    writer.commit(true);
+  }
+  writer.finish();
+  test::assertEqualVectors(
+      makeFlatVector<bool>({false, true, false, true, false}), result);
+
+  writer.setOffset(0);
+  auto& current = writer.current();
+  ASSERT_THROW(current.castTo<int32_t>(), VeloxUserError);
+
+  ASSERT_NO_THROW(current.tryCastTo<int32_t>());
+  ASSERT_TRUE(current.tryCastTo<int32_t>() == nullptr);
+}
+
+TEST_F(GenericWriterTest, integer) {
+  VectorPtr result;
+  BaseVector::ensureWritable(SelectivityVector(100), BIGINT(), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 100; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current();
+    current.castTo<int64_t>() = i + 1000;
+
+    writer.commit(true);
+  }
+  writer.finish();
+  test::assertEqualVectors(
+      makeFlatVector<int64_t>(100, [](auto row) { return row + 1000; }),
+      result);
+}
+
+TEST_F(GenericWriterTest, varchar) {
+  VectorPtr result;
+  BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 5; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current().castTo<Varchar>();
+    current.copy_from(std::to_string(i + 10));
+
+    writer.commit(true);
+  }
+  writer.setOffset(5);
+  writer.current().castTo<Varchar>().copy_from(std::to_string(5 + 10));
+  writer.commitNull();
+
+  writer.finish();
+  test::assertEqualVectors(
+      makeNullableFlatVector<StringView>(
+          {"10"_sv, "11"_sv, "12"_sv, "13"_sv, "14"_sv, std::nullopt}),
+      result);
+}
+
+TEST_F(GenericWriterTest, array) {
+  VectorPtr result;
+  BaseVector::ensureWritable(
+      SelectivityVector(5), ARRAY(BIGINT()), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+  for (int i = 0; i < 5; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current().castTo<Array<Any>>();
+
+    current.add_item().castTo<int64_t>() = i * 3;
+    *current.add_item().tryCastTo<int64_t>() = i * 3 + 1;
+    current.add_item().castTo<int64_t>() = i * 3 + 2;
+
+    writer.commit(true);
+  }
+  writer.finish();
+
+  ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 15);
+
+  auto data = makeNullableArrayVector<int64_t>(
+      {{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}, {12, 13, 14}});
+  test::assertEqualVectors(data, result);
+
+  writer.setOffset(0);
+  auto& current = writer.current();
+  ASSERT_THROW(current.castTo<double>(), VeloxUserError);
+
+  ASSERT_NO_THROW(current.tryCastTo<double>());
+  ASSERT_TRUE(current.tryCastTo<double>() == nullptr);
+}
+
+TEST_F(GenericWriterTest, map) {
+  VectorPtr result;
+  BaseVector::ensureWritable(
+      SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 4; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current().castTo<Map<Any, Any>>();
+
+    auto tuple = current.add_item();
+    std::get<0>(tuple).castTo<Varchar>().copy_from(std::to_string(i * 2));
+    *std::get<1>(tuple).tryCastTo<int64_t>() = i * 2;
+
+    auto& key = current.add_null();
+    key.castTo<Varchar>().copy_from(std::to_string(i * 2 + 1));
+
+    writer.commit(true);
+  }
+  writer.finish();
+
+  ASSERT_EQ(result->as<MapVector>()->mapKeys()->size(), 8);
+  ASSERT_EQ(result->as<MapVector>()->mapValues()->size(), 8);
+
+  auto data = makeNullableMapVector<StringView, int64_t>(
+      {{{{"0"_sv, 0}, {"1"_sv, std::nullopt}}},
+       {{{"2"_sv, 2}, {"3"_sv, std::nullopt}}},
+       {{{"4"_sv, 4}, {"5"_sv, std::nullopt}}},
+       {{{"6"_sv, 6}, {"7"_sv, std::nullopt}}}});
+  test::assertEqualVectors(data, result);
+}
+
+TEST_F(GenericWriterTest, nested) {
+  VectorPtr result;
+  BaseVector::ensureWritable(
+      SelectivityVector(3), MAP(BIGINT(), ARRAY(BIGINT())), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 3; ++i) {
+    writer.setOffset(i);
+
+    auto& current = writer.current().castTo<Map<Any, Any>>();
+
+    auto pair = current.add_item();
+    std::get<0>(pair).castTo<int64_t>() = i * 3;
+
+    auto& array = std::get<1>(pair).castTo<Array<Any>>();
+    array.add_item().castTo<int64_t>() = i * 3 + 1;
+    *array.add_item().tryCastTo<int64_t>() = i * 3 + 2;
+    array.add_null();
+
+    writer.commit(true);
+  }
+  writer.finish();
+
+  ASSERT_EQ(result->as<MapVector>()->mapKeys()->size(), 3);
+  ASSERT_EQ(result->as<MapVector>()->mapValues()->size(), 3);
+  ASSERT_EQ(
+      result->as<MapVector>()
+          ->mapValues()
+          ->as<ArrayVector>()
+          ->elements()
+          ->size(),
+      9);
+
+  auto arrayVector = makeNullableArrayVector<int64_t>(
+      {{1, 2, std::nullopt}, {4, 5, std::nullopt}, {7, 8, std::nullopt}});
+  auto keyVector = makeNullableFlatVector<int64_t>({0, 3, 6});
+
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(3, pool());
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(3, pool());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+
+  rawSizes[0] = rawSizes[1] = rawSizes[2] = 1;
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 1;
+  rawOffsets[2] = 2;
+
+  auto mapVector = std::make_shared<MapVector>(
+      pool(),
+      MAP(BIGINT(), ARRAY(BIGINT())),
+      nullptr,
+      3,
+      offsets,
+      sizes,
+      keyVector,
+      arrayVector,
+      0);
+
+  test::assertEqualVectors(mapVector, result);
+}
+
+TEST_F(GenericWriterTest, commitNull) {
+  VectorPtr result;
+  BaseVector::ensureWritable(SelectivityVector(3), BIGINT(), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (int i = 0; i < 3; ++i) {
+    writer.setOffset(i);
+    writer.commitNull();
+  }
+  writer.finish();
+
+  auto data = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  test::assertEqualVectors(data, result);
+}
+
+TEST_F(GenericWriterTest, handleMisuse) {
+  auto initializeAndAddElements = [](const VectorPtr& vector,
+                                     VectorWriter<Any>& writer) {
+    writer.init(*vector);
+    writer.setOffset(0);
+
+    auto& current = writer.current().castTo<Array<Any>>();
+    current.add_item().castTo<int64_t>() = 1;
+    current.add_item().castTo<int64_t>() = 2;
+  };
+
+  // Test finish without commit.
+  VectorPtr result;
+  BaseVector::ensureWritable(
+      SelectivityVector(1), ARRAY(BIGINT()), pool(), &result);
+
+  VectorWriter<Any> writer1;
+  initializeAndAddElements(result, writer1);
+
+  writer1.finish();
+  ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
+
+  // Test commitNull after adding elements.
+  VectorWriter<Any> writer2;
+  initializeAndAddElements(result, writer2);
+
+  writer2.commitNull();
+  writer2.finish();
+
+  ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
+  ASSERT_TRUE(result->as<ArrayVector>()->isNullAt(0));
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -49,7 +49,11 @@ class CastBaseTest : public FunctionBaseTest {
             std::vector<std::shared_ptr<const core::ITypedExpr>>{inputField},
             tryCast);
 
-    return evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    if constexpr (std::is_same_v<TTo, ComplexType>) {
+      return evaluate(castExpr, input);
+    } else {
+      return evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    }
   }
 
   template <typename TTo>
@@ -83,7 +87,12 @@ class CastBaseTest : public FunctionBaseTest {
             std::vector<std::shared_ptr<const core::ITypedExpr>>{callExpr},
             tryCast);
 
-    auto result = evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    VectorPtr result;
+    if constexpr (std::is_same_v<TTo, ComplexType>) {
+      result = evaluate(castExpr, input);
+    } else {
+      result = evaluate<SimpleVector<EvalType<TTo>>>(castExpr, input);
+    }
 
     auto indices =
         ::facebook::velox::test::makeIndicesInReverse(expected->size(), pool());

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -124,10 +124,23 @@ class CastBaseTest : public FunctionBaseTest {
       const TypePtr& toType,
       std::vector<std::optional<TFrom>> input,
       std::vector<std::optional<TTo>> expected) {
-    auto inputVector = makeNullableFlatVector<TFrom>(input);
+    auto inputVector = makeNullableFlatVector<TFrom>(input, fromType);
     auto expectedVector = makeNullableFlatVector<TTo>(expected, toType);
 
     testCast<TTo>(fromType, toType, inputVector, expectedVector);
+  }
+
+  template <typename TFrom, typename TTo>
+  void testThrow(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      std::vector<std::optional<TFrom>> input) {
+    EXPECT_THROW(
+        evaluateCast<TTo>(
+            fromType,
+            toType,
+            makeRowVector({makeNullableFlatVector<TFrom>(input, fromType)})),
+        VeloxException);
   }
 };
 

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -850,3 +850,8 @@ TEST_F(JsonCastTest, toBoolean) {
   testThrow<Json, bool>(JSON(), BOOLEAN(), {R"("abc")"_sv});
   testThrow<Json, bool>(JSON(), BOOLEAN(), {""_sv});
 }
+
+TEST_F(JsonCastTest, toInvalid) {
+  testThrow<Json, Timestamp>(JSON(), TIMESTAMP(), {"null"});
+  testThrow<Json, Date>(JSON(), DATE(), {"null"});
+}

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -723,3 +723,44 @@ TEST_F(JsonCastTest, unsupportedTypes) {
               {"123"_sv, R"("abc")"_sv, ""_sv, std::nullopt}, JSON())})),
       VeloxException);
 }
+
+TEST_F(JsonCastTest, toVarchar) {
+  testCast<Json, StringView>(
+      JSON(),
+      VARCHAR(),
+      {R"("aaa")"_sv, R"("bbb")"_sv, R"("ccc")"_sv},
+      {"aaa"_sv, "bbb"_sv, "ccc"_sv});
+  testCast<Json, StringView>(
+      JSON(),
+      VARCHAR(),
+      {"\"\""_sv,
+       std::nullopt,
+       R"("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\"\\ .")"_sv},
+      {""_sv,
+       std::nullopt,
+       "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\"\\ ."_sv});
+  testCast<Json, StringView>(
+      JSON(),
+      VARCHAR(),
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  testCast<Json, StringView>(
+      JSON(),
+      VARCHAR(),
+      {"123"_sv,
+       "-12.3"_sv,
+       "true"_sv,
+       "false"_sv,
+       "NaN"_sv,
+       "Infinity"_sv,
+       "-Infinity"_sv,
+       "null"_sv},
+      {"123"_sv,
+       "-12.3"_sv,
+       "true"_sv,
+       "false"_sv,
+       "NaN"_sv,
+       "Infinity"_sv,
+       "-Infinity"_sv,
+       std::nullopt});
+}

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -603,7 +603,7 @@ bool isSupportedBasicType(const TypePtr& type) {
 
 } // namespace
 
-bool JsonCastOperator::isSupportedType(const TypePtr& other) const {
+bool JsonCastOperator::isSupportedFromType(const TypePtr& other) const {
   if (isSupportedBasicType(other)) {
     return true;
   }
@@ -614,10 +614,10 @@ bool JsonCastOperator::isSupportedType(const TypePtr& other) const {
     case TypeKind::TIMESTAMP:
       return true;
     case TypeKind::ARRAY:
-      return isSupportedType(other->childAt(0));
+      return isSupportedFromType(other->childAt(0));
     case TypeKind::ROW:
-      for (auto& child : other->as<TypeKind::ROW>().children()) {
-        if (!isSupportedType(child)) {
+      for (const auto& child : other->as<TypeKind::ROW>().children()) {
+        if (!isSupportedFromType(child)) {
           return false;
         }
       }
@@ -625,7 +625,31 @@ bool JsonCastOperator::isSupportedType(const TypePtr& other) const {
     case TypeKind::MAP:
       return (
           isSupportedBasicType(other->childAt(0)) &&
-          isSupportedType(other->childAt(1)));
+          isSupportedFromType(other->childAt(1)));
+    default:
+      return false;
+  }
+}
+
+bool JsonCastOperator::isSupportedToType(const TypePtr& other) const {
+  if (isSupportedBasicType(other)) {
+    return true;
+  }
+
+  switch (other->kind()) {
+    case TypeKind::ARRAY:
+      return isSupportedToType(other->childAt(0));
+    case TypeKind::ROW:
+      for (const auto& child : other->as<TypeKind::ROW>().children()) {
+        if (!isSupportedToType(child)) {
+          return false;
+        }
+      }
+      return true;
+    case TypeKind::MAP:
+      return (
+          isSupportedBasicType(other->childAt(0)) &&
+          isSupportedToType(other->childAt(1)));
     default:
       return false;
   }

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -30,7 +30,9 @@ class JsonCastOperator : public exec::CastOperator {
     return instance;
   }
 
-  bool isSupportedType(const TypePtr& other) const override;
+  bool isSupportedFromType(const TypePtr& other) const override;
+
+  bool isSupportedToType(const TypePtr& other) const override;
 
   void castTo(
       const BaseVector& input,

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -40,13 +40,11 @@ class JsonCastOperator : public exec::CastOperator {
       BaseVector& result) const override;
 
   void castFrom(
-      const BaseVector& /*input*/,
-      exec::EvalCtx& /*context*/,
-      const SelectivityVector& /*rows*/,
-      bool /*nullOnFailure*/,
-      BaseVector& /*result*/) const override {
-    VELOX_NYI("Casting from JSON is not implemented yet.");
-  }
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      bool nullOnFailure,
+      BaseVector& result) const override;
 
  private:
   JsonCastOperator() = default;


### PR DESCRIPTION
Summary: Casting JSON to ROW type or complex types that have ROW type nested inside are not supported yet.

Differential Revision: D37197502

