### PR TITLE
Remove the old docker image from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ workflows:
 executors:
   build:
     docker:
-      - image : prestocpp/velox-circleci:kevinwilfong-20220426
       - image : prestocpp/velox-avx-circleci:mikesh-20220628
     resource_class: 2xlarge
     environment:


### PR DESCRIPTION
Remove the old docker image from circleci that I forgot to remove previously.