### PR TITLE
Separate the user exception stack trace collection control from the system one

### DIFF
--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include <folly/Random.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -67,6 +68,172 @@ void verifyVeloxException(
             << "\nException message prefix mismatch.\n\nExpected prefix: "
             << messagePrefix << "\n\nActual message: " << e.what();
       });
+}
+
+void testExceptionTraceCollectionControl(
+    bool userException,
+    bool enabled,
+    bool testNewFlag) {
+  // Disable rate control in the test.
+  FLAGS_velox_exception_stacktrace_rate_limit_ms = 0;
+  FLAGS_velox_exception_user_stacktrace_rate_limit_ms = 0;
+  FLAGS_velox_exception_system_stacktrace_rate_limit_ms = 0;
+
+  // Test the old flag to deprecate.
+  if (testNewFlag) {
+    FLAGS_velox_exception_stacktrace = false;
+    if (userException) {
+      FLAGS_velox_exception_user_stacktrace_enabled = enabled ? true : false;
+      FLAGS_velox_exception_system_stacktrace_enabled = folly::Random::oneIn(2);
+    } else {
+      FLAGS_velox_exception_system_stacktrace_enabled = enabled ? true : false;
+      FLAGS_velox_exception_user_stacktrace_enabled = folly::Random::oneIn(2);
+    }
+  } else {
+    FLAGS_velox_exception_stacktrace = enabled ? true : false;
+    if (userException) {
+      FLAGS_velox_exception_user_stacktrace_enabled =
+          enabled ? folly::Random::oneIn(2) : false;
+      FLAGS_velox_exception_system_stacktrace_enabled = folly::Random::oneIn(2);
+    } else {
+      FLAGS_velox_exception_system_stacktrace_enabled =
+          enabled ? folly::Random::oneIn(2) : false;
+      FLAGS_velox_exception_user_stacktrace_enabled = folly::Random::oneIn(2);
+    }
+  }
+  try {
+    if (userException) {
+      throw ::facebook::velox::VeloxUserError(
+          "file_name",
+          1,
+          "function_name()",
+          "operator()",
+          "test message",
+          "",
+          ::facebook::velox::error_code::kArithmeticError,
+          false);
+    } else {
+      throw ::facebook::velox::VeloxRuntimeError(
+          "file_name",
+          1,
+          "function_name()",
+          "operator()",
+          "test message",
+          "",
+          ::facebook::velox::error_code::kArithmeticError,
+          false);
+    }
+  } catch (::facebook::velox::VeloxException& e) {
+    SCOPED_TRACE(fmt::format(
+        "enabled: {}, legacy flag: {}, user flag: {}, sys flag: {}",
+        enabled,
+        FLAGS_velox_exception_stacktrace,
+        FLAGS_velox_exception_user_stacktrace_enabled,
+        FLAGS_velox_exception_system_stacktrace_enabled));
+    ASSERT_EQ(
+        userException,
+        e.exceptionType() == ::facebook::velox::VeloxException::Type::kUser);
+    ASSERT_EQ(enabled, e.stackTrace() != nullptr);
+  }
+}
+
+void testExceptionTraceCollectionRateControl(
+    bool userException,
+    bool hasRateLimit,
+    bool testNewFlag) {
+  // Disable rate control in the test.
+  // Enable trace rate control in the test.
+  FLAGS_velox_exception_stacktrace = true;
+  FLAGS_velox_exception_user_stacktrace_enabled = true;
+  FLAGS_velox_exception_system_stacktrace_enabled = true;
+  // Set rate control interval to a large value to avoid time related test
+  // flakiness.
+  const int kRateLimitIntervalMs = 4000;
+  if (hasRateLimit) {
+    // Wait a bit to ensure that the last stack trace collection time has
+    // passed sufficient long.
+    /* sleep override */
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(kRateLimitIntervalMs)); // NOLINT
+  }
+  // Test the old flag to deprecate.
+  if (testNewFlag) {
+    FLAGS_velox_exception_stacktrace_rate_limit_ms = 0;
+    if (userException) {
+      FLAGS_velox_exception_user_stacktrace_rate_limit_ms =
+          hasRateLimit ? kRateLimitIntervalMs : 0;
+      FLAGS_velox_exception_system_stacktrace_rate_limit_ms =
+          folly::Random::rand32();
+    } else {
+      // Set rate control to a large interval to avoid time related test
+      // flakiness.
+      FLAGS_velox_exception_system_stacktrace_rate_limit_ms =
+          hasRateLimit ? kRateLimitIntervalMs : 0;
+      FLAGS_velox_exception_user_stacktrace_rate_limit_ms =
+          folly::Random::rand32();
+    }
+  } else {
+    // Set rate control to a large interval to avoid time related test
+    // flakiness.
+    FLAGS_velox_exception_stacktrace_rate_limit_ms =
+        hasRateLimit ? kRateLimitIntervalMs : 0;
+    if (userException) {
+      FLAGS_velox_exception_user_stacktrace_rate_limit_ms =
+          hasRateLimit ? folly::Random::rand32() : 0;
+      FLAGS_velox_exception_system_stacktrace_rate_limit_ms =
+          folly::Random::rand32();
+    } else {
+      FLAGS_velox_exception_system_stacktrace_rate_limit_ms =
+          hasRateLimit ? folly::Random::rand32() : 0;
+      FLAGS_velox_exception_user_stacktrace_rate_limit_ms =
+          folly::Random::rand32();
+    }
+  }
+  for (int iter = 0; iter < 3; ++iter) {
+    try {
+      if (userException) {
+        throw ::facebook::velox::VeloxUserError(
+            "file_name",
+            1,
+            "function_name()",
+            "operator()",
+            "test message",
+            "",
+            ::facebook::velox::error_code::kArithmeticError,
+            false);
+      } else {
+        throw ::facebook::velox::VeloxRuntimeError(
+            "file_name",
+            1,
+            "function_name()",
+            "operator()",
+            "test message",
+            "",
+            ::facebook::velox::error_code::kArithmeticError,
+            false);
+      }
+    } catch (::facebook::velox::VeloxException& e) {
+      SCOPED_TRACE(fmt::format(
+          "userException: {}, testNewFlag: {}, hasRateLimit: {}, legacy limit: {}ms, user limit: {}ms, sys limit: {}ms",
+          userException,
+          testNewFlag,
+          hasRateLimit,
+          FLAGS_velox_exception_stacktrace_rate_limit_ms,
+          FLAGS_velox_exception_user_stacktrace_rate_limit_ms,
+          FLAGS_velox_exception_system_stacktrace_rate_limit_ms));
+      ASSERT_EQ(
+          userException,
+          e.exceptionType() == ::facebook::velox::VeloxException::Type::kUser);
+      ASSERT_EQ(!hasRateLimit || ((iter % 2) == 0), e.stackTrace() != nullptr);
+      // NOTE: with rate limit control, we want to verify if we can collect
+      // stack trace after waiting for a while.
+      if (hasRateLimit && (iter % 2 != 0)) {
+        /* sleep override */
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(kRateLimitIntervalMs)); // NOLINT
+      }
+    }
+  }
 }
 
 // Ensures that expressions on the stream are not evaluated unless the condition
@@ -516,4 +683,28 @@ TEST(ExceptionTest, context) {
       "\nExpression: 1 == 3"
       "\nFunction: operator()"
       "\nFile: ");
+}
+
+TEST(ExceptionTest, traceCollectionEnabling) {
+  // Switch on/off tests.
+  for (const bool enabled : {false, true}) {
+    for (const bool userException : {false, true}) {
+      for (const bool testNewFlag : {false, true}) {
+        testExceptionTraceCollectionControl(
+            userException, enabled, testNewFlag);
+      }
+    }
+  }
+}
+
+TEST(ExceptionTest, traceCollectionRateControl) {
+  // Rate limit tests.
+  for (const bool withLimit : {false, true}) {
+    for (const bool userException : {false, true}) {
+      for (const bool testNewFlag : {false, true}) {
+        testExceptionTraceCollectionRateControl(
+            userException, withLimit, testNewFlag);
+      }
+    }
+  }
 }

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -45,16 +45,46 @@ DEFINE_bool(
 
 // Used in common/base/VeloxException.cpp
 
+/// TODO: deprecate 'FLAGS_deprecate velox_exception_stacktrace' flag once after
+/// 'FLAGS_velox_exception_user_stacktrace_enabled' and
+/// 'FLAGS_velox_exception_system_stacktrace_enabled' have been rolled out in
+/// production.
 DEFINE_bool(
     velox_exception_stacktrace,
     true,
     "Enable the stacktrace for VeloxException");
 
+DEFINE_bool(
+    velox_exception_user_stacktrace_enabled,
+    false,
+    "Enable the stacktrace for user type of VeloxException");
+
+DEFINE_bool(
+    velox_exception_system_stacktrace_enabled,
+    true,
+    "Enable the stacktrace for system type of VeloxException");
+
+/// TODO: deprecate 'FLAGS_velox_exception_stacktrace_rate_limit_ms' flag once
+/// after 'FLAGS_velox_exception_user_stacktrace_rate_limit_ms' and
+/// 'FLAGS_velox_exception_system_stacktrace_rate_limit_ms' have been rolled out
+/// in production.
 DEFINE_int32(
     velox_exception_stacktrace_rate_limit_ms,
     0, // effectively turns off rate-limiting
     "Min time interval in milliseconds between stack traces captured in"
     " VeloxException; off when set to 0 (the default)");
+
+DEFINE_int32(
+    velox_exception_user_stacktrace_rate_limit_ms,
+    0, // effectively turns off rate-limiting
+    "Min time interval in milliseconds between stack traces captured in"
+    " user type of VeloxException; off when set to 0 (the default)");
+
+DEFINE_int32(
+    velox_exception_system_stacktrace_rate_limit_ms,
+    0, // effectively turns off rate-limiting
+    "Min time interval in milliseconds between stack traces captured in"
+    " system type of VeloxException; off when set to 0 (the default)");
 
 // Used in common/base/ProcessBase.cpp
 


### PR DESCRIPTION
Separate the user exception stack trace collection control from the system one.

Two new pair of flags are added in this PR for this purpose:
User exception control flags:
FLAGS_velox_exception_user_stacktrace_enabled 
FLAGS_velox_exception_user_stacktrace_rate_limit_ms

System exception control flags:
FLAGS_velox_exception_system_stacktrace_enabled
FLAGS_velox_exception_system_stacktrace_rate_limit_ms

By default, the user exception trace collection is disabled and the system one is enabled. Once the change of this PR has been rolled out in production, we will deprecate the old flags: FLAGS_velox_exception_stacktrace and velox_exception_stacktrace_rate_limit_ms.
