### PR TITLE
Implement NegatedBytesValues filter class

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -270,6 +270,12 @@ inline std::unique_ptr<common::BytesValues> in(
   return std::make_unique<common::BytesValues>(values, nullAllowed);
 }
 
+inline std::unique_ptr<common::NegatedBytesValues> notIn(
+    const std::vector<std::string>& values,
+    bool nullAllowed = false) {
+  return std::make_unique<common::NegatedBytesValues>(values, nullAllowed);
+}
+
 inline std::unique_ptr<common::BoolValue> boolEqual(
     bool value,
     bool nullAllowed = false) {


### PR DESCRIPTION
Summary:
This diff adds support for strings (`varchar`) as a supported type for `NegatedValues` filters. Previously, these filter classes supported integers only, however, queries of the form `NOT IN [list]` for other types would still use the default `MultiRange` filters. Code for the `NegatedBytesValues` class forms a wrapper around `BytesValues` objects, and is contained in `Filter.h` and `Filter.cpp`, except for the `MergeWith` functions which will be added in a future diff.

To create unit tests, an additional set of tests has been added to `FilterTest.cpp`. An additional support function for these tests has been added to `ExprToSubfieldFilter.h`, which is a version of `notIn` for vectors of string values rather than vectors of integer values.

Reviewed By: gggrace14

Differential Revision: D37325631

