### PR TITLE
Fix docker image build scripts and update the image using the updated script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ executors:
   build:
     docker:
       - image : prestocpp/velox-circleci:kevinwilfong-20220426
+      - image : prestocpp/velox-avx-circleci:mikesh-20220628
     resource_class: 2xlarge
     environment:
         CC:  /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -70,11 +70,11 @@ wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
 wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
 wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
-wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz
+wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop
 
 wait  # For cmake and source downloads to complete.
 
-cp -a hadoop-2.10.1 /usr/local/
+cp -a hadoop /usr/local/
 
 # Build & install.
 (

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -100,7 +100,7 @@ function get_cxx_flags {
     ;;
 
     "avx")
-      echo -n "-mavx2 -mfma -mavx -mf16c -masm=intel -mlzcnt -std=c++17"
+      echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17"
     ;;
 
     "sse")


### PR DESCRIPTION
This is to address issue #1882 The velox code (StringImpl.h) requires a newer versions of folly. presto_cpp is still using an older version of docker image. docker image has to be updated to presto_cpp to pick up the latest image from velox.
But before we can do that, we need to fix the scripts in velox which were broken after those cpu_arch-related commits (like this one https://github.com/facebookincubator/velox/pull/1761).
The changes include:
* fix hadoop install script
* remove masm flag which will break folly build which uses att assembly syntax
* build a new velox docker image build (prestocpp/velox-avx-circleci:mikesh-20220628) and use it in circleci config

