### PR TITLE
Add supportsSingleThreadedExecution() function to Task

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -182,6 +182,24 @@ memory::MappedMemory* FOLLY_NONNULL Task::addOperatorMemory(
   return mappedMemory.get();
 }
 
+bool Task::supportsSingleThreadedExecution() const {
+  std::vector<std::unique_ptr<DriverFactory>> driverFactories;
+
+  if (consumerSupplier_) {
+    return false;
+  }
+
+  LocalPlanner::plan(planFragment_, nullptr, &driverFactories, 1);
+
+  for (const auto& factory : driverFactories) {
+    if (!factory->supportsSingleThreadedExecution()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 RowVectorPtr Task::next() {
   VELOX_CHECK_EQ(
       core::ExecutionStrategy::kUngrouped,

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -118,6 +118,10 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t maxDrivers,
       uint32_t concurrentSplitGroups = 1);
 
+  /// If this returns true, this Task supports the single-threaded execution API
+  /// next().
+  bool supportsSingleThreadedExecution() const;
+
   /// Single-threaded execution API. Runs the query and returns results one
   /// batch at a time. Returns nullptr if query evaluation is finished and no
   /// more data will be produced. Throws an exception if query execution


### PR DESCRIPTION
Summary:
The logic for deciding whether or not a Task supports single thread execution (i.e. calls to next()) is complicated and spread across the LocalPlanner and Driver classes.

This change adds a function supportsSingleThreadedExecution() to Task that makes it easy for users to check in a single place whether or not they can call next() on a Task, or whether they need to use the multi-threaded API.

Reviewed By: mbasmanova

Differential Revision: D37499915

