### PR TITLE
Remove unnecessary and misleading RowVector::loadedChildAt method

### DIFF
--- a/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
@@ -268,7 +268,7 @@ void E2EFilterTestBase::readWithFilter(
       // Load eventual LazyVectors inside the timed section.
       auto rowVector = batch->asUnchecked<RowVector>();
       for (auto i = 0; i < rowVector->childrenSize(); ++i) {
-        rowVector->loadedChildAt(i);
+        rowVector->childAt(i)->loadedVector();
       }
       if (skipCheck) {
         // Fetch next batch inside timed section.

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -231,7 +231,8 @@ std::shared_ptr<T> getOnlyChild(const std::shared_ptr<F>& batch) {
   auto rowVector = std::dynamic_pointer_cast<RowVector>(batch);
   EXPECT_TRUE(rowVector.get() != nullptr)
       << "Vector is not a struct: " << typeid(F).name();
-  auto child = std::dynamic_pointer_cast<T>(rowVector->loadedChildAt(0));
+  auto child = std::dynamic_pointer_cast<T>(
+      BaseVector::loadedVectorShared(rowVector->childAt(0)));
   EXPECT_TRUE(child.get() != nullptr)
       << "Child vector type doesn't match " << typeid(T).name();
   return child;
@@ -239,8 +240,8 @@ std::shared_ptr<T> getOnlyChild(const std::shared_ptr<F>& batch) {
 
 template <typename T, typename F>
 std::shared_ptr<T> getChild(std::shared_ptr<F>& batch, size_t index) {
-  auto child = std::dynamic_pointer_cast<T>(
-      std::dynamic_pointer_cast<RowVector>(batch)->loadedChildAt(index));
+  auto child = std::dynamic_pointer_cast<T>(BaseVector::loadedVectorShared(
+      std::dynamic_pointer_cast<RowVector>(batch)->childAt(index)));
   EXPECT_TRUE(child.get() != nullptr);
   return child;
 }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -175,7 +175,7 @@ void GroupingSet::addInputForActiveRows(
     // A null in any of the keys disables the row.
     deselectRowsWithNulls(*input, keyChannels_, activeRows_, execCtx_);
     for (int32_t i = 0; i < hashers.size(); ++i) {
-      auto key = input->loadedChildAt(hashers[i]->channel());
+      auto key = input->childAt(hashers[i]->channel())->loadedVector();
       if (mode != BaseHashTable::HashMode::kHash) {
         if (!hashers[i]->computeValueIds(*key, activeRows_, lookup_->hashes)) {
           rehash = true;
@@ -186,7 +186,7 @@ void GroupingSet::addInputForActiveRows(
     }
   } else {
     for (int32_t i = 0; i < hashers.size(); ++i) {
-      auto key = input->loadedChildAt(hashers[i]->channel());
+      auto key = input->childAt(hashers[i]->channel())->loadedVector();
       if (mode != BaseHashTable::HashMode::kHash) {
         if (!hashers[i]->computeValueIds(*key, activeRows_, lookup_->hashes)) {
           rehash = true;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -156,15 +156,18 @@ void HashBuild::addInput(RowVectorPtr input) {
     // TODO: Load only for active rows, except if right/full outer join.
     if (analyzeKeys_) {
       hasher->computeValueIds(
-          *input->loadedChildAt(hasher->channel()), activeRows_, hashes_);
+          *input->childAt(hasher->channel())->loadedVector(),
+          activeRows_,
+          hashes_);
       analyzeKeys_ = hasher->mayUseValueIds();
     } else {
-      hasher->decode(*input->loadedChildAt(hasher->channel()), activeRows_);
+      hasher->decode(
+          *input->childAt(hasher->channel())->loadedVector(), activeRows_);
     }
   }
   for (auto i = 0; i < dependentChannels_.size(); ++i) {
     decoders_[i]->decode(
-        *input->loadedChildAt(dependentChannels_[i]), activeRows_);
+        *input->childAt(dependentChannels_[i])->loadedVector(), activeRows_);
   }
   auto rows = table_->rows();
   auto nextOffset = rows->nextOffset();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -234,7 +234,7 @@ void HashProbe::addInput(RowVectorPtr input) {
   auto mode = table_->hashMode();
   auto& buildHashers = table_->hashers();
   for (auto i = 0; i < keyChannels_.size(); ++i) {
-    auto key = input_->loadedChildAt(keyChannels_[i]);
+    auto key = input_->childAt(keyChannels_[i])->loadedVector();
     if (mode != BaseHashTable::HashMode::kHash) {
       buildHashers[i]->lookupValueIds(
           *key, activeRows_, scratchMemory_, lookup_->hashes);

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -35,7 +35,7 @@ void deselectRowsWithNulls(
     auto& child = const_cast<VectorPtr&>(input.childAt(channel));
     LazyVector::ensureLoadedRows(
         child, rows, scratchDecodedVector, scratchRows);
-    auto key = input.loadedChildAt(channel);
+    auto key = input.childAt(channel)->loadedVector();
     if (key->mayHaveNulls()) {
       auto nulls = key->flatRawNulls(rows);
       anyChange = true;

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -95,7 +95,7 @@ std::optional<int32_t> RowVector::compare(
   auto compareSize = std::min(children_.size(), otherRow->children_.size());
   for (int32_t i = 0; i < compareSize; ++i) {
     BaseVector* child = children_[i].get();
-    BaseVector* otherChild = otherRow->loadedChildAt(i).get();
+    BaseVector* otherChild = otherRow->childAt(i)->loadedVector();
     if (!child && !otherChild) {
       continue;
     }
@@ -129,7 +129,7 @@ void RowVector::appendToChildren(
     vector_size_t index) {
   for (int32_t i = 0; i < children_.size(); ++i) {
     auto& child = children_[i];
-    child->copy(source->loadedChildAt(i).get(), index, sourceIndex, count);
+    child->copy(source->childAt(i)->loadedVector(), index, sourceIndex, count);
   }
 }
 
@@ -203,7 +203,10 @@ void RowVector::copy(
       vector_size_t wrappedIndex = source->wrappedIndex(sourceIndex + i);
       for (int32_t j = 0; j < children_.size(); ++j) {
         childAt(j)->copy(
-            sourceAsRow->loadedChildAt(j).get(), childIndex, wrappedIndex, 1);
+            sourceAsRow->childAt(j)->loadedVector(),
+            childIndex,
+            wrappedIndex,
+            1);
       }
     }
   }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -108,14 +108,6 @@ class RowVector : public BaseVector {
     VELOX_USER_CHECK_LT(index, childrenSize_);
     return children_[index];
   }
-  const VectorPtr& loadedChildAt(column_index_t index) const {
-    VELOX_USER_CHECK_LT(index, childrenSize_);
-    auto& child = children_[index];
-    if (child->encoding() == VectorEncoding::Simple::LAZY) {
-      child = child->as<LazyVector>()->loadedVectorShared();
-    }
-    return child;
-  }
 
   std::vector<VectorPtr>& children() {
     return children_;

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -259,7 +259,7 @@ void exportRowVector(
 
   // Convert each child.
   for (size_t i = 0; i < numChildren; ++i) {
-    auto childVector = rowVector->loadedChildAt(i);
+    auto childVector = BaseVector::loadedVectorShared(rowVector->childAt(i));
     exportToArrow(childVector, *bridgeHolder.allocateChild(i), pool);
   }
 


### PR DESCRIPTION
RowVector::loadedChildAt was loading child vector only it is was a LazyVector,
but not if it was a LazyVector wrapped in one or more levels of dictionary.
This behavior is inconsistent with BaseVector::loadedVector and therefore is
misleading. Removed this method and replaced the callsites to use
RowVector::childAt + BaseVector::loadedVector or loadedVectorShared.