### PR TITLE
Add TPCH query 10 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -135,6 +135,11 @@ BENCHMARK(q6) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q10) {
+  const auto planContext = queryBuilder->getQueryPlan(10);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q13) {
   const auto planContext = queryBuilder->getQueryPlan(13);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -137,45 +137,27 @@ std::shared_ptr<exec::test::TempDirectoryPath> ParquetTpchTest::tempDirectory_ =
 TpchQueryBuilder ParquetTpchTest::tpchBuilder_(
     dwio::common::FileFormat::PARQUET);
 
-std::unordered_map<std::string, std::string>
-    ParquetTpchTest::duckDbParquetWriteSQL_ = {
-        std::make_pair(
-            "lineitem",
-            R"(COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber,
+std::unordered_map<std::string, std::string> ParquetTpchTest::duckDbParquetWriteSQL_ =
+    {std::make_pair(
+         "lineitem",
+         R"(COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber,
         l_quantity::DOUBLE as quantity, l_extendedprice::DOUBLE as extendedprice, l_discount::DOUBLE as discount,
         l_tax::DOUBLE as tax, l_returnflag, l_linestatus, l_shipdate AS shipdate, l_commitdate, l_receiptdate,
         l_shipinstruct, l_shipmode, l_comment FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "orders",
-            R"(COPY (SELECT o_orderkey, o_custkey, o_orderstatus,
+     std::make_pair(
+         "orders",
+         R"(COPY (SELECT o_orderkey, o_custkey, o_orderstatus,
         o_totalprice::DOUBLE as o_totalprice,
         o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
         FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "customer",
-            R"(COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone,
+     std::make_pair(
+         "customer",
+         R"(COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone,
         c_acctbal::DOUBLE as c_acctbal, c_mktsegment, c_comment
         FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "nation",
-            R"(COPY (SELECT n_nationkey, n_name, n_regionkey, n_comment
-        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "region",
-            R"(COPY (SELECT r_regionkey, r_name, r_comment
-        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "part",
-            R"(COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment
-        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "supplier",
-            R"(COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment
-        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-        std::make_pair(
-            "partsupp",
-            R"(COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment
-        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
+     std::make_pair(
+         "nation",
+         R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
 
 TEST_F(ParquetTpchTest, Q1) {
   assertQuery(1, 2, 10);
@@ -191,7 +173,8 @@ TEST_F(ParquetTpchTest, Q6) {
 }
 
 TEST_F(ParquetTpchTest, Q10) {
-  assertQuery(10, 5, 40);
+  std::vector<uint32_t> sortingKeys{2};
+  assertQuery(10, 5, 40, std::move(sortingKeys));
 }
 
 TEST_F(ParquetTpchTest, Q13) {

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -156,7 +156,26 @@ std::unordered_map<std::string, std::string>
             R"(COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone,
         c_acctbal::DOUBLE as c_acctbal, c_mktsegment, c_comment
         FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
-};
+        std::make_pair(
+            "nation",
+            R"(COPY (SELECT n_nationkey, n_name, n_regionkey, n_comment
+        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+        std::make_pair(
+            "region",
+            R"(COPY (SELECT r_regionkey, r_name, r_comment
+        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+        std::make_pair(
+            "part",
+            R"(COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment
+        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+        std::make_pair(
+            "supplier",
+            R"(COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment
+        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+        std::make_pair(
+            "partsupp",
+            R"(COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment
+        FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
 
 TEST_F(ParquetTpchTest, Q1) {
   assertQuery(1, 2, 10);
@@ -169,6 +188,10 @@ TEST_F(ParquetTpchTest, Q3) {
 
 TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6, 2, 10);
+}
+
+TEST_F(ParquetTpchTest, Q10) {
+  assertQuery(10, 5, 40);
 }
 
 TEST_F(ParquetTpchTest, Q13) {

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -106,6 +106,11 @@ class TpchQueryBuilder {
   static const std::unordered_map<std::string, std::vector<std::string>>
       kTables_;
   static const std::vector<std::string> kTableNames_;
+
+  static constexpr const char* kLineitem = "lineitem";
+  static constexpr const char* kCustomer = "customer";
+  static constexpr const char* kOrders = "orders";
+  static constexpr const char* kNation = "nation";
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -79,6 +79,7 @@ class TpchQueryBuilder {
   TpchPlan getQ1Plan() const;
   TpchPlan getQ3Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ10Plan() const;
   TpchPlan getQ13Plan() const;
   TpchPlan getQ18Plan() const;
 


### PR DESCRIPTION
Adds TPC-H query 10 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 10.
Performance comparing DuckDB.
```
# Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds)
            1          |       12.30    |      30.63 
            4          |        5.33    |      10.42
            8          |        4.59    |       4.95
```