### PR TITLE
Add TPCH query 9 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -157,6 +157,11 @@ BENCHMARK(q6) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q9) {
+  const auto planContext = queryBuilder->getQueryPlan(9);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q10) {
   const auto planContext = queryBuilder->getQueryPlan(10);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -161,7 +161,11 @@ std::unordered_map<std::string, std::string> ParquetTpchTest::duckDbParquetWrite
         R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
     std::make_pair(
         "supplier",
-        R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
+        R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+    std::make_pair(
+        "partsupp",
+        R"(COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost::DOUBLE as supplycost,
+        ps_comment FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
 
 TEST_F(ParquetTpchTest, Q1) {
   assertQuery(1);
@@ -179,6 +183,11 @@ TEST_F(ParquetTpchTest, Q5) {
 
 TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6);
+}
+
+TEST_F(ParquetTpchTest, Q9) {
+  std::vector<uint32_t> sortingKeys{0, 1};
+  assertQuery(9, std::move(sortingKeys));
 }
 
 TEST_F(ParquetTpchTest, Q10) {

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -80,6 +80,7 @@ class TpchQueryBuilder {
   TpchPlan getQ3Plan() const;
   TpchPlan getQ5Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ9Plan() const;
   TpchPlan getQ10Plan() const;
   TpchPlan getQ12Plan() const;
   TpchPlan getQ13Plan() const;
@@ -119,6 +120,7 @@ class TpchQueryBuilder {
   static constexpr const char* kRegion = "region";
   static constexpr const char* kPart = "part";
   static constexpr const char* kSupplier = "supplier";
+  static constexpr const char* kPartsupp = "partsupp";
   std::unique_ptr<memory::ScopedMemoryPool> pool_ =
       memory::getDefaultScopedMemoryPool();
 };


### PR DESCRIPTION
Adds TPC-H query 9 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 9.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      31.37     |      72.49      |
|            4           |      7.83      |      20.03      |
|            8           |      5.68      |      12.40      |
|           16           |      5.45      |      12.17      |
```
The join order between DuckDb and Velox plans differ considerably. 
DuckDb join order is as follows:
(((((lineitem JOIN partsupp ON partkey, suppkey) JOIN orders ON orderkey) JOIN (supplier JOIN nation ON nationkey) ON suppkey) JOIN part ON partkey)
The Presto plan is more optimal since it is more reducing:
((((((lineitem JOIN part ON partkey) JOIN supplier ON suppkey) JOIN partsupp ON partkey, suppkey) JOIN orders ON orderkey) JOIN nation ON nationkey)