### PR TITLE
Add TPCH query 11 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -221,6 +221,11 @@ BENCHMARK(q10) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q11) {
+  const auto planContext = queryBuilder->getQueryPlan(11);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q12) {
   const auto planContext = queryBuilder->getQueryPlan(12);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -63,6 +63,11 @@ TEST_P(MultiParquetTpchTest, Q10) {
   assertQuery(10, std::move(sortingKeys));
 }
 
+TEST_P(MultiParquetTpchTest, Q11) {
+  std::vector<uint32_t> sortingKeys{1};
+  assertQuery(11, std::move(sortingKeys));
+}
+
 TEST_P(MultiParquetTpchTest, Q12) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(12, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -84,6 +84,7 @@ class TpchQueryBuilder {
   TpchPlan getQ8Plan() const;
   TpchPlan getQ9Plan() const;
   TpchPlan getQ10Plan() const;
+  TpchPlan getQ11Plan() const;
   TpchPlan getQ12Plan() const;
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;


### PR DESCRIPTION
Adds TPC-H query 11 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 11.
Performance comparison with DuckDb (with Parquet file format):
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      1.25      |       4.25      |  
|            4           |      0.67      |       1.01      |  
|            8           |      0.91      |       0.62      | 
|           16           |      0.86      |       0.54      |
```