### PR TITLE
Ensure broken main does not fail benchmark CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,15 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make benchmarks-basic-build NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+
+            # If benchmark build on main is broken, print a warning message and let the job fail.
+            make benchmarks-basic-build NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8 || ( \
+              echo -e "\n\n" \
+                      "=============================================================\n" \
+                      "Benchmark execution uses the main branch as the baseline,\n" \
+                      "but it looks like builds on main are broken.\n" \
+                      "Please rebase your PR once main is fixed to unblock this job.\n" \
+                      "=============================================================\n"; exit 1)
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
Summary: Just experimenting for now. Nothing to see here yet.

Differential Revision: D37508791

