### PR TITLE
Add MultiRange filter to support boolean usecase

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -663,6 +663,27 @@ std::unique_ptr<Filter> MultiRange::clone(
   }
 }
 
+bool MultiRange::testBool(bool value) const {
+  for (const auto& filter : filters_) {
+    if (filter->testBool(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MultiRange::testInt64(int64_t value) const {
+  if (std::isnan(value)) {
+    return nanAllowed_;
+  }
+  for (const auto& filter : filters_) {
+    if (filter->testInt64(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool MultiRange::testDouble(double value) const {
   if (std::isnan(value)) {
     return nanAllowed_;

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1425,6 +1425,10 @@ class MultiRange final : public Filter {
   std::unique_ptr<Filter> clone(
       std::optional<bool> nullAllowed = std::nullopt) const final;
 
+  bool testBool(bool value) const final;
+
+  bool testInt64(int64_t value) const final;
+
   bool testDouble(double value) const final;
 
   bool testFloat(float value) const final;


### PR DESCRIPTION
Boolean inequalities can produce multi range filters. 

For example "col_name" <> true filter will be represented as bool ranges (-infinity, true) or (true, +infinity) from Presto/Prestissimo plans sent from coordinator.

Currently MutiRange does not support bool and int64. We need these 2 types to be supported in order to support boolean inequalities.

This change will work along with this Prestissimo PR to fix the issue https://github.com/facebookexternal/presto_cpp/pull/783

Tests are presented in Prestissimo PR.