### PR TITLE
Optimize Expr::isSpecialForm

### DIFF
--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -38,11 +38,12 @@ class SpecialForm : public Expr {
       std::vector<ExprPtr>&& inputs,
       const std::string& name,
       bool trackCpuUsage)
-      : Expr(std::move(type), std::move(inputs), name, trackCpuUsage) {}
-
-  bool isSpecialForm() const override {
-    return true;
-  }
+      : Expr(
+            std::move(type),
+            std::move(inputs),
+            name,
+            true /* specialForm */,
+            trackCpuUsage) {}
 };
 
 enum class BooleanMix { kAllTrue, kAllFalse, kAllNull, kMixNonNull, kMix };

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -57,11 +57,13 @@ class Expr {
       TypePtr type,
       std::vector<std::shared_ptr<Expr>>&& inputs,
       std::string name,
+      bool specialForm,
       bool trackCpuUsage)
       : type_(std::move(type)),
         inputs_(std::move(inputs)),
         name_(std::move(name)),
         vectorFunction_(nullptr),
+        specialForm_{specialForm},
         trackCpuUsage_{trackCpuUsage} {}
 
   Expr(
@@ -74,6 +76,7 @@ class Expr {
         inputs_(std::move(inputs)),
         name_(std::move(name)),
         vectorFunction_(std::move(vectorFunction)),
+        specialForm_{false},
         trackCpuUsage_{trackCpuUsage} {}
 
   virtual ~Expr() = default;
@@ -136,8 +139,8 @@ class Expr {
     return type()->kind() == TypeKind::VARCHAR;
   }
 
-  virtual bool isSpecialForm() const {
-    return false;
+  bool isSpecialForm() const {
+    return specialForm_;
   }
 
   virtual bool isConditional() const {
@@ -308,6 +311,7 @@ class Expr {
   const std::vector<std::shared_ptr<Expr>> inputs_;
   const std::string name_;
   const std::shared_ptr<VectorFunction> vectorFunction_;
+  const bool specialForm_;
   const bool trackCpuUsage_;
 
   // TODO make the following metadata const, e.g. call computeMetadata in the


### PR DESCRIPTION
SpecialForm::isSpecialForm shows in the profile of ML pre-processing workloads.
Optimize it away by taking specialForm flag in Expr's constructor and
making Expr::isSpecialForm non-virtual.