### PR TITLE
Fix AllocationPool exceeding largest size class bug

### DIFF
--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "velox/common/memory/AllocationPool.h"
+#include <velox/common/base/Exceptions.h>
+#include <velox/common/memory/MappedMemory.h>
 #include "velox/common/base/BitUtil.h"
 
 namespace facebook::velox {
@@ -22,12 +24,33 @@ void AllocationPool::clear() {
   // Trigger Allocation's destructor to free allocated memory
   auto copy = std::move(allocation_);
   allocations_.clear();
+  auto copyLarge = std::move(largeAllocations_);
+  largeAllocations_.clear();
 }
 
 char* AllocationPool::allocateFixed(uint64_t bytes) {
   VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
+
+  auto numPages = bits::roundUp(bytes, memory::MappedMemory::kPageSize) /
+      memory::MappedMemory::kPageSize;
+
+  // Use contiguous allocations from mapped memory if allocation size is large
+  if (numPages > mappedMemory_->largestSizeClass()) {
+    auto largeAlloc =
+        std::make_unique<memory::MappedMemory::ContiguousAllocation>();
+    largeAlloc->reset(mappedMemory_, nullptr, 0);
+    if (!mappedMemory_->allocateContiguous(numPages, nullptr, *largeAlloc)) {
+      throw std::bad_alloc();
+    }
+    largeAllocations_.emplace_back(std::move(largeAlloc));
+    auto res = largeAllocations_.back()->data<char>();
+    VELOX_CHECK_NOT_NULL(
+        res, "Unexpected nullptr for large contiguous allocation");
+    return res;
+  }
+
   if (availableInRun() < bytes) {
-    newRun(bytes);
+    newRunImpl(numPages);
   }
   auto run = currentRun();
   uint64_t size = run.numBytes();
@@ -36,16 +59,13 @@ char* AllocationPool::allocateFixed(uint64_t bytes) {
   return reinterpret_cast<char*>(run.data() + currentOffset_ - bytes);
 }
 
-void AllocationPool::newRun(int32_t preferredSize) {
+void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
   ++currentRun_;
   if (currentRun_ >= allocation_.numRuns()) {
     if (allocation_.numRuns()) {
       allocations_.push_back(std::make_unique<memory::MappedMemory::Allocation>(
           std::move(allocation_)));
     }
-    auto numPages =
-        bits::roundUp(preferredSize, memory::MappedMemory::kPageSize) /
-        memory::MappedMemory::kPageSize;
     if (!mappedMemory_->allocate(
             std::max<int32_t>(kMinPages, numPages),
             owner_,
@@ -57,6 +77,13 @@ void AllocationPool::newRun(int32_t preferredSize) {
     currentRun_ = 0;
   }
   currentOffset_ = 0;
+}
+
+void AllocationPool::newRun(int32_t preferredSize) {
+  auto numPages =
+      bits::roundUp(preferredSize, memory::MappedMemory::kPageSize) /
+      memory::MappedMemory::kPageSize;
+  newRunImpl(numPages);
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -398,7 +398,8 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
 void HashStringAllocator::checkConsistency() const {
   uint64_t numFree = 0;
   uint64_t freeBytes = 0;
-  for (auto i = 0; i < pool_.numAllocations(); ++i) {
+  VELOX_CHECK_EQ(pool_.numLargeAllocations(), 0);
+  for (auto i = 0; i < pool_.numSmallAllocations(); ++i) {
     auto allocation = pool_.allocationAt(i);
     for (auto runIndex = 0; runIndex < allocation->numRuns(); ++runIndex) {
       auto run = allocation->runAt(runIndex);

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -424,6 +424,10 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   static void destroyTestOnly();
 
+  virtual MachinePageCount largestSizeClass() const {
+    return sizeClassSizes_.back();
+  }
+
   virtual const std::vector<MachinePageCount>& sizeClasses() const {
     return sizeClassSizes_;
   }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -668,7 +668,8 @@ class RowContainer {
       char** rows) {
     int32_t count = 0;
     uint64_t totalBytes = 0;
-    auto numAllocations = rows_.numAllocations();
+    VELOX_CHECK_EQ(rows_.numLargeAllocations(), 0);
+    auto numAllocations = rows_.numSmallAllocations();
     if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
         iter->rowOffset == 0) {
       iter->normalizedKeysLeft = numRowsWithNormalizedKey_;


### PR DESCRIPTION
Summary: AllocationPool throws when allocating larger than largest size class pages. This is due to AllocationPool passes the needed pages as minimal size class. We should pass largest size class in this case.

Differential Revision: D37542630

