### PR TITLE
Move DirectDecoder to dwio::common

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -29,8 +29,10 @@ add_library(
   DataBuffer.cpp
   DataSink.cpp
   DecoderUtil.cpp
+  DirectDecoder.cpp
   DwioMetricsLog.cpp
   InputStream.cpp
+  IntDecoder.cpp
   IoStatistics.cpp
   MemoryInputStream.cpp
   Options.cpp

--- a/velox/dwio/common/DirectDecoder.cpp
+++ b/velox/dwio/common/DirectDecoder.cpp
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/DirectDecoder.h"
+#include "velox/dwio/common/DirectDecoder.h"
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 template <bool isSigned>
 void DirectDecoder<isSigned>::seekToRowGroup(
@@ -106,4 +107,4 @@ template void DirectDecoder<false>::next(
     const uint64_t numValues,
     const uint64_t* nulls);
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DirectDecoder.h
+++ b/velox/dwio/common/DirectDecoder.h
@@ -18,9 +18,9 @@
 
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/common/IntDecoder.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 struct DropValues;
 
@@ -98,7 +98,8 @@ class DirectDecoder : public IntDecoder<isSigned> {
   void fastPath(const uint64_t* nulls, Visitor& visitor) {
     using T = typename Visitor::DataType;
     constexpr bool hasFilter =
-        !std::is_same<typename Visitor::FilterType, common::AlwaysTrue>::value;
+        !std::is_same<typename Visitor::FilterType, velox::common::AlwaysTrue>::
+            value;
     constexpr bool filterOnly =
         std::is_same<typename Visitor::Extract, DropValues>::value;
     constexpr bool hasHook =
@@ -217,4 +218,4 @@ class DirectDecoder : public IntDecoder<isSigned> {
   }
 };
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/IntCodecCommon.h
+++ b/velox/dwio/common/IntCodecCommon.h
@@ -18,7 +18,7 @@
 
 #include <cstdint>
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 constexpr uint32_t SHORT_BYTE_SIZE = 2;
 constexpr uint32_t INT_BYTE_SIZE = 4;
@@ -26,8 +26,6 @@ constexpr uint32_t LONG_BYTE_SIZE = 8;
 
 constexpr uint64_t BASE_128_MASK = 0x7f;
 constexpr uint64_t BASE_256_MASK = 0xff;
-
-enum RleVersion { RleVersion_1, RleVersion_2 };
 
 // Timezone constants
 constexpr int64_t SECONDS_PER_HOUR = 60 * 60;
@@ -45,8 +43,4 @@ constexpr int64_t MAX_NANOS = 999'999'999;
 // 1 is reduced to epoch, as writer adds 1 for negative seconds.
 constexpr int64_t MIN_SECONDS = INT64_MIN + (EPOCH_OFFSET - 1);
 
-constexpr int32_t RLE_MINIMUM_REPEAT = 3;
-constexpr int32_t RLE_MAXIMUM_REPEAT = 127 + RLE_MINIMUM_REPEAT;
-constexpr int32_t RLE_MAX_LITERAL_SIZE = 128;
-
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/IntDecoder.cpp
+++ b/velox/dwio/common/IntDecoder.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/common/IntDecoder.h"
 
 #include "velox/common/base/SimdUtil.h"
-#include "velox/dwio/dwrf/common/DirectDecoder.h"
+#include "velox/dwio/common/DirectDecoder.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 template <bool isSigned>
 void IntDecoder<isSigned>::skipLongs(uint64_t numValues) {
@@ -2581,4 +2581,4 @@ void printVarintSwitch(int32_t mask_len, bool sparse) {
 
 #endif
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/IntDecoder.h
+++ b/velox/dwio/common/IntDecoder.h
@@ -17,16 +17,16 @@
 #pragma once
 
 #include "velox/common/encode/Coding.h"
+#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/StreamUtil.h"
 #include "velox/dwio/common/exception/Exception.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
 
 #include <folly/Likely.h>
 #include <folly/Range.h>
 #include <folly/Varint.h>
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 template <bool isSigned>
 class IntDecoder {
@@ -317,4 +317,4 @@ inline int64_t IntDecoder<isSigned>::readLong() {
   }
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -27,9 +27,9 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 class ColumnReaderFactory;
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common
 
 namespace facebook {
 namespace velox {

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -41,3 +41,8 @@ add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
 target_link_libraries(
   velox_dwio_common_data_buffer_benchmark velox_dwio_common velox_memory
   velox_dwio_common_exception ${FOLLY} ${FOLLY_BENCHMARK})
+
+add_executable(velox_dwio_common_int_decoder_benchmark IntDecoderBenchmark.cpp)
+target_link_libraries(
+  velox_dwio_common_int_decoder_benchmark velox_dwio_common_exception
+  velox_exception velox_dwio_dwrf_common ${FOLLY} ${FOLLY_BENCHMARK})

--- a/velox/dwio/common/tests/IntDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/IntDecoderBenchmark.cpp
@@ -17,18 +17,15 @@
 #include <limits>
 #include "folly/Benchmark.h"
 #include "folly/CpuId.h"
-#include "folly/Portability.h"
 #include "folly/Random.h"
 #include "folly/Varint.h"
 #include "folly/init/Init.h"
 #include "folly/lang/Bits.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/dwio/common/exception/Exception.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 
 using namespace facebook::velox::dwio;
-using namespace facebook::velox::dwrf;
 namespace bits = facebook::velox::bits;
 
 const size_t kNumElements = 1000000;
@@ -125,7 +122,7 @@ uint64_t readVuLong(const char* buffer, size_t& len) {
     size_t pos = 0;
     do {
       ch = buffer[pos++];
-      result |= (ch & BASE_128_MASK) << offset;
+      result |= (ch & facebook::velox::dwio::common::BASE_128_MASK) << offset;
       offset += 7;
       len--;
     } while (ch < 0);
@@ -881,7 +878,8 @@ size_t writeVulongToBuffer(uint64_t val, char* buffer, size_t pos) {
       buffer[pos++] = static_cast<char>(val);
       return pos;
     } else {
-      buffer[pos++] = static_cast<char>(0x80 | (val & BASE_128_MASK));
+      buffer[pos++] = static_cast<char>(
+          0x80 | (val & facebook::velox::dwio::common::BASE_128_MASK));
       // cast val to unsigned so as to force 0-fill right shift
       val = (static_cast<uint64_t>(val) >> 7);
     }

--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -16,16 +16,17 @@
 
 #pragma once
 
-#include <memory>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Nulls.h"
+#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/Common.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/Range.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/vector/TypeAliases.h"
+
+#include <memory>
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -20,10 +20,8 @@ add_library(
   Config.cpp
   DataBufferHolder.cpp
   Decryption.cpp
-  DirectDecoder.cpp
   Encryption.cpp
   EncryptionSpecification.cpp
-  IntDecoder.cpp
   IntEncoder.cpp
   OutputStream.cpp
   PagedInputStream.cpp

--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <string>
-
 #include "folly/Range.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/dwio/common/Common.h"
@@ -26,6 +23,9 @@
 #include "velox/dwio/common/StreamIdentifier.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/common/wrap/orc-proto-wrapper.h"
+
+#include <fmt/format.h>
+#include <string>
 
 namespace facebook::velox::dwrf {
 
@@ -339,5 +339,11 @@ class PostScript {
   uint64_t metadataLength_;
   uint64_t stripeStatisticsLength_;
 };
+
+enum class RleVersion { RleVersion_1, RleVersion_2 };
+
+constexpr int32_t RLE_MINIMUM_REPEAT = 3;
+constexpr int32_t RLE_MAXIMUM_REPEAT = 127 + RLE_MINIMUM_REPEAT;
+constexpr int32_t RLE_MAX_LITERAL_SIZE = 128;
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/common/DirectDecoder.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/common/DirectDecoder.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/RLEv1.h"
 #include "velox/dwio/dwrf/common/RLEv2.h"
 
@@ -29,7 +29,7 @@ namespace facebook::velox::dwrf {
  * @param pool memory pool to use for allocation
  */
 template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> createRleDecoder(
+std::unique_ptr<dwio::common::IntDecoder<isSigned>> createRleDecoder(
     std::unique_ptr<dwio::common::SeekableInputStream> input,
     RleVersion version,
     memory::MemoryPool& pool,
@@ -51,11 +51,11 @@ std::unique_ptr<IntDecoder<isSigned>> createRleDecoder(
  * Create a direct decoder
  */
 template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> createDirectDecoder(
+std::unique_ptr<dwio::common::IntDecoder<isSigned>> createDirectDecoder(
     std::unique_ptr<dwio::common::SeekableInputStream> input,
     bool useVInts,
     uint32_t numBytes) {
-  return std::make_unique<DirectDecoder<isSigned>>(
+  return std::make_unique<dwio::common::DirectDecoder<isSigned>>(
       std::move(input), useVInts, numBytes);
 }
 

--- a/velox/dwio/dwrf/common/DecoderUtil.h
+++ b/velox/dwio/dwrf/common/DecoderUtil.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/common/DirectDecoder.h"
+#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/dwrf/common/RLEv1.h"
+#include "velox/dwio/dwrf/common/RLEv2.h"
+
+namespace facebook::velox::dwrf {
+/**
+ * Create an RLE decoder.
+ * @param input the input stream to read from
+ * @param version version of RLE decoding to do
+ * @param pool memory pool to use for allocation
+ */
+template <bool isSigned>
+std::unique_ptr<IntDecoder<isSigned>> createRleDecoder(
+    std::unique_ptr<dwio::common::SeekableInputStream> input,
+    RleVersion version,
+    memory::MemoryPool& pool,
+    bool useVInts,
+    uint32_t numBytes) {
+  switch (version) {
+    case RleVersion::RleVersion_1:
+      return std::make_unique<RleDecoderV1<isSigned>>(
+          std::move(input), useVInts, numBytes);
+    case RleVersion::RleVersion_2:
+      return std::make_unique<RleDecoderV2<isSigned>>(std::move(input), pool);
+    default:
+      DWIO_RAISE("RleVersion not supported");
+      return {};
+  }
+}
+
+/**
+ * Create a direct decoder
+ */
+template <bool isSigned>
+std::unique_ptr<IntDecoder<isSigned>> createDirectDecoder(
+    std::unique_ptr<dwio::common::SeekableInputStream> input,
+    bool useVInts,
+    uint32_t numBytes) {
+  return std::make_unique<DirectDecoder<isSigned>>(
+      std::move(input), useVInts, numBytes);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/EncoderUtil.h
+++ b/velox/dwio/dwrf/common/EncoderUtil.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/common/IntEncoder.h"
+#include "velox/dwio/dwrf/common/RLEv1.h"
+
+namespace facebook::velox::dwrf {
+
+/**
+ * Create an RLE encoder.
+ * @param version version of RLE encoding to do
+ * @param output the output stream to write to
+ * @param useVInts whether varint encoding will be used
+ * @param numBytes number of bytes the encoder will write for an integer
+ */
+template <bool isSigned>
+std::unique_ptr<IntEncoder<isSigned>> createRleEncoder(
+    RleVersion version,
+    std::unique_ptr<BufferedOutputStream> output,
+    bool useVInts,
+    uint32_t numBytes) {
+  switch (version) {
+    case RleVersion::RleVersion_1:
+      return std::make_unique<RleEncoderV1<isSigned>>(
+          std::move(output), useVInts, numBytes);
+    case RleVersion::RleVersion_2:
+    default:
+      DWIO_RAISE("RleVersion not supported");
+      return {};
+  }
+}
+
+template <bool isSigned>
+std::unique_ptr<IntEncoder<isSigned>> createDirectEncoder(
+    std::unique_ptr<BufferedOutputStream> output,
+    bool useVInts,
+    uint32_t numBytes) {
+  return std::make_unique<IntEncoder<isSigned>>(
+      std::move(output), useVInts, numBytes);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/IntDecoder.cpp
+++ b/velox/dwio/dwrf/common/IntDecoder.cpp
@@ -15,10 +15,9 @@
  */
 
 #include "velox/dwio/dwrf/common/IntDecoder.h"
+
 #include "velox/common/base/SimdUtil.h"
 #include "velox/dwio/dwrf/common/DirectDecoder.h"
-#include "velox/dwio/dwrf/common/RLEv1.h"
-#include "velox/dwio/dwrf/common/RLEv2.h"
 
 namespace facebook::velox::dwrf {
 
@@ -2406,56 +2405,6 @@ template void IntDecoder<false>::bulkReadRows(
     RowSet rows,
     int16_t* result,
     int32_t initialRow);
-
-template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> IntDecoder<isSigned>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes) {
-  switch (static_cast<int64_t>(version)) {
-    case RleVersion_1:
-      return std::make_unique<RleDecoderV1<isSigned>>(
-          std::move(input), useVInts, numBytes);
-    case RleVersion_2:
-      return std::make_unique<RleDecoderV2<isSigned>>(std::move(input), pool);
-    default:
-      DWIO_ENSURE(false, "not supported");
-      return {};
-  }
-}
-
-template std::unique_ptr<IntDecoder<true>> IntDecoder<true>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntDecoder<false>> IntDecoder<false>::createRle(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    RleVersion version,
-    memory::MemoryPool& pool,
-    bool useVInts,
-    uint32_t numBytes);
-
-template <bool isSigned>
-std::unique_ptr<IntDecoder<isSigned>> IntDecoder<isSigned>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes) {
-  return std::make_unique<DirectDecoder<isSigned>>(
-      std::move(input), useVInts, numBytes);
-}
-
-template std::unique_ptr<IntDecoder<true>> IntDecoder<true>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntDecoder<false>> IntDecoder<false>::createDirect(
-    std::unique_ptr<dwio::common::SeekableInputStream> input,
-    bool useVInts,
-    uint32_t numBytes);
 
 #ifdef CODEGEN_BULK_VARINTS
 // Codegen for vint bulk decode. This is to document how varintSwitch

--- a/velox/dwio/dwrf/common/IntDecoder.h
+++ b/velox/dwio/dwrf/common/IntDecoder.h
@@ -16,14 +16,15 @@
 
 #pragma once
 
-#include <folly/Likely.h>
-#include <folly/Range.h>
-#include <folly/Varint.h>
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/StreamUtil.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
+
+#include <folly/Likely.h>
+#include <folly/Range.h>
+#include <folly/Varint.h>
 
 namespace facebook::velox::dwrf {
 
@@ -102,27 +103,6 @@ class IntDecoder {
   size_t loadIndices(size_t startIndex) {
     return inputStream->positionSize() + startIndex + 1;
   }
-
-  /**
-   * Create an RLE decoder.
-   * @param input the input stream to read from
-   * @param version version of RLE decoding to do
-   * @param pool memory pool to use for allocation
-   */
-  static std::unique_ptr<IntDecoder<isSigned>> createRle(
-      std::unique_ptr<dwio::common::SeekableInputStream> input,
-      RleVersion version,
-      memory::MemoryPool& pool,
-      bool useVInts,
-      uint32_t numBytes);
-
-  /**
-   * Create a direct decoder
-   */
-  static std::unique_ptr<IntDecoder<isSigned>> createDirect(
-      std::unique_ptr<dwio::common::SeekableInputStream> input,
-      bool useVInts,
-      uint32_t numBytes);
 
   void skipLongs(uint64_t numValues);
 

--- a/velox/dwio/dwrf/common/IntEncoder.cpp
+++ b/velox/dwio/dwrf/common/IntEncoder.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/RLEv1.h"
 
 namespace facebook::velox::dwrf {
 
@@ -29,51 +28,5 @@ uint64_t IntEncoder<isSigned>::flush() {
 
 template uint64_t IntEncoder<true>::flush();
 template uint64_t IntEncoder<false>::flush();
-
-template <bool isSigned>
-std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes) {
-  switch (static_cast<int64_t>(version)) {
-    case RleVersion_1:
-      return std::make_unique<RleEncoderV1<isSigned>>(
-          std::move(output), useVInts, numBytes);
-    case RleVersion_2:
-    default:
-      DWIO_ENSURE(false, "not supported");
-      return {};
-  }
-}
-
-template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createRle(
-    RleVersion version,
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-
-template <bool isSigned>
-std::unique_ptr<IntEncoder<isSigned>> IntEncoder<isSigned>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes) {
-  return std::make_unique<IntEncoder<isSigned>>(
-      std::move(output), useVInts, numBytes);
-}
-
-template std::unique_ptr<IntEncoder<true>> IntEncoder<true>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
-template std::unique_ptr<IntEncoder<false>> IntEncoder<false>::createDirect(
-    std::unique_ptr<BufferedOutputStream> output,
-    bool useVInts,
-    uint32_t numBytes);
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -17,11 +17,13 @@
 #pragma once
 
 #include <folly/Varint.h>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/common/encode/Coding.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
+#include "velox/dwio/common/IntCodecCommon.h"
+#include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/Range.h"
 
@@ -268,7 +270,7 @@ template <int32_t size>
     uint64_t value,
     char* buffer) {
   for (int32_t i = 1; i < size; i++) {
-    *buffer = static_cast<char>(0x80 | (value & BASE_128_MASK));
+    *buffer = static_cast<char>(0x80 | (value & dwio::common::BASE_128_MASK));
     value >>= 7;
     buffer++;
   }
@@ -322,7 +324,7 @@ int32_t IntEncoder<isSigned>::writeVulong(int64_t val, char* buffer) {
 template <bool isSigned>
 int32_t IntEncoder<isSigned>::writeLongLE(int64_t val, char* buffer) {
   for (int32_t i = 0; i < numBytes_; i++) {
-    *buffer = val & BASE_256_MASK;
+    *buffer = val & dwio::common::BASE_256_MASK;
     val >>= 8;
     buffer++;
   }
@@ -339,7 +341,7 @@ void IntEncoder<isSigned>::writeVulong(int64_t val) {
       writeByte(static_cast<char>(val));
       return;
     } else {
-      writeByte(static_cast<char>(0x80 | (val & BASE_128_MASK)));
+      writeByte(static_cast<char>(0x80 | (val & dwio::common::BASE_128_MASK)));
       // cast val to unsigned so as to force 0-fill right shift
       val = (static_cast<uint64_t>(val) >> 7);
     }
@@ -349,7 +351,7 @@ void IntEncoder<isSigned>::writeVulong(int64_t val) {
 template <bool isSigned>
 void IntEncoder<isSigned>::writeLongLE(int64_t val) {
   for (int32_t i = 0; i < numBytes_; i++) {
-    writeByte(static_cast<char>(val & BASE_256_MASK));
+    writeByte(static_cast<char>(val & dwio::common::BASE_256_MASK));
     val >>= 8;
   }
 }

--- a/velox/dwio/dwrf/common/RLEv1.cpp
+++ b/velox/dwio/dwrf/common/RLEv1.cpp
@@ -67,9 +67,10 @@ template <bool isSigned>
 void RleDecoderV1<isSigned>::seekToRowGroup(
     dwio::common::PositionProvider& location) {
   // move the input stream
-  IntDecoder<isSigned>::inputStream->seekToPosition(location);
+  dwio::common::IntDecoder<isSigned>::inputStream->seekToPosition(location);
   // force a re-read from the stream
-  IntDecoder<isSigned>::bufferEnd = IntDecoder<isSigned>::bufferStart;
+  dwio::common::IntDecoder<isSigned>::bufferEnd =
+      dwio::common::IntDecoder<isSigned>::bufferStart;
   // force reading a new header
   remainingValues = 0;
   // skip ahead the given number of records
@@ -93,7 +94,7 @@ void RleDecoderV1<isSigned>::skip(uint64_t numValues) {
     if (repeating) {
       value += delta * static_cast<int64_t>(count);
     } else {
-      IntDecoder<isSigned>::skipLongs(count);
+      dwio::common::IntDecoder<isSigned>::skipLongs(count);
     }
   }
 }
@@ -142,10 +143,10 @@ void RleDecoderV1<isSigned>::next(
       int64_t* const datapEnd = datap + count;
       if (nulls) {
         int32_t idx = position;
-        if (!IntDecoder<isSigned>::useVInts) {
+        if (!dwio::common::IntDecoder<isSigned>::useVInts) {
           while (datap != datapEnd) {
             if (LIKELY(!bits::isBitNull(nulls, idx++))) {
-              *(datap++) = IntDecoder<isSigned>::readLongLE();
+              *(datap++) = dwio::common::IntDecoder<isSigned>::readLongLE();
               ++consumed;
             } else {
               *(datap++) = 0;
@@ -154,7 +155,7 @@ void RleDecoderV1<isSigned>::next(
         } else if constexpr (isSigned) {
           while (datap != datapEnd) {
             if (LIKELY(!bits::isBitNull(nulls, idx++))) {
-              *(datap++) = IntDecoder<isSigned>::readVsLong();
+              *(datap++) = dwio::common::IntDecoder<isSigned>::readVsLong();
               ++consumed;
             } else {
               *(datap++) = 0;
@@ -163,8 +164,8 @@ void RleDecoderV1<isSigned>::next(
         } else {
           while (datap != datapEnd) {
             if (LIKELY(!bits::isBitNull(nulls, idx++))) {
-              *(datap++) =
-                  static_cast<int64_t>(IntDecoder<isSigned>::readVuLong());
+              *(datap++) = static_cast<int64_t>(
+                  dwio::common::IntDecoder<isSigned>::readVuLong());
               ++consumed;
             } else {
               *(datap++) = 0;
@@ -172,18 +173,18 @@ void RleDecoderV1<isSigned>::next(
           }
         }
       } else {
-        if (!IntDecoder<isSigned>::useVInts) {
+        if (!dwio::common::IntDecoder<isSigned>::useVInts) {
           while (datap != datapEnd) {
-            *(datap++) = IntDecoder<isSigned>::readLongLE();
+            *(datap++) = dwio::common::IntDecoder<isSigned>::readLongLE();
           }
         } else if constexpr (isSigned) {
           while (datap != datapEnd) {
-            *(datap++) = IntDecoder<isSigned>::readVsLong();
+            *(datap++) = dwio::common::IntDecoder<isSigned>::readVsLong();
           }
         } else {
           while (datap != datapEnd) {
-            *(datap++) =
-                static_cast<int64_t>(IntDecoder<isSigned>::readVuLong());
+            *(datap++) = static_cast<int64_t>(
+                dwio::common::IntDecoder<isSigned>::readVuLong());
           }
         }
         consumed = count;
@@ -231,7 +232,7 @@ void RleDecoderV1<isSigned>::nextLengths(
       consumed = count;
       value += static_cast<int64_t>(consumed) * delta;
     } else {
-      IntDecoder<isSigned>::bulkRead(count, data + position);
+      dwio::common::IntDecoder<isSigned>::bulkRead(count, data + position);
       consumed = count;
     }
     remainingValues -= consumed;

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -20,7 +20,7 @@
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/common/Adaptor.h"
 #include "velox/dwio/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 
 #include <memory>
@@ -228,15 +228,16 @@ uint64_t RleEncoderV1<isSigned>::addImpl(
 struct DropValues;
 
 template <bool isSigned>
-class RleDecoderV1 : public IntDecoder<isSigned> {
+class RleDecoderV1 : public dwio::common::IntDecoder<isSigned> {
  public:
-  using super = IntDecoder<isSigned>;
+  using super = dwio::common::IntDecoder<isSigned>;
 
   RleDecoderV1(
       std::unique_ptr<dwio::common::SeekableInputStream> input,
       bool useVInts,
       uint32_t numBytes)
-      : IntDecoder<isSigned>{std::move(input), useVInts, numBytes},
+      : dwio::common::IntDecoder<
+            isSigned>{std::move(input), useVInts, numBytes},
         remainingValues(0),
         value(0),
         delta(0),
@@ -266,7 +267,7 @@ class RleDecoderV1 : public IntDecoder<isSigned> {
       if (repeating) {
         value += delta * static_cast<int64_t>(count);
       } else {
-        IntDecoder<isSigned>::skipLongsFast(count);
+        dwio::common::IntDecoder<isSigned>::skipLongsFast(count);
       }
     }
   }
@@ -304,7 +305,7 @@ class RleDecoderV1 : public IntDecoder<isSigned> {
           toSkip = visitor.process(value, atEnd);
           value += delta;
         } else {
-          value = IntDecoder<isSigned>::readLong();
+          value = dwio::common::IntDecoder<isSigned>::readLong();
           toSkip = visitor.process(value, atEnd);
         }
         --remainingValues;
@@ -489,15 +490,15 @@ class RleDecoderV1 : public IntDecoder<isSigned> {
   }
 
   inline void readHeader() {
-    signed char ch = IntDecoder<isSigned>::readByte();
+    signed char ch = dwio::common::IntDecoder<isSigned>::readByte();
     if (ch < 0) {
       remainingValues = static_cast<uint64_t>(-ch);
       repeating = false;
     } else {
       remainingValues = static_cast<uint64_t>(ch) + RLE_MINIMUM_REPEAT;
       repeating = true;
-      delta = IntDecoder<isSigned>::readByte();
-      value = IntDecoder<isSigned>::readLong();
+      delta = dwio::common::IntDecoder<isSigned>::readByte();
+      value = dwio::common::IntDecoder<isSigned>::readLong();
     }
   }
 

--- a/velox/dwio/dwrf/common/RLEv2.h
+++ b/velox/dwio/dwrf/common/RLEv2.h
@@ -20,15 +20,15 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/Adaptor.h"
 #include "velox/dwio/common/DataBuffer.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/exception/Exception.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 
 #include <vector>
 
 namespace facebook::velox::dwrf {
 
 template <bool isSigned>
-class RleDecoderV2 : public IntDecoder<isSigned> {
+class RleDecoderV2 : public dwio::common::IntDecoder<isSigned> {
  public:
   enum EncodingType {
     SHORT_REPEAT = 0,
@@ -86,22 +86,23 @@ class RleDecoderV2 : public IntDecoder<isSigned> {
   }
 
   unsigned char readByte() {
-    if (IntDecoder<isSigned>::bufferStart == IntDecoder<isSigned>::bufferEnd) {
+    if (dwio::common::IntDecoder<isSigned>::bufferStart ==
+        dwio::common::IntDecoder<isSigned>::bufferEnd) {
       int32_t bufferLength;
       const void* bufferPointer;
       DWIO_ENSURE(
-          IntDecoder<isSigned>::inputStream->Next(
+          dwio::common::IntDecoder<isSigned>::inputStream->Next(
               &bufferPointer, &bufferLength),
           "bad read in RleDecoderV2::readByte, ",
-          IntDecoder<isSigned>::inputStream->getName());
-      IntDecoder<isSigned>::bufferStart =
+          dwio::common::IntDecoder<isSigned>::inputStream->getName());
+      dwio::common::IntDecoder<isSigned>::bufferStart =
           static_cast<const char*>(bufferPointer);
-      IntDecoder<isSigned>::bufferEnd =
-          IntDecoder<isSigned>::bufferStart + bufferLength;
+      dwio::common::IntDecoder<isSigned>::bufferEnd =
+          dwio::common::IntDecoder<isSigned>::bufferStart + bufferLength;
     }
 
-    unsigned char result =
-        static_cast<unsigned char>(*IntDecoder<isSigned>::bufferStart++);
+    unsigned char result = static_cast<unsigned char>(
+        *dwio::common::IntDecoder<isSigned>::bufferStart++);
     return result;
   }
 

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
+
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exceptions.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/IntCodecCommon.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
@@ -362,12 +364,12 @@ IntegerDirectColumnReader<ReqT>::IntegerDirectColumnReader(
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
   if (stripe.getFormat() == dwio::common::FileFormat::DWRF) {
-    ints = IntDecoder</*isSigned*/ true>::createDirect(
+    ints = createDirectDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), dataVInts, numBytes);
   } else {
     auto encoding = stripe.getEncoding(encodingKey);
     RleVersion vers = convertRleVersion(encoding.kind());
-    ints = IntDecoder</*isSigned*/ true>::createRle(
+    ints = createRleDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), vers, memoryPool_, dataVInts, numBytes);
   }
 }
@@ -495,7 +497,7 @@ IntegerDictionaryColumnReader<ReqT>::IntegerDictionaryColumnReader(
   RleVersion vers = convertRleVersion(encoding.kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
-  dataReader = IntDecoder</* isSigned = */ false>::createRle(
+  dataReader = createRleDecoder</* isSigned = */ false>(
       stripe.getStream(data, true), vers, memoryPool_, dataVInts, numBytes);
 
   // make a lazy dictionary initializer
@@ -608,11 +610,11 @@ TimestampColumnReader::TimestampColumnReader(
   RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
-  seconds = IntDecoder</*isSigned*/ true>::createRle(
+  seconds = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
   bool nanoVInts = stripe.getUseVInts(nanoData);
-  nano = IntDecoder</*isSigned*/ false>::createRle(
+  nano = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(nanoData, true),
       vers,
       memoryPool_,
@@ -922,7 +924,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
   const auto dataId = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dictVInts = stripe.getUseVInts(dataId);
-  dictIndex = IntDecoder</*isSigned*/ false>::createRle(
+  dictIndex = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, true),
       rleVersion,
       memoryPool_,
@@ -931,7 +933,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, false),
       rleVersion,
       memoryPool_,
@@ -961,7 +963,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
     const auto strideDictLenId =
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH);
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
-    strideDictLengthDecoder = IntDecoder</*isSigned*/ false>::createRle(
+    strideDictLengthDecoder = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, true),
         rleVersion,
         memoryPool_,
@@ -1403,7 +1405,7 @@ StringDirectColumnReader::StringDirectColumnReader(
       convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true),
       rleVersion,
       memoryPool_,
@@ -1687,7 +1689,7 @@ ListColumnReader::ListColumnReader(
 
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();
@@ -1845,7 +1847,7 @@ MapColumnReader::MapColumnReader(
 
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
-  length = IntDecoder</*isSigned*/ false>::createRle(
+  length = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -16,11 +16,11 @@
 
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 
+#include "velox/dwio/common/IntCodecCommon.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
 #include "velox/dwio/dwrf/reader/FlatMapColumnReader.h"
 #include "velox/type/Type.h"
@@ -34,6 +34,7 @@
 
 namespace facebook::velox::dwrf {
 
+using dwio::common::IntDecoder;
 using dwio::common::typeutils::CompatChecker;
 using memory::MemoryPool;
 
@@ -62,7 +63,7 @@ void fillTimestamps(
           nanos *= 10;
         }
       }
-      auto seconds = secondsPtr[i] + EPOCH_OFFSET;
+      auto seconds = secondsPtr[i] + dwio::common::EPOCH_OFFSET;
       if (seconds < 0 && nanos != 0) {
         seconds -= 1;
       }
@@ -77,10 +78,10 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
   switch (static_cast<int64_t>(kind)) {
     case proto::ColumnEncoding_Kind_DIRECT:
     case proto::ColumnEncoding_Kind_DICTIONARY:
-      return RleVersion_1;
+      return RleVersion::RleVersion_1;
     case proto::ColumnEncoding_Kind_DIRECT_V2:
     case proto::ColumnEncoding_Kind_DICTIONARY_V2:
-      return RleVersion_2;
+      return RleVersion::RleVersion_2;
     default:
       DWIO_RAISE("Unknown encoding in convertRleVersion");
   }
@@ -337,7 +338,7 @@ void nextValues(
 template <class ReqT>
 class IntegerDirectColumnReader : public ColumnReader {
  private:
-  std::unique_ptr<IntDecoder</*isSigned*/ true>> ints;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ true>> ints;
 
  public:
   IntegerDirectColumnReader(
@@ -420,7 +421,7 @@ class IntegerDictionaryColumnReader : public ColumnReader {
   BufferPtr dictionary;
   BufferPtr inDictionary;
   std::unique_ptr<ByteRleDecoder> inDictionaryReader;
-  std::unique_ptr<IntDecoder</* isSigned = */ false>> dataReader;
+  std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ false>> dataReader;
   uint64_t dictionarySize;
   std::function<BufferPtr()> dictInit;
   bool initialized_{false};
@@ -582,8 +583,8 @@ void IntegerDictionaryColumnReader<ReqT>::ensureInitialized() {
 
 class TimestampColumnReader : public ColumnReader {
  private:
-  std::unique_ptr<IntDecoder</*isSigned*/ true>> seconds;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> nano;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ true>> seconds;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> nano;
 
   BufferPtr secondsBuffer_;
   BufferPtr nanosBuffer_;
@@ -611,7 +612,11 @@ TimestampColumnReader::TimestampColumnReader(
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
   seconds = createRleDecoder</*isSigned*/ true>(
-      stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
+      stripe.getStream(data, true),
+      vers,
+      memoryPool_,
+      vints,
+      dwio::common::LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
   bool nanoVInts = stripe.getUseVInts(nanoData);
   nano = createRleDecoder</*isSigned*/ false>(
@@ -619,7 +624,7 @@ TimestampColumnReader::TimestampColumnReader(
       vers,
       memoryPool_,
       nanoVInts,
-      LONG_BYTE_SIZE);
+      dwio::common::LONG_BYTE_SIZE);
 }
 
 uint64_t TimestampColumnReader::skip(uint64_t numValues) {
@@ -845,10 +850,11 @@ class StringDictionaryColumnReader : public ColumnReader {
   BufferPtr strideDict;
   BufferPtr strideDictOffset;
   BufferPtr indices_;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> dictIndex;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> dictIndex;
   std::unique_ptr<ByteRleDecoder> inDictionaryReader;
   std::unique_ptr<dwio::common::SeekableInputStream> strideDictStream;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> strideDictLengthDecoder;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>>
+      strideDictLengthDecoder;
 
   FlatVectorPtr<StringView> combinedDictionaryValues_;
   FlatVectorPtr<StringView> dictionaryValues_;
@@ -864,7 +870,7 @@ class StringDictionaryColumnReader : public ColumnReader {
   const StrideIndexProvider& provider;
 
   // lazy load the dictionary
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> lengthDecoder;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder;
   std::unique_ptr<dwio::common::SeekableInputStream> blobStream;
   const bool returnFlatVector_;
   bool initialized_{false};
@@ -929,7 +935,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
       rleVersion,
       memoryPool_,
       dictVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
@@ -938,7 +944,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
       rleVersion,
       memoryPool_,
       lenVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
 
   blobStream = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_DICTIONARY_DATA), false);
@@ -968,7 +974,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
         rleVersion,
         memoryPool_,
         strideLenVInt,
-        INT_BYTE_SIZE);
+        dwio::common::INT_BYTE_SIZE);
   }
 }
 
@@ -1367,7 +1373,7 @@ void StringDictionaryColumnReader::ensureInitialized() {
 
 class StringDirectColumnReader : public ColumnReader {
  private:
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> length;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length;
   std::unique_ptr<dwio::common::SeekableInputStream> blobStream;
 
   /**
@@ -1410,7 +1416,7 @@ StringDirectColumnReader::StringDirectColumnReader(
       rleVersion,
       memoryPool_,
       lenVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   blobStream =
       stripe.getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true);
 }
@@ -1658,7 +1664,7 @@ void StructColumnReader::next(
 class ListColumnReader : public ColumnReader {
  private:
   std::unique_ptr<ColumnReader> child;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> length;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length;
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 
  public:
@@ -1690,7 +1696,11 @@ ListColumnReader::ListColumnReader(
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
   length = createRleDecoder</*isSigned*/ false>(
-      stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
+      stripe.getStream(lenId, true),
+      vers,
+      memoryPool_,
+      vints,
+      dwio::common::INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();
   auto& childType = requestedType_->childAt(0);
@@ -1816,7 +1826,7 @@ class MapColumnReader : public ColumnReader {
  private:
   std::unique_ptr<ColumnReader> keyReader;
   std::unique_ptr<ColumnReader> elementReader;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> length;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length;
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 
  public:
@@ -1848,7 +1858,11 @@ MapColumnReader::MapColumnReader(
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool vints = stripe.getUseVInts(lenId);
   length = createRleDecoder</*isSigned*/ false>(
-      stripe.getStream(lenId, true), vers, memoryPool_, vints, INT_BYTE_SIZE);
+      stripe.getStream(lenId, true),
+      vers,
+      memoryPool_,
+      vints,
+      dwio::common::INT_BYTE_SIZE);
 
   const auto& cs = stripe.getColumnSelector();
   auto& keyType = requestedType_->childAt(0);
@@ -2104,21 +2118,21 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
       return buildIntegerReader(
           dataType,
           requestedType->type->kind(),
-          INT_BYTE_SIZE,
+          dwio::common::INT_BYTE_SIZE,
           std::move(flatMapContext),
           stripe);
     case TypeKind::BIGINT:
       return buildIntegerReader(
           dataType,
           requestedType->type->kind(),
-          LONG_BYTE_SIZE,
+          dwio::common::LONG_BYTE_SIZE,
           std::move(flatMapContext),
           stripe);
     case TypeKind::SMALLINT:
       return buildIntegerReader(
           dataType,
           requestedType->type->kind(),
-          SHORT_BYTE_SIZE,
+          dwio::common::SHORT_BYTE_SIZE,
           std::move(flatMapContext),
           stripe);
     case TypeKind::VARBINARY:

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.cpp
@@ -16,17 +16,14 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
-
 #include "velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h"
-#include "velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h"
-
-#include "velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h"
-#include "velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h"
-
 #include "velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h"
+#include "velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h"
+#include "velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveStructColumnReader.h"
+#include "velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h"
 
 namespace facebook::velox::dwrf {
 
@@ -379,7 +376,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveColumnReader::build(
           std::move(flatMapContext),
           dataType,
           stripe,
-          INT_BYTE_SIZE,
+          dwio::common::INT_BYTE_SIZE,
           scanSpec);
     case TypeKind::BIGINT:
       return buildIntegerReader(
@@ -387,7 +384,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveColumnReader::build(
           std::move(flatMapContext),
           dataType,
           stripe,
-          LONG_BYTE_SIZE,
+          dwio::common::LONG_BYTE_SIZE,
           scanSpec);
     case TypeKind::SMALLINT:
       return buildIntegerReader(
@@ -395,7 +392,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveColumnReader::build(
           std::move(flatMapContext),
           dataType,
           stripe,
-          SHORT_BYTE_SIZE,
+          dwio::common::SHORT_BYTE_SIZE,
           scanSpec);
     case TypeKind::ARRAY:
       return std::make_unique<SelectiveListColumnReader>(

--- a/velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h
@@ -17,8 +17,9 @@
 #pragma once
 
 #include "velox/common/base/Portability.h"
+#include "velox/dwio/common/DirectDecoder.h"
 #include "velox/dwio/common/TypeUtils.h"
-#include "velox/dwio/dwrf/common/DirectDecoder.h"
+#include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/FloatingPointDecoder.h"
 #include "velox/dwio/dwrf/common/RLEv1.h"
 #include "velox/dwio/dwrf/reader/ColumnVisitors.h"
@@ -52,7 +53,7 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
   switch (static_cast<int64_t>(kind)) {
     case proto::ColumnEncoding_Kind_DIRECT:
     case proto::ColumnEncoding_Kind_DICTIONARY:
-      return RleVersion_1;
+      return RleVersion::RleVersion_1;
     default:
       DWIO_RAISE("Unknown encoding in convertRleVersion");
   }

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 using namespace dwio::common;
 
@@ -36,7 +38,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
   rleVersion_ = convertRleVersion(encoding.kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dataVInts = stripe.getUseVInts(data);
-  dataReader_ = IntDecoder</* isSigned = */ false>::createRle(
+  dataReader_ = createRleDecoder</* isSigned = */ false>(
       stripe.getStream(data, true),
       rleVersion_,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -63,8 +63,8 @@ class SelectiveIntegerDictionaryColumnReader
   void ensureInitialized();
 
   std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
-  std::unique_ptr<IntDecoder</* isSigned = */ false>> dataReader_;
-  std::unique_ptr<IntDecoder</* isSigned = */ true>> dictReader_;
+  std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ false>> dataReader_;
+  std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ true>> dictReader_;
   std::function<BufferPtr()> dictInit_;
   RleVersion rleVersion_;
   bool initialized_{false};
@@ -75,7 +75,7 @@ void SelectiveIntegerDictionaryColumnReader::readWithVisitor(
     RowSet rows,
     ColumnVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
-  VELOX_CHECK_EQ(rleVersion_, RleVersion_1);
+  VELOX_CHECK_EQ(rleVersion_, RleVersion::RleVersion_1);
   auto dictVisitor = visitor.toDictionaryColumnVisitor();
   auto reader = reinterpret_cast<RleDecoderV1<false>*>(dataReader_.get());
   if (nullsInReadRange_) {

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -42,7 +42,8 @@ class SelectiveIntegerDirectColumnReader : public SelectiveIntegerColumnReader {
     auto decoder = createDirectDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), dataVInts, numBytes);
     auto rawDecoder = decoder.release();
-    auto directDecoder = dynamic_cast<DirectDecoder<true>*>(rawDecoder);
+    auto directDecoder =
+        dynamic_cast<dwio::common::DirectDecoder<true>*>(rawDecoder);
     ints.reset(directDecoder);
   }
 
@@ -74,7 +75,7 @@ class SelectiveIntegerDirectColumnReader : public SelectiveIntegerColumnReader {
   void readWithVisitor(RowSet rows, ColumnVisitor visitor);
 
  private:
-  std::unique_ptr<DirectDecoder</*isSigned*/ true>> ints;
+  std::unique_ptr<dwio::common::DirectDecoder</*isSigned*/ true>> ints;
 };
 
 template <typename ColumnVisitor>

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h"
 
 namespace facebook::velox::dwrf {
@@ -38,7 +39,7 @@ class SelectiveIntegerDirectColumnReader : public SelectiveIntegerColumnReader {
     EncodingKey encodingKey{nodeType_->id, flatMapContext_.sequence};
     auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
     bool dataVInts = stripe.getUseVInts(data);
-    auto decoder = IntDecoder</*isSigned*/ true>::createDirect(
+    auto decoder = createDirectDecoder</*isSigned*/ true>(
         stripe.getStream(data, true), dataVInts, numBytes);
     auto rawDecoder = decoder.release();
     auto directDecoder = dynamic_cast<DirectDecoder<true>*>(rawDecoder);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -54,7 +54,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
         rleVersion,
         memoryPool_,
         lenVints,
-        INT_BYTE_SIZE);
+        dwio::common::INT_BYTE_SIZE);
   }
 
   void makeNestedRowSet(RowSet rows) {
@@ -169,7 +169,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   // read up to the last position corresponding to
   // the last non-null parent.
   vector_size_t childTargetReadOffset_ = 0;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> length_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length_;
 };
 
 class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
@@ -48,7 +49,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     auto rleVersion = convertRleVersion(stripe.getEncoding(encodingKey).kind());
     auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
     bool lenVints = stripe.getUseVInts(lenId);
-    length_ = IntDecoder</*isSigned*/ false>::createRle(
+    length_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(lenId, true),
         rleVersion,
         memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 using namespace dwio::common;
@@ -41,7 +43,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
 
   const auto dataId = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dictVInts = stripe.getUseVInts(dataId);
-  dictIndex_ = IntDecoder</*isSigned*/ false>::createRle(
+  dictIndex_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, true),
       rleVersion,
       memoryPool_,
@@ -50,7 +52,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, false),
       rleVersion,
       memoryPool_,
@@ -77,7 +79,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
     const auto strideDictLenId =
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH);
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
-    strideDictLengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+    strideDictLengthDecoder_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, true),
         rleVersion,
         memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -48,7 +48,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
       rleVersion,
       memoryPool_,
       dictVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
@@ -57,7 +57,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
       rleVersion,
       memoryPool_,
       lenVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
 
   blobStream_ = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_DICTIONARY_DATA), false);
@@ -84,7 +84,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
         rleVersion,
         memoryPool_,
         strideLenVInt,
-        INT_BYTE_SIZE);
+        dwio::common::INT_BYTE_SIZE);
   }
   scanState_.updateRawState();
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -87,13 +87,14 @@ class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
   // values is in 'values.numValues'.
   void loadDictionary(
       dwio::common::SeekableInputStream& data,
-      IntDecoder</*isSigned*/ false>& lengthDecoder,
+      dwio::common::IntDecoder</*isSigned*/ false>& lengthDecoder,
       DictionaryValues& values);
   void ensureInitialized();
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> dictIndex_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> dictIndex_;
   std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
   std::unique_ptr<dwio::common::SeekableInputStream> strideDictStream_;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> strideDictLengthDecoder_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>>
+      strideDictLengthDecoder_;
 
   FlatVectorPtr<StringView> dictionaryValues_;
 
@@ -104,7 +105,7 @@ class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
   const StrideIndexProvider& provider_;
 
   // lazy load the dictionary
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> lengthDecoder_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder_;
   std::unique_ptr<dwio::common::SeekableInputStream> blobStream_;
   bool initialized_{false};
 };

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -41,7 +41,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
       rleVersion,
       memoryPool_,
       lenVInts,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   blobStream_ =
       stripe.getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true);
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
@@ -34,7 +36,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
       convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder_ = IntDecoder</*isSigned*/ false>::createRle(
+  lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, true),
       rleVersion,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -100,7 +100,7 @@ class SelectiveStringDirectColumnReader : public SelectiveColumnReader {
   template <bool scatter, bool skip>
   bool try8Consecutive(int32_t start, const int32_t* rows, int32_t row);
 
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> lengthDecoder_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder_;
   std::unique_ptr<dwio::common::SeekableInputStream> blobStream_;
   const char* bufferStart_ = nullptr;
   const char* bufferEnd_ = nullptr;

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h"
 
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
 namespace facebook::velox::dwrf {
 
 using namespace dwio::common;
@@ -35,11 +37,11 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
   RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
-  seconds_ = IntDecoder</*isSigned*/ true>::createRle(
+  seconds_ = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
   bool nanoVInts = stripe.getUseVInts(nanoData);
-  nano_ = IntDecoder</*isSigned*/ false>::createRle(
+  nano_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(nanoData, true),
       vers,
       memoryPool_,

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -42,8 +42,8 @@ class SelectiveTimestampColumnReader : public SelectiveColumnReader {
   template <bool dense>
   void readHelper(RowSet rows);
 
-  std::unique_ptr<IntDecoder</*isSigned*/ true>> seconds_;
-  std::unique_ptr<IntDecoder</*isSigned*/ false>> nano_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ true>> seconds_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> nano_;
 
   // Values from copied from 'seconds_'. Nanos are in 'values_'.
   BufferPtr secondsValues_;

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.h
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.h
@@ -16,12 +16,12 @@
 
 #pragma once
 
-#include <folly/Function.h>
-
 #include "velox/common/base/GTestMacros.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/Common.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/vector/BaseVector.h"
+
+#include <folly/Function.h>
 
 namespace facebook::velox::dwrf {
 class StripeDictionaryCache {

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -94,7 +94,7 @@ static inline void ensureCapacity(
 
 template <typename T>
 BufferPtr readDict(
-    IntDecoder<true>* dictReader,
+    dwio::common::IntDecoder<true>* dictReader,
     int64_t dictionarySize,
     velox::memory::MemoryPool* pool) {
   BufferPtr dictionaryBuffer = AlignedBuffer::allocate<T>(dictionarySize, pool);

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-#include <folly/ScopeGuard.h>
+#include "velox/dwio/dwrf/reader/StripeStream.h"
 
 #include "velox/common/base/BitSet.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/wrap/coded-stream-wrapper.h"
-#include "velox/dwio/dwrf/reader/StripeStream.h"
+
+#include <folly/ScopeGuard.h>
 
 namespace facebook::velox::dwrf {
 
@@ -121,7 +123,7 @@ StripeStreamsBase::getIntDictionaryInitializerForNode(
   DWIO_ENSURE(dataStream.get());
   stripeDictionaryCache_->registerIntDictionary(
       localEk,
-      [dictReader = IntDecoder</* isSigned = */ true>::createDirect(
+      [dictReader = createDirectDecoder</* isSigned = */ true>(
            std::move(dataStream), dictVInts, elementWidth),
        dictionaryWidth,
        dictionarySize](velox::memory::MemoryPool* pool) mutable {

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -475,11 +475,6 @@ target_link_libraries(
   ${ZLIB_LIBRARIES}
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwrf_int_decoder_benchmark IntDecoderBenchmark.cpp)
-target_link_libraries(
-  velox_dwrf_int_decoder_benchmark velox_dwio_common_exception velox_exception
-  velox_dwio_dwrf_common ${FOLLY} ${FOLLY_BENCHMARK})
-
 add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
 target_link_libraries(
   velox_dwrf_int_encoder_benchmark velox_dwio_dwrf_common velox_memory

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/test/utils/MapBuilder.h"
@@ -3743,7 +3743,11 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
 
   // read it as long
   auto decoder = createRleDecoder<false>(
-      std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
+      std::move(stream),
+      RleVersion::RleVersion_1,
+      pool,
+      streams.getUseVInts(si),
+      8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
   for (auto i = 0; i < size; ++i) {
@@ -3789,7 +3793,11 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
 
   // read it as long
   auto decoder = createRleDecoder<false>(
-      std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
+      std::move(stream),
+      RleVersion::RleVersion_1,
+      pool,
+      streams.getUseVInts(si),
+      8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
   for (auto i = 0; i < size; ++i) {

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-#include <folly/Random.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <algorithm>
-#include <optional>
-#include <vector>
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
@@ -31,6 +26,14 @@
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/type/Type.h"
 #include "velox/vector/DictionaryVector.h"
+
+#include <folly/Random.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <optional>
+#include <vector>
+
 using namespace ::testing;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::dwrf;
@@ -3739,7 +3742,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
   auto stream = streams.getStream(si, true);
 
   // read it as long
-  auto decoder = IntDecoder<false>::createRle(
+  auto decoder = createRleDecoder<false>(
       std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
@@ -3785,7 +3788,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
   auto stream = streams.getStream(si, true);
 
   // read it as long
-  auto decoder = IntDecoder<false>::createRle(
+  auto decoder = createRleDecoder<false>(
       std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/dwrf/common/DataBufferHolder.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
+#include "velox/dwio/dwrf/common/IntEncoder.h"
+#include "velox/dwio/dwrf/common/Range.h"
+
 #include <folly/Benchmark.h>
 #include <folly/Varint.h>
 #include <folly/init/Init.h>
-#include "velox/common/memory/Memory.h"
-#include "velox/dwio/dwrf/common/DataBufferHolder.h"
-#include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/Range.h"
 
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox;
@@ -33,7 +35,7 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
   DataBufferHolder holder{*scopedPool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<true>::createDirect(std::move(output), true, sizeof(int64_t));
+      createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));
 
   for (int64_t i = 0; i < count; i++) {
     encoder->writeValue(startId + i);
@@ -47,7 +49,7 @@ static size_t generateAutoId2(int64_t startId, int64_t count) {
   DataBufferHolder holder{*scopedPool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<true>::createDirect(std::move(output), true, sizeof(int64_t));
+      createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));
 
   int64_t buffer[1024];
   int64_t currentId = startId;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -16,15 +16,15 @@
 
 #pragma once
 
-#include <google/protobuf/wire_format_lite.h>
+#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/dwio/dwrf/common/Encryption.h"
-#include "velox/dwio/dwrf/common/IntCodecCommon.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 #include "velox/dwio/dwrf/test/utils/DataFiles.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/WriterBase.h"
 
 #include <gmock/gmock.h>
+#include <google/protobuf/wire_format_lite.h>
 
 namespace facebook::velox::dwrf {
 
@@ -131,11 +131,12 @@ inline int64_t zigZagDecode(uint64_t val) {
 
 inline size_t writeVuLong(char* buffer, size_t pos, uint64_t val) {
   while (true) {
-    if ((val & ~BASE_128_MASK) == 0) {
+    if ((val & ~dwio::common::BASE_128_MASK) == 0) {
       buffer[pos++] = static_cast<char>(val);
       return pos;
     } else {
-      buffer[pos++] = static_cast<char>((val & BASE_128_MASK) | 0x80);
+      buffer[pos++] =
+          static_cast<char>((val & dwio::common::BASE_128_MASK) | 0x80);
       val >>= 7;
     }
   }

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "velox/common/base/Nulls.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/common/EncoderUtil.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
 

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -45,7 +46,7 @@ void testInts(std::function<T()> generator) {
   DataBufferHolder holder{pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
-      IntEncoder<isSigned>::createDirect(std::move(output), vInt, sizeof(T));
+      createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));
 
   encoder->add(buffer.data(), Ranges::of(0, count), nulls.data());
 

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -72,7 +72,7 @@ void decodeAndVerify(
       std::make_unique<SeekableArrayInputStream>(
           memSink.getData(), memSink.size()),
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
 
   int64_t* decodedData = new int64_t[numValues];
   decoder.next(decodedData, numValues, nulls);

--- a/velox/dwio/dwrf/test/TestRle.cpp
+++ b/velox/dwio/dwrf/test/TestRle.cpp
@@ -15,9 +15,10 @@
  */
 
 #include "velox/common/base/Nulls.h"
+#include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/SeekableInputStream.h"
+#include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/common/IntDecoder.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
 
 #include <gtest/gtest.h>
@@ -32,12 +33,12 @@ std::vector<int64_t> decodeRLEv2(
     size_t count,
     const uint64_t* nulls = nullptr) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::make_unique<dwio::common::SeekableArrayInputStream>(bytes, l),
-      RleVersion_2,
+      RleVersion::RleVersion_2,
       *scopedPool,
       true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+      dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> results;
   size_t totalRead = 0;
   std::vector<uint64_t> remainingNulls;
@@ -177,14 +178,15 @@ TEST(RLEv2, delta0Width) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {
       0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42, 0x0};
-  std::unique_ptr<IntDecoder<false>> decoder = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(
-          new dwio::common::SeekableArrayInputStream(
-              buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_2,
-      *scopedPool,
-      true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+  std::unique_ptr<dwio::common::IntDecoder<false>> decoder =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(
+              new dwio::common::SeekableArrayInputStream(
+                  buffer, VELOX_ARRAY_SIZE(buffer))),
+          RleVersion::RleVersion_2,
+          *scopedPool,
+          true /* doesn't matter */,
+          dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   int64_t values[6];
   decoder->next(values, 6, 0);
   EXPECT_EQ(0, values[0]);
@@ -269,14 +271,14 @@ TEST(RLEv2, multiByteShortRepeats) {
 TEST(RLEv2, 0to2Repeat1Direct) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {0x46, 0x02, 0x02, 0x40};
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_2,
+      RleVersion::RleVersion_2,
       *scopedPool,
       true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+      dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> data(3);
   rle->next(data.data(), 3, nullptr);
 
@@ -371,14 +373,14 @@ TEST(RLEv2, largeNegativesDirect) {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x02, 0x99, 0xa5, 0xcc, 0x28, 0x03, 0xf7, 0xe0, 0xff};
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_2,
+      RleVersion::RleVersion_2,
       *scopedPool,
       true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+      dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> data(5);
   rle->next(data.data(), 5, nullptr);
 
@@ -573,13 +575,13 @@ TEST(RLEv2, basicDirectSeek) {
       0x04};
   unsigned long l = sizeof(bytes) / sizeof(char);
 
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(bytes, l)),
-      RleVersion_2,
+      RleVersion::RleVersion_2,
       *scopedPool,
       true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+      dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<uint64_t> position;
   position.push_back(7); // byte position; skip first 20 [0 to 19]
   position.push_back(13); // value position; skip 13 more [20 to 32]
@@ -649,13 +651,13 @@ TEST(RLEv2, bitsLeftByPreviousStream) {
               9,  141, 12,   6,   15, 25};
   unsigned long D = 118, P = sizeof(v) / sizeof(long), N = D + P;
 
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(bytes, l)),
-      RleVersion_2,
+      RleVersion::RleVersion_2,
       *scopedPool,
       true /* doesn't matter */,
-      INT_BYTE_SIZE /* doesn't matter */);
+      dwio::common::INT_BYTE_SIZE /* doesn't matter */);
 
   std::vector<int64_t> data(N);
   rle->next(data.data(), N, nullptr);
@@ -669,14 +671,15 @@ TEST(RLEv1, simpleTest) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {
       0x61, 0xff, 0x64, 0xfb, 0x02, 0x03, 0x5, 0x7, 0xb};
-  std::unique_ptr<IntDecoder<false>> rle = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(
-          new dwio::common::SeekableArrayInputStream(
-              buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_1,
-      *scopedPool,
-      true,
-      INT_BYTE_SIZE);
+  std::unique_ptr<dwio::common::IntDecoder<false>> rle =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(
+              new dwio::common::SeekableArrayInputStream(
+                  buffer, VELOX_ARRAY_SIZE(buffer))),
+          RleVersion::RleVersion_1,
+          *scopedPool,
+          true,
+          dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(105);
   rle->next(data.data(), 105, nullptr);
 
@@ -693,14 +696,14 @@ TEST(RLEv1, simpleTest) {
 TEST(RLEv1, signedNullLiteralTest) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_1,
+      RleVersion::RleVersion_1,
       *scopedPool,
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(8);
   std::vector<uint64_t> nulls(1, ~0);
   rle->next(data.data(), 8, nulls.data());
@@ -713,14 +716,15 @@ TEST(RLEv1, signedNullLiteralTest) {
 TEST(RLEv1, splitHeader) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {0x0, 0x00, 0xdc, 0xba, 0x98, 0x76};
-  std::unique_ptr<IntDecoder<false>> rle = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(
-          new dwio::common::SeekableArrayInputStream(
-              buffer, VELOX_ARRAY_SIZE(buffer), 4)),
-      RleVersion_1,
-      *scopedPool,
-      true,
-      INT_BYTE_SIZE);
+  std::unique_ptr<dwio::common::IntDecoder<false>> rle =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(
+              new dwio::common::SeekableArrayInputStream(
+                  buffer, VELOX_ARRAY_SIZE(buffer), 4)),
+          RleVersion::RleVersion_1,
+          *scopedPool,
+          true,
+          dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(200);
   rle->next(data.data(), 3, nullptr);
 
@@ -736,12 +740,13 @@ TEST(RLEv1, splitRuns) {
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
           buffer, VELOX_ARRAY_SIZE(buffer));
-  std::unique_ptr<IntDecoder<false>> rle = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
-      *scopedPool,
-      true,
-      INT_BYTE_SIZE);
+  std::unique_ptr<dwio::common::IntDecoder<false>> rle =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(stream),
+          RleVersion::RleVersion_1,
+          *scopedPool,
+          true,
+          dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(200);
   for (size_t i = 0; i < 42; ++i) {
     rle->next(data.data(), 3, nullptr);
@@ -768,12 +773,12 @@ TEST(RLEv1, testSigned) {
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
           buffer, VELOX_ARRAY_SIZE(buffer));
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
+      RleVersion::RleVersion_1,
       *scopedPool,
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(100);
   rle->next(data.data(), data.size(), nullptr);
   for (size_t i = 0; i < data.size(); ++i) {
@@ -792,12 +797,12 @@ TEST(RLEv1, testNull) {
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
           buffer, VELOX_ARRAY_SIZE(buffer));
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
+      RleVersion::RleVersion_1,
       *scopedPool,
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(24);
   uint64_t nulls[1] = {bits::kNotNull64};
   for (size_t i = 0; i < data.size(); ++i) {
@@ -826,12 +831,13 @@ TEST(RLEv1, testAllNulls) {
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
           buffer, VELOX_ARRAY_SIZE(buffer));
-  std::unique_ptr<IntDecoder<false>> rle = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
-      *scopedPool,
-      true,
-      INT_BYTE_SIZE);
+  std::unique_ptr<dwio::common::IntDecoder<false>> rle =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(stream),
+          RleVersion::RleVersion_1,
+          *scopedPool,
+          true,
+          dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(16, -1);
   std::vector<uint64_t> allNull(1, bits::kNull64);
   std::vector<uint64_t> noNull(1, bits::kNotNull64);
@@ -1078,12 +1084,12 @@ TEST(RLEv1, skipTest) {
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
           buffer, VELOX_ARRAY_SIZE(buffer));
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
+      RleVersion::RleVersion_1,
       *scopedPool,
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(1);
   for (size_t i = 0; i < 2048; i += 10) {
     rle->next(data.data(), 1, nullptr);
@@ -2958,12 +2964,12 @@ TEST(RLEv1, seekTest) {
     positions[i].push_back(fileLoc[i]);
     positions[i].push_back(rleLoc[i]);
   }
-  std::unique_ptr<IntDecoder<true>> rle = createRleDecoder<true>(
+  std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
-      RleVersion_1,
+      RleVersion::RleVersion_1,
       *scopedPool,
       true,
-      INT_BYTE_SIZE);
+      dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(2048);
   rle->next(data.data(), data.size(), nullptr);
   for (size_t i = 0; i < data.size(); ++i) {
@@ -3012,14 +3018,15 @@ TEST(RLEv1, seekTest) {
 TEST(RLEv1, testLeadingNulls) {
   auto scopedPool = memory::getDefaultScopedMemoryPool();
   const unsigned char buffer[] = {0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
-  std::unique_ptr<IntDecoder<false>> rle = createRleDecoder<false>(
-      std::unique_ptr<dwio::common::SeekableInputStream>(
-          new dwio::common::SeekableArrayInputStream(
-              buffer, VELOX_ARRAY_SIZE(buffer))),
-      RleVersion_1,
-      *scopedPool,
-      true,
-      INT_BYTE_SIZE);
+  std::unique_ptr<dwio::common::IntDecoder<false>> rle =
+      createRleDecoder<false>(
+          std::unique_ptr<dwio::common::SeekableInputStream>(
+              new dwio::common::SeekableArrayInputStream(
+                  buffer, VELOX_ARRAY_SIZE(buffer))),
+          RleVersion::RleVersion_1,
+          *scopedPool,
+          true,
+          dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(10);
   uint64_t isNull[1] = {bits::kNotNull};
   for (int32_t i = 0; i < 10; i++) {

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -387,7 +387,7 @@ class IntegerColumnWriter : public BaseColumnWriter {
     if (!data_ && !dataDirect_) {
       if (dictEncoding) {
         data_ = createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_DATA),
             getConfig(Config::USE_VINTS),
             sizeof(T));
@@ -659,12 +659,12 @@ class TimestampColumnWriter : public BaseColumnWriter {
       std::function<void(IndexBuilder&)> onRecordPosition)
       : BaseColumnWriter{context, type, sequence, onRecordPosition},
         seconds_{createRleEncoder</* isSigned = */ true>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_DATA),
             context.getConfig(Config::USE_VINTS),
             LONG_BYTE_SIZE)},
         nanos_{createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_NANO_DATA),
             context.getConfig(Config::USE_VINTS),
             LONG_BYTE_SIZE)} {
@@ -767,7 +767,8 @@ uint64_t TimestampColumnWriter::write(
   }
 
   // Seconds is Long, Nanos is int.
-  constexpr uint32_t TimeStampSize = LONG_BYTE_SIZE + INT_BYTE_SIZE;
+  constexpr uint32_t TimeStampSize =
+      LONG_BYTE_SIZE + dwio::common::INT_BYTE_SIZE;
   auto rawSize = count * TimeStampSize + (ranges.size() - count) * NULL_SIZE;
   indexStatsBuilder_->increaseRawSize(rawSize);
   return rawSize;
@@ -981,14 +982,14 @@ class StringColumnWriter : public BaseColumnWriter {
     if (!data_ && !dataDirect_) {
       if (dictEncoding) {
         data_ = createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_DATA),
             getConfig(Config::USE_VINTS),
             sizeof(uint32_t));
         dictionaryData_ = std::make_unique<AppendOnlyBufferedStream>(
             newStream(StreamKind::StreamKind_DICTIONARY_DATA));
         dictionaryDataLength_ = createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_LENGTH),
             getConfig(Config::USE_VINTS),
             sizeof(uint32_t));
@@ -997,7 +998,7 @@ class StringColumnWriter : public BaseColumnWriter {
         strideDictionaryData_ = std::make_unique<AppendOnlyBufferedStream>(
             newStream(StreamKind::StreamKind_STRIDE_DICTIONARY));
         strideDictionaryDataLength_ = createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_STRIDE_DICTIONARY_LENGTH),
             getConfig(Config::USE_VINTS),
             sizeof(uint32_t));
@@ -1005,7 +1006,7 @@ class StringColumnWriter : public BaseColumnWriter {
         dataDirect_ = std::make_unique<AppendOnlyBufferedStream>(
             newStream(StreamKind::StreamKind_DATA));
         dataDirectLength_ = createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_LENGTH),
             getConfig(Config::USE_VINTS),
             sizeof(uint32_t));
@@ -1458,10 +1459,10 @@ class BinaryColumnWriter : public BaseColumnWriter {
       : BaseColumnWriter{context, type, sequence, onRecordPosition},
         data_{newStream(StreamKind::StreamKind_DATA)},
         lengths_{createRleEncoder</* isSigned */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_LENGTH),
             context.getConfig(Config::USE_VINTS),
-            INT_BYTE_SIZE)} {
+            dwio::common::INT_BYTE_SIZE)} {
     reset();
   }
 
@@ -1700,10 +1701,10 @@ class ListColumnWriter : public BaseColumnWriter {
       std::function<void(IndexBuilder&)> onRecordPosition)
       : BaseColumnWriter{context, type, sequence, onRecordPosition},
         lengths_{createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_LENGTH),
             context.getConfig(Config::USE_VINTS),
-            INT_BYTE_SIZE)} {
+            dwio::common::INT_BYTE_SIZE)} {
     reset();
   }
 
@@ -1823,10 +1824,10 @@ class MapColumnWriter : public BaseColumnWriter {
       std::function<void(IndexBuilder&)> onRecordPosition)
       : BaseColumnWriter{context, type, sequence, onRecordPosition},
         lengths_{createRleEncoder</* isSigned = */ false>(
-            RleVersion_1,
+            RleVersion::RleVersion_1,
             newStream(StreamKind::StreamKind_LENGTH),
             context.getConfig(Config::USE_VINTS),
-            INT_BYTE_SIZE)} {
+            dwio::common::INT_BYTE_SIZE)} {
     reset();
   }
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -19,6 +19,7 @@
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Compression.h"
+#include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
 #include "velox/dwio/dwrf/writer/RatioTracker.h"
@@ -145,7 +146,7 @@ class WriterContext : public CompressionBufferPool {
               dictionaryPool,
               generalPool,
               getConfig(Config::DICTIONARY_SORT_KEYS),
-              IntEncoder</* isSigned = */ true>::createDirect(
+              createDirectEncoder</* isSigned */ true>(
                   newStream(
                       {ek.node,
                        ek.sequence,


### PR DESCRIPTION
DirectDecoder will be used by both DWRF and Parquet readers. This PR moves it and its parent class IntDecoder to dwio::common. The encoders were not moved.

Depends on https://github.com/facebookincubator/velox/pull/1849