### PR TITLE
Add aggregate function last(expr, [,ignoreNull])

### DIFF
--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -11,31 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(
-  velox_functions_spark
-  ArraySort.cpp
-  CompareFunctionsNullSafe.cpp
-  Hash.cpp
-  In.cpp
-  LeastGreatest.cpp
-  Map.cpp
-  RegexFunctions.cpp
-  Register.cpp
-  RegisterArithmetic.cpp
-  RegisterCompare.cpp
-  Size.cpp
-  SplitFunctions.cpp
-  String.cpp
-  Subscript.cpp)
+add_library(velox_functions_spark_aggregates LastAggregate.cpp Register.cpp)
 
-target_link_libraries(velox_functions_spark velox_functions_lib
-                      velox_functions_prestosql_impl Folly::folly)
-
-set_property(TARGET velox_functions_spark PROPERTY JOB_POOL_COMPILE
-                                                   high_memory_pool)
+target_link_libraries(velox_functions_spark_aggregates ${FMT} velox_exec
+                      velox_expression_functions velox_aggregates velox_vector)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
-  add_subdirectory(benchmarks)
-  add_subdirectory(aggregates)
 endif()

--- a/velox/functions/sparksql/aggregates/LastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/LastAggregate.cpp
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/aggregates/LastAggregate.h"
+
+#include <fmt/format.h>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::functions::sparksql::aggregates {
+
+namespace {
+
+/// LastAggregateNumeric returns the last value of |expr| for a group of rows.
+/// If |ignoreNull| is true, returns only non-null values.
+/// Usage: last(expr [,ignoreNull])
+///
+/// The function is non-deterministic because its results depends on the order
+/// of the rows which may be non-deterministic after a shuffle.  This can be
+/// made deterministic by providing explicit ordering by adding order by or sort
+/// by in query.
+///
+/// Supported types: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE
+template <typename TDataType>
+class LastAggregateNumeric : public exec::Aggregate {
+ public:
+  explicit LastAggregateNumeric(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(TDataType);
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    setIgnoreNull(rows, args);
+
+    if (decoded.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!decoded.isNullAt(i)) {
+          updateValue(groups[i], decoded.valueAt<TDataType>(i));
+        } else if (!ignoreNull_.value()) {
+          setNull(groups[i]);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateValue(groups[i], decoded.valueAt<TDataType>(i));
+      });
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    setIgnoreNull(rows, decoded);
+    auto valueVector = rowVector->childAt(0)->as<SimpleVector<TDataType>>();
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+      auto decodedIndex = decoded.index(i);
+      if (!valueVector->isNullAt(decodedIndex)) {
+        updateValue(groups[i], valueVector->valueAt(decodedIndex));
+      } else if (!ignoreNull_.value()) {
+        setNull(groups[i]);
+      }
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    setIgnoreNull(rows, args);
+
+    auto i = rows.end() - 1;
+    while (i >= rows.begin()) {
+      if (!rows.isValid(i)) {
+        --i;
+        continue;
+      }
+      if (!decoded.isNullAt(i)) {
+        updateValue(group, decoded.valueAt<TDataType>(i));
+        return;
+      }
+      if (!ignoreNull_.value()) {
+        setNull(group);
+        return;
+      }
+      --i;
+    }
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    setIgnoreNull(rows, decoded);
+    auto valueVector = rowVector->childAt(0)->as<SimpleVector<TDataType>>();
+
+    auto i = rows.end() - 1;
+    while (i >= rows.begin()) {
+      if (!rows.isValid(i) || decoded.isNullAt(i)) {
+        --i;
+        continue;
+      }
+      auto decodedIndex = decoded.index(i);
+      if (!valueVector->isNullAt(decodedIndex)) {
+        updateValue(group, valueVector->valueAt(decodedIndex));
+        return;
+      }
+      if (!ignoreNull_.value()) {
+        setNull(group);
+        return;
+      }
+      --i;
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::FLAT);
+    auto vector = (*result)->as<FlatVector<TDataType>>();
+    VELOX_CHECK(
+        vector,
+        "Unexpected type of the result vector: {}",
+        (*result)->type()->toString());
+    VELOX_CHECK_EQ(vector->elementSize(), sizeof(TDataType));
+
+    vector->resize(numGroups);
+    TDataType* rawValues = vector->mutableRawValues();
+    uint64_t* rawNulls = getRawNulls(vector);
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        vector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        rawValues[i] = *value<TDataType>(group);
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    auto valueVector = rowVector->childAt(0)->asFlatVector<TDataType>();
+    auto ignoreNullVector = rowVector->childAt(1)->asFlatVector<bool>();
+
+    rowVector->resize(numGroups);
+    valueVector->resize(numGroups);
+    ignoreNullVector->resize(numGroups);
+
+    uint64_t* rawNulls = getRawNulls(rowVector);
+    TDataType* rawValues = valueVector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (!ignoreNull_.has_value()) {
+        // ignoreNull_ will remain unset if extractAccumulators is called
+        // without calling addRawInput or addIntermediateResults.  We mark
+        // the row as null in this case.
+        rowVector->setNull(i, true);
+        continue;
+      }
+      clearNull(rawNulls, i);
+      ignoreNullVector->set(i, ignoreNull_.value());
+      if (isNull(group)) {
+        valueVector->setNull(i, true);
+      } else {
+        valueVector->setNull(i, false);
+        rawValues[i] = *value<TDataType>(group);
+      }
+    }
+  }
+
+  void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
+
+ private:
+  /// For raw input, if second argument is present read ignoreNull from this
+  /// constant mapping.
+  inline void setIgnoreNull(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    if (args.size() == 1) {
+      // By default do not ignore null values.
+      ignoreNull_ = false;
+      return;
+    }
+    DecodedVector ignoreNullVector(*args[1], rows);
+    VELOX_CHECK(
+        ignoreNullVector.isConstantMapping(),
+        "ignoreNull argument must be constant for all input rows");
+    ignoreNull_ = ignoreNullVector.valueAt<bool>(0);
+  }
+
+  /// For intermediate results, read ignoreNull from any selected row. This flag
+  /// will have same value for all non null rows in input.
+  inline void setIgnoreNull(
+      const SelectivityVector& rows,
+      const DecodedVector& decoded) {
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    auto ignoreNullVector = rowVector->childAt(1)->as<SimpleVector<bool>>();
+
+    rows.testSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return true;
+      }
+      ignoreNull_ = ignoreNullVector->valueAt(decoded.index(i));
+      return false;
+    });
+  }
+
+  inline void updateValue(char* group, TDataType value) {
+    clearNull(group);
+    *Aggregate::value<TDataType>(group) = value;
+  }
+
+  std::optional<bool> ignoreNull_;
+};
+
+/// LastAggregateNonNumeric returns the last value of |expr| for a group of
+/// rows. If |ignoreNull| is true, returns only non-null values. Usage:
+/// last(expr [,ignoreNull])
+///
+/// The function is non-deterministic because its results depends on the order
+/// of the rows which may be non-deterministic after a shuffle.  This can be
+/// made deterministic by providing explicit ordering by adding order by or sort
+/// by in query.
+//
+/// Supported types: VARCHAR, ARRAY, MAP
+class LastAggregateNonNumeric : public exec::Aggregate {
+ public:
+  explicit LastAggregateNonNumeric(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
+
+  /// We use singleValueAccumulator to save the results for each group. This
+  /// struct will allow us to save variable-width value.
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(aggregate::SingleValueAccumulator);
+  }
+
+  /// Initialize each group.
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) aggregate::SingleValueAccumulator();
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    setIgnoreNull(rows, args);
+
+    const auto* indices = decoded.indices();
+    const auto* baseVector = decoded.base();
+    if (decoded.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!decoded.isNullAt(i)) {
+          updateValue(groups[i], baseVector, indices[i]);
+        } else if (!ignoreNull_.value()) {
+          setNull(groups[i]);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateValue(groups[i], baseVector, indices[i]);
+      });
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    setIgnoreNull(rows, decoded);
+    auto baseVector = rowVector->childAt(0).get();
+
+    const auto* indices = decoded.indices();
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+      if (!baseVector->isNullAt(indices[i])) {
+        updateValue(groups[i], baseVector, indices[i]);
+      } else if (!ignoreNull_.value()) {
+        setNull(groups[i]);
+      }
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows, true);
+    setIgnoreNull(rows, args);
+
+    const auto* indices = decoded.indices();
+    const auto* baseVector = decoded.base();
+
+    auto i = rows.end() - 1;
+    while (i >= rows.begin()) {
+      if (!rows.isValid(i)) {
+        --i;
+        continue;
+      }
+      if (!decoded.isNullAt(i)) {
+        updateValue(group, baseVector, indices[i]);
+        return;
+      }
+      if (!ignoreNull_.value()) {
+        setNull(group);
+        return;
+      }
+      --i;
+    }
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    DecodedVector decoded(*args[0], rows);
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    setIgnoreNull(rows, decoded);
+    auto baseVector = rowVector->childAt(0).get();
+
+    const auto* indices = decoded.indices();
+    auto i = rows.end() - 1;
+    while (i >= rows.begin()) {
+      if (!rows.isValid(i) || decoded.isNullAt(i)) {
+        --i;
+        continue;
+      }
+      if (!baseVector->isNullAt(indices[i])) {
+        updateValue(group, baseVector, indices[i]);
+        return;
+      }
+      if (!ignoreNull_.value()) {
+        setNull(group);
+        return;
+      }
+      --i;
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK(result);
+    (*result)->resize(numGroups);
+
+    auto* rawNulls = getRawNulls(result->get());
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        (*result)->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        auto accumulator = value<aggregate::SingleValueAccumulator>(group);
+        accumulator->read(*result, i);
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    VELOX_CHECK_EQ(
+        rowVector->childrenSize(),
+        2,
+        "intermediate results must have 2 children");
+
+    auto baseVector = rowVector->childAt(0);
+    auto ignoreNullVector = rowVector->childAt(1)->asFlatVector<bool>();
+
+    rowVector->resize(numGroups);
+    baseVector->resize(numGroups);
+    ignoreNullVector->resize(numGroups);
+
+    uint64_t* rawNulls = getRawNulls(rowVector);
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (!ignoreNull_.has_value()) {
+        // ignoreNull_ will remain unset if extractAccumulators is called
+        // without calling addRawInput or addIntermediateResults.  We mark
+        // the row as null in this case.
+        rowVector->setNull(i, true);
+        continue;
+      }
+      clearNull(rawNulls, i);
+      ignoreNullVector->set(i, ignoreNull_.value());
+      if (isNull(group)) {
+        (*result)->setNull(i, true);
+      } else {
+        (*result)->setNull(i, false);
+        auto accumulator = value<aggregate::SingleValueAccumulator>(group);
+        accumulator->read(baseVector, i);
+      }
+    }
+  }
+
+  void destroy(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      value<aggregate::SingleValueAccumulator>(group)->destroy(allocator_);
+    }
+  }
+
+  void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
+
+ private:
+  /// For raw input, if second argument is present read ignoreNull from this
+  /// constant mapping.
+  inline void setIgnoreNull(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    if (args.size() == 1) {
+      // By default do not ignore null values.
+      ignoreNull_ = false;
+      return;
+    }
+    DecodedVector ignoreNullVector(*args[1], rows);
+    VELOX_CHECK(
+        ignoreNullVector.isConstantMapping(),
+        "ignoreNull argument must be constant for all input rows");
+    ignoreNull_ = ignoreNullVector.valueAt<bool>(0);
+  }
+
+  /// For intermediate results, read ignoreNull from any selected row. This flag
+  /// will have same value for all non null rows in input.
+  inline void setIgnoreNull(
+      const SelectivityVector& rows,
+      const DecodedVector& decoded) {
+    auto rowVector = dynamic_cast<const RowVector*>(decoded.base());
+    VELOX_CHECK_NOT_NULL(rowVector);
+    auto ignoreNullVector = rowVector->childAt(1)->as<SimpleVector<bool>>();
+
+    rows.testSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return true;
+      }
+      ignoreNull_ = ignoreNullVector->valueAt(decoded.index(i));
+      return false;
+    });
+  }
+
+  inline void
+  updateValue(char* group, const BaseVector* baseVector, vector_size_t index) {
+    clearNull(group);
+    auto* accumulator = value<aggregate::SingleValueAccumulator>(group);
+    accumulator->write(baseVector, index, allocator_);
+  }
+
+  std::optional<bool> ignoreNull_;
+};
+
+} // namespace
+
+bool registerLastAggregate(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .argumentType("T")
+          .intermediateType("row(T, boolean)")
+          .returnType("T")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .argumentType("T")
+          .argumentType("boolean")
+          .intermediateType("row(T, boolean)")
+          .returnType("T")
+          .build(),
+  };
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_LE(
+            argTypes.size(), 2, "{} takes at most 2 arguments", name);
+        const auto& inputType = argTypes[0];
+        TypeKind dataKind = exec::isRawInput(step)
+            ? inputType->kind()
+            : inputType->childAt(0)->kind();
+        switch (dataKind) {
+          case TypeKind::TINYINT:
+            return std::make_unique<LastAggregateNumeric<int8_t>>(resultType);
+          case TypeKind::SMALLINT:
+            return std::make_unique<LastAggregateNumeric<int16_t>>(resultType);
+          case TypeKind::INTEGER:
+            return std::make_unique<LastAggregateNumeric<int32_t>>(resultType);
+          case TypeKind::BIGINT:
+            return std::make_unique<LastAggregateNumeric<int64_t>>(resultType);
+          case TypeKind::REAL:
+            return std::make_unique<LastAggregateNumeric<float>>(resultType);
+          case TypeKind::DOUBLE:
+            return std::make_unique<LastAggregateNumeric<double>>(resultType);
+          case TypeKind::VARCHAR:
+          case TypeKind::ARRAY:
+          case TypeKind::MAP:
+            return std::make_unique<LastAggregateNonNumeric>(resultType);
+          default:
+            VELOX_FAIL(
+                "Unknown input type for {} aggregation {}",
+                name,
+                inputType->toString());
+        }
+      });
+}
+
+} // namespace facebook::velox::functions::sparksql::aggregates

--- a/velox/functions/sparksql/aggregates/LastAggregate.h
+++ b/velox/functions/sparksql/aggregates/LastAggregate.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions::sparksql::aggregates {
+
+bool registerLastAggregate(const std::string& name);
+
+} // namespace facebook::velox::functions::sparksql::aggregates

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+#include "velox/functions/sparksql/aggregates/LastAggregate.h"
+
+namespace facebook::velox::functions::sparksql::aggregates {
+
+void registerAggregateFunctions(const std::string& prefix) {
+  aggregates::registerLastAggregate(prefix + "last");
+}
+} // namespace facebook::velox::functions::sparksql::aggregates

--- a/velox/functions/sparksql/aggregates/Register.h
+++ b/velox/functions/sparksql/aggregates/Register.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions::sparksql::aggregates {
+void registerAggregateFunctions(const std::string& prefix);
+} // namespace facebook::velox::functions::sparksql::aggregates

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_functions_spark_aggregates_test LastAggregateTest.cpp
+                                                     Main.cpp)
+
+add_test(velox_functions_spark_aggregates_test
+         velox_functions_spark_aggregates_test)
+
+target_link_libraries(
+  velox_functions_spark_aggregates_test
+  velox_exec_test_util
+  velox_vector_test_lib
+  velox_aggregates_test_lib
+  velox_functions_spark_aggregates
+  ${gflags_LIBRARIES}
+  gtest
+  gtest_main)

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+namespace facebook::velox::functions::sparksql::aggregates::test {
+
+namespace {
+
+class LastAggregateTest : public aggregate::test::AggregationTestBase {
+ public:
+  LastAggregateTest() {
+    aggregates::registerAggregateFunctions("");
+    disableSpill();
+  }
+
+  template <typename T>
+  void testGroupBy() {
+    auto vectors = {makeRowVector({
+        makeFlatVector<int32_t>(98, [](auto row) { return row % 7; }),
+        makeFlatVector<T>(
+            98, // size
+            [](auto row) { return row; }, // valueAt
+            [](auto row) { return row % 3 == 0; }), // nullAt
+        makeConstant<bool>(true, 98),
+        makeConstant<bool>(false, 98),
+    })};
+
+    createDuckDbTable(vectors);
+
+    // Verify when ignoreNull is true.
+    testAggregations(
+        vectors,
+        {"c0"},
+        {"last(c1, c2)"},
+        "SELECT c0, last(c1 ORDER BY c1) FROM tmp GROUP BY c0");
+
+    // Verify when ignoreNull is false.
+    // Expected result should have last 7 rows [91..98) including nulls.
+    auto expected = {makeRowVector({
+        makeFlatVector<int32_t>(7, [](auto row) { return row; }),
+        makeFlatVector<T>(
+            7, // size
+            [](auto row) { return 91 + row; }, // valueAt
+            [](auto row) { return (91 + row) % 3 == 0; }), // nullAt
+    })};
+    testAggregations(vectors, {"c0"}, {"last(c1, c3)"}, expected);
+
+    // Verify when ignoreNull is not provided. Defaults to false.
+    testAggregations(vectors, {"c0"}, {"last(c1)"}, expected);
+  }
+
+  template <typename T>
+  void testGlobalAggregation() {
+    auto vectors = {makeRowVector({
+        makeNullableFlatVector<T>({std::nullopt, 1, 2, std::nullopt}),
+        makeConstant<bool>(true, 4),
+        makeConstant<bool>(false, 4),
+    })};
+
+    // Verify when ignoreNull is true.
+    auto expectedTrue = {makeRowVector({makeNullableFlatVector<T>({2})})};
+    testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+
+    // Verify when ignoreNull is false.
+    auto expectedFalse = {
+        makeRowVector({makeNullableFlatVector<T>({std::nullopt})})};
+    testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+
+    // Verify when ignoreNull is not provided. Defaults to false.
+    testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
+  }
+};
+
+// Verify aggregation with group by keys for TINYINT.
+TEST_F(LastAggregateTest, tinyIntGroupBy) {
+  testGroupBy<int8_t>();
+}
+
+// Verify global aggregation for TINYINT.
+TEST_F(LastAggregateTest, tinyIntGlobal) {
+  testGlobalAggregation<int8_t>();
+}
+
+// Verify aggregation with group by keys for SMALLINT.
+TEST_F(LastAggregateTest, smallIntGroupBy) {
+  testGroupBy<int16_t>();
+}
+
+// Verify global aggregation for SMALLINT.
+TEST_F(LastAggregateTest, smallIntGlobal) {
+  testGlobalAggregation<int16_t>();
+}
+
+// Verify aggregation with group by keys for INTEGER.
+TEST_F(LastAggregateTest, integerGroupBy) {
+  testGroupBy<int32_t>();
+}
+
+// Verify global aggregation for INTEGER.
+TEST_F(LastAggregateTest, integerGlobal) {
+  testGlobalAggregation<int32_t>();
+}
+
+// Verify aggregation with group by keys for BIGINT.
+TEST_F(LastAggregateTest, bigintGroupBy) {
+  testGroupBy<int64_t>();
+}
+
+// Verify global aggregation for BIGINT.
+TEST_F(LastAggregateTest, bigintGlobal) {
+  testGlobalAggregation<int64_t>();
+}
+
+// Verify aggregation with group by keys for REAL.
+TEST_F(LastAggregateTest, realGroupBy) {
+  testGroupBy<float>();
+}
+
+// Verify global aggregation for REAL.
+TEST_F(LastAggregateTest, realGlobal) {
+  testGlobalAggregation<float>();
+}
+
+// Verify aggregation with group by keys for DOUBLE.
+TEST_F(LastAggregateTest, doubleGroupBy) {
+  testGroupBy<double>();
+}
+
+// Verify global aggregation for DOUBLE.
+TEST_F(LastAggregateTest, doubleGlobal) {
+  testGlobalAggregation<double>();
+}
+
+// Vefify aggregation with group by keys for VARCHAR.
+TEST_F(LastAggregateTest, varcharGroupBy) {
+  std::vector<std::string> data(98);
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>(98, [](auto row) { return row % 7; }),
+      makeFlatVector<StringView>(
+          98, // size
+          [&data](auto row) {
+            data[row] = std::to_string(row);
+            return StringView(data[row]);
+          }, // valueAt
+          [](auto row) { return row % 3 == 0; }), // nullAt
+      makeConstant<bool>(true, 98),
+      makeConstant<bool>(false, 98),
+  })};
+
+  createDuckDbTable(vectors);
+
+  // Verify when ignoreNull is true.
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"last(c1, c2)"},
+      "SELECT c0, last(c1 ORDER BY c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0");
+
+  // Verify when ignoreNull is false.
+  // Expected result should have last 7 rows [91..98) including nulls.
+  auto expected = {makeRowVector({
+      makeFlatVector<int32_t>(7, [](auto row) { return row; }),
+      makeFlatVector<StringView>(
+          7, // size
+          [&data](auto row) { return StringView(data[91 + row]); }, // valueAt
+          [](auto row) { return (91 + row) % 3 == 0; }), // nullAt
+  })};
+  testAggregations(vectors, {"c0"}, {"last(c1, c3)"}, expected);
+
+  // Verify when ignoreNull is not provided. Defaults to false.
+  testAggregations(vectors, {"c0"}, {"last(c1)"}, expected);
+}
+
+// Verify global aggregation for VARCHAR.
+TEST_F(LastAggregateTest, varcharGlobal) {
+  auto vectors = {makeRowVector({
+      makeNullableFlatVector<std::string>(
+          {std::nullopt, "a", "b", std::nullopt}),
+      makeConstant<bool>(true, 4),
+      makeConstant<bool>(false, 4),
+  })};
+
+  // Verify when ignoreNull is true.
+  auto expectedTrue = {
+      makeRowVector({makeNullableFlatVector<std::string>({"b"})})};
+  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+
+  // Verify when ignoreNull is false.
+  auto expectedFalse = {
+      makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})})};
+  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+
+  // Verify when ignoreNull is not provided. Defaults to false.
+  testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
+}
+
+// Verify aggregation with group by keys for ARRAY.
+TEST_F(LastAggregateTest, arrayGroupBy) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>(98, [](auto row) { return row % 7; }),
+      makeArrayVector<int64_t>(
+          98, // size
+          [](auto row) { return row % 3; }, // sizeAt
+          [](auto row, auto idx) { return row * 100 + idx; }, // valueAt
+          // Even rows are null.
+          [](auto row) { return row % 2 == 0; }), // nullAt
+      makeConstant<bool>(true, 98),
+      makeConstant<bool>(false, 98),
+  })};
+
+  auto expectedTrue = {makeRowVector({
+      makeFlatVector<int32_t>(7, [](auto row) { return row; }),
+      makeArrayVector<int64_t>(
+          7,
+          [](auto row) {
+            // Even rows are null, for these return values for (row - 7)
+            return ((91 + row) % 2) ? (91 + row) % 3 : (91 + row - 7) % 3;
+          },
+          [](auto row, auto idx) {
+            // Even rows are null, for these return values for (row - 7)
+            return ((91 + row) % 2) ? (91 + row) * 100 + idx
+                                    : (91 + row - 7) * 100 + idx;
+          }),
+  })};
+
+  // Verify when ignoreNull is true.
+  testAggregations(vectors, {"c0"}, {"last(c1, c2)"}, expectedTrue);
+
+  // Verify when ignoreNull is false.
+  // Expected result should have last 7 rows [91..98) of input |vectors|
+  auto expectedFalse = {makeRowVector({
+      makeFlatVector<int32_t>(7, [](auto row) { return row; }),
+      makeArrayVector<int64_t>(
+          7, // size
+          [](auto row) { return (91 + row) % 3; }, // sizeAt
+          [](auto row, auto idx) { return (91 + row) * 100 + idx; }, // valueAt
+          [](auto row) { return (91 + row) % 2 == 0; }), // nullAt
+  })};
+
+  testAggregations(vectors, {"c0"}, {"last(c1, c3)"}, expectedFalse);
+
+  // Verify when ignoreNull is not provided. Defaults to false.
+  testAggregations(vectors, {"c0"}, {"last(c1)"}, expectedFalse);
+}
+
+// Verify global aggregation for ARRAY.
+TEST_F(LastAggregateTest, arrayGlobal) {
+  auto vectors = {makeRowVector({
+      makeVectorWithNullArrays<int64_t>(
+          {std::nullopt, {{1, 2}}, {{3, 4}}, std::nullopt}),
+      makeConstant<bool>(true, 4),
+      makeConstant<bool>(false, 4),
+  })};
+
+  auto expectedTrue = {makeRowVector({
+      makeVectorWithNullArrays<int64_t>({{{3, 4}}}),
+  })};
+
+  // Verify when ignoreNull is true.
+  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+
+  // Verify when ignoreNull is false.
+  auto expectedFalse = {makeRowVector({
+      makeVectorWithNullArrays<int64_t>({std::nullopt}),
+  })};
+  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+
+  // Verify when ignoreNull is not provided. Defaults to false.
+  testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
+}
+
+// Verify aggregation with group by keys for MAP column.
+TEST_F(LastAggregateTest, mapGroupBy) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>(98, [](auto row) { return row % 7; }),
+      makeMapVector<int64_t, float>(
+          98, // size
+          [](auto row) { return row % 2 ? 0 : 2; }, // sizeAt
+          [](auto idx) { return idx; }, // keyAt
+          [](auto idx) { return idx * 0.1; }), // valueAt
+  })};
+
+  // Expected result should have last 7 rows of input |vectors|
+  auto expected = {makeRowVector({
+      makeFlatVector<int32_t>(7, [](auto row) { return row; }),
+      makeMapVector<int64_t, float>(
+          7, // size
+          [](auto row) { return row % 2 ? 2 : 0; }, // sizeAt
+          [](auto idx) { return 92 + idx; }, // keyAt
+          [](auto idx) { return (92 + idx) * 0.1; }), // valueAt
+  })};
+
+  testAggregations(vectors, {"c0"}, {"last(c1)"}, expected);
+}
+
+// Verify global aggregation for MAP column.
+TEST_F(LastAggregateTest, mapGlobal) {
+  auto O = [](const std::vector<std::pair<int64_t, std::optional<float>>>& m) {
+    return std::make_optional(m);
+  };
+  auto vectors = {makeRowVector({
+      makeNullableMapVector<int64_t, float>(
+          {std::nullopt, O({{1, 2.0}}), O({{2, 4.0}}), std::nullopt}),
+      makeConstant<bool>(true, 4),
+      makeConstant<bool>(false, 4),
+  })};
+
+  auto expectedTrue = {makeRowVector({
+      makeNullableMapVector<int64_t, float>({O({{2, 4.0}})}),
+  })};
+
+  // Verify when ignoreNull is true.
+  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+
+  // Verify when ignoreNull is false.
+  auto expectedFalse = {makeRowVector({
+      makeNullableMapVector<int64_t, float>({std::nullopt}),
+  })};
+  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+
+  // Verify when ignoreFalse is not provided. Defaults to false.
+  testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::aggregates::test

--- a/velox/functions/sparksql/aggregates/tests/Main.cpp
+++ b/velox/functions/sparksql/aggregates/tests/Main.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Implement last aggregate function
last(expr[, ignoreNull])
Returns the last value of expr for a group of rows.
If isIgnoreNull is true, returns only non-null values

Reference: https://spark.apache.org/docs/latest/api/sql/#last

Differential Revision: D37360558

