### PR TITLE
Add fix to build failure

### DIFF
--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
   velox_exec_test_util
   velox_dwio_common
   velox_dwio_common_exception
-  velox_dwio_duckdb_parquet_reader
+  velox_dwio_parquet_reader
   velox_dwio_type_fbhive
   velox_dwrf_test_utils
   velox_hive_connector


### PR DESCRIPTION
Fix for build failure resulting from movement of DuckDB parquet reader