### PR TITLE
Add additional info to MEM_CAP_EXCEEDED error

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -34,6 +34,7 @@
 #include "folly/experimental/FunctionScheduler.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/GTestMacros.h"
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
@@ -668,7 +669,11 @@ void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
       ALIGNER<ALIGNMENT>{}, p, alignedSize, alignedNewSize);
   if (UNLIKELY(!newP)) {
     free(p, alignedSize);
-    VELOX_MEM_CAP_EXCEEDED(cap_);
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(difference));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
   }
 
   return newP;
@@ -833,7 +838,11 @@ void MemoryPoolImpl<Allocator, ALIGNMENT>::reserve(int64_t size) {
     if (manualCap) {
       VELOX_MEM_MANUAL_CAP();
     }
-    VELOX_MEM_CAP_EXCEEDED(cap_);
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(size));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
   }
 }
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -388,7 +388,9 @@ TEST(MemoryPoolTest, MemoryCapExceptions) {
       EXPECT_EQ(error_source::kErrorSourceRuntime.c_str(), ex.errorSource());
       EXPECT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
       EXPECT_TRUE(ex.isRetriable());
-      EXPECT_EQ("Exceeded memory cap of 63 MB", ex.message());
+      EXPECT_EQ(
+          "Exceeded memory cap of 63.00MB when requesting 64.00MB",
+          ex.message());
     }
     ASSERT_FALSE(pool.isMemoryCapped());
   }

--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -26,7 +26,7 @@ class CallbackSink : public Operator {
       int32_t operatorId,
       DriverCtx* driverCtx,
       std::function<BlockingReason(RowVectorPtr, ContinueFuture*)> callback)
-      : Operator(driverCtx, nullptr, operatorId, "N/A", "N/A"),
+      : Operator(driverCtx, nullptr, operatorId, "N/A", "CallbackSink"),
         callback_{callback} {}
 
   void addInput(RowVectorPtr input) override {

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -590,6 +590,15 @@ Driver::findOperator(std::string_view planNodeId) const {
   return nullptr;
 }
 
+std::vector<Operator*> Driver::operators() const {
+  std::vector<Operator*> operators;
+  operators.reserve(operators_.size());
+  for (auto& op : operators_) {
+    operators.push_back(op.get());
+  }
+  return operators;
+}
+
 void Driver::setError(std::exception_ptr exception) {
   task()->setError(exception);
 }

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -253,6 +253,9 @@ class Driver : public std::enable_shared_from_this<Driver> {
   // build by id.
   Operator* FOLLY_NULLABLE findOperator(std::string_view planNodeId) const;
 
+  // Returns a list of all operators.
+  std::vector<Operator*> operators() const;
+
   void setError(std::exception_ptr exception);
 
   std::string toString();

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/expression/Expr.h"
 
@@ -79,6 +80,32 @@ OperatorCtx::createConnectorQueryCtx(
       expressionEvaluator_.get(),
       driverCtx_->task->queryCtx()->mappedMemory(),
       fmt::format("{}.{}", driverCtx_->task->taskId(), planNodeId));
+}
+
+Operator::Operator(
+    DriverCtx* driverCtx,
+    std::shared_ptr<const RowType> outputType,
+    int32_t operatorId,
+    std::string planNodeId,
+    std::string operatorType)
+    : operatorCtx_(std::make_unique<OperatorCtx>(driverCtx)),
+      stats_(
+          operatorId,
+          driverCtx->pipelineId,
+          std::move(planNodeId),
+          std::move(operatorType)),
+      outputType_(std::move(outputType)) {
+  auto tracker = pool()->getMemoryUsageTracker();
+  if (tracker) {
+    tracker->setMakeMemoryCapExceededMessage(
+        [&](memory::MemoryUsageTracker& tracker) {
+          std::stringstream out;
+          out << "Failed Operator: " << stats_.operatorType << "_#"
+              << stats_.operatorId << ": "
+              << succinctBytes(tracker.getCurrentTotalBytes());
+          return out.str();
+        });
+  }
 }
 
 std::vector<std::unique_ptr<Operator::PlanNodeTranslator>>&

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -248,14 +248,7 @@ class Operator {
       std::shared_ptr<const RowType> outputType,
       int32_t operatorId,
       std::string planNodeId,
-      std::string operatorType)
-      : operatorCtx_(std::make_unique<OperatorCtx>(driverCtx)),
-        stats_(
-            operatorId,
-            driverCtx->pipelineId,
-            std::move(planNodeId),
-            std::move(operatorType)),
-        outputType_(std::move(outputType)) {}
+      std::string operatorType);
 
   virtual ~Operator() = default;
 

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -63,7 +63,7 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   // Populating number of drivers for plan nodes with multiple operators is not
   // useful. Each operator could have been executed in different pipelines with
   // different number of drivers.
-  if (!isMultiOperatorNode()) {
+  if (!isMultiOperatorTypeNode()) {
     numDrivers += stats.numDrivers;
   } else {
     numDrivers = 0;
@@ -203,7 +203,7 @@ std::string printPlanWithStats(
 
         // Include break down by operator type for plan nodes with multiple
         // operators. Print input rows and sizes for all such nodes.
-        if (stats.isMultiOperatorNode()) {
+        if (stats.isMultiOperatorTypeNode()) {
           for (const auto& entry : stats.operatorStats) {
             stream << std::endl;
             stream << indentation << entry.first << ": "

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -104,7 +104,7 @@ struct PlanNodeStats {
 
   std::string toString(bool includeInputStats = false) const;
 
-  bool isMultiOperatorNode() const {
+  bool isMultiOperatorTypeNode() const {
     return operatorStats.size() > 1;
   }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -18,6 +18,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "velox/codegen/Codegen.h"
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/CrossJoinBuild.h"
 #include "velox/exec/Exchange.h"
@@ -144,7 +145,15 @@ Task::Task(
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
       pool_(queryCtx_->pool()->addScopedChild("task_root")),
-      bufferManager_(PartitionedOutputBufferManager::getInstance()) {}
+      bufferManager_(PartitionedOutputBufferManager::getInstance()) {
+  auto tracker = pool()->getMemoryUsageTracker();
+  if (tracker) {
+    tracker->setMakeMemoryCapExceededMessage(
+        [&](memory::MemoryUsageTracker& tracker) {
+          return this->getErrorMsgOnMemCapExceeded(tracker);
+        });
+  }
+}
 
 Task::~Task() {
   try {
@@ -1643,5 +1652,86 @@ void Task::TaskCompletionNotifier::notify() {
 
     active_ = false;
   }
+}
+
+std::string Task::getErrorMsgOnMemCapExceeded(
+    memory::MemoryUsageTracker& tracker) {
+  std::stringstream out;
+  out << "Task total: " << succinctBytes(tracker.getCurrentTotalBytes())
+      << " Peak: " << succinctBytes(tracker.getPeakTotalBytes()) << ".";
+  // Aggregate relevant metrics for each operator across all drivers.
+  struct MemoryUsageStats {
+    int operatorId{0};
+    std::string operatorType;
+    int64_t cumulativeTotalBytes{0};
+    int64_t peakTotalBytes{0};
+    int numInstances{0};
+
+    MemoryUsageStats() = default;
+    MemoryUsageStats(Operator* op) {
+      operatorId = op->stats().operatorId;
+      operatorType = op->stats().operatorType;
+    }
+
+    void add(const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
+      this->cumulativeTotalBytes += tracker->getCurrentTotalBytes();
+      this->peakTotalBytes =
+          std::max(this->peakTotalBytes, tracker->getPeakTotalBytes());
+      this->numInstances++;
+    }
+  };
+  std::unordered_map<int, MemoryUsageStats> operatorStats;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    for (auto& driver : drivers_) {
+      if (!driver) {
+        continue;
+      }
+      auto operators = driver->operators();
+      for (auto op : operators) {
+        auto it = operatorStats.find(op->stats().operatorId);
+        if (it == operatorStats.end()) {
+          it = operatorStats.insert({op->stats().operatorId, {op}}).first;
+        }
+        it->second.add(op->pool()->getMemoryUsageTracker());
+      }
+    }
+  }
+  std::vector<MemoryUsageStats> operatorStatsArray;
+  operatorStatsArray.reserve(operatorStats.size());
+  for (auto& [operatorId, stats] : operatorStats) {
+    operatorStatsArray.push_back(std::move(stats));
+  }
+  static auto compareByCumulativeTotalBytes =
+      [](const MemoryUsageStats& left, const MemoryUsageStats& right) {
+        return left.cumulativeTotalBytes > right.cumulativeTotalBytes;
+      };
+  // Get the top 3.
+  if (operatorStatsArray.size() > 3) {
+    std::nth_element(
+        operatorStatsArray.begin(),
+        operatorStatsArray.begin() + 2,
+        operatorStatsArray.end(),
+        compareByCumulativeTotalBytes);
+    operatorStatsArray.resize(3);
+  }
+  std::sort(
+      operatorStatsArray.begin(),
+      operatorStatsArray.end(),
+      compareByCumulativeTotalBytes);
+  out << " Top " << operatorStatsArray.size()
+      << " Operators (by aggregate usage across all drivers): ";
+  int remainingStatsToAdd = operatorStatsArray.size();
+  for (auto& stats : operatorStatsArray) {
+    out << stats.operatorType << "_#" << stats.operatorId << "_x"
+        << stats.numInstances << ": "
+        << succinctBytes(stats.cumulativeTotalBytes)
+        << " Peak: " << succinctBytes(stats.peakTotalBytes);
+    remainingStatsToAdd--;
+    if (remainingStatsToAdd > 0) {
+      out << ", ";
+    }
+  }
+  return out.str();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -568,6 +568,17 @@ class Task : public std::enable_shared_from_this<Task> {
 
   int getOutputPipelineId() const;
 
+  /// Callback function added to the MemoryUsageTracker to return a descriptive
+  /// message to be added to the error when a MEM_CAP_EXCEEDED error is
+  /// encountered.
+  /// Example Error Message generated:
+  /// Exceeded memory cap of 12.00MB when requesting 1.00MB. Task total: 8.00MB
+  /// Peak: 12.00MB. Top 3 Operators (by aggregate usage across all drivers):
+  /// Aggregation_#1_x6: 168.00KB Peak: 1.00MB, TableScan_#0_x6: 51.46KB
+  /// Peak: 1.00MB, CallbackSink_#2_x6: 0B Peak: 0B. Failed Operator:
+  /// Aggregation_#1: 0B
+  std::string getErrorMsgOnMemCapExceeded(memory::MemoryUsageTracker& tracker);
+
   // RAII helper class to satisfy 'stateChangePromises_' and notify listeners
   // that task is complete outside of the mutex. Inactive on creation. Must be
   // activated explicitly by calling 'activate'.
@@ -632,6 +643,9 @@ class Task : public std::enable_shared_from_this<Task> {
   mutable std::mutex mutex_;
 
   ConsumerSupplier consumerSupplier_;
+
+  // The function that is executed when the task encounters its first error,
+  // that is, serError() is called for the first time.
   std::function<void(std::exception_ptr)> onError_;
 
   std::vector<std::unique_ptr<DriverFactory>> driverFactories_;

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   DriverTest.cpp
   EnforceSingleRowTest.cpp
   FilterProjectTest.cpp
+  FunctionResolutionTest.cpp
   FunctionSignatureBuilderTest.cpp
   HashJoinTest.cpp
   HashTableTest.cpp
@@ -42,7 +43,7 @@ add_executable(
   PrintPlanWithStatsTest.cpp
   RoundRobinPartitionFunctionTest.cpp
   RowContainerTest.cpp
-  FunctionResolutionTest.cpp
+  MemoryCapExceededTest.cpp
   SpillTest.cpp
   SpillerTest.cpp
   StreamingAggregationTest.cpp

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <gmock/gmock.h>
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class MemoryCapExceededTest : public OperatorTestBase {};
+
+TEST_F(MemoryCapExceededTest, singleDriver) {
+  // Executes a plan with a single driver and query memory limit that forces it
+  // to throw MEM_CAP_EXCEEDED exception. Verifies that the error message
+  // contains all the details expected.
+
+  vector_size_t size = 1'024;
+  // This limit ensures that only the Aggregation Operator fails.
+  constexpr int64_t kMaxBytes = 5LL << 20; // 5MB
+  // Regex is used to offset the fact that operators with the same usage (in
+  // this case the ones with zero usage) are not deterministically sorted and
+  // the last one that makes its way to the top 3 can change between runs.
+  std::string expectedErrorMsgRegex =
+      "Exceeded memory cap of 5.00MB when requesting 2.00MB. Task total: "
+      "5.00MB Peak: 5.00MB. Top 3 Operators \\(by aggregate usage across "
+      "all drivers\\): Aggregation_#2_x1: 1.77MB Peak: 4.00MB, "
+      "FilterProject_#1_x1: 12.00KB Peak: 1.00MB, .+_x1: 0B Peak: "
+      "0B. Failed Operator: Aggregation_#2: 1.77MB";
+  std::vector<RowVectorPtr> data;
+  for (auto i = 0; i < 100; ++i) {
+    data.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            size, [&i](auto row) { return row + (i * 1000); }),
+        makeFlatVector<int64_t>(size, [](auto row) { return row + 3; }),
+    }));
+  }
+
+  // Plan created to allow multiple operators to show up in the top 3 memory
+  // usage list in the error message.
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .project({"c0", "c0 + c1"})
+                  .singleAggregation({"c0"}, {"sum(p1)"})
+                  .orderBy({"c0"}, false)
+                  .planNode();
+  auto queryCtx = core::QueryCtx::createForTest();
+  queryCtx->pool()->setMemoryUsageTracker(
+      velox::memory::MemoryUsageTracker::create(
+          kMaxBytes, kMaxBytes, kMaxBytes));
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+  try {
+    readCursor(params, [](Task*) {});
+    FAIL() << "Expected a MEM_CAP_EXCEEDED RuntimeException.";
+  } catch (const VeloxException& e) {
+    auto errorMessage = e.message();
+    ASSERT_THAT(errorMessage, ::testing::MatchesRegex(expectedErrorMsgRegex));
+  }
+}
+
+TEST_F(MemoryCapExceededTest, multipleDrivers) {
+  // Executes a plan that runs with ten drivers and query memory limit that
+  // forces it to throw MEM_CAP_EXCEEDED exception. Verifies that the error
+  // message contains information that acknowledges the existence of 10 drivers.
+  // Rest of the message is not verified as the contents are non-deterministic
+  // with respect to which operators make it to the top 3 and their memory
+  // usage.
+  vector_size_t size = 1'024;
+  const int32_t numSplits = 100;
+  constexpr int64_t kMaxBytes = 12LL << 20; // 12MB
+  std::vector<RowVectorPtr> data;
+  for (auto i = 0; i < numSplits; ++i) {
+    auto rowVector = makeRowVector({
+        makeFlatVector<int32_t>(
+            size, [&i](auto row) { return row + (i * 1000); }),
+        makeFlatVector<int32_t>(size, [](auto row) { return row + 3; }),
+    });
+    data.push_back(rowVector);
+  }
+
+  auto plan = PlanBuilder()
+                  .values(data, true)
+                  .singleAggregation({"c0"}, {"sum(c1)"})
+                  .planNode();
+  auto queryCtx = core::QueryCtx::createForTest();
+  queryCtx->pool()->setMemoryUsageTracker(
+      velox::memory::MemoryUsageTracker::create(
+          kMaxBytes, kMaxBytes, kMaxBytes));
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+  params.maxDrivers = 10;
+  VELOX_ASSERT_THROW(readCursor(params, [](Task*) {}), "x10");
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
This patch adds a mechanism to the MemoryUsageTracker class that
allows its user to register a callback to add additional info to a
MEM_CAP_EXCEEDED error when encountered during a call to increase
reservation. Moreover, this mechanism is leveraged to add details
at the Task and Operator level in the memory tracker hierarchy.

Additionally, also fixes an inconsistency in memory accounting where
drivers that increment memory reservation within limits can also hit
memory limit exceeds error. This happened because the atomic that
accounts for current memory usage is read again after being modified
by the driver which allows it to pickup changes by other drivers that
might have pushed the current usage over limits.

Also adds an appropriate value for operator type to CallBackSink
operator which is used as a named identifier for reporting.

Example error message:
Exceeded memory cap of 5.00MB when requesting 2.00MB. Task total:
5.00MB Peak: 5.00MB. Top 3 Operators (by aggregate usage across
all drivers): Aggregation_#2_x1: 1.77MB Peak: 4.00MB,
FilterProject_#1_x1: 12.00KB Peak: 1.00MB, CallbackSink_#4_x1: 0B
Peak: 0B. Failed Operator: Aggregation_#2: 1.77MB

Test plan:
Added tests to force this error and verify details added to the
error message.