### PR TITLE
Optimize BaseVector::isConstantEncoding

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -304,8 +304,8 @@ class BaseVector {
   }
 
   // Returns true if this vector is encoded as constant (ConstantVector).
-  virtual bool isConstantEncoding() const {
-    return false;
+  bool isConstantEncoding() const {
+    return encoding_ == VectorEncoding::Simple::CONSTANT;
   }
 
   // Returns true if this vector has a scalar type. If so, values are

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -251,10 +251,6 @@ class ConstantVector final : public SimpleVector<T> {
     return true;
   }
 
-  bool isConstantEncoding() const override {
-    return true;
-  }
-
   bool isScalar() const override {
     return valueVector_ ? valueVector_->isScalar() : true;
   }


### PR DESCRIPTION
BaseVector::isConstantEncoding shows in the profile of ML pre-processing
workloads. Optimize it away by making it non-virtual.