### PR TITLE
Struct fields are captured as top level columns in lambdas

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -221,12 +221,15 @@ class FieldAccessTypedExpr : public ITypedExpr {
  public:
   /// Used as a leaf in an expression tree specifying input column by name.
   FieldAccessTypedExpr(TypePtr type, std::string name)
-      : ITypedExpr{move(type)}, name_(std::move(name)) {}
+      : ITypedExpr{move(type)}, name_(std::move(name)), isInputColumn_(true) {}
 
   /// Used as a dereference expression which selects a subfield in a struct by
   /// name.
   FieldAccessTypedExpr(TypePtr type, TypedExprPtr input, std::string name)
-      : ITypedExpr{move(type), {move(input)}}, name_(std::move(name)) {}
+      : ITypedExpr{move(type), {move(input)}},
+        name_(std::move(name)),
+        isInputColumn_(dynamic_cast<const InputTypedExpr*>(inputs()[0].get())) {
+  }
 
   const std::string& name() const {
     return name_;
@@ -278,8 +281,14 @@ class FieldAccessTypedExpr : public ITypedExpr {
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
 
+  /// Is this FieldAccess accessing an input column or a field in a struct.
+  bool isInputColumn() const {
+    return isInputColumn_;
+  }
+
  private:
   const std::string name_;
+  const bool isInputColumn_;
 };
 
 using FieldAccessTypedExprPtr = std::shared_ptr<const FieldAccessTypedExpr>;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -401,7 +401,11 @@ ExprPtr compileExpression(
           dynamic_cast<const core::FieldAccessTypedExpr*>(expr.get())) {
     auto fieldReference = std::make_shared<FieldReference>(
         expr->type(), move(compiledInputs), access->name());
-    captureFieldReference(fieldReference.get(), expr.get(), scope);
+    if (access->isInputColumn()) {
+      // We only want to capture references to top level fields, not struct
+      // fields.
+      captureFieldReference(fieldReference.get(), expr.get(), scope);
+    }
     result = fieldReference;
   } else if (auto row = dynamic_cast<const core::InputTypedExpr*>(expr.get())) {
     VELOX_UNSUPPORTED("InputTypedExpr '{}' is not supported", row->toString());

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2805,3 +2805,25 @@ TEST_F(ExprTest, invalidInputs) {
       exec::EvalCtx(execCtx_.get(), exprSet.get(), input.get()),
       VeloxRuntimeError);
 }
+
+TEST_F(ExprTest, lambdaWithRowField) {
+  auto array = makeArrayVector<int64_t>(
+      10, [](auto /*row*/) { return 5; }, [](auto row) { return row * 3; });
+  auto row = vectorMaker_->rowVector(
+      {"val"},
+      {makeFlatVector<int64_t>(10, [](vector_size_t row) { return row; })});
+  core::Expressions::registerLambda(
+      "lambda1",
+      ROW({"x"}, {BIGINT()}),
+      ROW({"c0", "c1"}, {ROW({"val"}, {BIGINT()}), ARRAY(BIGINT())}),
+      parse::parseExpr("x + c0.val >= 0"),
+      execCtx_->pool());
+
+  auto rowVector = vectorMaker_->rowVector({"c0", "c1"}, {row, array});
+
+  // We use strpos and c1 to ensure that the constant is peeled before calling
+  // always_throws, not before the try.
+  auto evalResult = evaluate("filter(c1, function('lambda1'))", rowVector);
+
+  assertEqualVectors(array, evalResult);
+}


### PR DESCRIPTION
Summary:
Lambdas currently capture all FieldAccesses that don't reference a parameter to the lambda.  These are then treated as if they are accessing a column in the input data (e.g. getting added to the distinctFields_ of the expression).

However, not all FieldAccesses are actually accessing input columns, they can also be accessing fields of a struct.  If this is the case, the query will fail as it won't be able to find the field in the input columns.

This change fixes this by checking to see if the FieldAccess is accessing an input column, and only capturing it if so (e.g. if the struct is an input column that struct will be captured, but accessing a field in that struct will not).

I also added a general purpose function to FieldAccessTypedExpr to help distinguish between input columns and struct fields (I plan to do a similar check elsewhere and the logic is slightly non-obvious so it's cleaner to just abstract it in one place).

Differential Revision: D37389547

