### PR TITLE
Optimize basic arithmetic operations

### DIFF
--- a/velox/functions/prestosql/Arithmetic.cpp
+++ b/velox/functions/prestosql/Arithmetic.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/Arithmetic.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/ArithmeticImpl.h"
+#include "velox/functions/prestosql/CheckedArithmeticImpl.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+template <typename T, typename Operation>
+class BaseFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& resultType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    if (args[0]->isConstantEncoding() &&
+        args[1]->encoding() == VectorEncoding::Simple::FLAT) {
+      // Fast path for (flat, const).
+      auto constant = args[0]->asUnchecked<SimpleVector<T>>()->valueAt(0);
+      auto flatValues = args[1]->asUnchecked<FlatVector<T>>();
+      auto rawValues = flatValues->mutableRawValues();
+
+      auto rawResults =
+          getRawResults(rows, args[1], rawValues, resultType, context, result);
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        rawResults[row] = Operation::apply(constant, rawValues[row]);
+      });
+    } else if (
+        args[0]->encoding() == VectorEncoding::Simple::FLAT &&
+        args[1]->isConstantEncoding()) {
+      // Fast path for (const, flat).
+      auto constant = args[1]->asUnchecked<SimpleVector<T>>()->valueAt(0);
+      auto flatValues = args[0]->asUnchecked<FlatVector<T>>();
+      auto rawValues = flatValues->mutableRawValues();
+
+      auto rawResults =
+          getRawResults(rows, args[0], rawValues, resultType, context, result);
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        rawResults[row] = Operation::apply(rawValues[row], constant);
+      });
+    } else if (
+        args[0]->encoding() == VectorEncoding::Simple::FLAT &&
+        args[1]->encoding() == VectorEncoding::Simple::FLAT) {
+      // Fast path for (flat, flat).
+      auto flatA = args[0]->asUnchecked<FlatVector<T>>();
+      auto rawA = flatA->mutableRawValues();
+      auto flatB = args[1]->asUnchecked<FlatVector<T>>();
+      auto rawB = flatB->mutableRawValues();
+
+      T* rawResults = nullptr;
+      if (!(*result)) {
+        if (BaseVector::isReusableFlatVector(args[0])) {
+          rawResults = rawA;
+          *result = std::move(args[0]);
+        } else if (BaseVector::isReusableFlatVector(args[1])) {
+          rawResults = rawB;
+          *result = std::move(args[1]);
+        }
+      }
+      if (!rawResults) {
+        rawResults = prepareResults(rows, resultType, context, result);
+      }
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        rawResults[row] = Operation::apply(rawA[row], rawB[row]);
+      });
+    } else {
+      exec::DecodedArgs decodedArgs(rows, args, context);
+
+      auto a = decodedArgs.at(0);
+      auto b = decodedArgs.at(1);
+
+      BaseVector::ensureWritable(rows, resultType, context->pool(), result);
+      auto rawResults =
+          (*result)->asUnchecked<FlatVector<T>>()->mutableRawValues();
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        rawResults[row] =
+            Operation::apply(a->valueAt<T>(row), b->valueAt<T>(row));
+      });
+    }
+  }
+
+ private:
+  T* prepareResults(
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const {
+    BaseVector::ensureWritable(rows, resultType, context->pool(), result);
+    (*result)->clearNulls(rows);
+    return (*result)->asUnchecked<FlatVector<T>>()->mutableRawValues();
+  }
+
+  T* getRawResults(
+      const SelectivityVector& rows,
+      VectorPtr& flat,
+      T* rawValues,
+      const TypePtr& resultType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const {
+    // Check if input can be reused for results.
+    T* rawResults;
+    if (!(*result) && BaseVector::isReusableFlatVector(flat)) {
+      rawResults = rawValues;
+      *result = std::move(flat);
+    } else {
+      rawResults = prepareResults(rows, resultType, context, result);
+    }
+
+    return rawResults;
+  }
+};
+
+class Addition {
+ public:
+  template <typename T>
+  static T apply(T left, T right) {
+    return plus(left, right);
+  }
+};
+
+class CheckedAddition {
+ public:
+  template <
+      typename T,
+      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return plus(left, right);
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return checkedPlus(left, right);
+  }
+};
+
+class Subtraction {
+ public:
+  template <typename T>
+  static T apply(T left, T right) {
+    return minus(left, right);
+  }
+};
+
+class CheckedSubtraction {
+ public:
+  template <
+      typename T,
+      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return minus(left, right);
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return checkedMinus(left, right);
+  }
+};
+
+class Multiplication {
+ public:
+  template <typename T>
+  static T apply(T left, T right) {
+    return multiply(left, right);
+  }
+};
+
+class CheckedMultiplication {
+ public:
+  template <
+      typename T,
+      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return multiply(left, right);
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return checkedMultiply(left, right);
+  }
+};
+
+class Division {
+ public:
+  template <typename T>
+  static T apply(T left, T right) {
+    return divide(left, right);
+  }
+};
+
+class CheckedDivision {
+ public:
+  template <
+      typename T,
+      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return divide(left, right);
+  }
+
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  static T apply(T left, T right) {
+    return checkedDivide(left, right);
+  }
+};
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  for (auto type :
+       {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
+    signatures.push_back(exec::FunctionSignatureBuilder()
+                             .returnType(type)
+                             .argumentType(type)
+                             .argumentType(type)
+                             .build());
+  }
+  return signatures;
+}
+
+template <typename Operation>
+std::shared_ptr<exec::VectorFunction> make(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  auto typeKind = inputArgs[0].type->kind();
+  switch (typeKind) {
+    case TypeKind::TINYINT:
+      return std::make_shared<BaseFunction<int8_t, Operation>>();
+    case TypeKind::SMALLINT:
+      return std::make_shared<BaseFunction<int16_t, Operation>>();
+    case TypeKind::INTEGER:
+      return std::make_shared<BaseFunction<int32_t, Operation>>();
+    case TypeKind::BIGINT:
+      return std::make_shared<BaseFunction<int64_t, Operation>>();
+    case TypeKind::REAL:
+      return std::make_shared<BaseFunction<float, Operation>>();
+    case TypeKind::DOUBLE:
+      return std::make_shared<BaseFunction<double, Operation>>();
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+} // namespace
+
+void registerPlus(const std::string& name) {
+  exec::registerStatefulVectorFunction(name, signatures(), make<Addition>);
+}
+
+void registerCheckedPlus(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, signatures(), make<CheckedAddition>);
+}
+
+void registerMinus(const std::string& name) {
+  exec::registerStatefulVectorFunction(name, signatures(), make<Subtraction>);
+}
+
+void registerCheckedMinus(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, signatures(), make<CheckedSubtraction>);
+}
+
+void registerMultiply(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, signatures(), make<Multiplication>);
+}
+
+void registerCheckedMultiply(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, signatures(), make<CheckedMultiplication>);
+}
+
+void registerDivide(const std::string& name) {
+  exec::registerStatefulVectorFunction(name, signatures(), make<Division>);
+}
+
+void registerCheckedDivide(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, signatures(), make<CheckedDivision>);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -165,16 +165,6 @@ struct MinFunction {
 };
 
 template <typename T>
-struct ClampFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(TInput& result, const TInput& v, const TInput& lo, const TInput& hi) {
-    VELOX_USER_CHECK_LE(lo, hi, "Lo > hi in clamp.");
-    result = std::clamp(v, lo, hi);
-  }
-};
-
-template <typename T>
 struct LnFunction {
   FOLLY_ALWAYS_INLINE void call(double& result, double a) {
     result = std::log(a);

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -38,48 +38,17 @@ inline constexpr char digits[36] = {
     'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
     'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
 
-template <typename T>
-struct PlusFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = plus(a, b);
-  }
-};
+void registerPlus(const std::string& name);
+void registerCheckedPlus(const std::string& name);
 
-template <typename T>
-struct MinusFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = minus(a, b);
-  }
-};
+void registerMinus(const std::string& name);
+void registerCheckedMinus(const std::string& name);
 
-template <typename T>
-struct MultiplyFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = multiply(a, b);
-  }
-};
+void registerMultiply(const std::string& name);
+void registerCheckedMultiply(const std::string& name);
 
-template <typename T>
-struct DivideFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void
-  call(TInput& result, const TInput& a, const TInput& b)
-// depend on compiler have correct behaviour for divide by zero
-#if defined(__has_feature)
-#if __has_feature(__address_sanitizer__)
-      __attribute__((__no_sanitize__("float-divide-by-zero")))
-#endif
-#endif
-  {
-    result = a / b;
-  }
-};
+void registerDivide(const std::string& name);
+void registerCheckedDivide(const std::string& name);
 
 template <typename T>
 struct ModulusFunction {

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(types)
 
 add_library(
   velox_functions_prestosql_impl OBJECT
+  Arithmetic.cpp
   ArrayConstructor.cpp
   ArrayContains.cpp
   ArrayDistinct.cpp

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   ArrayIntersectExcept.cpp
   ArrayMinMax.cpp
   ArrayPosition.cpp
+  Clamp.cpp
   ElementAt.cpp
   FilterFunctions.cpp
   FromUnixTime.cpp

--- a/velox/functions/prestosql/CheckedArithmetic.h
+++ b/velox/functions/prestosql/CheckedArithmetic.h
@@ -24,46 +24,6 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-struct CheckedPlusFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = checkedPlus(a, b);
-    return true;
-  }
-};
-
-template <typename T>
-struct CheckedMinusFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = checkedMinus(a, b);
-    return true;
-  }
-};
-
-template <typename T>
-struct CheckedMultiplyFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = checkedMultiply(a, b);
-    return true;
-  }
-};
-
-template <typename T>
-struct CheckedDivideFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool
-  call(TInput& result, const TInput& a, const TInput& b) {
-    result = checkedDivide(a, b);
-    return true;
-  }
-};
-
-template <typename T>
 struct CheckedModulusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool

--- a/velox/functions/prestosql/Clamp.cpp
+++ b/velox/functions/prestosql/Clamp.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/Clamp.h"
+#include <folly/Likely.h>
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+template <typename T>
+class ClampFunction : public exec::VectorFunction {
+ public:
+  ClampFunction() : constLowHigh_{false}, low_{}, high_{} {}
+
+  ClampFunction(T low, T high) : constLowHigh_{true}, low_{low}, high_{high} {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& resultType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    if (constLowHigh_ && args[0]->encoding() == VectorEncoding::Simple::FLAT) {
+      // Fast path for (flat, const, const).
+
+      // We cannot perform this check in the constructor because the error
+      // should not occur unless the function was applied to at least one row.
+      VELOX_USER_CHECK_LE(low_, high_, "Low > high in clamp.");
+
+      auto flatValues = args[0]->asUnchecked<FlatVector<T>>();
+      auto rawValues = flatValues->mutableRawValues();
+
+      // Check if input can be reused for results.
+      T* rawResults;
+      if (!(*result) && BaseVector::isReusableFlatVector(args[0])) {
+        rawResults = rawValues;
+        *result = std::move(args[0]);
+      } else {
+        rawResults = prepareResult(rows, resultType, context, result);
+      }
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        rawResults[row] = std::clamp(rawValues[row], low_, high_);
+      });
+    } else {
+      exec::DecodedArgs decodedArgs(rows, args, context);
+
+      auto values = decodedArgs.at(0);
+      auto lows = decodedArgs.at(1);
+      auto highs = decodedArgs.at(2);
+
+      auto rawResults = prepareResult(rows, resultType, context, result);
+
+      context->applyToSelectedNoThrow(rows, [&](auto row) {
+        auto low = lows->valueAt<T>(row);
+        auto high = highs->valueAt<T>(row);
+
+        VELOX_USER_CHECK_LE(low, high, "Low > high in clamp.");
+        rawResults[row] = std::clamp(values->valueAt<T>(row), low, high);
+      });
+    }
+  }
+
+ private:
+  T* prepareResult(
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const {
+    BaseVector::ensureWritable(rows, resultType, context->pool(), result);
+    (*result)->clearNulls(rows);
+    return (*result)->asUnchecked<FlatVector<T>>()->mutableRawValues();
+  }
+
+  const bool constLowHigh_;
+  const T low_;
+  const T high_;
+};
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> clampSignatures() {
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  for (auto type :
+       {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
+    signatures.push_back(exec::FunctionSignatureBuilder()
+                             .returnType(type)
+                             .argumentType(type)
+                             .argumentType(type)
+                             .argumentType(type)
+                             .build());
+  }
+  return signatures;
+}
+
+template <typename T>
+std::shared_ptr<exec::VectorFunction> makeClampTyped(
+    const VectorPtr& lowConst,
+    const VectorPtr& highConst) {
+  // Constant folding is not sophisticated enough to detect a function call with
+  // some inputs being null.
+  if (lowConst && highConst && !lowConst->isNullAt(0) &&
+      !highConst->isNullAt(0)) {
+    auto low = lowConst->as<SimpleVector<T>>()->valueAt(0);
+    auto high = highConst->as<SimpleVector<T>>()->valueAt(0);
+    return std::make_shared<ClampFunction<T>>(low, high);
+  } else {
+    return std::make_shared<ClampFunction<T>>();
+  }
+}
+
+std::shared_ptr<exec::VectorFunction> makeClamp(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  auto typeKind = inputArgs[0].type->kind();
+  auto& low = inputArgs[1].constantValue;
+  auto& high = inputArgs[2].constantValue;
+  switch (typeKind) {
+    case TypeKind::TINYINT:
+      return makeClampTyped<int8_t>(low, high);
+    case TypeKind::SMALLINT:
+      return makeClampTyped<int16_t>(low, high);
+    case TypeKind::INTEGER:
+      return makeClampTyped<int32_t>(low, high);
+    case TypeKind::BIGINT:
+      return makeClampTyped<int64_t>(low, high);
+    case TypeKind::REAL:
+      return makeClampTyped<float>(low, high);
+    case TypeKind::DOUBLE:
+      return makeClampTyped<double>(low, high);
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+} // namespace
+
+void registerClamp(const std::string& name) {
+  exec::registerStatefulVectorFunction(name, clampSignatures(), makeClamp);
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Clamp.h
+++ b/velox/functions/prestosql/Clamp.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions {
+void registerClamp(const std::string& name);
+}

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/prestosql/Bitwise.h"
+#include "velox/functions/prestosql/Clamp.h"
 #include "velox/functions/prestosql/Rand.h"
 
 namespace facebook::velox::functions {
@@ -44,15 +45,6 @@ void registerSimpleFunctions() {
   registerFunction<PowerFunction, double, double, double>({"power", "pow"});
   registerFunction<PowerFunction, double, int64_t, int64_t>({"power", "pow"});
   registerFunction<ExpFunction, double, double>({"exp"});
-  registerFunction<ClampFunction, int8_t, int8_t, int8_t, int8_t>({"clamp"});
-  registerFunction<ClampFunction, int16_t, int16_t, int16_t, int16_t>(
-      {"clamp"});
-  registerFunction<ClampFunction, int32_t, int32_t, int32_t, int32_t>(
-      {"clamp"});
-  registerFunction<ClampFunction, int64_t, int64_t, int64_t, int64_t>(
-      {"clamp"});
-  registerFunction<ClampFunction, double, double, double, double>({"clamp"});
-  registerFunction<ClampFunction, float, float, float, float>({"clamp"});
   registerFunction<LnFunction, double, double>({"ln"});
   registerFunction<Log2Function, double, double>({"log2"});
   registerFunction<Log10Function, double, double>({"log10"});
@@ -86,6 +78,8 @@ void registerSimpleFunctions() {
   registerFunction<ToBaseFunction, Varchar, int64_t, int64_t>({"to_base"});
   registerFunction<PiFunction, double>({"pi"});
   registerFunction<EulerConstantFunction, double>({"e"});
+
+  registerClamp("clamp");
 }
 
 } // namespace

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -24,10 +24,11 @@ namespace facebook::velox::functions {
 
 namespace {
 void registerSimpleFunctions() {
-  registerBinaryFloatingPoint<PlusFunction>({"plus"});
-  registerBinaryFloatingPoint<MinusFunction>({"minus"});
-  registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
-  registerBinaryFloatingPoint<DivideFunction>({"divide"});
+  registerPlus("plus");
+  registerMinus("minus");
+  registerMultiply("multiply");
+  registerDivide("divide");
+
   registerBinaryFloatingPoint<ModulusFunction>({"mod"});
   registerUnaryNumeric<CeilFunction>({"ceil", "ceiling"});
   registerUnaryNumeric<FloorFunction>({"floor"});

--- a/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
+++ b/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
@@ -15,16 +15,18 @@
  */
 
 #include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/prestosql/Arithmetic.h"
 #include "velox/functions/prestosql/CheckedArithmetic.h"
 
 namespace facebook::velox::functions {
 
 void registerCheckedArithmeticFunctions() {
-  registerBinaryIntegral<CheckedPlusFunction>({"plus"});
-  registerBinaryIntegral<CheckedMinusFunction>({"minus"});
-  registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
+  registerCheckedPlus("plus");
+  registerCheckedMinus("minus");
+  registerCheckedMultiply("multiply");
+  registerCheckedDivide("divide");
+
   registerBinaryIntegral<CheckedModulusFunction>({"mod"});
-  registerBinaryIntegral<CheckedDivideFunction>({"divide"});
   registerUnaryIntegral<CheckedNegateFunction>({"negate"});
 }
 

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -23,9 +23,10 @@ namespace facebook::velox::functions::sparksql {
 
 void registerArithmeticFunctions(const std::string& prefix) {
   // Operators.
-  registerBinaryNumeric<PlusFunction>({prefix + "add"});
-  registerBinaryNumeric<MinusFunction>({prefix + "subtract"});
-  registerBinaryNumeric<MultiplyFunction>({prefix + "multiply"});
+  registerPlus(prefix + "add");
+  registerMinus(prefix + "subtract");
+  registerMultiply(prefix + "multiply");
+
   registerFunction<DivideFunction, double, double, double>({prefix + "divide"});
   registerBinaryIntegral<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});


### PR DESCRIPTION
Basic arithmetic operations are used extensively in ML preprocessing workloads.
The overhead of the SimpleFunctionAdapter shows up on the profile and slows
down these computations. The solution here is to re-implement these operations
as a stateful vector function.