### PR TITLE
Add size class time and volume meters

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -480,20 +480,6 @@ struct CacheStats {
   // lifetime for entries in cache.
   int64_t sumEvictScore{};
 };
-
-class ClockTimer {
- public:
-  explicit ClockTimer(std::atomic<uint64_t>& total)
-      : total_(&total), start_(folly::hardware_timestamp()) {}
-  ~ClockTimer() {
-    *total_ += folly::hardware_timestamp() - start_;
-  }
-
- private:
-  std::atomic<uint64_t>* FOLLY_NONNULL total_;
-  uint64_t start_;
-};
-
 // Collection of cache entries whose key hashes to the same shard of
 // the hash number space.  The cache population is divided into shards
 // to decrease contention on the mutex for the key to entry mapping
@@ -724,6 +710,10 @@ class AsyncDataCache : public memory::MappedMemory {
 
   int32_t& numSkippedSaves() {
     return numSkippedSaves_;
+  }
+
+  memory::Stats stats() const override {
+    return mappedMemory_->stats();
   }
 
  private:

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -26,11 +26,118 @@
 #include <gflags/gflags.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
+#include "velox/common/time/Timer.h"
 
 DECLARE_bool(velox_use_malloc);
 DECLARE_int32(velox_memory_pool_mb);
+DECLARE_bool(velox_time_allocations);
 
 namespace facebook::velox::memory {
+
+struct SizeClassStats {
+  //// Size of the tracked size class  in pages.
+  int32_t size{0};
+
+  /// Cumulative CPU clocks spent inside allocation.
+  std::atomic<uint64_t> allocateClocks{0};
+
+  /// Cumulative CPU clocks spent inside free.
+  std::atomic<uint64_t> freeClocks{0};
+
+  /// Cumulative count of distinct allocations.
+  std::atomic<int64_t> numAllocations{0};
+
+  /// Cumulative count of bytes allocated. This is not size * numAllocations for
+  /// large classes where the allocation does not have the exact size of the
+  /// size class.
+  std::atomic<int64_t> totalBytes{0};
+
+  SizeClassStats() {}
+  SizeClassStats(const SizeClassStats& other) {
+    *this = other;
+  }
+
+  void operator=(const SizeClassStats& other) {
+    size = other.size;
+    allocateClocks = static_cast<int64_t>(other.allocateClocks);
+    freeClocks = static_cast<int64_t>(other.freeClocks);
+    numAllocations = static_cast<int64_t>(other.numAllocations);
+    totalBytes = static_cast<int64_t>(other.totalBytes);
+  }
+
+  SizeClassStats operator-(const SizeClassStats& other) const {
+    SizeClassStats result;
+    result.size = size;
+    result.allocateClocks = allocateClocks - other.allocateClocks;
+    result.allocateClocks = freeClocks - other.freeClocks;
+    result.numAllocations = numAllocations - other.numAllocations;
+    result.totalBytes = totalBytes - other.totalBytes;
+    return result;
+  }
+
+  // Returns the total clocks for this size class.
+  uint64_t clocks() const {
+    return allocateClocks + freeClocks;
+  }
+};
+
+struct Stats {
+  /// 20 size classes in powers of 2 are tracked, from 4K to 4G. The
+  /// allocation is recorded to the class corresponding to the closest
+  /// power of 2 >= the allocation size.
+  static constexpr int32_t kNumSizes = 20;
+  Stats() {
+    for (auto i = 0; i < sizes.size(); ++i) {
+      sizes[i].size = 1 << i;
+    }
+  }
+
+  Stats operator-(const Stats& stats) const;
+
+  template <typename Op>
+  void recordAllocate(int64_t bytes, int32_t count, Op op) {
+    if (FLAGS_velox_time_allocations) {
+      auto index = sizeIndex(bytes);
+      velox::ClockTimer timer(sizes[index].allocateClocks);
+      op();
+      sizes[index].numAllocations += count;
+      sizes[index].totalBytes += bytes * count;
+    } else {
+      op();
+    }
+  }
+
+  template <typename Op>
+  void recordFree(int64_t bytes, Op op) {
+    if (FLAGS_velox_time_allocations) {
+      auto index = sizeIndex(bytes);
+      ClockTimer timer(sizes[index].freeClocks);
+      op();
+    } else {
+      op();
+    }
+  }
+
+  std::string toString() const;
+
+  /// Returns the size class index for a given size. Here the accounting is in
+  /// steps of powers of two. Allocators may have their own size classes or
+  /// allocate exact sizes.
+  static int32_t sizeIndex(int64_t size) {
+    constexpr int32_t kPageSize = 4096;
+    if (!size) {
+      return 0;
+    }
+    int64_t power = bits::nextPowerOfTwo(size / kPageSize);
+    return std::min(kNumSizes - 1, 63 - bits::countLeadingZeros(power));
+  }
+
+  /// Counters for each size class.
+  std::array<SizeClassStats, kNumSizes> sizes;
+
+  /// Cumulative count of pages advised away, if the allocator exposes this.
+  int64_t numAdvise{0};
+};
 
 class ScopedMappedMemory;
 
@@ -179,6 +286,14 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       data_ = nullptr;
     }
 
+    ContiguousAllocation(ContiguousAllocation&& other) noexcept {
+      mappedMemory_ = other.mappedMemory_;
+      data_ = other.data_;
+      size_ = other.size_;
+      other.data_ = nullptr;
+      other.size_ = 0;
+    }
+
     MappedMemory* FOLLY_NULLABLE mappedMemory() const {
       return mappedMemory_;
     }
@@ -211,13 +326,21 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   };
 
   // Stats on memory allocated by allocateBytes().
-  struct AllocateBytesCounters {
+  struct AllocateBytesStats {
     // Total size of small allocations.
     uint64_t totalSmall;
     // Total size of allocations from some size class.
     uint64_t totalInSizeClasses;
     // Total in standalone large allocations via allocateContiguous().
     uint64_t totalLarge;
+
+    AllocateBytesStats operator-(const AllocateBytesStats other) const {
+      auto result = *this;
+      result.totalSmall -= other.totalSmall;
+      result.totalInSizeClasses -= other.totalInSizeClasses;
+      result.totalLarge -= other.totalLarge;
+      return result;
+    }
   };
 
   MappedMemory() {}
@@ -277,15 +400,15 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
-  // Allocates 'size'contiguous bytes and returns the pointer to the
-  // first byte. If 'size' is less than 'maxMallocSize', delegates the
-  // allocation to malloc. If the size is above that and below the
-  // largest size class, allocates one element of the next size
-  // class. If 'size' is greater than the largest size class, calls
-  // allocateContiguous(). Returns nullptr if there is no space. The
-  // amount to allocate is subject to the size limit of 'this'. This
-  // function is not virtual but calls the virtual functions allocate
-  // and allocateContiguous, which can track sizes and enforce caps etc.
+  // Allocates 'bytes' contiguous bytes and returns the pointer to the first
+  // byte. If 'bytes' is less than 'maxMallocSize', delegates the allocation to
+  // malloc. If the size is above that and below the largest size classes' size,
+  // allocates one element of the next size classes' size. If 'size' is greater
+  // than the largest size classes' size, calls allocateContiguous(). Returns
+  // nullptr if there is no space. The amount to allocate is subject to the size
+  // limit of 'this'. This function is not virtual but calls the virtual
+  // functions allocate and allocateContiguous, which can track sizes and
+  // enforce caps etc.
   void* FOLLY_NULLABLE
   allocateBytes(uint64_t bytes, uint64_t maxMallocSize = kMaxMallocBytes);
 
@@ -318,11 +441,15 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   // Returns static counters for allocateBytes usage.
 
-  static AllocateBytesCounters allocateBytesStats() {
+  static AllocateBytesStats allocateBytesStats() {
     return {
         totalSmallAllocateBytes_,
         totalSizeClassAllocateBytes_,
         totalLargeAllocateBytes_};
+  }
+
+  virtual Stats stats() const {
+    return Stats();
   }
 
   virtual std::string toString() const;
@@ -361,6 +488,7 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   // by getInstance().
   static MappedMemory* FOLLY_NULLABLE customInstance_;
   static std::mutex initMutex_;
+
   // Static counters for STL and memoryPool users of
   // MappedMemory. Updated by allocateBytes() and freeBytes(). These
   // are intended to be exported via StatsReporter. These are
@@ -443,6 +571,10 @@ class ScopedMappedMemory final : public MappedMemory {
 
   MemoryUsageTracker* FOLLY_NULLABLE tracker() const override {
     return tracker_.get();
+  }
+
+  Stats stats() const override {
+    return parent_->stats();
   }
 
  private:

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -67,14 +67,27 @@ class MmapAllocator : public MappedMemory {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB = nullptr) override;
+      std::function<void(int64_t)> beforeAllocCB = nullptr) override {
+    bool result;
+    stats_.recordAllocate(numPages * kPageSize, 1, [&]() {
+      result = allocateContiguousImpl(
+          numPages, collateral, allocation, beforeAllocCB);
+    });
+    return result;
+  }
 
-  void freeContiguous(ContiguousAllocation& allocation) override;
+  void freeContiguous(ContiguousAllocation& allocation) override {
+    stats_.recordFree(
+        allocation.size(), [&]() { freeContiguousImpl(allocation); });
+  }
 
   // Checks internal consistency of allocation data
   // structures. Returns true if OK. May return false if there are
   // concurrent alocations and frees during the consistency check. This
   // is a false positive but not dangerous.
+  //
+  // Checks that the totals of mapped free and mapped and allocated
+  // pages match the data in the bitmaps in the size classes.
   bool checkConsistency() const override;
 
   MachinePageCount capacity() const {
@@ -96,6 +109,12 @@ class MmapAllocator : public MappedMemory {
   }
 
   std::string toString() const override;
+
+  Stats stats() const override {
+    auto stats = stats_;
+    stats.numAdvise = numAdvisedPages_;
+    return stats;
+  }
 
  private:
   static constexpr uint64_t kAllSet = 0xffffffffffffffff;
@@ -224,6 +243,14 @@ class MmapAllocator : public MappedMemory {
     uint64_t numAdvisedAway_ = 0;
   };
 
+  bool allocateContiguousImpl(
+      MachinePageCount numPages,
+      Allocation* FOLLY_NULLABLE collateral,
+      ContiguousAllocation& allocation,
+      std::function<void(int64_t)> beforeAllocCB);
+
+  void freeContiguousImpl(ContiguousAllocation& allocation);
+
   // Ensures that there are at least 'newMappedNeeded' pages that are
   // not backing any existing allocation. If capacity_ - numMapped_ <
   // newMappedNeeded, advises away enough pages backing freed slots in
@@ -271,6 +298,7 @@ class MmapAllocator : public MappedMemory {
   uint64_t numAllocatedPages_ = 0;
   uint64_t numAdvisedPages_ = 0;
   Failure injectedFailure_{Failure::kNone};
+  Stats stats_;
 };
 
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -316,7 +316,8 @@ TEST_P(MappedMemoryTest, singleAllocationTest) {
   const std::vector<MachinePageCount>& sizes = instance_->sizeClasses();
   MachinePageCount capacity = kCapacity;
   std::vector<std::unique_ptr<MappedMemory::Allocation>> allocations;
-  for (auto& size : sizes) {
+  for (auto i = 0; i < sizes.size(); ++i) {
+    auto size = sizes[i];
     allocateMultiple(size, capacity / size + 10, allocations);
     EXPECT_EQ(allocations.size() - 1, capacity / size);
     EXPECT_TRUE(instance_->checkConsistency());
@@ -324,6 +325,12 @@ TEST_P(MappedMemoryTest, singleAllocationTest) {
 
     allocations.clear();
     EXPECT_EQ(instance_->numAllocated(), 0);
+
+    auto stats = instance_->stats();
+    EXPECT_LT(0, stats.sizes[i].clocks());
+    EXPECT_GE(stats.sizes[i].totalBytes, capacity * MappedMemory::kPageSize);
+    EXPECT_GE(stats.sizes[i].numAllocations, capacity / size);
+
     if (useMmap_) {
       EXPECT_EQ(instance_->numMapped(), kCapacity);
     }

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -15,13 +15,19 @@
  */
 #pragma once
 
+#include <folly/CppAttributes.h>
+#include <folly/chrono/Hardware.h>
+#include <atomic>
 #include <chrono>
 
 namespace facebook::velox {
 
+// Measures the time between construction and destruction with
+// std::chrono::steady_clock and increments a user-supplied counter
+// with the elapsed time in microseconds.
 class MicrosecondTimer {
  public:
-  MicrosecondTimer(uint64_t* timer) : timer_(timer) {
+  MicrosecondTimer(uint64_t* FOLLY_NONNULL timer) : timer_(timer) {
     start_ = std::chrono::steady_clock::now();
   }
 
@@ -34,7 +40,33 @@ class MicrosecondTimer {
 
  private:
   std::chrono::steady_clock::time_point start_;
-  uint64_t* timer_;
+  uint64_t* FOLLY_NONNULL timer_;
+};
+
+// Measures the time between construction and destruction with
+// CPU clock counter (rdtsc on X86) and increments a user-supplied counter
+// with the cycle count.
+class ClockTimer {
+ public:
+  explicit ClockTimer(uint64_t& total)
+      : total_(&total), start_(folly::hardware_timestamp()) {}
+
+  explicit ClockTimer(std::atomic<uint64_t>& total)
+      : atomicTotal_(&total), start_(folly::hardware_timestamp()) {}
+
+  ~ClockTimer() {
+    auto elapsed = folly::hardware_timestamp() - start_;
+    if (total_) {
+      *total_ += elapsed;
+    } else {
+      *atomicTotal_ += elapsed;
+    }
+  }
+
+ private:
+  uint64_t* FOLLY_NULLABLE total_{nullptr};
+  std::atomic<uint64_t>* FOLLY_NULLABLE atomicTotal_{nullptr};
+  uint64_t start_;
 };
 
 // Returns the current epoch time in milliseconds.

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -43,6 +43,11 @@ DEFINE_bool(
     true,
     "Use malloc for file cache and large operator allocations");
 
+DEFINE_bool(
+    velox_time_allocations,
+    true,
+    "Record time and volume for large allocation/free");
+
 // Used in common/base/VeloxException.cpp
 
 DEFINE_bool(


### PR DESCRIPTION
Adds instrumentation for quantifying volume and time spent in memory
allocation per size class.

Moves ClockTimer from common/caching to common/time.