### PR TITLE
Split large DuckDB amalgamated file - part 1

### DIFF
--- a/velox/external/duckdb/duckdb-1.cpp
+++ b/velox/external/duckdb/duckdb-1.cpp
@@ -1,0 +1,16259 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string SimilarCatalogEntry::GetQualifiedName() const {
+	D_ASSERT(Found());
+
+	return schema->name + "." + name;
+}
+
+Catalog::Catalog(DatabaseInstance &db)
+    : db(db), schemas(make_unique<CatalogSet>(*this, make_unique<DefaultSchemaGenerator>(*this))),
+      dependency_manager(make_unique<DependencyManager>(*this)) {
+	catalog_version = 0;
+}
+Catalog::~Catalog() {
+}
+
+Catalog &Catalog::GetCatalog(ClientContext &context) {
+	return context.db->GetCatalog();
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {
+	auto schema = GetSchema(context, info->base->schema);
+	return CreateTable(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, unique_ptr<CreateTableInfo> info) {
+	auto binder = Binder::CreateBinder(context);
+	auto bound_info = binder->BindCreateTableInfo(move(info));
+	return CreateTable(context, bound_info.get());
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, SchemaCatalogEntry *schema, BoundCreateTableInfo *info) {
+	return schema->CreateTable(context, info);
+}
+
+CatalogEntry *Catalog::CreateView(ClientContext &context, CreateViewInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateView(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateView(ClientContext &context, SchemaCatalogEntry *schema, CreateViewInfo *info) {
+	return schema->CreateView(context, info);
+}
+
+CatalogEntry *Catalog::CreateSequence(ClientContext &context, CreateSequenceInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateSequence(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateType(ClientContext &context, CreateTypeInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateType(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateSequence(ClientContext &context, SchemaCatalogEntry *schema, CreateSequenceInfo *info) {
+	return schema->CreateSequence(context, info);
+}
+
+CatalogEntry *Catalog::CreateType(ClientContext &context, SchemaCatalogEntry *schema, CreateTypeInfo *info) {
+	return schema->CreateType(context, info);
+}
+
+CatalogEntry *Catalog::CreateTableFunction(ClientContext &context, CreateTableFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateTableFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateTableFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                           CreateTableFunctionInfo *info) {
+	return schema->CreateTableFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateCopyFunction(ClientContext &context, CreateCopyFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateCopyFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateCopyFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                          CreateCopyFunctionInfo *info) {
+	return schema->CreateCopyFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreatePragmaFunction(ClientContext &context, CreatePragmaFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreatePragmaFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreatePragmaFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                            CreatePragmaFunctionInfo *info) {
+	return schema->CreatePragmaFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateFunction(ClientContext &context, SchemaCatalogEntry *schema, CreateFunctionInfo *info) {
+	return schema->CreateFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateCollation(ClientContext &context, CreateCollationInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateCollation(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateCollation(ClientContext &context, SchemaCatalogEntry *schema, CreateCollationInfo *info) {
+	return schema->CreateCollation(context, info);
+}
+
+CatalogEntry *Catalog::CreateSchema(ClientContext &context, CreateSchemaInfo *info) {
+	D_ASSERT(!info->schema.empty());
+	if (info->schema == TEMP_SCHEMA) {
+		throw CatalogException("Cannot create built-in schema \"%s\"", info->schema);
+	}
+
+	unordered_set<CatalogEntry *> dependencies;
+	auto entry = make_unique<SchemaCatalogEntry>(this, info->schema, info->internal);
+	auto result = entry.get();
+	if (!schemas->CreateEntry(context, info->schema, move(entry), dependencies)) {
+		if (info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw CatalogException("Schema with name %s already exists!", info->schema);
+		} else {
+			D_ASSERT(info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
+		}
+		return nullptr;
+	}
+	return result;
+}
+
+void Catalog::DropSchema(ClientContext &context, DropInfo *info) {
+	D_ASSERT(!info->name.empty());
+	ModifyCatalog();
+	if (!schemas->DropEntry(context, info->name, info->cascade)) {
+		if (!info->if_exists) {
+			throw CatalogException("Schema with name \"%s\" does not exist!", info->name);
+		}
+	}
+}
+
+void Catalog::DropEntry(ClientContext &context, DropInfo *info) {
+	ModifyCatalog();
+	if (info->type == CatalogType::SCHEMA_ENTRY) {
+		// DROP SCHEMA
+		DropSchema(context, info);
+		return;
+	}
+
+	auto lookup = LookupEntry(context, info->type, info->schema, info->name, info->if_exists);
+	if (!lookup.Found()) {
+		return;
+	}
+
+	lookup.schema->DropEntry(context, info);
+}
+
+CatalogEntry *Catalog::AddFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return AddFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::AddFunction(ClientContext &context, SchemaCatalogEntry *schema, CreateFunctionInfo *info) {
+	return schema->AddFunction(context, info);
+}
+
+SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &schema_name, bool if_exists,
+                                       QueryErrorContext error_context) {
+	D_ASSERT(!schema_name.empty());
+	if (schema_name == TEMP_SCHEMA) {
+		return ClientData::Get(context).temporary_objects.get();
+	}
+	auto entry = schemas->GetEntry(context, schema_name);
+	if (!entry && !if_exists) {
+		throw CatalogException(error_context.FormatError("Schema with name %s does not exist!", schema_name));
+	}
+	return (SchemaCatalogEntry *)entry;
+}
+
+void Catalog::ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback) {
+	// create all default schemas first
+	schemas->Scan(context, [&](CatalogEntry *entry) { callback(entry); });
+}
+
+SimilarCatalogEntry Catalog::SimilarEntryInSchemas(ClientContext &context, const string &entry_name, CatalogType type,
+                                                   const vector<SchemaCatalogEntry *> &schemas) {
+
+	vector<CatalogSet *> sets;
+	std::transform(schemas.begin(), schemas.end(), std::back_inserter(sets),
+	               [type](SchemaCatalogEntry *s) -> CatalogSet * { return &s->GetCatalogSet(type); });
+	pair<string, idx_t> most_similar {"", (idx_t)-1};
+	SchemaCatalogEntry *schema_of_most_similar = nullptr;
+	for (auto schema : schemas) {
+		auto entry = schema->GetCatalogSet(type).SimilarEntry(context, entry_name);
+		if (!entry.first.empty() && (most_similar.first.empty() || most_similar.second > entry.second)) {
+			most_similar = entry;
+			schema_of_most_similar = schema;
+		}
+	}
+
+	return {most_similar.first, most_similar.second, schema_of_most_similar};
+}
+
+CatalogException Catalog::CreateMissingEntryException(ClientContext &context, const string &entry_name,
+                                                      CatalogType type, const vector<SchemaCatalogEntry *> &schemas,
+                                                      QueryErrorContext error_context) {
+	auto entry = SimilarEntryInSchemas(context, entry_name, type, schemas);
+
+	vector<SchemaCatalogEntry *> unseen_schemas;
+	this->schemas->Scan([&schemas, &unseen_schemas](CatalogEntry *entry) {
+		auto schema_entry = (SchemaCatalogEntry *)entry;
+		if (std::find(schemas.begin(), schemas.end(), schema_entry) == schemas.end()) {
+			unseen_schemas.emplace_back(schema_entry);
+		}
+	});
+	auto unseen_entry = SimilarEntryInSchemas(context, entry_name, type, unseen_schemas);
+
+	string did_you_mean;
+	if (unseen_entry.Found() && unseen_entry.distance < entry.distance) {
+		did_you_mean = "\nDid you mean \"" + unseen_entry.GetQualifiedName() + "\"?";
+	} else if (entry.Found()) {
+		did_you_mean = "\nDid you mean \"" + entry.name + "\"?";
+	}
+
+	return CatalogException(error_context.FormatError("%s with name %s does not exist!%s", CatalogTypeToString(type),
+	                                                  entry_name, did_you_mean));
+}
+
+CatalogEntryLookup Catalog::LookupEntry(ClientContext &context, CatalogType type, const string &schema_name,
+                                        const string &name, bool if_exists, QueryErrorContext error_context) {
+	if (!schema_name.empty()) {
+		auto schema = GetSchema(context, schema_name, if_exists, error_context);
+		if (!schema) {
+			D_ASSERT(if_exists);
+			return {nullptr, nullptr};
+		}
+
+		auto entry = schema->GetCatalogSet(type).GetEntry(context, name);
+		if (!entry && !if_exists) {
+			throw CreateMissingEntryException(context, name, type, {schema}, error_context);
+		}
+
+		return {schema, entry};
+	}
+
+	const auto &paths = ClientData::Get(context).catalog_search_path->Get();
+	for (const auto &path : paths) {
+		auto lookup = LookupEntry(context, type, path, name, true, error_context);
+		if (lookup.Found()) {
+			return lookup;
+		}
+	}
+
+	if (!if_exists) {
+		vector<SchemaCatalogEntry *> schemas;
+		for (const auto &path : paths) {
+			auto schema = GetSchema(context, path, true);
+			if (schema) {
+				schemas.emplace_back(schema);
+			}
+		}
+
+		throw CreateMissingEntryException(context, name, type, schemas, error_context);
+	}
+
+	return {nullptr, nullptr};
+}
+
+CatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema, const string &name) {
+	vector<CatalogType> entry_types {CatalogType::TABLE_ENTRY, CatalogType::SEQUENCE_ENTRY};
+
+	for (auto entry_type : entry_types) {
+		CatalogEntry *result = GetEntry(context, entry_type, schema, name, true);
+		if (result != nullptr) {
+			return result;
+		}
+	}
+
+	throw CatalogException("CatalogElement \"%s.%s\" does not exist!", schema, name);
+}
+
+CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, const string &schema_name, const string &name,
+                                bool if_exists, QueryErrorContext error_context) {
+	return LookupEntry(context, type, schema_name, name, if_exists, error_context).entry;
+}
+
+template <>
+TableCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                     bool if_exists, QueryErrorContext error_context) {
+	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, schema_name, name, if_exists);
+	if (!entry) {
+		return nullptr;
+	}
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		throw CatalogException(error_context.FormatError("%s is not a table", name));
+	}
+	return (TableCatalogEntry *)entry;
+}
+
+template <>
+SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                        bool if_exists, QueryErrorContext error_context) {
+	return (SequenceCatalogEntry *)GetEntry(context, CatalogType::SEQUENCE_ENTRY, schema_name, name, if_exists,
+	                                        error_context);
+}
+
+template <>
+TableFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                             bool if_exists, QueryErrorContext error_context) {
+	return (TableFunctionCatalogEntry *)GetEntry(context, CatalogType::TABLE_FUNCTION_ENTRY, schema_name, name,
+	                                             if_exists, error_context);
+}
+
+template <>
+CopyFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                            bool if_exists, QueryErrorContext error_context) {
+	return (CopyFunctionCatalogEntry *)GetEntry(context, CatalogType::COPY_FUNCTION_ENTRY, schema_name, name, if_exists,
+	                                            error_context);
+}
+
+template <>
+PragmaFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                              bool if_exists, QueryErrorContext error_context) {
+	return (PragmaFunctionCatalogEntry *)GetEntry(context, CatalogType::PRAGMA_FUNCTION_ENTRY, schema_name, name,
+	                                              if_exists, error_context);
+}
+
+template <>
+AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                                 bool if_exists, QueryErrorContext error_context) {
+	auto entry = GetEntry(context, CatalogType::AGGREGATE_FUNCTION_ENTRY, schema_name, name, if_exists, error_context);
+	if (entry->type != CatalogType::AGGREGATE_FUNCTION_ENTRY) {
+		throw CatalogException(error_context.FormatError("%s is not an aggregate function", name));
+	}
+	return (AggregateFunctionCatalogEntry *)entry;
+}
+
+template <>
+CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                       bool if_exists, QueryErrorContext error_context) {
+	return (CollateCatalogEntry *)GetEntry(context, CatalogType::COLLATION_ENTRY, schema_name, name, if_exists,
+	                                       error_context);
+}
+
+template <>
+TypeCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                    bool if_exists, QueryErrorContext error_context) {
+	return (TypeCatalogEntry *)GetEntry(context, CatalogType::TYPE_ENTRY, schema_name, name, if_exists, error_context);
+}
+
+LogicalType Catalog::GetType(ClientContext &context, const string &schema, const string &name) {
+	auto user_type_catalog = GetEntry<TypeCatalogEntry>(context, schema, name);
+	auto result_type = user_type_catalog->user_type;
+	LogicalType::SetCatalog(result_type, user_type_catalog);
+	return result_type;
+}
+
+void Catalog::Alter(ClientContext &context, AlterInfo *info) {
+	ModifyCatalog();
+	auto lookup = LookupEntry(context, info->GetCatalogType(), info->schema, info->name);
+	D_ASSERT(lookup.Found()); // It must have thrown otherwise.
+	return lookup.schema->Alter(context, info);
+}
+
+idx_t Catalog::GetCatalogVersion() {
+	return catalog_version;
+}
+
+idx_t Catalog::ModifyCatalog() {
+	return catalog_version++;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+ColumnDependencyManager::ColumnDependencyManager() {
+}
+
+ColumnDependencyManager::~ColumnDependencyManager() {
+}
+
+void ColumnDependencyManager::AddGeneratedColumn(const ColumnDefinition &column,
+                                                 const case_insensitive_map_t<column_t> &name_map) {
+	D_ASSERT(column.Generated());
+	vector<string> referenced_columns;
+	column.GetListOfDependencies(referenced_columns);
+	vector<column_t> indices;
+	for (auto &col : referenced_columns) {
+		auto entry = name_map.find(col);
+		if (entry == name_map.end()) {
+			throw InvalidInputException("Referenced column \"%s\" was not found in the table", col);
+		}
+		indices.push_back(entry->second);
+	}
+	return AddGeneratedColumn(column.Oid(), indices);
+}
+
+void ColumnDependencyManager::AddGeneratedColumn(column_t index, const vector<column_t> &indices, bool root) {
+	if (indices.empty()) {
+		return;
+	}
+	auto &list = dependents_map[index];
+	// Create a link between the dependencies
+	for (auto &dep : indices) {
+		// Add this column as a dependency of the new column
+		list.insert(dep);
+		// Add the new column as a dependent of the column
+		dependencies_map[dep].insert(index);
+		// Inherit the dependencies
+		if (HasDependencies(dep)) {
+			auto &inherited_deps = dependents_map[dep];
+			D_ASSERT(!inherited_deps.empty());
+			for (auto &inherited_dep : inherited_deps) {
+				list.insert(inherited_dep);
+				dependencies_map[inherited_dep].insert(index);
+			}
+		}
+		if (!root) {
+			continue;
+		}
+		direct_dependencies[index].insert(dep);
+	}
+	if (!HasDependents(index)) {
+		return;
+	}
+	auto &dependents = dependencies_map[index];
+	if (dependents.count(index)) {
+		throw InvalidInputException("Circular dependency encountered when resolving generated column expressions");
+	}
+	// Also let the dependents of this generated column inherit the dependencies
+	for (auto &dependent : dependents) {
+		AddGeneratedColumn(dependent, indices, false);
+	}
+}
+
+vector<column_t> ColumnDependencyManager::RemoveColumn(column_t index, column_t column_amount) {
+	// Always add the initial column
+	deleted_columns.insert(index);
+
+	RemoveGeneratedColumn(index);
+	RemoveStandardColumn(index);
+
+	// Clean up the internal list
+	vector<column_t> new_indices = CleanupInternals(column_amount);
+	D_ASSERT(deleted_columns.empty());
+	return new_indices;
+}
+
+bool ColumnDependencyManager::IsDependencyOf(column_t gcol, column_t col) const {
+	auto entry = dependents_map.find(gcol);
+	if (entry == dependents_map.end()) {
+		return false;
+	}
+	auto &list = entry->second;
+	return list.count(col);
+}
+
+bool ColumnDependencyManager::HasDependencies(column_t index) const {
+	auto entry = dependents_map.find(index);
+	if (entry == dependents_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+const unordered_set<column_t> &ColumnDependencyManager::GetDependencies(column_t index) const {
+	auto entry = dependents_map.find(index);
+	D_ASSERT(entry != dependents_map.end());
+	return entry->second;
+}
+
+bool ColumnDependencyManager::HasDependents(column_t index) const {
+	auto entry = dependencies_map.find(index);
+	if (entry == dependencies_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+const unordered_set<column_t> &ColumnDependencyManager::GetDependents(column_t index) const {
+	auto entry = dependencies_map.find(index);
+	D_ASSERT(entry != dependencies_map.end());
+	return entry->second;
+}
+
+void ColumnDependencyManager::RemoveStandardColumn(column_t index) {
+	if (!HasDependents(index)) {
+		return;
+	}
+	auto dependents = dependencies_map[index];
+	for (auto &gcol : dependents) {
+		// If index is a direct dependency of gcol, remove it from the list
+		if (direct_dependencies.find(gcol) != direct_dependencies.end()) {
+			direct_dependencies[gcol].erase(index);
+		}
+		RemoveGeneratedColumn(gcol);
+	}
+	// Remove this column from the dependencies map
+	dependencies_map.erase(index);
+}
+
+void ColumnDependencyManager::RemoveGeneratedColumn(column_t index) {
+	deleted_columns.insert(index);
+	if (!HasDependencies(index)) {
+		return;
+	}
+	auto &dependencies = dependents_map[index];
+	for (auto &col : dependencies) {
+		// Remove this generated column from the list of this column
+		auto &col_dependents = dependencies_map[col];
+		D_ASSERT(col_dependents.count(index));
+		col_dependents.erase(index);
+		// If the resulting list is empty, remove the column from the dependencies map altogether
+		if (col_dependents.empty()) {
+			dependencies_map.erase(col);
+		}
+	}
+	// Remove this column from the dependents_map map
+	dependents_map.erase(index);
+}
+
+void ColumnDependencyManager::AdjustSingle(column_t idx, idx_t offset) {
+	D_ASSERT(idx >= offset);
+	column_t new_idx = idx - offset;
+	// Adjust this index in the dependents of this column
+	bool has_dependents = HasDependents(idx);
+	bool has_dependencies = HasDependencies(idx);
+
+	if (has_dependents) {
+		auto &dependents = GetDependents(idx);
+		for (auto &dep : dependents) {
+			auto &dep_dependencies = dependents_map[dep];
+			dep_dependencies.erase(idx);
+			D_ASSERT(!dep_dependencies.count(new_idx));
+			dep_dependencies.insert(new_idx);
+		}
+	}
+	if (has_dependencies) {
+		auto &dependencies = GetDependencies(idx);
+		for (auto &dep : dependencies) {
+			auto &dep_dependents = dependencies_map[dep];
+			dep_dependents.erase(idx);
+			D_ASSERT(!dep_dependents.count(new_idx));
+			dep_dependents.insert(new_idx);
+		}
+	}
+	if (has_dependents) {
+		D_ASSERT(!dependencies_map.count(new_idx));
+		dependencies_map[new_idx] = move(dependencies_map[idx]);
+		dependencies_map.erase(idx);
+	}
+	if (has_dependencies) {
+		D_ASSERT(!dependents_map.count(new_idx));
+		dependents_map[new_idx] = move(dependents_map[idx]);
+		dependents_map.erase(idx);
+	}
+}
+
+vector<column_t> ColumnDependencyManager::CleanupInternals(column_t column_amount) {
+	vector<column_t> to_adjust;
+	D_ASSERT(!deleted_columns.empty());
+	// Get the lowest index that was deleted
+	vector<column_t> new_indices(column_amount, DConstants::INVALID_INDEX);
+	column_t threshold = *deleted_columns.begin();
+
+	idx_t offset = 0;
+	for (column_t i = 0; i < column_amount; i++) {
+		new_indices[i] = i - offset;
+		if (deleted_columns.count(i)) {
+			offset++;
+			continue;
+		}
+		if (i > threshold && (HasDependencies(i) || HasDependents(i))) {
+			to_adjust.push_back(i);
+		}
+	}
+
+	// Adjust all indices inside the dependency managers internal mappings
+	for (auto &col : to_adjust) {
+		offset = col - new_indices[col];
+		AdjustSingle(col, offset);
+	}
+	deleted_columns.clear();
+	return new_indices;
+}
+
+stack<column_t> ColumnDependencyManager::GetBindOrder(const vector<ColumnDefinition> &columns) {
+	stack<column_t> bind_order;
+	queue<column_t> to_visit;
+	unordered_set<column_t> visited;
+
+	for (auto &entry : direct_dependencies) {
+		auto dependent = entry.first;
+		//! Skip the dependents that are also dependencies
+		if (dependencies_map.find(dependent) != dependencies_map.end()) {
+			continue;
+		}
+		bind_order.push(dependent);
+		visited.insert(dependent);
+		for (auto &dependency : direct_dependencies[dependent]) {
+			to_visit.push(dependency);
+		}
+	}
+
+	while (!to_visit.empty()) {
+		auto column = to_visit.front();
+		to_visit.pop();
+
+		//! If this column does not have dependencies, the queue stops getting filled
+		if (direct_dependencies.find(column) == direct_dependencies.end()) {
+			continue;
+		}
+		bind_order.push(column);
+		visited.insert(column);
+
+		for (auto &dependency : direct_dependencies[column]) {
+			to_visit.push(dependency);
+		}
+	}
+
+	// Add generated columns that have no dependencies, but still might need to have their type resolved
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		// Not a generated column
+		if (!col.Generated()) {
+			continue;
+		}
+		// Already added to the bind_order stack
+		if (visited.count(i)) {
+			continue;
+		}
+		bind_order.push(i);
+	}
+
+	return bind_order;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+CopyFunctionCatalogEntry::CopyFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                   CreateCopyFunctionInfo *info)
+    : StandardEntry(CatalogType::COPY_FUNCTION_ENTRY, schema, catalog, info->name), function(info->function) {
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+IndexCatalogEntry::IndexCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateIndexInfo *info)
+    : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info->index_name), index(nullptr), sql(info->sql) {
+}
+
+IndexCatalogEntry::~IndexCatalogEntry() {
+	// remove the associated index from the info
+	if (!info || !index) {
+		return;
+	}
+	info->indexes.RemoveIndex(index);
+}
+
+string IndexCatalogEntry::ToSQL() {
+	if (sql.empty()) {
+		throw InternalException("Cannot convert INDEX to SQL because it was not created with a SQL statement");
+	}
+	if (sql[sql.size() - 1] != ';') {
+		sql += ";";
+	}
+	return sql;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PragmaFunctionCatalogEntry::PragmaFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                       CreatePragmaFunctionInfo *info)
+    : StandardEntry(CatalogType::PRAGMA_FUNCTION_ENTRY, schema, catalog, info->name), functions(move(info->functions)) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+MacroCatalogEntry::MacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : StandardEntry(
+          (info->function->type == MacroType::SCALAR_MACRO ? CatalogType::MACRO_ENTRY : CatalogType::TABLE_MACRO_ENTRY),
+          schema, catalog, info->name),
+      function(move(info->function)) {
+	this->temporary = info->temporary;
+	this->internal = info->internal;
+}
+
+ScalarMacroCatalogEntry::ScalarMacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : MacroCatalogEntry(catalog, schema, info) {
+}
+
+void ScalarMacroCatalogEntry::Serialize(Serializer &main_serializer) {
+	D_ASSERT(!internal);
+	auto &scalar_function = (ScalarMacroFunction &)*function;
+	FieldWriter writer(main_serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(*scalar_function.expression);
+	// writer.WriteSerializableList(function->parameters);
+	writer.WriteSerializableList(function->parameters);
+	writer.WriteField<uint32_t>((uint32_t)function->default_parameters.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &kv : function->default_parameters) {
+		serializer.WriteString(kv.first);
+		kv.second->Serialize(serializer);
+	}
+	writer.Finalize();
+}
+
+unique_ptr<CreateMacroInfo> ScalarMacroCatalogEntry::Deserialize(Deserializer &main_source) {
+	auto info = make_unique<CreateMacroInfo>(CatalogType::MACRO_ENTRY);
+	FieldReader reader(main_source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	auto expression = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto func = make_unique<ScalarMacroFunction>(move(expression));
+	info->function = move(func);
+	info->function->parameters = reader.ReadRequiredSerializableList<ParsedExpression>();
+	auto default_param_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < default_param_count; i++) {
+		auto name = source.Read<string>();
+		info->function->default_parameters[name] = ParsedExpression::Deserialize(source);
+	}
+	// dont like this
+	// info->type=CatalogType::MACRO_ENTRY;
+	reader.Finalize();
+	return info;
+}
+
+TableMacroCatalogEntry::TableMacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : MacroCatalogEntry(catalog, schema, info) {
+}
+
+void TableMacroCatalogEntry::Serialize(Serializer &main_serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(main_serializer);
+
+	auto &table_function = (TableMacroFunction &)*function;
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(*table_function.query_node);
+	writer.WriteSerializableList(function->parameters);
+	writer.WriteField<uint32_t>((uint32_t)function->default_parameters.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &kv : function->default_parameters) {
+		serializer.WriteString(kv.first);
+		kv.second->Serialize(serializer);
+	}
+	writer.Finalize();
+}
+
+unique_ptr<CreateMacroInfo> TableMacroCatalogEntry::Deserialize(Deserializer &main_source) {
+	auto info = make_unique<CreateMacroInfo>(CatalogType::TABLE_MACRO_ENTRY);
+	FieldReader reader(main_source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	auto query_node = reader.ReadRequiredSerializable<QueryNode>();
+	auto table_function = make_unique<TableMacroFunction>(move(query_node));
+	info->function = move(table_function);
+	info->function->parameters = reader.ReadRequiredSerializableList<ParsedExpression>();
+	auto default_param_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < default_param_count; i++) {
+		auto name = source.Read<string>();
+		info->function->default_parameters[name] = ParsedExpression::Deserialize(source);
+	}
+
+	reader.Finalize();
+
+	return info;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+void FindForeignKeyInformation(CatalogEntry *entry, AlterForeignKeyType alter_fk_type,
+                               vector<unique_ptr<AlterForeignKeyInfo>> &fk_arrays) {
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		return;
+	}
+	auto *table_entry = (TableCatalogEntry *)entry;
+	for (idx_t i = 0; i < table_entry->constraints.size(); i++) {
+		auto &cond = table_entry->constraints[i];
+		if (cond->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		auto &fk = (ForeignKeyConstraint &)*cond;
+		if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+			fk_arrays.push_back(make_unique<AlterForeignKeyInfo>(fk.info.schema, fk.info.table, entry->name,
+			                                                     fk.pk_columns, fk.fk_columns, fk.info.pk_keys,
+			                                                     fk.info.fk_keys, alter_fk_type));
+		} else if (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE &&
+		           alter_fk_type == AlterForeignKeyType::AFT_DELETE) {
+			throw CatalogException("Could not drop the table because this table is main key table of the table \"%s\"",
+			                       fk.info.table);
+		}
+	}
+}
+
+SchemaCatalogEntry::SchemaCatalogEntry(Catalog *catalog, string name_p, bool internal)
+    : CatalogEntry(CatalogType::SCHEMA_ENTRY, catalog, move(name_p)),
+      tables(*catalog, make_unique<DefaultViewGenerator>(*catalog, this)), indexes(*catalog), table_functions(*catalog),
+      copy_functions(*catalog), pragma_functions(*catalog),
+      functions(*catalog, make_unique<DefaultFunctionGenerator>(*catalog, this)), sequences(*catalog),
+      collations(*catalog), types(*catalog, make_unique<DefaultTypeGenerator>(*catalog, this)) {
+	this->internal = internal;
+}
+
+CatalogEntry *SchemaCatalogEntry::AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry,
+                                           OnCreateConflict on_conflict, unordered_set<CatalogEntry *> dependencies) {
+	auto entry_name = entry->name;
+	auto entry_type = entry->type;
+	auto result = entry.get();
+
+	// first find the set for this entry
+	auto &set = GetCatalogSet(entry_type);
+
+	if (name != TEMP_SCHEMA) {
+		dependencies.insert(this);
+	} else {
+		entry->temporary = true;
+	}
+	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		// CREATE OR REPLACE: first try to drop the entry
+		auto old_entry = set.GetEntry(context, entry_name);
+		if (old_entry) {
+			if (old_entry->type != entry_type) {
+				throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", entry_name,
+				                       CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type));
+			}
+			(void)set.DropEntry(context, entry_name, false);
+		}
+	}
+	// now try to add the entry
+	if (!set.CreateEntry(context, entry_name, move(entry), dependencies)) {
+		// entry already exists!
+		if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw CatalogException("%s with name \"%s\" already exists!", CatalogTypeToString(entry_type), entry_name);
+		} else {
+			return nullptr;
+		}
+	}
+	return result;
+}
+
+CatalogEntry *SchemaCatalogEntry::AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry,
+                                           OnCreateConflict on_conflict) {
+	unordered_set<CatalogEntry *> dependencies;
+	return AddEntry(context, move(entry), on_conflict, dependencies);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateSequence(ClientContext &context, CreateSequenceInfo *info) {
+	auto sequence = make_unique<SequenceCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(sequence), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateType(ClientContext &context, CreateTypeInfo *info) {
+	auto type_entry = make_unique<TypeCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(type_entry), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {
+	auto table = make_unique<TableCatalogEntry>(catalog, this, info);
+	table->storage->info->cardinality = table->storage->GetTotalRows();
+
+	CatalogEntry *entry = AddEntry(context, move(table), info->Base().on_conflict, info->dependencies);
+	if (!entry) {
+		return nullptr;
+	}
+
+	// add a foreign key constraint in main key table if there is a foreign key constraint
+	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
+	FindForeignKeyInformation(entry, AlterForeignKeyType::AFT_ADD, fk_arrays);
+	for (idx_t i = 0; i < fk_arrays.size(); i++) {
+		// alter primary key table
+		AlterForeignKeyInfo *fk_info = fk_arrays[i].get();
+		catalog->Alter(context, fk_info);
+
+		// make a dependency between this table and referenced table
+		auto &set = GetCatalogSet(CatalogType::TABLE_ENTRY);
+		info->dependencies.insert(set.GetEntry(context, fk_info->name));
+	}
+	return entry;
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateView(ClientContext &context, CreateViewInfo *info) {
+	auto view = make_unique<ViewCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(view), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table) {
+	unordered_set<CatalogEntry *> dependencies;
+	dependencies.insert(table);
+	auto index = make_unique<IndexCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(index), info->on_conflict, dependencies);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateCollation(ClientContext &context, CreateCollationInfo *info) {
+	auto collation = make_unique<CollateCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(collation), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateTableFunction(ClientContext &context, CreateTableFunctionInfo *info) {
+	auto table_function = make_unique<TableFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(table_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateCopyFunction(ClientContext &context, CreateCopyFunctionInfo *info) {
+	auto copy_function = make_unique<CopyFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(copy_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreatePragmaFunction(ClientContext &context, CreatePragmaFunctionInfo *info) {
+	auto pragma_function = make_unique<PragmaFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(pragma_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateFunction(ClientContext &context, CreateFunctionInfo *info) {
+	unique_ptr<StandardEntry> function;
+	switch (info->type) {
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		function = make_unique_base<StandardEntry, ScalarFunctionCatalogEntry>(catalog, this,
+		                                                                       (CreateScalarFunctionInfo *)info);
+		break;
+	case CatalogType::MACRO_ENTRY:
+		// create a macro function
+		function = make_unique_base<StandardEntry, ScalarMacroCatalogEntry>(catalog, this, (CreateMacroInfo *)info);
+		break;
+
+	case CatalogType::TABLE_MACRO_ENTRY:
+		// create a macro function
+		function = make_unique_base<StandardEntry, TableMacroCatalogEntry>(catalog, this, (CreateMacroInfo *)info);
+		break;
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+		D_ASSERT(info->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+		// create an aggregate function
+		function = make_unique_base<StandardEntry, AggregateFunctionCatalogEntry>(catalog, this,
+		                                                                          (CreateAggregateFunctionInfo *)info);
+		break;
+	default:
+		throw InternalException("Unknown function type \"%s\"", CatalogTypeToString(info->type));
+	}
+	return AddEntry(context, move(function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::AddFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto entry = GetCatalogSet(info->type).GetEntry(context, info->name);
+	if (!entry) {
+		return CreateFunction(context, info);
+	}
+
+	info->on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	switch (info->type) {
+	case CatalogType::SCALAR_FUNCTION_ENTRY: {
+		auto scalar_info = (CreateScalarFunctionInfo *)info;
+		auto &scalars = *(ScalarFunctionCatalogEntry *)entry;
+		for (const auto &scalar : scalars.functions) {
+			scalar_info->functions.emplace_back(scalar);
+		}
+		break;
+	}
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
+		auto agg_info = (CreateAggregateFunctionInfo *)info;
+		auto &aggs = *(AggregateFunctionCatalogEntry *)entry;
+		for (const auto &agg : aggs.functions) {
+			agg_info->functions.AddFunction(agg);
+		}
+		break;
+	}
+	default:
+		// Macros can only be replaced because there is only one of each name.
+		throw InternalException("Unsupported function type \"%s\" for adding", CatalogTypeToString(info->type));
+	}
+	return CreateFunction(context, info);
+}
+
+void SchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo *info) {
+	auto &set = GetCatalogSet(info->type);
+
+	// first find the entry
+	auto existing_entry = set.GetEntry(context, info->name);
+	if (!existing_entry) {
+		if (!info->if_exists) {
+			throw CatalogException("%s with name \"%s\" does not exist!", CatalogTypeToString(info->type), info->name);
+		}
+		return;
+	}
+	if (existing_entry->type != info->type) {
+		throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", info->name,
+		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info->type));
+	}
+
+	// if there is a foreign key constraint, get that information
+	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
+	FindForeignKeyInformation(existing_entry, AlterForeignKeyType::AFT_DELETE, fk_arrays);
+
+	if (!set.DropEntry(context, info->name, info->cascade)) {
+		throw InternalException("Could not drop element because of an internal error");
+	}
+
+	// remove the foreign key constraint in main key table if main key table's name is valid
+	for (idx_t i = 0; i < fk_arrays.size(); i++) {
+		// alter primary key tablee
+		Catalog::GetCatalog(context).Alter(context, fk_arrays[i].get());
+	}
+}
+
+void SchemaCatalogEntry::Alter(ClientContext &context, AlterInfo *info) {
+	CatalogType type = info->GetCatalogType();
+	auto &set = GetCatalogSet(type);
+	if (info->type == AlterType::CHANGE_OWNERSHIP) {
+		if (!set.AlterOwnership(context, (ChangeOwnershipInfo *)info)) {
+			throw CatalogException("Couldn't change ownership!");
+		}
+	} else {
+		string name = info->name;
+		if (!set.AlterEntry(context, name, info)) {
+			throw CatalogException("Entry with name \"%s\" does not exist!", name);
+		}
+	}
+}
+
+void SchemaCatalogEntry::Scan(ClientContext &context, CatalogType type,
+                              const std::function<void(CatalogEntry *)> &callback) {
+	auto &set = GetCatalogSet(type);
+	set.Scan(context, callback);
+}
+
+void SchemaCatalogEntry::Scan(CatalogType type, const std::function<void(CatalogEntry *)> &callback) {
+	auto &set = GetCatalogSet(type);
+	set.Scan(callback);
+}
+
+void SchemaCatalogEntry::Serialize(Serializer &serializer) {
+	FieldWriter writer(serializer);
+	writer.WriteString(name);
+	writer.Finalize();
+}
+
+unique_ptr<CreateSchemaInfo> SchemaCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateSchemaInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	reader.Finalize();
+
+	return info;
+}
+
+string SchemaCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	ss << "CREATE SCHEMA " << name << ";";
+	return ss.str();
+}
+
+CatalogSet &SchemaCatalogEntry::GetCatalogSet(CatalogType type) {
+	switch (type) {
+	case CatalogType::VIEW_ENTRY:
+	case CatalogType::TABLE_ENTRY:
+		return tables;
+	case CatalogType::INDEX_ENTRY:
+		return indexes;
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return table_functions;
+	case CatalogType::COPY_FUNCTION_ENTRY:
+		return copy_functions;
+	case CatalogType::PRAGMA_FUNCTION_ENTRY:
+		return pragma_functions;
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+	case CatalogType::MACRO_ENTRY:
+		return functions;
+	case CatalogType::SEQUENCE_ENTRY:
+		return sequences;
+	case CatalogType::COLLATION_ENTRY:
+		return collations;
+	case CatalogType::TYPE_ENTRY:
+		return types;
+	default:
+		throw InternalException("Unsupported catalog type in schema");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+SequenceCatalogEntry::SequenceCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateSequenceInfo *info)
+    : StandardEntry(CatalogType::SEQUENCE_ENTRY, schema, catalog, info->name), usage_count(info->usage_count),
+      counter(info->start_value), increment(info->increment), start_value(info->start_value),
+      min_value(info->min_value), max_value(info->max_value), cycle(info->cycle) {
+	this->temporary = info->temporary;
+}
+
+void SequenceCatalogEntry::Serialize(Serializer &serializer) {
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteField<uint64_t>(usage_count);
+	writer.WriteField<int64_t>(increment);
+	writer.WriteField<int64_t>(min_value);
+	writer.WriteField<int64_t>(max_value);
+	writer.WriteField<int64_t>(counter);
+	writer.WriteField<bool>(cycle);
+	writer.Finalize();
+}
+
+unique_ptr<CreateSequenceInfo> SequenceCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateSequenceInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	info->usage_count = reader.ReadRequired<uint64_t>();
+	info->increment = reader.ReadRequired<int64_t>();
+	info->min_value = reader.ReadRequired<int64_t>();
+	info->max_value = reader.ReadRequired<int64_t>();
+	info->start_value = reader.ReadRequired<int64_t>();
+	info->cycle = reader.ReadRequired<bool>();
+	reader.Finalize();
+
+	return info;
+}
+
+string SequenceCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	ss << "CREATE SEQUENCE ";
+	ss << name;
+	ss << " INCREMENT BY " << increment;
+	ss << " MINVALUE " << min_value;
+	ss << " MAXVALUE " << max_value;
+	ss << " START " << counter;
+	ss << " " << (cycle ? "CYCLE" : "NO CYCLE") << ";";
+	return ss.str();
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+const string &TableCatalogEntry::GetColumnName(column_t index) {
+	return columns[index].Name();
+}
+
+column_t TableCatalogEntry::GetColumnIndex(string &column_name, bool if_exists) {
+	auto entry = name_map.find(column_name);
+	if (entry == name_map.end()) {
+		// entry not found: try lower-casing the name
+		entry = name_map.find(StringUtil::Lower(column_name));
+		if (entry == name_map.end()) {
+			if (if_exists) {
+				return DConstants::INVALID_INDEX;
+			}
+			throw BinderException("Table \"%s\" does not have a column with name \"%s\"", name, column_name);
+		}
+	}
+	column_name = GetColumnName(entry->second);
+	return entry->second;
+}
+
+void AddDataTableIndex(DataTable *storage, vector<ColumnDefinition> &columns, vector<idx_t> &keys,
+                       IndexConstraintType constraint_type) {
+	// fetch types and create expressions for the index from the columns
+	vector<column_t> column_ids;
+	vector<unique_ptr<Expression>> unbound_expressions;
+	vector<unique_ptr<Expression>> bound_expressions;
+	idx_t key_nr = 0;
+	for (auto &key : keys) {
+		D_ASSERT(key < columns.size());
+		auto &column = columns[key];
+		if (column.Generated()) {
+			throw InvalidInputException("Creating index on generated column is not supported");
+		}
+
+		unbound_expressions.push_back(make_unique<BoundColumnRefExpression>(columns[key].Name(), columns[key].Type(),
+		                                                                    ColumnBinding(0, column_ids.size())));
+
+		bound_expressions.push_back(make_unique<BoundReferenceExpression>(columns[key].Type(), key_nr++));
+		column_ids.push_back(column.StorageOid());
+	}
+	// create an adaptive radix tree around the expressions
+	auto art = make_unique<ART>(column_ids, move(unbound_expressions), constraint_type);
+	storage->AddIndex(move(art), bound_expressions);
+}
+
+TableCatalogEntry::TableCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, BoundCreateTableInfo *info,
+                                     std::shared_ptr<DataTable> inherited_storage)
+    : StandardEntry(CatalogType::TABLE_ENTRY, schema, catalog, info->Base().table), storage(move(inherited_storage)),
+      columns(move(info->Base().columns)), constraints(move(info->Base().constraints)),
+      bound_constraints(move(info->bound_constraints)),
+      column_dependency_manager(move(info->column_dependency_manager)) {
+	this->temporary = info->Base().temporary;
+	// add lower case aliases
+	this->name_map = move(info->name_map);
+#ifdef DEBUG
+	D_ASSERT(name_map.size() == columns.size());
+	for (idx_t i = 0; i < columns.size(); i++) {
+		D_ASSERT(name_map[columns[i].Name()] == i);
+	}
+#endif
+	// add the "rowid" alias, if there is no rowid column specified in the table
+	if (name_map.find("rowid") == name_map.end()) {
+		name_map["rowid"] = COLUMN_IDENTIFIER_ROW_ID;
+	}
+	if (!storage) {
+		// create the physical storage
+		vector<ColumnDefinition> storage_columns;
+		vector<ColumnDefinition> get_columns;
+		for (auto &col_def : columns) {
+			get_columns.push_back(col_def.Copy());
+			if (col_def.Generated()) {
+				continue;
+			}
+			storage_columns.push_back(col_def.Copy());
+		}
+		storage = make_shared<DataTable>(catalog->db, schema->name, name, move(storage_columns), move(info->data));
+
+		// create the unique indexes for the UNIQUE and PRIMARY KEY and FOREIGN KEY constraints
+		for (idx_t i = 0; i < bound_constraints.size(); i++) {
+			auto &constraint = bound_constraints[i];
+			if (constraint->type == ConstraintType::UNIQUE) {
+				// unique constraint: create a unique index
+				auto &unique = (BoundUniqueConstraint &)*constraint;
+				IndexConstraintType constraint_type = IndexConstraintType::UNIQUE;
+				if (unique.is_primary_key) {
+					constraint_type = IndexConstraintType::PRIMARY;
+				}
+				AddDataTableIndex(storage.get(), get_columns, unique.keys, constraint_type);
+			} else if (constraint->type == ConstraintType::FOREIGN_KEY) {
+				// foreign key constraint: create a foreign key index
+				auto &bfk = (BoundForeignKeyConstraint &)*constraint;
+				if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+				    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+					AddDataTableIndex(storage.get(), get_columns, bfk.info.fk_keys, IndexConstraintType::FOREIGN);
+				}
+			}
+		}
+	}
+}
+
+bool TableCatalogEntry::ColumnExists(const string &name) {
+	auto iterator = name_map.find(name);
+	if (iterator == name_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+idx_t TableCatalogEntry::StandardColumnCount() const {
+	idx_t count = 0;
+	for (auto &col : columns) {
+		if (col.Category() == TableColumnType::STANDARD) {
+			count++;
+		}
+	}
+	return count;
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	D_ASSERT(!internal);
+	if (info->type != AlterType::ALTER_TABLE) {
+		throw CatalogException("Can only modify table with ALTER TABLE statement");
+	}
+	auto table_info = (AlterTableInfo *)info;
+	switch (table_info->alter_table_type) {
+	case AlterTableType::RENAME_COLUMN: {
+		auto rename_info = (RenameColumnInfo *)table_info;
+		return RenameColumn(context, *rename_info);
+	}
+	case AlterTableType::RENAME_TABLE: {
+		auto rename_info = (RenameTableInfo *)table_info;
+		auto copied_table = Copy(context);
+		copied_table->name = rename_info->new_table_name;
+		return copied_table;
+	}
+	case AlterTableType::ADD_COLUMN: {
+		auto add_info = (AddColumnInfo *)table_info;
+		return AddColumn(context, *add_info);
+	}
+	case AlterTableType::REMOVE_COLUMN: {
+		auto remove_info = (RemoveColumnInfo *)table_info;
+		return RemoveColumn(context, *remove_info);
+	}
+	case AlterTableType::SET_DEFAULT: {
+		auto set_default_info = (SetDefaultInfo *)table_info;
+		return SetDefault(context, *set_default_info);
+	}
+	case AlterTableType::ALTER_COLUMN_TYPE: {
+		auto change_type_info = (ChangeColumnTypeInfo *)table_info;
+		return ChangeColumnType(context, *change_type_info);
+	}
+	case AlterTableType::FOREIGN_KEY_CONSTRAINT: {
+		auto foreign_key_constraint_info = (AlterForeignKeyInfo *)table_info;
+		return SetForeignKeyConstraint(context, *foreign_key_constraint_info);
+	}
+	default:
+		throw InternalException("Unrecognized alter table type!");
+	}
+}
+
+static void RenameExpression(ParsedExpression &expr, RenameColumnInfo &info) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = (ColumnRefExpression &)expr;
+		if (colref.column_names.back() == info.old_name) {
+			colref.column_names.back() = info.new_name;
+		}
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](const ParsedExpression &child) { RenameExpression((ParsedExpression &)child, info); });
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::RenameColumn(ClientContext &context, RenameColumnInfo &info) {
+	auto rename_idx = GetColumnIndex(info.old_name);
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+
+		if (rename_idx == i) {
+			copy.SetName(info.new_name);
+		}
+		create_info->columns.push_back(move(copy));
+		auto &col = create_info->columns[i];
+		if (col.Generated() && column_dependency_manager.IsDependencyOf(i, rename_idx)) {
+			RenameExpression(col.GeneratedExpressionMutable(), info);
+		}
+	}
+	for (idx_t c_idx = 0; c_idx < constraints.size(); c_idx++) {
+		auto copy = constraints[c_idx]->Copy();
+		switch (copy->type) {
+		case ConstraintType::NOT_NULL:
+			// NOT NULL constraint: no adjustments necessary
+			break;
+		case ConstraintType::CHECK: {
+			// CHECK constraint: need to rename column references that refer to the renamed column
+			auto &check = (CheckConstraint &)*copy;
+			RenameExpression(*check.expression, info);
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			// UNIQUE constraint: possibly need to rename columns
+			auto &unique = (UniqueConstraint &)*copy;
+			for (idx_t i = 0; i < unique.columns.size(); i++) {
+				if (unique.columns[i] == info.old_name) {
+					unique.columns[i] = info.new_name;
+				}
+			}
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			// FOREIGN KEY constraint: possibly need to rename columns
+			auto &fk = (ForeignKeyConstraint &)*copy;
+			vector<string> columns = fk.pk_columns;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				columns = fk.fk_columns;
+			} else if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < fk.fk_columns.size(); i++) {
+					columns.push_back(fk.fk_columns[i]);
+				}
+			}
+			for (idx_t i = 0; i < columns.size(); i++) {
+				if (columns[i] == info.old_name) {
+					throw CatalogException(
+					    "Cannot rename column \"%s\" because this is involved in the foreign key constraint",
+					    info.old_name);
+				}
+			}
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+		create_info->constraints.push_back(move(copy));
+	}
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::AddColumn(ClientContext &context, AddColumnInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+	for (auto &constraint : constraints) {
+		create_info->constraints.push_back(constraint->Copy());
+	}
+	Binder::BindLogicalType(context, info.new_column.TypeMutable(), schema->name);
+	info.new_column.SetOid(columns.size());
+	info.new_column.SetStorageOid(storage->column_definitions.size());
+
+	auto col = info.new_column.Copy();
+
+	create_info->columns.push_back(move(col));
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	auto new_storage =
+	    make_shared<DataTable>(context, *storage, info.new_column, bound_create_info->bound_defaults.back().get());
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+	                                      new_storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context, RemoveColumnInfo &info) {
+	auto removed_index = GetColumnIndex(info.removed_column, info.if_exists);
+	if (removed_index == DConstants::INVALID_INDEX) {
+		return nullptr;
+	}
+
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	unordered_set<column_t> removed_columns;
+	if (column_dependency_manager.HasDependents(removed_index)) {
+		removed_columns = column_dependency_manager.GetDependents(removed_index);
+	}
+	if (!removed_columns.empty() && !info.cascade) {
+		throw CatalogException("Cannot drop column: column is a dependency of 1 or more generated column(s)");
+	}
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (i == removed_index || removed_columns.count(i)) {
+			continue;
+		}
+		create_info->columns.push_back(col.Copy());
+	}
+	if (create_info->columns.empty()) {
+		throw CatalogException("Cannot drop column: table only has one column remaining!");
+	}
+	vector<column_t> adjusted_indices = column_dependency_manager.RemoveColumn(removed_index, columns.size());
+	// handle constraints for the new table
+	D_ASSERT(constraints.size() == bound_constraints.size());
+	for (idx_t constr_idx = 0; constr_idx < constraints.size(); constr_idx++) {
+		auto &constraint = constraints[constr_idx];
+		auto &bound_constraint = bound_constraints[constr_idx];
+		switch (constraint->type) {
+		case ConstraintType::NOT_NULL: {
+			auto &not_null_constraint = (BoundNotNullConstraint &)*bound_constraint;
+			if (not_null_constraint.index != removed_index) {
+				// the constraint is not about this column: we need to copy it
+				// we might need to shift the index back by one though, to account for the removed column
+				idx_t new_index = not_null_constraint.index;
+				new_index = adjusted_indices[new_index];
+				create_info->constraints.push_back(make_unique<NotNullConstraint>(new_index));
+			}
+			break;
+		}
+		case ConstraintType::CHECK: {
+			// CHECK constraint
+			auto &bound_check = (BoundCheckConstraint &)*bound_constraint;
+			// check if the removed column is part of the check constraint
+			if (bound_check.bound_columns.find(removed_index) != bound_check.bound_columns.end()) {
+				if (bound_check.bound_columns.size() > 1) {
+					// CHECK constraint that concerns mult
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a CHECK constraint that depends on it",
+					    info.removed_column);
+				} else {
+					// CHECK constraint that ONLY concerns this column, strip the constraint
+				}
+			} else {
+				// check constraint does not concern the removed column: simply re-add it
+				create_info->constraints.push_back(constraint->Copy());
+			}
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			auto copy = constraint->Copy();
+			auto &unique = (UniqueConstraint &)*copy;
+			if (unique.index != DConstants::INVALID_INDEX) {
+				if (unique.index == removed_index) {
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a UNIQUE constraint that depends on it",
+					    info.removed_column);
+				}
+				unique.index = adjusted_indices[unique.index];
+			}
+			create_info->constraints.push_back(move(copy));
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto copy = constraint->Copy();
+			auto &fk = (ForeignKeyConstraint &)*copy;
+			vector<string> columns = fk.pk_columns;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				columns = fk.fk_columns;
+			} else if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < fk.fk_columns.size(); i++) {
+					columns.push_back(fk.fk_columns[i]);
+				}
+			}
+			for (idx_t i = 0; i < columns.size(); i++) {
+				if (columns[i] == info.removed_column) {
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a FOREIGN KEY constraint that depends on it",
+					    info.removed_column);
+				}
+			}
+			create_info->constraints.push_back(move(copy));
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	if (columns[removed_index].Generated()) {
+		return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+		                                      storage);
+	}
+	auto new_storage = make_shared<DataTable>(context, *storage, removed_index);
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+	                                      new_storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::SetDefault(ClientContext &context, SetDefaultInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	auto default_idx = GetColumnIndex(info.column_name);
+
+	// Copy all the columns, changing the value of the one that was specified by 'column_name'
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+		if (default_idx == i) {
+			// set the default value of this column
+			D_ASSERT(!copy.Generated()); // Shouldnt reach here - DEFAULT value isn't supported for Generated Columns
+			copy.SetDefaultValue(info.expression ? info.expression->Copy() : nullptr);
+		}
+		create_info->columns.push_back(move(copy));
+	}
+	// Copy all the constraints
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info) {
+	if (info.target_type.id() == LogicalTypeId::USER) {
+		auto &catalog = Catalog::GetCatalog(context);
+		info.target_type = catalog.GetType(context, schema->name, UserType::GetTypeName(info.target_type));
+	}
+	auto change_idx = GetColumnIndex(info.column_name);
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+		if (change_idx == i) {
+			// set the type of this column
+			if (copy.Generated()) {
+				throw NotImplementedException("Changing types of generated columns is not supported yet");
+				// copy.ChangeGeneratedExpressionType(info.target_type);
+			}
+			copy.SetType(info.target_type);
+		}
+		// TODO: check if the generated_expression breaks, only delete it if it does
+		if (copy.Generated() && column_dependency_manager.IsDependencyOf(i, change_idx)) {
+			throw BinderException(
+			    "This column is referenced by the generated column \"%s\", so its type can not be changed",
+			    copy.Name());
+		}
+		create_info->columns.push_back(move(copy));
+	}
+
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		switch (constraint->type) {
+		case ConstraintType::CHECK: {
+			auto &bound_check = (BoundCheckConstraint &)*bound_constraints[i];
+			if (bound_check.bound_columns.find(change_idx) != bound_check.bound_columns.end()) {
+				throw BinderException("Cannot change the type of a column that has a CHECK constraint specified");
+			}
+			break;
+		}
+		case ConstraintType::NOT_NULL:
+			break;
+		case ConstraintType::UNIQUE: {
+			auto &bound_unique = (BoundUniqueConstraint &)*bound_constraints[i];
+			if (bound_unique.key_set.find(change_idx) != bound_unique.key_set.end()) {
+				throw BinderException(
+				    "Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
+			}
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto &bfk = (BoundForeignKeyConstraint &)*bound_constraints[i];
+			unordered_set<idx_t> key_set = bfk.pk_key_set;
+			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				key_set = bfk.fk_key_set;
+			} else if (bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < bfk.info.fk_keys.size(); i++) {
+					key_set.insert(bfk.info.fk_keys[i]);
+				}
+			}
+			if (key_set.find(change_idx) != key_set.end()) {
+				throw BinderException("Cannot change the type of a column that has a FOREIGN KEY constraint specified");
+			}
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	// bind the specified expression
+	vector<column_t> bound_columns;
+	AlterBinder expr_binder(*binder, context, *this, bound_columns, info.target_type);
+	auto expression = info.expression->Copy();
+	auto bound_expression = expr_binder.Bind(expression);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	if (bound_columns.empty()) {
+		bound_columns.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+
+	auto new_storage =
+	    make_shared<DataTable>(context, *storage, change_idx, info.target_type, move(bound_columns), *bound_expression);
+	auto result =
+	    make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), new_storage);
+	return move(result);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::SetForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		if (constraint->type == ConstraintType::FOREIGN_KEY) {
+			ForeignKeyConstraint &fk = (ForeignKeyConstraint &)*constraint;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && fk.info.table == info.fk_table) {
+				continue;
+			}
+		}
+		create_info->constraints.push_back(move(constraint));
+	}
+	if (info.type == AlterForeignKeyType::AFT_ADD) {
+		ForeignKeyInfo fk_info;
+		fk_info.type = ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE;
+		fk_info.schema = info.schema;
+		fk_info.table = info.fk_table;
+		fk_info.pk_keys = info.pk_keys;
+		fk_info.fk_keys = info.fk_keys;
+		create_info->constraints.push_back(
+		    make_unique<ForeignKeyConstraint>(info.pk_columns, info.fk_columns, move(fk_info)));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+ColumnDefinition &TableCatalogEntry::GetColumn(const string &name) {
+	auto entry = name_map.find(name);
+	if (entry == name_map.end() || entry->second == COLUMN_IDENTIFIER_ROW_ID) {
+		throw CatalogException("Column with name %s does not exist!", name);
+	}
+	auto column_index = entry->second;
+	return columns[column_index];
+}
+
+vector<LogicalType> TableCatalogEntry::GetTypes() {
+	vector<LogicalType> types;
+	for (auto &it : columns) {
+		if (it.Generated()) {
+			continue;
+		}
+		types.push_back(it.Type());
+	}
+	return types;
+}
+
+void TableCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteRegularSerializableList(columns);
+	writer.WriteSerializableList(constraints);
+	writer.Finalize();
+}
+
+unique_ptr<CreateTableInfo> TableCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateTableInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->table = reader.ReadRequired<string>();
+	info->columns = reader.ReadRequiredSerializableList<ColumnDefinition, ColumnDefinition>();
+	info->constraints = reader.ReadRequiredSerializableList<Constraint>();
+	reader.Finalize();
+
+	return info;
+}
+
+string TableCatalogEntry::ToSQL() {
+	std::stringstream ss;
+
+	ss << "CREATE TABLE ";
+
+	if (schema->name != DEFAULT_SCHEMA) {
+		ss << KeywordHelper::WriteOptionallyQuoted(schema->name) << ".";
+	}
+
+	ss << KeywordHelper::WriteOptionallyQuoted(name) << "(";
+
+	// find all columns that have NOT NULL specified, but are NOT primary key columns
+	unordered_set<idx_t> not_null_columns;
+	unordered_set<idx_t> unique_columns;
+	unordered_set<idx_t> pk_columns;
+	unordered_set<string> multi_key_pks;
+	vector<string> extra_constraints;
+	for (auto &constraint : constraints) {
+		if (constraint->type == ConstraintType::NOT_NULL) {
+			auto &not_null = (NotNullConstraint &)*constraint;
+			not_null_columns.insert(not_null.index);
+		} else if (constraint->type == ConstraintType::UNIQUE) {
+			auto &pk = (UniqueConstraint &)*constraint;
+			vector<string> constraint_columns = pk.columns;
+			if (pk.index != DConstants::INVALID_INDEX) {
+				// no columns specified: single column constraint
+				if (pk.is_primary_key) {
+					pk_columns.insert(pk.index);
+				} else {
+					unique_columns.insert(pk.index);
+				}
+			} else {
+				// multi-column constraint, this constraint needs to go at the end after all columns
+				if (pk.is_primary_key) {
+					// multi key pk column: insert set of columns into multi_key_pks
+					for (auto &col : pk.columns) {
+						multi_key_pks.insert(col);
+					}
+				}
+				extra_constraints.push_back(constraint->ToString());
+			}
+		} else if (constraint->type == ConstraintType::FOREIGN_KEY) {
+			auto &fk = (ForeignKeyConstraint &)*constraint;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+			    fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				extra_constraints.push_back(constraint->ToString());
+			}
+		} else {
+			extra_constraints.push_back(constraint->ToString());
+		}
+	}
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i > 0) {
+			ss << ", ";
+		}
+		auto &column = columns[i];
+		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
+		ss << column.Type().ToString();
+		bool not_null = not_null_columns.find(column.Oid()) != not_null_columns.end();
+		bool is_single_key_pk = pk_columns.find(column.Oid()) != pk_columns.end();
+		bool is_multi_key_pk = multi_key_pks.find(column.Name()) != multi_key_pks.end();
+		bool is_unique = unique_columns.find(column.Oid()) != unique_columns.end();
+		if (not_null && !is_single_key_pk && !is_multi_key_pk) {
+			// NOT NULL but not a primary key column
+			ss << " NOT NULL";
+		}
+		if (is_single_key_pk) {
+			// single column pk: insert constraint here
+			ss << " PRIMARY KEY";
+		}
+		if (is_unique) {
+			// single column unique: insert constraint here
+			ss << " UNIQUE";
+		}
+		if (column.DefaultValue()) {
+			ss << " DEFAULT(" << column.DefaultValue()->ToString() << ")";
+		}
+		if (column.Generated()) {
+			ss << " GENERATED ALWAYS AS(" << column.GeneratedExpression().ToString() << ")";
+		}
+	}
+	// print any extra constraints that still need to be printed
+	for (auto &extra_constraint : extra_constraints) {
+		ss << ", ";
+		ss << extra_constraint;
+	}
+
+	ss << ");";
+	return ss.str();
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::Copy(ClientContext &context) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+void TableCatalogEntry::SetAsRoot() {
+	storage->SetAsRoot();
+}
+
+void TableCatalogEntry::CommitAlter(AlterInfo &info) {
+	D_ASSERT(info.type == AlterType::ALTER_TABLE);
+	auto &alter_table = (AlterTableInfo &)info;
+	string column_name;
+	switch (alter_table.alter_table_type) {
+	case AlterTableType::REMOVE_COLUMN: {
+		auto &remove_info = (RemoveColumnInfo &)alter_table;
+		column_name = remove_info.removed_column;
+		break;
+	}
+	case AlterTableType::ALTER_COLUMN_TYPE: {
+		auto &change_info = (ChangeColumnTypeInfo &)alter_table;
+		column_name = change_info.column_name;
+		break;
+	}
+	default:
+		break;
+	}
+	if (column_name.empty()) {
+		return;
+	}
+	idx_t removed_index = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (col.Name() == column_name) {
+			// No need to alter storage, removed column is generated column
+			if (col.Generated()) {
+				return;
+			}
+			removed_index = i;
+			break;
+		}
+	}
+	D_ASSERT(removed_index != DConstants::INVALID_INDEX);
+	storage->CommitDropColumn(removed_index);
+}
+
+void TableCatalogEntry::CommitDrop() {
+	storage->CommitDropTable();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                     CreateTableFunctionInfo *info)
+    : StandardEntry(CatalogType::TABLE_FUNCTION_ENTRY, schema, catalog, info->name), functions(move(info->functions)) {
+	D_ASSERT(this->functions.size() > 0);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+TypeCatalogEntry::TypeCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateTypeInfo *info)
+    : StandardEntry(CatalogType::TYPE_ENTRY, schema, catalog, info->name), user_type(info->type) {
+	this->temporary = info->temporary;
+	this->internal = info->internal;
+}
+
+void TypeCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(user_type);
+	writer.Finalize();
+}
+
+unique_ptr<CreateTypeInfo> TypeCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateTypeInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	info->type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	reader.Finalize();
+
+	return info;
+}
+
+string TypeCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	switch (user_type.id()) {
+	case (LogicalTypeId::ENUM): {
+		Vector values_insert_order(EnumType::GetValuesInsertOrder(user_type));
+		idx_t size = EnumType::GetSize(user_type);
+		ss << "CREATE TYPE ";
+		ss << KeywordHelper::WriteOptionallyQuoted(name);
+		ss << " AS ENUM ( ";
+
+		for (idx_t i = 0; i < size; i++) {
+			ss << "'" << values_insert_order.GetValue(i).ToString() << "'";
+			if (i != size - 1) {
+				ss << ", ";
+			}
+		}
+		ss << ");";
+		break;
+	}
+	default:
+		throw InternalException("Logical Type can't be used as a User Defined Type");
+	}
+
+	return ss.str();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+void ViewCatalogEntry::Initialize(CreateViewInfo *info) {
+	query = move(info->query);
+	this->aliases = info->aliases;
+	this->types = info->types;
+	this->temporary = info->temporary;
+	this->sql = info->sql;
+	this->internal = info->internal;
+}
+
+ViewCatalogEntry::ViewCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateViewInfo *info)
+    : StandardEntry(CatalogType::VIEW_ENTRY, schema, catalog, info->view_name) {
+	Initialize(info);
+}
+
+unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	D_ASSERT(!internal);
+	if (info->type != AlterType::ALTER_VIEW) {
+		throw CatalogException("Can only modify view with ALTER VIEW statement");
+	}
+	auto view_info = (AlterViewInfo *)info;
+	switch (view_info->alter_view_type) {
+	case AlterViewType::RENAME_VIEW: {
+		auto rename_info = (RenameViewInfo *)view_info;
+		auto copied_view = Copy(context);
+		copied_view->name = rename_info->new_view_name;
+		return copied_view;
+	}
+	default:
+		throw InternalException("Unrecognized alter view type!");
+	}
+}
+
+void ViewCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteString(sql);
+	writer.WriteSerializable(*query);
+	writer.WriteList<string>(aliases);
+	writer.WriteRegularSerializableList<LogicalType>(types);
+	writer.Finalize();
+}
+
+unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateViewInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->view_name = reader.ReadRequired<string>();
+	info->sql = reader.ReadRequired<string>();
+	info->query = reader.ReadRequiredSerializable<SelectStatement>();
+	info->aliases = reader.ReadRequiredList<string>();
+	info->types = reader.ReadRequiredSerializableList<LogicalType, LogicalType>();
+	reader.Finalize();
+
+	return info;
+}
+
+string ViewCatalogEntry::ToSQL() {
+	if (sql.empty()) {
+		//! Return empty sql with view name so pragma view_tables don't complain
+		return sql;
+	}
+	return sql + "\n;";
+}
+
+unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
+	D_ASSERT(!internal);
+	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
+	create_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
+	for (idx_t i = 0; i < aliases.size(); i++) {
+		create_info->aliases.push_back(aliases[i]);
+	}
+	for (idx_t i = 0; i < types.size(); i++) {
+		create_info->types.push_back(types[i]);
+	}
+	create_info->temporary = temporary;
+	create_info->sql = sql;
+
+	return make_unique<ViewCatalogEntry>(catalog, schema, create_info.get());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+CatalogEntry::CatalogEntry(CatalogType type, Catalog *catalog_p, string name_p)
+    : oid(catalog_p->ModifyCatalog()), type(type), catalog(catalog_p), set(nullptr), name(move(name_p)), deleted(false),
+      temporary(false), internal(false), parent(nullptr) {
+}
+
+CatalogEntry::~CatalogEntry() {
+}
+
+void CatalogEntry::SetAsRoot() {
+}
+
+// LCOV_EXCL_START
+unique_ptr<CatalogEntry> CatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	throw InternalException("Unsupported alter type for catalog entry!");
+}
+
+unique_ptr<CatalogEntry> CatalogEntry::Copy(ClientContext &context) {
+	throw InternalException("Unsupported copy type for catalog entry!");
+}
+
+string CatalogEntry::ToSQL() {
+	throw InternalException("Unsupported catalog type for ToSQL()");
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+CatalogSearchPath::CatalogSearchPath(ClientContext &context_p) : context(context_p) {
+	SetPaths(ParsePaths(""));
+}
+
+void CatalogSearchPath::Set(const string &new_value, bool is_set_schema) {
+	auto new_paths = ParsePaths(new_value);
+	if (is_set_schema && new_paths.size() != 1) {
+		throw CatalogException("SET schema can set only 1 schema. This has %d", new_paths.size());
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	for (const auto &path : new_paths) {
+		if (!catalog.GetSchema(context, StringUtil::Lower(path), true)) {
+			throw CatalogException("SET %s: No schema named %s found.", is_set_schema ? "schema" : "search_path", path);
+		}
+	}
+	this->set_paths = move(new_paths);
+	SetPaths(set_paths);
+}
+
+const vector<string> &CatalogSearchPath::Get() {
+	return paths;
+}
+
+const string &CatalogSearchPath::GetOrDefault(const string &name) {
+	return name == INVALID_SCHEMA ? GetDefault() : name; // NOLINT
+}
+
+const string &CatalogSearchPath::GetDefault() {
+	const auto &paths = Get();
+	D_ASSERT(paths.size() >= 2);
+	D_ASSERT(paths[0] == TEMP_SCHEMA);
+	return paths[1];
+}
+
+void CatalogSearchPath::SetPaths(vector<string> new_paths) {
+	paths.clear();
+	paths.reserve(new_paths.size() + 3);
+	paths.emplace_back(TEMP_SCHEMA);
+	for (auto &path : new_paths) {
+		paths.push_back(move(path));
+	}
+	paths.emplace_back(DEFAULT_SCHEMA);
+	paths.emplace_back("pg_catalog");
+}
+
+vector<string> CatalogSearchPath::ParsePaths(const string &value) {
+	return StringUtil::SplitWithQuote(StringUtil::Lower(value));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! Class responsible to keep track of state when removing entries from the catalog.
+//! When deleting, many types of errors can be thrown, since we want to avoid try/catch blocks
+//! this class makes sure that whatever elements were modified are returned to a correct state
+//! when exceptions are thrown.
+//! The idea here is to use RAII (Resource acquisition is initialization) to mimic a try/catch/finally block.
+//! If any exception is raised when this object exists, then its destructor will be called
+//! and the entry will return to its previous state during deconstruction.
+class EntryDropper {
+public:
+	//! Both constructor and destructor are privates because they should only be called by DropEntryDependencies
+	explicit EntryDropper(CatalogSet &catalog_set, idx_t entry_index)
+	    : catalog_set(catalog_set), entry_index(entry_index) {
+		old_deleted = catalog_set.entries[entry_index].get()->deleted;
+	}
+
+	~EntryDropper() {
+		catalog_set.entries[entry_index].get()->deleted = old_deleted;
+	}
+
+private:
+	//! The current catalog_set
+	CatalogSet &catalog_set;
+	//! Keeps track of the state of the entry before starting the delete
+	bool old_deleted;
+	//! Index of entry to be deleted
+	idx_t entry_index;
+};
+
+CatalogSet::CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults)
+    : catalog(catalog), defaults(move(defaults)) {
+}
+
+bool CatalogSet::CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,
+                             unordered_set<CatalogEntry *> &dependencies) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	// lock this catalog set to disallow reading
+	unique_lock<mutex> read_lock(catalog_lock);
+
+	// first check if the entry exists in the unordered set
+	idx_t entry_index;
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value == nullptr || mapping_value->deleted) {
+		// if it does not: entry has never been created
+
+		// check if there is a default entry
+		auto entry = CreateDefaultEntry(context, name, read_lock);
+		if (entry) {
+			return false;
+		}
+
+		// first create a dummy deleted entry for this entry
+		// so transactions started before the commit of this transaction don't
+		// see it yet
+		entry_index = current_entry++;
+		auto dummy_node = make_unique<CatalogEntry>(CatalogType::INVALID, value->catalog, name);
+		dummy_node->timestamp = 0;
+		dummy_node->deleted = true;
+		dummy_node->set = this;
+
+		entries[entry_index] = move(dummy_node);
+		PutMapping(context, name, entry_index);
+	} else {
+		entry_index = mapping_value->index;
+		auto &current = *entries[entry_index];
+		// if it does, we have to check version numbers
+		if (HasConflict(context, current.timestamp)) {
+			// current version has been written to by a currently active
+			// transaction
+			throw TransactionException("Catalog write-write conflict on create with \"%s\"", current.name);
+		}
+		// there is a current version that has been committed
+		// if it has not been deleted there is a conflict
+		if (!current.deleted) {
+			return false;
+		}
+	}
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it at the dummy node
+	value->timestamp = transaction.transaction_id;
+	value->set = this;
+
+	// now add the dependency set of this object to the dependency manager
+	catalog.dependency_manager->AddObject(context, value.get(), dependencies);
+
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get());
+	entries[entry_index] = move(value);
+	return true;
+}
+
+bool CatalogSet::GetEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry *&catalog_entry) {
+	catalog_entry = entries[entry_index].get();
+	// if it does: we have to retrieve the entry and to check version numbers
+	if (HasConflict(context, catalog_entry->timestamp)) {
+		// current version has been written to by a currently active
+		// transaction
+		throw TransactionException("Catalog write-write conflict on alter with \"%s\"", catalog_entry->name);
+	}
+	// there is a current version that has been committed by this transaction
+	if (catalog_entry->deleted) {
+		// if the entry was already deleted, it now does not exist anymore
+		// so we return that we could not find it
+		return false;
+	}
+	return true;
+}
+
+bool CatalogSet::GetEntryInternal(ClientContext &context, const string &name, idx_t &entry_index,
+                                  CatalogEntry *&catalog_entry) {
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value == nullptr || mapping_value->deleted) {
+		// the entry does not exist, check if we can create a default entry
+		return false;
+	}
+	entry_index = mapping_value->index;
+	return GetEntryInternal(context, entry_index, catalog_entry);
+}
+
+bool CatalogSet::AlterOwnership(ClientContext &context, ChangeOwnershipInfo *info) {
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, info->name, entry_index, entry)) {
+		return false;
+	}
+
+	auto owner_entry = catalog.GetEntry(context, info->owner_schema, info->owner_name);
+	if (!owner_entry) {
+		return false;
+	}
+
+	catalog.dependency_manager->AddOwnership(context, owner_entry, entry);
+
+	return true;
+}
+
+bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInfo *alter_info) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	// first check if the entry exists in the unordered set
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
+		return false;
+	}
+	if (entry->internal) {
+		throw CatalogException("Cannot alter entry \"%s\" because it is an internal system entry", entry->name);
+	}
+
+	// lock this catalog set to disallow reading
+	lock_guard<mutex> read_lock(catalog_lock);
+
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it to the updated table node
+	string original_name = entry->name;
+	auto value = entry->AlterEntry(context, alter_info);
+	if (!value) {
+		// alter failed, but did not result in an error
+		return true;
+	}
+
+	if (value->name != original_name) {
+		auto mapping_value = GetMapping(context, value->name);
+		if (mapping_value && !mapping_value->deleted) {
+			auto entry = GetEntryForTransaction(context, entries[mapping_value->index].get());
+			if (!entry->deleted) {
+				string rename_err_msg =
+				    "Could not rename \"%s\" to \"%s\": another entry with this name already exists!";
+				throw CatalogException(rename_err_msg, original_name, value->name);
+			}
+		}
+		PutMapping(context, value->name, entry_index);
+		DeleteMapping(context, original_name);
+	}
+	//! Check the dependency manager to verify that there are no conflicting dependencies with this alter
+	catalog.dependency_manager->AlterObject(context, entry, value.get());
+
+	value->timestamp = transaction.transaction_id;
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	value->set = this;
+
+	// serialize the AlterInfo into a temporary buffer
+	BufferedSerializer serializer;
+	alter_info->Serialize(serializer);
+	BinaryData serialized_alter = serializer.GetData();
+
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get(), serialized_alter.data.get(), serialized_alter.size);
+	entries[entry_index] = move(value);
+
+	return true;
+}
+
+void CatalogSet::DropEntryDependencies(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade) {
+
+	// Stores the deleted value of the entry before starting the process
+	EntryDropper dropper(*this, entry_index);
+
+	// To correctly delete the object and its dependencies, it temporarily is set to deleted.
+	entries[entry_index].get()->deleted = true;
+
+	// check any dependencies of this object
+	entry.catalog->dependency_manager->DropObject(context, &entry, cascade);
+
+	// dropper destructor is called here
+	// the destructor makes sure to return the value to the previous state
+	// dropper.~EntryDropper()
+}
+
+void CatalogSet::DropEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade) {
+	auto &transaction = Transaction::GetTransaction(context);
+
+	DropEntryDependencies(context, entry_index, entry, cascade);
+
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it at the dummy node
+	auto value = make_unique<CatalogEntry>(CatalogType::DELETED_ENTRY, entry.catalog, entry.name);
+	value->timestamp = transaction.transaction_id;
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	value->set = this;
+	value->deleted = true;
+
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get());
+
+	entries[entry_index] = move(value);
+}
+
+bool CatalogSet::DropEntry(ClientContext &context, const string &name, bool cascade) {
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	// we can only delete an entry that exists
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
+		return false;
+	}
+	if (entry->internal) {
+		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
+	}
+
+	DropEntryInternal(context, entry_index, *entry, cascade);
+	return true;
+}
+
+void CatalogSet::CleanupEntry(CatalogEntry *catalog_entry) {
+	// destroy the backed up entry: it is no longer required
+	D_ASSERT(catalog_entry->parent);
+	if (catalog_entry->parent->type != CatalogType::UPDATED_ENTRY) {
+		lock_guard<mutex> lock(catalog_lock);
+		if (!catalog_entry->deleted) {
+			// delete the entry from the dependency manager, if it is not deleted yet
+			catalog_entry->catalog->dependency_manager->EraseObject(catalog_entry);
+		}
+		auto parent = catalog_entry->parent;
+		parent->child = move(catalog_entry->child);
+		if (parent->deleted && !parent->child && !parent->parent) {
+			auto mapping_entry = mapping.find(parent->name);
+			D_ASSERT(mapping_entry != mapping.end());
+			auto index = mapping_entry->second->index;
+			auto entry = entries.find(index);
+			D_ASSERT(entry != entries.end());
+			if (entry->second.get() == parent) {
+				mapping.erase(mapping_entry);
+				entries.erase(entry);
+			}
+		}
+	}
+}
+
+bool CatalogSet::HasConflict(ClientContext &context, transaction_t timestamp) {
+	auto &transaction = Transaction::GetTransaction(context);
+	return (timestamp >= TRANSACTION_ID_START && timestamp != transaction.transaction_id) ||
+	       (timestamp < TRANSACTION_ID_START && timestamp > transaction.start_time);
+}
+
+MappingValue *CatalogSet::GetMapping(ClientContext &context, const string &name, bool get_latest) {
+	MappingValue *mapping_value;
+	auto entry = mapping.find(name);
+	if (entry != mapping.end()) {
+		mapping_value = entry->second.get();
+	} else {
+
+		return nullptr;
+	}
+	if (get_latest) {
+		return mapping_value;
+	}
+	while (mapping_value->child) {
+		if (UseTimestamp(context, mapping_value->timestamp)) {
+			break;
+		}
+		mapping_value = mapping_value->child.get();
+		D_ASSERT(mapping_value);
+	}
+	return mapping_value;
+}
+
+void CatalogSet::PutMapping(ClientContext &context, const string &name, idx_t entry_index) {
+	auto entry = mapping.find(name);
+	auto new_value = make_unique<MappingValue>(entry_index);
+	new_value->timestamp = Transaction::GetTransaction(context).transaction_id;
+	if (entry != mapping.end()) {
+		if (HasConflict(context, entry->second->timestamp)) {
+			throw TransactionException("Catalog write-write conflict on name \"%s\"", name);
+		}
+		new_value->child = move(entry->second);
+		new_value->child->parent = new_value.get();
+	}
+	mapping[name] = move(new_value);
+}
+
+void CatalogSet::DeleteMapping(ClientContext &context, const string &name) {
+	auto entry = mapping.find(name);
+	D_ASSERT(entry != mapping.end());
+	auto delete_marker = make_unique<MappingValue>(entry->second->index);
+	delete_marker->deleted = true;
+	delete_marker->timestamp = Transaction::GetTransaction(context).transaction_id;
+	delete_marker->child = move(entry->second);
+	delete_marker->child->parent = delete_marker.get();
+	mapping[name] = move(delete_marker);
+}
+
+bool CatalogSet::UseTimestamp(ClientContext &context, transaction_t timestamp) {
+	auto &transaction = Transaction::GetTransaction(context);
+	if (timestamp == transaction.transaction_id) {
+		// we created this version
+		return true;
+	}
+	if (timestamp < transaction.start_time) {
+		// this version was commited before we started the transaction
+		return true;
+	}
+	return false;
+}
+
+CatalogEntry *CatalogSet::GetEntryForTransaction(ClientContext &context, CatalogEntry *current) {
+	while (current->child) {
+		if (UseTimestamp(context, current->timestamp)) {
+			break;
+		}
+		current = current->child.get();
+		D_ASSERT(current);
+	}
+	return current;
+}
+
+CatalogEntry *CatalogSet::GetCommittedEntry(CatalogEntry *current) {
+	while (current->child) {
+		if (current->timestamp < TRANSACTION_ID_START) {
+			// this entry is committed: use it
+			break;
+		}
+		current = current->child.get();
+		D_ASSERT(current);
+	}
+	return current;
+}
+
+pair<string, idx_t> CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
+	unique_lock<mutex> lock(catalog_lock);
+	CreateDefaultEntries(context, lock);
+
+	string result;
+	idx_t current_score = (idx_t)-1;
+	for (auto &kv : mapping) {
+		auto mapping_value = GetMapping(context, kv.first);
+		if (mapping_value && !mapping_value->deleted) {
+			auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
+			if (ldist < current_score) {
+				current_score = ldist;
+				result = kv.first;
+			}
+		}
+	}
+	return {result, current_score};
+}
+
+CatalogEntry *CatalogSet::CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry) {
+	if (mapping.find(entry->name) != mapping.end()) {
+		return nullptr;
+	}
+	auto &name = entry->name;
+	auto entry_index = current_entry++;
+	auto catalog_entry = entry.get();
+
+	entry->set = this;
+	entry->timestamp = 0;
+
+	PutMapping(context, name, entry_index);
+	mapping[name]->timestamp = 0;
+	entries[entry_index] = move(entry);
+	return catalog_entry;
+}
+
+CatalogEntry *CatalogSet::CreateDefaultEntry(ClientContext &context, const string &name, unique_lock<mutex> &lock) {
+	// no entry found with this name, check for defaults
+	if (!defaults || defaults->created_all_entries) {
+		// no defaults either: return null
+		return nullptr;
+	}
+	// this catalog set has a default map defined
+	// check if there is a default entry that we can create with this name
+	lock.unlock();
+	auto entry = defaults->CreateDefaultEntry(context, name);
+
+	lock.lock();
+	if (!entry) {
+		// no default entry
+		return nullptr;
+	}
+	// there is a default entry! create it
+	auto result = CreateEntryInternal(context, move(entry));
+	if (result) {
+		return result;
+	}
+	// we found a default entry, but failed
+	// this means somebody else created the entry first
+	// just retry?
+	lock.unlock();
+	return GetEntry(context, name);
+}
+
+CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
+	unique_lock<mutex> lock(catalog_lock);
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value != nullptr && !mapping_value->deleted) {
+		// we found an entry for this name
+		// check the version numbers
+
+		auto catalog_entry = entries[mapping_value->index].get();
+		CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
+		if (current->deleted || (current->name != name && !UseTimestamp(context, mapping_value->timestamp))) {
+			return nullptr;
+		}
+		return current;
+	}
+	return CreateDefaultEntry(context, name, lock);
+}
+
+void CatalogSet::UpdateTimestamp(CatalogEntry *entry, transaction_t timestamp) {
+	entry->timestamp = timestamp;
+	mapping[entry->name]->timestamp = timestamp;
+}
+
+void CatalogSet::AdjustUserDependency(CatalogEntry *entry, ColumnDefinition &column, bool remove) {
+	CatalogEntry *user_type_catalog = (CatalogEntry *)LogicalType::GetCatalog(column.Type());
+	if (user_type_catalog) {
+		if (remove) {
+			catalog.dependency_manager->dependents_map[user_type_catalog].erase(entry->parent);
+			catalog.dependency_manager->dependencies_map[entry->parent].erase(user_type_catalog);
+		} else {
+			catalog.dependency_manager->dependents_map[user_type_catalog].insert(entry);
+			catalog.dependency_manager->dependencies_map[entry].insert(user_type_catalog);
+		}
+	}
+}
+
+void CatalogSet::AdjustDependency(CatalogEntry *entry, TableCatalogEntry *table, ColumnDefinition &column,
+                                  bool remove) {
+	bool found = false;
+	if (column.Type().id() == LogicalTypeId::ENUM) {
+		for (auto &old_column : table->columns) {
+			if (old_column.Name() == column.Name() && old_column.Type().id() != LogicalTypeId::ENUM) {
+				AdjustUserDependency(entry, column, remove);
+				found = true;
+			}
+		}
+		if (!found) {
+			AdjustUserDependency(entry, column, remove);
+		}
+	} else if (!(column.Type().GetAlias().empty())) {
+		auto alias = column.Type().GetAlias();
+		for (auto &old_column : table->columns) {
+			auto old_alias = old_column.Type().GetAlias();
+			if (old_column.Name() == column.Name() && old_alias != alias) {
+				AdjustUserDependency(entry, column, remove);
+				found = true;
+			}
+		}
+		if (!found) {
+			AdjustUserDependency(entry, column, remove);
+		}
+	}
+}
+
+void CatalogSet::AdjustTableDependencies(CatalogEntry *entry) {
+	if (entry->type == CatalogType::TABLE_ENTRY && entry->parent->type == CatalogType::TABLE_ENTRY) {
+		// If it's a table entry we have to check for possibly removing or adding user type dependencies
+		auto old_table = (TableCatalogEntry *)entry->parent;
+		auto new_table = (TableCatalogEntry *)entry;
+
+		for (auto &new_column : new_table->columns) {
+			AdjustDependency(entry, old_table, new_column, false);
+		}
+		for (auto &old_column : old_table->columns) {
+			AdjustDependency(entry, new_table, old_column, true);
+		}
+	}
+}
+
+void CatalogSet::Undo(CatalogEntry *entry) {
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	lock_guard<mutex> lock(catalog_lock);
+
+	// entry has to be restored
+	// and entry->parent has to be removed ("rolled back")
+
+	// i.e. we have to place (entry) as (entry->parent) again
+	auto &to_be_removed_node = entry->parent;
+
+	AdjustTableDependencies(entry);
+
+	if (!to_be_removed_node->deleted) {
+		// delete the entry from the dependency manager as well
+		catalog.dependency_manager->EraseObject(to_be_removed_node);
+	}
+	if (entry->name != to_be_removed_node->name) {
+		// rename: clean up the new name when the rename is rolled back
+		auto removed_entry = mapping.find(to_be_removed_node->name);
+		if (removed_entry->second->child) {
+			removed_entry->second->child->parent = nullptr;
+			mapping[to_be_removed_node->name] = move(removed_entry->second->child);
+		} else {
+			mapping.erase(removed_entry);
+		}
+	}
+	if (to_be_removed_node->parent) {
+		// if the to be removed node has a parent, set the child pointer to the
+		// to be restored node
+		to_be_removed_node->parent->child = move(to_be_removed_node->child);
+		entry->parent = to_be_removed_node->parent;
+	} else {
+		// otherwise we need to update the base entry tables
+		auto &name = entry->name;
+		to_be_removed_node->child->SetAsRoot();
+		entries[mapping[name]->index] = move(to_be_removed_node->child);
+		entry->parent = nullptr;
+	}
+
+	// restore the name if it was deleted
+	auto restored_entry = mapping.find(entry->name);
+	if (restored_entry->second->deleted || entry->type == CatalogType::INVALID) {
+		if (restored_entry->second->child) {
+			restored_entry->second->child->parent = nullptr;
+			mapping[entry->name] = move(restored_entry->second->child);
+		} else {
+			mapping.erase(restored_entry);
+		}
+	}
+	// we mark the catalog as being modified, since this action can lead to e.g. tables being dropped
+	entry->catalog->ModifyCatalog();
+}
+
+void CatalogSet::CreateDefaultEntries(ClientContext &context, unique_lock<mutex> &lock) {
+	if (!defaults || defaults->created_all_entries) {
+		return;
+	}
+	// this catalog set has a default set defined:
+	auto default_entries = defaults->GetDefaultEntries();
+	for (auto &default_entry : default_entries) {
+		auto map_entry = mapping.find(default_entry);
+		if (map_entry == mapping.end()) {
+			// we unlock during the CreateEntry, since it might reference other catalog sets...
+			// specifically for views this can happen since the view will be bound
+			lock.unlock();
+			auto entry = defaults->CreateDefaultEntry(context, default_entry);
+			if (!entry) {
+				throw InternalException("Failed to create default entry for %s", default_entry);
+			}
+
+			lock.lock();
+			CreateEntryInternal(context, move(entry));
+		}
+	}
+	defaults->created_all_entries = true;
+}
+
+void CatalogSet::Scan(ClientContext &context, const std::function<void(CatalogEntry *)> &callback) {
+	// lock the catalog set
+	unique_lock<mutex> lock(catalog_lock);
+	CreateDefaultEntries(context, lock);
+
+	for (auto &kv : entries) {
+		auto entry = kv.second.get();
+		entry = GetEntryForTransaction(context, entry);
+		if (!entry->deleted) {
+			callback(entry);
+		}
+	}
+}
+
+void CatalogSet::Scan(const std::function<void(CatalogEntry *)> &callback) {
+	// lock the catalog set
+	lock_guard<mutex> lock(catalog_lock);
+	for (auto &kv : entries) {
+		auto entry = kv.second.get();
+		entry = GetCommittedEntry(entry);
+		if (!entry->deleted) {
+			callback(entry);
+		}
+	}
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static DefaultMacro internal_macros[] = {
+	{DEFAULT_SCHEMA, "current_user", {nullptr}, "'duckdb'"},                       // user name of current execution context
+	{DEFAULT_SCHEMA, "current_catalog", {nullptr}, "'duckdb'"},                    // name of current database (called "catalog" in the SQL standard)
+	{DEFAULT_SCHEMA, "current_database", {nullptr}, "'duckdb'"},                   // name of current database
+	{DEFAULT_SCHEMA, "user", {nullptr}, "current_user"},                           // equivalent to current_user
+	{DEFAULT_SCHEMA, "session_user", {nullptr}, "'duckdb'"},                       // session user name
+	{"pg_catalog", "inet_client_addr", {nullptr}, "NULL"},                       // address of the remote connection
+	{"pg_catalog", "inet_client_port", {nullptr}, "NULL"},                       // port of the remote connection
+	{"pg_catalog", "inet_server_addr", {nullptr}, "NULL"},                       // address of the local connection
+	{"pg_catalog", "inet_server_port", {nullptr}, "NULL"},                       // port of the local connection
+	{"pg_catalog", "pg_my_temp_schema", {nullptr}, "0"},                         // OID of session's temporary schema, or 0 if none
+	{"pg_catalog", "pg_is_other_temp_schema", {"schema_id", nullptr}, "false"},  // is schema another session's temporary schema?
+
+	{"pg_catalog", "pg_conf_load_time", {nullptr}, "current_timestamp"},         // configuration load time
+	{"pg_catalog", "pg_postmaster_start_time", {nullptr}, "current_timestamp"},  // server start time
+
+	{"pg_catalog", "pg_typeof", {"expression", nullptr}, "lower(typeof(expression))"},  // get the data type of any value
+
+	// privilege functions
+	// {"has_any_column_privilege", {"user", "table", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for any column of table
+	{"pg_catalog", "has_any_column_privilege", {"table", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for any column of table
+	// {"has_column_privilege", {"user", "table", "column", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for column
+	{"pg_catalog", "has_column_privilege", {"table", "column", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for column
+	// {"has_database_privilege", {"user", "database", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for database
+	{"pg_catalog", "has_database_privilege", {"database", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for database
+	// {"has_foreign_data_wrapper_privilege", {"user", "fdw", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for foreign-data wrapper
+	{"pg_catalog", "has_foreign_data_wrapper_privilege", {"fdw", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for foreign-data wrapper
+	// {"has_function_privilege", {"user", "function", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for function
+	{"pg_catalog", "has_function_privilege", {"function", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for function
+	// {"has_language_privilege", {"user", "language", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for language
+	{"pg_catalog", "has_language_privilege", {"language", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for language
+	// {"has_schema_privilege", {"user", "schema, privilege", nullptr}, "true"},  //boolean  //does user have privilege for schema
+	{"pg_catalog", "has_schema_privilege", {"schema", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for schema
+	// {"has_sequence_privilege", {"user", "sequence", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for sequence
+	{"pg_catalog", "has_sequence_privilege", {"sequence", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for sequence
+	// {"has_server_privilege", {"user", "server", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for foreign server
+	{"pg_catalog", "has_server_privilege", {"server", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for foreign server
+	// {"has_table_privilege", {"user", "table", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for table
+	{"pg_catalog", "has_table_privilege", {"table", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for table
+	// {"has_tablespace_privilege", {"user", "tablespace", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for tablespace
+	{"pg_catalog", "has_tablespace_privilege", {"tablespace", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for tablespace
+
+	// various postgres system functions
+	{"pg_catalog", "pg_get_viewdef", {"oid", nullptr}, "(select sql from duckdb_views() v where v.view_oid=oid)"},
+	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid/1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
+	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", nullptr}, "pg_node_tree"},
+	{"pg_catalog", "format_pg_type", {"type_name", nullptr}, "case when logical_type='FLOAT' then 'real' when logical_type='DOUBLE' then 'double precision' when logical_type='DECIMAL' then 'numeric' when logical_type='VARCHAR' then 'character varying' when logical_type='BLOB' then 'bytea' when logical_type='TIMESTAMP' then 'timestamp without time zone' when logical_type='TIME' then 'time without time zone' else lower(logical_type) end"},
+	{"pg_catalog", "format_type", {"type_oid", "typemod", nullptr}, "(select format_pg_type(type_name) from duckdb_types() t where t.type_oid=type_oid) || case when typemod>0 then concat('(', typemod/1000, ',', typemod%1000, ')') else '' end"},
+
+	{"pg_catalog", "pg_has_role", {"user", "role", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for role
+	{"pg_catalog", "pg_has_role", {"role", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for role
+
+	{"pg_catalog", "col_description", {"table_oid", "column_number", nullptr}, "NULL"},   // get comment for a table column
+	{"pg_catalog", "obj_description", {"object_oid", "catalog_name", nullptr}, "NULL"},   // get comment for a database object
+	{"pg_catalog", "shobj_description", {"object_oid", "catalog_name", nullptr}, "NULL"}, // get comment for a shared database object
+
+	// visibility functions
+	{"pg_catalog", "pg_collation_is_visible", {"collation_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_conversion_is_visible", {"conversion_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_function_is_visible", {"function_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_opclass_is_visible", {"opclass_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_operator_is_visible", {"operator_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_opfamily_is_visible", {"opclass_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_table_is_visible", {"table_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_config_is_visible", {"config_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_dict_is_visible", {"dict_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_parser_is_visible", {"parser_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_template_is_visible", {"template_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_type_is_visible", {"type_oid", nullptr}, "true"},
+
+	{DEFAULT_SCHEMA, "round_even", {"x", "n", nullptr}, "CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
+	{DEFAULT_SCHEMA, "roundbankers", {"x", "n", nullptr}, "round_even(x, n)"},
+	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},
+	{DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
+	{DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
+	{DEFAULT_SCHEMA, "list_prepend", {"e", "l", nullptr}, "list_concat(list_value(e), l)"},
+	{DEFAULT_SCHEMA, "array_prepend", {"el", "arr", nullptr}, "list_prepend(el, arr)"},
+	{DEFAULT_SCHEMA, "array_pop_back", {"arr", nullptr}, "arr[:LEN(arr)-1]"},
+	{DEFAULT_SCHEMA, "array_pop_front", {"arr", nullptr}, "arr[2:]"},
+	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
+	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
+	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
+	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
+	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},
+
+	// algebraic list aggregates
+	{DEFAULT_SCHEMA, "list_avg", {"l", nullptr}, "list_aggr(l, 'avg')"},
+	{DEFAULT_SCHEMA, "list_var_samp", {"l", nullptr}, "list_aggr(l, 'var_samp')"},
+	{DEFAULT_SCHEMA, "list_var_pop", {"l", nullptr}, "list_aggr(l, 'var_pop')"},
+	{DEFAULT_SCHEMA, "list_stddev_pop", {"l", nullptr}, "list_aggr(l, 'stddev_pop')"},
+	{DEFAULT_SCHEMA, "list_stddev_samp", {"l", nullptr}, "list_aggr(l, 'stddev_samp')"},
+	{DEFAULT_SCHEMA, "list_sem", {"l", nullptr}, "list_aggr(l, 'sem')"},
+
+	// distributive list aggregates
+	{DEFAULT_SCHEMA, "list_approx_count_distinct", {"l", nullptr}, "list_aggr(l, 'approx_count_distinct')"},
+	{DEFAULT_SCHEMA, "list_bit_xor", {"l", nullptr}, "list_aggr(l, 'bit_xor')"},
+	{DEFAULT_SCHEMA, "list_bit_or", {"l", nullptr}, "list_aggr(l, 'bit_or')"},
+	{DEFAULT_SCHEMA, "list_bit_and", {"l", nullptr}, "list_aggr(l, 'bit_and')"},
+	{DEFAULT_SCHEMA, "list_bool_and", {"l", nullptr}, "list_aggr(l, 'bool_and')"},
+	{DEFAULT_SCHEMA, "list_bool_or", {"l", nullptr}, "list_aggr(l, 'bool_or')"},
+	{DEFAULT_SCHEMA, "list_count", {"l", nullptr}, "list_aggr(l, 'count')"},
+	{DEFAULT_SCHEMA, "list_entropy", {"l", nullptr}, "list_aggr(l, 'entropy')"},
+	{DEFAULT_SCHEMA, "list_last", {"l", nullptr}, "list_aggr(l, 'last')"},
+	{DEFAULT_SCHEMA, "list_first", {"l", nullptr}, "list_aggr(l, 'first')"},
+	{DEFAULT_SCHEMA, "list_kurtosis", {"l", nullptr}, "list_aggr(l, 'kurtosis')"},
+	{DEFAULT_SCHEMA, "list_min", {"l", nullptr}, "list_aggr(l, 'min')"},
+	{DEFAULT_SCHEMA, "list_max", {"l", nullptr}, "list_aggr(l, 'max')"},
+	{DEFAULT_SCHEMA, "list_product", {"l", nullptr}, "list_aggr(l, 'product')"},
+	{DEFAULT_SCHEMA, "list_skewness", {"l", nullptr}, "list_aggr(l, 'skewness')"},
+	{DEFAULT_SCHEMA, "list_sum", {"l", nullptr}, "list_aggr(l, 'sum')"},
+	{DEFAULT_SCHEMA, "list_string_agg", {"l", nullptr}, "list_aggr(l, 'string_agg')"},
+
+	// holistic list aggregates
+	{DEFAULT_SCHEMA, "list_mode", {"l", nullptr}, "list_aggr(l, 'mode')"},
+	{DEFAULT_SCHEMA, "list_median", {"l", nullptr}, "list_aggr(l, 'median')"},
+	{DEFAULT_SCHEMA, "list_mad", {"l", nullptr}, "list_aggr(l, 'mad')"},
+
+	// nested list aggregates
+	{DEFAULT_SCHEMA, "list_histogram", {"l", nullptr}, "list_aggr(l, 'histogram')"},
+
+	{nullptr, nullptr, {nullptr}, nullptr}
+	};
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalTableMacroInfo(DefaultMacro &default_macro, unique_ptr<MacroFunction> function) {
+	for (idx_t param_idx = 0; default_macro.parameters[param_idx] != nullptr; param_idx++) {
+		function->parameters.push_back(
+		    make_unique<ColumnRefExpression>(default_macro.parameters[param_idx]));
+	}
+
+	auto bind_info = make_unique<CreateMacroInfo>();
+	bind_info->schema = default_macro.schema;
+	bind_info->name = default_macro.name;
+	bind_info->temporary = true;
+	bind_info->internal = true;
+	bind_info->type = function->type == MacroType::TABLE_MACRO ? CatalogType::TABLE_MACRO_ENTRY : CatalogType::MACRO_ENTRY;
+	bind_info->function = move(function);
+	return bind_info;
+
+}
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalMacroInfo(DefaultMacro &default_macro) {
+	// parse the expression
+	auto expressions = Parser::ParseExpressionList(default_macro.macro);
+	D_ASSERT(expressions.size() == 1);
+
+	auto result = make_unique<ScalarMacroFunction>(move(expressions[0]));
+	return CreateInternalTableMacroInfo(default_macro, move(result));
+}
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalTableMacroInfo(DefaultMacro &default_macro) {
+	Parser parser;
+	parser.ParseQuery(default_macro.macro);
+	D_ASSERT(parser.statements.size() == 1);
+	D_ASSERT(parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+
+	auto &select = (SelectStatement &) *parser.statements[0];
+	auto result = make_unique<TableMacroFunction>(move(select.node));
+	return CreateInternalTableMacroInfo(default_macro, move(result));
+}
+
+static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &input_schema, const string &input_name) {
+	auto schema = StringUtil::Lower(input_schema);
+	auto name = StringUtil::Lower(input_name);
+	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {
+		if (internal_macros[index].schema == schema && internal_macros[index].name == name) {
+			return DefaultFunctionGenerator::CreateInternalMacroInfo(internal_macros[index]);
+		}
+	}
+	return nullptr;
+}
+
+DefaultFunctionGenerator::DefaultFunctionGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultFunctionGenerator::CreateDefaultEntry(ClientContext &context,
+                                                                      const string &entry_name) {
+	auto info = GetDefaultFunction(schema->name, entry_name);
+	if (info) {
+		return make_unique_base<CatalogEntry, ScalarMacroCatalogEntry>(&catalog, schema, (CreateMacroInfo *)info.get());
+	}
+	return nullptr;
+}
+
+vector<string> DefaultFunctionGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {
+		if (internal_macros[index].schema == schema->name) {
+			result.emplace_back(internal_macros[index].name);
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct DefaultSchema {
+	const char *name;
+};
+
+static DefaultSchema internal_schemas[] = {{"information_schema"}, {"pg_catalog"}, {nullptr}};
+
+static bool GetDefaultSchema(const string &input_schema) {
+	auto schema = StringUtil::Lower(input_schema);
+	for (idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+		if (internal_schemas[index].name == schema) {
+			return true;
+		}
+	}
+	return false;
+}
+
+DefaultSchemaGenerator::DefaultSchemaGenerator(Catalog &catalog) : DefaultGenerator(catalog) {
+}
+
+unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (GetDefaultSchema(entry_name)) {
+		return make_unique_base<CatalogEntry, SchemaCatalogEntry>(&catalog, StringUtil::Lower(entry_name), true);
+	}
+	return nullptr;
+}
+
+vector<string> DefaultSchemaGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+		result.emplace_back(internal_schemas[index].name);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultType {
+	const char *name;
+	LogicalTypeId type;
+};
+
+static DefaultType internal_types[] = {{"int", LogicalTypeId::INTEGER},
+                                       {"int4", LogicalTypeId::INTEGER},
+                                       {"signed", LogicalTypeId::INTEGER},
+                                       {"integer", LogicalTypeId::INTEGER},
+                                       {"integral", LogicalTypeId::INTEGER},
+                                       {"int32", LogicalTypeId::INTEGER},
+                                       {"varchar", LogicalTypeId::VARCHAR},
+                                       {"bpchar", LogicalTypeId::VARCHAR},
+                                       {"text", LogicalTypeId::VARCHAR},
+                                       {"string", LogicalTypeId::VARCHAR},
+                                       {"char", LogicalTypeId::VARCHAR},
+                                       {"nvarchar", LogicalTypeId::VARCHAR},
+                                       {"bytea", LogicalTypeId::BLOB},
+                                       {"blob", LogicalTypeId::BLOB},
+                                       {"varbinary", LogicalTypeId::BLOB},
+                                       {"binary", LogicalTypeId::BLOB},
+                                       {"int8", LogicalTypeId::BIGINT},
+                                       {"bigint", LogicalTypeId::BIGINT},
+                                       {"int64", LogicalTypeId::BIGINT},
+                                       {"long", LogicalTypeId::BIGINT},
+                                       {"oid", LogicalTypeId::BIGINT},
+                                       {"int2", LogicalTypeId::SMALLINT},
+                                       {"smallint", LogicalTypeId::SMALLINT},
+                                       {"short", LogicalTypeId::SMALLINT},
+                                       {"int16", LogicalTypeId::SMALLINT},
+                                       {"timestamp", LogicalTypeId::TIMESTAMP},
+                                       {"datetime", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_us", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_ms", LogicalTypeId::TIMESTAMP_MS},
+                                       {"timestamp_ns", LogicalTypeId::TIMESTAMP_NS},
+                                       {"timestamp_s", LogicalTypeId::TIMESTAMP_SEC},
+                                       {"bool", LogicalTypeId::BOOLEAN},
+                                       {"boolean", LogicalTypeId::BOOLEAN},
+                                       {"logical", LogicalTypeId::BOOLEAN},
+                                       {"decimal", LogicalTypeId::DECIMAL},
+                                       {"dec", LogicalTypeId::DECIMAL},
+                                       {"numeric", LogicalTypeId::DECIMAL},
+                                       {"real", LogicalTypeId::FLOAT},
+                                       {"float4", LogicalTypeId::FLOAT},
+                                       {"float", LogicalTypeId::FLOAT},
+                                       {"double", LogicalTypeId::DOUBLE},
+                                       {"float8", LogicalTypeId::DOUBLE},
+                                       {"tinyint", LogicalTypeId::TINYINT},
+                                       {"int1", LogicalTypeId::TINYINT},
+                                       {"date", LogicalTypeId::DATE},
+                                       {"time", LogicalTypeId::TIME},
+                                       {"interval", LogicalTypeId::INTERVAL},
+                                       {"hugeint", LogicalTypeId::HUGEINT},
+                                       {"int128", LogicalTypeId::HUGEINT},
+                                       {"uuid", LogicalTypeId::UUID},
+                                       {"guid", LogicalTypeId::UUID},
+                                       {"struct", LogicalTypeId::STRUCT},
+                                       {"row", LogicalTypeId::STRUCT},
+                                       {"list", LogicalTypeId::LIST},
+                                       {"map", LogicalTypeId::MAP},
+                                       {"utinyint", LogicalTypeId::UTINYINT},
+                                       {"uint8", LogicalTypeId::UTINYINT},
+                                       {"usmallint", LogicalTypeId::USMALLINT},
+                                       {"uint16", LogicalTypeId::USMALLINT},
+                                       {"uinteger", LogicalTypeId::UINTEGER},
+                                       {"uint32", LogicalTypeId::UINTEGER},
+                                       {"ubigint", LogicalTypeId::UBIGINT},
+                                       {"uint64", LogicalTypeId::UBIGINT},
+                                       {"timestamptz", LogicalTypeId::TIMESTAMP_TZ},
+                                       {"timetz", LogicalTypeId::TIME_TZ},
+                                       {"json", LogicalTypeId::JSON},
+                                       {"null", LogicalTypeId::SQLNULL},
+                                       {nullptr, LogicalTypeId::INVALID}};
+
+LogicalTypeId DefaultTypeGenerator::GetDefaultType(const string &name) {
+	auto lower_str = StringUtil::Lower(name);
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		if (internal_types[index].name == lower_str) {
+			return internal_types[index].type;
+		}
+	}
+	return LogicalTypeId::INVALID;
+}
+
+DefaultTypeGenerator::DefaultTypeGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultTypeGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (schema->name != DEFAULT_SCHEMA) {
+		return nullptr;
+	}
+	auto type_id = GetDefaultType(entry_name);
+	if (type_id == LogicalTypeId::INVALID) {
+		return nullptr;
+	}
+	CreateTypeInfo info;
+	info.name = entry_name;
+	info.type = LogicalType(type_id);
+	info.internal = true;
+	info.temporary = true;
+	return make_unique_base<CatalogEntry, TypeCatalogEntry>(&catalog, schema, &info);
+}
+
+vector<string> DefaultTypeGenerator::GetDefaultEntries() {
+	vector<string> result;
+	if (schema->name != DEFAULT_SCHEMA) {
+		return result;
+	}
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		result.emplace_back(internal_types[index].name);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultView {
+	const char *schema;
+	const char *name;
+	const char *sql;
+};
+
+static DefaultView internal_views[] = {
+    {DEFAULT_SCHEMA, "pragma_database_list", "SELECT * FROM pragma_database_list()"},
+    {DEFAULT_SCHEMA, "sqlite_master", "select 'table' \"type\", table_name \"name\", table_name \"tbl_name\", 0 rootpage, sql from duckdb_tables union all select 'view' \"type\", view_name \"name\", view_name \"tbl_name\", 0 rootpage, sql from duckdb_views union all select 'index' \"type\", index_name \"name\", table_name \"tbl_name\", 0 rootpage, sql from duckdb_indexes;"},
+    {DEFAULT_SCHEMA, "sqlite_schema", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "sqlite_temp_master", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "sqlite_temp_schema", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "duckdb_constraints", "SELECT * FROM duckdb_constraints()"},
+    {DEFAULT_SCHEMA, "duckdb_columns", "SELECT * FROM duckdb_columns() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_indexes", "SELECT * FROM duckdb_indexes()"},
+    {DEFAULT_SCHEMA, "duckdb_schemas", "SELECT * FROM duckdb_schemas() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_tables", "SELECT * FROM duckdb_tables() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_types", "SELECT * FROM duckdb_types()"},
+    {DEFAULT_SCHEMA, "duckdb_views", "SELECT * FROM duckdb_views() WHERE NOT internal"},
+    {"pg_catalog", "pg_am", "SELECT 0 oid, 'art' amname, NULL amhandler, 'i' amtype"},
+    {"pg_catalog", "pg_attribute", "SELECT table_oid attrelid, column_name attname, data_type_id atttypid, 0 attstattarget, NULL attlen, column_index attnum, 0 attndims, -1 attcacheoff, case when data_type ilike '%decimal%' then numeric_precision*1000+numeric_scale else -1 end atttypmod, false attbyval, NULL attstorage, NULL attalign, NOT is_nullable attnotnull, column_default IS NOT NULL atthasdef, false atthasmissing, '' attidentity, '' attgenerated, false attisdropped, true attislocal, 0 attinhcount, 0 attcollation, NULL attcompression, NULL attacl, NULL attoptions, NULL attfdwoptions, NULL attmissingval FROM duckdb_columns()"},
+    {"pg_catalog", "pg_attrdef", "SELECT column_index oid, table_oid adrelid, column_index adnum, column_default adbin from duckdb_columns() where column_default is not null;"},
+    {"pg_catalog", "pg_class", "SELECT table_oid oid, table_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, estimated_size::real reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, index_count > 0 relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'r' relkind, column_count relnatts, check_constraint_count relchecks, false relhasoids, has_primary_key relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_tables() UNION ALL SELECT view_oid oid, view_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'v' relkind, column_count relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_views() UNION ALL SELECT sequence_oid oid, sequence_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'S' relkind, 0 relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_sequences() UNION ALL SELECT index_oid oid, index_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, 't' relpersistence, 'i' relkind, NULL relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_constraint", "SELECT table_oid*1000000+constraint_index oid, constraint_text conname, schema_oid connamespace, CASE WHEN constraint_type='CHECK' then 'c' WHEN constraint_type='UNIQUE' then 'u' WHEN constraint_type='PRIMARY KEY' THEN 'p' ELSE 'x' END contype, false condeferrable, false condeferred, true convalidated, table_oid conrelid, 0 contypid, 0 conindid, 0 conparentid, 0 confrelid, NULL confupdtype, NULL confdeltype, NULL confmatchtype, true conislocal, 0 coninhcount, false connoinherit, constraint_column_indexes conkey, NULL confkey, NULL conpfeqop, NULL conppeqop, NULL conffeqop, NULL conexclop, expression conbin FROM duckdb_constraints()"},
+    {"pg_catalog", "pg_depend", "SELECT * FROM duckdb_dependencies()"},
+	{"pg_catalog", "pg_description", "SELECT NULL objoid, NULL classoid, NULL objsubid, NULL description WHERE 1=0"},
+    {"pg_catalog", "pg_enum", "SELECT NULL oid, NULL enumtypid, NULL enumsortorder, NULL enumlabel WHERE 1=0"},
+    {"pg_catalog", "pg_index", "SELECT index_oid indexrelid, table_oid indrelid, 0 indnatts, 0 indnkeyatts, is_unique indisunique, is_primary indisprimary, false indisexclusion, true indimmediate, false indisclustered, true indisvalid, false indcheckxmin, true indisready, true indislive, false indisreplident, NULL::INT[] indkey, NULL::OID[] indcollation, NULL::OID[] indclass, NULL::INT[] indoption, expressions indexprs, NULL indpred FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_indexes", "SELECT schema_name schemaname, table_name tablename, index_name indexname, NULL \"tablespace\", sql indexdef FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_namespace", "SELECT oid, schema_name nspname, 0 nspowner, NULL nspacl FROM duckdb_schemas()"},
+    {"pg_catalog", "pg_sequence", "SELECT sequence_oid seqrelid, 0 seqtypid, start_value seqstart, increment_by seqincrement, max_value seqmax, min_value seqmin, 0 seqcache, cycle seqcycle FROM duckdb_sequences()"},
+	{"pg_catalog", "pg_sequences", "SELECT schema_name schemaname, sequence_name sequencename, 'duckdb' sequenceowner, 0 data_type, start_value, min_value, max_value, increment_by, cycle, 0 cache_size, last_value FROM duckdb_sequences()"},
+    {"pg_catalog", "pg_tables", "SELECT schema_name schemaname, table_name tablename, 'duckdb' tableowner, NULL \"tablespace\", index_count > 0 hasindexes, false hasrules, false hastriggers FROM duckdb_tables()"},
+    {"pg_catalog", "pg_tablespace", "SELECT 0 oid, 'pg_default' spcname, 0 spcowner, NULL spcacl, NULL spcoptions"},
+    {"pg_catalog", "pg_type", "SELECT type_oid oid, format_pg_type(type_name) typname, schema_oid typnamespace, 0 typowner, type_size typlen, false typbyval, 'b' typtype, CASE WHEN type_category='NUMERIC' THEN 'N' WHEN type_category='STRING' THEN 'S' WHEN type_category='DATETIME' THEN 'D' WHEN type_category='BOOLEAN' THEN 'B' WHEN type_category='COMPOSITE' THEN 'C' WHEN type_category='USER' THEN 'U' ELSE 'X' END typcategory, false typispreferred, true typisdefined, NULL typdelim, NULL typrelid, NULL typsubscript, NULL typelem, NULL typarray, NULL typinput, NULL typoutput, NULL typreceive, NULL typsend, NULL typmodin, NULL typmodout, NULL typanalyze, 'd' typalign, 'p' typstorage, NULL typnotnull, NULL typbasetype, NULL typtypmod, NULL typndims, NULL typcollation, NULL typdefaultbin, NULL typdefault, NULL typacl FROM duckdb_types();"},
+    {"pg_catalog", "pg_views", "SELECT schema_name schemaname, view_name viewname, 'duckdb' viewowner, sql definition FROM duckdb_views()"},
+    {"information_schema", "columns", "SELECT NULL table_catalog, schema_name table_schema, table_name, column_name, column_index ordinal_position, column_default, CASE WHEN is_nullable THEN 'YES' ELSE 'NO' END is_nullable, data_type, character_maximum_length, NULL character_octet_length, numeric_precision, numeric_precision_radix, numeric_scale, NULL datetime_precision, NULL interval_type, NULL interval_precision, NULL character_set_catalog, NULL character_set_schema, NULL character_set_name, NULL collation_catalog, NULL collation_schema, NULL collation_name, NULL domain_catalog, NULL domain_schema, NULL domain_name, NULL udt_catalog, NULL udt_schema, NULL udt_name, NULL scope_catalog, NULL scope_schema, NULL scope_name, NULL maximum_cardinality, NULL dtd_identifier, NULL is_self_referencing, NULL is_identity, NULL identity_generation, NULL identity_start, NULL identity_increment, NULL identity_maximum, NULL identity_minimum, NULL identity_cycle, NULL is_generated, NULL generation_expression, NULL is_updatable FROM duckdb_columns;"},
+    {"information_schema", "schemata", "SELECT NULL catalog_name, schema_name, 'duckdb' schema_owner, NULL default_character_set_catalog, NULL default_character_set_schema, NULL default_character_set_name, sql sql_path FROM duckdb_schemas()"},
+    {"information_schema", "tables", "SELECT NULL table_catalog, schema_name table_schema, table_name, CASE WHEN temporary THEN 'LOCAL TEMPORARY' ELSE 'BASE TABLE' END table_type, NULL self_referencing_column_name, NULL reference_generation, NULL user_defined_type_catalog, NULL user_defined_type_schema, NULL user_defined_type_name, 'YES' is_insertable_into, 'NO' is_typed, CASE WHEN temporary THEN 'PRESERVE' ELSE NULL END commit_action FROM duckdb_tables() UNION ALL SELECT NULL table_catalog, schema_name table_schema, view_name table_name, 'VIEW' table_type, NULL self_referencing_column_name, NULL reference_generation, NULL user_defined_type_catalog, NULL user_defined_type_schema, NULL user_defined_type_name, 'NO' is_insertable_into, 'NO' is_typed, NULL commit_action FROM duckdb_views;"},
+    {nullptr, nullptr, nullptr}};
+
+static unique_ptr<CreateViewInfo> GetDefaultView(const string &input_schema, const string &input_name) {
+	auto schema = StringUtil::Lower(input_schema);
+	auto name = StringUtil::Lower(input_name);
+	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
+		if (internal_views[index].schema == schema && internal_views[index].name == name) {
+			auto result = make_unique<CreateViewInfo>();
+			result->schema = schema;
+			result->sql = internal_views[index].sql;
+
+			Parser parser;
+			parser.ParseQuery(internal_views[index].sql);
+			D_ASSERT(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+			result->query = unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
+			result->temporary = true;
+			result->internal = true;
+			result->view_name = name;
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+DefaultViewGenerator::DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultViewGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	auto info = GetDefaultView(schema->name, entry_name);
+	if (info) {
+		auto binder = Binder::CreateBinder(context);
+		binder->BindCreateViewInfo(*info);
+
+		return make_unique_base<CatalogEntry, ViewCatalogEntry>(&catalog, schema, info.get());
+	}
+	return nullptr;
+}
+
+vector<string> DefaultViewGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
+		if (internal_views[index].schema == schema->name) {
+			result.emplace_back(internal_views[index].name);
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DependencyManager::DependencyManager(Catalog &catalog) : catalog(catalog) {
+}
+
+void DependencyManager::AddObject(ClientContext &context, CatalogEntry *object,
+                                  unordered_set<CatalogEntry *> &dependencies) {
+	// check for each object in the sources if they were not deleted yet
+	for (auto &dependency : dependencies) {
+		idx_t entry_index;
+		CatalogEntry *catalog_entry;
+		if (!dependency->set) {
+			throw InternalException("Dependency has no set");
+		}
+		if (!dependency->set->GetEntryInternal(context, dependency->name, entry_index, catalog_entry)) {
+			throw InternalException("Dependency has already been deleted?");
+		}
+	}
+	// indexes do not require CASCADE to be dropped, they are simply always dropped along with the table
+	auto dependency_type = object->type == CatalogType::INDEX_ENTRY ? DependencyType::DEPENDENCY_AUTOMATIC
+	                                                                : DependencyType::DEPENDENCY_REGULAR;
+	// add the object to the dependents_map of each object that it depends on
+	for (auto &dependency : dependencies) {
+		dependents_map[dependency].insert(Dependency(object, dependency_type));
+	}
+	// create the dependents map for this object: it starts out empty
+	dependents_map[object] = dependency_set_t();
+	dependencies_map[object] = dependencies;
+}
+
+void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object, bool cascade) {
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
+
+	// first check the objects that depend on this object
+	auto &dependent_objects = dependents_map[object];
+	for (auto &dep : dependent_objects) {
+		// look up the entry in the catalog set
+		auto &catalog_set = *dep.entry->set;
+		auto mapping_value = catalog_set.GetMapping(context, dep.entry->name, true /* get_latest */);
+		if (mapping_value == nullptr) {
+			continue;
+		}
+		idx_t entry_index = mapping_value->index;
+		CatalogEntry *dependency_entry;
+
+		if (!catalog_set.GetEntryInternal(context, entry_index, dependency_entry)) {
+			// the dependent object was already deleted, no conflict
+			continue;
+		}
+		// conflict: attempting to delete this object but the dependent object still exists
+		if (cascade || dep.dependency_type == DependencyType::DEPENDENCY_AUTOMATIC ||
+		    dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			// cascade: drop the dependent object
+			catalog_set.DropEntryInternal(context, entry_index, *dependency_entry, cascade);
+		} else {
+			// no cascade and there are objects that depend on this object: throw error
+			throw CatalogException("Cannot drop entry \"%s\" because there are entries that "
+			                       "depend on it. Use DROP...CASCADE to drop all dependents.",
+			                       object->name);
+		}
+	}
+}
+
+void DependencyManager::AlterObject(ClientContext &context, CatalogEntry *old_obj, CatalogEntry *new_obj) {
+	D_ASSERT(dependents_map.find(old_obj) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(old_obj) != dependencies_map.end());
+
+	// first check the objects that depend on this object
+	vector<CatalogEntry *> owned_objects_to_add;
+	auto &dependent_objects = dependents_map[old_obj];
+	for (auto &dep : dependent_objects) {
+		// look up the entry in the catalog set
+		auto &catalog_set = *dep.entry->set;
+		idx_t entry_index;
+		CatalogEntry *dependency_entry;
+		if (!catalog_set.GetEntryInternal(context, dep.entry->name, entry_index, dependency_entry)) {
+			// the dependent object was already deleted, no conflict
+			continue;
+		}
+		if (dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			// the dependent object is owned by the current object
+			owned_objects_to_add.push_back(dep.entry);
+			continue;
+		}
+		// conflict: attempting to alter this object but the dependent object still exists
+		// no cascade and there are objects that depend on this object: throw error
+		throw CatalogException("Cannot alter entry \"%s\" because there are entries that "
+		                       "depend on it.",
+		                       old_obj->name);
+	}
+	// add the new object to the dependents_map of each object that it depends on
+	auto &old_dependencies = dependencies_map[old_obj];
+	vector<CatalogEntry *> to_delete;
+	for (auto &dependency : old_dependencies) {
+		if (dependency->type == CatalogType::TYPE_ENTRY) {
+			auto user_type = (TypeCatalogEntry *)dependency;
+			auto table = (TableCatalogEntry *)new_obj;
+			bool deleted_dependency = true;
+			for (auto &column : table->columns) {
+				if (column.Type() == user_type->user_type) {
+					deleted_dependency = false;
+					break;
+				}
+			}
+			if (deleted_dependency) {
+				to_delete.push_back(dependency);
+				continue;
+			}
+		}
+		dependents_map[dependency].insert(new_obj);
+	}
+	for (auto &dependency : to_delete) {
+		old_dependencies.erase(dependency);
+		dependents_map[dependency].erase(old_obj);
+	}
+
+	// We might have to add a type dependency
+	vector<CatalogEntry *> to_add;
+	if (new_obj->type == CatalogType::TABLE_ENTRY) {
+		auto table = (TableCatalogEntry *)new_obj;
+		for (auto &column : table->columns) {
+			auto user_type_catalog = LogicalType::GetCatalog(column.Type());
+			if (user_type_catalog) {
+				to_add.push_back(user_type_catalog);
+			}
+		}
+	}
+	// add the new object to the dependency manager
+	dependents_map[new_obj] = dependency_set_t();
+	dependencies_map[new_obj] = old_dependencies;
+
+	for (auto &dependency : to_add) {
+		dependencies_map[new_obj].insert(dependency);
+		dependents_map[dependency].insert(new_obj);
+	}
+
+	for (auto &dependency : owned_objects_to_add) {
+		dependents_map[new_obj].insert(Dependency(dependency, DependencyType::DEPENDENCY_OWNS));
+		dependents_map[dependency].insert(Dependency(new_obj, DependencyType::DEPENDENCY_OWNED_BY));
+		dependencies_map[new_obj].insert(dependency);
+	}
+}
+
+void DependencyManager::EraseObject(CatalogEntry *object) {
+	// obtain the writing lock
+	EraseObjectInternal(object);
+}
+
+void DependencyManager::EraseObjectInternal(CatalogEntry *object) {
+	if (dependents_map.find(object) == dependents_map.end()) {
+		// dependencies already removed
+		return;
+	}
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(object) != dependencies_map.end());
+	// now for each of the dependencies, erase the entries from the dependents_map
+	for (auto &dependency : dependencies_map[object]) {
+		auto entry = dependents_map.find(dependency);
+		if (entry != dependents_map.end()) {
+			D_ASSERT(entry->second.find(object) != entry->second.end());
+			entry->second.erase(object);
+		}
+	}
+	// erase the dependents and dependencies for this object
+	dependents_map.erase(object);
+	dependencies_map.erase(object);
+}
+
+void DependencyManager::Scan(const std::function<void(CatalogEntry *, CatalogEntry *, DependencyType)> &callback) {
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	for (auto &entry : dependents_map) {
+		for (auto &dependent : entry.second) {
+			callback(entry.first, dependent.entry, dependent.dependency_type);
+		}
+	}
+}
+
+void DependencyManager::AddOwnership(ClientContext &context, CatalogEntry *owner, CatalogEntry *entry) {
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	// If the owner is already owned by something else, throw an error
+	for (auto &dep : dependents_map[owner]) {
+		if (dep.dependency_type == DependencyType::DEPENDENCY_OWNED_BY) {
+			throw CatalogException(owner->name + " already owned by " + dep.entry->name);
+		}
+	}
+
+	// If the entry is already owned, throw an error
+	for (auto &dep : dependents_map[entry]) {
+		// if the entry is already owned, throw error
+		if (dep.entry != owner) {
+			throw CatalogException(entry->name + " already depends on " + dep.entry->name);
+		}
+		// if the entry owns the owner, throw error
+		if (dep.entry == owner && dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			throw CatalogException(entry->name + " already owns " + owner->name +
+			                       ". Cannot have circular dependencies");
+		}
+	}
+
+	// Emplace guarantees that the same object cannot be inserted twice in the unordered_set
+	// In the case AddOwnership is called twice, because of emplace, the object will not be repeated in the set.
+	// We use an automatic dependency because if the Owner gets deleted, then the owned objects are also deleted
+	dependents_map[owner].emplace(Dependency(entry, DependencyType::DEPENDENCY_OWNS));
+	dependents_map[entry].emplace(Dependency(owner, DependencyType::DEPENDENCY_OWNED_BY));
+	dependencies_map[owner].emplace(entry);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size)
+    : allocator(allocator), pointer(pointer), allocated_size(allocated_size) {
+}
+AllocatedData::~AllocatedData() {
+	Reset();
+}
+
+void AllocatedData::Reset() {
+	if (!pointer) {
+		return;
+	}
+	allocator.FreeData(pointer, allocated_size);
+	pointer = nullptr;
+}
+
+Allocator::Allocator()
+    : allocate_function(Allocator::DefaultAllocate), free_function(Allocator::DefaultFree),
+      reallocate_function(Allocator::DefaultReallocate) {
+}
+
+Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
+                     reallocate_function_ptr_t reallocate_function_p, unique_ptr<PrivateAllocatorData> private_data)
+    : allocate_function(allocate_function_p), free_function(free_function_p),
+      reallocate_function(reallocate_function_p), private_data(move(private_data)) {
+}
+
+data_ptr_t Allocator::AllocateData(idx_t size) {
+	return allocate_function(private_data.get(), size);
+}
+
+void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
+	if (!pointer) {
+		return;
+	}
+	return free_function(private_data.get(), pointer, size);
+}
+
+data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t size) {
+	if (!pointer) {
+		return pointer;
+	}
+	return reallocate_function(private_data.get(), pointer, size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ArrowSchemaWrapper::~ArrowSchemaWrapper() {
+	if (arrow_schema.release) {
+		for (int64_t child_idx = 0; child_idx < arrow_schema.n_children; child_idx++) {
+			auto &child = *arrow_schema.children[child_idx];
+			if (child.release) {
+				child.release(&child);
+			}
+		}
+		arrow_schema.release(&arrow_schema);
+		arrow_schema.release = nullptr;
+	}
+}
+
+ArrowArrayWrapper::~ArrowArrayWrapper() {
+	if (arrow_array.release) {
+		for (int64_t child_idx = 0; child_idx < arrow_array.n_children; child_idx++) {
+			auto &child = *arrow_array.children[child_idx];
+			if (child.release) {
+				child.release(&child);
+			}
+		}
+		arrow_array.release(&arrow_array);
+		arrow_array.release = nullptr;
+	}
+}
+
+ArrowArrayStreamWrapper::~ArrowArrayStreamWrapper() {
+	if (arrow_array_stream.release) {
+		arrow_array_stream.release(&arrow_array_stream);
+		arrow_array_stream.release = nullptr;
+	}
+}
+
+void ArrowArrayStreamWrapper::GetSchema(ArrowSchemaWrapper &schema) {
+	D_ASSERT(arrow_array_stream.get_schema);
+	// LCOV_EXCL_START
+	if (arrow_array_stream.get_schema(&arrow_array_stream, &schema.arrow_schema)) {
+		throw InvalidInputException("arrow_scan: get_schema failed(): %s", string(GetError()));
+	}
+	if (!schema.arrow_schema.release) {
+		throw InvalidInputException("arrow_scan: released schema passed");
+	}
+	if (schema.arrow_schema.n_children < 1) {
+		throw InvalidInputException("arrow_scan: empty schema passed");
+	}
+	// LCOV_EXCL_STOP
+}
+
+shared_ptr<ArrowArrayWrapper> ArrowArrayStreamWrapper::GetNextChunk() {
+	auto current_chunk = make_shared<ArrowArrayWrapper>();
+	if (arrow_array_stream.get_next(&arrow_array_stream, &current_chunk->arrow_array)) { // LCOV_EXCL_START
+		throw InvalidInputException("arrow_scan: get_next failed(): %s", string(GetError()));
+	} // LCOV_EXCL_STOP
+
+	return current_chunk;
+}
+
+const char *ArrowArrayStreamWrapper::GetError() { // LCOV_EXCL_START
+	return arrow_array_stream.get_last_error(&arrow_array_stream);
+} // LCOV_EXCL_STOP
+
+int ResultArrowArrayStreamWrapper::MyStreamGetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
+	if (!stream->release) {
+		return -1;
+	}
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	if (!my_stream->column_types.empty()) {
+		QueryResult::ToArrowSchema(out, my_stream->column_types, my_stream->column_names, my_stream->timezone_config);
+		return 0;
+	}
+
+	auto &result = *my_stream->result;
+	if (!result.success) {
+		my_stream->last_error = "Query Failed";
+		return -1;
+	}
+	if (result.type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = (StreamQueryResult &)result;
+		if (!stream_result.IsOpen()) {
+			my_stream->last_error = "Query Stream is closed";
+			return -1;
+		}
+	}
+	if (my_stream->column_types.empty()) {
+		my_stream->column_types = result.types;
+		my_stream->column_names = result.names;
+	}
+	QueryResult::ToArrowSchema(out, my_stream->column_types, my_stream->column_names, my_stream->timezone_config);
+	return 0;
+}
+
+int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stream, struct ArrowArray *out) {
+	if (!stream->release) {
+		return -1;
+	}
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	auto &result = *my_stream->result;
+	if (!result.success) {
+		my_stream->last_error = "Query Failed";
+		return -1;
+	}
+	if (result.type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = (StreamQueryResult &)result;
+		if (!stream_result.IsOpen()) {
+			// Nothing to output
+			out->release = nullptr;
+			return 0;
+		}
+	}
+	if (my_stream->column_types.empty()) {
+		my_stream->column_types = result.types;
+		my_stream->column_names = result.names;
+	}
+	unique_ptr<DataChunk> chunk_result = result.Fetch();
+	if (!chunk_result) {
+		// Nothing to output
+		out->release = nullptr;
+		return 0;
+	}
+	unique_ptr<DataChunk> agg_chunk_result = make_unique<DataChunk>();
+	agg_chunk_result->Initialize(chunk_result->GetTypes());
+	agg_chunk_result->Append(*chunk_result, true);
+
+	while (agg_chunk_result->size() < my_stream->batch_size) {
+		auto new_chunk = result.Fetch();
+		if (!new_chunk) {
+			break;
+		} else {
+			agg_chunk_result->Append(*new_chunk, true);
+		}
+	}
+	agg_chunk_result->ToArrowArray(out);
+	return 0;
+}
+
+void ResultArrowArrayStreamWrapper::MyStreamRelease(struct ArrowArrayStream *stream) {
+	if (!stream->release) {
+		return;
+	}
+	stream->release = nullptr;
+	delete (ResultArrowArrayStreamWrapper *)stream->private_data;
+}
+
+const char *ResultArrowArrayStreamWrapper::MyStreamGetLastError(struct ArrowArrayStream *stream) {
+	if (!stream->release) {
+		return "stream was released";
+	}
+	D_ASSERT(stream->private_data);
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	return my_stream->last_error.c_str();
+}
+ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result_p, idx_t batch_size_p)
+    : result(move(result_p)) {
+	//! We first initialize the private data of the stream
+	stream.private_data = this;
+	//! Ceil Approx_Batch_Size/STANDARD_VECTOR_SIZE
+	if (batch_size_p == 0) {
+		throw std::runtime_error("Approximate Batch Size of Record Batch MUST be higher than 0");
+	}
+	batch_size = batch_size_p;
+	//! We initialize the stream functions
+	stream.get_schema = ResultArrowArrayStreamWrapper::MyStreamGetSchema;
+	stream.get_next = ResultArrowArrayStreamWrapper::MyStreamGetNext;
+	stream.release = ResultArrowArrayStreamWrapper::MyStreamRelease;
+	stream.get_last_error = ResultArrowArrayStreamWrapper::MyStreamGetLastError;
+}
+
+unique_ptr<DataChunk> ArrowUtil::FetchNext(QueryResult &result) {
+	auto chunk = result.Fetch();
+	if (!result.success) {
+		throw std::runtime_error(result.error);
+	}
+	return chunk;
+}
+
+unique_ptr<DataChunk> ArrowUtil::FetchChunk(QueryResult *result, idx_t chunk_size) {
+
+	auto data_chunk = FetchNext(*result);
+	if (!data_chunk) {
+		return data_chunk;
+	}
+	while (data_chunk->size() < chunk_size) {
+		auto next_chunk = FetchNext(*result);
+		if (!next_chunk || next_chunk->size() == 0) {
+			break;
+		}
+		data_chunk->Append(*next_chunk, true);
+	}
+	return data_chunk;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr) {
+	if (condition) {
+		return;
+	}
+	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+uint64_t Checksum(uint8_t *buffer, size_t size) {
+	uint64_t result = 5381;
+	uint64_t *ptr = (uint64_t *)buffer;
+	size_t i;
+	// for efficiency, we first hash uint64_t values
+	for (i = 0; i < size / 8; i++) {
+		result ^= Hash(ptr[i]);
+	}
+	if (size - i * 8 > 0) {
+		// the remaining 0-7 bytes we hash using a string hash
+		result ^= Hash(buffer + i * 8, size - i * 8);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+StreamWrapper::~StreamWrapper() {
+}
+
+CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path)
+    : FileHandle(fs, path), compressed_fs(fs), child_handle(move(child_handle_p)) {
+}
+
+CompressedFile::~CompressedFile() {
+	Close();
+}
+
+void CompressedFile::Initialize(bool write) {
+	Close();
+
+	this->write = write;
+	stream_data.in_buf_size = compressed_fs.InBufferSize();
+	stream_data.out_buf_size = compressed_fs.OutBufferSize();
+	stream_data.in_buff = unique_ptr<data_t[]>(new data_t[stream_data.in_buf_size]);
+	stream_data.in_buff_start = stream_data.in_buff.get();
+	stream_data.in_buff_end = stream_data.in_buff.get();
+	stream_data.out_buff = unique_ptr<data_t[]>(new data_t[stream_data.out_buf_size]);
+	stream_data.out_buff_start = stream_data.out_buff.get();
+	stream_data.out_buff_end = stream_data.out_buff.get();
+
+	stream_wrapper = compressed_fs.CreateStream();
+	stream_wrapper->Initialize(*this, write);
+}
+
+int64_t CompressedFile::ReadData(void *buffer, int64_t remaining) {
+	idx_t total_read = 0;
+	while (true) {
+		// first check if there are input bytes available in the output buffers
+		if (stream_data.out_buff_start != stream_data.out_buff_end) {
+			// there is! copy it into the output buffer
+			idx_t available = MinValue<idx_t>(remaining, stream_data.out_buff_end - stream_data.out_buff_start);
+			memcpy(data_ptr_t(buffer) + total_read, stream_data.out_buff_start, available);
+
+			// increment the total read variables as required
+			stream_data.out_buff_start += available;
+			total_read += available;
+			remaining -= available;
+			if (remaining == 0) {
+				// done! read enough
+				return total_read;
+			}
+		}
+		if (!stream_wrapper) {
+			return total_read;
+		}
+
+		// ran out of buffer: read more data from the child stream
+		stream_data.out_buff_start = stream_data.out_buff.get();
+		stream_data.out_buff_end = stream_data.out_buff.get();
+		D_ASSERT(stream_data.in_buff_start <= stream_data.in_buff_end);
+		D_ASSERT(stream_data.in_buff_end <= stream_data.in_buff_start + stream_data.in_buf_size);
+
+		// read more input if none available
+		if (stream_data.in_buff_start == stream_data.in_buff_end) {
+			// empty input buffer: refill from the start
+			stream_data.in_buff_start = stream_data.in_buff.get();
+			stream_data.in_buff_end = stream_data.in_buff_start;
+			auto sz = child_handle->Read(stream_data.in_buff.get(), stream_data.in_buf_size);
+			if (sz <= 0) {
+				stream_wrapper.reset();
+				break;
+			}
+			stream_data.in_buff_end = stream_data.in_buff_start + sz;
+		}
+
+		auto finished = stream_wrapper->Read(stream_data);
+		if (finished) {
+			stream_wrapper.reset();
+		}
+	}
+	return total_read;
+}
+
+int64_t CompressedFile::WriteData(data_ptr_t buffer, int64_t nr_bytes) {
+	stream_wrapper->Write(*this, stream_data, buffer, nr_bytes);
+	return nr_bytes;
+}
+
+void CompressedFile::Close() {
+	if (stream_wrapper) {
+		stream_wrapper->Close();
+		stream_wrapper.reset();
+	}
+	stream_data.in_buff.reset();
+	stream_data.out_buff.reset();
+	stream_data.out_buff_start = nullptr;
+	stream_data.out_buff_end = nullptr;
+	stream_data.in_buff_start = nullptr;
+	stream_data.in_buff_end = nullptr;
+	stream_data.in_buf_size = 0;
+	stream_data.out_buf_size = 0;
+}
+
+int64_t CompressedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.ReadData(buffer, nr_bytes);
+}
+
+int64_t CompressedFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.WriteData((data_ptr_t)buffer, nr_bytes);
+}
+
+void CompressedFileSystem::Reset(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	compressed_file.child_handle->Reset();
+	compressed_file.Initialize(compressed_file.write);
+}
+
+int64_t CompressedFileSystem::GetFileSize(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.child_handle->GetFileSize();
+}
+
+bool CompressedFileSystem::OnDiskFile(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.child_handle->OnDiskFile();
+}
+
+bool CompressedFileSystem::CanSeek() {
+	return false;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+constexpr const idx_t DConstants::INVALID_INDEX;
+const row_t MAX_ROW_ID = 4611686018427388000ULL; // 2^62
+const column_t COLUMN_IDENTIFIER_ROW_ID = (column_t)-1;
+const sel_t ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
+const double PI = 3.141592653589793;
+
+const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
+const transaction_t MAX_TRANSACTION_ID = NumericLimits<transaction_t>::Maximum(); // 2^63
+const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1
+const transaction_t MAXIMUM_QUERY_ID = NumericLimits<transaction_t>::Maximum();   // 2^64
+
+uint64_t NextPowerOfTwo(uint64_t v) {
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v |= v >> 32;
+	v++;
+	return v;
+}
+
+} // namespace duckdb
+/*
+** This code taken from the SQLite test library.  Originally found on
+** the internet.  The original header comment follows this comment.
+** The code is largerly unchanged, but there have been some modifications.
+*/
+/*
+ * This code implements the MD5 message-digest algorithm.
+ * The algorithm is due to Ron Rivest.  This code was
+ * written by Colin Plumb in 1993, no copyright is claimed.
+ * This code is in the public domain; do with it what you wish.
+ *
+ * Equivalent code is available from RSA Data Security, Inc.
+ * This code has been tested against that, and is equivalent,
+ * except that you don't need to include two pages of legalese
+ * with every copy.
+ *
+ * To compute the message digest of a chunk of bytes, declare an
+ * MD5Context structure, pass it to MD5Init, call MD5Update as
+ * needed on buffers full of bytes, and then call MD5Final, which
+ * will fill a supplied 16-byte array with the digest.
+ */
+
+
+namespace duckdb {
+
+/*
+ * Note: this code is harmless on little-endian machines.
+ */
+static void ByteReverse(unsigned char *buf, unsigned longs) {
+	uint32_t t;
+	do {
+		t = (uint32_t)((unsigned)buf[3] << 8 | buf[2]) << 16 | ((unsigned)buf[1] << 8 | buf[0]);
+		*(uint32_t *)buf = t;
+		buf += 4;
+	} while (--longs);
+}
+/* The four core functions - F1 is optimized somewhat */
+
+/* #define F1(x, y, z) (x & y | ~x & z) */
+#define F1(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
+#define F2(x, y, z) F1(z, x, y)
+#define F3(x, y, z) ((x) ^ (y) ^ (z))
+#define F4(x, y, z) ((y) ^ ((x) | ~(z)))
+
+/* This is the central step in the MD5 algorithm. */
+#define MD5STEP(f, w, x, y, z, data, s) ((w) += f(x, y, z) + (data), (w) = (w) << (s) | (w) >> (32 - (s)), (w) += (x))
+
+/*
+ * The core of the MD5 algorithm, this alters an existing MD5 hash to
+ * reflect the addition of 16 longwords of new data.  MD5Update blocks
+ * the data and converts bytes into longwords for this routine.
+ */
+static void MD5Transform(uint32_t buf[4], const uint32_t in[16]) {
+	uint32_t a, b, c, d;
+
+	a = buf[0];
+	b = buf[1];
+	c = buf[2];
+	d = buf[3];
+
+	MD5STEP(F1, a, b, c, d, in[0] + 0xd76aa478, 7);
+	MD5STEP(F1, d, a, b, c, in[1] + 0xe8c7b756, 12);
+	MD5STEP(F1, c, d, a, b, in[2] + 0x242070db, 17);
+	MD5STEP(F1, b, c, d, a, in[3] + 0xc1bdceee, 22);
+	MD5STEP(F1, a, b, c, d, in[4] + 0xf57c0faf, 7);
+	MD5STEP(F1, d, a, b, c, in[5] + 0x4787c62a, 12);
+	MD5STEP(F1, c, d, a, b, in[6] + 0xa8304613, 17);
+	MD5STEP(F1, b, c, d, a, in[7] + 0xfd469501, 22);
+	MD5STEP(F1, a, b, c, d, in[8] + 0x698098d8, 7);
+	MD5STEP(F1, d, a, b, c, in[9] + 0x8b44f7af, 12);
+	MD5STEP(F1, c, d, a, b, in[10] + 0xffff5bb1, 17);
+	MD5STEP(F1, b, c, d, a, in[11] + 0x895cd7be, 22);
+	MD5STEP(F1, a, b, c, d, in[12] + 0x6b901122, 7);
+	MD5STEP(F1, d, a, b, c, in[13] + 0xfd987193, 12);
+	MD5STEP(F1, c, d, a, b, in[14] + 0xa679438e, 17);
+	MD5STEP(F1, b, c, d, a, in[15] + 0x49b40821, 22);
+
+	MD5STEP(F2, a, b, c, d, in[1] + 0xf61e2562, 5);
+	MD5STEP(F2, d, a, b, c, in[6] + 0xc040b340, 9);
+	MD5STEP(F2, c, d, a, b, in[11] + 0x265e5a51, 14);
+	MD5STEP(F2, b, c, d, a, in[0] + 0xe9b6c7aa, 20);
+	MD5STEP(F2, a, b, c, d, in[5] + 0xd62f105d, 5);
+	MD5STEP(F2, d, a, b, c, in[10] + 0x02441453, 9);
+	MD5STEP(F2, c, d, a, b, in[15] + 0xd8a1e681, 14);
+	MD5STEP(F2, b, c, d, a, in[4] + 0xe7d3fbc8, 20);
+	MD5STEP(F2, a, b, c, d, in[9] + 0x21e1cde6, 5);
+	MD5STEP(F2, d, a, b, c, in[14] + 0xc33707d6, 9);
+	MD5STEP(F2, c, d, a, b, in[3] + 0xf4d50d87, 14);
+	MD5STEP(F2, b, c, d, a, in[8] + 0x455a14ed, 20);
+	MD5STEP(F2, a, b, c, d, in[13] + 0xa9e3e905, 5);
+	MD5STEP(F2, d, a, b, c, in[2] + 0xfcefa3f8, 9);
+	MD5STEP(F2, c, d, a, b, in[7] + 0x676f02d9, 14);
+	MD5STEP(F2, b, c, d, a, in[12] + 0x8d2a4c8a, 20);
+
+	MD5STEP(F3, a, b, c, d, in[5] + 0xfffa3942, 4);
+	MD5STEP(F3, d, a, b, c, in[8] + 0x8771f681, 11);
+	MD5STEP(F3, c, d, a, b, in[11] + 0x6d9d6122, 16);
+	MD5STEP(F3, b, c, d, a, in[14] + 0xfde5380c, 23);
+	MD5STEP(F3, a, b, c, d, in[1] + 0xa4beea44, 4);
+	MD5STEP(F3, d, a, b, c, in[4] + 0x4bdecfa9, 11);
+	MD5STEP(F3, c, d, a, b, in[7] + 0xf6bb4b60, 16);
+	MD5STEP(F3, b, c, d, a, in[10] + 0xbebfbc70, 23);
+	MD5STEP(F3, a, b, c, d, in[13] + 0x289b7ec6, 4);
+	MD5STEP(F3, d, a, b, c, in[0] + 0xeaa127fa, 11);
+	MD5STEP(F3, c, d, a, b, in[3] + 0xd4ef3085, 16);
+	MD5STEP(F3, b, c, d, a, in[6] + 0x04881d05, 23);
+	MD5STEP(F3, a, b, c, d, in[9] + 0xd9d4d039, 4);
+	MD5STEP(F3, d, a, b, c, in[12] + 0xe6db99e5, 11);
+	MD5STEP(F3, c, d, a, b, in[15] + 0x1fa27cf8, 16);
+	MD5STEP(F3, b, c, d, a, in[2] + 0xc4ac5665, 23);
+
+	MD5STEP(F4, a, b, c, d, in[0] + 0xf4292244, 6);
+	MD5STEP(F4, d, a, b, c, in[7] + 0x432aff97, 10);
+	MD5STEP(F4, c, d, a, b, in[14] + 0xab9423a7, 15);
+	MD5STEP(F4, b, c, d, a, in[5] + 0xfc93a039, 21);
+	MD5STEP(F4, a, b, c, d, in[12] + 0x655b59c3, 6);
+	MD5STEP(F4, d, a, b, c, in[3] + 0x8f0ccc92, 10);
+	MD5STEP(F4, c, d, a, b, in[10] + 0xffeff47d, 15);
+	MD5STEP(F4, b, c, d, a, in[1] + 0x85845dd1, 21);
+	MD5STEP(F4, a, b, c, d, in[8] + 0x6fa87e4f, 6);
+	MD5STEP(F4, d, a, b, c, in[15] + 0xfe2ce6e0, 10);
+	MD5STEP(F4, c, d, a, b, in[6] + 0xa3014314, 15);
+	MD5STEP(F4, b, c, d, a, in[13] + 0x4e0811a1, 21);
+	MD5STEP(F4, a, b, c, d, in[4] + 0xf7537e82, 6);
+	MD5STEP(F4, d, a, b, c, in[11] + 0xbd3af235, 10);
+	MD5STEP(F4, c, d, a, b, in[2] + 0x2ad7d2bb, 15);
+	MD5STEP(F4, b, c, d, a, in[9] + 0xeb86d391, 21);
+
+	buf[0] += a;
+	buf[1] += b;
+	buf[2] += c;
+	buf[3] += d;
+}
+
+/*
+ * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
+ * initialization constants.
+ */
+MD5Context::MD5Context() {
+	buf[0] = 0x67452301;
+	buf[1] = 0xefcdab89;
+	buf[2] = 0x98badcfe;
+	buf[3] = 0x10325476;
+	bits[0] = 0;
+	bits[1] = 0;
+}
+
+/*
+ * Update context to reflect the concatenation of another buffer full
+ * of bytes.
+ */
+void MD5Context::MD5Update(const_data_ptr_t input, idx_t len) {
+	uint32_t t;
+
+	/* Update bitcount */
+
+	t = bits[0];
+	if ((bits[0] = t + ((uint32_t)len << 3)) < t) {
+		bits[1]++; /* Carry from low to high */
+	}
+	bits[1] += len >> 29;
+
+	t = (t >> 3) & 0x3f; /* Bytes already in shsInfo->data */
+
+	/* Handle any leading odd-sized chunks */
+
+	if (t) {
+		unsigned char *p = (unsigned char *)in + t;
+
+		t = 64 - t;
+		if (len < t) {
+			memcpy(p, input, len);
+			return;
+		}
+		memcpy(p, input, t);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+		input += t;
+		len -= t;
+	}
+
+	/* Process data in 64-byte chunks */
+
+	while (len >= 64) {
+		memcpy(in, input, 64);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+		input += 64;
+		len -= 64;
+	}
+
+	/* Handle any remaining bytes of data. */
+	memcpy(in, input, len);
+}
+
+/*
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
+ * 1 0* (64-bit count of bits processed, MSB-first)
+ */
+void MD5Context::Finish(data_ptr_t out_digest) {
+	unsigned count;
+	unsigned char *p;
+
+	/* Compute number of bytes mod 64 */
+	count = (bits[0] >> 3) & 0x3F;
+
+	/* Set the first char of padding to 0x80.  This is safe since there is
+	   always at least one byte free */
+	p = in + count;
+	*p++ = 0x80;
+
+	/* Bytes of padding needed to make 64 bytes */
+	count = 64 - 1 - count;
+
+	/* Pad out to 56 mod 64 */
+	if (count < 8) {
+		/* Two lots of padding:  Pad the first block to 64 bytes */
+		memset(p, 0, count);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+
+		/* Now fill the next block with 56 bytes */
+		memset(in, 0, 56);
+	} else {
+		/* Pad block to 56 bytes */
+		memset(p, 0, count - 8);
+	}
+	ByteReverse(in, 14);
+
+	/* Append length in bits and transform */
+	((uint32_t *)in)[14] = bits[0];
+	((uint32_t *)in)[15] = bits[1];
+
+	MD5Transform(buf, (uint32_t *)in);
+	ByteReverse((unsigned char *)buf, 4);
+	memcpy(out_digest, buf, 16);
+}
+
+void MD5Context::DigestToBase16(const_data_ptr_t digest, char *zbuf) {
+	static char const HEX_CODES[] = "0123456789abcdef";
+	int i, j;
+
+	for (j = i = 0; i < 16; i++) {
+		int a = digest[i];
+		zbuf[j++] = HEX_CODES[(a >> 4) & 0xf];
+		zbuf[j++] = HEX_CODES[a & 0xf];
+	}
+}
+
+void MD5Context::FinishHex(char *out_digest) {
+	data_t digest[MD5_HASH_LENGTH_BINARY];
+	Finish(digest);
+	DigestToBase16(digest, out_digest);
+}
+
+string MD5Context::FinishHex() {
+	char digest[MD5_HASH_LENGTH_TEXT];
+	FinishHex(digest);
+	return string(digest, MD5_HASH_LENGTH_TEXT);
+}
+
+void MD5Context::Add(const char *data) {
+	MD5Update((const_data_ptr_t)data, strlen(data));
+}
+
+} // namespace duckdb
+// This file is licensed under Apache License 2.0
+// Source code taken from https://github.com/google/benchmark
+// It is highly modified
+
+
+
+
+namespace duckdb {
+
+inline uint64_t ChronoNow() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
+	           std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now())
+	               .time_since_epoch())
+	    .count();
+}
+
+inline uint64_t Now() {
+#if defined(RDTSC)
+#if defined(__i386__)
+	uint64_t ret;
+	__asm__ volatile("rdtsc" : "=A"(ret));
+	return ret;
+#elif defined(__x86_64__) || defined(__amd64__)
+	uint64_t low, high;
+	__asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+	return (high << 32) | low;
+#elif defined(__powerpc__) || defined(__ppc__)
+	uint64_t tbl, tbu0, tbu1;
+	asm("mftbu %0" : "=r"(tbu0));
+	asm("mftb  %0" : "=r"(tbl));
+	asm("mftbu %0" : "=r"(tbu1));
+	tbl &= -static_cast<int64>(tbu0 == tbu1);
+	return (tbu1 << 32) | tbl;
+#elif defined(__sparc__)
+	uint64_t tick;
+	asm(".byte 0x83, 0x41, 0x00, 0x00");
+	asm("mov   %%g1, %0" : "=r"(tick));
+	return tick;
+#elif defined(__ia64__)
+	uint64_t itc;
+	asm("mov %0 = ar.itc" : "=r"(itc));
+	return itc;
+#elif defined(COMPILER_MSVC) && defined(_M_IX86)
+	_asm rdtsc
+#elif defined(COMPILER_MSVC)
+	return __rdtsc();
+#elif defined(__aarch64__)
+	uint64_t virtual_timer_value;
+	asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
+	return virtual_timer_value;
+#elif defined(__ARM_ARCH)
+#if (__ARM_ARCH >= 6)
+	uint32_t pmccntr;
+	uint32_t pmuseren;
+	uint32_t pmcntenset;
+	asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
+	if (pmuseren & 1) { // Allows reading perfmon counters for user mode code.
+		asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
+		if (pmcntenset & 0x80000000ul) { // Is it counting?
+			asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
+			return static_cast<uint64_t>(pmccntr) * 64; // Should optimize to << 6
+		}
+	}
+#endif
+	return ChronoNow();
+#else
+	return ChronoNow();
+#endif
+#else
+	return ChronoNow();
+#endif // defined(RDTSC)
+}
+uint64_t CycleCounter::Tick() const {
+	return Now();
+}
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string CatalogTypeToString(CatalogType type) {
+	switch (type) {
+	case CatalogType::COLLATION_ENTRY:
+		return "Collation";
+	case CatalogType::TYPE_ENTRY:
+		return "Type";
+	case CatalogType::TABLE_ENTRY:
+		return "Table";
+	case CatalogType::SCHEMA_ENTRY:
+		return "Schema";
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+		return "Table Function";
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		return "Scalar Function";
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+		return "Aggregate Function";
+	case CatalogType::COPY_FUNCTION_ENTRY:
+		return "Copy Function";
+	case CatalogType::PRAGMA_FUNCTION_ENTRY:
+		return "Pragma Function";
+	case CatalogType::MACRO_ENTRY:
+		return "Macro Function";
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return "Table Macro Function";
+	case CatalogType::VIEW_ENTRY:
+		return "View";
+	case CatalogType::INDEX_ENTRY:
+		return "Index";
+	case CatalogType::PREPARED_STATEMENT:
+		return "Prepared Statement";
+	case CatalogType::SEQUENCE_ENTRY:
+		return "Sequence";
+	case CatalogType::INVALID:
+	case CatalogType::DELETED_ENTRY:
+	case CatalogType::UPDATED_ENTRY:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+CompressionType CompressionTypeFromString(const string &str) {
+	auto compression = StringUtil::Lower(str);
+	if (compression == "uncompressed") {
+		return CompressionType::COMPRESSION_UNCOMPRESSED;
+	} else if (compression == "rle") {
+		return CompressionType::COMPRESSION_RLE;
+	} else if (compression == "dictionary") {
+		return CompressionType::COMPRESSION_DICTIONARY;
+	} else if (compression == "pfor") {
+		return CompressionType::COMPRESSION_PFOR_DELTA;
+	} else if (compression == "bitpacking") {
+		return CompressionType::COMPRESSION_BITPACKING;
+	} else if (compression == "fsst") {
+		return CompressionType::COMPRESSION_FSST;
+	} else {
+		return CompressionType::COMPRESSION_AUTO;
+	}
+}
+
+string CompressionTypeToString(CompressionType type) {
+	switch (type) {
+	case CompressionType::COMPRESSION_UNCOMPRESSED:
+		return "Uncompressed";
+	case CompressionType::COMPRESSION_CONSTANT:
+		return "Constant";
+	case CompressionType::COMPRESSION_RLE:
+		return "RLE";
+	case CompressionType::COMPRESSION_DICTIONARY:
+		return "Dictionary";
+	case CompressionType::COMPRESSION_PFOR_DELTA:
+		return "PFOR";
+	case CompressionType::COMPRESSION_BITPACKING:
+		return "BitPacking";
+	case CompressionType::COMPRESSION_FSST:
+		return "FSST";
+	default:
+		throw InternalException("Unrecognized compression type!");
+	}
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string ExpressionTypeToString(ExpressionType type) {
+	switch (type) {
+	case ExpressionType::OPERATOR_CAST:
+		return "CAST";
+	case ExpressionType::OPERATOR_NOT:
+		return "NOT";
+	case ExpressionType::OPERATOR_IS_NULL:
+		return "IS_NULL";
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		return "IS_NOT_NULL";
+	case ExpressionType::COMPARE_EQUAL:
+		return "EQUAL";
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return "NOTEQUAL";
+	case ExpressionType::COMPARE_LESSTHAN:
+		return "LESSTHAN";
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return "GREATERTHAN";
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "LESSTHANOREQUALTO";
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return "GREATERTHANOREQUALTO";
+	case ExpressionType::COMPARE_IN:
+		return "IN";
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return "DISTINCT_FROM";
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return "NOT_DISTINCT_FROM";
+	case ExpressionType::CONJUNCTION_AND:
+		return "AND";
+	case ExpressionType::CONJUNCTION_OR:
+		return "OR";
+	case ExpressionType::VALUE_CONSTANT:
+		return "CONSTANT";
+	case ExpressionType::VALUE_PARAMETER:
+		return "PARAMETER";
+	case ExpressionType::VALUE_TUPLE:
+		return "TUPLE";
+	case ExpressionType::VALUE_TUPLE_ADDRESS:
+		return "TUPLE_ADDRESS";
+	case ExpressionType::VALUE_NULL:
+		return "NULL";
+	case ExpressionType::VALUE_VECTOR:
+		return "VECTOR";
+	case ExpressionType::VALUE_SCALAR:
+		return "SCALAR";
+	case ExpressionType::AGGREGATE:
+		return "AGGREGATE";
+	case ExpressionType::WINDOW_AGGREGATE:
+		return "WINDOW_AGGREGATE";
+	case ExpressionType::WINDOW_RANK:
+		return "RANK";
+	case ExpressionType::WINDOW_RANK_DENSE:
+		return "RANK_DENSE";
+	case ExpressionType::WINDOW_PERCENT_RANK:
+		return "PERCENT_RANK";
+	case ExpressionType::WINDOW_ROW_NUMBER:
+		return "ROW_NUMBER";
+	case ExpressionType::WINDOW_FIRST_VALUE:
+		return "FIRST_VALUE";
+	case ExpressionType::WINDOW_LAST_VALUE:
+		return "LAST_VALUE";
+	case ExpressionType::WINDOW_NTH_VALUE:
+		return "NTH_VALUE";
+	case ExpressionType::WINDOW_CUME_DIST:
+		return "CUME_DIST";
+	case ExpressionType::WINDOW_LEAD:
+		return "LEAD";
+	case ExpressionType::WINDOW_LAG:
+		return "LAG";
+	case ExpressionType::WINDOW_NTILE:
+		return "NTILE";
+	case ExpressionType::FUNCTION:
+		return "FUNCTION";
+	case ExpressionType::CASE_EXPR:
+		return "CASE";
+	case ExpressionType::OPERATOR_NULLIF:
+		return "NULLIF";
+	case ExpressionType::OPERATOR_COALESCE:
+		return "COALESCE";
+	case ExpressionType::ARRAY_EXTRACT:
+		return "ARRAY_EXTRACT";
+	case ExpressionType::ARRAY_SLICE:
+		return "ARRAY_SLICE";
+	case ExpressionType::STRUCT_EXTRACT:
+		return "STRUCT_EXTRACT";
+	case ExpressionType::SUBQUERY:
+		return "SUBQUERY";
+	case ExpressionType::STAR:
+		return "STAR";
+	case ExpressionType::PLACEHOLDER:
+		return "PLACEHOLDER";
+	case ExpressionType::COLUMN_REF:
+		return "COLUMN_REF";
+	case ExpressionType::FUNCTION_REF:
+		return "FUNCTION_REF";
+	case ExpressionType::TABLE_REF:
+		return "TABLE_REF";
+	case ExpressionType::CAST:
+		return "CAST";
+	case ExpressionType::COMPARE_NOT_IN:
+		return "COMPARE_NOT_IN";
+	case ExpressionType::COMPARE_BETWEEN:
+		return "COMPARE_BETWEEN";
+	case ExpressionType::COMPARE_NOT_BETWEEN:
+		return "COMPARE_NOT_BETWEEN";
+	case ExpressionType::VALUE_DEFAULT:
+		return "VALUE_DEFAULT";
+	case ExpressionType::BOUND_REF:
+		return "BOUND_REF";
+	case ExpressionType::BOUND_COLUMN_REF:
+		return "BOUND_COLUMN_REF";
+	case ExpressionType::BOUND_FUNCTION:
+		return "BOUND_FUNCTION";
+	case ExpressionType::BOUND_AGGREGATE:
+		return "BOUND_AGGREGATE";
+	case ExpressionType::GROUPING_FUNCTION:
+		return "GROUPING";
+	case ExpressionType::ARRAY_CONSTRUCTOR:
+		return "ARRAY_CONSTRUCTOR";
+	case ExpressionType::TABLE_STAR:
+		return "TABLE_STAR";
+	case ExpressionType::BOUND_UNNEST:
+		return "BOUND_UNNEST";
+	case ExpressionType::COLLATE:
+		return "COLLATE";
+	case ExpressionType::POSITIONAL_REFERENCE:
+		return "POSITIONAL_REFERENCE";
+	case ExpressionType::LAMBDA:
+		return "LAMBDA";
+	case ExpressionType::ARROW:
+		return "ARROW";
+	case ExpressionType::INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+string ExpressionTypeToOperator(ExpressionType type) {
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return "=";
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return "!=";
+	case ExpressionType::COMPARE_LESSTHAN:
+		return "<";
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return ">";
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "<=";
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return ">=";
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return "IS DISTINCT FROM";
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return "IS NOT DISTINCT FROM";
+	case ExpressionType::CONJUNCTION_AND:
+		return "AND";
+	case ExpressionType::CONJUNCTION_OR:
+		return "OR";
+	default:
+		return "";
+	}
+}
+
+ExpressionType NegateComparisionExpression(ExpressionType type) {
+	ExpressionType negated_type = ExpressionType::INVALID;
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		negated_type = ExpressionType::COMPARE_NOTEQUAL;
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		negated_type = ExpressionType::COMPARE_EQUAL;
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		negated_type = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		negated_type = ExpressionType::COMPARE_LESSTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		negated_type = ExpressionType::COMPARE_GREATERTHAN;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		negated_type = ExpressionType::COMPARE_LESSTHAN;
+		break;
+	default:
+		throw InternalException("Unsupported comparison type in negation");
+	}
+	return negated_type;
+}
+
+ExpressionType FlipComparisionExpression(ExpressionType type) {
+	ExpressionType flipped_type = ExpressionType::INVALID;
+	switch (type) {
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_EQUAL:
+		flipped_type = type;
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		flipped_type = ExpressionType::COMPARE_GREATERTHAN;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		flipped_type = ExpressionType::COMPARE_LESSTHAN;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		flipped_type = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		flipped_type = ExpressionType::COMPARE_LESSTHANOREQUALTO;
+		break;
+	default:
+		throw InternalException("Unsupported comparison type in flip");
+	}
+	return flipped_type;
+}
+
+ExpressionType OperatorToExpressionType(const string &op) {
+	if (op == "=" || op == "==") {
+		return ExpressionType::COMPARE_EQUAL;
+	} else if (op == "!=" || op == "<>") {
+		return ExpressionType::COMPARE_NOTEQUAL;
+	} else if (op == "<") {
+		return ExpressionType::COMPARE_LESSTHAN;
+	} else if (op == ">") {
+		return ExpressionType::COMPARE_GREATERTHAN;
+	} else if (op == "<=") {
+		return ExpressionType::COMPARE_LESSTHANOREQUALTO;
+	} else if (op == ">=") {
+		return ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+	}
+	return ExpressionType::INVALID;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+FileCompressionType FileCompressionTypeFromString(const string &input) {
+	auto parameter = StringUtil::Lower(input);
+	if (parameter == "infer" || parameter == "auto") {
+		return FileCompressionType::AUTO_DETECT;
+	} else if (parameter == "gzip") {
+		return FileCompressionType::GZIP;
+	} else if (parameter == "zstd") {
+		return FileCompressionType::ZSTD;
+	} else if (parameter == "uncompressed" || parameter == "none" || parameter.empty()) {
+		return FileCompressionType::UNCOMPRESSED;
+	} else {
+		throw ParserException("Unrecognized file compression type \"%s\"", input);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+string JoinTypeToString(JoinType type) {
+	switch (type) {
+	case JoinType::LEFT:
+		return "LEFT";
+	case JoinType::RIGHT:
+		return "RIGHT";
+	case JoinType::INNER:
+		return "INNER";
+	case JoinType::OUTER:
+		return "FULL";
+	case JoinType::SEMI:
+		return "SEMI";
+	case JoinType::ANTI:
+		return "ANTI";
+	case JoinType::SINGLE:
+		return "SINGLE";
+	case JoinType::MARK:
+		return "MARK";
+	case JoinType::INVALID: // LCOV_EXCL_START
+		break;
+	}
+	return "INVALID";
+} // LCOV_EXCL_STOP
+
+bool IsLeftOuterJoin(JoinType type) {
+	return type == JoinType::LEFT || type == JoinType::OUTER;
+}
+
+bool IsRightOuterJoin(JoinType type) {
+	return type == JoinType::OUTER || type == JoinType::RIGHT;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Value <--> String Utilities
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+string LogicalOperatorToString(LogicalOperatorType type) {
+	switch (type) {
+	case LogicalOperatorType::LOGICAL_GET:
+		return "GET";
+	case LogicalOperatorType::LOGICAL_CHUNK_GET:
+		return "CHUNK_GET";
+	case LogicalOperatorType::LOGICAL_DELIM_GET:
+		return "DELIM_GET";
+	case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
+		return "EMPTY_RESULT";
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
+		return "EXPRESSION_GET";
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		return "ANY_JOIN";
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		return "COMPARISON_JOIN";
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return "DELIM_JOIN";
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return "PROJECTION";
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return "FILTER";
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return "AGGREGATE";
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return "WINDOW";
+	case LogicalOperatorType::LOGICAL_UNNEST:
+		return "UNNEST";
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return "LIMIT";
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return "ORDER_BY";
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		return "TOP_N";
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		return "SAMPLE";
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT:
+		return "LIMIT_PERCENT";
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
+		return "COPY_TO_FILE";
+	case LogicalOperatorType::LOGICAL_JOIN:
+		return "JOIN";
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return "CROSS_PRODUCT";
+	case LogicalOperatorType::LOGICAL_UNION:
+		return "UNION";
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+		return "EXCEPT";
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return "INTERSECT";
+	case LogicalOperatorType::LOGICAL_INSERT:
+		return "INSERT";
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return "DISTINCT";
+	case LogicalOperatorType::LOGICAL_DELETE:
+		return "DELETE";
+	case LogicalOperatorType::LOGICAL_UPDATE:
+		return "UPDATE";
+	case LogicalOperatorType::LOGICAL_PREPARE:
+		return "PREPARE";
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+		return "DUMMY_SCAN";
+	case LogicalOperatorType::LOGICAL_CREATE_INDEX:
+		return "CREATE_INDEX";
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return "CREATE_TABLE";
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+		return "CREATE_MACRO";
+	case LogicalOperatorType::LOGICAL_EXPLAIN:
+		return "EXPLAIN";
+	case LogicalOperatorType::LOGICAL_EXECUTE:
+		return "EXECUTE";
+	case LogicalOperatorType::LOGICAL_VACUUM:
+		return "VACUUM";
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+		return "REC_CTE";
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		return "CTE_SCAN";
+	case LogicalOperatorType::LOGICAL_SHOW:
+		return "SHOW";
+	case LogicalOperatorType::LOGICAL_ALTER:
+		return "ALTER";
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return "CREATE_TYPE";
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+		return "CREATE_VIEW";
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case LogicalOperatorType::LOGICAL_DROP:
+		return "DROP";
+	case LogicalOperatorType::LOGICAL_PRAGMA:
+		return "PRAGMA";
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+		return "TRANSACTION";
+	case LogicalOperatorType::LOGICAL_EXPORT:
+		return "EXPORT";
+	case LogicalOperatorType::LOGICAL_SET:
+		return "SET";
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return "LOAD";
+	case LogicalOperatorType::LOGICAL_INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultOptimizerType {
+	const char *name;
+	OptimizerType type;
+};
+
+static DefaultOptimizerType internal_optimizer_types[] = {
+    {"expression_rewriter", OptimizerType::EXPRESSION_REWRITER},
+    {"filter_pullup", OptimizerType::FILTER_PULLUP},
+    {"filter_pushdown", OptimizerType::FILTER_PUSHDOWN},
+    {"regex_range", OptimizerType::REGEX_RANGE},
+    {"in_clause", OptimizerType::IN_CLAUSE},
+    {"join_order", OptimizerType::JOIN_ORDER},
+    {"deliminator", OptimizerType::DELIMINATOR},
+    {"unused_columns", OptimizerType::UNUSED_COLUMNS},
+    {"statistics_propagation", OptimizerType::STATISTICS_PROPAGATION},
+    {"common_subexpressions", OptimizerType::COMMON_SUBEXPRESSIONS},
+    {"common_aggregate", OptimizerType::COMMON_AGGREGATE},
+    {"column_lifetime", OptimizerType::COLUMN_LIFETIME},
+    {"top_n", OptimizerType::TOP_N},
+    {"reorder_filter", OptimizerType::REORDER_FILTER},
+    {nullptr, OptimizerType::INVALID}};
+
+string OptimizerTypeToString(OptimizerType type) {
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		if (internal_optimizer_types[i].type == type) {
+			return internal_optimizer_types[i].name;
+		}
+	}
+	throw InternalException("Invalid optimizer type");
+}
+
+OptimizerType OptimizerTypeFromString(const string &str) {
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		if (internal_optimizer_types[i].name == str) {
+			return internal_optimizer_types[i].type;
+		}
+	}
+	// optimizer not found, construct candidate list
+	vector<string> optimizer_names;
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		optimizer_names.emplace_back(internal_optimizer_types[i].name);
+	}
+	throw ParserException("Optimizer type \"%s\" not recognized\n%s", str,
+	                      StringUtil::CandidatesErrorMessage(optimizer_names, str, "Candidate optimizers"));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string PhysicalOperatorToString(PhysicalOperatorType type) {
+	switch (type) {
+	case PhysicalOperatorType::TABLE_SCAN:
+		return "TABLE_SCAN";
+	case PhysicalOperatorType::DUMMY_SCAN:
+		return "DUMMY_SCAN";
+	case PhysicalOperatorType::CHUNK_SCAN:
+		return "CHUNK_SCAN";
+	case PhysicalOperatorType::DELIM_SCAN:
+		return "DELIM_SCAN";
+	case PhysicalOperatorType::ORDER_BY:
+		return "ORDER_BY";
+	case PhysicalOperatorType::LIMIT:
+		return "LIMIT";
+	case PhysicalOperatorType::LIMIT_PERCENT:
+		return "LIMIT_PERCENT";
+	case PhysicalOperatorType::STREAMING_LIMIT:
+		return "STREAMING_LIMIT";
+	case PhysicalOperatorType::RESERVOIR_SAMPLE:
+		return "RESERVOIR_SAMPLE";
+	case PhysicalOperatorType::STREAMING_SAMPLE:
+		return "STREAMING_SAMPLE";
+	case PhysicalOperatorType::TOP_N:
+		return "TOP_N";
+	case PhysicalOperatorType::WINDOW:
+		return "WINDOW";
+	case PhysicalOperatorType::STREAMING_WINDOW:
+		return "STREAMING_WINDOW";
+	case PhysicalOperatorType::UNNEST:
+		return "UNNEST";
+	case PhysicalOperatorType::SIMPLE_AGGREGATE:
+		return "SIMPLE_AGGREGATE";
+	case PhysicalOperatorType::HASH_GROUP_BY:
+		return "HASH_GROUP_BY";
+	case PhysicalOperatorType::PERFECT_HASH_GROUP_BY:
+		return "PERFECT_HASH_GROUP_BY";
+	case PhysicalOperatorType::FILTER:
+		return "FILTER";
+	case PhysicalOperatorType::PROJECTION:
+		return "PROJECTION";
+	case PhysicalOperatorType::COPY_TO_FILE:
+		return "COPY_TO_FILE";
+	case PhysicalOperatorType::DELIM_JOIN:
+		return "DELIM_JOIN";
+	case PhysicalOperatorType::BLOCKWISE_NL_JOIN:
+		return "BLOCKWISE_NL_JOIN";
+	case PhysicalOperatorType::NESTED_LOOP_JOIN:
+		return "NESTED_LOOP_JOIN";
+	case PhysicalOperatorType::HASH_JOIN:
+		return "HASH_JOIN";
+	case PhysicalOperatorType::INDEX_JOIN:
+		return "INDEX_JOIN";
+	case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:
+		return "PIECEWISE_MERGE_JOIN";
+	case PhysicalOperatorType::IE_JOIN:
+		return "IE_JOIN";
+	case PhysicalOperatorType::CROSS_PRODUCT:
+		return "CROSS_PRODUCT";
+	case PhysicalOperatorType::UNION:
+		return "UNION";
+	case PhysicalOperatorType::INSERT:
+		return "INSERT";
+	case PhysicalOperatorType::DELETE_OPERATOR:
+		return "DELETE";
+	case PhysicalOperatorType::UPDATE:
+		return "UPDATE";
+	case PhysicalOperatorType::EMPTY_RESULT:
+		return "EMPTY_RESULT";
+	case PhysicalOperatorType::CREATE_TABLE:
+		return "CREATE_TABLE";
+	case PhysicalOperatorType::CREATE_TABLE_AS:
+		return "CREATE_TABLE_AS";
+	case PhysicalOperatorType::CREATE_INDEX:
+		return "CREATE_INDEX";
+	case PhysicalOperatorType::EXPLAIN:
+		return "EXPLAIN";
+	case PhysicalOperatorType::EXPLAIN_ANALYZE:
+		return "EXPLAIN_ANALYZE";
+	case PhysicalOperatorType::EXECUTE:
+		return "EXECUTE";
+	case PhysicalOperatorType::VACUUM:
+		return "VACUUM";
+	case PhysicalOperatorType::RECURSIVE_CTE:
+		return "REC_CTE";
+	case PhysicalOperatorType::RECURSIVE_CTE_SCAN:
+		return "REC_CTE_SCAN";
+	case PhysicalOperatorType::EXPRESSION_SCAN:
+		return "EXPRESSION_SCAN";
+	case PhysicalOperatorType::ALTER:
+		return "ALTER";
+	case PhysicalOperatorType::CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case PhysicalOperatorType::CREATE_VIEW:
+		return "CREATE_VIEW";
+	case PhysicalOperatorType::CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case PhysicalOperatorType::CREATE_MACRO:
+		return "CREATE_MACRO";
+	case PhysicalOperatorType::DROP:
+		return "DROP";
+	case PhysicalOperatorType::PRAGMA:
+		return "PRAGMA";
+	case PhysicalOperatorType::TRANSACTION:
+		return "TRANSACTION";
+	case PhysicalOperatorType::PREPARE:
+		return "PREPARE";
+	case PhysicalOperatorType::EXPORT:
+		return "EXPORT";
+	case PhysicalOperatorType::SET:
+		return "SET";
+	case PhysicalOperatorType::LOAD:
+		return "LOAD";
+	case PhysicalOperatorType::INOUT_FUNCTION:
+		return "INOUT_FUNCTION";
+	case PhysicalOperatorType::CREATE_TYPE:
+		return "CREATE_TYPE";
+	case PhysicalOperatorType::RESULT_COLLECTOR:
+		return "RESULT_COLLECTOR";
+	case PhysicalOperatorType::INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string RelationTypeToString(RelationType type) {
+	switch (type) {
+	case RelationType::TABLE_RELATION:
+		return "TABLE_RELATION";
+	case RelationType::PROJECTION_RELATION:
+		return "PROJECTION_RELATION";
+	case RelationType::FILTER_RELATION:
+		return "FILTER_RELATION";
+	case RelationType::EXPLAIN_RELATION:
+		return "EXPLAIN_RELATION";
+	case RelationType::CROSS_PRODUCT_RELATION:
+		return "CROSS_PRODUCT_RELATION";
+	case RelationType::JOIN_RELATION:
+		return "JOIN_RELATION";
+	case RelationType::AGGREGATE_RELATION:
+		return "AGGREGATE_RELATION";
+	case RelationType::SET_OPERATION_RELATION:
+		return "SET_OPERATION_RELATION";
+	case RelationType::DISTINCT_RELATION:
+		return "DISTINCT_RELATION";
+	case RelationType::LIMIT_RELATION:
+		return "LIMIT_RELATION";
+	case RelationType::ORDER_RELATION:
+		return "ORDER_RELATION";
+	case RelationType::CREATE_VIEW_RELATION:
+		return "CREATE_VIEW_RELATION";
+	case RelationType::CREATE_TABLE_RELATION:
+		return "CREATE_TABLE_RELATION";
+	case RelationType::INSERT_RELATION:
+		return "INSERT_RELATION";
+	case RelationType::VALUE_LIST_RELATION:
+		return "VALUE_LIST_RELATION";
+	case RelationType::DELETE_RELATION:
+		return "DELETE_RELATION";
+	case RelationType::UPDATE_RELATION:
+		return "UPDATE_RELATION";
+	case RelationType::WRITE_CSV_RELATION:
+		return "WRITE_CSV_RELATION";
+	case RelationType::READ_CSV_RELATION:
+		return "READ_CSV_RELATION";
+	case RelationType::SUBQUERY_RELATION:
+		return "SUBQUERY_RELATION";
+	case RelationType::TABLE_FUNCTION_RELATION:
+		return "TABLE_FUNCTION_RELATION";
+	case RelationType::VIEW_RELATION:
+		return "VIEW_RELATION";
+	case RelationType::QUERY_RELATION:
+		return "QUERY_RELATION";
+	case RelationType::INVALID_RELATION:
+		break;
+	}
+	return "INVALID_RELATION";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string StatementTypeToString(StatementType type) {
+	switch (type) {
+	case StatementType::SELECT_STATEMENT:
+		return "SELECT";
+	case StatementType::INSERT_STATEMENT:
+		return "INSERT";
+	case StatementType::UPDATE_STATEMENT:
+		return "UPDATE";
+	case StatementType::DELETE_STATEMENT:
+		return "DELETE";
+	case StatementType::PREPARE_STATEMENT:
+		return "PREPARE";
+	case StatementType::EXECUTE_STATEMENT:
+		return "EXECUTE";
+	case StatementType::ALTER_STATEMENT:
+		return "ALTER";
+	case StatementType::TRANSACTION_STATEMENT:
+		return "TRANSACTION";
+	case StatementType::COPY_STATEMENT:
+		return "COPY";
+	case StatementType::ANALYZE_STATEMENT:
+		return "ANALYZE";
+	case StatementType::VARIABLE_SET_STATEMENT:
+		return "VARIABLE_SET";
+	case StatementType::CREATE_FUNC_STATEMENT:
+		return "CREATE_FUNC";
+	case StatementType::EXPLAIN_STATEMENT:
+		return "EXPLAIN";
+	case StatementType::CREATE_STATEMENT:
+		return "CREATE";
+	case StatementType::DROP_STATEMENT:
+		return "DROP";
+	case StatementType::PRAGMA_STATEMENT:
+		return "PRAGMA";
+	case StatementType::SHOW_STATEMENT:
+		return "SHOW";
+	case StatementType::VACUUM_STATEMENT:
+		return "VACUUM";
+	case StatementType::RELATION_STATEMENT:
+		return "RELATION";
+	case StatementType::EXPORT_STATEMENT:
+		return "EXPORT";
+	case StatementType::CALL_STATEMENT:
+		return "CALL";
+	case StatementType::SET_STATEMENT:
+		return "SET";
+	case StatementType::LOAD_STATEMENT:
+		return "LOAD";
+	case StatementType::INVALID_STATEMENT:
+		break;
+	}
+	return "INVALID";
+}
+
+string StatementReturnTypeToString(StatementReturnType type) {
+	switch (type) {
+	case StatementReturnType::QUERY_RESULT:
+		return "QUERY_RESULT";
+	case StatementReturnType::CHANGED_ROWS:
+		return "CHANGED_ROWS";
+	case StatementReturnType::NOTHING:
+		return "NOTHING";
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+Exception::Exception(const string &msg) : std::exception(), type(ExceptionType::INVALID) {
+	exception_message_ = msg;
+}
+
+Exception::Exception(ExceptionType exception_type, const string &message) : std::exception(), type(exception_type) {
+	exception_message_ = ExceptionTypeToString(exception_type) + " Error: " + message;
+}
+
+const char *Exception::what() const noexcept {
+	return exception_message_.c_str();
+}
+
+bool Exception::UncaughtException() {
+#if __cplusplus >= 201703L
+	return std::uncaught_exceptions() > 0;
+#else
+	return std::uncaught_exception();
+#endif
+}
+
+string Exception::ConstructMessageRecursive(const string &msg, vector<ExceptionFormatValue> &values) {
+	return ExceptionFormatValue::Format(msg, values);
+}
+
+string Exception::ExceptionTypeToString(ExceptionType type) {
+	switch (type) {
+	case ExceptionType::INVALID:
+		return "Invalid";
+	case ExceptionType::OUT_OF_RANGE:
+		return "Out of Range";
+	case ExceptionType::CONVERSION:
+		return "Conversion";
+	case ExceptionType::UNKNOWN_TYPE:
+		return "Unknown Type";
+	case ExceptionType::DECIMAL:
+		return "Decimal";
+	case ExceptionType::MISMATCH_TYPE:
+		return "Mismatch Type";
+	case ExceptionType::DIVIDE_BY_ZERO:
+		return "Divide by Zero";
+	case ExceptionType::OBJECT_SIZE:
+		return "Object Size";
+	case ExceptionType::INVALID_TYPE:
+		return "Invalid type";
+	case ExceptionType::SERIALIZATION:
+		return "Serialization";
+	case ExceptionType::TRANSACTION:
+		return "TransactionContext";
+	case ExceptionType::NOT_IMPLEMENTED:
+		return "Not implemented";
+	case ExceptionType::EXPRESSION:
+		return "Expression";
+	case ExceptionType::CATALOG:
+		return "Catalog";
+	case ExceptionType::PARSER:
+		return "Parser";
+	case ExceptionType::BINDER:
+		return "Binder";
+	case ExceptionType::PLANNER:
+		return "Planner";
+	case ExceptionType::SCHEDULER:
+		return "Scheduler";
+	case ExceptionType::EXECUTOR:
+		return "Executor";
+	case ExceptionType::CONSTRAINT:
+		return "Constraint";
+	case ExceptionType::INDEX:
+		return "Index";
+	case ExceptionType::STAT:
+		return "Stat";
+	case ExceptionType::CONNECTION:
+		return "Connection";
+	case ExceptionType::SYNTAX:
+		return "Syntax";
+	case ExceptionType::SETTINGS:
+		return "Settings";
+	case ExceptionType::OPTIMIZER:
+		return "Optimizer";
+	case ExceptionType::NULL_POINTER:
+		return "NullPointer";
+	case ExceptionType::IO:
+		return "IO";
+	case ExceptionType::INTERRUPT:
+		return "INTERRUPT";
+	case ExceptionType::FATAL:
+		return "FATAL";
+	case ExceptionType::INTERNAL:
+		return "INTERNAL";
+	case ExceptionType::INVALID_INPUT:
+		return "Invalid Input";
+	case ExceptionType::OUT_OF_MEMORY:
+		return "Out of Memory";
+	case ExceptionType::PERMISSION:
+		return "Permission";
+	default:
+		return "Unknown";
+	}
+}
+
+StandardException::StandardException(ExceptionType exception_type, const string &message)
+    : Exception(exception_type, message) {
+}
+
+CastException::CastException(const PhysicalType orig_type, const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
+}
+
+CastException::CastException(const LogicalType &orig_type, const LogicalType &new_type)
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const int64_t value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " +
+                                               to_string((intmax_t)value) +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const double value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " + to_string(value) +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const hugeint_t value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " + value.ToString() +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const PhysicalType var_type, const idx_t length)
+    : Exception(ExceptionType::OUT_OF_RANGE,
+                "The value is too long to fit into type " + TypeIdToString(var_type) + "(" + to_string(length) + ")") {
+}
+
+ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
+}
+
+InvalidTypeException::InvalidTypeException(PhysicalType type, const string &msg)
+    : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + TypeIdToString(type) + "]: " + msg) {
+}
+
+InvalidTypeException::InvalidTypeException(const LogicalType &type, const string &msg)
+    : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + type.ToString() + "]: " + msg) {
+}
+
+TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg)
+    : Exception(ExceptionType::MISMATCH_TYPE,
+                "Type " + TypeIdToString(type_1) + " does not match with " + TypeIdToString(type_2) + ". " + msg) {
+}
+
+TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
+    : Exception(ExceptionType::MISMATCH_TYPE,
+                "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg) {
+}
+
+TransactionException::TransactionException(const string &msg) : Exception(ExceptionType::TRANSACTION, msg) {
+}
+
+NotImplementedException::NotImplementedException(const string &msg) : Exception(ExceptionType::NOT_IMPLEMENTED, msg) {
+}
+
+OutOfRangeException::OutOfRangeException(const string &msg) : Exception(ExceptionType::OUT_OF_RANGE, msg) {
+}
+
+CatalogException::CatalogException(const string &msg) : StandardException(ExceptionType::CATALOG, msg) {
+}
+
+ParserException::ParserException(const string &msg) : StandardException(ExceptionType::PARSER, msg) {
+}
+
+PermissionException::PermissionException(const string &msg) : StandardException(ExceptionType::PERMISSION, msg) {
+}
+
+SyntaxException::SyntaxException(const string &msg) : Exception(ExceptionType::SYNTAX, msg) {
+}
+
+ConstraintException::ConstraintException(const string &msg) : Exception(ExceptionType::CONSTRAINT, msg) {
+}
+
+BinderException::BinderException(const string &msg) : StandardException(ExceptionType::BINDER, msg) {
+}
+
+IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) {
+}
+
+SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {
+}
+
+SequenceException::SequenceException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {
+}
+
+InterruptException::InterruptException() : Exception(ExceptionType::INTERRUPT, "Interrupted!") {
+}
+
+FatalException::FatalException(const string &msg) : Exception(ExceptionType::FATAL, msg) {
+}
+
+InternalException::InternalException(const string &msg) : Exception(ExceptionType::INTERNAL, msg) {
+}
+
+InvalidInputException::InvalidInputException(const string &msg) : Exception(ExceptionType::INVALID_INPUT, msg) {
+}
+
+OutOfMemoryException::OutOfMemoryException(const string &msg) : Exception(ExceptionType::OUT_OF_MEMORY, msg) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ExceptionFormatValue::ExceptionFormatValue(double dbl_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE), dbl_val(dbl_val) {
+}
+ExceptionFormatValue::ExceptionFormatValue(int64_t int_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER), int_val(int_val) {
+}
+ExceptionFormatValue::ExceptionFormatValue(hugeint_t huge_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(Hugeint::ToString(huge_val)) {
+}
+ExceptionFormatValue::ExceptionFormatValue(string str_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(move(str_val)) {
+}
+
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value) {
+	return ExceptionFormatValue(TypeIdToString(value));
+}
+template <>
+ExceptionFormatValue
+ExceptionFormatValue::CreateFormatValue(LogicalType value) { // NOLINT: templating requires us to copy value here
+	return ExceptionFormatValue(value.ToString());
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value) {
+	return ExceptionFormatValue(double(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value) {
+	return ExceptionFormatValue(double(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value) {
+	return ExceptionFormatValue(move(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value) {
+	return ExceptionFormatValue(string(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value) {
+	return ExceptionFormatValue(string(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(hugeint_t value) {
+	return ExceptionFormatValue(value);
+}
+
+string ExceptionFormatValue::Format(const string &msg, vector<ExceptionFormatValue> &values) {
+	std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
+	for (auto &val : values) {
+		switch (val.type) {
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
+			break;
+		}
+	}
+	return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
+	                                     format_args.data(), static_cast<int>(format_args.size())));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Field Writer
+//===--------------------------------------------------------------------===//
+FieldWriter::FieldWriter(Serializer &serializer_p)
+    : serializer(serializer_p), buffer(make_unique<BufferedSerializer>()), field_count(0), finalized(false) {
+}
+
+FieldWriter::~FieldWriter() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	D_ASSERT(finalized);
+	// finalize should always have been called, unless this is destroyed as part of stack unwinding
+	D_ASSERT(!buffer);
+}
+
+void FieldWriter::WriteData(const_data_ptr_t buffer_ptr, idx_t write_size) {
+	D_ASSERT(buffer);
+	buffer->WriteData(buffer_ptr, write_size);
+}
+
+template <>
+void FieldWriter::Write(const string &val) {
+	Write<uint32_t>((uint32_t)val.size());
+	if (!val.empty()) {
+		WriteData((const_data_ptr_t)val.c_str(), val.size());
+	}
+}
+
+void FieldWriter::Finalize() {
+	D_ASSERT(buffer);
+	D_ASSERT(!finalized);
+	finalized = true;
+	serializer.Write<uint32_t>(field_count);
+	serializer.Write<uint64_t>(buffer->blob.size);
+	serializer.WriteData(buffer->blob.data.get(), buffer->blob.size);
+
+	buffer.reset();
+}
+
+//===--------------------------------------------------------------------===//
+// Field Deserializer
+//===--------------------------------------------------------------------===//
+FieldDeserializer::FieldDeserializer(Deserializer &root) : root(root), remaining_data(idx_t(-1)) {
+}
+
+void FieldDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
+	D_ASSERT(remaining_data != idx_t(-1));
+	D_ASSERT(read_size <= remaining_data);
+	root.ReadData(buffer, read_size);
+	remaining_data -= read_size;
+}
+
+idx_t FieldDeserializer::RemainingData() {
+	return remaining_data;
+}
+
+void FieldDeserializer::SetRemainingData(idx_t remaining_data) {
+	this->remaining_data = remaining_data;
+}
+
+//===--------------------------------------------------------------------===//
+// Field Reader
+//===--------------------------------------------------------------------===//
+FieldReader::FieldReader(Deserializer &source_p) : source(source_p), field_count(0), finalized(false) {
+	max_field_count = source_p.Read<uint32_t>();
+	total_size = source_p.Read<uint64_t>();
+	D_ASSERT(max_field_count > 0);
+	source.SetRemainingData(total_size);
+}
+
+FieldReader::~FieldReader() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	D_ASSERT(finalized);
+}
+
+void FieldReader::Finalize() {
+	D_ASSERT(!finalized);
+	finalized = true;
+	if (field_count < max_field_count) {
+		// we can handle this case by calling source.ReadData(buffer, source.RemainingData())
+		throw SerializationException("Not all fields were read. This file might have been written with a newer version "
+		                             "of DuckDB and is incompatible with this version of DuckDB.");
+	}
+	D_ASSERT(source.RemainingData() == 0);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+FileBuffer::FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz)
+    : allocator(allocator), type(type), malloced_buffer(nullptr) {
+	SetMallocedSize(bufsiz);
+	malloced_buffer = allocator.AllocateData(malloced_size);
+	Construct(bufsiz);
+}
+
+FileBuffer::FileBuffer(FileBuffer &source, FileBufferType type_p) : allocator(source.allocator), type(type_p) {
+	// take over the structures of the source buffer
+	buffer = source.buffer;
+	size = source.size;
+	internal_buffer = source.internal_buffer;
+	internal_size = source.internal_size;
+	malloced_buffer = source.malloced_buffer;
+	malloced_size = source.malloced_size;
+
+	source.buffer = nullptr;
+	source.size = 0;
+	source.internal_buffer = nullptr;
+	source.internal_size = 0;
+	source.malloced_buffer = nullptr;
+	source.malloced_size = 0;
+}
+
+FileBuffer::~FileBuffer() {
+	allocator.FreeData(malloced_buffer, malloced_size);
+}
+
+void FileBuffer::SetMallocedSize(uint64_t &bufsiz) {
+	// make room for the block header (if this is not the db file header)
+	if (type == FileBufferType::MANAGED_BUFFER && bufsiz != Storage::FILE_HEADER_SIZE) {
+		bufsiz += Storage::BLOCK_HEADER_SIZE;
+	}
+	if (type == FileBufferType::BLOCK) {
+		const int sector_size = Storage::SECTOR_SIZE;
+		// round up to the nearest sector_size
+		if (bufsiz % sector_size != 0) {
+			bufsiz += sector_size - (bufsiz % sector_size);
+		}
+		D_ASSERT(bufsiz % sector_size == 0);
+		D_ASSERT(bufsiz >= sector_size);
+		// we add (sector_size - 1) to ensure that we can align the buffer to sector_size
+		malloced_size = bufsiz + (sector_size - 1);
+	} else {
+		malloced_size = bufsiz;
+	}
+}
+
+void FileBuffer::Construct(uint64_t bufsiz) {
+	if (!malloced_buffer) {
+		throw std::bad_alloc();
+	}
+	if (type == FileBufferType::BLOCK) {
+		const int sector_size = Storage::SECTOR_SIZE;
+		// round to multiple of sector_size
+		uint64_t num = (uint64_t)malloced_buffer;
+		uint64_t remainder = num % sector_size;
+		if (remainder != 0) {
+			num = num + sector_size - remainder;
+		}
+		D_ASSERT(num % sector_size == 0);
+		D_ASSERT(num + bufsiz <= ((uint64_t)malloced_buffer + bufsiz + (sector_size - 1)));
+		D_ASSERT(num >= (uint64_t)malloced_buffer);
+		// construct the FileBuffer object
+		internal_buffer = (data_ptr_t)num;
+		internal_size = bufsiz;
+	} else {
+		internal_buffer = malloced_buffer;
+		internal_size = malloced_size;
+	}
+	buffer = internal_buffer + Storage::BLOCK_HEADER_SIZE;
+	size = internal_size - Storage::BLOCK_HEADER_SIZE;
+}
+
+void FileBuffer::Resize(uint64_t bufsiz) {
+	D_ASSERT(type == FileBufferType::MANAGED_BUFFER);
+	SetMallocedSize(bufsiz);
+	malloced_buffer = allocator.ReallocateData(malloced_buffer, malloced_size);
+	Construct(bufsiz);
+}
+
+void FileBuffer::Read(FileHandle &handle, uint64_t location) {
+	handle.Read(internal_buffer, internal_size, location);
+}
+
+void FileBuffer::ReadAndChecksum(FileHandle &handle, uint64_t location) {
+	// read the buffer from disk
+	Read(handle, location);
+	// compute the checksum
+	auto stored_checksum = Load<uint64_t>(internal_buffer);
+	uint64_t computed_checksum = Checksum(buffer, size);
+	// verify the checksum
+	if (stored_checksum != computed_checksum) {
+		throw IOException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block",
+		                  computed_checksum, stored_checksum);
+	}
+}
+
+void FileBuffer::Write(FileHandle &handle, uint64_t location) {
+	handle.Write(internal_buffer, internal_size, location);
+}
+
+void FileBuffer::ChecksumAndWrite(FileHandle &handle, uint64_t location) {
+	// compute the checksum and write it to the start of the buffer (if not temp buffer)
+	uint64_t checksum = Checksum(buffer, size);
+	Store<uint64_t>(checksum, internal_buffer);
+	// now write the buffer
+	Write(handle, location);
+}
+
+void FileBuffer::Clear() {
+	memset(internal_buffer, 0, internal_size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstdint>
+#include <cstdio>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
+#include <string>
+#include <sysinfoapi.h>
+
+#ifdef __MINGW32__
+// need to manually define this for mingw
+extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG);
+#endif
+
+#undef FILE_CREATE // woo mingw
+#endif
+
+namespace duckdb {
+
+FileSystem::~FileSystem() {
+}
+
+FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
+	return *context.db->config.file_system;
+}
+
+FileOpener *FileSystem::GetFileOpener(ClientContext &context) {
+	return ClientData::Get(context).file_opener.get();
+}
+
+#ifndef _WIN32
+string FileSystem::PathSeparator() {
+	return "/";
+}
+
+void FileSystem::SetWorkingDirectory(const string &path) {
+	if (chdir(path.c_str()) != 0) {
+		throw IOException("Could not change working directory!");
+	}
+}
+
+idx_t FileSystem::GetAvailableMemory() {
+	errno = 0;
+	idx_t max_memory = MinValue<idx_t>((idx_t)sysconf(_SC_PHYS_PAGES) * (idx_t)sysconf(_SC_PAGESIZE), UINTPTR_MAX);
+	if (errno != 0) {
+		return DConstants::INVALID_INDEX;
+	}
+	return max_memory;
+}
+
+string FileSystem::GetWorkingDirectory() {
+	auto buffer = unique_ptr<char[]>(new char[PATH_MAX]);
+	char *ret = getcwd(buffer.get(), PATH_MAX);
+	if (!ret) {
+		throw IOException("Could not get working directory!");
+	}
+	return string(buffer.get());
+}
+#else
+
+string FileSystem::PathSeparator() {
+	return "\\";
+}
+
+void FileSystem::SetWorkingDirectory(const string &path) {
+	if (!SetCurrentDirectory(path.c_str())) {
+		throw IOException("Could not change working directory!");
+	}
+}
+
+idx_t FileSystem::GetAvailableMemory() {
+	ULONGLONG available_memory_kb;
+	if (GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
+		return MinValue<idx_t>(available_memory_kb * 1024, UINTPTR_MAX);
+	}
+	// fallback: try GlobalMemoryStatusEx
+	MEMORYSTATUSEX mem_state;
+	mem_state.dwLength = sizeof(MEMORYSTATUSEX);
+
+	if (GlobalMemoryStatusEx(&mem_state)) {
+		return MinValue<idx_t>(mem_state.ullTotalPhys, UINTPTR_MAX);
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+string FileSystem::GetWorkingDirectory() {
+	idx_t count = GetCurrentDirectory(0, nullptr);
+	if (count == 0) {
+		throw IOException("Could not get working directory!");
+	}
+	auto buffer = unique_ptr<char[]>(new char[count]);
+	idx_t ret = GetCurrentDirectory(count, buffer.get());
+	if (count != ret + 1) {
+		throw IOException("Could not get working directory!");
+	}
+	return string(buffer.get(), ret);
+}
+
+#endif
+
+string FileSystem::JoinPath(const string &a, const string &b) {
+	// FIXME: sanitize paths
+	return a + PathSeparator() + b;
+}
+
+string FileSystem::ConvertSeparators(const string &path) {
+	auto separator_str = PathSeparator();
+	char separator = separator_str[0];
+	if (separator == '/') {
+		// on unix-based systems we only accept / as a separator
+		return path;
+	}
+	// on windows-based systems we accept both
+	string result = path;
+	for (idx_t i = 0; i < result.size(); i++) {
+		if (result[i] == '/') {
+			result[i] = separator;
+		}
+	}
+	return result;
+}
+
+string FileSystem::ExtractBaseName(const string &path) {
+	auto normalized_path = ConvertSeparators(path);
+	auto sep = PathSeparator();
+	auto vec = StringUtil::Split(StringUtil::Split(normalized_path, sep).back(), ".");
+	return vec[0];
+}
+
+string FileSystem::GetHomeDirectory() {
+#ifdef DUCKDB_WINDOWS
+	const char *homedir = getenv("USERPROFILE");
+#else
+	const char *homedir = getenv("HOME");
+#endif
+	if (homedir) {
+		return homedir;
+	}
+	return string();
+}
+
+// LCOV_EXCL_START
+unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
+                                            FileCompressionType compression, FileOpener *opener) {
+	throw NotImplementedException("%s: OpenFile is not implemented!", GetName());
+}
+
+void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
+}
+
+void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	throw NotImplementedException("%s: Write (with location) is not implemented!", GetName());
+}
+
+int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	throw NotImplementedException("%s: Read is not implemented!", GetName());
+}
+
+int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	throw NotImplementedException("%s: Write is not implemented!", GetName());
+}
+
+int64_t FileSystem::GetFileSize(FileHandle &handle) {
+	throw NotImplementedException("%s: GetFileSize is not implemented!", GetName());
+}
+
+time_t FileSystem::GetLastModifiedTime(FileHandle &handle) {
+	throw NotImplementedException("%s: GetLastModifiedTime is not implemented!", GetName());
+}
+
+FileType FileSystem::GetFileType(FileHandle &handle) {
+	return FileType::FILE_TYPE_INVALID;
+}
+
+void FileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	throw NotImplementedException("%s: Truncate is not implemented!", GetName());
+}
+
+bool FileSystem::DirectoryExists(const string &directory) {
+	throw NotImplementedException("%s: DirectoryExists is not implemented!", GetName());
+}
+
+void FileSystem::CreateDirectory(const string &directory) {
+	throw NotImplementedException("%s: CreateDirectory is not implemented!", GetName());
+}
+
+void FileSystem::RemoveDirectory(const string &directory) {
+	throw NotImplementedException("%s: RemoveDirectory is not implemented!", GetName());
+}
+
+bool FileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	throw NotImplementedException("%s: ListFiles is not implemented!", GetName());
+}
+
+void FileSystem::MoveFile(const string &source, const string &target) {
+	throw NotImplementedException("%s: MoveFile is not implemented!", GetName());
+}
+
+bool FileSystem::FileExists(const string &filename) {
+	throw NotImplementedException("%s: FileExists is not implemented!", GetName());
+}
+
+bool FileSystem::IsPipe(const string &filename) {
+	throw NotImplementedException("%s: IsPipe is not implemented!", GetName());
+}
+
+void FileSystem::RemoveFile(const string &filename) {
+	throw NotImplementedException("%s: RemoveFile is not implemented!", GetName());
+}
+
+void FileSystem::FileSync(FileHandle &handle) {
+	throw NotImplementedException("%s: FileSync is not implemented!", GetName());
+}
+
+vector<string> FileSystem::Glob(const string &path, FileOpener *opener) {
+	throw NotImplementedException("%s: Glob is not implemented!", GetName());
+}
+
+vector<string> FileSystem::Glob(const string &path, ClientContext &context) {
+	return Glob(path, GetFileOpener(context));
+}
+
+void FileSystem::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
+	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
+}
+
+void FileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> sub_fs) {
+	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
+}
+
+bool FileSystem::CanHandleFile(const string &fpath) {
+	throw NotImplementedException("%s: CanHandleFile is not implemented!", GetName());
+}
+
+void FileSystem::Seek(FileHandle &handle, idx_t location) {
+	throw NotImplementedException("%s: Seek is not implemented!", GetName());
+}
+
+void FileSystem::Reset(FileHandle &handle) {
+	handle.Seek(0);
+}
+
+idx_t FileSystem::SeekPosition(FileHandle &handle) {
+	throw NotImplementedException("%s: SeekPosition is not implemented!", GetName());
+}
+
+bool FileSystem::CanSeek() {
+	throw NotImplementedException("%s: CanSeek is not implemented!", GetName());
+}
+
+unique_ptr<FileHandle> FileSystem::OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) {
+	throw NotImplementedException("%s: OpenCompressedFile is not implemented!", GetName());
+}
+
+bool FileSystem::OnDiskFile(FileHandle &handle) {
+	throw NotImplementedException("%s: OnDiskFile is not implemented!", GetName());
+}
+// LCOV_EXCL_STOP
+
+FileHandle::FileHandle(FileSystem &file_system, string path_p) : file_system(file_system), path(move(path_p)) {
+}
+
+FileHandle::~FileHandle() {
+}
+
+int64_t FileHandle::Read(void *buffer, idx_t nr_bytes) {
+	return file_system.Read(*this, buffer, nr_bytes);
+}
+
+int64_t FileHandle::Write(void *buffer, idx_t nr_bytes) {
+	return file_system.Write(*this, buffer, nr_bytes);
+}
+
+void FileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
+	file_system.Read(*this, buffer, nr_bytes, location);
+}
+
+void FileHandle::Write(void *buffer, idx_t nr_bytes, idx_t location) {
+	file_system.Write(*this, buffer, nr_bytes, location);
+}
+
+void FileHandle::Seek(idx_t location) {
+	file_system.Seek(*this, location);
+}
+
+void FileHandle::Reset() {
+	file_system.Reset(*this);
+}
+
+idx_t FileHandle::SeekPosition() {
+	return file_system.SeekPosition(*this);
+}
+
+bool FileHandle::CanSeek() {
+	return file_system.CanSeek();
+}
+
+string FileHandle::ReadLine() {
+	string result;
+	char buffer[1];
+	while (true) {
+		idx_t tuples_read = Read(buffer, 1);
+		if (tuples_read == 0 || buffer[0] == '\n') {
+			return result;
+		}
+		if (buffer[0] != '\r') {
+			result += buffer[0];
+		}
+	}
+}
+
+bool FileHandle::OnDiskFile() {
+	return file_system.OnDiskFile(*this);
+}
+
+idx_t FileHandle::GetFileSize() {
+	return file_system.GetFileSize(*this);
+}
+
+void FileHandle::Sync() {
+	file_system.FileSync(*this);
+}
+
+void FileHandle::Truncate(int64_t new_size) {
+	file_system.Truncate(*this, new_size);
+}
+
+FileType FileHandle::GetType() {
+	return file_system.GetFileType(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+/*
+
+  0      2 bytes  magic header  0x1f, 0x8b (\037 \213)
+  2      1 byte   compression method
+                     0: store (copied)
+                     1: compress
+                     2: pack
+                     3: lzh
+                     4..7: reserved
+                     8: deflate
+  3      1 byte   flags
+                     bit 0 set: file probably ascii text
+                     bit 1 set: continuation of multi-part gzip file, part number present
+                     bit 2 set: extra field present
+                     bit 3 set: original file name present
+                     bit 4 set: file comment present
+                     bit 5 set: file is encrypted, encryption header present
+                     bit 6,7:   reserved
+  4      4 bytes  file modification time in Unix format
+  8      1 byte   extra flags (depend on compression method)
+  9      1 byte   OS type
+[
+         2 bytes  optional part number (second part=1)
+]?
+[
+         2 bytes  optional extra field length (e)
+        (e)bytes  optional extra field
+]?
+[
+           bytes  optional original file name, zero terminated
+]?
+[
+           bytes  optional file comment, zero terminated
+]?
+[
+        12 bytes  optional encryption header
+]?
+           bytes  compressed data
+         4 bytes  crc32
+         4 bytes  uncompressed input size modulo 2^32
+
+ */
+
+static idx_t GZipConsumeString(FileHandle &input) {
+	idx_t size = 1; // terminator
+	char buffer[1];
+	while (input.Read(buffer, 1) == 1) {
+		if (buffer[0] == '\0') {
+			break;
+		}
+		size++;
+	}
+	return size;
+}
+
+struct MiniZStreamWrapper : public StreamWrapper {
+	~MiniZStreamWrapper() override;
+
+	CompressedFile *file = nullptr;
+	duckdb_miniz::mz_stream *mz_stream_ptr = nullptr;
+	bool writing = false;
+	duckdb_miniz::mz_ulong crc;
+	idx_t total_size;
+
+public:
+	void Initialize(CompressedFile &file, bool write) override;
+
+	bool Read(StreamData &stream_data) override;
+	void Write(CompressedFile &file, StreamData &stream_data, data_ptr_t buffer, int64_t nr_bytes) override;
+
+	void Close() override;
+
+	void FlushStream();
+};
+
+MiniZStreamWrapper::~MiniZStreamWrapper() {
+	// avoid closing if destroyed during stack unwinding
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	try {
+		Close();
+	} catch (...) {
+	}
+}
+
+void MiniZStreamWrapper::Initialize(CompressedFile &file, bool write) {
+	Close();
+	this->file = &file;
+	mz_stream_ptr = new duckdb_miniz::mz_stream();
+	memset(mz_stream_ptr, 0, sizeof(duckdb_miniz::mz_stream));
+	this->writing = write;
+
+	// TODO use custom alloc/free methods in miniz to throw exceptions on OOM
+	uint8_t gzip_hdr[GZIP_HEADER_MINSIZE];
+	if (write) {
+		crc = MZ_CRC32_INIT;
+		total_size = 0;
+
+		MiniZStream::InitializeGZIPHeader(gzip_hdr);
+		file.child_handle->Write(gzip_hdr, GZIP_HEADER_MINSIZE);
+
+		auto ret = mz_deflateInit2((duckdb_miniz::mz_streamp)mz_stream_ptr, duckdb_miniz::MZ_DEFAULT_LEVEL, MZ_DEFLATED,
+		                           -MZ_DEFAULT_WINDOW_BITS, 1, 0);
+		if (ret != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to initialize miniz");
+		}
+	} else {
+		idx_t data_start = GZIP_HEADER_MINSIZE;
+		auto read_count = file.child_handle->Read(gzip_hdr, GZIP_HEADER_MINSIZE);
+		GZipFileSystem::VerifyGZIPHeader(gzip_hdr, read_count);
+
+		if (gzip_hdr[3] & GZIP_FLAG_NAME) {
+			file.child_handle->Seek(data_start);
+			data_start += GZipConsumeString(*file.child_handle);
+		}
+		file.child_handle->Seek(data_start);
+		// stream is now set to beginning of payload data
+		auto ret = duckdb_miniz::mz_inflateInit2((duckdb_miniz::mz_streamp)mz_stream_ptr, -MZ_DEFAULT_WINDOW_BITS);
+		if (ret != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to initialize miniz");
+		}
+	}
+}
+
+bool MiniZStreamWrapper::Read(StreamData &sd) {
+	// actually decompress
+	mz_stream_ptr->next_in = (data_ptr_t)sd.in_buff_start;
+	D_ASSERT(sd.in_buff_end - sd.in_buff_start < NumericLimits<int32_t>::Maximum());
+	mz_stream_ptr->avail_in = (uint32_t)(sd.in_buff_end - sd.in_buff_start);
+	mz_stream_ptr->next_out = (data_ptr_t)sd.out_buff_end;
+	mz_stream_ptr->avail_out = (uint32_t)((sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_end);
+	auto ret = duckdb_miniz::mz_inflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+	if (ret != duckdb_miniz::MZ_OK && ret != duckdb_miniz::MZ_STREAM_END) {
+		throw IOException("Failed to decode gzip stream: %s", duckdb_miniz::mz_error(ret));
+	}
+	// update pointers following inflate()
+	sd.in_buff_start = (data_ptr_t)mz_stream_ptr->next_in;
+	sd.in_buff_end = sd.in_buff_start + mz_stream_ptr->avail_in;
+	sd.out_buff_end = (data_ptr_t)mz_stream_ptr->next_out;
+	D_ASSERT(sd.out_buff_end + mz_stream_ptr->avail_out == sd.out_buff.get() + sd.out_buf_size);
+	// if stream ended, deallocate inflator
+	if (ret == duckdb_miniz::MZ_STREAM_END) {
+		Close();
+		return true;
+	}
+	return false;
+}
+
+void MiniZStreamWrapper::Write(CompressedFile &file, StreamData &sd, data_ptr_t uncompressed_data,
+                               int64_t uncompressed_size) {
+	// update the src and the total size
+	crc = duckdb_miniz::mz_crc32(crc, (const unsigned char *)uncompressed_data, uncompressed_size);
+	total_size += uncompressed_size;
+
+	auto remaining = uncompressed_size;
+	while (remaining > 0) {
+		idx_t output_remaining = (sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_start;
+
+		mz_stream_ptr->next_in = (const unsigned char *)uncompressed_data;
+		mz_stream_ptr->avail_in = remaining;
+		mz_stream_ptr->next_out = sd.out_buff_start;
+		mz_stream_ptr->avail_out = output_remaining;
+
+		auto res = mz_deflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+		if (res != duckdb_miniz::MZ_OK) {
+			D_ASSERT(res != duckdb_miniz::MZ_STREAM_END);
+			throw InternalException("Failed to compress GZIP block");
+		}
+		sd.out_buff_start += output_remaining - mz_stream_ptr->avail_out;
+		if (mz_stream_ptr->avail_out == 0) {
+			// no more output buffer available: flush
+			file.child_handle->Write(sd.out_buff.get(), sd.out_buff_start - sd.out_buff.get());
+			sd.out_buff_start = sd.out_buff.get();
+		}
+		idx_t written = remaining - mz_stream_ptr->avail_in;
+		uncompressed_data += written;
+		remaining = mz_stream_ptr->avail_in;
+	}
+}
+
+void MiniZStreamWrapper::FlushStream() {
+	auto &sd = file->stream_data;
+	mz_stream_ptr->next_in = nullptr;
+	mz_stream_ptr->avail_in = 0;
+	while (true) {
+		auto output_remaining = (sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_start;
+		mz_stream_ptr->next_out = sd.out_buff_start;
+		mz_stream_ptr->avail_out = output_remaining;
+
+		auto res = mz_deflate(mz_stream_ptr, duckdb_miniz::MZ_FINISH);
+		sd.out_buff_start += (output_remaining - mz_stream_ptr->avail_out);
+		if (sd.out_buff_start > sd.out_buff.get()) {
+			file->child_handle->Write(sd.out_buff.get(), sd.out_buff_start - sd.out_buff.get());
+			sd.out_buff_start = sd.out_buff.get();
+		}
+		if (res == duckdb_miniz::MZ_STREAM_END) {
+			break;
+		}
+		if (res != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to compress GZIP block");
+		}
+	}
+}
+
+void MiniZStreamWrapper::Close() {
+	if (!mz_stream_ptr) {
+		return;
+	}
+	if (writing) {
+		// flush anything remaining in the stream
+		FlushStream();
+
+		// write the footer
+		unsigned char gzip_footer[MiniZStream::GZIP_FOOTER_SIZE];
+		MiniZStream::InitializeGZIPFooter(gzip_footer, crc, total_size);
+		file->child_handle->Write(gzip_footer, MiniZStream::GZIP_FOOTER_SIZE);
+
+		duckdb_miniz::mz_deflateEnd(mz_stream_ptr);
+	} else {
+		duckdb_miniz::mz_inflateEnd(mz_stream_ptr);
+	}
+	delete mz_stream_ptr;
+	mz_stream_ptr = nullptr;
+	file = nullptr;
+}
+
+class GZipFile : public CompressedFile {
+public:
+	GZipFile(unique_ptr<FileHandle> child_handle_p, const string &path, bool write)
+	    : CompressedFile(gzip_fs, move(child_handle_p), path) {
+		Initialize(write);
+	}
+
+	GZipFileSystem gzip_fs;
+};
+
+void GZipFileSystem::VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count) {
+	// check for incorrectly formatted files
+	if (read_count != GZIP_HEADER_MINSIZE) {
+		throw IOException("Input is not a GZIP stream");
+	}
+	if (gzip_hdr[0] != 0x1F || gzip_hdr[1] != 0x8B) { // magic header
+		throw IOException("Input is not a GZIP stream");
+	}
+	if (gzip_hdr[2] != GZIP_COMPRESSION_DEFLATE) { // compression method
+		throw IOException("Unsupported GZIP compression method");
+	}
+	if (gzip_hdr[3] & GZIP_FLAG_UNSUPPORTED) {
+		throw IOException("Unsupported GZIP archive");
+	}
+}
+
+string GZipFileSystem::UncompressGZIPString(const string &in) {
+	// decompress file
+	auto body_ptr = in.data();
+
+	auto mz_stream_ptr = new duckdb_miniz::mz_stream();
+	memset(mz_stream_ptr, 0, sizeof(duckdb_miniz::mz_stream));
+
+	uint8_t gzip_hdr[GZIP_HEADER_MINSIZE];
+
+	// check for incorrectly formatted files
+
+	// TODO this is mostly the same as gzip_file_system.cpp
+	if (in.size() < GZIP_HEADER_MINSIZE) {
+		throw IOException("Input is not a GZIP stream");
+	}
+	memcpy(gzip_hdr, body_ptr, GZIP_HEADER_MINSIZE);
+	body_ptr += GZIP_HEADER_MINSIZE;
+	GZipFileSystem::VerifyGZIPHeader(gzip_hdr, GZIP_HEADER_MINSIZE);
+
+	if (gzip_hdr[3] & GZIP_FLAG_NAME) {
+		char c;
+		do {
+			c = *body_ptr;
+			body_ptr++;
+		} while (c != '\0' && (idx_t)(body_ptr - in.data()) < in.size());
+	}
+
+	// stream is now set to beginning of payload data
+	auto status = duckdb_miniz::mz_inflateInit2(mz_stream_ptr, -MZ_DEFAULT_WINDOW_BITS);
+	if (status != duckdb_miniz::MZ_OK) {
+		throw InternalException("Failed to initialize miniz");
+	}
+
+	auto bytes_remaining = in.size() - (body_ptr - in.data());
+	mz_stream_ptr->next_in = (unsigned char *)body_ptr;
+	mz_stream_ptr->avail_in = bytes_remaining;
+
+	unsigned char decompress_buffer[BUFSIZ];
+	string decompressed;
+
+	while (status == duckdb_miniz::MZ_OK) {
+		mz_stream_ptr->next_out = decompress_buffer;
+		mz_stream_ptr->avail_out = sizeof(decompress_buffer);
+		status = mz_inflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+		if (status != duckdb_miniz::MZ_STREAM_END && status != duckdb_miniz::MZ_OK) {
+			throw IOException("Failed to uncompress");
+		}
+		decompressed.append((char *)decompress_buffer, mz_stream_ptr->total_out - decompressed.size());
+	}
+	duckdb_miniz::mz_inflateEnd(mz_stream_ptr);
+	if (decompressed.empty()) {
+		throw IOException("Failed to uncompress");
+	}
+	return decompressed;
+}
+
+unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) {
+	auto path = handle->path;
+	return make_unique<GZipFile>(move(handle), path, write);
+}
+
+unique_ptr<StreamWrapper> GZipFileSystem::CreateStream() {
+	return make_unique<MiniZStreamWrapper>();
+}
+
+idx_t GZipFileSystem::InBufferSize() {
+	return BUFFER_SIZE;
+}
+
+idx_t GZipFileSystem::OutBufferSize() {
+	return BUFFER_SIZE;
+}
+
+} // namespace duckdb
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+using std::numeric_limits;
+
+int8_t NumericLimits<int8_t>::Minimum() {
+	return numeric_limits<int8_t>::lowest();
+}
+
+int8_t NumericLimits<int8_t>::Maximum() {
+	return numeric_limits<int8_t>::max();
+}
+
+int16_t NumericLimits<int16_t>::Minimum() {
+	return numeric_limits<int16_t>::lowest();
+}
+
+int16_t NumericLimits<int16_t>::Maximum() {
+	return numeric_limits<int16_t>::max();
+}
+
+int32_t NumericLimits<int32_t>::Minimum() {
+	return numeric_limits<int32_t>::lowest();
+}
+
+int32_t NumericLimits<int32_t>::Maximum() {
+	return numeric_limits<int32_t>::max();
+}
+
+int64_t NumericLimits<int64_t>::Minimum() {
+	return numeric_limits<int64_t>::lowest();
+}
+
+int64_t NumericLimits<int64_t>::Maximum() {
+	return numeric_limits<int64_t>::max();
+}
+
+float NumericLimits<float>::Minimum() {
+	return numeric_limits<float>::lowest();
+}
+
+float NumericLimits<float>::Maximum() {
+	return numeric_limits<float>::max();
+}
+
+double NumericLimits<double>::Minimum() {
+	return numeric_limits<double>::lowest();
+}
+
+double NumericLimits<double>::Maximum() {
+	return numeric_limits<double>::max();
+}
+
+uint8_t NumericLimits<uint8_t>::Minimum() {
+	return numeric_limits<uint8_t>::lowest();
+}
+
+uint8_t NumericLimits<uint8_t>::Maximum() {
+	return numeric_limits<uint8_t>::max();
+}
+
+uint16_t NumericLimits<uint16_t>::Minimum() {
+	return numeric_limits<uint16_t>::lowest();
+}
+
+uint16_t NumericLimits<uint16_t>::Maximum() {
+	return numeric_limits<uint16_t>::max();
+}
+
+uint32_t NumericLimits<uint32_t>::Minimum() {
+	return numeric_limits<uint32_t>::lowest();
+}
+
+uint32_t NumericLimits<uint32_t>::Maximum() {
+	return numeric_limits<uint32_t>::max();
+}
+
+uint64_t NumericLimits<uint64_t>::Minimum() {
+	return numeric_limits<uint64_t>::lowest();
+}
+
+uint64_t NumericLimits<uint64_t>::Maximum() {
+	return numeric_limits<uint64_t>::max();
+}
+
+hugeint_t NumericLimits<hugeint_t>::Minimum() {
+	hugeint_t result;
+	result.lower = 1;
+	result.upper = numeric_limits<int64_t>::lowest();
+	return result;
+}
+
+hugeint_t NumericLimits<hugeint_t>::Maximum() {
+	hugeint_t result;
+	result.lower = numeric_limits<uint64_t>::max();
+	result.upper = numeric_limits<int64_t>::max();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstdint>
+#include <cstdio>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
+
+
+#include <io.h>
+#include <string>
+
+#ifdef __MINGW32__
+// need to manually define this for mingw
+extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG);
+#endif
+
+#undef FILE_CREATE // woo mingw
+#endif
+
+namespace duckdb {
+
+static void AssertValidFileFlags(uint8_t flags) {
+#ifdef DEBUG
+	bool is_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool is_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	// require either READ or WRITE (or both)
+	D_ASSERT(is_read || is_write);
+	// CREATE/Append flags require writing
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_APPEND));
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_FILE_CREATE));
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+	// cannot combine CREATE and CREATE_NEW flags
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_FILE_CREATE && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+#endif
+}
+
+#ifndef _WIN32
+bool LocalFileSystem::FileExists(const string &filename) {
+	if (!filename.empty()) {
+		if (access(filename.c_str(), 0) == 0) {
+			struct stat status;
+			stat(filename.c_str(), &status);
+			if (S_ISREG(status.st_mode)) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+bool LocalFileSystem::IsPipe(const string &filename) {
+	if (!filename.empty()) {
+		if (access(filename.c_str(), 0) == 0) {
+			struct stat status;
+			stat(filename.c_str(), &status);
+			if (S_ISFIFO(status.st_mode)) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+#else
+bool LocalFileSystem::FileExists(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	const wchar_t *wpath = unicode_path.c_str();
+	if (_waccess(wpath, 0) == 0) {
+		struct _stati64 status;
+		_wstati64(wpath, &status);
+		if (status.st_mode & S_IFREG) {
+			return true;
+		}
+	}
+	return false;
+}
+bool LocalFileSystem::IsPipe(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	const wchar_t *wpath = unicode_path.c_str();
+	if (_waccess(wpath, 0) == 0) {
+		struct _stati64 status;
+		_wstati64(wpath, &status);
+		if (status.st_mode & _S_IFCHR) {
+			return true;
+		}
+	}
+	return false;
+}
+#endif
+
+#ifndef _WIN32
+// somehow sometimes this is missing
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+// Solaris
+#ifndef O_DIRECT
+#define O_DIRECT 0
+#endif
+
+struct UnixFileHandle : public FileHandle {
+public:
+	UnixFileHandle(FileSystem &file_system, string path, int fd) : FileHandle(file_system, move(path)), fd(fd) {
+	}
+	~UnixFileHandle() override {
+		Close();
+	}
+
+	int fd;
+
+public:
+	void Close() override {
+		if (fd != -1) {
+			close(fd);
+		}
+	};
+};
+
+static FileType GetFileTypeInternal(int fd) { // LCOV_EXCL_START
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return FileType::FILE_TYPE_INVALID;
+	}
+	switch (s.st_mode & S_IFMT) {
+	case S_IFBLK:
+		return FileType::FILE_TYPE_BLOCKDEV;
+	case S_IFCHR:
+		return FileType::FILE_TYPE_CHARDEV;
+	case S_IFIFO:
+		return FileType::FILE_TYPE_FIFO;
+	case S_IFDIR:
+		return FileType::FILE_TYPE_DIR;
+	case S_IFLNK:
+		return FileType::FILE_TYPE_LINK;
+	case S_IFREG:
+		return FileType::FILE_TYPE_REGULAR;
+	case S_IFSOCK:
+		return FileType::FILE_TYPE_SOCKET;
+	default:
+		return FileType::FILE_TYPE_INVALID;
+	}
+} // LCOV_EXCL_STOP
+
+unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
+                                                 FileCompressionType compression, FileOpener *opener) {
+	if (compression != FileCompressionType::UNCOMPRESSED) {
+		throw NotImplementedException("Unsupported compression type for default file system");
+	}
+
+	AssertValidFileFlags(flags);
+
+	int open_flags = 0;
+	int rc;
+	bool open_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool open_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	if (open_read && open_write) {
+		open_flags = O_RDWR;
+	} else if (open_read) {
+		open_flags = O_RDONLY;
+	} else if (open_write) {
+		open_flags = O_WRONLY;
+	} else {
+		throw InternalException("READ, WRITE or both should be specified when opening a file");
+	}
+	if (open_write) {
+		// need Read or Write
+		D_ASSERT(flags & FileFlags::FILE_FLAGS_WRITE);
+		open_flags |= O_CLOEXEC;
+		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {
+			open_flags |= O_CREAT;
+		} else if (flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW) {
+			open_flags |= O_CREAT | O_TRUNC;
+		}
+		if (flags & FileFlags::FILE_FLAGS_APPEND) {
+			open_flags |= O_APPEND;
+		}
+	}
+	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+#if defined(__sun) && defined(__SVR4)
+		throw Exception("DIRECT_IO not supported on Solaris");
+#endif
+#if defined(__DARWIN__) || defined(__APPLE__) || defined(__OpenBSD__)
+		// OSX does not have O_DIRECT, instead we need to use fcntl afterwards to support direct IO
+		open_flags |= O_SYNC;
+#else
+		open_flags |= O_DIRECT | O_SYNC;
+#endif
+	}
+	int fd = open(path.c_str(), open_flags, 0666);
+	if (fd == -1) {
+		throw IOException("Cannot open file \"%s\": %s", path, strerror(errno));
+	}
+	// #if defined(__DARWIN__) || defined(__APPLE__)
+	// 	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+	// 		// OSX requires fcntl for Direct IO
+	// 		rc = fcntl(fd, F_NOCACHE, 1);
+	// 		if (fd == -1) {
+	// 			throw IOException("Could not enable direct IO for file \"%s\": %s", path, strerror(errno));
+	// 		}
+	// 	}
+	// #endif
+	if (lock_type != FileLockType::NO_LOCK) {
+		// set lock on file
+		// but only if it is not an input/output stream
+		auto file_type = GetFileTypeInternal(fd);
+		if (file_type != FileType::FILE_TYPE_FIFO && file_type != FileType::FILE_TYPE_SOCKET) {
+			struct flock fl;
+			memset(&fl, 0, sizeof fl);
+			fl.l_type = lock_type == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
+			fl.l_whence = SEEK_SET;
+			fl.l_start = 0;
+			fl.l_len = 0;
+			rc = fcntl(fd, F_SETLK, &fl);
+			if (rc == -1) {
+				throw IOException("Could not set lock on file \"%s\": %s", path, strerror(errno));
+			}
+		}
+	}
+	return make_unique<UnixFileHandle>(*this, path, fd);
+}
+
+void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	off_t offset = lseek(fd, location, SEEK_SET);
+	if (offset == (off_t)-1) {
+		throw IOException("Could not seek to location %lld for file \"%s\": %s", location, handle.path,
+		                  strerror(errno));
+	}
+}
+
+idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	off_t position = lseek(fd, 0, SEEK_CUR);
+	if (position == (off_t)-1) {
+		throw IOException("Could not get file position file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return position;
+}
+
+void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_read = pread(fd, buffer, nr_bytes, location);
+	if (bytes_read == -1) {
+		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
+}
+
+int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_read = read(fd, buffer, nr_bytes);
+	if (bytes_read == -1) {
+		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return bytes_read;
+}
+
+void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_written = pwrite(fd, buffer, nr_bytes, location);
+	if (bytes_written == -1) {
+		throw IOException("Could not write file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes to file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
+}
+
+int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_written = write(fd, buffer, nr_bytes);
+	if (bytes_written == -1) {
+		throw IOException("Could not write file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return bytes_written;
+}
+
+int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return -1;
+	}
+	return s.st_size;
+}
+
+time_t LocalFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return -1;
+	}
+	return s.st_mtime;
+}
+
+FileType LocalFileSystem::GetFileType(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	return GetFileTypeInternal(fd);
+}
+
+void LocalFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	if (ftruncate(fd, new_size) != 0) {
+		throw IOException("Could not truncate file \"%s\": %s", handle.path, strerror(errno));
+	}
+}
+
+bool LocalFileSystem::DirectoryExists(const string &directory) {
+	if (!directory.empty()) {
+		if (access(directory.c_str(), 0) == 0) {
+			struct stat status;
+			stat(directory.c_str(), &status);
+			if (status.st_mode & S_IFDIR) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+void LocalFileSystem::CreateDirectory(const string &directory) {
+	struct stat st;
+
+	if (stat(directory.c_str(), &st) != 0) {
+		/* Directory does not exist. EEXIST for race condition */
+		if (mkdir(directory.c_str(), 0755) != 0 && errno != EEXIST) {
+			throw IOException("Failed to create directory \"%s\"!", directory);
+		}
+	} else if (!S_ISDIR(st.st_mode)) {
+		throw IOException("Failed to create directory \"%s\": path exists but is not a directory!", directory);
+	}
+}
+
+int RemoveDirectoryRecursive(const char *path) {
+	DIR *d = opendir(path);
+	idx_t path_len = (idx_t)strlen(path);
+	int r = -1;
+
+	if (d) {
+		struct dirent *p;
+		r = 0;
+		while (!r && (p = readdir(d))) {
+			int r2 = -1;
+			char *buf;
+			idx_t len;
+			/* Skip the names "." and ".." as we don't want to recurse on them. */
+			if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) {
+				continue;
+			}
+			len = path_len + (idx_t)strlen(p->d_name) + 2;
+			buf = new char[len];
+			if (buf) {
+				struct stat statbuf;
+				snprintf(buf, len, "%s/%s", path, p->d_name);
+				if (!stat(buf, &statbuf)) {
+					if (S_ISDIR(statbuf.st_mode)) {
+						r2 = RemoveDirectoryRecursive(buf);
+					} else {
+						r2 = unlink(buf);
+					}
+				}
+				delete[] buf;
+			}
+			r = r2;
+		}
+		closedir(d);
+	}
+	if (!r) {
+		r = rmdir(path);
+	}
+	return r;
+}
+
+void LocalFileSystem::RemoveDirectory(const string &directory) {
+	RemoveDirectoryRecursive(directory.c_str());
+}
+
+void LocalFileSystem::RemoveFile(const string &filename) {
+	if (std::remove(filename.c_str()) != 0) {
+		throw IOException("Could not remove file \"%s\": %s", filename, strerror(errno));
+	}
+}
+
+bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	if (!DirectoryExists(directory)) {
+		return false;
+	}
+	DIR *dir = opendir(directory.c_str());
+	if (!dir) {
+		return false;
+	}
+	struct dirent *ent;
+	// loop over all files in the directory
+	while ((ent = readdir(dir)) != nullptr) {
+		string name = string(ent->d_name);
+		// skip . .. and empty files
+		if (name.empty() || name == "." || name == "..") {
+			continue;
+		}
+		// now stat the file to figure out if it is a regular file or directory
+		string full_path = JoinPath(directory, name);
+		if (access(full_path.c_str(), 0) != 0) {
+			continue;
+		}
+		struct stat status;
+		stat(full_path.c_str(), &status);
+		if (!(status.st_mode & S_IFREG) && !(status.st_mode & S_IFDIR)) {
+			// not a file or directory: skip
+			continue;
+		}
+		// invoke callback
+		callback(name, status.st_mode & S_IFDIR);
+	}
+	closedir(dir);
+	return true;
+}
+
+void LocalFileSystem::FileSync(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	if (fsync(fd) != 0) {
+		throw FatalException("fsync failed!");
+	}
+}
+
+void LocalFileSystem::MoveFile(const string &source, const string &target) {
+	//! FIXME: rename does not guarantee atomicity or overwriting target file if it exists
+	if (rename(source.c_str(), target.c_str()) != 0) {
+		throw IOException("Could not rename file!");
+	}
+}
+
+std::string LocalFileSystem::GetLastErrorAsString() {
+	return string();
+}
+
+#else
+
+constexpr char PIPE_PREFIX[] = "\\\\.\\pipe\\";
+
+// Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string LocalFileSystem::GetLastErrorAsString() {
+	// Get the error message, if any.
+	DWORD errorMessageID = GetLastError();
+	if (errorMessageID == 0)
+		return std::string(); // No error message has been recorded
+
+	LPSTR messageBuffer = nullptr;
+	idx_t size =
+	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+	std::string message(messageBuffer, size);
+
+	// Free the buffer.
+	LocalFree(messageBuffer);
+
+	return message;
+}
+
+struct WindowsFileHandle : public FileHandle {
+public:
+	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd)
+	    : FileHandle(file_system, path), position(0), fd(fd) {
+	}
+	virtual ~WindowsFileHandle() {
+		Close();
+	}
+
+	idx_t position;
+	HANDLE fd;
+
+public:
+	void Close() override {
+		CloseHandle(fd);
+	};
+};
+
+unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
+                                                 FileCompressionType compression, FileOpener *opener) {
+	if (compression != FileCompressionType::UNCOMPRESSED) {
+		throw NotImplementedException("Unsupported compression type for default file system");
+	}
+	AssertValidFileFlags(flags);
+
+	DWORD desired_access;
+	DWORD share_mode;
+	DWORD creation_disposition = OPEN_EXISTING;
+	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL;
+	bool open_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool open_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	if (open_read && open_write) {
+		desired_access = GENERIC_READ | GENERIC_WRITE;
+		share_mode = 0;
+	} else if (open_read) {
+		desired_access = GENERIC_READ;
+		share_mode = FILE_SHARE_READ;
+	} else if (open_write) {
+		desired_access = GENERIC_WRITE;
+		share_mode = 0;
+	} else {
+		throw InternalException("READ, WRITE or both should be specified when opening a file");
+	}
+	if (open_write) {
+		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {
+			creation_disposition = OPEN_ALWAYS;
+		} else if (flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW) {
+			creation_disposition = CREATE_ALWAYS;
+		}
+	}
+	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+		flags_and_attributes |= FILE_FLAG_NO_BUFFERING;
+	}
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(path.c_str());
+	HANDLE hFile = CreateFileW(unicode_path.c_str(), desired_access, share_mode, NULL, creation_disposition,
+	                           flags_and_attributes, NULL);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Cannot open file \"%s\": %s", path.c_str(), error);
+	}
+	auto handle = make_unique<WindowsFileHandle>(*this, path.c_str(), hFile);
+	if (flags & FileFlags::FILE_FLAGS_APPEND) {
+		auto file_size = GetFileSize(*handle);
+		SetFilePointer(*handle, file_size);
+	}
+	return move(handle);
+}
+
+void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
+	((WindowsFileHandle &)handle).position = location;
+}
+
+idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
+	return ((WindowsFileHandle &)handle).position;
+}
+
+static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
+	DWORD bytes_read = 0;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, &ov);
+	if (!rc) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
+	}
+	return bytes_read;
+}
+
+void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, nr_bytes, location);
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
+}
+
+int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	auto n = std::min<idx_t>(std::max<idx_t>(GetFileSize(handle), pos) - pos, nr_bytes);
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, n, pos);
+	pos += bytes_read;
+	return bytes_read;
+}
+
+static DWORD FSInternalWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
+	DWORD bytes_written = 0;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, &bytes_written, &ov);
+	if (!rc) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Could not write file \"%s\" (error in WriteFile): %s", handle.path, error);
+	}
+	return bytes_written;
+}
+
+void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, location);
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes from file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
+}
+
+int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, pos);
+	pos += bytes_written;
+	return bytes_written;
+}
+
+int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	LARGE_INTEGER result;
+	if (!GetFileSizeEx(hFile, &result)) {
+		return -1;
+	}
+	return result.QuadPart;
+}
+
+time_t LocalFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfiletime
+	FILETIME last_write;
+	if (GetFileTime(hFile, nullptr, nullptr, &last_write) == 0) {
+		return -1;
+	}
+
+	// https://stackoverflow.com/questions/29266743/what-is-dwlowdatetime-and-dwhighdatetime
+	ULARGE_INTEGER ul;
+	ul.LowPart = last_write.dwLowDateTime;
+	ul.HighPart = last_write.dwHighDateTime;
+	int64_t fileTime64 = ul.QuadPart;
+
+	// fileTime64 contains a 64-bit value representing the number of
+	// 100-nanosecond intervals since January 1, 1601 (UTC).
+	// https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
+
+	// Adapted from: https://stackoverflow.com/questions/6161776/convert-windows-filetime-to-second-in-unix-linux
+	const auto WINDOWS_TICK = 10000000;
+	const auto SEC_TO_UNIX_EPOCH = 11644473600LL;
+	time_t result = (fileTime64 / WINDOWS_TICK - SEC_TO_UNIX_EPOCH);
+	return result;
+}
+
+void LocalFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	// seek to the location
+	SetFilePointer(handle, new_size);
+	// now set the end of file position
+	if (!SetEndOfFile(hFile)) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Failure in SetEndOfFile call on file \"%s\": %s", handle.path, error);
+	}
+}
+
+static DWORD WindowsGetFileAttributes(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	return GetFileAttributesW(unicode_path.c_str());
+}
+
+bool LocalFileSystem::DirectoryExists(const string &directory) {
+	DWORD attrs = WindowsGetFileAttributes(directory);
+	return (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY));
+}
+
+void LocalFileSystem::CreateDirectory(const string &directory) {
+	if (DirectoryExists(directory)) {
+		return;
+	}
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(directory.c_str());
+	if (directory.empty() || !CreateDirectoryW(unicode_path.c_str(), NULL) || !DirectoryExists(directory)) {
+		throw IOException("Could not create directory!");
+	}
+}
+
+static void DeleteDirectoryRecursive(FileSystem &fs, string directory) {
+	fs.ListFiles(directory, [&](const string &fname, bool is_directory) {
+		if (is_directory) {
+			DeleteDirectoryRecursive(fs, fs.JoinPath(directory, fname));
+		} else {
+			fs.RemoveFile(fs.JoinPath(directory, fname));
+		}
+	});
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(directory.c_str());
+	if (!RemoveDirectoryW(unicode_path.c_str())) {
+		throw IOException("Failed to delete directory");
+	}
+}
+
+void LocalFileSystem::RemoveDirectory(const string &directory) {
+	if (FileExists(directory)) {
+		throw IOException("Attempting to delete directory \"%s\", but it is a file and not a directory!", directory);
+	}
+	if (!DirectoryExists(directory)) {
+		return;
+	}
+	DeleteDirectoryRecursive(*this, directory.c_str());
+}
+
+void LocalFileSystem::RemoveFile(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	DeleteFileW(unicode_path.c_str());
+}
+
+bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	string search_dir = JoinPath(directory, "*");
+
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(search_dir.c_str());
+
+	WIN32_FIND_DATAW ffd;
+	HANDLE hFind = FindFirstFileW(unicode_path.c_str(), &ffd);
+	if (hFind == INVALID_HANDLE_VALUE) {
+		return false;
+	}
+	do {
+		string cFileName = WindowsUtil::UnicodeToUTF8(ffd.cFileName);
+		if (cFileName == "." || cFileName == "..") {
+			continue;
+		}
+		callback(cFileName, ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+	} while (FindNextFileW(hFind, &ffd) != 0);
+
+	DWORD dwError = GetLastError();
+	if (dwError != ERROR_NO_MORE_FILES) {
+		FindClose(hFind);
+		return false;
+	}
+
+	FindClose(hFind);
+	return true;
+}
+
+void LocalFileSystem::FileSync(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	if (FlushFileBuffers(hFile) == 0) {
+		throw IOException("Could not flush file handle to disk!");
+	}
+}
+
+void LocalFileSystem::MoveFile(const string &source, const string &target) {
+	auto source_unicode = WindowsUtil::UTF8ToUnicode(source.c_str());
+	auto target_unicode = WindowsUtil::UTF8ToUnicode(target.c_str());
+	if (!MoveFileW(source_unicode.c_str(), target_unicode.c_str())) {
+		throw IOException("Could not move file");
+	}
+}
+
+FileType LocalFileSystem::GetFileType(FileHandle &handle) {
+	auto path = ((WindowsFileHandle &)handle).path;
+	// pipes in windows are just files in '\\.\pipe\' folder
+	if (strncmp(path.c_str(), PIPE_PREFIX, strlen(PIPE_PREFIX)) == 0) {
+		return FileType::FILE_TYPE_FIFO;
+	}
+	DWORD attrs = WindowsGetFileAttributes(path.c_str());
+	if (attrs != INVALID_FILE_ATTRIBUTES) {
+		if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+			return FileType::FILE_TYPE_DIR;
+		} else {
+			return FileType::FILE_TYPE_REGULAR;
+		}
+	}
+	return FileType::FILE_TYPE_INVALID;
+}
+#endif
+
+bool LocalFileSystem::CanSeek() {
+	return true;
+}
+
+bool LocalFileSystem::OnDiskFile(FileHandle &handle) {
+	return true;
+}
+
+void LocalFileSystem::Seek(FileHandle &handle, idx_t location) {
+	if (!CanSeek()) {
+		throw IOException("Cannot seek in files of this type");
+	}
+	SetFilePointer(handle, location);
+}
+
+idx_t LocalFileSystem::SeekPosition(FileHandle &handle) {
+	if (!CanSeek()) {
+		throw IOException("Cannot seek in files of this type");
+	}
+	return GetFilePointer(handle);
+}
+
+static bool HasGlob(const string &str) {
+	for (idx_t i = 0; i < str.size(); i++) {
+		switch (str[i]) {
+		case '*':
+		case '?':
+		case '[':
+			return true;
+		default:
+			break;
+		}
+	}
+	return false;
+}
+
+static void GlobFiles(FileSystem &fs, const string &path, const string &glob, bool match_directory,
+                      vector<string> &result, bool join_path) {
+	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
+		if (is_directory != match_directory) {
+			return;
+		}
+		if (LikeFun::Glob(fname.c_str(), fname.size(), glob.c_str(), glob.size())) {
+			if (join_path) {
+				result.push_back(fs.JoinPath(path, fname));
+			} else {
+				result.push_back(fname);
+			}
+		}
+	});
+}
+
+vector<string> LocalFileSystem::Glob(const string &path, FileOpener *opener) {
+	if (path.empty()) {
+		return vector<string>();
+	}
+	// split up the path into separate chunks
+	vector<string> splits;
+	idx_t last_pos = 0;
+	for (idx_t i = 0; i < path.size(); i++) {
+		if (path[i] == '\\' || path[i] == '/') {
+			if (i == last_pos) {
+				// empty: skip this position
+				last_pos = i + 1;
+				continue;
+			}
+			if (splits.empty()) {
+				splits.push_back(path.substr(0, i));
+			} else {
+				splits.push_back(path.substr(last_pos, i - last_pos));
+			}
+			last_pos = i + 1;
+		}
+	}
+	splits.push_back(path.substr(last_pos, path.size() - last_pos));
+	// handle absolute paths
+	bool absolute_path = false;
+	if (path[0] == '/') {
+		// first character is a slash -  unix absolute path
+		absolute_path = true;
+	} else if (StringUtil::Contains(splits[0], ":")) {
+		// first split has a colon -  windows absolute path
+		absolute_path = true;
+	} else if (splits[0] == "~") {
+		// starts with home directory
+		auto home_directory = GetHomeDirectory();
+		if (!home_directory.empty()) {
+			absolute_path = true;
+			splits[0] = home_directory;
+		}
+	}
+	// Check if the path has a glob at all
+	if (!HasGlob(path)) {
+		// no glob: return only the file (if it exists or is a pipe)
+		vector<string> result;
+		if (FileExists(path) || IsPipe(path)) {
+			result.push_back(path);
+		} else if (!absolute_path) {
+			Value value;
+			if (opener->TryGetCurrentSetting("file_search_path", value)) {
+				auto search_paths_str = value.ToString();
+				std::vector<std::string> search_paths = StringUtil::Split(search_paths_str, ',');
+				for (const auto &search_path : search_paths) {
+					auto joined_path = JoinPath(search_path, path);
+					if (FileExists(joined_path) || IsPipe(joined_path)) {
+						result.push_back(joined_path);
+					}
+				}
+			}
+		}
+		return result;
+	}
+	vector<string> previous_directories;
+	if (absolute_path) {
+		// for absolute paths, we don't start by scanning the current directory
+		previous_directories.push_back(splits[0]);
+	}
+	for (idx_t i = absolute_path ? 1 : 0; i < splits.size(); i++) {
+		bool is_last_chunk = i + 1 == splits.size();
+		bool has_glob = HasGlob(splits[i]);
+		// if it's the last chunk we need to find files, otherwise we find directories
+		// not the last chunk: gather a list of all directories that match the glob pattern
+		vector<string> result;
+		if (!has_glob) {
+			// no glob, just append as-is
+			if (previous_directories.empty()) {
+				result.push_back(splits[i]);
+			} else {
+				for (auto &prev_directory : previous_directories) {
+					result.push_back(JoinPath(prev_directory, splits[i]));
+				}
+			}
+		} else {
+			if (previous_directories.empty()) {
+				// no previous directories: list in the current path
+				GlobFiles(*this, ".", splits[i], !is_last_chunk, result, false);
+			} else {
+				// previous directories
+				// we iterate over each of the previous directories, and apply the glob of the current directory
+				for (auto &prev_directory : previous_directories) {
+					GlobFiles(*this, prev_directory, splits[i], !is_last_chunk, result, true);
+				}
+			}
+		}
+		if (is_last_chunk || result.empty()) {
+			return result;
+		}
+		previous_directories = move(result);
+	}
+	return vector<string>();
+}
+
+unique_ptr<FileSystem> FileSystem::CreateLocal() {
+	return make_unique<LocalFileSystem>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Cast bool -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(bool input, bool &result, bool strict) {
+	return NumericTryCast::Operation<bool, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, float &result, bool strict) {
+	return NumericTryCast::Operation<bool, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, double &result, bool strict) {
+	return NumericTryCast::Operation<bool, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int8_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int8_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int16_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int16_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int32_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int32_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int64_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int64_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast hugeint_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(hugeint_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint8_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint8_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint16_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint16_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint32_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint32_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint64_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint64_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast float -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(float input, bool &result, bool strict) {
+	return NumericTryCast::Operation<float, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<float, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, float &result, bool strict) {
+	return NumericTryCast::Operation<float, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, double &result, bool strict) {
+	return NumericTryCast::Operation<float, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast double -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(double input, bool &result, bool strict) {
+	return NumericTryCast::Operation<double, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<double, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, float &result, bool strict) {
+	return NumericTryCast::Operation<double, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, double &result, bool strict) {
+	return NumericTryCast::Operation<double, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast String -> Numeric
+//===--------------------------------------------------------------------===//
+template <typename T>
+struct IntegerCastData {
+	using Result = T;
+	Result result;
+	bool seen_decimal;
+};
+
+struct IntegerCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &state, uint8_t digit) {
+		using result_t = typename T::Result;
+		if (NEGATIVE) {
+			if (state.result < (NumericLimits<result_t>::Minimum() + digit) / 10) {
+				return false;
+			}
+			state.result = state.result * 10 - digit;
+		} else {
+			if (state.result > (NumericLimits<result_t>::Maximum() - digit) / 10) {
+				return false;
+			}
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &state, int32_t exponent) {
+		using result_t = typename T::Result;
+		double dbl_res = state.result * std::pow(10.0L, exponent);
+		if (dbl_res < NumericLimits<result_t>::Minimum() || dbl_res > NumericLimits<result_t>::Maximum()) {
+			return false;
+		}
+		state.result = (result_t)std::nearbyint(dbl_res);
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &state, uint8_t digit) {
+		if (state.seen_decimal) {
+			return true;
+		}
+		state.seen_decimal = true;
+		// round the integer based on what is after the decimal point
+		// if digit >= 5, then we round up (or down in case of negative numbers)
+		auto increment = digit >= 5;
+		if (!increment) {
+			return true;
+		}
+		if (NEGATIVE) {
+			if (state.result == NumericLimits<typename T::Result>::Minimum()) {
+				return false;
+			}
+			state.result--;
+		} else {
+			if (state.result == NumericLimits<typename T::Result>::Maximum()) {
+				return false;
+			}
+			state.result++;
+		}
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &state) {
+		return true;
+	}
+};
+
+template <class T, bool NEGATIVE, bool ALLOW_EXPONENT, class OP = IntegerCastOperation>
+static bool IntegerCastLoop(const char *buf, idx_t len, T &result, bool strict) {
+	idx_t start_pos = NEGATIVE || *buf == '+' ? 1 : 0;
+	idx_t pos = start_pos;
+	while (pos < len) {
+		if (!StringUtil::CharacterIsDigit(buf[pos])) {
+			// not a digit!
+			if (buf[pos] == '.') {
+				if (strict) {
+					return false;
+				}
+				bool number_before_period = pos > start_pos;
+				// decimal point: we accept decimal values for integers as well
+				// we just truncate them
+				// make sure everything after the period is a number
+				pos++;
+				idx_t start_digit = pos;
+				while (pos < len) {
+					if (!StringUtil::CharacterIsDigit(buf[pos])) {
+						break;
+					}
+					if (!OP::template HandleDecimal<T, NEGATIVE>(result, buf[pos] - '0')) {
+						return false;
+					}
+					pos++;
+				}
+				// make sure there is either (1) one number after the period, or (2) one number before the period
+				// i.e. we accept "1." and ".1" as valid numbers, but not "."
+				if (!(number_before_period || pos > start_digit)) {
+					return false;
+				}
+				if (pos >= len) {
+					break;
+				}
+			}
+			if (StringUtil::CharacterIsSpace(buf[pos])) {
+				// skip any trailing spaces
+				while (++pos < len) {
+					if (!StringUtil::CharacterIsSpace(buf[pos])) {
+						return false;
+					}
+				}
+				break;
+			}
+			if (ALLOW_EXPONENT) {
+				if (buf[pos] == 'e' || buf[pos] == 'E') {
+					if (pos == start_pos) {
+						return false;
+					}
+					pos++;
+					if (pos >= len) {
+						return false;
+					}
+					using ExponentData = IntegerCastData<int32_t>;
+					ExponentData exponent {0, false};
+					int negative = buf[pos] == '-';
+					if (negative) {
+						if (!IntegerCastLoop<ExponentData, true, false>(buf + pos, len - pos, exponent, strict)) {
+							return false;
+						}
+					} else {
+						if (!IntegerCastLoop<ExponentData, false, false>(buf + pos, len - pos, exponent, strict)) {
+							return false;
+						}
+					}
+					return OP::template HandleExponent<T, NEGATIVE>(result, exponent.result);
+				}
+			}
+			return false;
+		}
+		uint8_t digit = buf[pos++] - '0';
+		if (!OP::template HandleDigit<T, NEGATIVE>(result, digit)) {
+			return false;
+		}
+	}
+	if (!OP::template Finalize<T>(result)) {
+		return false;
+	}
+	return pos > start_pos;
+}
+
+template <class T, bool IS_SIGNED = true, bool ALLOW_EXPONENT = true, class OP = IntegerCastOperation,
+          bool ZERO_INITIALIZE = true>
+static bool TryIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
+	// skip any spaces at the start
+	while (len > 0 && StringUtil::CharacterIsSpace(*buf)) {
+		buf++;
+		len--;
+	}
+	if (len == 0) {
+		return false;
+	}
+	int negative = *buf == '-';
+
+	if (ZERO_INITIALIZE) {
+		memset(&result, 0, sizeof(T));
+	}
+	if (!negative) {
+		return IntegerCastLoop<T, false, ALLOW_EXPONENT, OP>(buf, len, result, strict);
+	} else {
+		if (!IS_SIGNED) {
+			// Need to check if its not -0
+			idx_t pos = 1;
+			while (pos < len) {
+				if (buf[pos++] != '0') {
+					return false;
+				}
+			}
+		}
+		return IntegerCastLoop<T, true, ALLOW_EXPONENT, OP>(buf, len, result, strict);
+	}
+}
+
+template <typename T, bool IS_SIGNED = true>
+static inline bool TrySimpleIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
+	IntegerCastData<T> data;
+	if (TryIntegerCast<IntegerCastData<T>, IS_SIGNED>(buf, len, data, strict)) {
+		result = data.result;
+		return true;
+	}
+	return false;
+}
+
+template <>
+bool TryCast::Operation(string_t input, bool &result, bool strict) {
+	auto input_data = input.GetDataUnsafe();
+	auto input_size = input.GetSize();
+
+	switch (input_size) {
+	case 1: {
+		char c = std::tolower(*input_data);
+		if (c == 't' || (!strict && c == '1')) {
+			result = true;
+			return true;
+		} else if (c == 'f' || (!strict && c == '0')) {
+			result = false;
+			return true;
+		}
+		return false;
+	}
+	case 4: {
+		char t = std::tolower(input_data[0]);
+		char r = std::tolower(input_data[1]);
+		char u = std::tolower(input_data[2]);
+		char e = std::tolower(input_data[3]);
+		if (t == 't' && r == 'r' && u == 'u' && e == 'e') {
+			result = true;
+			return true;
+		}
+		return false;
+	}
+	case 5: {
+		char f = std::tolower(input_data[0]);
+		char a = std::tolower(input_data[1]);
+		char l = std::tolower(input_data[2]);
+		char s = std::tolower(input_data[3]);
+		char e = std::tolower(input_data[4]);
+		if (f == 'f' && a == 'a' && l == 'l' && s == 's' && e == 'e') {
+			result = false;
+			return true;
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
+}
+template <>
+bool TryCast::Operation(string_t input, int8_t &result, bool strict) {
+	return TrySimpleIntegerCast<int8_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int16_t &result, bool strict) {
+	return TrySimpleIntegerCast<int16_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int32_t &result, bool strict) {
+	return TrySimpleIntegerCast<int32_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int64_t &result, bool strict) {
+	return TrySimpleIntegerCast<int64_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <>
+bool TryCast::Operation(string_t input, uint8_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint8_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint16_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint16_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint32_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint32_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint64_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint64_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <class T>
+static bool TryDoubleCast(const char *buf, idx_t len, T &result, bool strict) {
+	// skip any spaces at the start
+	while (len > 0 && StringUtil::CharacterIsSpace(*buf)) {
+		buf++;
+		len--;
+	}
+	if (len == 0) {
+		return false;
+	}
+	if (*buf == '+') {
+		buf++;
+		len--;
+	}
+	auto endptr = buf + len;
+	auto parse_result = duckdb_fast_float::from_chars(buf, buf + len, result);
+	if (parse_result.ec != std::errc()) {
+		return false;
+	}
+	auto current_end = parse_result.ptr;
+	if (!strict) {
+		while (current_end < endptr && StringUtil::CharacterIsSpace(*current_end)) {
+			current_end++;
+		}
+	}
+	return current_end == endptr;
+}
+
+template <>
+bool TryCast::Operation(string_t input, float &result, bool strict) {
+	return TryDoubleCast<float>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <>
+bool TryCast::Operation(string_t input, double &result, bool strict) {
+	return TryDoubleCast<double>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Date
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(date_t input, date_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+template <>
+bool TryCast::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (input == date_t::infinity()) {
+		result = timestamp_t::infinity();
+		return true;
+	} else if (input == date_t::ninfinity()) {
+		result = timestamp_t::ninfinity();
+		return true;
+	}
+	return Timestamp::TryFromDatetime(input, Time::FromTime(0, 0, 0), result);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Time
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(dtime_t input, dtime_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Timestamps
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(timestamp_t input, date_t &result, bool strict) {
+	result = Timestamp::GetDate(input);
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_t input, dtime_t &result, bool strict) {
+	if (!Timestamp::IsFinite(input)) {
+		return false;
+	}
+	result = Timestamp::GetTime(input);
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_t input, timestamp_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast from Interval
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(interval_t input, interval_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Non-Standard Timestamps
+//===--------------------------------------------------------------------===//
+template <>
+duckdb::string_t CastFromTimestampNS::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochNanoSeconds(input.value), result);
+}
+template <>
+duckdb::string_t CastFromTimestampMS::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochMs(input.value), result);
+}
+template <>
+duckdb::string_t CastFromTimestampSec::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochSeconds(input.value), result);
+}
+
+template <>
+timestamp_t CastTimestampUsToMs::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochMs(input));
+	return cast_timestamp;
+}
+
+template <>
+timestamp_t CastTimestampUsToNs::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochNanoSeconds(input));
+	return cast_timestamp;
+}
+
+template <>
+timestamp_t CastTimestampUsToSec::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochSeconds(input));
+	return cast_timestamp;
+}
+template <>
+timestamp_t CastTimestampMsToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochMs(input.value);
+}
+
+template <>
+timestamp_t CastTimestampNsToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochNanoSeconds(input.value);
+}
+
+template <>
+timestamp_t CastTimestampSecToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochSeconds(input.value);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Timestamp
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToTimestampNS::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochNanoSeconds(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampMS::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochMs(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampSec::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochSeconds(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampNS::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	if (!TryMultiplyOperator::Operation(result.value, Interval::NANOS_PER_MICRO, result.value)) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCastToTimestampMS::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result.value /= Interval::MICROS_PER_MSEC;
+	return true;
+}
+
+template <>
+bool TryCastToTimestampSec::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result.value /= Interval::MICROS_PER_MSEC * Interval::MSECS_PER_SEC;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Blob
+//===--------------------------------------------------------------------===//
+template <>
+string_t CastFromBlob::Operation(string_t input, Vector &vector) {
+	idx_t result_size = Blob::GetStringSize(input);
+
+	string_t result = StringVector::EmptyString(vector, result_size);
+	Blob::ToString(input, result.GetDataWriteable());
+	result.Finalize();
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Blob
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
+                              bool strict) {
+	idx_t result_size;
+	if (!Blob::TryGetBlobSize(input, result_size, error_message)) {
+		return false;
+	}
+
+	result = StringVector::EmptyString(result_vector, result_size);
+	Blob::ToBlob(input, (data_ptr_t)result.GetDataWriteable());
+	result.Finalize();
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From UUID
+//===--------------------------------------------------------------------===//
+template <>
+string_t CastFromUUID::Operation(hugeint_t input, Vector &vector) {
+	string_t result = StringVector::EmptyString(vector, 36);
+	UUID::ToString(input, result.GetDataWriteable());
+	result.Finalize();
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To UUID
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector, string *error_message,
+                              bool strict) {
+	return UUID::FromString(input.GetString(), result);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Date
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, date_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, date_t>(input, result, strict)) {
+		HandleCastError::AssignError(Date::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, date_t &result, bool strict) {
+	idx_t pos;
+	return Date::TryConvertDate(input.GetDataUnsafe(), input.GetSize(), pos, result, strict);
+}
+
+template <>
+date_t Cast::Operation(string_t input) {
+	return Date::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Time
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, dtime_t>(input, result, strict)) {
+		HandleCastError::AssignError(Time::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, dtime_t &result, bool strict) {
+	idx_t pos;
+	return Time::TryConvertTime(input.GetDataUnsafe(), input.GetSize(), pos, result, strict);
+}
+
+template <>
+dtime_t Cast::Operation(string_t input) {
+	return Time::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Timestamp
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		HandleCastError::AssignError(Timestamp::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, timestamp_t &result, bool strict) {
+	return Timestamp::TryConvertTimestamp(input.GetDataUnsafe(), input.GetSize(), result);
+}
+
+template <>
+timestamp_t Cast::Operation(string_t input) {
+	return Timestamp::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Interval
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, interval_t &result, string *error_message, bool strict) {
+	return Interval::FromCString(input.GetDataUnsafe(), input.GetSize(), result, error_message, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Hugeint
+//===--------------------------------------------------------------------===//
+// parsing hugeint from string is done a bit differently for performance reasons
+// for other integer types we keep track of a single value
+// and multiply that value by 10 for every digit we read
+// however, for hugeints, multiplication is very expensive (>20X as expensive as for int64)
+// for that reason, we parse numbers first into an int64 value
+// when that value is full, we perform a HUGEINT multiplication to flush it into the hugeint
+// this takes the number of HUGEINT multiplications down from [0-38] to [0-2]
+struct HugeIntCastData {
+	hugeint_t hugeint;
+	int64_t intermediate;
+	uint8_t digits;
+	bool decimal;
+
+	bool Flush() {
+		if (digits == 0 && intermediate == 0) {
+			return true;
+		}
+		if (hugeint.lower != 0 || hugeint.upper != 0) {
+			if (digits > 38) {
+				return false;
+			}
+			if (!Hugeint::TryMultiply(hugeint, Hugeint::POWERS_OF_TEN[digits], hugeint)) {
+				return false;
+			}
+		}
+		if (!Hugeint::AddInPlace(hugeint, hugeint_t(intermediate))) {
+			return false;
+		}
+		digits = 0;
+		intermediate = 0;
+		return true;
+	}
+};
+
+struct HugeIntegerCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &result, uint8_t digit) {
+		if (NEGATIVE) {
+			if (result.intermediate < (NumericLimits<int64_t>::Minimum() + digit) / 10) {
+				// intermediate is full: need to flush it
+				if (!result.Flush()) {
+					return false;
+				}
+			}
+			result.intermediate = result.intermediate * 10 - digit;
+		} else {
+			if (result.intermediate > (NumericLimits<int64_t>::Maximum() - digit) / 10) {
+				if (!result.Flush()) {
+					return false;
+				}
+			}
+			result.intermediate = result.intermediate * 10 + digit;
+		}
+		result.digits++;
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &result, int32_t exponent) {
+		if (!result.Flush()) {
+			return false;
+		}
+		if (exponent < -38 || exponent > 38) {
+			// out of range for exact exponent: use double and convert
+			double dbl_res = Hugeint::Cast<double>(result.hugeint) * std::pow(10.0L, exponent);
+			if (dbl_res < Hugeint::Cast<double>(NumericLimits<hugeint_t>::Minimum()) ||
+			    dbl_res > Hugeint::Cast<double>(NumericLimits<hugeint_t>::Maximum())) {
+				return false;
+			}
+			result.hugeint = Hugeint::Convert(dbl_res);
+			return true;
+		}
+		if (exponent < 0) {
+			// negative exponent: divide by power of 10
+			result.hugeint = Hugeint::Divide(result.hugeint, Hugeint::POWERS_OF_TEN[-exponent]);
+			return true;
+		} else {
+			// positive exponent: multiply by power of 10
+			return Hugeint::TryMultiply(result.hugeint, Hugeint::POWERS_OF_TEN[exponent], result.hugeint);
+		}
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &result, uint8_t digit) {
+		// Integer casts round
+		if (!result.decimal) {
+			if (!result.Flush()) {
+				return false;
+			}
+			if (NEGATIVE) {
+				result.intermediate = -(digit >= 5);
+			} else {
+				result.intermediate = (digit >= 5);
+			}
+		}
+		result.decimal = true;
+
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &result) {
+		return result.Flush();
+	}
+};
+
+template <>
+bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
+	HugeIntCastData data;
+	if (!TryIntegerCast<HugeIntCastData, true, true, HugeIntegerCastOperation>(input.GetDataUnsafe(), input.GetSize(),
+	                                                                           data, strict)) {
+		return false;
+	}
+	result = data.hugeint;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal String Cast
+//===--------------------------------------------------------------------===//
+template <class T>
+struct DecimalCastData {
+	T result;
+	uint8_t width;
+	uint8_t scale;
+	uint8_t digit_count;
+	uint8_t decimal_count;
+};
+
+struct DecimalCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &state, uint8_t digit) {
+		if (state.result == 0 && digit == 0) {
+			// leading zero's don't count towards the digit count
+			return true;
+		}
+		if (state.digit_count == state.width - state.scale) {
+			// width of decimal type is exceeded!
+			return false;
+		}
+		state.digit_count++;
+		if (NEGATIVE) {
+			state.result = state.result * 10 - digit;
+		} else {
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &state, int32_t exponent) {
+		Finalize<T>(state);
+		if (exponent < 0) {
+			for (idx_t i = 0; i < idx_t(-int64_t(exponent)); i++) {
+				state.result /= 10;
+				if (state.result == 0) {
+					break;
+				}
+			}
+			return true;
+		} else {
+			// positive exponent: append 0's
+			for (idx_t i = 0; i < idx_t(exponent); i++) {
+				if (!HandleDigit<T, NEGATIVE>(state, 0)) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &state, uint8_t digit) {
+		if (state.decimal_count == state.scale) {
+			// we exceeded the amount of supported decimals
+			// however, we don't throw an error here
+			// we just truncate the decimal
+			return true;
+		}
+		state.decimal_count++;
+		if (NEGATIVE) {
+			state.result = state.result * 10 - digit;
+		} else {
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &state) {
+		// if we have not gotten exactly "scale" decimals, we need to multiply the result
+		// e.g. if we have a string "1.0" that is cast to a DECIMAL(9,3), the value needs to be 1000
+		// but we have only gotten the value "10" so far, so we multiply by 1000
+		for (uint8_t i = state.decimal_count; i < state.scale; i++) {
+			state.result *= 10;
+		}
+		return true;
+	}
+};
+
+template <class T>
+bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+	DecimalCastData<T> state;
+	state.result = 0;
+	state.width = width;
+	state.scale = scale;
+	state.digit_count = 0;
+	state.decimal_count = 0;
+	if (!TryIntegerCast<DecimalCastData<T>, true, true, DecimalCastOperation, false>(input.GetDataUnsafe(),
+	                                                                                 input.GetSize(), state, false)) {
+		string error = StringUtil::Format("Could not convert string \"%s\" to DECIMAL(%d,%d)", input.GetString(),
+		                                  (int)width, (int)scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = state.result;
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return TryDecimalStringCast<hugeint_t>(input, result, error_message, width, scale);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int16_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int16_t, uint16_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int32_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int32_t, uint32_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int64_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int64_t, uint64_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(hugeint_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return HugeintToStringCast::FormatDecimal(input, scale, result);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal Casts
+//===--------------------------------------------------------------------===//
+// Decimal <-> Bool
+//===--------------------------------------------------------------------===//
+template <class T, class OP = NumericHelper>
+bool TryCastBoolToDecimal(bool input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+	if (width > scale) {
+		result = input ? OP::POWERS_OF_TEN[scale] : 0;
+		return true;
+	} else {
+		return TryCast::Operation<bool, T>(input, result);
+	}
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<hugeint_t, Hugeint>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int16_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int32_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int64_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<hugeint_t, bool>(input, result);
+}
+
+//===--------------------------------------------------------------------===//
+// Numeric -> Decimal Cast
+//===--------------------------------------------------------------------===//
+struct SignedToDecimalOperator {
+	template <class SRC, class DST>
+	static bool Operation(SRC input, DST max_width) {
+		return int64_t(input) >= int64_t(max_width) || int64_t(input) <= int64_t(-max_width);
+	}
+};
+
+struct UnsignedToDecimalOperator {
+	template <class SRC, class DST>
+	static bool Operation(SRC input, DST max_width) {
+		return uint64_t(input) >= uint64_t(max_width);
+	}
+};
+
+template <class SRC, class DST, class OP = SignedToDecimalOperator>
+bool StandardNumericToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	DST max_width = NumericHelper::POWERS_OF_TEN[width - scale];
+	if (OP::template Operation<SRC, DST>(input, max_width)) {
+		string error = StringUtil::Format("Could not cast value %d to DECIMAL(%d,%d)", input, width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = DST(input) * NumericHelper::POWERS_OF_TEN[scale];
+	return true;
+}
+
+template <class SRC>
+bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
+	hugeint_t hinput = Hugeint::Convert(input);
+	if (hinput >= max_width || hinput <= -max_width) {
+		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", hinput.ToString(), width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = hinput * Hugeint::POWERS_OF_TEN[scale];
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int8_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return NumericToHugeDecimalCast<int8_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int16_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int16_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int32_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int32_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int64_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int64_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint8_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint8_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint16_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint16_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint32_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint32_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint64_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint64_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Hugeint -> Decimal Cast
+//===--------------------------------------------------------------------===//
+template <class DST>
+bool HugeintToDecimalCast(hugeint_t input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
+	if (input >= max_width || input <= -max_width) {
+		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", input.ToString(), width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = Hugeint::Cast<DST>(input * Hugeint::POWERS_OF_TEN[scale]);
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<hugeint_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Float/Double -> Decimal Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool DoubleToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	double value = input * NumericHelper::DOUBLE_POWERS_OF_TEN[scale];
+	// Add the sign (-1, 0, 1) times a tiny value to fix floating point issues (issue 3091)
+	double sign = (double(0) < value) - (value < double(0));
+	value += 1e-9 * sign;
+	if (value <= -NumericHelper::DOUBLE_POWERS_OF_TEN[width] || value >= NumericHelper::DOUBLE_POWERS_OF_TEN[width]) {
+		string error = StringUtil::Format("Could not cast value %f to DECIMAL(%d,%d)", value, width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = Cast::Operation<SRC, DST>(value);
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, hugeint_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, hugeint_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal -> Numeric Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool TryCastDecimalToNumeric(SRC input, DST &result, string *error_message, uint8_t scale) {
+	// Round away from 0.
+	const auto power = NumericHelper::POWERS_OF_TEN[scale];
+	// https://graphics.stanford.edu/~seander/bithacks.html#ConditionalNegate
+	const auto fNegate = int64_t(input < 0);
+	const auto rounding = ((power ^ -fNegate) + fNegate) / 2;
+	const auto scaled_value = (input + rounding) / power;
+	if (!TryCast::Operation<SRC, DST>(scaled_value, result)) {
+		string error = StringUtil::Format("Failed to cast decimal value %d to type %s", scaled_value, GetTypeId<DST>());
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	return true;
+}
+
+template <class DST>
+bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, string *error_message, uint8_t scale) {
+	const auto power = Hugeint::POWERS_OF_TEN[scale];
+	const auto rounding = ((input < 0) ? -power : power) / 2;
+	auto scaled_value = (input + rounding) / power;
+	if (!TryCast::Operation<hugeint_t, DST>(scaled_value, result)) {
+		string error = StringUtil::Format("Failed to cast decimal value %s to type %s",
+		                                  ConvertToString::Operation(scaled_value), GetTypeId<DST>());
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int8_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int8_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int16_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int16_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int32_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int32_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int64_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int64_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint8_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint8_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint16_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint16_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint32_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint32_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint64_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint64_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> hugeint_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<hugeint_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal -> Float/Double Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool TryCastDecimalToFloatingPoint(SRC input, DST &result, uint8_t scale) {
+	result = Cast::Operation<SRC, DST>(input) / DST(NumericHelper::DOUBLE_POWERS_OF_TEN[scale]);
+	return true;
+}
+
+// DECIMAL -> FLOAT
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int16_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int32_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int64_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, float &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<hugeint_t, float>(input, result, scale);
+}
+
+// DECIMAL -> DOUBLE
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int16_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int32_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int64_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, double &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<hugeint_t, double>(input, result, scale);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+string StandardStringCast(T input) {
+	Vector v(LogicalType::VARCHAR);
+	return StringCast::Operation(input, v).GetString();
+}
+
+template <>
+string ConvertToString::Operation(bool input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int8_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int16_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int32_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int64_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint8_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint16_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint32_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint64_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(hugeint_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(float input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(double input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(interval_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(date_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(dtime_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(timestamp_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(string_t input) {
+	return input.GetString();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Cast Numeric -> String
+//===--------------------------------------------------------------------===//
+template <>
+string_t StringCast::Operation(bool input, Vector &vector) {
+	if (input) {
+		return StringVector::AddString(vector, "true", 4);
+	} else {
+		return StringVector::AddString(vector, "false", 5);
+	}
+}
+
+template <>
+string_t StringCast::Operation(int8_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int8_t, uint8_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(int16_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int16_t, uint16_t>(input, vector);
+}
+template <>
+string_t StringCast::Operation(int32_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int32_t, uint32_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(int64_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int64_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint8_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint8_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint16_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint16_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint32_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint32_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint64_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint64_t, uint64_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(float input, Vector &vector) {
+	std::string s = duckdb_fmt::format("{}", input);
+	return StringVector::AddString(vector, s);
+}
+
+template <>
+string_t StringCast::Operation(double input, Vector &vector) {
+	std::string s = duckdb_fmt::format("{}", input);
+	return StringVector::AddString(vector, s);
+}
+
+template <>
+string_t StringCast::Operation(interval_t input, Vector &vector) {
+	char buffer[70];
+	idx_t length = IntervalToStringCast::Format(input, buffer);
+	return StringVector::AddString(vector, buffer, length);
+}
+
+template <>
+duckdb::string_t StringCast::Operation(hugeint_t input, Vector &vector) {
+	return HugeintToStringCast::FormatSigned(input, vector);
+}
+
+template <>
+duckdb::string_t StringCast::Operation(date_t input, Vector &vector) {
+	if (input == date_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == date_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	int32_t date[3];
+	Date::Convert(input, date[0], date[1], date[2]);
+
+	idx_t year_length;
+	bool add_bc;
+	idx_t length = DateToStringCast::Length(date, year_length, add_bc);
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	DateToStringCast::Format(data, date, year_length, add_bc);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(dtime_t input, Vector &vector) {
+	int32_t time[4];
+	Time::Convert(input, time[0], time[1], time[2], time[3]);
+
+	char micro_buffer[10];
+	idx_t length = TimeToStringCast::Length(time, micro_buffer);
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	TimeToStringCast::Format(data, length, time, micro_buffer);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(timestamp_t input, Vector &vector) {
+	if (input == timestamp_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == timestamp_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	date_t date_entry;
+	dtime_t time_entry;
+	Timestamp::Convert(input, date_entry, time_entry);
+
+	int32_t date[3], time[4];
+	Date::Convert(date_entry, date[0], date[1], date[2]);
+	Time::Convert(time_entry, time[0], time[1], time[2], time[3]);
+
+	// format for timestamp is DATE TIME (separated by space)
+	idx_t year_length;
+	bool add_bc;
+	char micro_buffer[6];
+	idx_t date_length = DateToStringCast::Length(date, year_length, add_bc);
+	idx_t time_length = TimeToStringCast::Length(time, micro_buffer);
+	idx_t length = date_length + time_length + 1;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	DateToStringCast::Format(data, date, year_length, add_bc);
+	data[date_length] = ' ';
+	TimeToStringCast::Format(data + date_length + 1, time_length, time, micro_buffer);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(duckdb::string_t input, Vector &result) {
+	return StringVector::AddStringOrBlob(result, input);
+}
+
+template <>
+string_t StringCastTZ::Operation(dtime_t input, Vector &vector) {
+	int32_t time[4];
+	Time::Convert(input, time[0], time[1], time[2], time[3]);
+
+	// format for timetz is TIME+00
+	char micro_buffer[10];
+	const auto time_length = TimeToStringCast::Length(time, micro_buffer);
+	const idx_t length = time_length + 3;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	idx_t pos = 0;
+	TimeToStringCast::Format(data + pos, length, time, micro_buffer);
+	pos += time_length;
+	data[pos++] = '+';
+	data[pos++] = '0';
+	data[pos++] = '0';
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+string_t StringCastTZ::Operation(timestamp_t input, Vector &vector) {
+	if (input == timestamp_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == timestamp_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	date_t date_entry;
+	dtime_t time_entry;
+	Timestamp::Convert(input, date_entry, time_entry);
+
+	int32_t date[3], time[4];
+	Date::Convert(date_entry, date[0], date[1], date[2]);
+	Time::Convert(time_entry, time[0], time[1], time[2], time[3]);
+
+	// format for timestamptz is DATE TIME+00 (separated by space)
+	idx_t year_length;
+	bool add_bc;
+	char micro_buffer[6];
+	const idx_t date_length = DateToStringCast::Length(date, year_length, add_bc);
+	const idx_t time_length = TimeToStringCast::Length(time, micro_buffer);
+	const idx_t length = date_length + 1 + time_length + 3;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	idx_t pos = 0;
+	DateToStringCast::Format(data + pos, date, year_length, add_bc);
+	pos += date_length;
+	data[pos++] = ' ';
+	TimeToStringCast::Format(data + pos, time_length, time, micro_buffer);
+	pos += time_length;
+	data[pos++] = '+';
+	data[pos++] = '0';
+	data[pos++] = '0';
+
+	result.Finalize();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+class PipeFile : public FileHandle {
+public:
+	PipeFile(unique_ptr<FileHandle> child_handle_p, const string &path)
+	    : FileHandle(pipe_fs, path), child_handle(move(child_handle_p)) {
+	}
+
+	PipeFileSystem pipe_fs;
+	unique_ptr<FileHandle> child_handle;
+
+public:
+	int64_t ReadChunk(void *buffer, int64_t nr_bytes);
+	int64_t WriteChunk(void *buffer, int64_t nr_bytes);
+
+	void Close() override {
+	}
+};
+
+int64_t PipeFile::ReadChunk(void *buffer, int64_t nr_bytes) {
+	return child_handle->Read(buffer, nr_bytes);
+}
+int64_t PipeFile::WriteChunk(void *buffer, int64_t nr_bytes) {
+	return child_handle->Write(buffer, nr_bytes);
+}
+
+void PipeFileSystem::Reset(FileHandle &handle) {
+	throw InternalException("Cannot reset pipe file system");
+}
+
+int64_t PipeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &pipe = (PipeFile &)handle;
+	return pipe.ReadChunk(buffer, nr_bytes);
+}
+
+int64_t PipeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &pipe = (PipeFile &)handle;
+	return pipe.WriteChunk(buffer, nr_bytes);
+}
+
+int64_t PipeFileSystem::GetFileSize(FileHandle &handle) {
+	return 0;
+}
+
+void PipeFileSystem::FileSync(FileHandle &handle) {
+}
+
+unique_ptr<FileHandle> PipeFileSystem::OpenPipe(unique_ptr<FileHandle> handle) {
+	auto path = handle->path;
+	return make_unique<PipeFile>(move(handle), path);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <stdio.h>
+
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+#include <io.h>
+#endif
+#endif
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+void Printer::Print(const string &str) {
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+	if (IsTerminal()) {
+		// print utf8 to terminal
+		auto unicode = WindowsUtil::UTF8ToMBCS(str.c_str());
+		fprintf(stderr, "%s\n", unicode.c_str());
+		return;
+	}
+#endif
+	fprintf(stderr, "%s\n", str.c_str());
+#endif
+}
+
+void Printer::PrintProgress(int percentage, const char *pbstr, int pbwidth) {
+#ifndef DUCKDB_DISABLE_PRINT
+	int lpad = (int)(percentage / 100.0 * pbwidth);
+	int rpad = pbwidth - lpad;
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr, rpad, "");
+	fflush(stdout);
+#endif
+}
+
+void Printer::FinishProgressBarPrint(const char *pbstr, int pbwidth) {
+#ifndef DUCKDB_DISABLE_PRINT
+	PrintProgress(100, pbstr, pbwidth);
+	printf(" \n");
+	fflush(stdout);
+#endif
+}
+
+bool Printer::IsTerminal() {
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+	return GetFileType(GetStdHandle(STD_ERROR_HANDLE)) == FILE_TYPE_CHAR;
+#else
+	throw InternalException("IsTerminal is only implemented for Windows");
+#endif
+#endif
+	return false;
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ProgressBar::ProgressBar(Executor &executor, idx_t show_progress_after, bool print_progress)
+    : executor(executor), show_progress_after(show_progress_after), current_percentage(-1),
+      print_progress(print_progress) {
+}
+
+double ProgressBar::GetCurrentPercentage() {
+	return current_percentage;
+}
+
+void ProgressBar::Start() {
+	profiler.Start();
+	current_percentage = 0;
+	supported = true;
+}
+
+void ProgressBar::Update(bool final) {
+	if (!supported) {
+		return;
+	}
+	double new_percentage;
+	supported = executor.GetPipelinesProgress(new_percentage);
+	if (!supported) {
+		return;
+	}
+	auto sufficient_time_elapsed = profiler.Elapsed() > show_progress_after / 1000.0;
+	if (new_percentage > current_percentage) {
+		current_percentage = new_percentage;
+	}
+	if (supported && print_progress && sufficient_time_elapsed && current_percentage > -1 && print_progress) {
+		if (final) {
+			Printer::FinishProgressBarPrint(PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+		} else {
+			Printer::PrintProgress(current_percentage, PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+#include <random>
+
+namespace duckdb {
+
+struct RandomState {
+	RandomState() {
+	}
+
+	pcg32 pcg;
+};
+
+RandomEngine::RandomEngine(int64_t seed) : random_state(make_unique<RandomState>()) {
+	if (seed < 0) {
+		random_state->pcg.seed(pcg_extras::seed_seq_from<std::random_device>());
+	} else {
+		random_state->pcg.seed(seed);
+	}
+}
+
+RandomEngine::~RandomEngine() {
+}
+
+double RandomEngine::NextRandom(double min, double max) {
+	D_ASSERT(max >= min);
+	return min + (NextRandom() * (max - min));
+}
+
+double RandomEngine::NextRandom() {
+	return random_state->pcg() / double(std::numeric_limits<uint32_t>::max());
+}
+uint32_t RandomEngine::NextRandomInteger() {
+	return random_state->pcg();
+}
+
+void RandomEngine::SetSeed(uint32_t seed) {
+	random_state->pcg.seed(seed);
+}
+
+} // namespace duckdb
+#include <vector>
+#include <memory>
+
+
+
+
+namespace duckdb_re2 {
+
+Regex::Regex(const std::string &pattern, RegexOptions options) {
+	RE2::Options o;
+	o.set_case_sensitive(options == RegexOptions::CASE_INSENSITIVE);
+	regex = std::make_shared<duckdb_re2::RE2>(StringPiece(pattern), o);
+}
+
+bool RegexSearchInternal(const char *input, Match &match, const Regex &r, RE2::Anchor anchor, size_t start,
+                         size_t end) {
+	auto &regex = r.GetRegex();
+	std::vector<StringPiece> target_groups;
+	auto group_count = regex.NumberOfCapturingGroups() + 1;
+	target_groups.resize(group_count);
+	match.groups.clear();
+	if (!regex.Match(StringPiece(input), start, end, anchor, target_groups.data(), group_count)) {
+		return false;
+	}
+	for (auto &group : target_groups) {
+		GroupMatch group_match;
+		group_match.text = group.ToString();
+		group_match.position = group.data() - input;
+		match.groups.emplace_back(group_match);
+	}
+	return true;
+}
+
+bool RegexSearch(const std::string &input, Match &match, const Regex &regex) {
+	return RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, 0, input.size());
+}
+
+bool RegexMatch(const std::string &input, Match &match, const Regex &regex) {
+	return RegexSearchInternal(input.c_str(), match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+}
+
+bool RegexMatch(const char *start, const char *end, Match &match, const Regex &regex) {
+	return RegexSearchInternal(start, match, regex, RE2::ANCHOR_BOTH, 0, end - start);
+}
+
+bool RegexMatch(const std::string &input, const Regex &regex) {
+	Match nop_match;
+	return RegexSearchInternal(input.c_str(), nop_match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+}
+
+std::vector<Match> RegexFindAll(const std::string &input, const Regex &regex) {
+	std::vector<Match> matches;
+	size_t position = 0;
+	Match match;
+	while (RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, position, input.size())) {
+		position += match.position(0) + match.length(0);
+		matches.emplace_back(std::move(match));
+	}
+	return matches;
+}
+
+} // namespace duckdb_re2
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_operations/row_aggregate.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+void RowOperations::InitializeStates(RowLayout &layout, Vector &addresses, const SelectionVector &sel, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+	auto pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	auto &offsets = layout.GetOffsets();
+	auto aggr_idx = layout.ColumnCount();
+
+	for (auto &aggr : layout.GetAggregates()) {
+		for (idx_t i = 0; i < count; ++i) {
+			auto row_idx = sel.get_index(i);
+			auto row = pointers[row_idx];
+			aggr.function.initialize(row + offsets[aggr_idx]);
+		}
+		++aggr_idx;
+	}
+}
+
+void RowOperations::DestroyStates(RowLayout &layout, Vector &addresses, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+	//	Move to the first aggregate state
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), count);
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			aggr.function.destructor(addresses, count);
+		}
+		// Move to the next aggregate state
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, count);
+	}
+}
+
+void RowOperations::UpdateStates(AggregateObject &aggr, Vector &addresses, DataChunk &payload, idx_t arg_idx,
+                                 idx_t count) {
+	AggregateInputData aggr_input_data(aggr.bind_data);
+	aggr.function.update(aggr.child_count == 0 ? nullptr : &payload.data[arg_idx], aggr_input_data, aggr.child_count,
+	                     addresses, count);
+}
+
+void RowOperations::UpdateFilteredStates(AggregateObject &aggr, Vector &addresses, DataChunk &payload, idx_t arg_idx) {
+	ExpressionExecutor filter_execution(aggr.filter);
+	SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+	auto count = filter_execution.SelectExpression(payload, true_sel);
+
+	DataChunk filtered_payload;
+	auto pay_types = payload.GetTypes();
+	filtered_payload.Initialize(pay_types);
+	filtered_payload.Slice(payload, true_sel, count);
+
+	Vector filtered_addresses(addresses, true_sel, count);
+	filtered_addresses.Normalify(count);
+
+	UpdateStates(aggr, filtered_addresses, filtered_payload, arg_idx, filtered_payload.size());
+}
+
+void RowOperations::CombineStates(RowLayout &layout, Vector &sources, Vector &targets, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+
+	//	Move to the first aggregate states
+	VectorOperations::AddInPlace(sources, layout.GetAggrOffset(), count);
+	VectorOperations::AddInPlace(targets, layout.GetAggrOffset(), count);
+	for (auto &aggr : layout.GetAggregates()) {
+		D_ASSERT(aggr.function.combine);
+		AggregateInputData aggr_input_data(aggr.bind_data);
+		aggr.function.combine(sources, targets, aggr_input_data, count);
+
+		// Move to the next aggregate states
+		VectorOperations::AddInPlace(sources, aggr.payload_size, count);
+		VectorOperations::AddInPlace(targets, aggr.payload_size, count);
+	}
+}
+
+void RowOperations::FinalizeStates(RowLayout &layout, Vector &addresses, DataChunk &result, idx_t aggr_idx) {
+	//	Move to the first aggregate state
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), result.size());
+
+	auto &aggregates = layout.GetAggregates();
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &target = result.data[aggr_idx + i];
+		auto &aggr = aggregates[i];
+		AggregateInputData aggr_input_data(aggr.bind_data);
+		aggr.function.finalize(addresses, aggr_input_data, target, result.size(), 0);
+
+		// Move to the next aggregate state
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, result.size());
+	}
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_operations/row_external.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+namespace duckdb {
+
+void RowOperations::SwizzleColumns(const RowLayout &layout, const data_ptr_t base_row_ptr, const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	data_ptr_t heap_row_ptrs[STANDARD_VECTOR_SIZE];
+	idx_t done = 0;
+	while (done != count) {
+		const idx_t next = MinValue<idx_t>(count - done, STANDARD_VECTOR_SIZE);
+		const data_ptr_t row_ptr = base_row_ptr + done * row_width;
+		// Load heap row pointers
+		data_ptr_t heap_ptr_ptr = row_ptr + layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < next; i++) {
+			heap_row_ptrs[i] = Load<data_ptr_t>(heap_ptr_ptr);
+			heap_ptr_ptr += row_width;
+		}
+		// Loop through the blob columns
+		for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
+			auto physical_type = layout.GetTypes()[col_idx].InternalType();
+			if (TypeIsConstantSize(physical_type)) {
+				continue;
+			}
+			data_ptr_t col_ptr = row_ptr + layout.GetOffsets()[col_idx];
+			if (physical_type == PhysicalType::VARCHAR) {
+				data_ptr_t string_ptr = col_ptr + sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+				for (idx_t i = 0; i < next; i++) {
+					if (Load<uint32_t>(col_ptr) > string_t::INLINE_LENGTH) {
+						// Overwrite the string pointer with the within-row offset (if not inlined)
+						Store<idx_t>(Load<data_ptr_t>(string_ptr) - heap_row_ptrs[i], string_ptr);
+					}
+					col_ptr += row_width;
+					string_ptr += row_width;
+				}
+			} else {
+				// Non-varchar blob columns
+				for (idx_t i = 0; i < next; i++) {
+					// Overwrite the column data pointer with the within-row offset
+					Store<idx_t>(Load<data_ptr_t>(col_ptr) - heap_row_ptrs[i], col_ptr);
+					col_ptr += row_width;
+				}
+			}
+		}
+		done += next;
+	}
+}
+
+void RowOperations::SwizzleHeapPointer(const RowLayout &layout, data_ptr_t row_ptr, const data_ptr_t heap_base_ptr,
+                                       const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	row_ptr += layout.GetHeapPointerOffset();
+	idx_t cumulative_offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		Store<idx_t>(cumulative_offset, row_ptr);
+		cumulative_offset += Load<uint32_t>(heap_base_ptr + cumulative_offset);
+		row_ptr += row_width;
+	}
+}
+
+void RowOperations::UnswizzlePointers(const RowLayout &layout, const data_ptr_t base_row_ptr,
+                                      const data_ptr_t base_heap_ptr, const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	data_ptr_t heap_row_ptrs[STANDARD_VECTOR_SIZE];
+	idx_t done = 0;
+	while (done != count) {
+		const idx_t next = MinValue<idx_t>(count - done, STANDARD_VECTOR_SIZE);
+		const data_ptr_t row_ptr = base_row_ptr + done * row_width;
+		// Restore heap row pointers
+		data_ptr_t heap_ptr_ptr = row_ptr + layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < next; i++) {
+			heap_row_ptrs[i] = base_heap_ptr + Load<idx_t>(heap_ptr_ptr);
+			Store<data_ptr_t>(heap_row_ptrs[i], heap_ptr_ptr);
+			heap_ptr_ptr += row_width;
+		}
+		// Loop through the blob columns
+		for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
+			auto physical_type = layout.GetTypes()[col_idx].InternalType();
+			if (TypeIsConstantSize(physical_type)) {
+				continue;
+			}
+			data_ptr_t col_ptr = row_ptr + layout.GetOffsets()[col_idx];
+			if (physical_type == PhysicalType::VARCHAR) {
+				data_ptr_t string_ptr = col_ptr + sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+				for (idx_t i = 0; i < next; i++) {
+					if (Load<uint32_t>(col_ptr) > string_t::INLINE_LENGTH) {
+						// Overwrite the string offset with the pointer (if not inlined)
+						Store<data_ptr_t>(heap_row_ptrs[i] + Load<idx_t>(string_ptr), string_ptr);
+					}
+					col_ptr += row_width;
+					string_ptr += row_width;
+				}
+			} else {
+				// Non-varchar blob columns
+				for (idx_t i = 0; i < next; i++) {
+					// Overwrite the column data offset with the pointer
+					Store<data_ptr_t>(heap_row_ptrs[i] + Load<idx_t>(col_ptr), col_ptr);
+					col_ptr += row_width;
+				}
+			}
+		}
+		done += next;
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_gather.cpp
+// Description: This file contains the implementation of the gather operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+template <class T>
+static void TemplatedGatherLoop(Vector &rows, const SelectionVector &row_sel, Vector &col,
+                                const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no,
+                                idx_t build_size) {
+	// Precompute mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	auto data = FlatVector::GetData<T>(col);
+	auto &col_mask = FlatVector::Validity(col);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row_idx = row_sel.get_index(i);
+		auto row = ptrs[row_idx];
+		auto col_idx = col_sel.get_index(i);
+		data[col_idx] = Load<T>(row + col_offset);
+		ValidityBytes row_mask(row);
+		if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+			if (build_size > STANDARD_VECTOR_SIZE && col_mask.AllValid()) {
+				//! We need to initialize the mask with the vector size.
+				col_mask.Initialize(build_size);
+			}
+			col_mask.SetInvalid(col_idx);
+		}
+	}
+}
+
+static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vector &col,
+                               const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no) {
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	// Build the gather locations
+	auto data_locations = unique_ptr<data_ptr_t[]>(new data_ptr_t[count]);
+	auto mask_locations = unique_ptr<data_ptr_t[]>(new data_ptr_t[count]);
+	for (idx_t i = 0; i < count; i++) {
+		auto row_idx = row_sel.get_index(i);
+		mask_locations[i] = ptrs[row_idx];
+		data_locations[i] = Load<data_ptr_t>(ptrs[row_idx] + col_offset);
+	}
+
+	// Deserialise into the selected locations
+	RowOperations::HeapGather(col, count, col_sel, col_no, data_locations.get(), mask_locations.get());
+}
+
+void RowOperations::Gather(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,
+                           const idx_t count, const idx_t col_offset, const idx_t col_no, const idx_t build_size) {
+	D_ASSERT(rows.GetVectorType() == VectorType::FLAT_VECTOR);
+	D_ASSERT(rows.GetType().id() == LogicalTypeId::POINTER); // "Cannot gather from non-pointer type!"
+
+	col.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (col.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		TemplatedGatherLoop<uint8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedGatherLoop<uint16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedGatherLoop<uint32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedGatherLoop<uint64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedGatherLoop<int8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGatherLoop<int16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGatherLoop<int32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGatherLoop<int64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT128:
+		TemplatedGatherLoop<hugeint_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGatherLoop<float>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGatherLoop<double>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedGatherLoop<interval_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedGatherLoop<string_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		GatherNestedVector(rows, row_sel, col, col_sel, count, col_offset, col_no);
+		break;
+	default:
+		throw InternalException("Unimplemented type for RowOperations::Gather");
+	}
+}
+
+template <class T>
+static void TemplatedFullScanLoop(Vector &rows, Vector &col, idx_t count, idx_t col_offset, idx_t col_no) {
+	// Precompute mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	auto data = FlatVector::GetData<T>(col);
+	//	auto &col_mask = FlatVector::Validity(col);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row = ptrs[i];
+		data[i] = Load<T>(row + col_offset);
+		ValidityBytes row_mask(row);
+		if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+			throw InternalException("Null value comparisons not implemented for perfect hash table yet");
+			//			col_mask.SetInvalid(i);
+		}
+	}
+}
+
+void RowOperations::FullScanColumn(const RowLayout &layout, Vector &rows, Vector &col, idx_t count, idx_t col_no) {
+	const auto col_offset = layout.GetOffsets()[col_no];
+	col.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (col.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		TemplatedFullScanLoop<uint8_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFullScanLoop<uint16_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFullScanLoop<uint32_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFullScanLoop<uint64_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT8:
+		TemplatedFullScanLoop<int8_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFullScanLoop<int16_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFullScanLoop<int32_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFullScanLoop<int64_t>(rows, col, count, col_offset, col_no);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for RowOperations::FullScanColumn");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = TemplatedValidityMask<uint8_t>;
+
+template <class T>
+static void TemplatedHeapGather(Vector &v, const idx_t count, const SelectionVector &sel, data_ptr_t *key_locations) {
+	auto target = FlatVector::GetData<T>(v);
+
+	for (idx_t i = 0; i < count; ++i) {
+		const auto col_idx = sel.get_index(i);
+		target[col_idx] = Load<T>(key_locations[i]);
+		key_locations[i] += sizeof(T);
+	}
+}
+
+static void HeapGatherStringVector(Vector &v, const idx_t vcount, const SelectionVector &sel,
+                                   data_ptr_t *key_locations) {
+	const auto &validity = FlatVector::Validity(v);
+	auto target = FlatVector::GetData<string_t>(v);
+
+	for (idx_t i = 0; i < vcount; i++) {
+		const auto col_idx = sel.get_index(i);
+		if (!validity.RowIsValid(col_idx)) {
+			continue;
+		}
+		auto len = Load<uint32_t>(key_locations[i]);
+		key_locations[i] += sizeof(uint32_t);
+		target[col_idx] = StringVector::AddStringOrBlob(v, string_t((const char *)key_locations[i], len));
+		key_locations[i] += len;
+	}
+}
+
+static void HeapGatherStructVector(Vector &v, const idx_t vcount, const SelectionVector &sel,
+                                   data_ptr_t *key_locations) {
+	// struct must have a validitymask for its fields
+	auto &child_types = StructType::GetChildTypes(v.GetType());
+	const idx_t struct_validitymask_size = (child_types.size() + 7) / 8;
+	data_ptr_t struct_validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < vcount; i++) {
+		// use key_locations as the validitymask, and create struct_key_locations
+		struct_validitymask_locations[i] = key_locations[i];
+		key_locations[i] += struct_validitymask_size;
+	}
+
+	// now deserialize into the struct vectors
+	auto &children = StructVector::GetEntries(v);
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		RowOperations::HeapGather(*children[i], vcount, sel, i, key_locations, struct_validitymask_locations);
+	}
+}
+
+static void HeapGatherListVector(Vector &v, const idx_t vcount, const SelectionVector &sel, data_ptr_t *key_locations) {
+	const auto &validity = FlatVector::Validity(v);
+
+	auto child_type = ListType::GetChildType(v.GetType());
+	auto list_data = ListVector::GetData(v);
+	data_ptr_t list_entry_locations[STANDARD_VECTOR_SIZE];
+
+	uint64_t entry_offset = ListVector::GetListSize(v);
+	for (idx_t i = 0; i < vcount; i++) {
+		const auto col_idx = sel.get_index(i);
+		if (!validity.RowIsValid(col_idx)) {
+			continue;
+		}
+		// read list length
+		auto entry_remaining = Load<uint64_t>(key_locations[i]);
+		key_locations[i] += sizeof(uint64_t);
+		// set list entry attributes
+		list_data[col_idx].length = entry_remaining;
+		list_data[col_idx].offset = entry_offset;
+		// skip over the validity mask
+		data_ptr_t validitymask_location = key_locations[i];
+		idx_t offset_in_byte = 0;
+		key_locations[i] += (entry_remaining + 7) / 8;
+		// entry sizes
+		data_ptr_t var_entry_size_ptr = nullptr;
+		if (!TypeIsConstantSize(child_type.InternalType())) {
+			var_entry_size_ptr = key_locations[i];
+			key_locations[i] += entry_remaining * sizeof(idx_t);
+		}
+
+		// now read the list data
+		while (entry_remaining > 0) {
+			auto next = MinValue(entry_remaining, (idx_t)STANDARD_VECTOR_SIZE);
+
+			// initialize a new vector to append
+			Vector append_vector(v.GetType());
+			append_vector.SetVectorType(v.GetVectorType());
+
+			auto &list_vec_to_append = ListVector::GetEntry(append_vector);
+
+			// set validity
+			//! Since we are constructing the vector, this will always be a flat vector.
+			auto &append_validity = FlatVector::Validity(list_vec_to_append);
+			for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+				append_validity.Set(entry_idx, *(validitymask_location) & (1 << offset_in_byte));
+				if (++offset_in_byte == 8) {
+					validitymask_location++;
+					offset_in_byte = 0;
+				}
+			}
+
+			// compute entry sizes and set locations where the list entries are
+			if (TypeIsConstantSize(child_type.InternalType())) {
+				// constant size list entries
+				const idx_t type_size = GetTypeIdSize(child_type.InternalType());
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += type_size;
+				}
+			} else {
+				// variable size list entries
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += Load<idx_t>(var_entry_size_ptr);
+					var_entry_size_ptr += sizeof(idx_t);
+				}
+			}
+
+			// now deserialize and add to listvector
+			RowOperations::HeapGather(list_vec_to_append, next, *FlatVector::IncrementalSelectionVector(), 0,
+			                          list_entry_locations, nullptr);
+			ListVector::Append(v, list_vec_to_append, next);
+
+			// update for next iteration
+			entry_remaining -= next;
+			entry_offset += next;
+		}
+	}
+}
+
+void RowOperations::HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, const idx_t &col_no,
+                               data_ptr_t *key_locations, data_ptr_t *validitymask_locations) {
+	v.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &validity = FlatVector::Validity(v);
+	if (validitymask_locations) {
+		// Precompute mask indexes
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+		for (idx_t i = 0; i < vcount; i++) {
+			ValidityBytes row_mask(validitymask_locations[i]);
+			const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+			const auto col_idx = sel.get_index(i);
+			validity.Set(col_idx, valid);
+		}
+	}
+
+	auto type = v.GetType().InternalType();
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedHeapGather<int8_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT16:
+		TemplatedHeapGather<int16_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT32:
+		TemplatedHeapGather<int32_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT64:
+		TemplatedHeapGather<int64_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedHeapGather<uint8_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedHeapGather<uint16_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedHeapGather<uint32_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedHeapGather<uint64_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT128:
+		TemplatedHeapGather<hugeint_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedHeapGather<float>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedHeapGather<double>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedHeapGather<interval_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::VARCHAR:
+		HeapGatherStringVector(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::STRUCT:
+		HeapGatherStructVector(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::LIST:
+		HeapGatherListVector(v, vcount, sel, key_locations);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented deserialize from row-format");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = TemplatedValidityMask<uint8_t>;
+
+static void ComputeStringEntrySizes(VectorData &vdata, idx_t entry_sizes[], const idx_t ser_count,
+                                    const SelectionVector &sel, const idx_t offset) {
+	auto strings = (string_t *)vdata.data;
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto str_idx = vdata.sel->get_index(idx) + offset;
+		if (vdata.validity.RowIsValid(str_idx)) {
+			entry_sizes[i] += sizeof(uint32_t) + strings[str_idx].GetSize();
+		}
+	}
+}
+
+static void ComputeStructEntrySizes(Vector &v, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                    const SelectionVector &sel, idx_t offset) {
+	// obtain child vectors
+	idx_t num_children;
+	auto &children = StructVector::GetEntries(v);
+	num_children = children.size();
+	// add struct validitymask size
+	const idx_t struct_validitymask_size = (num_children + 7) / 8;
+	for (idx_t i = 0; i < ser_count; i++) {
+		entry_sizes[i] += struct_validitymask_size;
+	}
+	// compute size of child vectors
+	for (auto &struct_vector : children) {
+		RowOperations::ComputeEntrySizes(*struct_vector, entry_sizes, vcount, ser_count, sel, offset);
+	}
+}
+
+static void ComputeListEntrySizes(Vector &v, VectorData &vdata, idx_t entry_sizes[], idx_t ser_count,
+                                  const SelectionVector &sel, idx_t offset) {
+	auto list_data = ListVector::GetData(v);
+	auto &child_vector = ListVector::GetEntry(v);
+	idx_t list_entry_sizes[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (vdata.validity.RowIsValid(source_idx)) {
+			auto list_entry = list_data[source_idx];
+
+			// make room for list length, list validitymask
+			entry_sizes[i] += sizeof(list_entry.length);
+			entry_sizes[i] += (list_entry.length + 7) / 8;
+
+			// serialize size of each entry (if non-constant size)
+			if (!TypeIsConstantSize(ListType::GetChildType(v.GetType()).InternalType())) {
+				entry_sizes[i] += list_entry.length * sizeof(list_entry.length);
+			}
+
+			// compute size of each the elements in list_entry and sum them
+			auto entry_remaining = list_entry.length;
+			auto entry_offset = list_entry.offset;
+			while (entry_remaining > 0) {
+				// the list entry can span multiple vectors
+				auto next = MinValue((idx_t)STANDARD_VECTOR_SIZE, entry_remaining);
+
+				// compute and add to the total
+				std::fill_n(list_entry_sizes, next, 0);
+				RowOperations::ComputeEntrySizes(child_vector, list_entry_sizes, next, next,
+				                                 *FlatVector::IncrementalSelectionVector(), entry_offset);
+				for (idx_t list_idx = 0; list_idx < next; list_idx++) {
+					entry_sizes[i] += list_entry_sizes[list_idx];
+				}
+
+				// update for next iteration
+				entry_remaining -= next;
+				entry_offset += next;
+			}
+		}
+	}
+}
+
+void RowOperations::ComputeEntrySizes(Vector &v, VectorData &vdata, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                      const SelectionVector &sel, idx_t offset) {
+	const auto physical_type = v.GetType().InternalType();
+	if (TypeIsConstantSize(physical_type)) {
+		const auto type_size = GetTypeIdSize(physical_type);
+		for (idx_t i = 0; i < ser_count; i++) {
+			entry_sizes[i] += type_size;
+		}
+	} else {
+		switch (physical_type) {
+		case PhysicalType::VARCHAR:
+			ComputeStringEntrySizes(vdata, entry_sizes, ser_count, sel, offset);
+			break;
+		case PhysicalType::STRUCT:
+			ComputeStructEntrySizes(v, entry_sizes, vcount, ser_count, sel, offset);
+			break;
+		case PhysicalType::LIST:
+			ComputeListEntrySizes(v, vdata, entry_sizes, ser_count, sel, offset);
+			break;
+		default:
+			// LCOV_EXCL_START
+			throw NotImplementedException("Column with variable size type %s cannot be serialized to row-format",
+			                              v.GetType().ToString());
+			// LCOV_EXCL_STOP
+		}
+	}
+}
+
+void RowOperations::ComputeEntrySizes(Vector &v, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                      const SelectionVector &sel, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+	ComputeEntrySizes(v, vdata, entry_sizes, vcount, ser_count, sel, offset);
+}
+
+template <class T>
+static void TemplatedHeapScatter(VectorData &vdata, const SelectionVector &sel, idx_t count, idx_t col_idx,
+                                 data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	auto source = (T *)vdata.data;
+	if (!validitymask_locations) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+
+			auto target = (T *)key_locations[i];
+			Store<T>(source[source_idx], (data_ptr_t)target);
+			key_locations[i] += sizeof(T);
+		}
+	} else {
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+		const auto bit = ~(1UL << idx_in_entry);
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+
+			auto target = (T *)key_locations[i];
+			Store<T>(source[source_idx], (data_ptr_t)target);
+			key_locations[i] += sizeof(T);
+
+			// set the validitymask
+			if (!vdata.validity.RowIsValid(source_idx)) {
+				*(validitymask_locations[i] + entry_idx) &= bit;
+			}
+		}
+	}
+}
+
+static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	auto strings = (string_t *)vdata.data;
+	if (!validitymask_locations) {
+		for (idx_t i = 0; i < ser_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			if (vdata.validity.RowIsValid(source_idx)) {
+				auto &string_entry = strings[source_idx];
+				// store string size
+				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
+				key_locations[i] += sizeof(uint32_t);
+				// store the string
+				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				key_locations[i] += string_entry.GetSize();
+			}
+		}
+	} else {
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+		const auto bit = ~(1UL << idx_in_entry);
+		for (idx_t i = 0; i < ser_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			if (vdata.validity.RowIsValid(source_idx)) {
+				auto &string_entry = strings[source_idx];
+				// store string size
+				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
+				key_locations[i] += sizeof(uint32_t);
+				// store the string
+				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				key_locations[i] += string_entry.GetSize();
+			} else {
+				// set the validitymask
+				*(validitymask_locations[i] + entry_idx) &= bit;
+			}
+		}
+	}
+}
+
+static void HeapScatterStructVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	auto &children = StructVector::GetEntries(v);
+	idx_t num_children = children.size();
+
+	// the whole struct itself can be NULL
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+	const auto bit = ~(1UL << idx_in_entry);
+
+	// struct must have a validitymask for its fields
+	const idx_t struct_validitymask_size = (num_children + 7) / 8;
+	data_ptr_t struct_validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < ser_count; i++) {
+		// initialize the struct validity mask
+		struct_validitymask_locations[i] = key_locations[i];
+		memset(struct_validitymask_locations[i], -1, struct_validitymask_size);
+		key_locations[i] += struct_validitymask_size;
+
+		// set whether the whole struct is null
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (validitymask_locations && !vdata.validity.RowIsValid(source_idx)) {
+			*(validitymask_locations[i] + entry_idx) &= bit;
+		}
+	}
+
+	// now serialize the struct vectors
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto &struct_vector = *children[i];
+		RowOperations::HeapScatter(struct_vector, vcount, sel, ser_count, i, key_locations,
+		                           struct_validitymask_locations, offset);
+	}
+}
+
+static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_no,
+                                  data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto list_data = ListVector::GetData(v);
+
+	auto &child_vector = ListVector::GetEntry(v);
+
+	VectorData list_vdata;
+	child_vector.Orrify(ListVector::GetListSize(v), list_vdata);
+	auto child_type = ListType::GetChildType(v.GetType()).InternalType();
+
+	idx_t list_entry_sizes[STANDARD_VECTOR_SIZE];
+	data_ptr_t list_entry_locations[STANDARD_VECTOR_SIZE];
+
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (!vdata.validity.RowIsValid(source_idx)) {
+			if (validitymask_locations) {
+				// set the row validitymask for this column to invalid
+				ValidityBytes row_mask(validitymask_locations[i]);
+				row_mask.SetInvalidUnsafe(entry_idx, idx_in_entry);
+			}
+			continue;
+		}
+		auto list_entry = list_data[source_idx];
+
+		// store list length
+		Store<uint64_t>(list_entry.length, key_locations[i]);
+		key_locations[i] += sizeof(list_entry.length);
+
+		// make room for the validitymask
+		data_ptr_t list_validitymask_location = key_locations[i];
+		idx_t entry_offset_in_byte = 0;
+		idx_t validitymask_size = (list_entry.length + 7) / 8;
+		memset(list_validitymask_location, -1, validitymask_size);
+		key_locations[i] += validitymask_size;
+
+		// serialize size of each entry (if non-constant size)
+		data_ptr_t var_entry_size_ptr = nullptr;
+		if (!TypeIsConstantSize(child_type)) {
+			var_entry_size_ptr = key_locations[i];
+			key_locations[i] += list_entry.length * sizeof(idx_t);
+		}
+
+		auto entry_remaining = list_entry.length;
+		auto entry_offset = list_entry.offset;
+		while (entry_remaining > 0) {
+			// the list entry can span multiple vectors
+			auto next = MinValue((idx_t)STANDARD_VECTOR_SIZE, entry_remaining);
+
+			// serialize list validity
+			for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+				auto list_idx = list_vdata.sel->get_index(entry_idx) + entry_offset;
+				if (!list_vdata.validity.RowIsValid(list_idx)) {
+					*(list_validitymask_location) &= ~(1UL << entry_offset_in_byte);
+				}
+				if (++entry_offset_in_byte == 8) {
+					list_validitymask_location++;
+					entry_offset_in_byte = 0;
+				}
+			}
+
+			if (TypeIsConstantSize(child_type)) {
+				// constant size list entries: set list entry locations
+				const idx_t type_size = GetTypeIdSize(child_type);
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += type_size;
+				}
+			} else {
+				// variable size list entries: compute entry sizes and set list entry locations
+				std::fill_n(list_entry_sizes, next, 0);
+				RowOperations::ComputeEntrySizes(child_vector, list_entry_sizes, next, next,
+				                                 *FlatVector::IncrementalSelectionVector(), entry_offset);
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += list_entry_sizes[entry_idx];
+					Store<idx_t>(list_entry_sizes[entry_idx], var_entry_size_ptr);
+					var_entry_size_ptr += sizeof(idx_t);
+				}
+			}
+
+			// now serialize to the locations
+			RowOperations::HeapScatter(child_vector, ListVector::GetListSize(v),
+			                           *FlatVector::IncrementalSelectionVector(), next, 0, list_entry_locations,
+			                           nullptr, entry_offset);
+
+			// update for next iteration
+			entry_remaining -= next;
+			entry_offset += next;
+		}
+	}
+}
+
+void RowOperations::HeapScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	if (TypeIsConstantSize(v.GetType().InternalType())) {
+		VectorData vdata;
+		v.Orrify(vcount, vdata);
+		RowOperations::HeapScatterVData(vdata, v.GetType().InternalType(), sel, ser_count, col_idx, key_locations,
+		                                validitymask_locations, offset);
+	} else {
+		switch (v.GetType().InternalType()) {
+		case PhysicalType::VARCHAR:
+			HeapScatterStringVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		case PhysicalType::STRUCT:
+			HeapScatterStructVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		case PhysicalType::LIST:
+			HeapScatterListVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		default:
+			// LCOV_EXCL_START
+			throw NotImplementedException("Serialization of variable length vector with type %s",
+			                              v.GetType().ToString());
+			// LCOV_EXCL_STOP
+		}
+	}
+}
+
+void RowOperations::HeapScatterVData(VectorData &vdata, PhysicalType type, const SelectionVector &sel, idx_t ser_count,
+                                     idx_t col_idx, data_ptr_t *key_locations, data_ptr_t *validitymask_locations,
+                                     idx_t offset) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedHeapScatter<int8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT16:
+		TemplatedHeapScatter<int16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT32:
+		TemplatedHeapScatter<int32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT64:
+		TemplatedHeapScatter<int64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedHeapScatter<uint8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedHeapScatter<uint16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedHeapScatter<uint32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedHeapScatter<uint64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT128:
+		TemplatedHeapScatter<hugeint_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedHeapScatter<float>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedHeapScatter<double>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedHeapScatter<interval_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	default:
+		throw NotImplementedException("FIXME: Serialize to of constant type column to row-format");
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_match.cpp
+// Description: This file contains the implementation of the match operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+using Predicates = RowOperations::Predicates;
+
+template <typename OP>
+static idx_t SelectComparison(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                              SelectionVector *true_sel, SelectionVector *false_sel) {
+	throw NotImplementedException("Unsupported nested comparison operand for RowOperations::Match");
+}
+
+template <>
+idx_t SelectComparison<Equals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<NotEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<GreaterThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<GreaterThanEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                          SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<LessThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                 SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<LessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                       SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <class T, class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchType(VectorData &col, Vector &rows, SelectionVector &sel, idx_t &count, idx_t col_offset,
+                               idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	// Precompute row_mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto data = (T *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	idx_t match_count = 0;
+	if (!col.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+
+			auto row = ptrs[idx];
+			ValidityBytes row_mask(row);
+			auto isnull = !row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+
+			auto col_idx = col.sel->get_index(idx);
+			if (!col.validity.RowIsValid(col_idx)) {
+				if (isnull) {
+					// match: move to next value to compare
+					sel.set_index(match_count++, idx);
+				} else {
+					if (NO_MATCH_SEL) {
+						no_match->set_index(no_match_count++, idx);
+					}
+				}
+			} else {
+				auto value = Load<T>(row + col_offset);
+				if (!isnull && OP::template Operation<T>(data[col_idx], value)) {
+					sel.set_index(match_count++, idx);
+				} else {
+					if (NO_MATCH_SEL) {
+						no_match->set_index(no_match_count++, idx);
+					}
+				}
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+
+			auto row = ptrs[idx];
+			ValidityBytes row_mask(row);
+			auto isnull = !row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+
+			auto col_idx = col.sel->get_index(idx);
+			auto value = Load<T>(row + col_offset);
+			if (!isnull && OP::template Operation<T>(data[col_idx], value)) {
+				sel.set_index(match_count++, idx);
+			} else {
+				if (NO_MATCH_SEL) {
+					no_match->set_index(no_match_count++, idx);
+				}
+			}
+		}
+	}
+	count = match_count;
+}
+
+template <class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchNested(Vector &col, Vector &rows, SelectionVector &sel, idx_t &count, const idx_t col_offset,
+                                 const idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	// Gather a dense Vector containing the column values being matched
+	Vector key(col.GetType());
+	RowOperations::Gather(rows, sel, key, *FlatVector::IncrementalSelectionVector(), count, col_offset, col_no);
+
+	// Densify the input column
+	Vector sliced(col, sel, count);
+
+	if (NO_MATCH_SEL) {
+		SelectionVector no_match_sel_offset(no_match->data() + no_match_count);
+		auto match_count = SelectComparison<OP>(sliced, key, sel, count, &sel, &no_match_sel_offset);
+		no_match_count += count - match_count;
+		count = match_count;
+	} else {
+		count = SelectComparison<OP>(sliced, key, sel, count, &sel, nullptr);
+	}
+}
+
+template <class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchOp(Vector &vec, VectorData &col, const RowLayout &layout, Vector &rows, SelectionVector &sel,
+                             idx_t &count, idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	if (count == 0) {
+		return;
+	}
+	auto col_offset = layout.GetOffsets()[col_no];
+	switch (layout.GetTypes()[col_no].InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedMatchType<int8_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                             no_match_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedMatchType<int16_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedMatchType<int32_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedMatchType<int64_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedMatchType<uint8_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedMatchType<uint16_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedMatchType<uint32_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedMatchType<uint64_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedMatchType<hugeint_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                                no_match_count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedMatchType<float, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                            no_match_count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedMatchType<double, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                             no_match_count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedMatchType<interval_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                                 no_match_count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedMatchType<string_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		TemplatedMatchNested<OP, NO_MATCH_SEL>(vec, rows, sel, count, col_offset, col_no, no_match, no_match_count);
+		break;
+	default:
+		throw InternalException("Unsupported column type for RowOperations::Match");
+	}
+}
+
+template <bool NO_MATCH_SEL>
+static void TemplatedMatch(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                           const Predicates &predicates, SelectionVector &sel, idx_t &count, SelectionVector *no_match,
+                           idx_t &no_match_count) {
+	for (idx_t col_no = 0; col_no < predicates.size(); ++col_no) {
+		auto &vec = columns.data[col_no];
+		auto &col = col_data[col_no];
+		switch (predicates[col_no]) {
+		case ExpressionType::COMPARE_EQUAL:
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			TemplatedMatchOp<Equals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                       no_match_count);
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+			TemplatedMatchOp<NotEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                          no_match_count);
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			TemplatedMatchOp<GreaterThan, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                            no_match_count);
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			TemplatedMatchOp<GreaterThanEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                                  no_match_count);
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+			TemplatedMatchOp<LessThan, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                         no_match_count);
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			TemplatedMatchOp<LessThanEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                               no_match_count);
+			break;
+		default:
+			throw InternalException("Unsupported comparison type for RowOperations::Match");
+		}
+	}
+}
+
+idx_t RowOperations::Match(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                           const Predicates &predicates, SelectionVector &sel, idx_t count, SelectionVector *no_match,
+                           idx_t &no_match_count) {
+	if (no_match) {
+		TemplatedMatch<true>(columns, col_data, layout, rows, predicates, sel, count, no_match, no_match_count);
+	} else {
+		TemplatedMatch<false>(columns, col_data, layout, rows, predicates, sel, count, no_match, no_match_count);
+	}
+
+	return count;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+void TemplatedRadixScatter(VectorData &vdata, const SelectionVector &sel, idx_t add_count, data_ptr_t *key_locations,
+                           const bool desc, const bool has_null, const bool nulls_first, const bool is_little_endian,
+                           const idx_t offset) {
+	auto source = (T *)vdata.data;
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				Radix::EncodeData<T>(key_locations[i] + 1, source[source_idx], is_little_endian);
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 1; s < sizeof(T) + 1; s++) {
+						*(key_locations[i] + s) = ~*(key_locations[i] + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', sizeof(T));
+			}
+			key_locations[i] += sizeof(T) + 1;
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write value
+			Radix::EncodeData<T>(key_locations[i], source[source_idx], is_little_endian);
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < sizeof(T); s++) {
+					*(key_locations[i] + s) = ~*(key_locations[i] + s);
+				}
+			}
+			key_locations[i] += sizeof(T);
+		}
+	}
+}
+
+void RadixScatterStringVector(VectorData &vdata, const SelectionVector &sel, idx_t add_count, data_ptr_t *key_locations,
+                              const bool desc, const bool has_null, const bool nulls_first, const idx_t prefix_len,
+                              idx_t offset) {
+	auto source = (string_t *)vdata.data;
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				Radix::EncodeStringDataPrefix(key_locations[i] + 1, source[source_idx], prefix_len);
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 1; s < prefix_len + 1; s++) {
+						*(key_locations[i] + s) = ~*(key_locations[i] + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', prefix_len);
+			}
+			key_locations[i] += prefix_len + 1;
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write value
+			Radix::EncodeStringDataPrefix(key_locations[i], source[source_idx], prefix_len);
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < prefix_len; s++) {
+					*(key_locations[i] + s) = ~*(key_locations[i] + s);
+				}
+			}
+			key_locations[i] += prefix_len;
+		}
+	}
+}
+
+void RadixScatterListVector(Vector &v, VectorData &vdata, const SelectionVector &sel, idx_t add_count,
+                            data_ptr_t *key_locations, const bool desc, const bool has_null, const bool nulls_first,
+                            const idx_t prefix_len, const idx_t width, const idx_t offset) {
+	auto list_data = ListVector::GetData(v);
+	auto &child_vector = ListVector::GetEntry(v);
+	auto list_size = ListVector::GetListSize(v);
+
+	// serialize null values
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			data_ptr_t key_location = key_locations[i] + 1;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				key_locations[i]++;
+				auto &list_entry = list_data[source_idx];
+				if (list_entry.length > 0) {
+					// denote that the list is not empty with a 1
+					key_locations[i][0] = 1;
+					key_locations[i]++;
+					RowOperations::RadixScatter(child_vector, list_size, *FlatVector::IncrementalSelectionVector(), 1,
+					                            key_locations + i, false, true, false, prefix_len, width - 1,
+					                            list_entry.offset);
+				} else {
+					// denote that the list is empty with a 0
+					key_locations[i][0] = 0;
+					key_locations[i]++;
+					memset(key_locations[i], '\0', width - 2);
+				}
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 0; s < width - 1; s++) {
+						*(key_location + s) = ~*(key_location + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', width - 1);
+				key_locations[i] += width;
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			auto &list_entry = list_data[source_idx];
+			data_ptr_t key_location = key_locations[i];
+			if (list_entry.length > 0) {
+				// denote that the list is not empty with a 1
+				key_locations[i][0] = 1;
+				key_locations[i]++;
+				RowOperations::RadixScatter(child_vector, list_size, *FlatVector::IncrementalSelectionVector(), 1,
+				                            key_locations + i, false, true, false, prefix_len, width - 1,
+				                            list_entry.offset);
+			} else {
+				// denote that the list is empty with a 0
+				key_locations[i][0] = 0;
+				key_locations[i]++;
+				memset(key_locations[i], '\0', width - 1);
+			}
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < width; s++) {
+					*(key_location + s) = ~*(key_location + s);
+				}
+			}
+		}
+	}
+}
+
+void RadixScatterStructVector(Vector &v, VectorData &vdata, idx_t vcount, const SelectionVector &sel, idx_t add_count,
+                              data_ptr_t *key_locations, const bool desc, const bool has_null, const bool nulls_first,
+                              const idx_t prefix_len, idx_t width, const idx_t offset) {
+	// serialize null values
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+			} else {
+				key_locations[i][0] = invalid;
+			}
+			key_locations[i]++;
+		}
+		width--;
+	}
+	// serialize the struct
+	auto &child_vector = *StructVector::GetEntries(v)[0];
+	RowOperations::RadixScatter(child_vector, vcount, *FlatVector::IncrementalSelectionVector(), add_count,
+	                            key_locations, false, true, false, prefix_len, width, offset);
+	// invert bits if desc
+	if (desc) {
+		for (idx_t i = 0; i < add_count; i++) {
+			for (idx_t s = 0; s < width; s++) {
+				*(key_locations[i] - width + s) = ~*(key_locations[i] - width + s);
+			}
+		}
+	}
+}
+
+void RowOperations::RadixScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                 data_ptr_t *key_locations, bool desc, bool has_null, bool nulls_first,
+                                 idx_t prefix_len, idx_t width, idx_t offset) {
+	auto is_little_endian = Radix::IsLittleEndian();
+
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+	switch (v.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedRadixScatter<int8_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                              is_little_endian, offset);
+		break;
+	case PhysicalType::INT16:
+		TemplatedRadixScatter<int16_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::INT32:
+		TemplatedRadixScatter<int32_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::INT64:
+		TemplatedRadixScatter<int64_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedRadixScatter<uint8_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedRadixScatter<uint16_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedRadixScatter<uint32_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedRadixScatter<uint64_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::INT128:
+		TemplatedRadixScatter<hugeint_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                 is_little_endian, offset);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedRadixScatter<float>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                             is_little_endian, offset);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedRadixScatter<double>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                              is_little_endian, offset);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedRadixScatter<interval_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                  is_little_endian, offset);
+		break;
+	case PhysicalType::VARCHAR:
+		RadixScatterStringVector(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first, prefix_len, offset);
+		break;
+	case PhysicalType::LIST:
+		RadixScatterListVector(v, vdata, sel, ser_count, key_locations, desc, has_null, nulls_first, prefix_len, width,
+		                       offset);
+		break;
+	case PhysicalType::STRUCT:
+		RadixScatterStructVector(v, vdata, vcount, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                         prefix_len, width, offset);
+		break;
+	default:
+		throw NotImplementedException("Cannot ORDER BY column with type %s", v.GetType().ToString());
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_scatter.cpp
+// Description: This file contains the implementation of the row scattering
+//              operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+template <class T>
+static void TemplatedScatter(VectorData &col, Vector &rows, const SelectionVector &sel, const idx_t count,
+                             const idx_t col_offset, const idx_t col_no) {
+	auto data = (T *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	if (!col.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto col_idx = col.sel->get_index(idx);
+			auto row = ptrs[idx];
+
+			auto isnull = !col.validity.RowIsValid(col_idx);
+			T store_value = isnull ? NullValue<T>() : data[col_idx];
+			Store<T>(store_value, row + col_offset);
+			if (isnull) {
+				ValidityBytes col_mask(ptrs[idx]);
+				col_mask.SetInvalidUnsafe(col_no);
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto col_idx = col.sel->get_index(idx);
+			auto row = ptrs[idx];
+
+			Store<T>(data[col_idx], row + col_offset);
+		}
+	}
+}
+
+static void ComputeStringEntrySizes(const VectorData &col, idx_t entry_sizes[], const SelectionVector &sel,
+                                    const idx_t count, const idx_t offset = 0) {
+	auto data = (const string_t *)col.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto col_idx = col.sel->get_index(idx) + offset;
+		const auto &str = data[col_idx];
+		if (col.validity.RowIsValid(col_idx) && !str.IsInlined()) {
+			entry_sizes[i] += str.GetSize();
+		}
+	}
+}
+
+static void ScatterStringVector(VectorData &col, Vector &rows, data_ptr_t str_locations[], const SelectionVector &sel,
+                                const idx_t count, const idx_t col_offset, const idx_t col_no) {
+	auto string_data = (string_t *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto col_idx = col.sel->get_index(idx);
+		auto row = ptrs[idx];
+		if (!col.validity.RowIsValid(col_idx)) {
+			ValidityBytes col_mask(row);
+			col_mask.SetInvalidUnsafe(col_no);
+			Store<string_t>(NullValue<string_t>(), row + col_offset);
+		} else if (string_data[col_idx].IsInlined()) {
+			Store<string_t>(string_data[col_idx], row + col_offset);
+		} else {
+			const auto &str = string_data[col_idx];
+			string_t inserted((const char *)str_locations[i], str.GetSize());
+			memcpy(inserted.GetDataWriteable(), str.GetDataUnsafe(), str.GetSize());
+			str_locations[i] += str.GetSize();
+			inserted.Finalize();
+			Store<string_t>(inserted, row + col_offset);
+		}
+	}
+}
+
+static void ScatterNestedVector(Vector &vec, VectorData &col, Vector &rows, data_ptr_t data_locations[],
+                                const SelectionVector &sel, const idx_t count, const idx_t col_offset,
+                                const idx_t col_no, const idx_t vcount) {
+	// Store pointers to the data in the row
+	// Do this first because SerializeVector destroys the locations
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	data_ptr_t validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto row = ptrs[idx];
+		validitymask_locations[i] = row;
+
+		Store<data_ptr_t>(data_locations[i], row + col_offset);
+	}
+
+	// Serialise the data
+	RowOperations::HeapScatter(vec, vcount, sel, count, col_no, data_locations, validitymask_locations);
+}
+
+void RowOperations::Scatter(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                            RowDataCollection &string_heap, const SelectionVector &sel, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+
+	// Set the validity mask for each row before inserting data
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	for (idx_t i = 0; i < count; ++i) {
+		auto row_idx = sel.get_index(i);
+		auto row = ptrs[row_idx];
+		ValidityBytes(row).SetAllValid(layout.ColumnCount());
+	}
+
+	const auto vcount = columns.size();
+	auto &offsets = layout.GetOffsets();
+	auto &types = layout.GetTypes();
+
+	// Compute the entry size of the variable size columns
+	vector<unique_ptr<BufferHandle>> handles;
+	data_ptr_t data_locations[STANDARD_VECTOR_SIZE];
+	if (!layout.AllConstant()) {
+		idx_t entry_sizes[STANDARD_VECTOR_SIZE];
+		std::fill_n(entry_sizes, count, sizeof(uint32_t));
+		for (idx_t col_no = 0; col_no < types.size(); col_no++) {
+			if (TypeIsConstantSize(types[col_no].InternalType())) {
+				continue;
+			}
+
+			auto &vec = columns.data[col_no];
+			auto &col = col_data[col_no];
+			switch (types[col_no].InternalType()) {
+			case PhysicalType::VARCHAR:
+				ComputeStringEntrySizes(col, entry_sizes, sel, count);
+				break;
+			case PhysicalType::LIST:
+			case PhysicalType::MAP:
+			case PhysicalType::STRUCT:
+				RowOperations::ComputeEntrySizes(vec, col, entry_sizes, vcount, count, sel);
+				break;
+			default:
+				throw InternalException("Unsupported type for RowOperations::Scatter");
+			}
+		}
+
+		// Build out the buffer space
+		string_heap.Build(count, data_locations, entry_sizes);
+
+		// Serialize information that is needed for swizzling if the computation goes out-of-core
+		const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < count; i++) {
+			auto row_idx = sel.get_index(i);
+			auto row = ptrs[row_idx];
+			// Pointer to this row in the heap block
+			Store<data_ptr_t>(data_locations[i], row + heap_pointer_offset);
+			// Row size is stored in the heap in front of each row
+			Store<uint32_t>(entry_sizes[i], data_locations[i]);
+			data_locations[i] += sizeof(uint32_t);
+		}
+	}
+
+	for (idx_t col_no = 0; col_no < types.size(); col_no++) {
+		auto &vec = columns.data[col_no];
+		auto &col = col_data[col_no];
+		auto col_offset = offsets[col_no];
+
+		switch (types[col_no].InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			TemplatedScatter<int8_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT16:
+			TemplatedScatter<int16_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT32:
+			TemplatedScatter<int32_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT64:
+			TemplatedScatter<int64_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedScatter<uint8_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedScatter<uint16_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedScatter<uint32_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedScatter<uint64_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT128:
+			TemplatedScatter<hugeint_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedScatter<float>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedScatter<double>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedScatter<interval_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::VARCHAR:
+			ScatterStringVector(col, rows, data_locations, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::LIST:
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			ScatterNestedVector(vec, col, rows, data_locations, sel, count, col_offset, col_no, vcount);
+			break;
+		default:
+			throw InternalException("Unsupported type for RowOperations::Scatter");
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+#include <cstring>
+
+namespace duckdb {
+
+BufferedDeserializer::BufferedDeserializer(data_ptr_t ptr, idx_t data_size) : ptr(ptr), endptr(ptr + data_size) {
+}
+
+BufferedDeserializer::BufferedDeserializer(BufferedSerializer &serializer)
+    : BufferedDeserializer(serializer.data, serializer.maximum_size) {
+}
+
+void BufferedDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
+	if (ptr + read_size > endptr) {
+		throw SerializationException("Failed to deserialize: not enough data in buffer to fulfill read request");
+	}
+	memcpy(buffer, ptr, read_size);
+	ptr += read_size;
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cstring>
+#include <algorithm>
+
+namespace duckdb {
+
+BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path, FileOpener *opener)
+    : fs(fs), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), read_data(0), total_read(0) {
+	handle =
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::READ_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	file_size = fs.GetFileSize(*handle);
+}
+
+void BufferedFileReader::ReadData(data_ptr_t target_buffer, uint64_t read_size) {
+	// first copy anything we can from the buffer
+	data_ptr_t end_ptr = target_buffer + read_size;
+	while (true) {
+		idx_t to_read = MinValue<idx_t>(end_ptr - target_buffer, read_data - offset);
+		if (to_read > 0) {
+			memcpy(target_buffer, data.get() + offset, to_read);
+			offset += to_read;
+			target_buffer += to_read;
+		}
+		if (target_buffer < end_ptr) {
+			D_ASSERT(offset == read_data);
+			total_read += read_data;
+			// did not finish reading yet but exhausted buffer
+			// read data into buffer
+			offset = 0;
+			read_data = fs.Read(*handle, data.get(), FILE_BUFFER_SIZE);
+			if (read_data == 0) {
+				throw SerializationException("not enough data in file to deserialize result");
+			}
+		} else {
+			return;
+		}
+	}
+}
+
+bool BufferedFileReader::Finished() {
+	return total_read + offset == file_size;
+}
+
+} // namespace duckdb
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+// Remove this when we switch C++17: https://stackoverflow.com/a/53350948
+constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
+
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags, FileOpener *opener)
+    : fs(fs), path(path_p), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), total_written(0) {
+	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+}
+
+int64_t BufferedFileWriter::GetFileSize() {
+	return fs.GetFileSize(*handle);
+}
+
+idx_t BufferedFileWriter::GetTotalWritten() {
+	return total_written + offset;
+}
+
+void BufferedFileWriter::WriteData(const_data_ptr_t buffer, uint64_t write_size) {
+	// first copy anything we can from the buffer
+	const_data_ptr_t end_ptr = buffer + write_size;
+	while (buffer < end_ptr) {
+		idx_t to_write = MinValue<idx_t>((end_ptr - buffer), FILE_BUFFER_SIZE - offset);
+		D_ASSERT(to_write > 0);
+		memcpy(data.get() + offset, buffer, to_write);
+		offset += to_write;
+		buffer += to_write;
+		if (offset == FILE_BUFFER_SIZE) {
+			Flush();
+		}
+	}
+}
+
+void BufferedFileWriter::Flush() {
+	if (offset == 0) {
+		return;
+	}
+	fs.Write(*handle, data.get(), offset);
+	total_written += offset;
+	offset = 0;
+}
+
+void BufferedFileWriter::Sync() {
+	Flush();
+	handle->Sync();
+}
+
+void BufferedFileWriter::Truncate(int64_t size) {
+	// truncate the physical file on disk
+	handle->Truncate(size);
+	// reset anything written in the buffer
+	offset = 0;
+}
+
+} // namespace duckdb
+
+
+#include <cstring>
+
+namespace duckdb {
+
+BufferedSerializer::BufferedSerializer(idx_t maximum_size)
+    : BufferedSerializer(unique_ptr<data_t[]>(new data_t[maximum_size]), maximum_size) {
+}
+
+BufferedSerializer::BufferedSerializer(unique_ptr<data_t[]> data, idx_t size) : maximum_size(size), data(data.get()) {
+	blob.size = 0;
+	blob.data = move(data);
+}
+
+BufferedSerializer::BufferedSerializer(data_ptr_t data, idx_t size) : maximum_size(size), data(data) {
+	blob.size = 0;
+}
+
+void BufferedSerializer::WriteData(const_data_ptr_t buffer, idx_t write_size) {
+	if (blob.size + write_size >= maximum_size) {
+		do {
+			maximum_size *= 2;
+		} while (blob.size + write_size > maximum_size);
+		auto new_data = new data_t[maximum_size];
+		memcpy(new_data, data, blob.size);
+		data = new_data;
+		blob.data = unique_ptr<data_t[]>(new_data);
+	}
+
+	memcpy(data + blob.size, buffer, write_size);
+	blob.size += write_size;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+template <>
+string Deserializer::Read() {
+	uint32_t size = Read<uint32_t>();
+	if (size == 0) {
+		return string();
+	}
+	auto buffer = unique_ptr<data_t[]>(new data_t[size]);
+	ReadData(buffer.get(), size);
+	return string((char *)buffer.get(), size);
+}
+
+void Deserializer::ReadStringVector(vector<string> &list) {
+	uint32_t sz = Read<uint32_t>();
+	list.resize(sz);
+	for (idx_t i = 0; i < sz; i++) {
+		list[i] = Read<string>();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+bool Comparators::TieIsBreakable(const idx_t &col_idx, const data_ptr_t row_ptr, const RowLayout &row_layout) {
+	// Check if the blob is NULL
+	ValidityBytes row_mask(row_ptr);
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+	if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+		// Can't break a NULL tie
+		return false;
+	}
+	if (row_layout.GetTypes()[col_idx].InternalType() == PhysicalType::VARCHAR) {
+		const auto &tie_col_offset = row_layout.GetOffsets()[col_idx];
+		string_t tie_string = Load<string_t>(row_ptr + tie_col_offset);
+		if (tie_string.GetSize() < string_t::INLINE_LENGTH) {
+			// No need to break the tie - we already compared the full string
+			return false;
+		}
+	}
+	return true;
+}
+
+int Comparators::CompareTuple(const SBScanState &left, const SBScanState &right, const data_ptr_t &l_ptr,
+                              const data_ptr_t &r_ptr, const SortLayout &sort_layout, const bool &external_sort) {
+	// Compare the sorting columns one by one
+	int comp_res = 0;
+	data_ptr_t l_ptr_offset = l_ptr;
+	data_ptr_t r_ptr_offset = r_ptr;
+	for (idx_t col_idx = 0; col_idx < sort_layout.column_count; col_idx++) {
+		comp_res = FastMemcmp(l_ptr_offset, r_ptr_offset, sort_layout.column_sizes[col_idx]);
+		if (comp_res == 0 && !sort_layout.constant_size[col_idx]) {
+			comp_res = BreakBlobTie(col_idx, left, right, sort_layout, external_sort);
+		}
+		if (comp_res != 0) {
+			break;
+		}
+		l_ptr_offset += sort_layout.column_sizes[col_idx];
+		r_ptr_offset += sort_layout.column_sizes[col_idx];
+	}
+	return comp_res;
+}
+
+int Comparators::CompareVal(const data_ptr_t l_ptr, const data_ptr_t r_ptr, const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::VARCHAR:
+		return TemplatedCompareVal<string_t>(l_ptr, r_ptr);
+	case PhysicalType::LIST:
+	case PhysicalType::STRUCT: {
+		auto l_nested_ptr = Load<data_ptr_t>(l_ptr);
+		auto r_nested_ptr = Load<data_ptr_t>(r_ptr);
+		return CompareValAndAdvance(l_nested_ptr, r_nested_ptr, type);
+	}
+	default:
+		throw NotImplementedException("Unimplemented CompareVal for type %s", type.ToString());
+	}
+}
+
+int Comparators::BreakBlobTie(const idx_t &tie_col, const SBScanState &left, const SBScanState &right,
+                              const SortLayout &sort_layout, const bool &external) {
+	const idx_t &col_idx = sort_layout.sorting_to_blob_col.at(tie_col);
+	data_ptr_t l_data_ptr = left.DataPtr(*left.sb->blob_sorting_data);
+	data_ptr_t r_data_ptr = right.DataPtr(*right.sb->blob_sorting_data);
+	if (!TieIsBreakable(col_idx, l_data_ptr, sort_layout.blob_layout)) {
+		// Quick check to see if ties can be broken
+		return 0;
+	}
+	// Align the pointers
+	const auto &tie_col_offset = sort_layout.blob_layout.GetOffsets()[col_idx];
+	l_data_ptr += tie_col_offset;
+	r_data_ptr += tie_col_offset;
+	// Do the comparison
+	const int order = sort_layout.order_types[tie_col] == OrderType::DESCENDING ? -1 : 1;
+	const auto &type = sort_layout.blob_layout.GetTypes()[col_idx];
+	int result;
+	if (external) {
+		// Store heap pointers
+		data_ptr_t l_heap_ptr = left.HeapPtr(*left.sb->blob_sorting_data);
+		data_ptr_t r_heap_ptr = right.HeapPtr(*right.sb->blob_sorting_data);
+		// Unswizzle offset to pointer
+		UnswizzleSingleValue(l_data_ptr, l_heap_ptr, type);
+		UnswizzleSingleValue(r_data_ptr, r_heap_ptr, type);
+		// Compare
+		result = CompareVal(l_data_ptr, r_data_ptr, type);
+		// Swizzle the pointers back to offsets
+		SwizzleSingleValue(l_data_ptr, l_heap_ptr, type);
+		SwizzleSingleValue(r_data_ptr, r_heap_ptr, type);
+	} else {
+		result = CompareVal(l_data_ptr, r_data_ptr, type);
+	}
+	return order * result;
+}
+
+template <class T>
+int Comparators::TemplatedCompareVal(const data_ptr_t &left_ptr, const data_ptr_t &right_ptr) {
+	const auto left_val = Load<T>(left_ptr);
+	const auto right_val = Load<T>(right_ptr);
+	if (Equals::Operation<T>(left_val, right_val)) {
+		return 0;
+	} else if (LessThan::Operation<T>(left_val, right_val)) {
+		return -1;
+	} else {
+		return 1;
+	}
+}
+
+int Comparators::CompareValAndAdvance(data_ptr_t &l_ptr, data_ptr_t &r_ptr, const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedCompareAndAdvance<int8_t>(l_ptr, r_ptr);
+	case PhysicalType::INT16:
+		return TemplatedCompareAndAdvance<int16_t>(l_ptr, r_ptr);
+	case PhysicalType::INT32:
+		return TemplatedCompareAndAdvance<int32_t>(l_ptr, r_ptr);
+	case PhysicalType::INT64:
+		return TemplatedCompareAndAdvance<int64_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT8:
+		return TemplatedCompareAndAdvance<uint8_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT16:
+		return TemplatedCompareAndAdvance<uint16_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT32:
+		return TemplatedCompareAndAdvance<uint32_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT64:
+		return TemplatedCompareAndAdvance<uint64_t>(l_ptr, r_ptr);
+	case PhysicalType::INT128:
+		return TemplatedCompareAndAdvance<hugeint_t>(l_ptr, r_ptr);
+	case PhysicalType::FLOAT:
+		return TemplatedCompareAndAdvance<float>(l_ptr, r_ptr);
+	case PhysicalType::DOUBLE:
+		return TemplatedCompareAndAdvance<double>(l_ptr, r_ptr);
+	case PhysicalType::INTERVAL:
+		return TemplatedCompareAndAdvance<interval_t>(l_ptr, r_ptr);
+	case PhysicalType::VARCHAR:
+		return CompareStringAndAdvance(l_ptr, r_ptr);
+	case PhysicalType::LIST:
+		return CompareListAndAdvance(l_ptr, r_ptr, ListType::GetChildType(type));
+	case PhysicalType::STRUCT:
+		return CompareStructAndAdvance(l_ptr, r_ptr, StructType::GetChildTypes(type));
+	default:
+		throw NotImplementedException("Unimplemented CompareValAndAdvance for type %s", type.ToString());
+	}
+}
+
+template <class T>
+int Comparators::TemplatedCompareAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr) {
+	auto result = TemplatedCompareVal<T>(left_ptr, right_ptr);
+	left_ptr += sizeof(T);
+	right_ptr += sizeof(T);
+	return result;
+}
+
+int Comparators::CompareStringAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr) {
+	// Construct the string_t
+	uint32_t left_string_size = Load<uint32_t>(left_ptr);
+	uint32_t right_string_size = Load<uint32_t>(right_ptr);
+	left_ptr += sizeof(uint32_t);
+	right_ptr += sizeof(uint32_t);
+	string_t left_val((const char *)left_ptr, left_string_size);
+	string_t right_val((const char *)right_ptr, right_string_size);
+	left_ptr += left_string_size;
+	right_ptr += right_string_size;
+	// Compare
+	return TemplatedCompareVal<string_t>((data_ptr_t)&left_val, (data_ptr_t)&right_val);
+}
+
+int Comparators::CompareStructAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr,
+                                         const child_list_t<LogicalType> &types) {
+	idx_t count = types.size();
+	// Load validity masks
+	ValidityBytes left_validity(left_ptr);
+	ValidityBytes right_validity(right_ptr);
+	left_ptr += (count + 7) / 8;
+	right_ptr += (count + 7) / 8;
+	// Initialize variables
+	bool left_valid;
+	bool right_valid;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	// Compare
+	int comp_res = 0;
+	for (idx_t i = 0; i < count; i++) {
+		ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+		left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		auto &type = types[i].second;
+		if ((left_valid && right_valid) || TypeIsConstantSize(type.InternalType())) {
+			comp_res = CompareValAndAdvance(left_ptr, right_ptr, types[i].second);
+		}
+		if (!left_valid && !right_valid) {
+			comp_res = 0;
+		} else if (!left_valid) {
+			comp_res = 1;
+		} else if (!right_valid) {
+			comp_res = -1;
+		}
+		if (comp_res != 0) {
+			break;
+		}
+	}
+	return comp_res;
+}
+
+int Comparators::CompareListAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr, const LogicalType &type) {
+	// Load list lengths
+	auto left_len = Load<idx_t>(left_ptr);
+	auto right_len = Load<idx_t>(right_ptr);
+	left_ptr += sizeof(idx_t);
+	right_ptr += sizeof(idx_t);
+	// Load list validity masks
+	ValidityBytes left_validity(left_ptr);
+	ValidityBytes right_validity(right_ptr);
+	left_ptr += (left_len + 7) / 8;
+	right_ptr += (right_len + 7) / 8;
+	// Compare
+	int comp_res = 0;
+	idx_t count = MinValue(left_len, right_len);
+	if (TypeIsConstantSize(type.InternalType())) {
+		// Templated code for fixed-size types
+		switch (type.InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			comp_res = TemplatedCompareListLoop<int8_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT16:
+			comp_res = TemplatedCompareListLoop<int16_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT32:
+			comp_res = TemplatedCompareListLoop<int32_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT64:
+			comp_res = TemplatedCompareListLoop<int64_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT8:
+			comp_res = TemplatedCompareListLoop<uint8_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT16:
+			comp_res = TemplatedCompareListLoop<uint16_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT32:
+			comp_res = TemplatedCompareListLoop<uint32_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT64:
+			comp_res = TemplatedCompareListLoop<uint64_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT128:
+			comp_res = TemplatedCompareListLoop<hugeint_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::FLOAT:
+			comp_res = TemplatedCompareListLoop<float>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::DOUBLE:
+			comp_res = TemplatedCompareListLoop<double>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INTERVAL:
+			comp_res = TemplatedCompareListLoop<interval_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		default:
+			throw NotImplementedException("CompareListAndAdvance for fixed-size type %s", type.ToString());
+		}
+	} else {
+		// Variable-sized list entries
+		bool left_valid;
+		bool right_valid;
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		// Size (in bytes) of all variable-sizes entries is stored before the entries begin,
+		// to make deserialization easier. We need to skip over them
+		left_ptr += left_len * sizeof(idx_t);
+		right_ptr += right_len * sizeof(idx_t);
+		for (idx_t i = 0; i < count; i++) {
+			ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+			left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+			right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+			if (left_valid && right_valid) {
+				switch (type.InternalType()) {
+				case PhysicalType::LIST:
+					comp_res = CompareListAndAdvance(left_ptr, right_ptr, ListType::GetChildType(type));
+					break;
+				case PhysicalType::VARCHAR:
+					comp_res = CompareStringAndAdvance(left_ptr, right_ptr);
+					break;
+				case PhysicalType::STRUCT:
+					comp_res = CompareStructAndAdvance(left_ptr, right_ptr, StructType::GetChildTypes(type));
+					break;
+				default:
+					throw NotImplementedException("CompareListAndAdvance for variable-size type %s", type.ToString());
+				}
+			} else if (!left_valid && !right_valid) {
+				comp_res = 0;
+			} else if (left_valid) {
+				comp_res = -1;
+			} else {
+				comp_res = 1;
+			}
+			if (comp_res != 0) {
+				break;
+			}
+		}
+	}
+	// All values that we looped over were equal
+	if (comp_res == 0 && left_len != right_len) {
+		// Smaller lists first
+		if (left_len < right_len) {
+			comp_res = -1;
+		} else {
+			comp_res = 1;
+		}
+	}
+	return comp_res;
+}
+
+template <class T>
+int Comparators::TemplatedCompareListLoop(data_ptr_t &left_ptr, data_ptr_t &right_ptr,
+                                          const ValidityBytes &left_validity, const ValidityBytes &right_validity,
+                                          const idx_t &count) {
+	int comp_res = 0;
+	bool left_valid;
+	bool right_valid;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	for (idx_t i = 0; i < count; i++) {
+		ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+		left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		comp_res = TemplatedCompareAndAdvance<T>(left_ptr, right_ptr);
+		if (!left_valid && !right_valid) {
+			comp_res = 0;
+		} else if (!left_valid) {
+			comp_res = 1;
+		} else if (!right_valid) {
+			comp_res = -1;
+		}
+		if (comp_res != 0) {
+			break;
+		}
+	}
+	return comp_res;
+}
+
+void Comparators::UnswizzleSingleValue(data_ptr_t data_ptr, const data_ptr_t &heap_ptr, const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		data_ptr += sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+	}
+	Store<data_ptr_t>(heap_ptr + Load<idx_t>(data_ptr), data_ptr);
+}
+
+void Comparators::SwizzleSingleValue(data_ptr_t data_ptr, const data_ptr_t &heap_ptr, const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		data_ptr += sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+	}
+	Store<idx_t>(Load<data_ptr_t>(data_ptr) - heap_ptr, data_ptr);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+MergeSorter::MergeSorter(GlobalSortState &state, BufferManager &buffer_manager)
+    : state(state), buffer_manager(buffer_manager), sort_layout(state.sort_layout) {
+}
+
+void MergeSorter::PerformInMergeRound() {
+	while (true) {
+		{
+			lock_guard<mutex> pair_guard(state.lock);
+			if (state.pair_idx == state.num_pairs) {
+				break;
+			}
+			GetNextPartition();
+		}
+		MergePartition();
+	}
+}
+
+void MergeSorter::MergePartition() {
+	auto &left_block = *left->sb;
+	auto &right_block = *right->sb;
+#ifdef DEBUG
+	D_ASSERT(left_block.radix_sorting_data.size() == left_block.payload_data->data_blocks.size());
+	D_ASSERT(right_block.radix_sorting_data.size() == right_block.payload_data->data_blocks.size());
+	if (!state.payload_layout.AllConstant() && state.external) {
+		D_ASSERT(left_block.payload_data->data_blocks.size() == left_block.payload_data->heap_blocks.size());
+		D_ASSERT(right_block.payload_data->data_blocks.size() == right_block.payload_data->heap_blocks.size());
+	}
+	if (!sort_layout.all_constant) {
+		D_ASSERT(left_block.radix_sorting_data.size() == left_block.blob_sorting_data->data_blocks.size());
+		D_ASSERT(right_block.radix_sorting_data.size() == right_block.blob_sorting_data->data_blocks.size());
+		if (state.external) {
+			D_ASSERT(left_block.blob_sorting_data->data_blocks.size() ==
+			         left_block.blob_sorting_data->heap_blocks.size());
+			D_ASSERT(right_block.blob_sorting_data->data_blocks.size() ==
+			         right_block.blob_sorting_data->heap_blocks.size());
+		}
+	}
+#endif
+	// Set up the write block
+	// Each merge task produces a SortedBlock with exactly state.block_capacity rows or less
+	result->InitializeWrite();
+	// Initialize arrays to store merge data
+	bool left_smaller[STANDARD_VECTOR_SIZE];
+	idx_t next_entry_sizes[STANDARD_VECTOR_SIZE];
+	// Merge loop
+#ifdef DEBUG
+	auto l_count = left->Remaining();
+	auto r_count = right->Remaining();
+#endif
+	while (true) {
+		auto l_remaining = left->Remaining();
+		auto r_remaining = right->Remaining();
+		if (l_remaining + r_remaining == 0) {
+			// Done
+			break;
+		}
+		const idx_t next = MinValue(l_remaining + r_remaining, (idx_t)STANDARD_VECTOR_SIZE);
+		if (l_remaining != 0 && r_remaining != 0) {
+			// Compute the merge (not needed if one side is exhausted)
+			ComputeMerge(next, left_smaller);
+		}
+		// Actually merge the data (radix, blob, and payload)
+		MergeRadix(next, left_smaller);
+		if (!sort_layout.all_constant) {
+			MergeData(*result->blob_sorting_data, *left_block.blob_sorting_data, *right_block.blob_sorting_data, next,
+			          left_smaller, next_entry_sizes, true);
+			D_ASSERT(result->radix_sorting_data.size() == result->blob_sorting_data->data_blocks.size());
+		}
+		MergeData(*result->payload_data, *left_block.payload_data, *right_block.payload_data, next, left_smaller,
+		          next_entry_sizes, false);
+		D_ASSERT(result->radix_sorting_data.size() == result->payload_data->data_blocks.size());
+	}
+#ifdef DEBUG
+	D_ASSERT(result->Count() == l_count + r_count);
+#endif
+}
+
+void MergeSorter::GetNextPartition() {
+	// Create result block
+	state.sorted_blocks_temp[state.pair_idx].push_back(make_unique<SortedBlock>(buffer_manager, state));
+	result = state.sorted_blocks_temp[state.pair_idx].back().get();
+	// Determine which blocks must be merged
+	auto &left_block = *state.sorted_blocks[state.pair_idx * 2];
+	auto &right_block = *state.sorted_blocks[state.pair_idx * 2 + 1];
+	const idx_t l_count = left_block.Count();
+	const idx_t r_count = right_block.Count();
+	// Initialize left and right reader
+	left = make_unique<SBScanState>(buffer_manager, state);
+	right = make_unique<SBScanState>(buffer_manager, state);
+	// Compute the work that this thread must do using Merge Path
+	idx_t l_end;
+	idx_t r_end;
+	if (state.l_start + state.r_start + state.block_capacity < l_count + r_count) {
+		left->sb = state.sorted_blocks[state.pair_idx * 2].get();
+		right->sb = state.sorted_blocks[state.pair_idx * 2 + 1].get();
+		const idx_t intersection = state.l_start + state.r_start + state.block_capacity;
+		GetIntersection(intersection, l_end, r_end);
+		D_ASSERT(l_end <= l_count);
+		D_ASSERT(r_end <= r_count);
+		D_ASSERT(intersection == l_end + r_end);
+	} else {
+		l_end = l_count;
+		r_end = r_count;
+	}
+	// Create slices of the data that this thread must merge
+	left->SetIndices(0, 0);
+	right->SetIndices(0, 0);
+	left_input = left_block.CreateSlice(state.l_start, l_end, left->entry_idx);
+	right_input = right_block.CreateSlice(state.r_start, r_end, right->entry_idx);
+	left->sb = left_input.get();
+	right->sb = right_input.get();
+	state.l_start = l_end;
+	state.r_start = r_end;
+	D_ASSERT(left->Remaining() + right->Remaining() == state.block_capacity || (l_end == l_count && r_end == r_count));
+	// Update global state
+	if (state.l_start == l_count && state.r_start == r_count) {
+		// Delete references to previous pair
+		state.sorted_blocks[state.pair_idx * 2] = nullptr;
+		state.sorted_blocks[state.pair_idx * 2 + 1] = nullptr;
+		// Advance pair
+		state.pair_idx++;
+		state.l_start = 0;
+		state.r_start = 0;
+	}
+}
+
+int MergeSorter::CompareUsingGlobalIndex(SBScanState &l, SBScanState &r, const idx_t l_idx, const idx_t r_idx) {
+	D_ASSERT(l_idx < l.sb->Count());
+	D_ASSERT(r_idx < r.sb->Count());
+
+	// Easy comparison using the previous result (intersections must increase monotonically)
+	if (l_idx < state.l_start) {
+		return -1;
+	}
+	if (r_idx < state.r_start) {
+		return 1;
+	}
+
+	l.sb->GlobalToLocalIndex(l_idx, l.block_idx, l.entry_idx);
+	r.sb->GlobalToLocalIndex(r_idx, r.block_idx, r.entry_idx);
+
+	l.PinRadix(l.block_idx);
+	r.PinRadix(r.block_idx);
+	data_ptr_t l_ptr = l.radix_handle->Ptr() + l.entry_idx * sort_layout.entry_size;
+	data_ptr_t r_ptr = r.radix_handle->Ptr() + r.entry_idx * sort_layout.entry_size;
+
+	int comp_res;
+	if (sort_layout.all_constant) {
+		comp_res = FastMemcmp(l_ptr, r_ptr, sort_layout.comparison_size);
+	} else {
+		l.PinData(*l.sb->blob_sorting_data);
+		r.PinData(*r.sb->blob_sorting_data);
+		comp_res = Comparators::CompareTuple(l, r, l_ptr, r_ptr, sort_layout, state.external);
+	}
+	return comp_res;
+}
+
+void MergeSorter::GetIntersection(const idx_t diagonal, idx_t &l_idx, idx_t &r_idx) {
+	const idx_t l_count = left->sb->Count();
+	const idx_t r_count = right->sb->Count();
+	// Cover some edge cases
+	// Code coverage off because these edge cases cannot happen unless other code changes
+	// Edge cases have been tested extensively while developing Merge Path in a script
+	// LCOV_EXCL_START
+	if (diagonal >= l_count + r_count) {
+		l_idx = l_count;
+		r_idx = r_count;
+		return;
+	} else if (diagonal == 0) {
+		l_idx = 0;
+		r_idx = 0;
+		return;
+	} else if (l_count == 0) {
+		l_idx = 0;
+		r_idx = diagonal;
+		return;
+	} else if (r_count == 0) {
+		r_idx = 0;
+		l_idx = diagonal;
+		return;
+	}
+	// LCOV_EXCL_STOP
+	// Determine offsets for the binary search
+	const idx_t l_offset = MinValue(l_count, diagonal);
+	const idx_t r_offset = diagonal > l_count ? diagonal - l_count : 0;
+	D_ASSERT(l_offset + r_offset == diagonal);
+	const idx_t search_space = diagonal > MaxValue(l_count, r_count) ? l_count + r_count - diagonal
+	                                                                 : MinValue(diagonal, MinValue(l_count, r_count));
+	// Double binary search
+	idx_t li = 0;
+	idx_t ri = search_space - 1;
+	idx_t middle;
+	int comp_res;
+	while (li <= ri) {
+		middle = (li + ri) / 2;
+		l_idx = l_offset - middle;
+		r_idx = r_offset + middle;
+		if (l_idx == l_count || r_idx == 0) {
+			comp_res = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
+			if (comp_res > 0) {
+				l_idx--;
+				r_idx++;
+			} else {
+				return;
+			}
+			if (l_idx == 0 || r_idx == r_count) {
+				// This case is incredibly difficult to cover as it is dependent on parallelism randomness
+				// But it has been tested extensively during development in a script
+				// LCOV_EXCL_START
+				return;
+				// LCOV_EXCL_STOP
+			} else {
+				break;
+			}
+		}
+		comp_res = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx);
+		if (comp_res > 0) {
+			li = middle + 1;
+		} else {
+			ri = middle - 1;
+		}
+	}
+	int l_r_min1 = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx - 1);
+	int l_min1_r = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
+	if (l_r_min1 > 0 && l_min1_r < 0) {
+		return;
+	} else if (l_r_min1 > 0) {
+		l_idx--;
+		r_idx++;
+	} else if (l_min1_r < 0) {
+		l_idx++;
+		r_idx--;
+	}
+}
+
+void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
+	auto &l = *left;
+	auto &r = *right;
+	auto &l_sorted_block = *l.sb;
+	auto &r_sorted_block = *r.sb;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+	// Data pointers for both sides
+	data_ptr_t l_radix_ptr;
+	data_ptr_t r_radix_ptr;
+	// Compute the merge of the next 'count' tuples
+	idx_t compared = 0;
+	while (compared < count) {
+		// Move to the next block (if needed)
+		if (l.block_idx < l_sorted_block.radix_sorting_data.size() &&
+		    l.entry_idx == l_sorted_block.radix_sorting_data[l.block_idx].count) {
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_sorted_block.radix_sorting_data.size() &&
+		    r.entry_idx == r_sorted_block.radix_sorting_data[r.block_idx].count) {
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_sorted_block.radix_sorting_data.size();
+		const bool r_done = r.block_idx == r_sorted_block.radix_sorting_data.size();
+		if (l_done || r_done) {
+			// One of the sides is exhausted, no need to compare
+			break;
+		}
+		// Pin the radix sorting data
+		if (!l_done) {
+			left->PinRadix(l.block_idx);
+			l_radix_ptr = left->RadixPtr();
+		}
+		if (!r_done) {
+			right->PinRadix(r.block_idx);
+			r_radix_ptr = right->RadixPtr();
+		}
+		const idx_t &l_count = !l_done ? l_sorted_block.radix_sorting_data[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_sorted_block.radix_sorting_data[r.block_idx].count : 0;
+		// Compute the merge
+		if (sort_layout.all_constant) {
+			// All sorting columns are constant size
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
+				left_smaller[compared] = FastMemcmp(l_radix_ptr, r_radix_ptr, sort_layout.comparison_size) < 0;
+				const bool &l_smaller = left_smaller[compared];
+				const bool r_smaller = !l_smaller;
+				// Use comparison bool (0 or 1) to increment entries and pointers
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
+				l_radix_ptr += l_smaller * sort_layout.entry_size;
+				r_radix_ptr += r_smaller * sort_layout.entry_size;
+			}
+		} else {
+			// Pin the blob data
+			if (!l_done) {
+				left->PinData(*l_sorted_block.blob_sorting_data);
+			}
+			if (!r_done) {
+				right->PinData(*r_sorted_block.blob_sorting_data);
+			}
+			// Merge with variable size sorting columns
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
+				left_smaller[compared] =
+				    Comparators::CompareTuple(*left, *right, l_radix_ptr, r_radix_ptr, sort_layout, state.external) < 0;
+				const bool &l_smaller = left_smaller[compared];
+				const bool r_smaller = !l_smaller;
+				// Use comparison bool (0 or 1) to increment entries and pointers
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
+				l_radix_ptr += l_smaller * sort_layout.entry_size;
+				r_radix_ptr += r_smaller * sort_layout.entry_size;
+			}
+		}
+	}
+	// Reset block indices
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
+}
+
+void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
+	auto &l_blocks = l.sb->radix_sorting_data;
+	auto &r_blocks = r.sb->radix_sorting_data;
+	RowDataBlock *l_block;
+	RowDataBlock *r_block;
+
+	data_ptr_t l_ptr;
+	data_ptr_t r_ptr;
+
+	RowDataBlock *result_block = &result->radix_sorting_data.back();
+	auto result_handle = buffer_manager.Pin(result_block->block);
+	data_ptr_t result_ptr = result_handle->Ptr() + result_block->count * sort_layout.entry_size;
+
+	idx_t copied = 0;
+	while (copied < count) {
+		// Move to the next block (if needed)
+		if (l.block_idx < l_blocks.size() && l.entry_idx == l_blocks[l.block_idx].count) {
+			// Delete reference to previous block
+			l_blocks[l.block_idx].block = nullptr;
+			// Advance block
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_blocks.size() && r.entry_idx == r_blocks[r.block_idx].count) {
+			// Delete reference to previous block
+			r_blocks[r.block_idx].block = nullptr;
+			// Advance block
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_blocks.size();
+		const bool r_done = r.block_idx == r_blocks.size();
+		// Pin the radix sortable blocks
+		if (!l_done) {
+			l_block = &l_blocks[l.block_idx];
+			left->PinRadix(l.block_idx);
+			l_ptr = l.RadixPtr();
+		}
+		if (!r_done) {
+			r_block = &r_blocks[r.block_idx];
+			r.PinRadix(r.block_idx);
+			r_ptr = r.RadixPtr();
+		}
+		const idx_t &l_count = !l_done ? l_block->count : 0;
+		const idx_t &r_count = !r_done ? r_block->count : 0;
+		// Copy using computed merge
+		if (!l_done && !r_done) {
+			// Both sides have data - merge
+			MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_block, result_ptr,
+			          sort_layout.entry_size, left_smaller, copied, count);
+		} else if (r_done) {
+			// Right side is exhausted
+			FlushRows(l_ptr, l.entry_idx, l_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+		} else {
+			// Left side is exhausted
+			FlushRows(r_ptr, r.entry_idx, r_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+		}
+	}
+	// Reset block indices
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
+}
+
+void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedData &r_data, const idx_t &count,
+                            const bool left_smaller[], idx_t next_entry_sizes[], bool reset_indices) {
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
+	const auto &layout = result_data.layout;
+	const idx_t row_width = layout.GetRowWidth();
+	const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+
+	// Left and right row data to merge
+	data_ptr_t l_ptr;
+	data_ptr_t r_ptr;
+	// Accompanying left and right heap data (if needed)
+	data_ptr_t l_heap_ptr;
+	data_ptr_t r_heap_ptr;
+
+	// Result rows to write to
+	RowDataBlock *result_data_block = &result_data.data_blocks.back();
+	auto result_data_handle = buffer_manager.Pin(result_data_block->block);
+	data_ptr_t result_data_ptr = result_data_handle->Ptr() + result_data_block->count * row_width;
+	// Result heap to write to (if needed)
+	RowDataBlock *result_heap_block;
+	unique_ptr<BufferHandle> result_heap_handle;
+	data_ptr_t result_heap_ptr;
+	if (!layout.AllConstant() && state.external) {
+		result_heap_block = &result_data.heap_blocks.back();
+		result_heap_handle = buffer_manager.Pin(result_heap_block->block);
+		result_heap_ptr = result_heap_handle->Ptr() + result_heap_block->byte_offset;
+	}
+
+	idx_t copied = 0;
+	while (copied < count) {
+		// Move to new data blocks (if needed)
+		if (l.block_idx < l_data.data_blocks.size() && l.entry_idx == l_data.data_blocks[l.block_idx].count) {
+			// Delete reference to previous block
+			l_data.data_blocks[l.block_idx].block = nullptr;
+			if (!layout.AllConstant() && state.external) {
+				l_data.heap_blocks[l.block_idx].block = nullptr;
+			}
+			// Advance block
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_data.data_blocks.size() && r.entry_idx == r_data.data_blocks[r.block_idx].count) {
+			// Delete reference to previous block
+			r_data.data_blocks[r.block_idx].block = nullptr;
+			if (!layout.AllConstant() && state.external) {
+				r_data.heap_blocks[r.block_idx].block = nullptr;
+			}
+			// Advance block
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_data.data_blocks.size();
+		const bool r_done = r.block_idx == r_data.data_blocks.size();
+		// Pin the row data blocks
+		if (!l_done) {
+			l.PinData(l_data);
+			l_ptr = l.DataPtr(l_data);
+		}
+		if (!r_done) {
+			r.PinData(r_data);
+			r_ptr = r.DataPtr(r_data);
+		}
+		const idx_t &l_count = !l_done ? l_data.data_blocks[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_data.data_blocks[r.block_idx].count : 0;
+		// Perform the merge
+		if (layout.AllConstant() || !state.external) {
+			// If all constant size, or if we are doing an in-memory sort, we do not need to touch the heap
+			if (!l_done && !r_done) {
+				// Both sides have data - merge
+				MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr,
+				          row_width, left_smaller, copied, count);
+			} else if (r_done) {
+				// Right side is exhausted
+				FlushRows(l_ptr, l.entry_idx, l_count, result_data_block, result_data_ptr, row_width, copied, count);
+			} else {
+				// Left side is exhausted
+				FlushRows(r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr, row_width, copied, count);
+			}
+		} else {
+			// External sorting with variable size data. Pin the heap blocks too
+			if (!l_done) {
+				l_heap_ptr = l.BaseHeapPtr(l_data) + Load<idx_t>(l_ptr + heap_pointer_offset);
+				D_ASSERT(l_heap_ptr - l.BaseHeapPtr(l_data) >= 0);
+				D_ASSERT((idx_t)(l_heap_ptr - l.BaseHeapPtr(l_data)) < l_data.heap_blocks[l.block_idx].byte_offset);
+			}
+			if (!r_done) {
+				r_heap_ptr = r.BaseHeapPtr(r_data) + Load<idx_t>(r_ptr + heap_pointer_offset);
+				D_ASSERT(r_heap_ptr - r.BaseHeapPtr(r_data) >= 0);
+				D_ASSERT((idx_t)(r_heap_ptr - r.BaseHeapPtr(r_data)) < r_data.heap_blocks[r.block_idx].byte_offset);
+			}
+			// Both the row and heap data need to be dealt with
+			if (!l_done && !r_done) {
+				// Both sides have data - merge
+				idx_t l_idx_copy = l.entry_idx;
+				idx_t r_idx_copy = r.entry_idx;
+				data_ptr_t result_data_ptr_copy = result_data_ptr;
+				idx_t copied_copy = copied;
+				// Merge row data
+				MergeRows(l_ptr, l_idx_copy, l_count, r_ptr, r_idx_copy, r_count, result_data_block,
+				          result_data_ptr_copy, row_width, left_smaller, copied_copy, count);
+				const idx_t merged = copied_copy - copied;
+				// Compute the entry sizes and number of heap bytes that will be copied
+				idx_t copy_bytes = 0;
+				data_ptr_t l_heap_ptr_copy = l_heap_ptr;
+				data_ptr_t r_heap_ptr_copy = r_heap_ptr;
+				for (idx_t i = 0; i < merged; i++) {
+					// Store base heap offset in the row data
+					Store<idx_t>(result_heap_block->byte_offset + copy_bytes, result_data_ptr + heap_pointer_offset);
+					result_data_ptr += row_width;
+					// Compute entry size and add to total
+					const bool &l_smaller = left_smaller[copied + i];
+					const bool r_smaller = !l_smaller;
+					auto &entry_size = next_entry_sizes[copied + i];
+					entry_size =
+					    l_smaller * Load<uint32_t>(l_heap_ptr_copy) + r_smaller * Load<uint32_t>(r_heap_ptr_copy);
+					D_ASSERT(entry_size >= sizeof(uint32_t));
+					D_ASSERT(l_heap_ptr_copy - l.BaseHeapPtr(l_data) + l_smaller * entry_size <=
+					         l_data.heap_blocks[l.block_idx].byte_offset);
+					D_ASSERT(r_heap_ptr_copy - r.BaseHeapPtr(r_data) + r_smaller * entry_size <=
+					         r_data.heap_blocks[r.block_idx].byte_offset);
+					l_heap_ptr_copy += l_smaller * entry_size;
+					r_heap_ptr_copy += r_smaller * entry_size;
+					copy_bytes += entry_size;
+				}
+				// Reallocate result heap block size (if needed)
+				if (result_heap_block->byte_offset + copy_bytes > result_heap_block->capacity) {
+					idx_t new_capacity = result_heap_block->byte_offset + copy_bytes;
+					buffer_manager.ReAllocate(result_heap_block->block, new_capacity);
+					result_heap_block->capacity = new_capacity;
+					result_heap_ptr = result_heap_handle->Ptr() + result_heap_block->byte_offset;
+				}
+				D_ASSERT(result_heap_block->byte_offset + copy_bytes <= result_heap_block->capacity);
+				// Now copy the heap data
+				for (idx_t i = 0; i < merged; i++) {
+					const bool &l_smaller = left_smaller[copied + i];
+					const bool r_smaller = !l_smaller;
+					const auto &entry_size = next_entry_sizes[copied + i];
+					memcpy(result_heap_ptr, (data_ptr_t)(l_smaller * (idx_t)l_heap_ptr + r_smaller * (idx_t)r_heap_ptr),
+					       entry_size);
+					D_ASSERT(Load<uint32_t>(result_heap_ptr) == entry_size);
+					result_heap_ptr += entry_size;
+					l_heap_ptr += l_smaller * entry_size;
+					r_heap_ptr += r_smaller * entry_size;
+					l.entry_idx += l_smaller;
+					r.entry_idx += r_smaller;
+				}
+				// Update result indices and pointers
+				result_heap_block->count += merged;
+				result_heap_block->byte_offset += copy_bytes;
+				copied += merged;
+			} else if (r_done) {
+				// Right side is exhausted - flush left
+				FlushBlobs(layout, l_count, l_ptr, l.entry_idx, l_heap_ptr, result_data_block, result_data_ptr,
+				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
+			} else {
+				// Left side is exhausted - flush right
+				FlushBlobs(layout, r_count, r_ptr, r.entry_idx, r_heap_ptr, result_data_block, result_data_ptr,
+				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
+			}
+			D_ASSERT(result_data_block->count == result_heap_block->count);
+		}
+	}
+	if (reset_indices) {
+		left->SetIndices(l_block_idx_before, l_entry_idx_before);
+		right->SetIndices(r_block_idx_before, r_entry_idx_before);
+	}
+}
+
+void MergeSorter::MergeRows(data_ptr_t &l_ptr, idx_t &l_entry_idx, const idx_t &l_count, data_ptr_t &r_ptr,
+                            idx_t &r_entry_idx, const idx_t &r_count, RowDataBlock *target_block,
+                            data_ptr_t &target_ptr, const idx_t &entry_size, const bool left_smaller[], idx_t &copied,
+                            const idx_t &count) {
+	const idx_t next = MinValue(count - copied, target_block->capacity - target_block->count);
+	idx_t i;
+	for (i = 0; i < next && l_entry_idx < l_count && r_entry_idx < r_count; i++) {
+		const bool &l_smaller = left_smaller[copied + i];
+		const bool r_smaller = !l_smaller;
+		// Use comparison bool (0 or 1) to copy an entry from either side
+		FastMemcpy(target_ptr, (data_ptr_t)(l_smaller * (idx_t)l_ptr + r_smaller * (idx_t)r_ptr), entry_size);
+		target_ptr += entry_size;
+		// Use the comparison bool to increment entries and pointers
+		l_entry_idx += l_smaller;
+		r_entry_idx += r_smaller;
+		l_ptr += l_smaller * entry_size;
+		r_ptr += r_smaller * entry_size;
+	}
+	// Update counts
+	target_block->count += i;
+	copied += i;
+}
+
+void MergeSorter::FlushRows(data_ptr_t &source_ptr, idx_t &source_entry_idx, const idx_t &source_count,
+                            RowDataBlock *target_block, data_ptr_t &target_ptr, const idx_t &entry_size, idx_t &copied,
+                            const idx_t &count) {
+	// Compute how many entries we can fit
+	idx_t next = MinValue(count - copied, target_block->capacity - target_block->count);
+	next = MinValue(next, source_count - source_entry_idx);
+	// Copy them all in a single memcpy
+	const idx_t copy_bytes = next * entry_size;
+	memcpy(target_ptr, source_ptr, copy_bytes);
+	target_ptr += copy_bytes;
+	source_ptr += copy_bytes;
+	// Update counts
+	source_entry_idx += next;
+	target_block->count += next;
+	copied += next;
+}
+
+void MergeSorter::FlushBlobs(const RowLayout &layout, const idx_t &source_count, data_ptr_t &source_data_ptr,
+                             idx_t &source_entry_idx, data_ptr_t &source_heap_ptr, RowDataBlock *target_data_block,
+                             data_ptr_t &target_data_ptr, RowDataBlock *target_heap_block,
+                             BufferHandle &target_heap_handle, data_ptr_t &target_heap_ptr, idx_t &copied,
+                             const idx_t &count) {
+	const idx_t row_width = layout.GetRowWidth();
+	const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+	idx_t source_entry_idx_copy = source_entry_idx;
+	data_ptr_t target_data_ptr_copy = target_data_ptr;
+	idx_t copied_copy = copied;
+	// Flush row data
+	FlushRows(source_data_ptr, source_entry_idx_copy, source_count, target_data_block, target_data_ptr_copy, row_width,
+	          copied_copy, count);
+	const idx_t flushed = copied_copy - copied;
+	// Compute the entry sizes and number of heap bytes that will be copied
+	idx_t copy_bytes = 0;
+	data_ptr_t source_heap_ptr_copy = source_heap_ptr;
+	for (idx_t i = 0; i < flushed; i++) {
+		// Store base heap offset in the row data
+		Store<idx_t>(target_heap_block->byte_offset + copy_bytes, target_data_ptr + heap_pointer_offset);
+		target_data_ptr += row_width;
+		// Compute entry size and add to total
+		auto entry_size = Load<uint32_t>(source_heap_ptr_copy);
+		D_ASSERT(entry_size >= sizeof(uint32_t));
+		source_heap_ptr_copy += entry_size;
+		copy_bytes += entry_size;
+	}
+	// Reallocate result heap block size (if needed)
+	if (target_heap_block->byte_offset + copy_bytes > target_heap_block->capacity) {
+		idx_t new_capacity = target_heap_block->byte_offset + copy_bytes;
+		buffer_manager.ReAllocate(target_heap_block->block, new_capacity);
+		target_heap_block->capacity = new_capacity;
+		target_heap_ptr = target_heap_handle.Ptr() + target_heap_block->byte_offset;
+	}
+	D_ASSERT(target_heap_block->byte_offset + copy_bytes <= target_heap_block->capacity);
+	// Copy the heap data in one go
+	memcpy(target_heap_ptr, source_heap_ptr, copy_bytes);
+	target_heap_ptr += copy_bytes;
+	source_heap_ptr += copy_bytes;
+	source_entry_idx += flushed;
+	copied += flushed;
+	// Update result indices and pointers
+	target_heap_block->count += flushed;
+	target_heap_block->byte_offset += copy_bytes;
+	D_ASSERT(target_heap_block->byte_offset <= target_heap_block->capacity);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//! Calls std::sort on strings that are tied by their prefix after the radix sort
+static void SortTiedBlobs(BufferManager &buffer_manager, const data_ptr_t dataptr, const idx_t &start, const idx_t &end,
+                          const idx_t &tie_col, bool *ties, const data_ptr_t blob_ptr, const SortLayout &sort_layout) {
+	const auto row_width = sort_layout.blob_layout.GetRowWidth();
+	const idx_t &col_idx = sort_layout.sorting_to_blob_col.at(tie_col);
+	// Locate the first blob row in question
+	data_ptr_t row_ptr = dataptr + start * sort_layout.entry_size;
+	data_ptr_t blob_row_ptr = blob_ptr + Load<uint32_t>(row_ptr + sort_layout.comparison_size) * row_width;
+	if (!Comparators::TieIsBreakable(col_idx, blob_row_ptr, sort_layout.blob_layout)) {
+		// Quick check to see if ties can be broken
+		return;
+	}
+	// Fill pointer array for sorting
+	auto ptr_block = unique_ptr<data_ptr_t[]>(new data_ptr_t[end - start]);
+	auto entry_ptrs = (data_ptr_t *)ptr_block.get();
+	for (idx_t i = start; i < end; i++) {
+		entry_ptrs[i - start] = row_ptr;
+		row_ptr += sort_layout.entry_size;
+	}
+	// Slow pointer-based sorting
+	const int order = sort_layout.order_types[tie_col] == OrderType::DESCENDING ? -1 : 1;
+	const auto &tie_col_offset = sort_layout.blob_layout.GetOffsets()[col_idx];
+	auto logical_type = sort_layout.blob_layout.GetTypes()[col_idx];
+	std::sort(entry_ptrs, entry_ptrs + end - start,
+	          [&blob_ptr, &order, &sort_layout, &tie_col_offset, &row_width, &logical_type](const data_ptr_t l,
+	                                                                                        const data_ptr_t r) {
+		          idx_t left_idx = Load<uint32_t>(l + sort_layout.comparison_size);
+		          idx_t right_idx = Load<uint32_t>(r + sort_layout.comparison_size);
+		          data_ptr_t left_ptr = blob_ptr + left_idx * row_width + tie_col_offset;
+		          data_ptr_t right_ptr = blob_ptr + right_idx * row_width + tie_col_offset;
+		          return order * Comparators::CompareVal(left_ptr, right_ptr, logical_type) < 0;
+	          });
+	// Re-order
+	auto temp_block =
+	    buffer_manager.Allocate(MaxValue((end - start) * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+	data_ptr_t temp_ptr = temp_block->Ptr();
+	for (idx_t i = 0; i < end - start; i++) {
+		FastMemcpy(temp_ptr, entry_ptrs[i], sort_layout.entry_size);
+		temp_ptr += sort_layout.entry_size;
+	}
+	memcpy(dataptr + start * sort_layout.entry_size, temp_block->Ptr(), (end - start) * sort_layout.entry_size);
+	// Determine if there are still ties (if this is not the last column)
+	if (tie_col < sort_layout.column_count - 1) {
+		data_ptr_t idx_ptr = dataptr + start * sort_layout.entry_size + sort_layout.comparison_size;
+		// Load current entry
+		data_ptr_t current_ptr = blob_ptr + Load<uint32_t>(idx_ptr) * row_width + tie_col_offset;
+		for (idx_t i = 0; i < end - start - 1; i++) {
+			// Load next entry and compare
+			idx_ptr += sort_layout.entry_size;
+			data_ptr_t next_ptr = blob_ptr + Load<uint32_t>(idx_ptr) * row_width + tie_col_offset;
+			ties[start + i] = Comparators::CompareVal(current_ptr, next_ptr, logical_type) == 0;
+			current_ptr = next_ptr;
+		}
+	}
+}
+
+//! Identifies sequences of rows that are tied by the prefix of a blob column, and sorts them
+static void SortTiedBlobs(BufferManager &buffer_manager, SortedBlock &sb, bool *ties, data_ptr_t dataptr,
+                          const idx_t &count, const idx_t &tie_col, const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	auto &blob_block = sb.blob_sorting_data->data_blocks.back();
+	auto blob_handle = buffer_manager.Pin(blob_block.block);
+	const data_ptr_t blob_ptr = blob_handle->Ptr();
+
+	for (idx_t i = 0; i < count; i++) {
+		if (!ties[i]) {
+			continue;
+		}
+		idx_t j;
+		for (j = i; j < count; j++) {
+			if (!ties[j]) {
+				break;
+			}
+		}
+		SortTiedBlobs(buffer_manager, dataptr, i, j + 1, tie_col, ties, blob_ptr, sort_layout);
+		i = j;
+	}
+}
+
+//! Returns whether there are any 'true' values in the ties[] array
+static bool AnyTies(bool ties[], const idx_t &count) {
+	D_ASSERT(!ties[count - 1]);
+	bool any_ties = false;
+	for (idx_t i = 0; i < count - 1; i++) {
+		any_ties = any_ties || ties[i];
+	}
+	return any_ties;
+}
+
+//! Compares subsequent rows to check for ties
+static void ComputeTies(data_ptr_t dataptr, const idx_t &count, const idx_t &col_offset, const idx_t &tie_size,
+                        bool ties[], const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	D_ASSERT(col_offset + tie_size <= sort_layout.comparison_size);
+	// Align dataptr
+	dataptr += col_offset;
+	for (idx_t i = 0; i < count - 1; i++) {
+		ties[i] = ties[i] && FastMemcmp(dataptr, dataptr + sort_layout.entry_size, tie_size) == 0;
+		dataptr += sort_layout.entry_size;
+	}
+}
+
+//! Textbook LSD radix sort
+void RadixSortLSD(BufferManager &buffer_manager, const data_ptr_t &dataptr, const idx_t &count, const idx_t &col_offset,
+                  const idx_t &row_width, const idx_t &sorting_size) {
+	auto temp_block = buffer_manager.Allocate(MaxValue(count * row_width, (idx_t)Storage::BLOCK_SIZE));
+	bool swap = false;
+
+	idx_t counts[SortConstants::VALUES_PER_RADIX];
+	for (idx_t r = 1; r <= sorting_size; r++) {
+		// Init counts to 0
+		memset(counts, 0, sizeof(counts));
+		// Const some values for convenience
+		const data_ptr_t source_ptr = swap ? temp_block->Ptr() : dataptr;
+		const data_ptr_t target_ptr = swap ? dataptr : temp_block->Ptr();
+		const idx_t offset = col_offset + sorting_size - r;
+		// Collect counts
+		data_ptr_t offset_ptr = source_ptr + offset;
+		for (idx_t i = 0; i < count; i++) {
+			counts[*offset_ptr]++;
+			offset_ptr += row_width;
+		}
+		// Compute offsets from counts
+		idx_t max_count = counts[0];
+		for (idx_t val = 1; val < SortConstants::VALUES_PER_RADIX; val++) {
+			max_count = MaxValue<idx_t>(max_count, counts[val]);
+			counts[val] = counts[val] + counts[val - 1];
+		}
+		if (max_count == count) {
+			continue;
+		}
+		// Re-order the data in temporary array
+		data_ptr_t row_ptr = source_ptr + (count - 1) * row_width;
+		for (idx_t i = 0; i < count; i++) {
+			idx_t &radix_offset = --counts[*(row_ptr + offset)];
+			FastMemcpy(target_ptr + radix_offset * row_width, row_ptr, row_width);
+			row_ptr -= row_width;
+		}
+		swap = !swap;
+	}
+	// Move data back to original buffer (if it was swapped)
+	if (swap) {
+		memcpy(dataptr, temp_block->Ptr(), count * row_width);
+	}
+}
+
+//! Insertion sort, used when count of values is low
+inline void InsertionSort(const data_ptr_t orig_ptr, const data_ptr_t temp_ptr, const idx_t &count,
+                          const idx_t &col_offset, const idx_t &row_width, const idx_t &total_comp_width,
+                          const idx_t &offset, bool swap) {
+	const data_ptr_t source_ptr = swap ? temp_ptr : orig_ptr;
+	const data_ptr_t target_ptr = swap ? orig_ptr : temp_ptr;
+	if (count > 1) {
+		const idx_t total_offset = col_offset + offset;
+		auto temp_val = unique_ptr<data_t[]>(new data_t[row_width]);
+		const data_ptr_t val = temp_val.get();
+		const auto comp_width = total_comp_width - offset;
+		for (idx_t i = 1; i < count; i++) {
+			FastMemcpy(val, source_ptr + i * row_width, row_width);
+			idx_t j = i;
+			while (j > 0 &&
+			       FastMemcmp(source_ptr + (j - 1) * row_width + total_offset, val + total_offset, comp_width) > 0) {
+				FastMemcpy(source_ptr + j * row_width, source_ptr + (j - 1) * row_width, row_width);
+				j--;
+			}
+			FastMemcpy(source_ptr + j * row_width, val, row_width);
+		}
+	}
+	if (swap) {
+		memcpy(target_ptr, source_ptr, count * row_width);
+	}
+}
+
+//! MSD radix sort that switches to insertion sort with low bucket sizes
+void RadixSortMSD(const data_ptr_t orig_ptr, const data_ptr_t temp_ptr, const idx_t &count, const idx_t &col_offset,
+                  const idx_t &row_width, const idx_t &comp_width, const idx_t &offset, idx_t locations[], bool swap) {
+	const data_ptr_t source_ptr = swap ? temp_ptr : orig_ptr;
+	const data_ptr_t target_ptr = swap ? orig_ptr : temp_ptr;
+	// Init counts to 0
+	memset(locations, 0, SortConstants::MSD_RADIX_LOCATIONS * sizeof(idx_t));
+	idx_t *counts = locations + 1;
+	// Collect counts
+	const idx_t total_offset = col_offset + offset;
+	data_ptr_t offset_ptr = source_ptr + total_offset;
+	for (idx_t i = 0; i < count; i++) {
+		counts[*offset_ptr]++;
+		offset_ptr += row_width;
+	}
+	// Compute locations from counts
+	idx_t max_count = 0;
+	for (idx_t radix = 0; radix < SortConstants::VALUES_PER_RADIX; radix++) {
+		max_count = MaxValue<idx_t>(max_count, counts[radix]);
+		counts[radix] += locations[radix];
+	}
+	if (max_count != count) {
+		// Re-order the data in temporary array
+		data_ptr_t row_ptr = source_ptr;
+		for (idx_t i = 0; i < count; i++) {
+			const idx_t &radix_offset = locations[*(row_ptr + total_offset)]++;
+			FastMemcpy(target_ptr + radix_offset * row_width, row_ptr, row_width);
+			row_ptr += row_width;
+		}
+		swap = !swap;
+	}
+	// Check if done
+	if (offset == comp_width - 1) {
+		if (swap) {
+			memcpy(orig_ptr, temp_ptr, count * row_width);
+		}
+		return;
+	}
+	if (max_count == count) {
+		RadixSortMSD(orig_ptr, temp_ptr, count, col_offset, row_width, comp_width, offset + 1,
+		             locations + SortConstants::MSD_RADIX_LOCATIONS, swap);
+		return;
+	}
+	// Recurse
+	idx_t radix_count = locations[0];
+	for (idx_t radix = 0; radix < SortConstants::VALUES_PER_RADIX; radix++) {
+		const idx_t loc = (locations[radix] - radix_count) * row_width;
+		if (radix_count > SortConstants::INSERTION_SORT_THRESHOLD) {
+			RadixSortMSD(orig_ptr + loc, temp_ptr + loc, radix_count, col_offset, row_width, comp_width, offset + 1,
+			             locations + SortConstants::MSD_RADIX_LOCATIONS, swap);
+		} else if (radix_count != 0) {
+			InsertionSort(orig_ptr + loc, temp_ptr + loc, radix_count, col_offset, row_width, comp_width, offset + 1,
+			              swap);
+		}
+		radix_count = locations[radix + 1] - locations[radix];
+	}
+}
+
+//! Calls different sort functions, depending on the count and sorting sizes
+void RadixSort(BufferManager &buffer_manager, const data_ptr_t &dataptr, const idx_t &count, const idx_t &col_offset,
+               const idx_t &sorting_size, const SortLayout &sort_layout) {
+	if (count <= SortConstants::INSERTION_SORT_THRESHOLD) {
+		InsertionSort(dataptr, nullptr, count, 0, sort_layout.entry_size, sort_layout.comparison_size, 0, false);
+	} else if (sorting_size <= SortConstants::MSD_RADIX_SORT_SIZE_THRESHOLD) {
+		RadixSortLSD(buffer_manager, dataptr, count, col_offset, sort_layout.entry_size, sorting_size);
+	} else {
+		auto temp_block = buffer_manager.Allocate(MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+		auto preallocated_array = unique_ptr<idx_t[]>(new idx_t[sorting_size * SortConstants::MSD_RADIX_LOCATIONS]);
+		RadixSortMSD(dataptr, temp_block->Ptr(), count, col_offset, sort_layout.entry_size, sorting_size, 0,
+		             preallocated_array.get(), false);
+	}
+}
+
+//! Identifies sequences of rows that are tied, and calls radix sort on these
+static void SubSortTiedTuples(BufferManager &buffer_manager, const data_ptr_t dataptr, const idx_t &count,
+                              const idx_t &col_offset, const idx_t &sorting_size, bool ties[],
+                              const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	for (idx_t i = 0; i < count; i++) {
+		if (!ties[i]) {
+			continue;
+		}
+		idx_t j;
+		for (j = i + 1; j < count; j++) {
+			if (!ties[j]) {
+				break;
+			}
+		}
+		RadixSort(buffer_manager, dataptr + i * sort_layout.entry_size, j - i + 1, col_offset, sorting_size,
+		          sort_layout);
+		i = j;
+	}
+}
+
+void LocalSortState::SortInMemory() {
+	auto &sb = *sorted_blocks.back();
+	auto &block = sb.radix_sorting_data.back();
+	const auto &count = block.count;
+	auto handle = buffer_manager->Pin(block.block);
+	const auto dataptr = handle->Ptr();
+	// Assign an index to each row
+	data_ptr_t idx_dataptr = dataptr + sort_layout->comparison_size;
+	for (uint32_t i = 0; i < count; i++) {
+		Store<uint32_t>(i, idx_dataptr);
+		idx_dataptr += sort_layout->entry_size;
+	}
+	// Radix sort and break ties until no more ties, or until all columns are sorted
+	idx_t sorting_size = 0;
+	idx_t col_offset = 0;
+	unique_ptr<bool[]> ties_ptr;
+	bool *ties = nullptr;
+	for (idx_t i = 0; i < sort_layout->column_count; i++) {
+		sorting_size += sort_layout->column_sizes[i];
+		if (sort_layout->constant_size[i] && i < sort_layout->column_count - 1) {
+			// Add columns to the sorting size until we reach a variable size column, or the last column
+			continue;
+		}
+
+		if (!ties) {
+			// This is the first sort
+			RadixSort(*buffer_manager, dataptr, count, col_offset, sorting_size, *sort_layout);
+			ties_ptr = unique_ptr<bool[]>(new bool[count]);
+			ties = ties_ptr.get();
+			std::fill_n(ties, count - 1, true);
+			ties[count - 1] = false;
+		} else {
+			// For subsequent sorts, we only have to subsort the tied tuples
+			SubSortTiedTuples(*buffer_manager, dataptr, count, col_offset, sorting_size, ties, *sort_layout);
+		}
+
+		if (sort_layout->constant_size[i] && i == sort_layout->column_count - 1) {
+			// All columns are sorted, no ties to break because last column is constant size
+			break;
+		}
+
+		ComputeTies(dataptr, count, col_offset, sorting_size, ties, *sort_layout);
+		if (!AnyTies(ties, count)) {
+			// No ties, stop sorting
+			break;
+		}
+
+		if (!sort_layout->constant_size[i]) {
+			SortTiedBlobs(*buffer_manager, sb, ties, dataptr, count, i, *sort_layout);
+			if (!AnyTies(ties, count)) {
+				// No more ties after tie-breaking, stop
+				break;
+			}
+		}
+
+		col_offset += sorting_size;
+		sorting_size = 0;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+idx_t GetNestedSortingColSize(idx_t &col_size, const LogicalType &type) {
+	auto physical_type = type.InternalType();
+	if (TypeIsConstantSize(physical_type)) {
+		col_size += GetTypeIdSize(physical_type);
+		return 0;
+	} else {
+		switch (physical_type) {
+		case PhysicalType::VARCHAR: {
+			// Nested strings are between 4 and 11 chars long for alignment
+			auto size_before_str = col_size;
+			col_size += 11;
+			col_size -= (col_size - 12) % 8;
+			return col_size - size_before_str;
+		}
+		case PhysicalType::LIST:
+			// Lists get 2 bytes (null and empty list)
+			col_size += 2;
+			return GetNestedSortingColSize(col_size, ListType::GetChildType(type));
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			// Structs get 1 bytes (null)
+			col_size++;
+			return GetNestedSortingColSize(col_size, StructType::GetChildType(type, 0));
+		default:
+			throw NotImplementedException("Unable to order column with type %s", type.ToString());
+		}
+	}
+}
+
+SortLayout::SortLayout(const vector<BoundOrderByNode> &orders)
+    : column_count(orders.size()), all_constant(true), comparison_size(0), entry_size(0) {
+	vector<LogicalType> blob_layout_types;
+	for (idx_t i = 0; i < column_count; i++) {
+		const auto &order = orders[i];
+
+		order_types.push_back(order.type);
+		order_by_null_types.push_back(order.null_order);
+		auto &expr = *order.expression;
+		logical_types.push_back(expr.return_type);
+
+		auto physical_type = expr.return_type.InternalType();
+		constant_size.push_back(TypeIsConstantSize(physical_type));
+
+		if (order.stats) {
+			stats.push_back(order.stats.get());
+			has_null.push_back(stats.back()->CanHaveNull());
+		} else {
+			stats.push_back(nullptr);
+			has_null.push_back(true);
+		}
+
+		idx_t col_size = has_null.back() ? 1 : 0;
+		prefix_lengths.push_back(0);
+		if (!TypeIsConstantSize(physical_type) && physical_type != PhysicalType::VARCHAR) {
+			prefix_lengths.back() = GetNestedSortingColSize(col_size, expr.return_type);
+		} else if (physical_type == PhysicalType::VARCHAR) {
+			idx_t size_before = col_size;
+			if (stats.back()) {
+				auto &str_stats = (StringStatistics &)*stats.back();
+				col_size += str_stats.max_string_length;
+				if (col_size > 12) {
+					col_size = 12;
+				} else {
+					constant_size.back() = true;
+				}
+			} else {
+				col_size = 12;
+			}
+			prefix_lengths.back() = col_size - size_before;
+		} else {
+			col_size += GetTypeIdSize(physical_type);
+		}
+
+		comparison_size += col_size;
+		column_sizes.push_back(col_size);
+	}
+	entry_size = comparison_size + sizeof(uint32_t);
+
+	// 8-byte alignment
+	if (entry_size % 8 != 0) {
+		// First assign more bytes to strings instead of aligning
+		idx_t bytes_to_fill = 8 - (entry_size % 8);
+		for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+			if (bytes_to_fill == 0) {
+				break;
+			}
+			if (logical_types[col_idx].InternalType() == PhysicalType::VARCHAR && stats[col_idx]) {
+				auto &str_stats = (StringStatistics &)*stats[col_idx];
+				idx_t diff = str_stats.max_string_length - prefix_lengths[col_idx];
+				if (diff > 0) {
+					// Increase all sizes accordingly
+					idx_t increase = MinValue(bytes_to_fill, diff);
+					column_sizes[col_idx] += increase;
+					prefix_lengths[col_idx] += increase;
+					constant_size[col_idx] = increase == diff;
+					comparison_size += increase;
+					entry_size += increase;
+					bytes_to_fill -= increase;
+				}
+			}
+		}
+		entry_size = AlignValue(entry_size);
+	}
+
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+		all_constant = all_constant && constant_size[col_idx];
+		if (!constant_size[col_idx]) {
+			sorting_to_blob_col[col_idx] = blob_layout_types.size();
+			blob_layout_types.push_back(logical_types[col_idx]);
+		}
+	}
+
+	blob_layout.Initialize(blob_layout_types);
+}
+
+LocalSortState::LocalSortState() : initialized(false) {
+}
+
+static idx_t EntriesPerBlock(idx_t width) {
+	return (Storage::BLOCK_SIZE + width * STANDARD_VECTOR_SIZE - 1) / width;
+}
+
+void LocalSortState::Initialize(GlobalSortState &global_sort_state, BufferManager &buffer_manager_p) {
+	sort_layout = &global_sort_state.sort_layout;
+	payload_layout = &global_sort_state.payload_layout;
+	buffer_manager = &buffer_manager_p;
+	// Radix sorting data
+	radix_sorting_data = make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(sort_layout->entry_size),
+	                                                    sort_layout->entry_size);
+	// Blob sorting data
+	if (!sort_layout->all_constant) {
+		auto blob_row_width = sort_layout->blob_layout.GetRowWidth();
+		blob_sorting_data =
+		    make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(blob_row_width), blob_row_width);
+		blob_sorting_heap = make_unique<RowDataCollection>(*buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+	}
+	// Payload data
+	auto payload_row_width = payload_layout->GetRowWidth();
+	payload_data =
+	    make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(payload_row_width), payload_row_width);
+	payload_heap = make_unique<RowDataCollection>(*buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+	// Init done
+	initialized = true;
+}
+
+void LocalSortState::SinkChunk(DataChunk &sort, DataChunk &payload) {
+	D_ASSERT(sort.size() == payload.size());
+	// Build and serialize sorting data to radix sortable rows
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	auto handles = radix_sorting_data->Build(sort.size(), data_pointers, nullptr);
+	for (idx_t sort_col = 0; sort_col < sort.ColumnCount(); sort_col++) {
+		bool has_null = sort_layout->has_null[sort_col];
+		bool nulls_first = sort_layout->order_by_null_types[sort_col] == OrderByNullType::NULLS_FIRST;
+		bool desc = sort_layout->order_types[sort_col] == OrderType::DESCENDING;
+		RowOperations::RadixScatter(sort.data[sort_col], sort.size(), sel_ptr, sort.size(), data_pointers, desc,
+		                            has_null, nulls_first, sort_layout->prefix_lengths[sort_col],
+		                            sort_layout->column_sizes[sort_col]);
+	}
+
+	// Also fully serialize blob sorting columns (to be able to break ties
+	if (!sort_layout->all_constant) {
+		DataChunk blob_chunk;
+		blob_chunk.SetCardinality(sort.size());
+		for (idx_t sort_col = 0; sort_col < sort.ColumnCount(); sort_col++) {
+			if (!sort_layout->constant_size[sort_col]) {
+				blob_chunk.data.emplace_back(sort.data[sort_col]);
+			}
+		}
+		handles = blob_sorting_data->Build(blob_chunk.size(), data_pointers, nullptr);
+		auto blob_data = blob_chunk.Orrify();
+		RowOperations::Scatter(blob_chunk, blob_data.get(), sort_layout->blob_layout, addresses, *blob_sorting_heap,
+		                       sel_ptr, blob_chunk.size());
+	}
+
+	// Finally, serialize payload data
+	handles = payload_data->Build(payload.size(), data_pointers, nullptr);
+	auto input_data = payload.Orrify();
+	RowOperations::Scatter(payload, input_data.get(), *payload_layout, addresses, *payload_heap, sel_ptr,
+	                       payload.size());
+}
+
+idx_t LocalSortState::SizeInBytes() const {
+	idx_t size_in_bytes = radix_sorting_data->SizeInBytes() + payload_data->SizeInBytes();
+	if (!sort_layout->all_constant) {
+		size_in_bytes += blob_sorting_data->SizeInBytes() + blob_sorting_heap->SizeInBytes();
+	}
+	if (!payload_layout->AllConstant()) {
+		size_in_bytes += payload_heap->SizeInBytes();
+	}
+	return size_in_bytes;
+}
+
+void LocalSortState::Sort(GlobalSortState &global_sort_state, bool reorder_heap) {
+	D_ASSERT(radix_sorting_data->count == payload_data->count);
+	if (radix_sorting_data->count == 0) {
+		return;
+	}
+	// Move all data to a single SortedBlock
+	sorted_blocks.emplace_back(make_unique<SortedBlock>(*buffer_manager, global_sort_state));
+	auto &sb = *sorted_blocks.back();
+	// Fixed-size sorting data
+	auto sorting_block = ConcatenateBlocks(*radix_sorting_data);
+	sb.radix_sorting_data.push_back(move(sorting_block));
+	// Variable-size sorting data
+	if (!sort_layout->all_constant) {
+		auto &blob_data = *blob_sorting_data;
+		auto new_block = ConcatenateBlocks(blob_data);
+		sb.blob_sorting_data->data_blocks.push_back(move(new_block));
+	}
+	// Payload data
+	auto payload_block = ConcatenateBlocks(*payload_data);
+	sb.payload_data->data_blocks.push_back(move(payload_block));
+	// Now perform the actual sort
+	SortInMemory();
+	// Re-order before the merge sort
+	ReOrder(global_sort_state, reorder_heap);
+}
+
+RowDataBlock LocalSortState::ConcatenateBlocks(RowDataCollection &row_data) {
+	// Create block with the correct capacity
+	const idx_t &entry_size = row_data.entry_size;
+	idx_t capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + entry_size - 1) / entry_size, row_data.count);
+	RowDataBlock new_block(*buffer_manager, capacity, entry_size);
+	new_block.count = row_data.count;
+	auto new_block_handle = buffer_manager->Pin(new_block.block);
+	data_ptr_t new_block_ptr = new_block_handle->Ptr();
+	// Copy the data of the blocks into a single block
+	for (auto &block : row_data.blocks) {
+		auto block_handle = buffer_manager->Pin(block.block);
+		memcpy(new_block_ptr, block_handle->Ptr(), block.count * entry_size);
+		new_block_ptr += block.count * entry_size;
+	}
+	row_data.blocks.clear();
+	row_data.count = 0;
+	return new_block;
+}
+
+void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataCollection &heap, GlobalSortState &gstate,
+                             bool reorder_heap) {
+	sd.swizzled = reorder_heap;
+	auto &unordered_data_block = sd.data_blocks.back();
+	const idx_t &count = unordered_data_block.count;
+	auto unordered_data_handle = buffer_manager->Pin(unordered_data_block.block);
+	const data_ptr_t unordered_data_ptr = unordered_data_handle->Ptr();
+	// Create new block that will hold re-ordered row data
+	RowDataBlock ordered_data_block(*buffer_manager, unordered_data_block.capacity, unordered_data_block.entry_size);
+	ordered_data_block.count = count;
+	auto ordered_data_handle = buffer_manager->Pin(ordered_data_block.block);
+	data_ptr_t ordered_data_ptr = ordered_data_handle->Ptr();
+	// Re-order fixed-size row layout
+	const idx_t row_width = sd.layout.GetRowWidth();
+	const idx_t sorting_entry_size = gstate.sort_layout.entry_size;
+	for (idx_t i = 0; i < count; i++) {
+		auto index = Load<uint32_t>(sorting_ptr);
+		FastMemcpy(ordered_data_ptr, unordered_data_ptr + index * row_width, row_width);
+		ordered_data_ptr += row_width;
+		sorting_ptr += sorting_entry_size;
+	}
+	// Replace the unordered data block with the re-ordered data block
+	sd.data_blocks.clear();
+	sd.data_blocks.push_back(move(ordered_data_block));
+	// Deal with the heap (if necessary)
+	if (!sd.layout.AllConstant() && reorder_heap) {
+		// Swizzle the column pointers to offsets
+		RowOperations::SwizzleColumns(sd.layout, ordered_data_handle->Ptr(), count);
+		// Create a single heap block to store the ordered heap
+		idx_t total_byte_offset = std::accumulate(heap.blocks.begin(), heap.blocks.end(), 0,
+		                                          [](idx_t a, const RowDataBlock &b) { return a + b.byte_offset; });
+		idx_t heap_block_size = MaxValue(total_byte_offset, (idx_t)Storage::BLOCK_SIZE);
+		RowDataBlock ordered_heap_block(*buffer_manager, heap_block_size, 1);
+		ordered_heap_block.count = count;
+		ordered_heap_block.byte_offset = total_byte_offset;
+		auto ordered_heap_handle = buffer_manager->Pin(ordered_heap_block.block);
+		data_ptr_t ordered_heap_ptr = ordered_heap_handle->Ptr();
+		// Fill the heap in order
+		ordered_data_ptr = ordered_data_handle->Ptr();
+		const idx_t heap_pointer_offset = sd.layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < count; i++) {
+			auto heap_row_ptr = Load<data_ptr_t>(ordered_data_ptr + heap_pointer_offset);
+			auto heap_row_size = Load<uint32_t>(heap_row_ptr);
+			memcpy(ordered_heap_ptr, heap_row_ptr, heap_row_size);
+			ordered_heap_ptr += heap_row_size;
+			ordered_data_ptr += row_width;
+		}
+		// Swizzle the base pointer to the offset of each row in the heap
+		RowOperations::SwizzleHeapPointer(sd.layout, ordered_data_handle->Ptr(), ordered_heap_handle->Ptr(), count);
+		// Move the re-ordered heap to the SortedData, and clear the local heap
+		sd.heap_blocks.push_back(move(ordered_heap_block));
+		heap.pinned_blocks.clear();
+		heap.blocks.clear();
+		heap.count = 0;
+	}
+}
+
+void LocalSortState::ReOrder(GlobalSortState &gstate, bool reorder_heap) {
+	auto &sb = *sorted_blocks.back();
+	auto sorting_handle = buffer_manager->Pin(sb.radix_sorting_data.back().block);
+	const data_ptr_t sorting_ptr = sorting_handle->Ptr() + gstate.sort_layout.comparison_size;
+	// Re-order variable size sorting columns
+	if (!gstate.sort_layout.all_constant) {
+		ReOrder(*sb.blob_sorting_data, sorting_ptr, *blob_sorting_heap, gstate, reorder_heap);
+	}
+	// And the payload
+	ReOrder(*sb.payload_data, sorting_ptr, *payload_heap, gstate, reorder_heap);
+}
+
+GlobalSortState::GlobalSortState(BufferManager &buffer_manager, const vector<BoundOrderByNode> &orders,
+                                 RowLayout &payload_layout)
+    : buffer_manager(buffer_manager), sort_layout(SortLayout(orders)), payload_layout(payload_layout),
+      block_capacity(0), external(false) {
+}
+
+void GlobalSortState::AddLocalState(LocalSortState &local_sort_state) {
+	if (!local_sort_state.radix_sorting_data) {
+		return;
+	}
+
+	// Sort accumulated data
+	// we only re-order the heap when the data is expected to not fit in memory
+	// re-ordering the heap avoids random access when reading/merging but incurs a significant cost of shuffling data
+	// when data fits in memory, doing random access on reads is cheaper than re-shuffling
+	local_sort_state.Sort(*this, external || !local_sort_state.sorted_blocks.empty());
+
+	// Append local state sorted data to this global state
+	lock_guard<mutex> append_guard(lock);
+	for (auto &sb : local_sort_state.sorted_blocks) {
+		sorted_blocks.push_back(move(sb));
+	}
+	auto &payload_heap = local_sort_state.payload_heap;
+	for (idx_t i = 0; i < payload_heap->blocks.size(); i++) {
+		heap_blocks.push_back(move(payload_heap->blocks[i]));
+		pinned_blocks.push_back(move(payload_heap->pinned_blocks[i]));
+	}
+	if (!sort_layout.all_constant) {
+		auto &blob_heap = local_sort_state.blob_sorting_heap;
+		for (idx_t i = 0; i < blob_heap->blocks.size(); i++) {
+			heap_blocks.push_back(move(blob_heap->blocks[i]));
+			pinned_blocks.push_back(move(blob_heap->pinned_blocks[i]));
+		}
+	}
+}
+
+void GlobalSortState::PrepareMergePhase() {
+	// Determine if we need to use do an external sort
+	idx_t total_heap_size =
+	    std::accumulate(sorted_blocks.begin(), sorted_blocks.end(), (idx_t)0,
+	                    [](idx_t a, const unique_ptr<SortedBlock> &b) { return a + b->HeapSize(); });
+	if (external || (pinned_blocks.empty() && total_heap_size > 0.25 * buffer_manager.GetMaxMemory())) {
+		external = true;
+	}
+	// Use the data that we have to determine which partition size to use during the merge
+	if (external && total_heap_size > 0) {
+		// If we have variable size data we need to be conservative, as there might be skew
+		idx_t max_block_size = 0;
+		for (auto &sb : sorted_blocks) {
+			idx_t size_in_bytes = sb->SizeInBytes();
+			if (size_in_bytes > max_block_size) {
+				max_block_size = size_in_bytes;
+				block_capacity = sb->Count();
+			}
+		}
+	} else {
+		for (auto &sb : sorted_blocks) {
+			block_capacity = MaxValue(block_capacity, sb->Count());
+		}
+	}
+	// Unswizzle and pin heap blocks if we can fit everything in memory
+	if (!external) {
+		for (auto &sb : sorted_blocks) {
+			sb->blob_sorting_data->Unswizzle();
+			sb->payload_data->Unswizzle();
+		}
+	}
+}
+
+void GlobalSortState::InitializeMergeRound() {
+	D_ASSERT(sorted_blocks_temp.empty());
+	// If we reverse this list, the blocks that were merged last will be merged first in the next round
+	// These are still in memory, therefore this reduces the amount of read/write to disk!
+	std::reverse(sorted_blocks.begin(), sorted_blocks.end());
+	// Uneven number of blocks - keep one on the side
+	if (sorted_blocks.size() % 2 == 1) {
+		odd_one_out = move(sorted_blocks.back());
+		sorted_blocks.pop_back();
+	}
+	// Init merge path path indices
+	pair_idx = 0;
+	num_pairs = sorted_blocks.size() / 2;
+	l_start = 0;
+	r_start = 0;
+	// Allocate room for merge results
+	for (idx_t p_idx = 0; p_idx < num_pairs; p_idx++) {
+		sorted_blocks_temp.emplace_back();
+	}
+}
+
+void GlobalSortState::CompleteMergeRound(bool keep_radix_data) {
+	sorted_blocks.clear();
+	for (auto &sorted_block_vector : sorted_blocks_temp) {
+		sorted_blocks.push_back(make_unique<SortedBlock>(buffer_manager, *this));
+		sorted_blocks.back()->AppendSortedBlocks(sorted_block_vector);
+	}
+	sorted_blocks_temp.clear();
+	if (odd_one_out) {
+		sorted_blocks.push_back(move(odd_one_out));
+		odd_one_out = nullptr;
+	}
+	// Only one block left: Done!
+	if (sorted_blocks.size() == 1 && !keep_radix_data) {
+		sorted_blocks[0]->radix_sorting_data.clear();
+		sorted_blocks[0]->blob_sorting_data = nullptr;
+	}
+}
+void GlobalSortState::Print() {
+	PayloadScanner scanner(*this, false);
+	DataChunk chunk;
+	chunk.Initialize(scanner.GetPayloadTypes());
+	for (;;) {
+		scanner.Scan(chunk);
+		const auto count = chunk.size();
+		if (!count) {
+			break;
+		}
+		chunk.Print();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+SortedData::SortedData(SortedDataType type, const RowLayout &layout, BufferManager &buffer_manager,
+                       GlobalSortState &state)
+    : type(type), layout(layout), swizzled(false), buffer_manager(buffer_manager), state(state) {
+}
+
+idx_t SortedData::Count() {
+	idx_t count = std::accumulate(data_blocks.begin(), data_blocks.end(), (idx_t)0,
+	                              [](idx_t a, const RowDataBlock &b) { return a + b.count; });
+	if (!layout.AllConstant() && state.external) {
+		D_ASSERT(count == std::accumulate(heap_blocks.begin(), heap_blocks.end(), (idx_t)0,
+		                                  [](idx_t a, const RowDataBlock &b) { return a + b.count; }));
+	}
+	return count;
+}
+
+void SortedData::CreateBlock() {
+	auto capacity =
+	    MaxValue(((idx_t)Storage::BLOCK_SIZE + layout.GetRowWidth() - 1) / layout.GetRowWidth(), state.block_capacity);
+	data_blocks.emplace_back(buffer_manager, capacity, layout.GetRowWidth());
+	if (!layout.AllConstant() && state.external) {
+		heap_blocks.emplace_back(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1);
+		D_ASSERT(data_blocks.size() == heap_blocks.size());
+	}
+}
+
+unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t end_block_index, idx_t end_entry_index) {
+	// Add the corresponding blocks to the result
+	auto result = make_unique<SortedData>(type, layout, buffer_manager, state);
+	for (idx_t i = start_block_index; i <= end_block_index; i++) {
+		result->data_blocks.push_back(data_blocks[i]);
+		if (!layout.AllConstant() && state.external) {
+			result->heap_blocks.push_back(heap_blocks[i]);
+		}
+	}
+	// All of the blocks that come before block with idx = start_block_idx can be reset (other references exist)
+	for (idx_t i = 0; i < start_block_index; i++) {
+		data_blocks[i].block = nullptr;
+		if (!layout.AllConstant() && state.external) {
+			heap_blocks[i].block = nullptr;
+		}
+	}
+	// Use start and end entry indices to set the boundaries
+	D_ASSERT(end_entry_index <= result->data_blocks.back().count);
+	result->data_blocks.back().count = end_entry_index;
+	if (!layout.AllConstant() && state.external) {
+		result->heap_blocks.back().count = end_entry_index;
+	}
+	return result;
+}
+
+void SortedData::Unswizzle() {
+	if (layout.AllConstant() || !swizzled) {
+		return;
+	}
+	for (idx_t i = 0; i < data_blocks.size(); i++) {
+		auto &data_block = data_blocks[i];
+		auto &heap_block = heap_blocks[i];
+		auto data_handle_p = buffer_manager.Pin(data_block.block);
+		auto heap_handle_p = buffer_manager.Pin(heap_block.block);
+		RowOperations::UnswizzlePointers(layout, data_handle_p->Ptr(), heap_handle_p->Ptr(), data_block.count);
+		state.heap_blocks.push_back(move(heap_block));
+		state.pinned_blocks.push_back(move(heap_handle_p));
+	}
+	heap_blocks.clear();
+}
+
+SortedBlock::SortedBlock(BufferManager &buffer_manager, GlobalSortState &state)
+    : buffer_manager(buffer_manager), state(state), sort_layout(state.sort_layout),
+      payload_layout(state.payload_layout) {
+	blob_sorting_data = make_unique<SortedData>(SortedDataType::BLOB, sort_layout.blob_layout, buffer_manager, state);
+	payload_data = make_unique<SortedData>(SortedDataType::PAYLOAD, payload_layout, buffer_manager, state);
+}
+
+idx_t SortedBlock::Count() const {
+	idx_t count = std::accumulate(radix_sorting_data.begin(), radix_sorting_data.end(), 0,
+	                              [](idx_t a, const RowDataBlock &b) { return a + b.count; });
+	if (!sort_layout.all_constant) {
+		D_ASSERT(count == blob_sorting_data->Count());
+	}
+	D_ASSERT(count == payload_data->Count());
+	return count;
+}
+
+void SortedBlock::InitializeWrite() {
+	CreateBlock();
+	if (!sort_layout.all_constant) {
+		blob_sorting_data->CreateBlock();
+	}
+	payload_data->CreateBlock();
+}
+
+void SortedBlock::CreateBlock() {
+	auto capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + sort_layout.entry_size - 1) / sort_layout.entry_size,
+	                         state.block_capacity);
+	radix_sorting_data.emplace_back(buffer_manager, capacity, sort_layout.entry_size);
+}
+
+void SortedBlock::AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks) {
+	D_ASSERT(Count() == 0);
+	for (auto &sb : sorted_blocks) {
+		for (auto &radix_block : sb->radix_sorting_data) {
+			radix_sorting_data.push_back(move(radix_block));
+		}
+		if (!sort_layout.all_constant) {
+			for (auto &blob_block : sb->blob_sorting_data->data_blocks) {
+				blob_sorting_data->data_blocks.push_back(move(blob_block));
+			}
+			for (auto &heap_block : sb->blob_sorting_data->heap_blocks) {
+				blob_sorting_data->heap_blocks.push_back(move(heap_block));
+			}
+		}
+		for (auto &payload_data_block : sb->payload_data->data_blocks) {
+			payload_data->data_blocks.push_back(move(payload_data_block));
+		}
+		if (!payload_data->layout.AllConstant()) {
+			for (auto &payload_heap_block : sb->payload_data->heap_blocks) {
+				payload_data->heap_blocks.push_back(move(payload_heap_block));
+			}
+		}
+	}
+}
+
+void SortedBlock::GlobalToLocalIndex(const idx_t &global_idx, idx_t &local_block_index, idx_t &local_entry_index) {
+	if (global_idx == Count()) {
+		local_block_index = radix_sorting_data.size() - 1;
+		local_entry_index = radix_sorting_data.back().count;
+		return;
+	}
+	D_ASSERT(global_idx < Count());
+	local_entry_index = global_idx;
+	for (local_block_index = 0; local_block_index < radix_sorting_data.size(); local_block_index++) {
+		const idx_t &block_count = radix_sorting_data[local_block_index].count;
+		if (local_entry_index >= block_count) {
+			local_entry_index -= block_count;
+		} else {
+			break;
+		}
+	}
+	D_ASSERT(local_entry_index < radix_sorting_data[local_block_index].count);
+}
+
+unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t end, idx_t &entry_idx) {
+	// Identify blocks/entry indices of this slice
+	idx_t start_block_index;
+	idx_t start_entry_index;
+	GlobalToLocalIndex(start, start_block_index, start_entry_index);
+	idx_t end_block_index;
+	idx_t end_entry_index;
+	GlobalToLocalIndex(end, end_block_index, end_entry_index);
+	// Add the corresponding blocks to the result
+	auto result = make_unique<SortedBlock>(buffer_manager, state);
+	for (idx_t i = start_block_index; i <= end_block_index; i++) {
+		result->radix_sorting_data.push_back(radix_sorting_data[i]);
+	}
+	// Reset all blocks that come before block with idx = start_block_idx (slice holds new reference)
+	for (idx_t i = 0; i < start_block_index; i++) {
+		radix_sorting_data[i].block = nullptr;
+	}
+	// Use start and end entry indices to set the boundaries
+	entry_idx = start_entry_index;
+	D_ASSERT(end_entry_index <= result->radix_sorting_data.back().count);
+	result->radix_sorting_data.back().count = end_entry_index;
+	// Same for the var size sorting data
+	if (!sort_layout.all_constant) {
+		result->blob_sorting_data = blob_sorting_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
+	}
+	// And the payload data
+	result->payload_data = payload_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
+	return result;
+}
+
+idx_t SortedBlock::HeapSize() const {
+	idx_t result = 0;
+	if (!sort_layout.all_constant) {
+		for (auto &block : blob_sorting_data->heap_blocks) {
+			result += block.capacity;
+		}
+	}
+	if (!payload_layout.AllConstant()) {
+		for (auto &block : payload_data->heap_blocks) {
+			result += block.capacity;
+		}
+	}
+	return result;
+}
+
+idx_t SortedBlock::SizeInBytes() const {
+	idx_t bytes = 0;
+	for (idx_t i = 0; i < radix_sorting_data.size(); i++) {
+		bytes += radix_sorting_data[i].capacity * sort_layout.entry_size;
+		if (!sort_layout.all_constant) {
+			bytes += blob_sorting_data->data_blocks[i].capacity * sort_layout.blob_layout.GetRowWidth();
+			bytes += blob_sorting_data->heap_blocks[i].capacity;
+		}
+		bytes += payload_data->data_blocks[i].capacity * payload_layout.GetRowWidth();
+		if (!payload_layout.AllConstant()) {
+			bytes += payload_data->heap_blocks[i].capacity;
+		}
+	}
+	return bytes;
+}
+
+SBScanState::SBScanState(BufferManager &buffer_manager, GlobalSortState &state)
+    : buffer_manager(buffer_manager), sort_layout(state.sort_layout), state(state), block_idx(0), entry_idx(0) {
+}
+
+void SBScanState::PinRadix(idx_t block_idx_to) {
+	auto &radix_sorting_data = sb->radix_sorting_data;
+	D_ASSERT(block_idx_to < radix_sorting_data.size());
+	auto &block = radix_sorting_data[block_idx_to];
+	if (!radix_handle || radix_handle->handle->BlockId() != block.block->BlockId()) {
+		radix_handle = buffer_manager.Pin(block.block);
+	}
+}
+
+void SBScanState::PinData(SortedData &sd) {
+	D_ASSERT(block_idx < sd.data_blocks.size());
+	auto &data_handle = sd.type == SortedDataType::BLOB ? blob_sorting_data_handle : payload_data_handle;
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? blob_sorting_heap_handle : payload_heap_handle;
+
+	auto &data_block = sd.data_blocks[block_idx];
+	if (!data_handle || data_handle->handle->BlockId() != data_block.block->BlockId()) {
+		data_handle = buffer_manager.Pin(data_block.block);
+	}
+	if (sd.layout.AllConstant() || !state.external) {
+		return;
+	}
+	auto &heap_block = sd.heap_blocks[block_idx];
+	if (!heap_handle || heap_handle->handle->BlockId() != heap_block.block->BlockId()) {
+		heap_handle = buffer_manager.Pin(heap_block.block);
+	}
+}
+
+data_ptr_t SBScanState::RadixPtr() const {
+	return radix_handle->Ptr() + entry_idx * sort_layout.entry_size;
+}
+
+data_ptr_t SBScanState::DataPtr(SortedData &sd) const {
+	auto &data_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_data_handle : *payload_data_handle;
+	D_ASSERT(sd.data_blocks[block_idx].block->Readers() != 0 &&
+	         data_handle.handle->BlockId() == sd.data_blocks[block_idx].block->BlockId());
+	return data_handle.Ptr() + entry_idx * sd.layout.GetRowWidth();
+}
+
+data_ptr_t SBScanState::HeapPtr(SortedData &sd) const {
+	return BaseHeapPtr(sd) + Load<idx_t>(DataPtr(sd) + sd.layout.GetHeapPointerOffset());
+}
+
+data_ptr_t SBScanState::BaseHeapPtr(SortedData &sd) const {
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_heap_handle : *payload_heap_handle;
+	D_ASSERT(!sd.layout.AllConstant() && state.external);
+	D_ASSERT(sd.heap_blocks[block_idx].block->Readers() != 0 &&
+	         heap_handle.handle->BlockId() == sd.heap_blocks[block_idx].block->BlockId());
+	return heap_handle.Ptr();
+}
+
+idx_t SBScanState::Remaining() const {
+	const auto &blocks = sb->radix_sorting_data;
+	idx_t remaining = 0;
+	if (block_idx < blocks.size()) {
+		remaining += blocks[block_idx].count - entry_idx;
+		for (idx_t i = block_idx + 1; i < blocks.size(); i++) {
+			remaining += blocks[i].count;
+		}
+	}
+	return remaining;
+}
+
+void SBScanState::SetIndices(idx_t block_idx_to, idx_t entry_idx_to) {
+	block_idx = block_idx_to;
+	entry_idx = entry_idx_to;
+}
+
+PayloadScanner::PayloadScanner(SortedData &sorted_data, GlobalSortState &global_sort_state, bool flush_p)
+    : sorted_data(sorted_data), read_state(global_sort_state.buffer_manager, global_sort_state),
+      total_count(sorted_data.Count()), global_sort_state(global_sort_state), total_scanned(0), flush(flush_p) {
+}
+
+PayloadScanner::PayloadScanner(GlobalSortState &global_sort_state, bool flush_p)
+    : PayloadScanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state, flush_p) {
+}
+
+PayloadScanner::PayloadScanner(GlobalSortState &global_sort_state, idx_t block_idx)
+    : sorted_data(*global_sort_state.sorted_blocks[0]->payload_data),
+      read_state(global_sort_state.buffer_manager, global_sort_state),
+      total_count(sorted_data.data_blocks[block_idx].count), global_sort_state(global_sort_state), total_scanned(0),
+      flush(false) {
+	read_state.SetIndices(block_idx, 0);
+}
+
+void PayloadScanner::Scan(DataChunk &chunk) {
+	auto count = MinValue((idx_t)STANDARD_VECTOR_SIZE, total_count - total_scanned);
+	if (count == 0) {
+		chunk.SetCardinality(count);
+		return;
+	}
+	// Eagerly delete references to blocks that we've passed
+	if (flush) {
+		for (idx_t i = 0; i < read_state.block_idx; i++) {
+			sorted_data.data_blocks[i].block = nullptr;
+		}
+	}
+	const idx_t &row_width = sorted_data.layout.GetRowWidth();
+	// Set up a batch of pointers to scan data from
+	idx_t scanned = 0;
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	while (scanned < count) {
+		read_state.PinData(sorted_data);
+		auto &data_block = sorted_data.data_blocks[read_state.block_idx];
+		idx_t next = MinValue(data_block.count - read_state.entry_idx, count - scanned);
+		const data_ptr_t data_ptr = read_state.payload_data_handle->Ptr() + read_state.entry_idx * row_width;
+		// Set up the next pointers
+		data_ptr_t row_ptr = data_ptr;
+		for (idx_t i = 0; i < next; i++) {
+			data_pointers[scanned + i] = row_ptr;
+			row_ptr += row_width;
+		}
+		// Unswizzle the offsets back to pointers (if needed)
+		if (!sorted_data.layout.AllConstant() && global_sort_state.external) {
+			RowOperations::UnswizzlePointers(sorted_data.layout, data_ptr, read_state.payload_heap_handle->Ptr(), next);
+		}
+		// Update state indices
+		read_state.entry_idx += next;
+		if (read_state.entry_idx == data_block.count) {
+			read_state.block_idx++;
+			read_state.entry_idx = 0;
+		}
+		scanned += next;
+	}
+	D_ASSERT(scanned == count);
+	// Deserialize the payload data
+	for (idx_t col_idx = 0; col_idx < sorted_data.layout.ColumnCount(); col_idx++) {
+		const auto col_offset = sorted_data.layout.GetOffsets()[col_idx];
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_idx],
+		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, col_idx);
+	}
+	chunk.SetCardinality(count);
+	chunk.Verify();
+	total_scanned += scanned;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cctype>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <stdarg.h>
+#include <string.h>
+
+namespace duckdb {
+
+bool StringUtil::Contains(const string &haystack, const string &needle) {
+	return (haystack.find(needle) != string::npos);
+}
+
+void StringUtil::LTrim(string &str) {
+	auto it = str.begin();
+	while (CharacterIsSpace(*it)) {
+		it++;
+	}
+	str.erase(str.begin(), it);
+}
+
+// Remove trailing ' ', '\f', '\n', '\r', '\t', '\v'
+void StringUtil::RTrim(string &str) {
+	str.erase(find_if(str.rbegin(), str.rend(), [](int ch) { return ch > 0 && !CharacterIsSpace(ch); }).base(),
+	          str.end());
+}
+
+void StringUtil::Trim(string &str) {
+	StringUtil::LTrim(str);
+	StringUtil::RTrim(str);
+}
+
+bool StringUtil::StartsWith(string str, string prefix) {
+	if (prefix.size() > str.size()) {
+		return false;
+	}
+	return equal(prefix.begin(), prefix.end(), str.begin());
+}
+
+bool StringUtil::EndsWith(const string &str, const string &suffix) {
+	if (suffix.size() > str.size()) {
+		return false;
+	}
+	return equal(suffix.rbegin(), suffix.rend(), str.rbegin());
+}
+
+string StringUtil::Repeat(const string &str, idx_t n) {
+	std::ostringstream os;
+	for (idx_t i = 0; i < n; i++) {
+		os << str;
+	}
+	return (os.str());
+}
+
+vector<string> StringUtil::Split(const string &str, char delimiter) {
+	std::stringstream ss(str);
+	vector<string> lines;
+	string temp;
+	while (getline(ss, temp, delimiter)) {
+		lines.push_back(temp);
+	}
+	return (lines);
+}
+
+namespace string_util_internal {
+
+inline void SkipSpaces(const string &str, idx_t &index) {
+	while (index < str.size() && std::isspace(str[index])) {
+		index++;
+	}
+}
+
+inline void ConsumeLetter(const string &str, idx_t &index, char expected) {
+	if (index >= str.size() || str[index] != expected) {
+		throw ParserException("Invalid quoted list: %s", str);
+	}
+
+	index++;
+}
+
+template <typename F>
+inline void TakeWhile(const string &str, idx_t &index, const F &cond, string &taker) {
+	while (index < str.size() && cond(str[index])) {
+		taker.push_back(str[index]);
+		index++;
+	}
+}
+
+inline string TakePossiblyQuotedItem(const string &str, idx_t &index, char delimiter, char quote) {
+	string entry;
+
+	if (str[index] == quote) {
+		index++;
+		TakeWhile(
+		    str, index, [quote](char c) { return c != quote; }, entry);
+		ConsumeLetter(str, index, quote);
+	} else {
+		TakeWhile(
+		    str, index, [delimiter, quote](char c) { return c != delimiter && c != quote && !std::isspace(c); }, entry);
+	}
+
+	return entry;
+}
+
+} // namespace string_util_internal
+
+vector<string> StringUtil::SplitWithQuote(const string &str, char delimiter, char quote) {
+	vector<string> entries;
+	idx_t i = 0;
+
+	string_util_internal::SkipSpaces(str, i);
+	while (i < str.size()) {
+		if (!entries.empty()) {
+			string_util_internal::ConsumeLetter(str, i, delimiter);
+		}
+
+		entries.emplace_back(string_util_internal::TakePossiblyQuotedItem(str, i, delimiter, quote));
+		string_util_internal::SkipSpaces(str, i);
+	}
+
+	return entries;
+}
+
+string StringUtil::Join(const vector<string> &input, const string &separator) {
+	return StringUtil::Join(input, input.size(), separator, [](const string &s) { return s; });
+}
+
+string StringUtil::BytesToHumanReadableString(idx_t bytes) {
+	string db_size;
+	auto kilobytes = bytes / 1000;
+	auto megabytes = kilobytes / 1000;
+	kilobytes -= megabytes * 1000;
+	auto gigabytes = megabytes / 1000;
+	megabytes -= gigabytes * 1000;
+	auto terabytes = gigabytes / 1000;
+	gigabytes -= terabytes * 1000;
+	if (terabytes > 0) {
+		return to_string(terabytes) + "." + to_string(gigabytes / 100) + "TB";
+	} else if (gigabytes > 0) {
+		return to_string(gigabytes) + "." + to_string(megabytes / 100) + "GB";
+	} else if (megabytes > 0) {
+		return to_string(megabytes) + "." + to_string(kilobytes / 100) + "MB";
+	} else if (kilobytes > 0) {
+		return to_string(kilobytes) + "KB";
+	} else {
+		return to_string(bytes) + " bytes";
+	}
+}
+
+string StringUtil::Upper(const string &str) {
+	string copy(str);
+	transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::toupper(c); });
+	return (copy);
+}
+
+string StringUtil::Lower(const string &str) {
+	string copy(str);
+	transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::tolower(c); });
+	return (copy);
+}
+
+vector<string> StringUtil::Split(const string &input, const string &split) {
+	vector<string> splits;
+
+	idx_t last = 0;
+	idx_t input_len = input.size();
+	idx_t split_len = split.size();
+	while (last <= input_len) {
+		idx_t next = input.find(split, last);
+		if (next == string::npos) {
+			next = input_len;
+		}
+
+		// Push the substring [last, next) on to splits
+		string substr = input.substr(last, next - last);
+		if (substr.empty() == false) {
+			splits.push_back(substr);
+		}
+		last = next + split_len;
+	}
+	return splits;
+}
+
+string StringUtil::Replace(string source, const string &from, const string &to) {
+	idx_t start_pos = 0;
+	while ((start_pos = source.find(from, start_pos)) != string::npos) {
+		source.replace(start_pos, from.length(), to);
+		start_pos += to.length(); // In case 'to' contains 'from', like
+		                          // replacing 'x' with 'yx'
+	}
+	return source;
+}
+
+vector<string> StringUtil::TopNStrings(vector<pair<string, idx_t>> scores, idx_t n, idx_t threshold) {
+	if (scores.empty()) {
+		return vector<string>();
+	}
+	sort(scores.begin(), scores.end(),
+	     [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) -> bool { return a.second < b.second; });
+	vector<string> result;
+	result.push_back(scores[0].first);
+	for (idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {
+		if (scores[i].second > threshold) {
+			break;
+		}
+		result.push_back(scores[i].first);
+	}
+	return result;
+}
+
+struct LevenshteinArray {
+	LevenshteinArray(idx_t len1, idx_t len2) : len1(len1) {
+		dist = unique_ptr<idx_t[]>(new idx_t[len1 * len2]);
+	}
+
+	idx_t &Score(idx_t i, idx_t j) {
+		return dist[GetIndex(i, j)];
+	}
+
+private:
+	idx_t len1;
+	unique_ptr<idx_t[]> dist;
+
+	idx_t GetIndex(idx_t i, idx_t j) {
+		return j * len1 + i;
+	}
+};
+
+// adapted from https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
+idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
+	auto s1 = StringUtil::Lower(s1_p);
+	auto s2 = StringUtil::Lower(s2_p);
+	idx_t len1 = s1.size();
+	idx_t len2 = s2.size();
+	if (len1 == 0) {
+		return len2;
+	}
+	if (len2 == 0) {
+		return len1;
+	}
+	LevenshteinArray array(len1 + 1, len2 + 1);
+	array.Score(0, 0) = 0;
+	for (idx_t i = 0; i <= len1; i++) {
+		array.Score(i, 0) = i;
+	}
+	for (idx_t j = 0; j <= len2; j++) {
+		array.Score(0, j) = j;
+	}
+	for (idx_t i = 1; i <= len1; i++) {
+		for (idx_t j = 1; j <= len2; j++) {
+			// d[i][j] = std::min({ d[i - 1][j] + 1,
+			//                      d[i][j - 1] + 1,
+			//                      d[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1) });
+			int equal = s1[i - 1] == s2[j - 1] ? 0 : 1;
+			idx_t adjacent_score1 = array.Score(i - 1, j) + 1;
+			idx_t adjacent_score2 = array.Score(i, j - 1) + 1;
+			idx_t adjacent_score3 = array.Score(i - 1, j - 1) + equal;
+
+			idx_t t = MinValue<idx_t>(adjacent_score1, adjacent_score2);
+			array.Score(i, j) = MinValue<idx_t>(t, adjacent_score3);
+		}
+	}
+	return array.Score(len1, len2);
+}
+
+vector<string> StringUtil::TopNLevenshtein(const vector<string> &strings, const string &target, idx_t n,
+                                           idx_t threshold) {
+	vector<pair<string, idx_t>> scores;
+	scores.reserve(strings.size());
+	for (auto &str : strings) {
+		scores.emplace_back(str, LevenshteinDistance(str, target));
+	}
+	return TopNStrings(scores, n, threshold);
+}
+
+string StringUtil::CandidatesMessage(const vector<string> &candidates, const string &candidate) {
+	string result_str;
+	if (!candidates.empty()) {
+		result_str = "\n" + candidate + ": ";
+		for (idx_t i = 0; i < candidates.size(); i++) {
+			if (i > 0) {
+				result_str += ", ";
+			}
+			result_str += "\"" + candidates[i] + "\"";
+		}
+	}
+	return result_str;
+}
+
+string StringUtil::CandidatesErrorMessage(const vector<string> &strings, const string &target,
+                                          const string &message_prefix, idx_t n) {
+	auto closest_strings = StringUtil::TopNLevenshtein(strings, target, n);
+	return StringUtil::CandidatesMessage(closest_strings, message_prefix);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+RenderTree::RenderTree(idx_t width_p, idx_t height_p) : width(width_p), height(height_p) {
+	nodes = unique_ptr<unique_ptr<RenderTreeNode>[]>(new unique_ptr<RenderTreeNode>[(width + 1) * (height + 1)]);
+}
+
+RenderTreeNode *RenderTree::GetNode(idx_t x, idx_t y) {
+	if (x >= width || y >= height) {
+		return nullptr;
+	}
+	return nodes[GetPosition(x, y)].get();
+}
+
+bool RenderTree::HasNode(idx_t x, idx_t y) {
+	if (x >= width || y >= height) {
+		return false;
+	}
+	return nodes[GetPosition(x, y)].get() != nullptr;
+}
+
+idx_t RenderTree::GetPosition(idx_t x, idx_t y) {
+	return y * width + x;
+}
+
+void RenderTree::SetNode(idx_t x, idx_t y, unique_ptr<RenderTreeNode> node) {
+	nodes[GetPosition(x, y)] = move(node);
+}
+
+void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+	for (idx_t x = 0; x < root.width; x++) {
+		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+			break;
+		}
+		if (root.HasNode(x, y)) {
+			ss << config.LTCORNER;
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			if (y == 0) {
+				// top level node: no node above this one
+				ss << config.HORIZONTAL;
+			} else {
+				// render connection to node above this one
+				ss << config.DMIDDLE;
+			}
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << config.RTCORNER;
+		} else {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+		}
+	}
+	ss << std::endl;
+}
+
+void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+	for (idx_t x = 0; x <= root.width; x++) {
+		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+			break;
+		}
+		if (root.HasNode(x, y)) {
+			ss << config.LDCORNER;
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			if (root.HasNode(x, y + 1)) {
+				// node below this one: connect to that one
+				ss << config.TMIDDLE;
+			} else {
+				// no node below this one: end the box
+				ss << config.HORIZONTAL;
+			}
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << config.RDCORNER;
+		} else if (root.HasNode(x, y + 1)) {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+			ss << config.VERTICAL;
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+		} else {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+		}
+	}
+	ss << std::endl;
+}
+
+string AdjustTextForRendering(string source, idx_t max_render_width) {
+	idx_t cpos = 0;
+	idx_t render_width = 0;
+	vector<pair<idx_t, idx_t>> render_widths;
+	while (cpos < source.size()) {
+		idx_t char_render_width = Utf8Proc::RenderWidth(source.c_str(), source.size(), cpos);
+		cpos = Utf8Proc::NextGraphemeCluster(source.c_str(), source.size(), cpos);
+		render_width += char_render_width;
+		render_widths.emplace_back(cpos, render_width);
+		if (render_width > max_render_width) {
+			break;
+		}
+	}
+	if (render_width > max_render_width) {
+		// need to find a position to truncate
+		for (idx_t pos = render_widths.size(); pos > 0; pos--) {
+			if (render_widths[pos - 1].second < max_render_width - 4) {
+				return source.substr(0, render_widths[pos - 1].first) + "..." +
+				       string(max_render_width - render_widths[pos - 1].second - 3, ' ');
+			}
+		}
+		source = "...";
+	}
+	// need to pad with spaces
+	idx_t total_spaces = max_render_width - render_width;
+	idx_t half_spaces = total_spaces / 2;
+	idx_t extra_left_space = total_spaces % 2 == 0 ? 0 : 1;
+	return string(half_spaces + extra_left_space, ' ') + source + string(half_spaces, ' ');
+}
+
+static bool NodeHasMultipleChildren(RenderTree &root, idx_t x, idx_t y) {
+	for (; x < root.width && !root.HasNode(x + 1, y); x++) {
+		if (root.HasNode(x + 1, y + 1)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y) {
+	// we first need to figure out how high our boxes are going to be
+	vector<vector<string>> extra_info;
+	idx_t extra_height = 0;
+	extra_info.resize(root.width);
+	for (idx_t x = 0; x < root.width; x++) {
+		auto node = root.GetNode(x, y);
+		if (node) {
+			SplitUpExtraInfo(node->extra_text, extra_info[x]);
+			if (extra_info[x].size() > extra_height) {
+				extra_height = extra_info[x].size();
+			}
+		}
+	}
+	extra_height = MinValue<idx_t>(extra_height, config.MAX_EXTRA_LINES);
+	idx_t halfway_point = (extra_height + 1) / 2;
+	// now we render the actual node
+	for (idx_t render_y = 0; render_y <= extra_height; render_y++) {
+		for (idx_t x = 0; x < root.width; x++) {
+			if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+				break;
+			}
+			auto node = root.GetNode(x, y);
+			if (!node) {
+				if (render_y == halfway_point) {
+					bool has_child_to_the_right = NodeHasMultipleChildren(root, x, y);
+					if (root.HasNode(x, y + 1)) {
+						// node right below this one
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+						ss << config.RTCORNER;
+						if (has_child_to_the_right) {
+							// but we have another child to the right! keep rendering the line
+							ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+						} else {
+							// only a child below this one: fill the rest with spaces
+							ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						}
+					} else if (has_child_to_the_right) {
+						// child to the right, but no child right below this one: render a full line
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH);
+					} else {
+						// empty spot: render spaces
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+					}
+				} else if (render_y >= halfway_point) {
+					if (root.HasNode(x, y + 1)) {
+						// we have a node below this empty spot: render a vertical line
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						ss << config.VERTICAL;
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+					} else {
+						// empty spot: render spaces
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+					}
+				} else {
+					// empty spot: render spaces
+					ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+				}
+			} else {
+				ss << config.VERTICAL;
+				// figure out what to render
+				string render_text;
+				if (render_y == 0) {
+					render_text = node->name;
+				} else {
+					if (render_y <= extra_info[x].size()) {
+						render_text = extra_info[x][render_y - 1];
+					}
+				}
+				render_text = AdjustTextForRendering(render_text, config.NODE_RENDER_WIDTH - 2);
+				ss << render_text;
+
+				if (render_y == halfway_point && NodeHasMultipleChildren(root, x, y)) {
+					ss << config.LMIDDLE;
+				} else {
+					ss << config.VERTICAL;
+				}
+			}
+		}
+		ss << std::endl;
+	}
+}
+
+string TreeRenderer::ToString(const LogicalOperator &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const PhysicalOperator &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const QueryProfiler::TreeNode &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const Pipeline &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+void TreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const QueryProfiler::TreeNode &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
+	while (root.width * config.NODE_RENDER_WIDTH > config.MAXIMUM_RENDER_WIDTH) {
+		if (config.NODE_RENDER_WIDTH - 2 < config.MINIMUM_RENDER_WIDTH) {
+			break;
+		}
+		config.NODE_RENDER_WIDTH -= 2;
+	}
+
+	for (idx_t y = 0; y < root.height; y++) {
+		// start by rendering the top layer
+		RenderTopLayer(root, ss, y);
+		// now we render the content of the boxes
+		RenderBoxContent(root, ss, y);
+		// render the bottom layer of each of the boxes
+		RenderBottomLayer(root, ss, y);
+	}
+}
+
+bool TreeRenderer::CanSplitOnThisChar(char l) {
+	return (l < '0' || (l > '9' && l < 'A') || (l > 'Z' && l < 'a')) && l != '_';
+}
+
+bool TreeRenderer::IsPadding(char l) {
+	return l == ' ' || l == '\t' || l == '\n' || l == '\r';
+}
+
+string TreeRenderer::RemovePadding(string l) {
+	idx_t start = 0, end = l.size();
+	while (start < l.size() && IsPadding(l[start])) {
+		start++;
+	}
+	while (end > 0 && IsPadding(l[end - 1])) {
+		end--;
+	}
+	return l.substr(start, end - start);
+}
+
+void TreeRenderer::SplitStringBuffer(const string &source, vector<string> &result) {
+	D_ASSERT(Utf8Proc::IsValid(source.c_str(), source.size()));
+	idx_t max_line_render_size = config.NODE_RENDER_WIDTH - 2;
+	// utf8 in prompt, get render width
+	idx_t cpos = 0;
+	idx_t start_pos = 0;
+	idx_t render_width = 0;
+	idx_t last_possible_split = 0;
+	while (cpos < source.size()) {
+		// check if we can split on this character
+		if (CanSplitOnThisChar(source[cpos])) {
+			last_possible_split = cpos;
+		}
+		size_t char_render_width = Utf8Proc::RenderWidth(source.c_str(), source.size(), cpos);
+		idx_t next_cpos = Utf8Proc::NextGraphemeCluster(source.c_str(), source.size(), cpos);
+		if (render_width + char_render_width > max_line_render_size) {
+			if (last_possible_split <= start_pos + 8) {
+				last_possible_split = cpos;
+			}
+			result.push_back(source.substr(start_pos, last_possible_split - start_pos));
+			start_pos = last_possible_split;
+			cpos = last_possible_split;
+			render_width = 0;
+		}
+		cpos = next_cpos;
+		render_width += char_render_width;
+	}
+	if (source.size() > start_pos) {
+		result.push_back(source.substr(start_pos, source.size() - start_pos));
+	}
+}
+
+void TreeRenderer::SplitUpExtraInfo(const string &extra_info, vector<string> &result) {
+	if (extra_info.empty()) {
+		return;
+	}
+	if (!Utf8Proc::IsValid(extra_info.c_str(), extra_info.size())) {
+		return;
+	}
+	auto splits = StringUtil::Split(extra_info, "\n");
+	if (!splits.empty() && splits[0] != "[INFOSEPARATOR]") {
+		result.push_back(ExtraInfoSeparator());
+	}
+	for (auto &split : splits) {
+		if (split == "[INFOSEPARATOR]") {
+			result.push_back(ExtraInfoSeparator());
+			continue;
+		}
+		string str = RemovePadding(split);
+		if (str.empty()) {
+			continue;
+		}
+		SplitStringBuffer(str, result);
+	}
+}
+
+string TreeRenderer::ExtraInfoSeparator() {
+	return StringUtil::Repeat(string(config.HORIZONTAL) + " ", (config.NODE_RENDER_WIDTH - 7) / 2);
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateRenderNode(string name, string extra_info) {
+	auto result = make_unique<RenderTreeNode>();
+	result->name = move(name);
+	result->extra_text = move(extra_info);
+	return result;
+}
+
+class TreeChildrenIterator {
+public:
+	template <class T>
+	static bool HasChildren(const T &op) {
+		return !op.children.empty();
+	}
+	template <class T>
+	static void Iterate(const T &op, const std::function<void(const T &child)> &callback) {
+		for (auto &child : op.children) {
+			callback(*child);
+		}
+	}
+};
+
+template <>
+bool TreeChildrenIterator::HasChildren(const PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::DELIM_JOIN) {
+		return true;
+	}
+	return !op.children.empty();
+}
+template <>
+void TreeChildrenIterator::Iterate(const PhysicalOperator &op,
+                                   const std::function<void(const PhysicalOperator &child)> &callback) {
+	for (auto &child : op.children) {
+		callback(*child);
+	}
+	if (op.type == PhysicalOperatorType::DELIM_JOIN) {
+		auto &delim = (PhysicalDelimJoin &)op;
+		callback(*delim.join);
+	}
+}
+
+struct PipelineRenderNode {
+	explicit PipelineRenderNode(PhysicalOperator &op) : op(op) {
+	}
+
+	PhysicalOperator &op;
+	unique_ptr<PipelineRenderNode> child;
+};
+
+template <>
+bool TreeChildrenIterator::HasChildren(const PipelineRenderNode &op) {
+	return op.child.get();
+}
+
+template <>
+void TreeChildrenIterator::Iterate(const PipelineRenderNode &op,
+                                   const std::function<void(const PipelineRenderNode &child)> &callback) {
+	if (op.child) {
+		callback(*op.child);
+	}
+}
+
+template <class T>
+static void GetTreeWidthHeight(const T &op, idx_t &width, idx_t &height) {
+	if (!TreeChildrenIterator::HasChildren(op)) {
+		width = 1;
+		height = 1;
+		return;
+	}
+	width = 0;
+	height = 0;
+
+	TreeChildrenIterator::Iterate<T>(op, [&](const T &child) {
+		idx_t child_width, child_height;
+		GetTreeWidthHeight<T>(child, child_width, child_height);
+		width += child_width;
+		height = MaxValue<idx_t>(height, child_height);
+	});
+	height++;
+}
+
+template <class T>
+idx_t TreeRenderer::CreateRenderTreeRecursive(RenderTree &result, const T &op, idx_t x, idx_t y) {
+	auto node = TreeRenderer::CreateNode(op);
+	result.SetNode(x, y, move(node));
+
+	if (!TreeChildrenIterator::HasChildren(op)) {
+		return 1;
+	}
+	idx_t width = 0;
+	// render the children of this node
+	TreeChildrenIterator::Iterate<T>(
+	    op, [&](const T &child) { width += CreateRenderTreeRecursive<T>(result, child, x + width, y + 1); });
+	return width;
+}
+
+template <class T>
+unique_ptr<RenderTree> TreeRenderer::CreateRenderTree(const T &op) {
+	idx_t width, height;
+	GetTreeWidthHeight<T>(op, width, height);
+
+	auto result = make_unique<RenderTree>(width, height);
+
+	// now fill in the tree
+	CreateRenderTreeRecursive<T>(*result, op, 0, 0);
+	return result;
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const LogicalOperator &op) {
+	return CreateRenderNode(op.GetName(), op.ParamsToString());
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const PhysicalOperator &op) {
+	return CreateRenderNode(op.GetName(), op.ParamsToString());
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const PipelineRenderNode &op) {
+	return CreateNode(op.op);
+}
+
+string TreeRenderer::ExtractExpressionsRecursive(ExpressionInfo &state) {
+	string result = "\n[INFOSEPARATOR]";
+	result += "\n" + state.function_name;
+	result += "\n" + StringUtil::Format("%.9f", double(state.function_time));
+	if (state.children.empty()) {
+		return result;
+	}
+	// render the children of this node
+	for (auto &child : state.children) {
+		result += ExtractExpressionsRecursive(*child);
+	}
+	return result;
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const QueryProfiler::TreeNode &op) {
+	auto result = TreeRenderer::CreateRenderNode(op.name, op.extra_info);
+	result->extra_text += "\n[INFOSEPARATOR]";
+	result->extra_text += "\n" + to_string(op.info.elements);
+	string timing = StringUtil::Format("%.2f", op.info.time);
+	result->extra_text += "\n(" + timing + "s)";
+	if (config.detailed) {
+		for (auto &info : op.info.executors_info) {
+			if (!info) {
+				continue;
+			}
+			for (auto &executor_info : info->roots) {
+				string sample_count = to_string(executor_info->sample_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\nsample_count: " + sample_count;
+				string sample_tuples_count = to_string(executor_info->sample_tuples_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\nsample_tuples_count: " + sample_tuples_count;
+				string total_count = to_string(executor_info->total_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\ntotal_count: " + total_count;
+				for (auto &state : executor_info->root->children) {
+					result->extra_text += ExtractExpressionsRecursive(*state);
+				}
+			}
+		}
+	}
+	return result;
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const LogicalOperator &op) {
+	return CreateRenderTree<LogicalOperator>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const PhysicalOperator &op) {
+	return CreateRenderTree<PhysicalOperator>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const QueryProfiler::TreeNode &op) {
+	return CreateRenderTree<QueryProfiler::TreeNode>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const Pipeline &op) {
+	auto operators = op.GetOperators();
+	D_ASSERT(!operators.empty());
+	unique_ptr<PipelineRenderNode> node;
+	for (auto &op : operators) {
+		auto new_node = make_unique<PipelineRenderNode>(*op);
+		new_node->child = move(node);
+		node = move(new_node);
+	}
+	return CreateRenderTree<PipelineRenderNode>(*node);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BatchedChunkCollection::BatchedChunkCollection() {
+}
+
+void BatchedChunkCollection::Append(DataChunk &input, idx_t batch_index) {
+	D_ASSERT(batch_index != DConstants::INVALID_INDEX);
+	auto entry = data.find(batch_index);
+	ChunkCollection *collection;
+	if (entry == data.end()) {
+		auto new_collection = make_unique<ChunkCollection>();
+		collection = new_collection.get();
+		data.insert(make_pair(batch_index, move(new_collection)));
+	} else {
+		collection = entry->second.get();
+	}
+	collection->Append(input);
+}
+
+void BatchedChunkCollection::Merge(BatchedChunkCollection &other) {
+	for (auto &entry : other.data) {
+		if (data.find(entry.first) != data.end()) {
+			throw InternalException(
+			    "BatchChunkCollection::Merge error - batch index %d is present in both collections. This occurs when "
+			    "batch indexes are not uniquely distributed over threads",
+			    entry.first);
+		}
+		data[entry.first] = move(entry.second);
+	}
+	other.data.clear();
+}
+
+void BatchedChunkCollection::InitializeScan(BatchedChunkScanState &state) {
+	state.iterator = data.begin();
+	state.chunk_index = 0;
+}
+
+void BatchedChunkCollection::Scan(BatchedChunkScanState &state, DataChunk &output) {
+	while (state.iterator != data.end()) {
+		// check if there is a chunk remaining in this collection
+		auto collection = state.iterator->second.get();
+		if (state.chunk_index < collection->ChunkCount()) {
+			// there is! increment the chunk count
+			output.Reference(collection->GetChunk(state.chunk_index));
+			state.chunk_index++;
+			return;
+		}
+		// there isn't! move to the next collection
+		state.iterator++;
+		state.chunk_index = 0;
+	}
+}
+
+string BatchedChunkCollection::ToString() const {
+	string result;
+	result += "Batched Chunk Collection\n";
+	for (auto &entry : data) {
+		result += "Batch Index - " + to_string(entry.first) + "\n";
+		result += entry.second->ToString() + "\n\n";
+	}
+	return result;
+}
+
+void BatchedChunkCollection::Print() const {
+	Printer::Print(ToString());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+constexpr const char *Blob::HEX_TABLE;
+const int Blob::HEX_MAP[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+idx_t Blob::GetStringSize(string_t blob) {
+	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto len = blob.GetSize();
+	idx_t str_len = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] >= 32 && data[i] <= 127 && data[i] != '\\') {
+			// ascii characters are rendered as-is
+			str_len++;
+		} else {
+			// non-ascii characters are rendered as hexadecimal (e.g. \x00)
+			str_len += 4;
+		}
+	}
+	return str_len;
+}
+
+void Blob::ToString(string_t blob, char *output) {
+	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto len = blob.GetSize();
+	idx_t str_idx = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] >= 32 && data[i] <= 127 && data[i] != '\\') {
+			// ascii characters are rendered as-is
+			output[str_idx++] = data[i];
+		} else {
+			auto byte_a = data[i] >> 4;
+			auto byte_b = data[i] & 0x0F;
+			D_ASSERT(byte_a >= 0 && byte_a < 16);
+			D_ASSERT(byte_b >= 0 && byte_b < 16);
+			// non-ascii characters are rendered as hexadecimal (e.g. \x00)
+			output[str_idx++] = '\\';
+			output[str_idx++] = 'x';
+			output[str_idx++] = Blob::HEX_TABLE[byte_a];
+			output[str_idx++] = Blob::HEX_TABLE[byte_b];
+		}
+	}
+	D_ASSERT(str_idx == GetStringSize(blob));
+}
+
+string Blob::ToString(string_t blob) {
+	auto str_len = GetStringSize(blob);
+	auto buffer = std::unique_ptr<char[]>(new char[str_len]);
+	Blob::ToString(blob, buffer.get());
+	return string(buffer.get(), str_len);
+}
+
+bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, string *error_message) {
+	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto len = str.GetSize();
+	str_len = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] == '\\') {
+			if (i + 3 >= len) {
+				string error = "Invalid hex escape code encountered in string -> blob conversion: "
+				               "unterminated escape code at end of blob";
+				HandleCastError::AssignError(error, error_message);
+				return false;
+			}
+			if (data[i + 1] != 'x' || Blob::HEX_MAP[data[i + 2]] < 0 || Blob::HEX_MAP[data[i + 3]] < 0) {
+				string error =
+				    StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion: %s",
+				                       string((char *)data + i, 4));
+				HandleCastError::AssignError(error, error_message);
+				return false;
+			}
+			str_len++;
+			i += 3;
+		} else if (data[i] >= 32 && data[i] <= 127) {
+			str_len++;
+		} else {
+			string error = "Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters "
+			               "must be escaped with hex codes (e.g. \\xAA)";
+			HandleCastError::AssignError(error, error_message);
+			return false;
+		}
+	}
+	return true;
+}
+
+idx_t Blob::GetBlobSize(string_t str) {
+	string error_message;
+	idx_t str_len;
+	if (!Blob::TryGetBlobSize(str, str_len, &error_message)) {
+		throw ConversionException(error_message);
+	}
+	return str_len;
+}
+
+void Blob::ToBlob(string_t str, data_ptr_t output) {
+	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto len = str.GetSize();
+	idx_t blob_idx = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] == '\\') {
+			int byte_a = Blob::HEX_MAP[data[i + 2]];
+			int byte_b = Blob::HEX_MAP[data[i + 3]];
+			D_ASSERT(i + 3 < len);
+			D_ASSERT(byte_a >= 0 && byte_b >= 0);
+			D_ASSERT(data[i + 1] == 'x');
+			output[blob_idx++] = (byte_a << 4) + byte_b;
+			i += 3;
+		} else if (data[i] >= 32 && data[i] <= 127) {
+			output[blob_idx++] = data_t(data[i]);
+		} else {
+			throw ConversionException("Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters "
+			                          "must be escaped with hex codes (e.g. \\xAA)");
+		}
+	}
+	D_ASSERT(blob_idx == GetBlobSize(str));
+}
+
+string Blob::ToBlob(string_t str) {
+	auto blob_len = GetBlobSize(str);
+	auto buffer = std::unique_ptr<char[]>(new char[blob_len]);
+	Blob::ToBlob(str, (data_ptr_t)buffer.get());
+	return string(buffer.get(), blob_len);
+}
+
+// base64 functions are adapted from https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594
+idx_t Blob::ToBase64Size(string_t blob) {
+	// every 4 characters in base64 encode 3 bytes, plus (potential) padding at the end
+	auto input_size = blob.GetSize();
+	return ((input_size + 2) / 3) * 4;
+}
+
+void Blob::ToBase64(string_t blob, char *output) {
+	auto input_data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto input_size = blob.GetSize();
+	idx_t out_idx = 0;
+	idx_t i;
+	// convert the bulk of the string to base64
+	// this happens in steps of 3 bytes -> 4 output bytes
+	for (i = 0; i + 2 < input_size; i += 3) {
+		output[out_idx++] = Blob::BASE64_MAP[(input_data[i] >> 2) & 0x3F];
+		output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4) | ((input_data[i + 1] & 0xF0) >> 4)];
+		output[out_idx++] = Blob::BASE64_MAP[((input_data[i + 1] & 0xF) << 2) | ((input_data[i + 2] & 0xC0) >> 6)];
+		output[out_idx++] = Blob::BASE64_MAP[input_data[i + 2] & 0x3F];
+	}
+
+	if (i < input_size) {
+		// there are one or two bytes left over: we have to insert padding
+		// first write the first 6 bits of the first byte
+		output[out_idx++] = Blob::BASE64_MAP[(input_data[i] >> 2) & 0x3F];
+		// now check the character count
+		if (i == input_size - 1) {
+			// single byte left over: convert the remainder of that byte and insert padding
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4)];
+			output[out_idx++] = Blob::BASE64_PADDING;
+		} else {
+			// two bytes left over: convert the second byte as well
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4) | ((input_data[i + 1] & 0xF0) >> 4)];
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i + 1] & 0xF) << 2)];
+		}
+		output[out_idx++] = Blob::BASE64_PADDING;
+	}
+}
+
+static constexpr int BASE64_DECODING_TABLE[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+    -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+    45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+idx_t Blob::FromBase64Size(string_t str) {
+	auto input_data = str.GetDataUnsafe();
+	auto input_size = str.GetSize();
+	if (input_size % 4 != 0) {
+		// valid base64 needs to always be cleanly divisible by 4
+		throw ConversionException("Could not decode string \"%s\" as base64: length must be a multiple of 4",
+		                          str.GetString());
+	}
+	if (input_size < 4) {
+		// empty string
+		return 0;
+	}
+	auto base_size = input_size / 4 * 3;
+	// check for padding to figure out the length
+	if (input_data[input_size - 2] == Blob::BASE64_PADDING) {
+		// two bytes of padding
+		return base_size - 2;
+	}
+	if (input_data[input_size - 1] == Blob::BASE64_PADDING) {
+		// one byte of padding
+		return base_size - 1;
+	}
+	// no padding
+	return base_size;
+}
+
+template <bool ALLOW_PADDING>
+uint32_t DecodeBase64Bytes(const string_t &str, const_data_ptr_t input_data, idx_t base_idx) {
+	int decoded_bytes[4];
+	for (idx_t decode_idx = 0; decode_idx < 4; decode_idx++) {
+		if (ALLOW_PADDING && decode_idx >= 2 && input_data[base_idx + decode_idx] == Blob::BASE64_PADDING) {
+			// the last two bytes of a base64 string can have padding: in this case we set the byte to 0
+			decoded_bytes[decode_idx] = 0;
+		} else {
+			decoded_bytes[decode_idx] = BASE64_DECODING_TABLE[input_data[base_idx + decode_idx]];
+		}
+		if (decoded_bytes[decode_idx] < 0) {
+			throw ConversionException(
+			    "Could not decode string \"%s\" as base64: invalid byte value '%d' at position %d", str.GetString(),
+			    input_data[base_idx + decode_idx], base_idx + decode_idx);
+		}
+	}
+	return (decoded_bytes[0] << 3 * 6) + (decoded_bytes[1] << 2 * 6) + (decoded_bytes[2] << 1 * 6) +
+	       (decoded_bytes[3] << 0 * 6);
+}
+
+void Blob::FromBase64(string_t str, data_ptr_t output, idx_t output_size) {
+	D_ASSERT(output_size == FromBase64Size(str));
+	auto input_data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto input_size = str.GetSize();
+	if (input_size == 0) {
+		return;
+	}
+	idx_t out_idx = 0;
+	idx_t i = 0;
+	for (i = 0; i + 4 < input_size; i += 4) {
+		auto combined = DecodeBase64Bytes<false>(str, input_data, i);
+		output[out_idx++] = (combined >> 2 * 8) & 0xFF;
+		output[out_idx++] = (combined >> 1 * 8) & 0xFF;
+		output[out_idx++] = (combined >> 0 * 8) & 0xFF;
+	}
+	// decode the final four bytes: padding is allowed here
+	auto combined = DecodeBase64Bytes<true>(str, input_data, i);
+	output[out_idx++] = (combined >> 2 * 8) & 0xFF;
+	if (out_idx < output_size) {
+		output[out_idx++] = (combined >> 1 * 8) & 0xFF;
+	}
+	if (out_idx < output_size) {
+		output[out_idx++] = (combined >> 0 * 8) & 0xFF;
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+const int64_t NumericHelper::POWERS_OF_TEN[] {1,
+                                              10,
+                                              100,
+                                              1000,
+                                              10000,
+                                              100000,
+                                              1000000,
+                                              10000000,
+                                              100000000,
+                                              1000000000,
+                                              10000000000,
+                                              100000000000,
+                                              1000000000000,
+                                              10000000000000,
+                                              100000000000000,
+                                              1000000000000000,
+                                              10000000000000000,
+                                              100000000000000000,
+                                              1000000000000000000};
+
+const double NumericHelper::DOUBLE_POWERS_OF_TEN[] {1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,
+                                                    1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+                                                    1e20, 1e21, 1e22, 1e23, 1e24, 1e25, 1e26, 1e27, 1e28, 1e29,
+                                                    1e30, 1e31, 1e32, 1e33, 1e34, 1e35, 1e36, 1e37, 1e38, 1e39};
+
+template <>
+int NumericHelper::UnsignedLength(uint8_t value) {
+	int length = 1;
+	length += value >= 10;
+	length += value >= 100;
+	return length;
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint16_t value) {
+	int length = 1;
+	length += value >= 10;
+	length += value >= 100;
+	length += value >= 1000;
+	length += value >= 10000;
+	return length;
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint32_t value) {
+	if (value >= 10000) {
+		int length = 5;
+		length += value >= 100000;
+		length += value >= 1000000;
+		length += value >= 10000000;
+		length += value >= 100000000;
+		length += value >= 1000000000;
+		return length;
+	} else {
+		int length = 1;
+		length += value >= 10;
+		length += value >= 100;
+		length += value >= 1000;
+		return length;
+	}
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint64_t value) {
+	if (value >= 10000000000ULL) {
+		if (value >= 1000000000000000ULL) {
+			int length = 16;
+			length += value >= 10000000000000000ULL;
+			length += value >= 100000000000000000ULL;
+			length += value >= 1000000000000000000ULL;
+			length += value >= 10000000000000000000ULL;
+			return length;
+		} else {
+			int length = 11;
+			length += value >= 100000000000ULL;
+			length += value >= 1000000000000ULL;
+			length += value >= 10000000000000ULL;
+			length += value >= 100000000000000ULL;
+			return length;
+		}
+	} else {
+		if (value >= 100000ULL) {
+			int length = 6;
+			length += value >= 1000000ULL;
+			length += value >= 10000000ULL;
+			length += value >= 100000000ULL;
+			length += value >= 1000000000ULL;
+			return length;
+		} else {
+			int length = 1;
+			length += value >= 10ULL;
+			length += value >= 100ULL;
+			length += value >= 1000ULL;
+			length += value >= 10000ULL;
+			return length;
+		}
+	}
+}
+
+template <>
+std::string NumericHelper::ToString(hugeint_t value) {
+	return Hugeint::ToString(value);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cstring>
+
+namespace duckdb {
+
+void ChunkCollection::Verify() {
+#ifdef DEBUG
+	for (auto &chunk : chunks) {
+		chunk->Verify();
+	}
+#endif
+}
+
+void ChunkCollection::Append(ChunkCollection &other) {
+	for (auto &chunk : other.chunks) {
+		Append(*chunk);
+	}
+}
+
+void ChunkCollection::Merge(ChunkCollection &other) {
+	if (other.count == 0) {
+		return;
+	}
+	if (count == 0) {
+		chunks = move(other.chunks);
+		types = move(other.types);
+		count = other.count;
+		return;
+	}
+	unique_ptr<DataChunk> old_back;
+	if (!chunks.empty() && chunks.back()->size() != STANDARD_VECTOR_SIZE) {
+		old_back = move(chunks.back());
+		chunks.pop_back();
+		count -= old_back->size();
+	}
+	for (auto &chunk : other.chunks) {
+		chunks.push_back(move(chunk));
+	}
+	count += other.count;
+	if (old_back) {
+		Append(*old_back);
+	}
+	Verify();
+}
+
+void ChunkCollection::Append(DataChunk &new_chunk) {
+	if (new_chunk.size() == 0) {
+		return;
+	}
+	new_chunk.Verify();
+
+	// we have to ensure that every chunk in the ChunkCollection is completely
+	// filled, otherwise our O(1) lookup in GetValue and SetValue does not work
+	// first fill the latest chunk, if it exists
+	count += new_chunk.size();
+
+	idx_t remaining_data = new_chunk.size();
+	idx_t offset = 0;
+	if (chunks.empty()) {
+		// first chunk
+		types = new_chunk.GetTypes();
+	} else {
+		// the types of the new chunk should match the types of the previous one
+		D_ASSERT(types.size() == new_chunk.ColumnCount());
+		auto new_types = new_chunk.GetTypes();
+		for (idx_t i = 0; i < types.size(); i++) {
+			if (new_types[i] != types[i]) {
+				throw TypeMismatchException(new_types[i], types[i], "Type mismatch when combining rows");
+			}
+			if (types[i].InternalType() == PhysicalType::LIST) {
+				// need to check all the chunks because they can have only-null list entries
+				for (auto &chunk : chunks) {
+					auto &chunk_vec = chunk->data[i];
+					auto &new_vec = new_chunk.data[i];
+					auto &chunk_type = chunk_vec.GetType();
+					auto &new_type = new_vec.GetType();
+					if (chunk_type != new_type) {
+						throw TypeMismatchException(chunk_type, new_type, "Type mismatch when combining lists");
+					}
+				}
+			}
+			// TODO check structs, too
+		}
+
+		// first append data to the current chunk
+		DataChunk &last_chunk = *chunks.back();
+		idx_t added_data = MinValue<idx_t>(remaining_data, STANDARD_VECTOR_SIZE - last_chunk.size());
+		if (added_data > 0) {
+			// copy <added_data> elements to the last chunk
+			new_chunk.Normalify();
+			// have to be careful here: setting the cardinality without calling normalify can cause incorrect partial
+			// decompression
+			idx_t old_count = new_chunk.size();
+			new_chunk.SetCardinality(added_data);
+
+			last_chunk.Append(new_chunk);
+			remaining_data -= added_data;
+			// reset the chunk to the old data
+			new_chunk.SetCardinality(old_count);
+			offset = added_data;
+		}
+	}
+
+	if (remaining_data > 0) {
+		// create a new chunk and fill it with the remainder
+		auto chunk = make_unique<DataChunk>();
+		chunk->Initialize(types);
+		new_chunk.Copy(*chunk, offset);
+		chunks.push_back(move(chunk));
+	}
+}
+
+void ChunkCollection::Append(unique_ptr<DataChunk> new_chunk) {
+	if (types.empty()) {
+		types = new_chunk->GetTypes();
+	}
+	D_ASSERT(types == new_chunk->GetTypes());
+	count += new_chunk->size();
+	chunks.push_back(move(new_chunk));
+}
+
+void ChunkCollection::Fuse(ChunkCollection &other) {
+	if (count == 0) {
+		chunks.reserve(other.ChunkCount());
+		for (idx_t chunk_idx = 0; chunk_idx < other.ChunkCount(); ++chunk_idx) {
+			auto lhs = make_unique<DataChunk>();
+			auto &rhs = other.GetChunk(chunk_idx);
+			lhs->data.reserve(rhs.data.size());
+			for (auto &v : rhs.data) {
+				lhs->data.emplace_back(Vector(v));
+			}
+			lhs->SetCardinality(rhs.size());
+			chunks.push_back(move(lhs));
+		}
+		count = other.Count();
+	} else {
+		D_ASSERT(this->ChunkCount() == other.ChunkCount());
+		for (idx_t chunk_idx = 0; chunk_idx < ChunkCount(); ++chunk_idx) {
+			auto &lhs = this->GetChunk(chunk_idx);
+			auto &rhs = other.GetChunk(chunk_idx);
+			D_ASSERT(lhs.size() == rhs.size());
+			for (auto &v : rhs.data) {
+				lhs.data.emplace_back(Vector(v));
+			}
+		}
+	}
+	types.insert(types.end(), other.types.begin(), other.types.end());
+}
+
+// returns an int similar to a C comparator:
+// -1 if left < right
+// 0 if left == right
+// 1 if left > right
+
+template <class TYPE>
+static int8_t TemplatedCompareValue(Vector &left_vec, Vector &right_vec, idx_t left_idx, idx_t right_idx) {
+	D_ASSERT(left_vec.GetType() == right_vec.GetType());
+	auto left_val = FlatVector::GetData<TYPE>(left_vec)[left_idx];
+	auto right_val = FlatVector::GetData<TYPE>(right_vec)[right_idx];
+	if (Equals::Operation<TYPE>(left_val, right_val)) {
+		return 0;
+	}
+	if (LessThan::Operation<TYPE>(left_val, right_val)) {
+		return -1;
+	}
+	return 1;
+}
+
+// return type here is int32 because strcmp() on some platforms returns rather large values
+static int32_t CompareValue(Vector &left_vec, Vector &right_vec, idx_t vector_idx_left, idx_t vector_idx_right,
+                            OrderByNullType null_order) {
+	auto left_null = FlatVector::IsNull(left_vec, vector_idx_left);
+	auto right_null = FlatVector::IsNull(right_vec, vector_idx_right);
+
+	if (left_null && right_null) {
+		return 0;
+	} else if (right_null) {
+		return null_order == OrderByNullType::NULLS_FIRST ? 1 : -1;
+	} else if (left_null) {
+		return null_order == OrderByNullType::NULLS_FIRST ? -1 : 1;
+	}
+
+	switch (left_vec.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedCompareValue<int8_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT16:
+		return TemplatedCompareValue<int16_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT32:
+		return TemplatedCompareValue<int32_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT64:
+		return TemplatedCompareValue<int64_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT8:
+		return TemplatedCompareValue<uint8_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT16:
+		return TemplatedCompareValue<uint16_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT32:
+		return TemplatedCompareValue<uint32_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT64:
+		return TemplatedCompareValue<uint64_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT128:
+		return TemplatedCompareValue<hugeint_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::FLOAT:
+		return TemplatedCompareValue<float>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::DOUBLE:
+		return TemplatedCompareValue<double>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::VARCHAR:
+		return TemplatedCompareValue<string_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INTERVAL:
+		return TemplatedCompareValue<interval_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	default:
+		throw NotImplementedException("Type for comparison");
+	}
+}
+
+static int CompareTuple(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                        idx_t left, idx_t right) {
+	D_ASSERT(sort_by);
+
+	idx_t chunk_idx_left = left / STANDARD_VECTOR_SIZE;
+	idx_t chunk_idx_right = right / STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_left = left % STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_right = right % STANDARD_VECTOR_SIZE;
+
+	auto &left_chunk = sort_by->GetChunk(chunk_idx_left);
+	auto &right_chunk = sort_by->GetChunk(chunk_idx_right);
+
+	for (idx_t col_idx = 0; col_idx < desc.size(); col_idx++) {
+		auto order_type = desc[col_idx];
+
+		auto &left_vec = left_chunk.data[col_idx];
+		auto &right_vec = right_chunk.data[col_idx];
+
+		D_ASSERT(left_vec.GetVectorType() == VectorType::FLAT_VECTOR);
+		D_ASSERT(right_vec.GetVectorType() == VectorType::FLAT_VECTOR);
+		D_ASSERT(left_vec.GetType() == right_vec.GetType());
+
+		auto comp_res = CompareValue(left_vec, right_vec, vector_idx_left, vector_idx_right, null_order[col_idx]);
+
+		if (comp_res == 0) {
+			continue;
+		}
+		return comp_res < 0 ? (order_type == OrderType::ASCENDING ? -1 : 1)
+		                    : (order_type == OrderType::ASCENDING ? 1 : -1);
+	}
+	return 0;
+}
+
+static int64_t QuicksortInitial(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                                idx_t *result) {
+	// select pivot
+	int64_t pivot = 0;
+	int64_t low = 0, high = sort_by->Count() - 1;
+	// now insert elements
+	for (idx_t i = 1; i < sort_by->Count(); i++) {
+		if (CompareTuple(sort_by, desc, null_order, i, pivot) <= 0) {
+			result[low++] = i;
+		} else {
+			result[high--] = i;
+		}
+	}
+	D_ASSERT(low == high);
+	result[low] = pivot;
+	return low;
+}
+
+struct QuicksortInfo {
+	QuicksortInfo(int64_t left_p, int64_t right_p) : left(left_p), right(right_p) {
+	}
+
+	int64_t left;
+	int64_t right;
+};
+
+struct QuicksortStack {
+	std::queue<QuicksortInfo> info_queue;
+
+	QuicksortInfo Pop() {
+		auto element = info_queue.front();
+		info_queue.pop();
+		return element;
+	}
+
+	bool IsEmpty() {
+		return info_queue.empty();
+	}
+
+	void Enqueue(int64_t left, int64_t right) {
+		if (left >= right) {
+			return;
+		}
+		info_queue.emplace(left, right);
+	}
+};
+
+static void QuicksortInPlace(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                             idx_t *result, QuicksortInfo info, QuicksortStack &stack) {
+	auto left = info.left;
+	auto right = info.right;
+
+	D_ASSERT(left < right);
+
+	int64_t middle = left + (right - left) / 2;
+	int64_t pivot = result[middle];
+	// move the mid point value to the front.
+	int64_t i = left + 1;
+	int64_t j = right;
+
+	std::swap(result[middle], result[left]);
+	bool all_equal = true;
+	while (i <= j) {
+		if (result) {
+			while (i <= j) {
+				int cmp = CompareTuple(sort_by, desc, null_order, result[i], pivot);
+				if (cmp < 0) {
+					all_equal = false;
+				} else if (cmp > 0) {
+					all_equal = false;
+					break;
+				}
+				i++;
+			}
+		}
+
+		while (i <= j && CompareTuple(sort_by, desc, null_order, result[j], pivot) > 0) {
+			j--;
+		}
+
+		if (i < j) {
+			std::swap(result[i], result[j]);
+		}
+	}
+	std::swap(result[i - 1], result[left]);
+	int64_t part = i - 1;
+
+	if (all_equal) {
+		return;
+	}
+
+	stack.Enqueue(left, part - 1);
+	stack.Enqueue(part + 1, right);
+}
+
+void ChunkCollection::Sort(vector<OrderType> &desc, vector<OrderByNullType> &null_order, idx_t result[]) {
+	if (count == 0) {
+		return;
+	}
+	D_ASSERT(result);
+
+	// start off with an initial quicksort
+	int64_t part = QuicksortInitial(this, desc, null_order, result);
+
+	// now continuously perform
+	QuicksortStack stack;
+	stack.Enqueue(0, part);
+	stack.Enqueue(part + 1, count - 1);
+	while (!stack.IsEmpty()) {
+		auto element = stack.Pop();
+		QuicksortInPlace(this, desc, null_order, result, element, stack);
+	}
+}
+
+// FIXME make this more efficient by not using the Value API
+// just use memcpy in the vectors
+// assert that there is no selection list
+void ChunkCollection::Reorder(idx_t order_org[]) {
+	auto order = unique_ptr<idx_t[]>(new idx_t[count]);
+	memcpy(order.get(), order_org, sizeof(idx_t) * count);
+
+	// adapted from https://stackoverflow.com/a/7366196/2652376
+
+	auto val_buf = vector<Value>();
+	val_buf.resize(ColumnCount());
+
+	idx_t j, k;
+	for (idx_t i = 0; i < count; i++) {
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			val_buf[col_idx] = GetValue(col_idx, i);
+		}
+		j = i;
+		while (true) {
+			k = order[j];
+			order[j] = j;
+			if (k == i) {
+				break;
+			}
+			for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+				SetValue(col_idx, j, GetValue(col_idx, k));
+			}
+			j = k;
+		}
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			SetValue(col_idx, j, val_buf[col_idx]);
+		}
+	}
+}
+
+Value ChunkCollection::GetValue(idx_t column, idx_t index) {
+	return chunks[LocateChunk(index)]->GetValue(column, index % STANDARD_VECTOR_SIZE);
+}
+
+void ChunkCollection::SetValue(idx_t column, idx_t index, const Value &value) {
+	chunks[LocateChunk(index)]->SetValue(column, index % STANDARD_VECTOR_SIZE, value);
+}
+
+void ChunkCollection::CopyCell(idx_t column, idx_t index, Vector &target, idx_t target_offset) {
+	auto &chunk = GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	VectorOperations::Copy(source, target, source_offset + 1, source_offset, target_offset);
+}
+
+string ChunkCollection::ToString() const {
+	return chunks.empty() ? "ChunkCollection [ 0 ]"
+	                      : "ChunkCollection [ " + std::to_string(count) + " ]: \n" + chunks[0]->ToString();
+}
+
+void ChunkCollection::Print() const {
+	Printer::Print(ToString());
+}
+
+bool ChunkCollection::Equals(ChunkCollection &other) {
+	if (count != other.count) {
+		return false;
+	}
+	if (ColumnCount() != other.ColumnCount()) {
+		return false;
+	}
+	// first try to compare the results as-is
+	bool compare_equals = true;
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			auto lvalue = GetValue(col_idx, row_idx);
+			auto rvalue = other.GetValue(col_idx, row_idx);
+			if (!Value::ValuesAreEqual(lvalue, rvalue)) {
+				compare_equals = false;
+				break;
+			}
+		}
+		if (!compare_equals) {
+			break;
+		}
+	}
+	if (compare_equals) {
+		return true;
+	}
+	// if the results are not equal,
+	// sort both chunk collections to ensure the comparison is not order insensitive
+	vector<OrderType> desc(ColumnCount(), OrderType::DESCENDING);
+	vector<OrderByNullType> null_order(ColumnCount(), OrderByNullType::NULLS_FIRST);
+	auto this_order = unique_ptr<idx_t[]>(new idx_t[count]);
+	auto other_order = unique_ptr<idx_t[]>(new idx_t[count]);
+	Sort(desc, null_order, this_order.get());
+	other.Sort(desc, null_order, other_order.get());
+
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		auto lrow = this_order[row_idx];
+		auto rrow = other_order[row_idx];
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			auto lvalue = GetValue(col_idx, lrow);
+			auto rvalue = other.GetValue(col_idx, rrow);
+			if (!Value::ValuesAreEqual(lvalue, rvalue)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-2.cpp
+++ b/velox/external/duckdb/duckdb-2.cpp
@@ -1,0 +1,17425 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DataChunk::DataChunk() : count(0), capacity(STANDARD_VECTOR_SIZE) {
+}
+
+DataChunk::~DataChunk() {
+}
+
+void DataChunk::InitializeEmpty(const vector<LogicalType> &types) {
+	capacity = STANDARD_VECTOR_SIZE;
+	D_ASSERT(data.empty());   // can only be initialized once
+	D_ASSERT(!types.empty()); // empty chunk not allowed
+	for (idx_t i = 0; i < types.size(); i++) {
+		data.emplace_back(Vector(types[i], nullptr));
+	}
+}
+
+void DataChunk::Initialize(const vector<LogicalType> &types) {
+	D_ASSERT(data.empty());   // can only be initialized once
+	D_ASSERT(!types.empty()); // empty chunk not allowed
+	capacity = STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < types.size(); i++) {
+		VectorCache cache(types[i]);
+		data.emplace_back(cache);
+		vector_caches.push_back(move(cache));
+	}
+}
+
+void DataChunk::Reset() {
+	if (data.empty()) {
+		return;
+	}
+	if (vector_caches.size() != data.size()) {
+		throw InternalException("VectorCache and column count mismatch in DataChunk::Reset");
+	}
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].ResetFromCache(vector_caches[i]);
+	}
+	capacity = STANDARD_VECTOR_SIZE;
+	SetCardinality(0);
+}
+
+void DataChunk::Destroy() {
+	data.clear();
+	vector_caches.clear();
+	capacity = 0;
+	SetCardinality(0);
+}
+
+Value DataChunk::GetValue(idx_t col_idx, idx_t index) const {
+	D_ASSERT(index < size());
+	return data[col_idx].GetValue(index);
+}
+
+void DataChunk::SetValue(idx_t col_idx, idx_t index, const Value &val) {
+	data[col_idx].SetValue(index, val);
+}
+
+void DataChunk::Reference(DataChunk &chunk) {
+	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
+	SetCardinality(chunk);
+	SetCapacity(chunk);
+	for (idx_t i = 0; i < chunk.ColumnCount(); i++) {
+		data[i].Reference(chunk.data[i]);
+	}
+}
+
+void DataChunk::Move(DataChunk &chunk) {
+	SetCardinality(chunk);
+	SetCapacity(chunk);
+	data = move(chunk.data);
+	vector_caches = move(chunk.vector_caches);
+
+	chunk.Destroy();
+}
+
+void DataChunk::Copy(DataChunk &other, idx_t offset) const {
+	D_ASSERT(ColumnCount() == other.ColumnCount());
+	D_ASSERT(other.size() == 0);
+
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(other.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		VectorOperations::Copy(data[i], other.data[i], size(), offset, 0);
+	}
+	other.SetCardinality(size() - offset);
+}
+
+void DataChunk::Copy(DataChunk &other, const SelectionVector &sel, const idx_t source_count, const idx_t offset) const {
+	D_ASSERT(ColumnCount() == other.ColumnCount());
+	D_ASSERT(other.size() == 0);
+	D_ASSERT((offset + source_count) <= size());
+
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(other.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		VectorOperations::Copy(data[i], other.data[i], sel, source_count, offset, 0);
+	}
+	other.SetCardinality(source_count - offset);
+}
+
+void DataChunk::Split(DataChunk &other, idx_t split_idx) {
+	D_ASSERT(other.size() == 0);
+	D_ASSERT(other.data.empty());
+	D_ASSERT(split_idx < data.size());
+	const idx_t num_cols = data.size();
+	for (idx_t col_idx = split_idx; col_idx < num_cols; col_idx++) {
+		other.data.push_back(move(data[col_idx]));
+		other.vector_caches.push_back(move(vector_caches[col_idx]));
+	}
+	for (idx_t col_idx = split_idx; col_idx < num_cols; col_idx++) {
+		data.pop_back();
+		vector_caches.pop_back();
+	}
+	other.SetCardinality(*this);
+	other.SetCapacity(*this);
+}
+
+void DataChunk::Fuse(DataChunk &other) {
+	D_ASSERT(other.size() == size());
+	const idx_t num_cols = other.data.size();
+	for (idx_t col_idx = 0; col_idx < num_cols; ++col_idx) {
+		data.emplace_back(move(other.data[col_idx]));
+		vector_caches.emplace_back(move(other.vector_caches[col_idx]));
+	}
+	other.Destroy();
+}
+
+void DataChunk::Append(const DataChunk &other, bool resize, SelectionVector *sel, idx_t sel_count) {
+	idx_t new_size = sel ? size() + sel_count : size() + other.size();
+	if (other.size() == 0) {
+		return;
+	}
+	if (ColumnCount() != other.ColumnCount()) {
+		throw InternalException("Column counts of appending chunk doesn't match!");
+	}
+	if (new_size > capacity) {
+		if (resize) {
+			for (idx_t i = 0; i < ColumnCount(); i++) {
+				data[i].Resize(size(), new_size);
+			}
+			capacity = new_size;
+		} else {
+			throw InternalException("Can't append chunk to other chunk without resizing");
+		}
+	}
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		if (sel) {
+			VectorOperations::Copy(other.data[i], data[i], *sel, sel_count, 0, size());
+		} else {
+			VectorOperations::Copy(other.data[i], data[i], other.size(), 0, size());
+		}
+	}
+	SetCardinality(new_size);
+}
+
+void DataChunk::Normalify() {
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].Normalify(size());
+	}
+}
+
+vector<LogicalType> DataChunk::GetTypes() {
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		types.push_back(data[i].GetType());
+	}
+	return types;
+}
+
+string DataChunk::ToString() const {
+	string retval = "Chunk - [" + to_string(ColumnCount()) + " Columns]\n";
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		retval += "- " + data[i].ToString(size()) + "\n";
+	}
+	return retval;
+}
+
+void DataChunk::Serialize(Serializer &serializer) {
+	// write the count
+	serializer.Write<sel_t>(size());
+	serializer.Write<idx_t>(ColumnCount());
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		// write the types
+		data[col_idx].GetType().Serialize(serializer);
+	}
+	// write the data
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		data[col_idx].Serialize(size(), serializer);
+	}
+}
+
+void DataChunk::Deserialize(Deserializer &source) {
+	auto rows = source.Read<sel_t>();
+	idx_t column_count = source.Read<idx_t>();
+
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < column_count; i++) {
+		types.push_back(LogicalType::Deserialize(source));
+	}
+	Initialize(types);
+	// now load the column data
+	SetCardinality(rows);
+	for (idx_t i = 0; i < column_count; i++) {
+		data[i].Deserialize(rows, source);
+	}
+	Verify();
+}
+
+void DataChunk::Slice(const SelectionVector &sel_vector, idx_t count_p) {
+	this->count = count_p;
+	SelCache merge_cache;
+	for (idx_t c = 0; c < ColumnCount(); c++) {
+		data[c].Slice(sel_vector, count_p, merge_cache);
+	}
+}
+
+void DataChunk::Slice(DataChunk &other, const SelectionVector &sel, idx_t count_p, idx_t col_offset) {
+	D_ASSERT(other.ColumnCount() <= col_offset + ColumnCount());
+	this->count = count_p;
+	SelCache merge_cache;
+	for (idx_t c = 0; c < other.ColumnCount(); c++) {
+		if (other.data[c].GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+			// already a dictionary! merge the dictionaries
+			data[col_offset + c].Reference(other.data[c]);
+			data[col_offset + c].Slice(sel, count_p, merge_cache);
+		} else {
+			data[col_offset + c].Slice(other.data[c], sel, count_p);
+		}
+	}
+}
+
+unique_ptr<VectorData[]> DataChunk::Orrify() {
+	auto orrified_data = unique_ptr<VectorData[]>(new VectorData[ColumnCount()]);
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		data[col_idx].Orrify(size(), orrified_data[col_idx]);
+	}
+	return orrified_data;
+}
+
+void DataChunk::Hash(Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
+	VectorOperations::Hash(data[0], result, size());
+	for (idx_t i = 1; i < ColumnCount(); i++) {
+		VectorOperations::CombineHash(result, data[i], size());
+	}
+}
+
+void DataChunk::Verify() {
+#ifdef DEBUG
+	D_ASSERT(size() <= capacity);
+	// verify that all vectors in this chunk have the chunk selection vector
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].Verify(size());
+	}
+#endif
+}
+
+void DataChunk::Print() {
+	Printer::Print(ToString());
+}
+
+struct DuckDBArrowArrayChildHolder {
+	ArrowArray array;
+	//! need max three pointers for strings
+	duckdb::array<const void *, 3> buffers = {{nullptr, nullptr, nullptr}};
+	unique_ptr<Vector> vector;
+	unique_ptr<data_t[]> offsets;
+	unique_ptr<data_t[]> data;
+	//! Children of nested structures
+	::duckdb::vector<DuckDBArrowArrayChildHolder> children;
+	::duckdb::vector<ArrowArray *> children_ptrs;
+};
+
+struct DuckDBArrowArrayHolder {
+	vector<DuckDBArrowArrayChildHolder> children = {};
+	vector<ArrowArray *> children_ptrs = {};
+	array<const void *, 1> buffers = {{nullptr}};
+	vector<shared_ptr<ArrowArrayWrapper>> arrow_original_array;
+};
+
+static void ReleaseDuckDBArrowArray(ArrowArray *array) {
+	if (!array || !array->release) {
+		return;
+	}
+	array->release = nullptr;
+	auto holder = static_cast<DuckDBArrowArrayHolder *>(array->private_data);
+	delete holder;
+}
+
+void InitializeChild(DuckDBArrowArrayChildHolder &child_holder, idx_t size) {
+	auto &child = child_holder.array;
+	child.private_data = nullptr;
+	child.release = ReleaseDuckDBArrowArray;
+	child.n_children = 0;
+	child.null_count = 0;
+	child.offset = 0;
+	child.dictionary = nullptr;
+	child.buffers = child_holder.buffers.data();
+
+	child.length = size;
+}
+
+void SetChildValidityMask(Vector &vector, ArrowArray &child) {
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+	auto &mask = FlatVector::Validity(vector);
+	if (!mask.AllValid()) {
+		//! any bits are set: might have nulls
+		child.null_count = -1;
+	} else {
+		//! no bits are set; we know there are no nulls
+		child.null_count = 0;
+	}
+	child.buffers[0] = (void *)mask.GetData();
+}
+
+void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size);
+
+void SetList(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Lists have two buffers
+	child.n_buffers = 2;
+	//! Second Buffer is the list offsets
+	child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+	child.buffers[1] = child_holder.offsets.get();
+	auto offset_ptr = (uint32_t *)child.buffers[1];
+	auto list_data = FlatVector::GetData<list_entry_t>(data);
+	auto list_mask = FlatVector::Validity(data);
+	idx_t offset = 0;
+	offset_ptr[0] = 0;
+	for (idx_t i = 0; i < size; i++) {
+		auto &le = list_data[i];
+
+		if (list_mask.RowIsValid(i)) {
+			offset += le.length;
+		}
+
+		offset_ptr[i + 1] = offset;
+	}
+	auto list_size = ListVector::GetListSize(data);
+	child_holder.children.resize(1);
+	InitializeChild(child_holder.children[0], list_size);
+	child.n_children = 1;
+	child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+	child.children = &child_holder.children_ptrs[0];
+	auto &child_vector = ListVector::GetEntry(data);
+	auto &child_type = ListType::GetChildType(type);
+	SetArrowChild(child_holder.children[0], child_type, child_vector, list_size);
+	SetChildValidityMask(child_vector, child_holder.children[0].array);
+}
+
+void SetStruct(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Structs only have validity buffers
+	child.n_buffers = 1;
+	auto &children = StructVector::GetEntries(*child_holder.vector);
+	child.n_children = children.size();
+	child_holder.children.resize(child.n_children);
+	for (auto &struct_child : child_holder.children) {
+		InitializeChild(struct_child, size);
+		child_holder.children_ptrs.push_back(&struct_child.array);
+	}
+	child.children = &child_holder.children_ptrs[0];
+	for (idx_t child_idx = 0; child_idx < child_holder.children.size(); child_idx++) {
+		SetArrowChild(child_holder.children[child_idx], StructType::GetChildType(type, child_idx), *children[child_idx],
+		              size);
+		SetChildValidityMask(*children[child_idx], child_holder.children[child_idx].array);
+	}
+}
+
+void SetStructMap(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Structs only have validity buffers
+	child.n_buffers = 1;
+	auto &children = StructVector::GetEntries(*child_holder.vector);
+	child.n_children = children.size();
+	child_holder.children.resize(child.n_children);
+	auto list_size = ListVector::GetListSize(*children[0]);
+	child.length = list_size;
+	for (auto &struct_child : child_holder.children) {
+		InitializeChild(struct_child, list_size);
+		child_holder.children_ptrs.push_back(&struct_child.array);
+	}
+	child.children = &child_holder.children_ptrs[0];
+	auto &child_types = StructType::GetChildTypes(type);
+	for (idx_t child_idx = 0; child_idx < child_holder.children.size(); child_idx++) {
+		auto &list_vector_child = ListVector::GetEntry(*children[child_idx]);
+		if (child_idx == 0) {
+			VectorData list_data;
+			children[child_idx]->Orrify(size, list_data);
+			auto list_child_validity = FlatVector::Validity(list_vector_child);
+			if (!list_child_validity.AllValid()) {
+				//! Get the offsets to check from the selection vector
+				auto list_offsets = FlatVector::GetData<list_entry_t>(*children[child_idx]);
+				for (idx_t list_idx = 0; list_idx < size; list_idx++) {
+					auto offset = list_offsets[list_data.sel->get_index(list_idx)];
+					if (!list_child_validity.CheckAllValid(offset.length + offset.offset, offset.offset)) {
+						throw std::runtime_error("Arrow doesnt accept NULL keys on Maps");
+					}
+				}
+			}
+		} else {
+			SetChildValidityMask(list_vector_child, child_holder.children[child_idx].array);
+		}
+		SetArrowChild(child_holder.children[child_idx], ListType::GetChildType(child_types[child_idx].second),
+		              list_vector_child, list_size);
+	}
+}
+
+struct ArrowUUIDConversion {
+	using internal_type_t = hugeint_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(LogicalType::VARCHAR, size);
+	}
+
+	static idx_t GetStringLength(hugeint_t value) {
+		return UUID::STRING_SIZE;
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		auto str_value = UUID::ToString(src_ptr[row]);
+		// Have to store this string
+		tgt_ptr[row] = StringVector::AddStringOrBlob(tgt_vec, str_value);
+		return tgt_ptr[row];
+	}
+};
+
+struct ArrowVarcharConversion {
+	using internal_type_t = string_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(data);
+	}
+	static idx_t GetStringLength(string_t value) {
+		return value.GetSize();
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		return src_ptr[row];
+	}
+};
+
+template <class CONVERT, class VECTOR_TYPE>
+void SetVarchar(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = CONVERT::InitializeVector(data, size);
+	auto target_data_ptr = FlatVector::GetData<string_t>(data);
+	child.n_buffers = 3;
+	child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+	child.buffers[1] = child_holder.offsets.get();
+	D_ASSERT(child.buffers[1]);
+	//! step 1: figure out total string length:
+	idx_t total_string_length = 0;
+	auto source_ptr = FlatVector::GetData<VECTOR_TYPE>(data);
+	auto &mask = FlatVector::Validity(data);
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		total_string_length += CONVERT::GetStringLength(source_ptr[row_idx]);
+	}
+	//! step 2: allocate this much
+	child_holder.data = unique_ptr<data_t[]>(new data_t[total_string_length]);
+	child.buffers[2] = child_holder.data.get();
+	D_ASSERT(child.buffers[2]);
+	//! step 3: assign buffers
+	idx_t current_heap_offset = 0;
+	auto target_ptr = (uint32_t *)child.buffers[1];
+
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		target_ptr[row_idx] = current_heap_offset;
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		string_t str = CONVERT::ConvertValue(*child_holder.vector, target_data_ptr, source_ptr, row_idx);
+		memcpy((void *)((uint8_t *)child.buffers[2] + current_heap_offset), str.GetDataUnsafe(), str.GetSize());
+		current_heap_offset += str.GetSize();
+	}
+	target_ptr[size] = current_heap_offset; //! need to terminate last string!
+}
+
+void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN: {
+		//! Gotta bitpack these booleans
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		idx_t num_bytes = (size + 8 - 1) / 8;
+		child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(uint8_t) * num_bytes]);
+		child.buffers[1] = child_holder.data.get();
+		auto source_ptr = FlatVector::GetData<uint8_t>(*child_holder.vector);
+		auto target_ptr = (uint8_t *)child.buffers[1];
+		idx_t target_pos = 0;
+		idx_t cur_bit = 0;
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (cur_bit == 8) {
+				target_pos++;
+				cur_bit = 0;
+			}
+			if (source_ptr[row_idx] == 0) {
+				//! We set the bit to 0
+				target_ptr[target_pos] &= ~(1 << cur_bit);
+			} else {
+				//! We set the bit to 1
+				target_ptr[target_pos] |= 1 << cur_bit;
+			}
+			cur_bit++;
+		}
+		break;
+	}
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIME_TZ:
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+		break;
+	case LogicalTypeId::SQLNULL:
+		child.n_buffers = 1;
+		break;
+	case LogicalTypeId::DECIMAL: {
+		child.n_buffers = 2;
+		child_holder.vector = make_unique<Vector>(data);
+
+		//! We have to convert to INT128
+		switch (type.InternalType()) {
+
+		case PhysicalType::INT16: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int16_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT32: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int32_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT64: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int64_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT128: {
+			child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported physical type for Decimal" + TypeIdToString(type.InternalType()));
+		}
+		break;
+	}
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		SetVarchar<ArrowVarcharConversion, string_t>(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::UUID: {
+		SetVarchar<ArrowUUIDConversion, hugeint_t>(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::LIST: {
+		SetList(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::STRUCT: {
+		SetStruct(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::MAP: {
+		child_holder.vector = make_unique<Vector>(data);
+
+		auto &map_mask = FlatVector::Validity(*child_holder.vector);
+		child.n_buffers = 2;
+		//! Maps have one child
+		child.n_children = 1;
+		child_holder.children.resize(1);
+		InitializeChild(child_holder.children[0], size);
+		child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+		//! Second Buffer is the offsets
+		child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+		child.buffers[1] = child_holder.offsets.get();
+		auto &struct_children = StructVector::GetEntries(data);
+		auto offset_ptr = (uint32_t *)child.buffers[1];
+		auto list_data = FlatVector::GetData<list_entry_t>(*struct_children[0]);
+		idx_t offset = 0;
+		offset_ptr[0] = 0;
+		for (idx_t i = 0; i < size; i++) {
+			auto &le = list_data[i];
+			if (map_mask.RowIsValid(i)) {
+				offset += le.length;
+			}
+			offset_ptr[i + 1] = offset;
+		}
+		child.children = &child_holder.children_ptrs[0];
+		//! We need to set up a struct
+		auto struct_type = LogicalType::STRUCT(StructType::GetChildTypes(type));
+
+		SetStructMap(child_holder.children[0], struct_type, *child_holder.vector, size);
+		break;
+	}
+	case LogicalTypeId::INTERVAL: {
+		//! convert interval from month/days/ucs to milliseconds
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(int64_t) * (size)]);
+		child.buffers[1] = child_holder.data.get();
+		auto source_ptr = FlatVector::GetData<interval_t>(*child_holder.vector);
+		auto target_ptr = (int64_t *)child.buffers[1];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			target_ptr[row_idx] = Interval::GetMilli(source_ptr[row_idx]);
+		}
+		break;
+	}
+	case LogicalTypeId::ENUM: {
+		// We need to initialize our dictionary
+		child_holder.children.resize(1);
+		idx_t dict_size = EnumType::GetSize(type);
+		InitializeChild(child_holder.children[0], dict_size);
+		Vector dictionary(EnumType::GetValuesInsertOrder(type));
+		SetArrowChild(child_holder.children[0], dictionary.GetType(), dictionary, dict_size);
+		child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+
+		// now we set the data
+		child.dictionary = child_holder.children_ptrs[0];
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+
+		break;
+	}
+	default:
+		throw std::runtime_error("Unsupported type " + type.ToString());
+	}
+}
+
+void DataChunk::ToArrowArray(ArrowArray *out_array) {
+	Normalify();
+	D_ASSERT(out_array);
+
+	// Allocate as unique_ptr first to cleanup properly on error
+	auto root_holder = make_unique<DuckDBArrowArrayHolder>();
+
+	// Allocate the children
+	root_holder->children.resize(ColumnCount());
+	root_holder->children_ptrs.resize(ColumnCount(), nullptr);
+	for (size_t i = 0; i < ColumnCount(); ++i) {
+		root_holder->children_ptrs[i] = &root_holder->children[i].array;
+	}
+	out_array->children = root_holder->children_ptrs.data();
+	out_array->n_children = ColumnCount();
+
+	// Configure root array
+	out_array->length = size();
+	out_array->n_children = ColumnCount();
+	out_array->n_buffers = 1;
+	out_array->buffers = root_holder->buffers.data(); // there is no actual buffer there since we don't have NULLs
+	out_array->offset = 0;
+	out_array->null_count = 0; // needs to be 0
+	out_array->dictionary = nullptr;
+
+	//! Configure child arrays
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		auto &child_holder = root_holder->children[col_idx];
+		InitializeChild(child_holder, size());
+		auto &vector = child_holder.vector;
+		auto &child = child_holder.array;
+		auto vec_buffer = data[col_idx].GetBuffer();
+		if (vec_buffer->GetAuxiliaryData() &&
+		    vec_buffer->GetAuxiliaryDataType() == VectorAuxiliaryDataType::ARROW_AUXILIARY) {
+			auto arrow_aux_data = (ArrowAuxiliaryData *)vec_buffer->GetAuxiliaryData();
+			root_holder->arrow_original_array.push_back(arrow_aux_data->arrow_array);
+		}
+		//! We could, in theory, output other types of vectors here, currently only FLAT Vectors
+		SetArrowChild(child_holder, GetTypes()[col_idx], data[col_idx], size());
+		SetChildValidityMask(*vector, child);
+		out_array->children[col_idx] = &child;
+	}
+
+	// Release ownership to caller
+	out_array->private_data = root_holder.release();
+	out_array->release = ReleaseDuckDBArrowArray;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <cstring>
+#include <cctype>
+#include <algorithm>
+
+namespace duckdb {
+
+static_assert(sizeof(date_t) == sizeof(int32_t), "date_t was padded");
+
+const char *Date::PINF = "infinity";  // NOLINT
+const char *Date::NINF = "-infinity"; // NOLINT
+const char *Date::EPOCH = "epoch";    // NOLINT
+
+const string_t Date::MONTH_NAMES_ABBREVIATED[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                                  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+const string_t Date::MONTH_NAMES[] = {"January", "February", "March",     "April",   "May",      "June",
+                                      "July",    "August",   "September", "October", "November", "December"};
+const string_t Date::DAY_NAMES[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+const string_t Date::DAY_NAMES_ABBREVIATED[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+const int32_t Date::NORMAL_DAYS[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+const int32_t Date::CUMULATIVE_DAYS[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+const int32_t Date::LEAP_DAYS[] = {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+const int32_t Date::CUMULATIVE_LEAP_DAYS[] = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
+const int8_t Date::MONTH_PER_DAY_OF_YEAR[] = {
+    1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+    1,  1,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+    2,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,
+    3,  3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+    4,  4,  4,  4,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,
+    5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,
+    6,  6,  6,  6,  6,  6,  6,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
+    7,  7,  7,  7,  7,  7,  7,  7,  7,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,
+    8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,
+    9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12};
+const int8_t Date::LEAP_MONTH_PER_DAY_OF_YEAR[] = {
+    1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+    1,  1,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+    2,  2,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,
+    3,  3,  3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+    4,  4,  4,  4,  4,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,
+    5,  5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,
+    6,  6,  6,  6,  6,  6,  6,  6,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
+    7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,
+    8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,
+    9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12};
+const int32_t Date::CUMULATIVE_YEAR_DAYS[] = {
+    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,   3287,   3652,   4018,   4383,   4748,
+    5113,   5479,   5844,   6209,   6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,   9862,
+    10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,  13149,  13514,  13879,  14245,  14610,  14975,
+    15340,  15706,  16071,  16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,  19723,  20089,
+    20454,  20819,  21184,  21550,  21915,  22280,  22645,  23011,  23376,  23741,  24106,  24472,  24837,  25202,
+    25567,  25933,  26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,  29585,  29950,  30316,
+    30681,  31046,  31411,  31777,  32142,  32507,  32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,
+    35794,  36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,  39447,  39812,  40177,  40543,
+    40908,  41273,  41638,  42004,  42369,  42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
+    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,  49308,  49673,  50038,  50403,  50769,
+    51134,  51499,  51864,  52230,  52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,  55882,
+    56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,  59169,  59535,  59900,  60265,  60630,  60996,
+    61361,  61726,  62091,  62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,  65744,  66109,
+    66474,  66840,  67205,  67570,  67935,  68301,  68666,  69031,  69396,  69762,  70127,  70492,  70857,  71223,
+    71588,  71953,  72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,  75606,  75971,  76336,
+    76701,  77067,  77432,  77797,  78162,  78528,  78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,
+    81815,  82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,  85466,  85832,  86197,  86562,
+    86927,  87293,  87658,  88023,  88388,  88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
+    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,  95328,  95693,  96059,  96424,  96789,
+    97154,  97520,  97885,  98250,  98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537, 101903,
+    102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825, 105190, 105555, 105920, 106286, 106651, 107016,
+    107381, 107747, 108112, 108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399, 111764, 112130,
+    112495, 112860, 113225, 113591, 113956, 114321, 114686, 115052, 115417, 115782, 116147, 116513, 116878, 117243,
+    117608, 117974, 118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260, 121625, 121990, 122356,
+    122721, 123086, 123451, 123817, 124182, 124547, 124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469,
+    127834, 128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122, 131487, 131852, 132217, 132583,
+    132948, 133313, 133678, 134044, 134409, 134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
+    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983, 141349, 141714, 142079, 142444, 142810,
+    143175, 143540, 143905, 144271, 144636, 145001, 145366, 145732, 146097};
+
+void Date::ExtractYearOffset(int32_t &n, int32_t &year, int32_t &year_offset) {
+	year = Date::EPOCH_YEAR;
+	// first we normalize n to be in the year range [1970, 2370]
+	// since leap years repeat every 400 years, we can safely normalize just by "shifting" the CumulativeYearDays array
+	while (n < 0) {
+		n += Date::DAYS_PER_YEAR_INTERVAL;
+		year -= Date::YEAR_INTERVAL;
+	}
+	while (n >= Date::DAYS_PER_YEAR_INTERVAL) {
+		n -= Date::DAYS_PER_YEAR_INTERVAL;
+		year += Date::YEAR_INTERVAL;
+	}
+	// interpolation search
+	// we can find an upper bound of the year by assuming each year has 365 days
+	year_offset = n / 365;
+	// because of leap years we might be off by a little bit: compensate by decrementing the year offset until we find
+	// our year
+	while (n < Date::CUMULATIVE_YEAR_DAYS[year_offset]) {
+		year_offset--;
+		D_ASSERT(year_offset >= 0);
+	}
+	year += year_offset;
+	D_ASSERT(n >= Date::CUMULATIVE_YEAR_DAYS[year_offset]);
+}
+
+void Date::Convert(date_t d, int32_t &year, int32_t &month, int32_t &day) {
+	auto n = d.days;
+	int32_t year_offset;
+	Date::ExtractYearOffset(n, year, year_offset);
+
+	day = n - Date::CUMULATIVE_YEAR_DAYS[year_offset];
+	D_ASSERT(day >= 0 && day <= 365);
+
+	bool is_leap_year = (Date::CUMULATIVE_YEAR_DAYS[year_offset + 1] - Date::CUMULATIVE_YEAR_DAYS[year_offset]) == 366;
+	if (is_leap_year) {
+		month = Date::LEAP_MONTH_PER_DAY_OF_YEAR[day];
+		day -= Date::CUMULATIVE_LEAP_DAYS[month - 1];
+	} else {
+		month = Date::MONTH_PER_DAY_OF_YEAR[day];
+		day -= Date::CUMULATIVE_DAYS[month - 1];
+	}
+	day++;
+	D_ASSERT(day > 0 && day <= (is_leap_year ? Date::LEAP_DAYS[month] : Date::NORMAL_DAYS[month]));
+	D_ASSERT(month > 0 && month <= 12);
+}
+
+bool Date::TryFromDate(int32_t year, int32_t month, int32_t day, date_t &result) {
+	int32_t n = 0;
+	if (!Date::IsValid(year, month, day)) {
+		return false;
+	}
+	n += Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month - 1] : Date::CUMULATIVE_DAYS[month - 1];
+	n += day - 1;
+	if (year < 1970) {
+		int32_t diff_from_base = 1970 - year;
+		int32_t year_index = 400 - (diff_from_base % 400);
+		int32_t fractions = diff_from_base / 400;
+		n += Date::CUMULATIVE_YEAR_DAYS[year_index];
+		n -= Date::DAYS_PER_YEAR_INTERVAL;
+		n -= fractions * Date::DAYS_PER_YEAR_INTERVAL;
+	} else if (year >= 2370) {
+		int32_t diff_from_base = year - 2370;
+		int32_t year_index = diff_from_base % 400;
+		int32_t fractions = diff_from_base / 400;
+		n += Date::CUMULATIVE_YEAR_DAYS[year_index];
+		n += Date::DAYS_PER_YEAR_INTERVAL;
+		n += fractions * Date::DAYS_PER_YEAR_INTERVAL;
+	} else {
+		n += Date::CUMULATIVE_YEAR_DAYS[year - 1970];
+	}
+#ifdef DEBUG
+	int32_t y, m, d;
+	Date::Convert(date_t(n), y, m, d);
+	D_ASSERT(year == y);
+	D_ASSERT(month == m);
+	D_ASSERT(day == d);
+#endif
+	result = date_t(n);
+	return true;
+}
+
+date_t Date::FromDate(int32_t year, int32_t month, int32_t day) {
+	date_t result;
+	if (!Date::TryFromDate(year, month, day, result)) {
+		throw ConversionException("Date out of range: %d-%d-%d", year, month, day);
+	}
+	return result;
+}
+
+bool Date::ParseDoubleDigit(const char *buf, idx_t len, idx_t &pos, int32_t &result) {
+	if (pos < len && StringUtil::CharacterIsDigit(buf[pos])) {
+		result = buf[pos++] - '0';
+		if (pos < len && StringUtil::CharacterIsDigit(buf[pos])) {
+			result = (buf[pos++] - '0') + result * 10;
+		}
+		return true;
+	}
+	return false;
+}
+
+static bool TryConvertDateSpecial(const char *buf, idx_t len, idx_t &pos, const char *special) {
+	auto p = pos;
+	for (; p < len && *special; ++p) {
+		const auto s = *special++;
+		if (!s || StringUtil::CharacterToLower(buf[p]) != s) {
+			return false;
+		}
+	}
+	pos = p;
+	return true;
+}
+
+bool Date::TryConvertDate(const char *buf, idx_t len, idx_t &pos, date_t &result, bool strict) {
+	pos = 0;
+	if (len == 0) {
+		return false;
+	}
+
+	int32_t day = 0;
+	int32_t month = -1;
+	int32_t year = 0;
+	bool yearneg = false;
+	int sep;
+
+	// skip leading spaces
+	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+		pos++;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+	if (buf[pos] == '-') {
+		yearneg = true;
+		pos++;
+		if (pos >= len) {
+			return false;
+		}
+	}
+	if (!StringUtil::CharacterIsDigit(buf[pos])) {
+		// Check for special values
+		if (TryConvertDateSpecial(buf, len, pos, PINF)) {
+			result = yearneg ? date_t::ninfinity() : date_t::infinity();
+		} else if (TryConvertDateSpecial(buf, len, pos, EPOCH)) {
+			result = date_t::epoch();
+		} else {
+			return false;
+		}
+		// skip trailing spaces - parsing must be strict here
+		while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+			pos++;
+		}
+		return pos == len;
+	}
+	// first parse the year
+	for (; pos < len && StringUtil::CharacterIsDigit(buf[pos]); pos++) {
+		if (year >= 100000000) {
+			return false;
+		}
+		year = (buf[pos] - '0') + year * 10;
+	}
+	if (yearneg) {
+		year = -year;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// fetch the separator
+	sep = buf[pos++];
+	if (sep != ' ' && sep != '-' && sep != '/' && sep != '\\') {
+		// invalid separator
+		return false;
+	}
+
+	// parse the month
+	if (!Date::ParseDoubleDigit(buf, len, pos, month)) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (buf[pos++] != sep) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// now parse the day
+	if (!Date::ParseDoubleDigit(buf, len, pos, day)) {
+		return false;
+	}
+
+	// check for an optional trailing " (BC)""
+	if (len - pos >= 5 && StringUtil::CharacterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
+	    StringUtil::CharacterToLower(buf[pos + 2]) == 'b' && StringUtil::CharacterToLower(buf[pos + 3]) == 'c' &&
+	    buf[pos + 4] == ')') {
+		if (yearneg || year == 0) {
+			return false;
+		}
+		year = -year + 1;
+		pos += 5;
+	}
+
+	// in strict mode, check remaining string for non-space characters
+	if (strict) {
+		// skip trailing spaces
+		while (pos < len && StringUtil::CharacterIsSpace((unsigned char)buf[pos])) {
+			pos++;
+		}
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < len) {
+			return false;
+		}
+	} else {
+		// in non-strict mode, check for any direct trailing digits
+		if (pos < len && StringUtil::CharacterIsDigit((unsigned char)buf[pos])) {
+			return false;
+		}
+	}
+
+	return Date::TryFromDate(year, month, day, result);
+}
+
+string Date::ConversionError(const string &str) {
+	return StringUtil::Format("date field value out of range: \"%s\", "
+	                          "expected format is (YYYY-MM-DD)",
+	                          str);
+}
+
+string Date::ConversionError(string_t str) {
+	return ConversionError(str.GetString());
+}
+
+date_t Date::FromCString(const char *buf, idx_t len, bool strict) {
+	date_t result;
+	idx_t pos;
+	if (!TryConvertDate(buf, len, pos, result, strict)) {
+		throw ConversionException(ConversionError(string(buf, len)));
+	}
+	return result;
+}
+
+date_t Date::FromString(const string &str, bool strict) {
+	return Date::FromCString(str.c_str(), str.size(), strict);
+}
+
+string Date::ToString(date_t date) {
+	// PG displays temporal infinities in lowercase,
+	// but numerics in Titlecase.
+	if (date == date_t::infinity()) {
+		return PINF;
+	} else if (date == date_t::ninfinity()) {
+		return NINF;
+	}
+	int32_t date_units[3];
+	idx_t year_length;
+	bool add_bc;
+	Date::Convert(date, date_units[0], date_units[1], date_units[2]);
+
+	auto length = DateToStringCast::Length(date_units, year_length, add_bc);
+	auto buffer = unique_ptr<char[]>(new char[length]);
+	DateToStringCast::Format(buffer.get(), date_units, year_length, add_bc);
+	return string(buffer.get(), length);
+}
+
+string Date::Format(int32_t year, int32_t month, int32_t day) {
+	return ToString(Date::FromDate(year, month, day));
+}
+
+bool Date::IsLeapYear(int32_t year) {
+	return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+bool Date::IsValid(int32_t year, int32_t month, int32_t day) {
+	if (month < 1 || month > 12) {
+		return false;
+	}
+	if (day < 1) {
+		return false;
+	}
+	if (year <= DATE_MIN_YEAR) {
+		if (year < DATE_MIN_YEAR) {
+			return false;
+		} else if (year == DATE_MIN_YEAR) {
+			if (month < DATE_MIN_MONTH || (month == DATE_MIN_MONTH && day < DATE_MIN_DAY)) {
+				return false;
+			}
+		}
+	}
+	if (year >= DATE_MAX_YEAR) {
+		if (year > DATE_MAX_YEAR) {
+			return false;
+		} else if (year == DATE_MAX_YEAR) {
+			if (month > DATE_MAX_MONTH || (month == DATE_MAX_MONTH && day > DATE_MAX_DAY)) {
+				return false;
+			}
+		}
+	}
+	return Date::IsLeapYear(year) ? day <= Date::LEAP_DAYS[month] : day <= Date::NORMAL_DAYS[month];
+}
+
+int32_t Date::MonthDays(int32_t year, int32_t month) {
+	D_ASSERT(month >= 1 && month <= 12);
+	return Date::IsLeapYear(year) ? Date::LEAP_DAYS[month] : Date::NORMAL_DAYS[month];
+}
+
+date_t Date::EpochDaysToDate(int32_t epoch) {
+	return (date_t)epoch;
+}
+
+int32_t Date::EpochDays(date_t date) {
+	return date.days;
+}
+
+date_t Date::EpochToDate(int64_t epoch) {
+	return date_t(epoch / Interval::SECS_PER_DAY);
+}
+
+int64_t Date::Epoch(date_t date) {
+	return ((int64_t)date.days) * Interval::SECS_PER_DAY;
+}
+
+int64_t Date::EpochNanoseconds(date_t date) {
+	return ((int64_t)date.days) * (Interval::MICROS_PER_DAY * 1000);
+}
+
+int32_t Date::ExtractYear(date_t d, int32_t *last_year) {
+	auto n = d.days;
+	// cached look up: check if year of this date is the same as the last one we looked up
+	// note that this only works for years in the range [1970, 2370]
+	if (n >= Date::CUMULATIVE_YEAR_DAYS[*last_year] && n < Date::CUMULATIVE_YEAR_DAYS[*last_year + 1]) {
+		return Date::EPOCH_YEAR + *last_year;
+	}
+	int32_t year;
+	Date::ExtractYearOffset(n, year, *last_year);
+	return year;
+}
+
+int32_t Date::ExtractYear(timestamp_t ts, int32_t *last_year) {
+	return Date::ExtractYear(Timestamp::GetDate(ts), last_year);
+}
+
+int32_t Date::ExtractYear(date_t d) {
+	int32_t year, year_offset;
+	Date::ExtractYearOffset(d.days, year, year_offset);
+	return year;
+}
+
+int32_t Date::ExtractMonth(date_t date) {
+	int32_t out_year, out_month, out_day;
+	Date::Convert(date, out_year, out_month, out_day);
+	return out_month;
+}
+
+int32_t Date::ExtractDay(date_t date) {
+	int32_t out_year, out_month, out_day;
+	Date::Convert(date, out_year, out_month, out_day);
+	return out_day;
+}
+
+int32_t Date::ExtractDayOfTheYear(date_t date) {
+	int32_t year, year_offset;
+	Date::ExtractYearOffset(date.days, year, year_offset);
+	return date.days - Date::CUMULATIVE_YEAR_DAYS[year_offset] + 1;
+}
+
+int32_t Date::ExtractISODayOfTheWeek(date_t date) {
+	// date of 0 is 1970-01-01, which was a Thursday (4)
+	// -7 = 4
+	// -6 = 5
+	// -5 = 6
+	// -4 = 7
+	// -3 = 1
+	// -2 = 2
+	// -1 = 3
+	// 0  = 4
+	// 1  = 5
+	// 2  = 6
+	// 3  = 7
+	// 4  = 1
+	// 5  = 2
+	// 6  = 3
+	// 7  = 4
+	if (date.days < 0) {
+		// negative date: start off at 4 and cycle downwards
+		return (7 - ((-int64_t(date.days) + 3) % 7));
+	} else {
+		// positive date: start off at 4 and cycle upwards
+		return ((int64_t(date.days) + 3) % 7) + 1;
+	}
+}
+
+static int32_t GetISOYearWeek(int32_t &year, int32_t month, int32_t day) {
+	auto day_of_the_year =
+	    (Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month] : Date::CUMULATIVE_DAYS[month]) + day;
+	// get the first day of the first week of the year
+	// the first week is the week that has the 4th of January in it
+	const auto weekday_of_the_fourth = Date::ExtractISODayOfTheWeek(Date::FromDate(year, 1, 4));
+	// if fourth is monday, then fourth is the first day
+	// if fourth is tuesday, third is the first day
+	// if fourth is wednesday, second is the first day
+	// if fourth is thursday, first is the first day
+	// if fourth is friday - sunday, day is in the previous year
+	// (day is 0-based, weekday is 1-based)
+	const auto first_day_of_the_first_isoweek = 4 - weekday_of_the_fourth;
+	if (day_of_the_year < first_day_of_the_first_isoweek) {
+		// day is part of last year (13th month)
+		--year;
+		return GetISOYearWeek(year, 12, day);
+	} else {
+		return ((day_of_the_year - first_day_of_the_first_isoweek) / 7) + 1;
+	}
+}
+
+void Date::ExtractISOYearWeek(date_t date, int32_t &year, int32_t &week) {
+	int32_t month, day;
+	Date::Convert(date, year, month, day);
+	week = GetISOYearWeek(year, month - 1, day - 1);
+}
+
+int32_t Date::ExtractISOWeekNumber(date_t date) {
+	int32_t year, week;
+	ExtractISOYearWeek(date, year, week);
+	return week;
+}
+
+int32_t Date::ExtractISOYearNumber(date_t date) {
+	int32_t year, week;
+	ExtractISOYearWeek(date, year, week);
+	return year;
+}
+
+int32_t Date::ExtractWeekNumberRegular(date_t date, bool monday_first) {
+	int32_t year, month, day;
+	Date::Convert(date, year, month, day);
+	month -= 1;
+	day -= 1;
+	// get the day of the year
+	auto day_of_the_year =
+	    (Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month] : Date::CUMULATIVE_DAYS[month]) + day;
+	// now figure out the first monday or sunday of the year
+	// what day is January 1st?
+	auto day_of_jan_first = Date::ExtractISODayOfTheWeek(Date::FromDate(year, 1, 1));
+	// monday = 1, sunday = 7
+	int32_t first_week_start;
+	if (monday_first) {
+		// have to find next "1"
+		if (day_of_jan_first == 1) {
+			// jan 1 is monday: starts immediately
+			first_week_start = 0;
+		} else {
+			// jan 1 is not monday: count days until next monday
+			first_week_start = 8 - day_of_jan_first;
+		}
+	} else {
+		first_week_start = 7 - day_of_jan_first;
+	}
+	if (day_of_the_year < first_week_start) {
+		// day occurs before first week starts: week 0
+		return 0;
+	}
+	return ((day_of_the_year - first_week_start) / 7) + 1;
+}
+
+// Returns the date of the monday of the current week.
+date_t Date::GetMondayOfCurrentWeek(date_t date) {
+	int32_t dotw = Date::ExtractISODayOfTheWeek(date);
+	return date - (dotw - 1);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+template <class SIGNED, class UNSIGNED>
+string TemplatedDecimalToString(SIGNED value, uint8_t scale) {
+	auto len = DecimalToString::DecimalLength<SIGNED, UNSIGNED>(value, scale);
+	auto data = unique_ptr<char[]>(new char[len + 1]);
+	DecimalToString::FormatDecimal<SIGNED, UNSIGNED>(value, scale, data.get(), len);
+	return string(data.get(), len);
+}
+
+string Decimal::ToString(int16_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int16_t, uint16_t>(value, scale);
+}
+
+string Decimal::ToString(int32_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int32_t, uint32_t>(value, scale);
+}
+
+string Decimal::ToString(int64_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int64_t, uint64_t>(value, scale);
+}
+
+string Decimal::ToString(hugeint_t value, uint8_t scale) {
+	auto len = HugeintToStringCast::DecimalLength(value, scale);
+	auto data = unique_ptr<char[]>(new char[len + 1]);
+	HugeintToStringCast::FormatDecimal(value, scale, data.get(), len);
+	return string(data.get(), len);
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+
+template <>
+hash_t Hash(uint64_t val) {
+	return murmurhash64(val);
+}
+
+template <>
+hash_t Hash(int64_t val) {
+	return murmurhash64((uint64_t)val);
+}
+
+template <>
+hash_t Hash(hugeint_t val) {
+	return murmurhash64(val.lower) ^ murmurhash64(val.upper);
+}
+
+template <>
+hash_t Hash(float val) {
+	return std::hash<float> {}(val);
+}
+
+template <>
+hash_t Hash(double val) {
+	return std::hash<double> {}(val);
+}
+
+template <>
+hash_t Hash(interval_t val) {
+	return Hash(val.days) ^ Hash(val.months) ^ Hash(val.micros);
+}
+
+template <>
+hash_t Hash(const char *str) {
+	return Hash(str, strlen(str));
+}
+
+template <>
+hash_t Hash(string_t val) {
+	return Hash(val.GetDataUnsafe(), val.GetSize());
+}
+
+template <>
+hash_t Hash(char *val) {
+	return Hash<const char *>(val);
+}
+
+// MIT License
+// Copyright (c) 2018-2021 Martin Ankerl
+// https://github.com/martinus/robin-hood-hashing/blob/3.11.5/LICENSE
+hash_t HashBytes(void *ptr, size_t len) noexcept {
+	static constexpr uint64_t M = UINT64_C(0xc6a4a7935bd1e995);
+	static constexpr uint64_t SEED = UINT64_C(0xe17a1465);
+	static constexpr unsigned int R = 47;
+
+	auto const *const data64 = static_cast<uint64_t const *>(ptr);
+	uint64_t h = SEED ^ (len * M);
+
+	size_t const n_blocks = len / 8;
+	for (size_t i = 0; i < n_blocks; ++i) {
+		auto k = Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(data64 + i));
+
+		k *= M;
+		k ^= k >> R;
+		k *= M;
+
+		h ^= k;
+		h *= M;
+	}
+
+	auto const *const data8 = reinterpret_cast<uint8_t const *>(data64 + n_blocks);
+	switch (len & 7U) {
+	case 7:
+		h ^= static_cast<uint64_t>(data8[6]) << 48U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 6:
+		h ^= static_cast<uint64_t>(data8[5]) << 40U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 5:
+		h ^= static_cast<uint64_t>(data8[4]) << 32U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 4:
+		h ^= static_cast<uint64_t>(data8[3]) << 24U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 3:
+		h ^= static_cast<uint64_t>(data8[2]) << 16U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 2:
+		h ^= static_cast<uint64_t>(data8[1]) << 8U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 1:
+		h ^= static_cast<uint64_t>(data8[0]);
+		h *= M;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	default:
+		break;
+	}
+	h ^= h >> R;
+	h *= M;
+	h ^= h >> R;
+	return static_cast<hash_t>(h);
+}
+
+hash_t Hash(const char *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+hash_t Hash(uint8_t *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cmath>
+#include <limits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// String Conversion
+//===--------------------------------------------------------------------===//
+const hugeint_t Hugeint::POWERS_OF_TEN[] {
+    hugeint_t(1),
+    hugeint_t(10),
+    hugeint_t(100),
+    hugeint_t(1000),
+    hugeint_t(10000),
+    hugeint_t(100000),
+    hugeint_t(1000000),
+    hugeint_t(10000000),
+    hugeint_t(100000000),
+    hugeint_t(1000000000),
+    hugeint_t(10000000000),
+    hugeint_t(100000000000),
+    hugeint_t(1000000000000),
+    hugeint_t(10000000000000),
+    hugeint_t(100000000000000),
+    hugeint_t(1000000000000000),
+    hugeint_t(10000000000000000),
+    hugeint_t(100000000000000000),
+    hugeint_t(1000000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10),
+    hugeint_t(1000000000000000000) * hugeint_t(100),
+    hugeint_t(1000000000000000000) * hugeint_t(1000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000) * hugeint_t(10),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000) * hugeint_t(100)};
+
+static uint8_t PositiveHugeintHighestBit(hugeint_t bits) {
+	uint8_t out = 0;
+	if (bits.upper) {
+		out = 64;
+		uint64_t up = bits.upper;
+		while (up) {
+			up >>= 1;
+			out++;
+		}
+	} else {
+		uint64_t low = bits.lower;
+		while (low) {
+			low >>= 1;
+			out++;
+		}
+	}
+	return out;
+}
+
+static bool PositiveHugeintIsBitSet(hugeint_t lhs, uint8_t bit_position) {
+	if (bit_position < 64) {
+		return lhs.lower & (uint64_t(1) << uint64_t(bit_position));
+	} else {
+		return lhs.upper & (uint64_t(1) << uint64_t(bit_position - 64));
+	}
+}
+
+hugeint_t PositiveHugeintLeftShift(hugeint_t lhs, uint32_t amount) {
+	D_ASSERT(amount > 0 && amount < 64);
+	hugeint_t result;
+	result.lower = lhs.lower << amount;
+	result.upper = (lhs.upper << amount) + (lhs.lower >> (64 - amount));
+	return result;
+}
+
+hugeint_t Hugeint::DivModPositive(hugeint_t lhs, uint64_t rhs, uint64_t &remainder) {
+	D_ASSERT(lhs.upper >= 0);
+	// DivMod code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// initialize the result and remainder to 0
+	hugeint_t div_result;
+	div_result.lower = 0;
+	div_result.upper = 0;
+	remainder = 0;
+
+	uint8_t highest_bit_set = PositiveHugeintHighestBit(lhs);
+	// now iterate over the amount of bits that are set in the LHS
+	for (uint8_t x = highest_bit_set; x > 0; x--) {
+		// left-shift the current result and remainder by 1
+		div_result = PositiveHugeintLeftShift(div_result, 1);
+		remainder <<= 1;
+		// we get the value of the bit at position X, where position 0 is the least-significant bit
+		if (PositiveHugeintIsBitSet(lhs, x - 1)) {
+			// increment the remainder
+			remainder++;
+		}
+		if (remainder >= rhs) {
+			// the remainder has passed the division multiplier: add one to the divide result
+			remainder -= rhs;
+			div_result.lower++;
+			if (div_result.lower == 0) {
+				// overflow
+				div_result.upper++;
+			}
+		}
+	}
+	return div_result;
+}
+
+string Hugeint::ToString(hugeint_t input) {
+	uint64_t remainder;
+	string result;
+	bool negative = input.upper < 0;
+	if (negative) {
+		NegateInPlace(input);
+	}
+	while (true) {
+		if (!input.lower && !input.upper) {
+			break;
+		}
+		input = Hugeint::DivModPositive(input, 10, remainder);
+		result = string(1, '0' + remainder) + result; // NOLINT
+	}
+	if (result.empty()) {
+		// value is zero
+		return "0";
+	}
+	return negative ? "-" + result : result;
+}
+
+//===--------------------------------------------------------------------===//
+// Multiply
+//===--------------------------------------------------------------------===//
+bool Hugeint::TryMultiply(hugeint_t lhs, hugeint_t rhs, hugeint_t &result) {
+	bool lhs_negative = lhs.upper < 0;
+	bool rhs_negative = rhs.upper < 0;
+	if (lhs_negative) {
+		NegateInPlace(lhs);
+	}
+	if (rhs_negative) {
+		NegateInPlace(rhs);
+	}
+#if ((__GNUC__ >= 5) || defined(__clang__)) && defined(__SIZEOF_INT128__)
+	__uint128_t left = __uint128_t(lhs.lower) + (__uint128_t(lhs.upper) << 64);
+	__uint128_t right = __uint128_t(rhs.lower) + (__uint128_t(rhs.upper) << 64);
+	__uint128_t result_i128;
+	if (__builtin_mul_overflow(left, right, &result_i128)) {
+		return false;
+	}
+	uint64_t upper = uint64_t(result_i128 >> 64);
+	if (upper & 0x8000000000000000) {
+		return false;
+	}
+	result.upper = int64_t(upper);
+	result.lower = uint64_t(result_i128 & 0xffffffffffffffff);
+#else
+	// Multiply code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// split values into 4 32-bit parts
+	uint64_t top[4] = {uint64_t(lhs.upper) >> 32, uint64_t(lhs.upper) & 0xffffffff, lhs.lower >> 32,
+	                   lhs.lower & 0xffffffff};
+	uint64_t bottom[4] = {uint64_t(rhs.upper) >> 32, uint64_t(rhs.upper) & 0xffffffff, rhs.lower >> 32,
+	                      rhs.lower & 0xffffffff};
+	uint64_t products[4][4];
+
+	// multiply each component of the values
+	for (auto x = 0; x < 4; x++) {
+		for (auto y = 0; y < 4; y++) {
+			products[x][y] = top[x] * bottom[y];
+		}
+	}
+
+	// if any of these products are set to a non-zero value, there is always an overflow
+	if (products[0][0] || products[0][1] || products[0][2] || products[1][0] || products[2][0] || products[1][1]) {
+		return false;
+	}
+	// if the high bits of any of these are set, there is always an overflow
+	if ((products[0][3] & 0xffffffff80000000) || (products[1][2] & 0xffffffff80000000) ||
+	    (products[2][1] & 0xffffffff80000000) || (products[3][0] & 0xffffffff80000000)) {
+		return false;
+	}
+
+	// otherwise we merge the result of the different products together in-order
+
+	// first row
+	uint64_t fourth32 = (products[3][3] & 0xffffffff);
+	uint64_t third32 = (products[3][2] & 0xffffffff) + (products[3][3] >> 32);
+	uint64_t second32 = (products[3][1] & 0xffffffff) + (products[3][2] >> 32);
+	uint64_t first32 = (products[3][0] & 0xffffffff) + (products[3][1] >> 32);
+
+	// second row
+	third32 += (products[2][3] & 0xffffffff);
+	second32 += (products[2][2] & 0xffffffff) + (products[2][3] >> 32);
+	first32 += (products[2][1] & 0xffffffff) + (products[2][2] >> 32);
+
+	// third row
+	second32 += (products[1][3] & 0xffffffff);
+	first32 += (products[1][2] & 0xffffffff) + (products[1][3] >> 32);
+
+	// fourth row
+	first32 += (products[0][3] & 0xffffffff);
+
+	// move carry to next digit
+	third32 += fourth32 >> 32;
+	second32 += third32 >> 32;
+	first32 += second32 >> 32;
+
+	// check if the combination of the different products resulted in an overflow
+	if (first32 & 0xffffff80000000) {
+		return false;
+	}
+
+	// remove carry from current digit
+	fourth32 &= 0xffffffff;
+	third32 &= 0xffffffff;
+	second32 &= 0xffffffff;
+	first32 &= 0xffffffff;
+
+	// combine components
+	result.lower = (third32 << 32) | fourth32;
+	result.upper = (first32 << 32) | second32;
+#endif
+	if (lhs_negative ^ rhs_negative) {
+		NegateInPlace(result);
+	}
+	return true;
+}
+
+hugeint_t Hugeint::Multiply(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t result;
+	if (!TryMultiply(lhs, rhs, result)) {
+		throw OutOfRangeException("Overflow in HUGEINT multiplication!");
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Divide
+//===--------------------------------------------------------------------===//
+hugeint_t Hugeint::DivMod(hugeint_t lhs, hugeint_t rhs, hugeint_t &remainder) {
+	// division by zero not allowed
+	D_ASSERT(!(rhs.upper == 0 && rhs.lower == 0));
+
+	bool lhs_negative = lhs.upper < 0;
+	bool rhs_negative = rhs.upper < 0;
+	if (lhs_negative) {
+		Hugeint::NegateInPlace(lhs);
+	}
+	if (rhs_negative) {
+		Hugeint::NegateInPlace(rhs);
+	}
+	// DivMod code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// initialize the result and remainder to 0
+	hugeint_t div_result;
+	div_result.lower = 0;
+	div_result.upper = 0;
+	remainder.lower = 0;
+	remainder.upper = 0;
+
+	uint8_t highest_bit_set = PositiveHugeintHighestBit(lhs);
+	// now iterate over the amount of bits that are set in the LHS
+	for (uint8_t x = highest_bit_set; x > 0; x--) {
+		// left-shift the current result and remainder by 1
+		div_result = PositiveHugeintLeftShift(div_result, 1);
+		remainder = PositiveHugeintLeftShift(remainder, 1);
+
+		// we get the value of the bit at position X, where position 0 is the least-significant bit
+		if (PositiveHugeintIsBitSet(lhs, x - 1)) {
+			// increment the remainder
+			Hugeint::AddInPlace(remainder, 1);
+		}
+		if (Hugeint::GreaterThanEquals(remainder, rhs)) {
+			// the remainder has passed the division multiplier: add one to the divide result
+			remainder = Hugeint::Subtract(remainder, rhs);
+			Hugeint::AddInPlace(div_result, 1);
+		}
+	}
+	if (lhs_negative ^ rhs_negative) {
+		Hugeint::NegateInPlace(div_result);
+	}
+	if (lhs_negative) {
+		Hugeint::NegateInPlace(remainder);
+	}
+	return div_result;
+}
+
+hugeint_t Hugeint::Divide(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t remainder;
+	return Hugeint::DivMod(lhs, rhs, remainder);
+}
+
+hugeint_t Hugeint::Modulo(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t remainder;
+	Hugeint::DivMod(lhs, rhs, remainder);
+	return remainder;
+}
+
+//===--------------------------------------------------------------------===//
+// Add/Subtract
+//===--------------------------------------------------------------------===//
+bool Hugeint::AddInPlace(hugeint_t &lhs, hugeint_t rhs) {
+	int overflow = lhs.lower + rhs.lower < lhs.lower;
+	if (rhs.upper >= 0) {
+		// RHS is positive: check for overflow
+		if (lhs.upper > (std::numeric_limits<int64_t>::max() - rhs.upper - overflow)) {
+			return false;
+		}
+		lhs.upper = lhs.upper + overflow + rhs.upper;
+	} else {
+		// RHS is negative: check for underflow
+		if (lhs.upper < std::numeric_limits<int64_t>::min() - rhs.upper - overflow) {
+			return false;
+		}
+		lhs.upper = lhs.upper + (overflow + rhs.upper);
+	}
+	lhs.lower += rhs.lower;
+	if (lhs.upper == std::numeric_limits<int64_t>::min() && lhs.lower == 0) {
+		return false;
+	}
+	return true;
+}
+
+bool Hugeint::SubtractInPlace(hugeint_t &lhs, hugeint_t rhs) {
+	// underflow
+	int underflow = lhs.lower - rhs.lower > lhs.lower;
+	if (rhs.upper >= 0) {
+		// RHS is positive: check for underflow
+		if (lhs.upper < (std::numeric_limits<int64_t>::min() + rhs.upper + underflow)) {
+			return false;
+		}
+		lhs.upper = (lhs.upper - rhs.upper) - underflow;
+	} else {
+		// RHS is negative: check for overflow
+		if (lhs.upper > std::numeric_limits<int64_t>::min() &&
+		    lhs.upper - 1 >= (std::numeric_limits<int64_t>::max() + rhs.upper + underflow)) {
+			return false;
+		}
+		lhs.upper = lhs.upper - (rhs.upper + underflow);
+	}
+	lhs.lower -= rhs.lower;
+	if (lhs.upper == std::numeric_limits<int64_t>::min() && lhs.lower == 0) {
+		return false;
+	}
+	return true;
+}
+
+hugeint_t Hugeint::Add(hugeint_t lhs, hugeint_t rhs) {
+	if (!AddInPlace(lhs, rhs)) {
+		throw OutOfRangeException("Overflow in HUGEINT addition");
+	}
+	return lhs;
+}
+
+hugeint_t Hugeint::Subtract(hugeint_t lhs, hugeint_t rhs) {
+	if (!SubtractInPlace(lhs, rhs)) {
+		throw OutOfRangeException("Underflow in HUGEINT addition");
+	}
+	return lhs;
+}
+
+//===--------------------------------------------------------------------===//
+// Hugeint Cast/Conversion
+//===--------------------------------------------------------------------===//
+template <class DST, bool SIGNED = true>
+bool HugeintTryCastInteger(hugeint_t input, DST &result) {
+	switch (input.upper) {
+	case 0:
+		// positive number: check if the positive number is in range
+		if (input.lower <= uint64_t(NumericLimits<DST>::Maximum())) {
+			result = DST(input.lower);
+			return true;
+		}
+		break;
+	case -1:
+		if (!SIGNED) {
+			return false;
+		}
+		// negative number: check if the negative number is in range
+		if (input.lower >= NumericLimits<uint64_t>::Maximum() - uint64_t(NumericLimits<DST>::Maximum())) {
+			result = -DST(NumericLimits<uint64_t>::Maximum() - input.lower) - 1;
+			return true;
+		}
+		break;
+	default:
+		break;
+	}
+	return false;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int8_t &result) {
+	return HugeintTryCastInteger<int8_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int16_t &result) {
+	return HugeintTryCastInteger<int16_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int32_t &result) {
+	return HugeintTryCastInteger<int32_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int64_t &result) {
+	return HugeintTryCastInteger<int64_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint8_t &result) {
+	return HugeintTryCastInteger<uint8_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint16_t &result) {
+	return HugeintTryCastInteger<uint16_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint32_t &result) {
+	return HugeintTryCastInteger<uint32_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint64_t &result) {
+	return HugeintTryCastInteger<uint64_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, hugeint_t &result) {
+	result = input;
+	return true;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, float &result) {
+	double dbl_result;
+	Hugeint::TryCast(input, dbl_result);
+	result = (float)dbl_result;
+	return true;
+}
+
+template <class REAL_T>
+bool CastBigintToFloating(hugeint_t input, REAL_T &result) {
+	switch (input.upper) {
+	case -1:
+		// special case for upper = -1 to avoid rounding issues in small negative numbers
+		result = -REAL_T(NumericLimits<uint64_t>::Maximum() - input.lower) - 1;
+		break;
+	default:
+		result = REAL_T(input.lower) + REAL_T(input.upper) * REAL_T(NumericLimits<uint64_t>::Maximum());
+		break;
+	}
+	return true;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, double &result) {
+	return CastBigintToFloating<double>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, long double &result) {
+	return CastBigintToFloating<long double>(input, result);
+}
+
+template <class DST>
+hugeint_t HugeintConvertInteger(DST input) {
+	hugeint_t result;
+	result.lower = (uint64_t)input;
+	result.upper = (input < 0) * -1;
+	return result;
+}
+
+template <>
+bool Hugeint::TryConvert(int8_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int8_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int16_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int16_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int32_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int32_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int64_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int64_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint8_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint8_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint16_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint16_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint32_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint32_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint64_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint64_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(float value, hugeint_t &result) {
+	return Hugeint::TryConvert(double(value), result);
+}
+
+template <class REAL_T>
+bool ConvertFloatingToBigint(REAL_T value, hugeint_t &result) {
+	if (!Value::IsFinite<REAL_T>(value)) {
+		return false;
+	}
+	if (value <= -170141183460469231731687303715884105728.0 || value >= 170141183460469231731687303715884105727.0) {
+		return false;
+	}
+	bool negative = value < 0;
+	if (negative) {
+		value = -value;
+	}
+	result.lower = (uint64_t)fmod(value, REAL_T(NumericLimits<uint64_t>::Maximum()));
+	result.upper = (uint64_t)(value / REAL_T(NumericLimits<uint64_t>::Maximum()));
+	if (negative) {
+		Hugeint::NegateInPlace(result);
+	}
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(double value, hugeint_t &result) {
+	return ConvertFloatingToBigint<double>(value, result);
+}
+
+template <>
+bool Hugeint::TryConvert(long double value, hugeint_t &result) {
+	return ConvertFloatingToBigint<long double>(value, result);
+}
+
+//===--------------------------------------------------------------------===//
+// hugeint_t operators
+//===--------------------------------------------------------------------===//
+hugeint_t::hugeint_t(int64_t value) {
+	auto result = Hugeint::Convert(value);
+	this->lower = result.lower;
+	this->upper = result.upper;
+}
+
+bool hugeint_t::operator==(const hugeint_t &rhs) const {
+	return Hugeint::Equals(*this, rhs);
+}
+
+bool hugeint_t::operator!=(const hugeint_t &rhs) const {
+	return Hugeint::NotEquals(*this, rhs);
+}
+
+bool hugeint_t::operator<(const hugeint_t &rhs) const {
+	return Hugeint::LessThan(*this, rhs);
+}
+
+bool hugeint_t::operator<=(const hugeint_t &rhs) const {
+	return Hugeint::LessThanEquals(*this, rhs);
+}
+
+bool hugeint_t::operator>(const hugeint_t &rhs) const {
+	return Hugeint::GreaterThan(*this, rhs);
+}
+
+bool hugeint_t::operator>=(const hugeint_t &rhs) const {
+	return Hugeint::GreaterThanEquals(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator+(const hugeint_t &rhs) const {
+	return Hugeint::Add(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator-(const hugeint_t &rhs) const {
+	return Hugeint::Subtract(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator*(const hugeint_t &rhs) const {
+	return Hugeint::Multiply(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator/(const hugeint_t &rhs) const {
+	return Hugeint::Divide(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator%(const hugeint_t &rhs) const {
+	return Hugeint::Modulo(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator-() const {
+	return Hugeint::Negate(*this);
+}
+
+hugeint_t hugeint_t::operator>>(const hugeint_t &rhs) const {
+	hugeint_t result;
+	uint64_t shift = rhs.lower;
+	if (rhs.upper != 0 || shift >= 128) {
+		return hugeint_t(0);
+	} else if (shift == 0) {
+		return *this;
+	} else if (shift == 64) {
+		result.upper = (upper < 0) ? -1 : 0;
+		result.lower = upper;
+	} else if (shift < 64) {
+		// perform lower shift in unsigned integer, and mask away the most significant bit
+		result.lower = (uint64_t(upper) << (64 - shift)) | (lower >> shift);
+		result.upper = upper >> shift;
+	} else {
+		D_ASSERT(shift < 128);
+		result.lower = upper >> (shift - 64);
+		result.upper = (upper < 0) ? -1 : 0;
+	}
+	return result;
+}
+
+hugeint_t hugeint_t::operator<<(const hugeint_t &rhs) const {
+	if (upper < 0) {
+		return hugeint_t(0);
+	}
+	hugeint_t result;
+	uint64_t shift = rhs.lower;
+	if (rhs.upper != 0 || shift >= 128) {
+		return hugeint_t(0);
+	} else if (shift == 64) {
+		result.upper = lower;
+		result.lower = 0;
+	} else if (shift == 0) {
+		return *this;
+	} else if (shift < 64) {
+		// perform upper shift in unsigned integer, and mask away the most significant bit
+		uint64_t upper_shift = ((uint64_t(upper) << shift) + (lower >> (64 - shift))) & 0x7FFFFFFFFFFFFFFF;
+		result.lower = lower << shift;
+		result.upper = upper_shift;
+	} else {
+		D_ASSERT(shift < 128);
+		result.lower = 0;
+		result.upper = (lower << (shift - 64)) & 0x7FFFFFFFFFFFFFFF;
+	}
+	return result;
+}
+
+hugeint_t hugeint_t::operator&(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower & rhs.lower;
+	result.upper = upper & rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator|(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower | rhs.lower;
+	result.upper = upper | rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator^(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower ^ rhs.lower;
+	result.upper = upper ^ rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator~() const {
+	hugeint_t result;
+	result.lower = ~lower;
+	result.upper = ~upper;
+	return result;
+}
+
+hugeint_t &hugeint_t::operator+=(const hugeint_t &rhs) {
+	Hugeint::AddInPlace(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator-=(const hugeint_t &rhs) {
+	Hugeint::SubtractInPlace(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator*=(const hugeint_t &rhs) {
+	*this = Hugeint::Multiply(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator/=(const hugeint_t &rhs) {
+	*this = Hugeint::Divide(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator%=(const hugeint_t &rhs) {
+	*this = Hugeint::Modulo(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator>>=(const hugeint_t &rhs) {
+	*this = *this >> rhs;
+	return *this;
+}
+hugeint_t &hugeint_t::operator<<=(const hugeint_t &rhs) {
+	*this = *this << rhs;
+	return *this;
+}
+hugeint_t &hugeint_t::operator&=(const hugeint_t &rhs) {
+	lower &= rhs.lower;
+	upper &= rhs.upper;
+	return *this;
+}
+hugeint_t &hugeint_t::operator|=(const hugeint_t &rhs) {
+	lower |= rhs.lower;
+	upper |= rhs.upper;
+	return *this;
+}
+hugeint_t &hugeint_t::operator^=(const hugeint_t &rhs) {
+	lower ^= rhs.lower;
+	upper ^= rhs.upper;
+	return *this;
+}
+
+string hugeint_t::ToString() const {
+	return Hugeint::ToString(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+HyperLogLog::HyperLogLog() : hll(nullptr) {
+	hll = duckdb_hll::hll_create();
+	// Insert into a dense hll can be vectorized, sparse cannot, so we immediately convert
+	duckdb_hll::hllSparseToDense((duckdb_hll::robj *)hll);
+}
+
+HyperLogLog::HyperLogLog(void *hll) : hll(hll) {
+}
+
+HyperLogLog::~HyperLogLog() {
+	duckdb_hll::hll_destroy((duckdb_hll::robj *)hll);
+}
+
+void HyperLogLog::Add(data_ptr_t element, idx_t size) {
+	if (duckdb_hll::hll_add((duckdb_hll::robj *)hll, element, size) == HLL_C_ERR) {
+		throw InternalException("Could not add to HLL?");
+	}
+}
+
+idx_t HyperLogLog::Count() const {
+	// exception from size_t ban
+	size_t result;
+
+	if (duckdb_hll::hll_count((duckdb_hll::robj *)hll, &result) != HLL_C_OK) {
+		throw InternalException("Could not count HLL?");
+	}
+	return result;
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog &other) {
+	duckdb_hll::robj *hlls[2];
+	hlls[0] = (duckdb_hll::robj *)hll;
+	hlls[1] = (duckdb_hll::robj *)other.hll;
+	auto new_hll = duckdb_hll::hll_merge(hlls, 2);
+	if (!new_hll) {
+		throw InternalException("Could not merge HLLs");
+	}
+	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
+}
+
+HyperLogLog *HyperLogLog::MergePointer(HyperLogLog &other) {
+	duckdb_hll::robj *hlls[2];
+	hlls[0] = (duckdb_hll::robj *)hll;
+	hlls[1] = (duckdb_hll::robj *)other.hll;
+	auto new_hll = duckdb_hll::hll_merge(hlls, 2);
+	if (!new_hll) {
+		throw Exception("Could not merge HLLs");
+	}
+	return new HyperLogLog((void *)new_hll);
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog logs[], idx_t count) {
+	auto hlls_uptr = unique_ptr<duckdb_hll::robj *[]> {
+		new duckdb_hll::robj *[count]
+	};
+	auto hlls = hlls_uptr.get();
+	for (idx_t i = 0; i < count; i++) {
+		hlls[i] = (duckdb_hll::robj *)logs[i].hll;
+	}
+	auto new_hll = duckdb_hll::hll_merge(hlls, count);
+	if (!new_hll) {
+		throw InternalException("Could not merge HLLs");
+	}
+	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
+}
+
+idx_t HyperLogLog::GetSize() {
+	return duckdb_hll::get_size();
+}
+
+data_ptr_t HyperLogLog::GetPtr() const {
+	return (data_ptr_t)((duckdb_hll::robj *)hll)->ptr;
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Copy() {
+	auto result = make_unique<HyperLogLog>();
+	lock_guard<mutex> guard(lock);
+	memcpy(result->GetPtr(), GetPtr(), GetSize());
+	D_ASSERT(result->Count() == Count());
+	return result;
+}
+
+void HyperLogLog::Serialize(FieldWriter &writer) const {
+	writer.WriteField<HLLStorageType>(HLLStorageType::UNCOMPRESSED);
+	writer.WriteBlob(GetPtr(), GetSize());
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Deserialize(FieldReader &reader) {
+	auto result = make_unique<HyperLogLog>();
+	auto storage_type = reader.ReadRequired<HLLStorageType>();
+	switch (storage_type) {
+	case HLLStorageType::UNCOMPRESSED:
+		reader.ReadBlob(result->GetPtr(), GetSize());
+		break;
+	default:
+		throw SerializationException("Unknown HyperLogLog storage type!");
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Vectorized HLL implementation
+//===--------------------------------------------------------------------===//
+//! Taken from https://nullprogram.com/blog/2018/07/31/
+template <class T>
+inline uint64_t TemplatedHash(const T &elem) {
+	uint64_t x = elem;
+	x ^= x >> 30;
+	x *= UINT64_C(0xbf58476d1ce4e5b9);
+	x ^= x >> 27;
+	x *= UINT64_C(0x94d049bb133111eb);
+	x ^= x >> 31;
+	return x;
+}
+
+template <>
+inline uint64_t TemplatedHash(const hugeint_t &elem) {
+	return TemplatedHash<uint64_t>(Load<uint64_t>((data_ptr_t)&elem.upper)) ^ TemplatedHash<uint64_t>(elem.lower);
+}
+
+template <idx_t rest>
+inline void CreateIntegerRecursive(const data_ptr_t &data, uint64_t &x) {
+	x ^= (uint64_t)data[rest - 1] << ((rest - 1) * 8);
+	return CreateIntegerRecursive<rest - 1>(data, x);
+}
+
+template <>
+inline void CreateIntegerRecursive<1>(const data_ptr_t &data, uint64_t &x) {
+	x ^= (uint64_t)data[0];
+}
+
+inline uint64_t HashOtherSize(const data_ptr_t &data, const idx_t &len) {
+	uint64_t x = 0;
+	switch (len & 7) {
+	case 7:
+		CreateIntegerRecursive<7>(data, x);
+		break;
+	case 6:
+		CreateIntegerRecursive<6>(data, x);
+		break;
+	case 5:
+		CreateIntegerRecursive<5>(data, x);
+		break;
+	case 4:
+		CreateIntegerRecursive<4>(data, x);
+		break;
+	case 3:
+		CreateIntegerRecursive<3>(data, x);
+		break;
+	case 2:
+		CreateIntegerRecursive<2>(data, x);
+		break;
+	case 1:
+		CreateIntegerRecursive<1>(data, x);
+		break;
+	case 0:
+		break;
+	}
+	return TemplatedHash<uint64_t>(x);
+}
+
+template <>
+inline uint64_t TemplatedHash(const string_t &elem) {
+	data_ptr_t data = (data_ptr_t)elem.GetDataUnsafe();
+	const auto &len = elem.GetSize();
+	uint64_t h = 0;
+	for (idx_t i = 0; i + sizeof(uint64_t) <= len; i += sizeof(uint64_t)) {
+		h ^= TemplatedHash<uint64_t>(Load<uint64_t>(data));
+		data += sizeof(uint64_t);
+	}
+	switch (len & (sizeof(uint64_t) - 1)) {
+	case 4:
+		h ^= TemplatedHash<uint32_t>(Load<uint32_t>(data));
+		break;
+	case 2:
+		h ^= TemplatedHash<uint16_t>(Load<uint16_t>(data));
+		break;
+	case 1:
+		h ^= TemplatedHash<uint8_t>(Load<uint8_t>(data));
+		break;
+	default:
+		h ^= HashOtherSize(data, len);
+	}
+	return h;
+}
+
+template <class T>
+void TemplatedComputeHashes(VectorData &vdata, const idx_t &count, uint64_t hashes[]) {
+	T *data = (T *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (vdata.validity.RowIsValid(idx)) {
+			hashes[i] = TemplatedHash<T>(data[idx]);
+		} else {
+			hashes[i] = 0;
+		}
+	}
+}
+
+static void ComputeHashes(VectorData &vdata, const LogicalType &type, uint64_t hashes[], idx_t count) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::UINT8:
+		return TemplatedComputeHashes<uint8_t>(vdata, count, hashes);
+	case PhysicalType::INT16:
+	case PhysicalType::UINT16:
+		return TemplatedComputeHashes<uint16_t>(vdata, count, hashes);
+	case PhysicalType::INT32:
+	case PhysicalType::UINT32:
+	case PhysicalType::FLOAT:
+		return TemplatedComputeHashes<uint32_t>(vdata, count, hashes);
+	case PhysicalType::INT64:
+	case PhysicalType::UINT64:
+	case PhysicalType::DOUBLE:
+		return TemplatedComputeHashes<uint64_t>(vdata, count, hashes);
+	case PhysicalType::INT128:
+	case PhysicalType::INTERVAL:
+		static_assert(sizeof(hugeint_t) == sizeof(interval_t), "ComputeHashes assumes these are the same size!");
+		return TemplatedComputeHashes<hugeint_t>(vdata, count, hashes);
+	case PhysicalType::VARCHAR:
+		return TemplatedComputeHashes<string_t>(vdata, count, hashes);
+	default:
+		throw InternalException("Unimplemented type for HyperLogLog::ComputeHashes");
+	}
+}
+
+//! Taken from https://stackoverflow.com/a/72088344
+static inline uint8_t CountTrailingZeros(uint64_t &x) {
+	static constexpr const uint64_t DEBRUIJN = 0x03f79d71b4cb0a89;
+	static constexpr const uint8_t LOOKUP[] = {0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61,
+	                                           54, 58, 35, 52, 50, 42, 21, 44, 38, 32, 29, 23, 17, 11, 4,  62,
+	                                           46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45,
+	                                           25, 39, 14, 33, 19, 30, 9,  24, 13, 18, 8,  12, 7,  6,  5,  63};
+	return LOOKUP[(DEBRUIJN * (x ^ (x - 1))) >> 58];
+}
+
+static inline void ComputeIndexAndCount(uint64_t &hash, uint8_t &prefix) {
+	uint64_t index = hash & ((1 << 12) - 1); /* Register index. */
+	hash >>= 12;                             /* Remove bits used to address the register. */
+	hash |= ((uint64_t)1 << (64 - 12));      /* Make sure the count will be <= Q+1. */
+
+	prefix = CountTrailingZeros(hash) + 1; /* Add 1 since we count the "00000...1" pattern. */
+	hash = index;
+}
+
+void HyperLogLog::ProcessEntries(VectorData &vdata, const LogicalType &type, uint64_t hashes[], uint8_t counts[],
+                                 idx_t count) {
+	ComputeHashes(vdata, type, hashes, count);
+	for (idx_t i = 0; i < count; i++) {
+		ComputeIndexAndCount(hashes[i], counts[i]);
+	}
+}
+
+void HyperLogLog::AddToLogs(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[], HyperLogLog **logs[],
+                            const SelectionVector *log_sel) {
+	AddToLogsInternal(vdata, count, indices, counts, (void ****)logs, log_sel);
+}
+
+void HyperLogLog::AddToLog(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[]) {
+	lock_guard<mutex> guard(lock);
+	AddToSingleLogInternal(vdata, count, indices, counts, hll);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+bool Interval::FromString(const string &str, interval_t &result) {
+	string error_message;
+	return Interval::FromCString(str.c_str(), str.size(), result, &error_message, false);
+}
+
+template <class T>
+void IntervalTryAddition(T &target, int64_t input, int64_t multiplier) {
+	int64_t addition;
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, multiplier, addition)) {
+		throw OutOfRangeException("interval value is out of range");
+	}
+	T addition_base = Cast::Operation<int64_t, T>(addition);
+	if (!TryAddOperator::Operation<T, T, T>(target, addition_base, target)) {
+		throw OutOfRangeException("interval value is out of range");
+	}
+}
+
+bool Interval::FromCString(const char *str, idx_t len, interval_t &result, string *error_message, bool strict) {
+	idx_t pos = 0;
+	idx_t start_pos;
+	bool negative;
+	bool found_any = false;
+	int64_t number;
+	DatePartSpecifier specifier;
+	string specifier_str;
+
+	result.days = 0;
+	result.micros = 0;
+	result.months = 0;
+
+	if (len == 0) {
+		return false;
+	}
+
+	switch (str[pos]) {
+	case '@':
+		pos++;
+		goto standard_interval;
+	case 'P':
+	case 'p':
+		pos++;
+		goto posix_interval;
+	default:
+		goto standard_interval;
+	}
+standard_interval:
+	// start parsing a standard interval (e.g. 2 years 3 months...)
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			// skip spaces
+			continue;
+		} else if (c >= '0' && c <= '9') {
+			// start parsing a positive number
+			negative = false;
+			goto interval_parse_number;
+		} else if (c == '-') {
+			// negative number
+			negative = true;
+			pos++;
+			goto interval_parse_number;
+		} else if (c == 'a' || c == 'A') {
+			// parse the word "ago" as the final specifier
+			goto interval_parse_ago;
+		} else {
+			// unrecognized character, expected a number or end of string
+			return false;
+		}
+	}
+	goto end_of_string;
+interval_parse_number:
+	start_pos = pos;
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c >= '0' && c <= '9') {
+			// the number continues
+			continue;
+		} else if (c == ':') {
+			// colon: we are parsing a time
+			goto interval_parse_time;
+		} else {
+			if (pos == start_pos) {
+				return false;
+			}
+			// finished the number, parse it from the string
+			string_t nr_string(str + start_pos, pos - start_pos);
+			number = Cast::Operation<string_t, int64_t>(nr_string);
+			if (negative) {
+				number = -number;
+			}
+			goto interval_parse_identifier;
+		}
+	}
+	goto end_of_string;
+interval_parse_time : {
+	// parse the remainder of the time as a Time type
+	dtime_t time;
+	idx_t pos;
+	if (!Time::TryConvertTime(str + start_pos, len - start_pos, pos, time)) {
+		return false;
+	}
+	result.micros += time.micros;
+	found_any = true;
+	goto end_of_string;
+}
+interval_parse_identifier:
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			// skip spaces at the start
+			continue;
+		} else {
+			break;
+		}
+	}
+	// now parse the identifier
+	start_pos = pos;
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+			// keep parsing the string
+			continue;
+		} else {
+			break;
+		}
+	}
+	specifier_str = string(str + start_pos, pos - start_pos);
+	if (!TryGetDatePartSpecifier(specifier_str, specifier)) {
+		HandleCastError::AssignError(StringUtil::Format("extract specifier \"%s\" not recognized", specifier_str),
+		                             error_message);
+		return false;
+	}
+	// add the specifier to the interval
+	switch (specifier) {
+	case DatePartSpecifier::MILLENNIUM:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_MILLENIUM);
+		break;
+	case DatePartSpecifier::CENTURY:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_CENTURY);
+		break;
+	case DatePartSpecifier::DECADE:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_DECADE);
+		break;
+	case DatePartSpecifier::YEAR:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_YEAR);
+		break;
+	case DatePartSpecifier::QUARTER:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_QUARTER);
+		break;
+	case DatePartSpecifier::MONTH:
+		IntervalTryAddition<int32_t>(result.months, number, 1);
+		break;
+	case DatePartSpecifier::DAY:
+		IntervalTryAddition<int32_t>(result.days, number, 1);
+		break;
+	case DatePartSpecifier::WEEK:
+		IntervalTryAddition<int32_t>(result.days, number, DAYS_PER_WEEK);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		IntervalTryAddition<int64_t>(result.micros, number, 1);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MSEC);
+		break;
+	case DatePartSpecifier::SECOND:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC);
+		break;
+	case DatePartSpecifier::MINUTE:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MINUTE);
+		break;
+	case DatePartSpecifier::HOUR:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_HOUR);
+		break;
+	default:
+		HandleCastError::AssignError(
+		    StringUtil::Format("extract specifier \"%s\" not supported for interval", specifier_str), error_message);
+		return false;
+	}
+	found_any = true;
+	goto standard_interval;
+interval_parse_ago:
+	D_ASSERT(str[pos] == 'a' || str[pos] == 'A');
+	// parse the "ago" string at the end of the interval
+	if (len - pos < 3) {
+		return false;
+	}
+	pos++;
+	if (!(str[pos] == 'g' || str[pos] == 'G')) {
+		return false;
+	}
+	pos++;
+	if (!(str[pos] == 'o' || str[pos] == 'O')) {
+		return false;
+	}
+	pos++;
+	// parse any trailing whitespace
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			continue;
+		} else {
+			return false;
+		}
+	}
+	// invert all the values
+	result.months = -result.months;
+	result.days = -result.days;
+	result.micros = -result.micros;
+	goto end_of_string;
+end_of_string:
+	if (!found_any) {
+		// end of string and no identifiers were found: cannot convert empty interval
+		return false;
+	}
+	return true;
+posix_interval:
+	return false;
+}
+
+string Interval::ToString(const interval_t &interval) {
+	char buffer[70];
+	idx_t length = IntervalToStringCast::Format(interval, buffer);
+	return string(buffer, length);
+}
+
+int64_t Interval::GetMilli(const interval_t &val) {
+	int64_t milli_month, milli_day, milli;
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, Interval::MICROS_PER_MONTH / 1000, milli_month)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, Interval::MICROS_PER_DAY / 1000, milli_day)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	milli = val.micros / 1000;
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_month, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_day, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	return milli;
+}
+
+int64_t Interval::GetMicro(const interval_t &val) {
+	int64_t micro_month, micro_day, micro_total;
+	micro_total = val.micros;
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, MICROS_PER_MONTH, micro_month)) {
+		throw ConversionException("Could not convert Month to Microseconds");
+	}
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, MICROS_PER_DAY, micro_day)) {
+		throw ConversionException("Could not convert Day to Microseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(micro_total, micro_month, micro_total)) {
+		throw ConversionException("Could not convert Interval to Microseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(micro_total, micro_day, micro_total)) {
+		throw ConversionException("Could not convert Interval to Microseconds");
+	}
+
+	return micro_total;
+}
+
+int64_t Interval::GetNanoseconds(const interval_t &val) {
+	int64_t nano;
+	const auto micro_total = GetMicro(val);
+	if (!TryMultiplyOperator::Operation(micro_total, NANOS_PER_MICRO, nano)) {
+		throw ConversionException("Could not convert Interval to Nanoseconds");
+	}
+
+	return nano;
+}
+
+interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	D_ASSERT(Timestamp::IsFinite(timestamp_1) && Timestamp::IsFinite(timestamp_2));
+	date_t date1, date2;
+	dtime_t time1, time2;
+
+	Timestamp::Convert(timestamp_1, date1, time1);
+	Timestamp::Convert(timestamp_2, date2, time2);
+
+	// and from date extract the years, months and days
+	int32_t year1, month1, day1;
+	int32_t year2, month2, day2;
+	Date::Convert(date1, year1, month1, day1);
+	Date::Convert(date2, year2, month2, day2);
+	// finally perform the differences
+	auto year_diff = year1 - year2;
+	auto month_diff = month1 - month2;
+	auto day_diff = day1 - day2;
+
+	// and from time extract hours, minutes, seconds and milliseconds
+	int32_t hour1, min1, sec1, micros1;
+	int32_t hour2, min2, sec2, micros2;
+	Time::Convert(time1, hour1, min1, sec1, micros1);
+	Time::Convert(time2, hour2, min2, sec2, micros2);
+	// finally perform the differences
+	auto hour_diff = hour1 - hour2;
+	auto min_diff = min1 - min2;
+	auto sec_diff = sec1 - sec2;
+	auto micros_diff = micros1 - micros2;
+
+	// flip sign if necessary
+	bool sign_flipped = false;
+	if (timestamp_1 < timestamp_2) {
+		year_diff = -year_diff;
+		month_diff = -month_diff;
+		day_diff = -day_diff;
+		hour_diff = -hour_diff;
+		min_diff = -min_diff;
+		sec_diff = -sec_diff;
+		micros_diff = -micros_diff;
+		sign_flipped = true;
+	}
+	// now propagate any negative field into the next higher field
+	while (micros_diff < 0) {
+		micros_diff += MICROS_PER_SEC;
+		sec_diff--;
+	}
+	while (sec_diff < 0) {
+		sec_diff += SECS_PER_MINUTE;
+		min_diff--;
+	}
+	while (min_diff < 0) {
+		min_diff += MINS_PER_HOUR;
+		hour_diff--;
+	}
+	while (hour_diff < 0) {
+		hour_diff += HOURS_PER_DAY;
+		day_diff--;
+	}
+	while (day_diff < 0) {
+		if (timestamp_1 < timestamp_2) {
+			day_diff += Date::IsLeapYear(year1) ? Date::LEAP_DAYS[month1] : Date::NORMAL_DAYS[month1];
+			month_diff--;
+		} else {
+			day_diff += Date::IsLeapYear(year2) ? Date::LEAP_DAYS[month2] : Date::NORMAL_DAYS[month2];
+			month_diff--;
+		}
+	}
+	while (month_diff < 0) {
+		month_diff += MONTHS_PER_YEAR;
+		year_diff--;
+	}
+
+	// recover sign if necessary
+	if (sign_flipped) {
+		year_diff = -year_diff;
+		month_diff = -month_diff;
+		day_diff = -day_diff;
+		hour_diff = -hour_diff;
+		min_diff = -min_diff;
+		sec_diff = -sec_diff;
+		micros_diff = -micros_diff;
+	}
+	interval_t interval;
+	interval.months = year_diff * MONTHS_PER_YEAR + month_diff;
+	interval.days = day_diff;
+	interval.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
+
+	return interval;
+}
+
+interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	if (!Timestamp::IsFinite(timestamp_1) || !Timestamp::IsFinite(timestamp_2)) {
+		throw InvalidInputException("Cannot subtract infinite timestamps");
+	}
+	const auto us_1 = Timestamp::GetEpochMicroSeconds(timestamp_1);
+	const auto us_2 = Timestamp::GetEpochMicroSeconds(timestamp_2);
+	int64_t delta_us;
+	if (!TrySubtractOperator::Operation(us_1, us_2, delta_us)) {
+		throw ConversionException("Timestamp difference is out of bounds");
+	}
+	return FromMicro(delta_us);
+}
+
+interval_t Interval::FromMicro(int64_t delta_us) {
+	interval_t result;
+	result.months = 0;
+	result.days = delta_us / Interval::MICROS_PER_DAY;
+	result.micros = delta_us % Interval::MICROS_PER_DAY;
+
+	return result;
+}
+
+static void NormalizeIntervalEntries(interval_t input, int64_t &months, int64_t &days, int64_t &micros) {
+	int64_t extra_months_d = input.days / Interval::DAYS_PER_MONTH;
+	int64_t extra_months_micros = input.micros / Interval::MICROS_PER_MONTH;
+	input.days -= extra_months_d * Interval::DAYS_PER_MONTH;
+	input.micros -= extra_months_micros * Interval::MICROS_PER_MONTH;
+
+	int64_t extra_days_micros = input.micros / Interval::MICROS_PER_DAY;
+	input.micros -= extra_days_micros * Interval::MICROS_PER_DAY;
+
+	months = input.months + extra_months_d + extra_months_micros;
+	days = input.days + extra_days_micros;
+	micros = input.micros;
+}
+
+bool Interval::Equals(interval_t left, interval_t right) {
+	return left.months == right.months && left.days == right.days && left.micros == right.micros;
+}
+
+bool Interval::GreaterThan(interval_t left, interval_t right) {
+	int64_t lmonths, ldays, lmicros;
+	int64_t rmonths, rdays, rmicros;
+	NormalizeIntervalEntries(left, lmonths, ldays, lmicros);
+	NormalizeIntervalEntries(right, rmonths, rdays, rmicros);
+
+	if (lmonths > rmonths) {
+		return true;
+	} else if (lmonths < rmonths) {
+		return false;
+	}
+	if (ldays > rdays) {
+		return true;
+	} else if (ldays < rdays) {
+		return false;
+	}
+	return lmicros > rmicros;
+}
+
+bool Interval::GreaterThanEquals(interval_t left, interval_t right) {
+	return GreaterThan(left, right) || Equals(left, right);
+}
+
+date_t Interval::Add(date_t left, interval_t right) {
+	if (!Date::IsFinite(left)) {
+		return left;
+	}
+	date_t result;
+	if (right.months != 0) {
+		int32_t year, month, day;
+		Date::Convert(left, year, month, day);
+		int32_t year_diff = right.months / Interval::MONTHS_PER_YEAR;
+		year += year_diff;
+		month += right.months - year_diff * Interval::MONTHS_PER_YEAR;
+		if (month > Interval::MONTHS_PER_YEAR) {
+			year++;
+			month -= Interval::MONTHS_PER_YEAR;
+		} else if (month <= 0) {
+			year--;
+			month += Interval::MONTHS_PER_YEAR;
+		}
+		day = MinValue<int32_t>(day, Date::MonthDays(year, month));
+		result = Date::FromDate(year, month, day);
+	} else {
+		result = left;
+	}
+	if (right.days != 0) {
+		if (!TryAddOperator::Operation(result.days, right.days, result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	if (right.micros != 0) {
+		if (!TryAddOperator::Operation(result.days, int32_t(right.micros / Interval::MICROS_PER_DAY), result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	if (!Date::IsFinite(result)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	return result;
+}
+
+dtime_t Interval::Add(dtime_t left, interval_t right, date_t &date) {
+	int64_t diff = right.micros - ((right.micros / Interval::MICROS_PER_DAY) * Interval::MICROS_PER_DAY);
+	left += diff;
+	if (left.micros >= Interval::MICROS_PER_DAY) {
+		left.micros -= Interval::MICROS_PER_DAY;
+		date.days++;
+	} else if (left.micros < 0) {
+		left.micros += Interval::MICROS_PER_DAY;
+		date.days--;
+	}
+	return left;
+}
+
+timestamp_t Interval::Add(timestamp_t left, interval_t right) {
+	if (!Timestamp::IsFinite(left)) {
+		return left;
+	}
+	date_t date;
+	dtime_t time;
+	Timestamp::Convert(left, date, time);
+	auto new_date = Interval::Add(date, right);
+	auto new_time = Interval::Add(time, right, new_date);
+	return Timestamp::FromDatetime(new_date, new_time);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+RowDataCollection::RowDataCollection(BufferManager &buffer_manager, idx_t block_capacity, idx_t entry_size,
+                                     bool keep_pinned)
+    : buffer_manager(buffer_manager), count(0), block_capacity(block_capacity), entry_size(entry_size),
+      keep_pinned(keep_pinned) {
+	D_ASSERT(block_capacity * entry_size >= Storage::BLOCK_SIZE);
+}
+
+idx_t RowDataCollection::AppendToBlock(RowDataBlock &block, BufferHandle &handle,
+                                       vector<BlockAppendEntry> &append_entries, idx_t remaining, idx_t entry_sizes[]) {
+	idx_t append_count = 0;
+	data_ptr_t dataptr;
+	if (entry_sizes) {
+		D_ASSERT(entry_size == 1);
+		// compute how many entries fit if entry size is variable
+		dataptr = handle.Ptr() + block.byte_offset;
+		for (idx_t i = 0; i < remaining; i++) {
+			if (block.byte_offset + entry_sizes[i] > block.capacity) {
+				if (block.count == 0 && append_count == 0 && entry_sizes[i] > block.capacity) {
+					// special case: single entry is bigger than block capacity
+					// resize current block to fit the entry, append it, and move to the next block
+					block.capacity = entry_sizes[i];
+					buffer_manager.ReAllocate(block.block, block.capacity);
+					dataptr = handle.Ptr();
+					append_count++;
+					block.byte_offset += entry_sizes[i];
+				}
+				break;
+			}
+			append_count++;
+			block.byte_offset += entry_sizes[i];
+		}
+	} else {
+		append_count = MinValue<idx_t>(remaining, block.capacity - block.count);
+		dataptr = handle.Ptr() + block.count * entry_size;
+	}
+	append_entries.emplace_back(dataptr, append_count);
+	block.count += append_count;
+	return append_count;
+}
+
+vector<unique_ptr<BufferHandle>> RowDataCollection::Build(idx_t added_count, data_ptr_t key_locations[],
+                                                          idx_t entry_sizes[], const SelectionVector *sel) {
+	vector<unique_ptr<BufferHandle>> handles;
+	vector<BlockAppendEntry> append_entries;
+
+	// first allocate space of where to serialize the keys and payload columns
+	idx_t remaining = added_count;
+	{
+		// first append to the last block (if any)
+		lock_guard<mutex> append_lock(rdc_lock);
+		count += added_count;
+
+		if (!blocks.empty()) {
+			auto &last_block = blocks.back();
+			if (last_block.count < last_block.capacity) {
+				// last block has space: pin the buffer of this block
+				auto handle = buffer_manager.Pin(last_block.block);
+				// now append to the block
+				idx_t append_count = AppendToBlock(last_block, *handle, append_entries, remaining, entry_sizes);
+				remaining -= append_count;
+				handles.push_back(move(handle));
+			}
+		}
+		while (remaining > 0) {
+			// now for the remaining data, allocate new buffers to store the data and append there
+			RowDataBlock new_block(buffer_manager, block_capacity, entry_size);
+			auto handle = buffer_manager.Pin(new_block.block);
+
+			// offset the entry sizes array if we have added entries already
+			idx_t *offset_entry_sizes = entry_sizes ? entry_sizes + added_count - remaining : nullptr;
+
+			idx_t append_count = AppendToBlock(new_block, *handle, append_entries, remaining, offset_entry_sizes);
+			D_ASSERT(new_block.count > 0);
+			remaining -= append_count;
+
+			blocks.push_back(move(new_block));
+			if (keep_pinned) {
+				pinned_blocks.push_back(move(handle));
+			} else {
+				handles.push_back(move(handle));
+			}
+		}
+	}
+	// now set up the key_locations based on the append entries
+	idx_t append_idx = 0;
+	for (auto &append_entry : append_entries) {
+		idx_t next = append_idx + append_entry.count;
+		if (entry_sizes) {
+			for (; append_idx < next; append_idx++) {
+				key_locations[append_idx] = append_entry.baseptr;
+				append_entry.baseptr += entry_sizes[append_idx];
+			}
+		} else {
+			for (; append_idx < next; append_idx++) {
+				auto idx = sel->get_index(append_idx);
+				key_locations[idx] = append_entry.baseptr;
+				append_entry.baseptr += entry_size;
+			}
+		}
+	}
+	// return the unique pointers to the handles because they must stay pinned
+	return handles;
+}
+
+void RowDataCollection::Merge(RowDataCollection &other) {
+	RowDataCollection temp(buffer_manager, Storage::BLOCK_SIZE, 1);
+	{
+		//	One lock at a time to avoid deadlocks
+		lock_guard<mutex> read_lock(other.rdc_lock);
+		temp.count = other.count;
+		temp.block_capacity = other.block_capacity;
+		temp.entry_size = other.entry_size;
+		temp.blocks = move(other.blocks);
+		other.count = 0;
+	}
+
+	lock_guard<mutex> write_lock(rdc_lock);
+	count += temp.count;
+	block_capacity = MaxValue(block_capacity, temp.block_capacity);
+	entry_size = MaxValue(entry_size, temp.entry_size);
+	for (auto &block : temp.blocks) {
+		blocks.emplace_back(move(block));
+	}
+	for (auto &handle : temp.pinned_blocks) {
+		pinned_blocks.emplace_back(move(handle));
+	}
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_layout.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+vector<AggregateObject> AggregateObject::CreateAggregateObjects(const vector<BoundAggregateExpression *> &bindings) {
+	vector<AggregateObject> aggregates;
+	for (auto &binding : bindings) {
+		auto payload_size = binding->function.state_size();
+#ifndef DUCKDB_ALLOW_UNDEFINED
+		payload_size = AlignValue(payload_size);
+#endif
+		aggregates.emplace_back(binding->function, binding->bind_info.get(), binding->children.size(), payload_size,
+		                        binding->distinct, binding->return_type.InternalType(), binding->filter.get());
+	}
+	return aggregates;
+}
+
+RowLayout::RowLayout()
+    : flag_width(0), data_width(0), aggr_width(0), row_width(0), all_constant(true), heap_pointer_offset(0) {
+}
+
+void RowLayout::Initialize(vector<LogicalType> types_p, Aggregates aggregates_p, bool align) {
+	offsets.clear();
+	types = move(types_p);
+
+	// Null mask at the front - 1 bit per value.
+	flag_width = ValidityBytes::ValidityMaskSize(types.size());
+	row_width = flag_width;
+
+	// Whether all columns are constant size.
+	for (const auto &type : types) {
+		all_constant = all_constant && TypeIsConstantSize(type.InternalType());
+	}
+
+	// This enables pointer swizzling for out-of-core computation.
+	if (!all_constant) {
+		// When unswizzled the pointer lives here.
+		// When swizzled, the pointer is replaced by an offset.
+		heap_pointer_offset = row_width;
+		// The 8 byte pointer will be replaced with an 8 byte idx_t when swizzled.
+		// However, this cannot be sizeof(data_ptr_t), since 32 bit builds use 4 byte pointers.
+		row_width += sizeof(idx_t);
+	}
+
+	// Data columns. No alignment required.
+	for (const auto &type : types) {
+		offsets.push_back(row_width);
+		const auto internal_type = type.InternalType();
+		if (TypeIsConstantSize(internal_type) || internal_type == PhysicalType::VARCHAR) {
+			row_width += GetTypeIdSize(type.InternalType());
+		} else {
+			// Variable size types use pointers to the actual data (can be swizzled).
+			// Again, we would use sizeof(data_ptr_t), but this is not guaranteed to be equal to sizeof(idx_t).
+			row_width += sizeof(idx_t);
+		}
+	}
+
+	// Alignment padding for aggregates
+#ifndef DUCKDB_ALLOW_UNDEFINED
+	if (align) {
+		row_width = AlignValue(row_width);
+	}
+#endif
+	data_width = row_width - flag_width;
+
+	// Aggregate fields.
+	aggregates = move(aggregates_p);
+	for (auto &aggregate : aggregates) {
+		offsets.push_back(row_width);
+		row_width += aggregate.payload_size;
+#ifndef DUCKDB_ALLOW_UNDEFINED
+		D_ASSERT(aggregate.payload_size == AlignValue(aggregate.payload_size));
+#endif
+	}
+	aggr_width = row_width - data_width - flag_width;
+
+	// Alignment padding for the next row
+#ifndef DUCKDB_ALLOW_UNDEFINED
+	if (align) {
+		row_width = AlignValue(row_width);
+	}
+#endif
+}
+
+void RowLayout::Initialize(vector<LogicalType> types_p, bool align) {
+	Initialize(move(types_p), Aggregates(), align);
+}
+
+void RowLayout::Initialize(Aggregates aggregates_p, bool align) {
+	Initialize(vector<LogicalType>(), move(aggregates_p), align);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SelectionData::SelectionData(idx_t count) {
+	owned_data = unique_ptr<sel_t[]>(new sel_t[count]);
+#ifdef DEBUG
+	for (idx_t i = 0; i < count; i++) {
+		owned_data[i] = std::numeric_limits<sel_t>::max();
+	}
+#endif
+}
+
+// LCOV_EXCL_START
+string SelectionVector::ToString(idx_t count) const {
+	string result = "Selection Vector (" + to_string(count) + ") [";
+	for (idx_t i = 0; i < count; i++) {
+		if (i != 0) {
+			result += ", ";
+		}
+		result += to_string(get_index(i));
+	}
+	result += "]";
+	return result;
+}
+
+void SelectionVector::Print(idx_t count) const {
+	Printer::Print(ToString(count));
+}
+// LCOV_EXCL_STOP
+
+buffer_ptr<SelectionData> SelectionVector::Slice(const SelectionVector &sel, idx_t count) const {
+	auto data = make_buffer<SelectionData>(count);
+	auto result_ptr = data->owned_data.get();
+	// for every element, we perform result[i] = target[new[i]]
+	for (idx_t i = 0; i < count; i++) {
+		auto new_idx = sel.get_index(i);
+		auto idx = this->get_index(new_idx);
+		result_ptr[i] = idx;
+	}
+	return data;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+#define MINIMUM_HEAP_SIZE 4096
+
+StringHeap::StringHeap() : tail(nullptr) {
+}
+
+string_t StringHeap::AddString(const char *data, idx_t len) {
+	D_ASSERT(Utf8Proc::Analyze(data, len) != UnicodeType::INVALID);
+	return AddBlob(data, len);
+}
+
+string_t StringHeap::AddString(const char *data) {
+	return AddString(data, strlen(data));
+}
+
+string_t StringHeap::AddString(const string &data) {
+	return AddString(data.c_str(), data.size());
+}
+
+string_t StringHeap::AddString(const string_t &data) {
+	return AddString(data.GetDataUnsafe(), data.GetSize());
+}
+
+string_t StringHeap::AddBlob(const char *data, idx_t len) {
+	auto insert_string = EmptyString(len);
+	auto insert_pos = insert_string.GetDataWriteable();
+	memcpy(insert_pos, data, len);
+	insert_string.Finalize();
+	return insert_string;
+}
+
+string_t StringHeap::EmptyString(idx_t len) {
+	D_ASSERT(len >= string_t::INLINE_LENGTH);
+	if (!chunk || chunk->current_position + len >= chunk->maximum_size) {
+		// have to make a new entry
+		auto new_chunk = make_unique<StringChunk>(MaxValue<idx_t>(len, MINIMUM_HEAP_SIZE));
+		new_chunk->prev = move(chunk);
+		chunk = move(new_chunk);
+		if (!tail) {
+			tail = chunk.get();
+		}
+	}
+	auto insert_pos = chunk->data.get() + chunk->current_position;
+	chunk->current_position += len;
+	return string_t(insert_pos, len);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+void string_t::Verify() {
+	auto dataptr = GetDataUnsafe();
+	(void)dataptr;
+	D_ASSERT(dataptr);
+
+#ifdef DEBUG
+	auto utf_type = Utf8Proc::Analyze(dataptr, GetSize());
+	D_ASSERT(utf_type != UnicodeType::INVALID);
+#endif
+
+	// verify that the prefix contains the first four characters of the string
+	for (idx_t i = 0; i < MinValue<uint32_t>(PREFIX_LENGTH, GetSize()); i++) {
+		D_ASSERT(GetPrefix()[i] == dataptr[i]);
+	}
+	// verify that for strings with length < INLINE_LENGTH, the rest of the string is zero
+	for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
+		D_ASSERT(GetDataUnsafe()[i] == '\0');
+	}
+}
+
+void string_t::VerifyNull() {
+	for (idx_t i = 0; i < GetSize(); i++) {
+		D_ASSERT(GetDataUnsafe()[i] != '\0');
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <cstring>
+#include <sstream>
+#include <cctype>
+
+namespace duckdb {
+
+static_assert(sizeof(dtime_t) == sizeof(int64_t), "dtime_t was padded");
+
+// string format is hh:mm:ss.microsecondsZ
+// microseconds and Z are optional
+// ISO 8601
+
+bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict) {
+	int32_t hour = -1, min = -1, sec = -1, micros = -1;
+	pos = 0;
+
+	if (len == 0) {
+		return false;
+	}
+
+	int sep;
+
+	// skip leading spaces
+	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+		pos++;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (!StringUtil::CharacterIsDigit(buf[pos])) {
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, hour)) {
+		return false;
+	}
+	if (hour < 0 || hour >= 24) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// fetch the separator
+	sep = buf[pos++];
+	if (sep != ':') {
+		// invalid separator
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, min)) {
+		return false;
+	}
+	if (min < 0 || min >= 60) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (buf[pos++] != sep) {
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, sec)) {
+		return false;
+	}
+	if (sec < 0 || sec >= 60) {
+		return false;
+	}
+
+	micros = 0;
+	if (pos < len && buf[pos] == '.') {
+		pos++;
+		// we expect some microseconds
+		int32_t mult = 100000;
+		for (; pos < len && StringUtil::CharacterIsDigit(buf[pos]); pos++, mult /= 10) {
+			if (mult > 0) {
+				micros += (buf[pos] - '0') * mult;
+			}
+		}
+	}
+
+	// in strict mode, check remaining string for non-space characters
+	if (strict) {
+		// skip trailing spaces
+		while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+			pos++;
+		}
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < len) {
+			return false;
+		}
+	}
+
+	result = Time::FromTime(hour, min, sec, micros);
+	return true;
+}
+
+bool Time::TryConvertTime(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict) {
+	if (!Time::TryConvertInternal(buf, len, pos, result, strict)) {
+		if (!strict) {
+			// last chance, check if we can parse as timestamp
+			timestamp_t timestamp;
+			if (Timestamp::TryConvertTimestamp(buf, len, timestamp)) {
+				result = Timestamp::GetTime(timestamp);
+				return true;
+			}
+		}
+		return false;
+	}
+	return true;
+}
+
+string Time::ConversionError(const string &str) {
+	return StringUtil::Format("time field value out of range: \"%s\", "
+	                          "expected format is ([YYYY-MM-DD ]HH:MM:SS[.MS])",
+	                          str);
+}
+
+string Time::ConversionError(string_t str) {
+	return Time::ConversionError(str.GetString());
+}
+
+dtime_t Time::FromCString(const char *buf, idx_t len, bool strict) {
+	dtime_t result;
+	idx_t pos;
+	if (!Time::TryConvertTime(buf, len, pos, result, strict)) {
+		throw ConversionException(ConversionError(string(buf, len)));
+	}
+	return result;
+}
+
+dtime_t Time::FromString(const string &str, bool strict) {
+	return Time::FromCString(str.c_str(), str.size(), strict);
+}
+
+string Time::ToString(dtime_t time) {
+	int32_t time_units[4];
+	Time::Convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
+
+	char micro_buffer[6];
+	auto length = TimeToStringCast::Length(time_units, micro_buffer);
+	auto buffer = unique_ptr<char[]>(new char[length]);
+	TimeToStringCast::Format(buffer.get(), length, time_units, micro_buffer);
+	return string(buffer.get(), length);
+}
+
+string Time::ToUTCOffset(int hour_offset, int minute_offset) {
+	dtime_t time((hour_offset * Interval::MINS_PER_HOUR + minute_offset) * Interval::MICROS_PER_MINUTE);
+
+	char buffer[1 + 2 + 1 + 2];
+	idx_t length = 0;
+	buffer[length++] = (time.micros < 0 ? '-' : '+');
+	time.micros = std::abs(time.micros);
+
+	int32_t time_units[4];
+	Time::Convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
+
+	TimeToStringCast::FormatTwoDigits(buffer + length, time_units[0]);
+	length += 2;
+	if (time_units[1]) {
+		buffer[length++] = ':';
+		TimeToStringCast::FormatTwoDigits(buffer + length, time_units[1]);
+		length += 2;
+	}
+
+	return string(buffer, length);
+}
+
+dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+	int64_t result;
+	result = hour;                                             // hours
+	result = result * Interval::MINS_PER_HOUR + minute;        // hours -> minutes
+	result = result * Interval::SECS_PER_MINUTE + second;      // minutes -> seconds
+	result = result * Interval::MICROS_PER_SEC + microseconds; // seconds -> microseconds
+	return dtime_t(result);
+}
+
+// LCOV_EXCL_START
+#ifdef DEBUG
+static bool AssertValidTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+	if (hour < 0 || hour >= 24) {
+		return false;
+	}
+	if (minute < 0 || minute >= 60) {
+		return false;
+	}
+	if (second < 0 || second > 60) {
+		return false;
+	}
+	if (microseconds < 0 || microseconds > 1000000) {
+		return false;
+	}
+	return true;
+}
+#endif
+// LCOV_EXCL_STOP
+
+void Time::Convert(dtime_t dtime, int32_t &hour, int32_t &min, int32_t &sec, int32_t &micros) {
+	int64_t time = dtime.micros;
+	hour = int32_t(time / Interval::MICROS_PER_HOUR);
+	time -= int64_t(hour) * Interval::MICROS_PER_HOUR;
+	min = int32_t(time / Interval::MICROS_PER_MINUTE);
+	time -= int64_t(min) * Interval::MICROS_PER_MINUTE;
+	sec = int32_t(time / Interval::MICROS_PER_SEC);
+	time -= int64_t(sec) * Interval::MICROS_PER_SEC;
+	micros = int32_t(time);
+#ifdef DEBUG
+	D_ASSERT(AssertValidTime(hour, min, sec, micros));
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <ctime>
+
+namespace duckdb {
+
+static_assert(sizeof(timestamp_t) == sizeof(int64_t), "timestamp_t was padded");
+
+// timestamp/datetime uses 64 bits, high 32 bits for date and low 32 bits for time
+// string format is YYYY-MM-DDThh:mm:ssZ
+// T may be a space
+// Z is optional
+// ISO 8601
+bool Timestamp::TryConvertTimestamp(const char *str, idx_t len, timestamp_t &result) {
+	idx_t pos;
+	date_t date;
+	dtime_t time;
+	if (!Date::TryConvertDate(str, len, pos, date)) {
+		return false;
+	}
+	if (pos == len) {
+		// no time: only a date or special
+		if (date == date_t::infinity()) {
+			result = timestamp_t::infinity();
+			return true;
+		} else if (date == date_t::ninfinity()) {
+			result = timestamp_t::ninfinity();
+			return true;
+		}
+		return Timestamp::TryFromDatetime(date, dtime_t(0), result);
+	}
+	// try to parse a time field
+	if (str[pos] == ' ' || str[pos] == 'T') {
+		pos++;
+	}
+	idx_t time_pos = 0;
+	if (!Time::TryConvertTime(str + pos, len - pos, time_pos, time)) {
+		return false;
+	}
+	pos += time_pos;
+	if (!Timestamp::TryFromDatetime(date, time, result)) {
+		return false;
+	}
+	if (pos < len) {
+		// skip a "Z" at the end (as per the ISO8601 specs)
+		if (str[pos] == 'Z') {
+			pos++;
+		}
+		int hour_offset, minute_offset;
+		if (Timestamp::TryParseUTCOffset(str, pos, len, hour_offset, minute_offset)) {
+			result -= hour_offset * Interval::MICROS_PER_HOUR + minute_offset * Interval::MICROS_PER_MINUTE;
+		}
+
+		// skip any spaces at the end
+		while (pos < len && StringUtil::CharacterIsSpace(str[pos])) {
+			pos++;
+		}
+		if (pos < len) {
+			return false;
+		}
+	}
+	return true;
+}
+
+string Timestamp::ConversionError(const string &str) {
+	return StringUtil::Format("timestamp field value out of range: \"%s\", "
+	                          "expected format is (YYYY-MM-DD HH:MM:SS[.MS])",
+	                          str);
+}
+
+string Timestamp::ConversionError(string_t str) {
+	return Timestamp::ConversionError(str.GetString());
+}
+
+timestamp_t Timestamp::FromCString(const char *str, idx_t len) {
+	timestamp_t result;
+	if (!Timestamp::TryConvertTimestamp(str, len, result)) {
+		throw ConversionException(Timestamp::ConversionError(string(str, len)));
+	}
+	return result;
+}
+
+bool Timestamp::TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hour_offset, int &minute_offset) {
+	minute_offset = 0;
+	idx_t curpos = pos;
+	// parse the next 3 characters
+	if (curpos + 3 > len) {
+		// no characters left to parse
+		return false;
+	}
+	char sign_char = str[curpos];
+	if (sign_char != '+' && sign_char != '-') {
+		// expected either + or -
+		return false;
+	}
+	curpos++;
+	if (!StringUtil::CharacterIsDigit(str[curpos]) || !StringUtil::CharacterIsDigit(str[curpos + 1])) {
+		// expected +HH or -HH
+		return false;
+	}
+	hour_offset = (str[curpos] - '0') * 10 + (str[curpos + 1] - '0');
+	if (sign_char == '-') {
+		hour_offset = -hour_offset;
+	}
+	curpos += 2;
+
+	// optional minute specifier: expected either "MM" or ":MM"
+	if (curpos >= len) {
+		// done, nothing left
+		pos = curpos;
+		return true;
+	}
+	if (str[curpos] == ':') {
+		curpos++;
+	}
+	if (curpos + 2 > len || !StringUtil::CharacterIsDigit(str[curpos]) ||
+	    !StringUtil::CharacterIsDigit(str[curpos + 1])) {
+		// no MM specifier
+		pos = curpos;
+		return true;
+	}
+	// we have an MM specifier: parse it
+	minute_offset = (str[curpos] - '0') * 10 + (str[curpos + 1] - '0');
+	if (sign_char == '-') {
+		minute_offset = -minute_offset;
+	}
+	pos = curpos + 2;
+	return true;
+}
+
+timestamp_t Timestamp::FromString(const string &str) {
+	return Timestamp::FromCString(str.c_str(), str.size());
+}
+
+string Timestamp::ToString(timestamp_t timestamp) {
+	if (timestamp == timestamp_t::infinity()) {
+		return Date::PINF;
+	} else if (timestamp == timestamp_t::ninfinity()) {
+		return Date::NINF;
+	}
+	date_t date;
+	dtime_t time;
+	Timestamp::Convert(timestamp, date, time);
+	return Date::ToString(date) + " " + Time::ToString(time);
+}
+
+date_t Timestamp::GetDate(timestamp_t timestamp) {
+	if (timestamp == timestamp_t::infinity()) {
+		return date_t::infinity();
+	} else if (timestamp == timestamp_t::ninfinity()) {
+		return date_t::ninfinity();
+	}
+	return date_t((timestamp.value + (timestamp.value < 0)) / Interval::MICROS_PER_DAY - (timestamp.value < 0));
+}
+
+dtime_t Timestamp::GetTime(timestamp_t timestamp) {
+	if (!IsFinite(timestamp)) {
+		throw ConversionException("Can't get TIME of infinite TIMESTAMP");
+	}
+	date_t date = Timestamp::GetDate(timestamp);
+	return dtime_t(timestamp.value - (int64_t(date.days) * int64_t(Interval::MICROS_PER_DAY)));
+}
+
+bool Timestamp::TryFromDatetime(date_t date, dtime_t time, timestamp_t &result) {
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY, result.value)) {
+		return false;
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(result.value, time.micros, result.value)) {
+		return false;
+	}
+	return Timestamp::IsFinite(result);
+}
+
+timestamp_t Timestamp::FromDatetime(date_t date, dtime_t time) {
+	timestamp_t result;
+	if (!TryFromDatetime(date, time, result)) {
+		throw Exception("Overflow exception in date/time -> timestamp conversion");
+	}
+	return result;
+}
+
+void Timestamp::Convert(timestamp_t timestamp, date_t &out_date, dtime_t &out_time) {
+	out_date = GetDate(timestamp);
+	int64_t days_micros;
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::MICROS_PER_DAY,
+	                                                               days_micros)) {
+		throw ConversionException("Date out of range in timestamp conversion");
+	}
+	out_time = dtime_t(timestamp.value - days_micros);
+	D_ASSERT(timestamp == Timestamp::FromDatetime(out_date, out_time));
+}
+
+timestamp_t Timestamp::GetCurrentTimestamp() {
+	auto now = system_clock::now();
+	auto epoch_ms = duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+	return Timestamp::FromEpochMs(epoch_ms);
+}
+
+timestamp_t Timestamp::FromEpochSeconds(int64_t sec) {
+	int64_t result;
+	if (!TryMultiplyOperator::Operation(sec, Interval::MICROS_PER_SEC, result)) {
+		throw ConversionException("Could not convert Timestamp(S) to Timestamp(US)");
+	}
+	return timestamp_t(result);
+}
+
+timestamp_t Timestamp::FromEpochMs(int64_t ms) {
+	int64_t result;
+	if (!TryMultiplyOperator::Operation(ms, Interval::MICROS_PER_MSEC, result)) {
+		throw ConversionException("Could not convert Timestamp(MS) to Timestamp(US)");
+	}
+	return timestamp_t(result);
+}
+
+timestamp_t Timestamp::FromEpochMicroSeconds(int64_t micros) {
+	return timestamp_t(micros);
+}
+
+timestamp_t Timestamp::FromEpochNanoSeconds(int64_t ns) {
+	return timestamp_t(ns / 1000);
+}
+
+int64_t Timestamp::GetEpochSeconds(timestamp_t timestamp) {
+	return timestamp.value / Interval::MICROS_PER_SEC;
+}
+
+int64_t Timestamp::GetEpochMs(timestamp_t timestamp) {
+	return timestamp.value / Interval::MICROS_PER_MSEC;
+}
+
+int64_t Timestamp::GetEpochMicroSeconds(timestamp_t timestamp) {
+	return timestamp.value;
+}
+
+int64_t Timestamp::GetEpochNanoSeconds(timestamp_t timestamp) {
+	int64_t result;
+	int64_t ns_in_us = 1000;
+	if (!TryMultiplyOperator::Operation(timestamp.value, ns_in_us, result)) {
+		throw ConversionException("Could not convert Timestamp(US) to Timestamp(NS)");
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+bool UUID::FromString(string str, hugeint_t &result) {
+	auto hex2char = [](char ch) -> unsigned char {
+		if (ch >= '0' && ch <= '9') {
+			return ch - '0';
+		}
+		if (ch >= 'a' && ch <= 'f') {
+			return 10 + ch - 'a';
+		}
+		if (ch >= 'A' && ch <= 'F') {
+			return 10 + ch - 'A';
+		}
+		return 0;
+	};
+	auto is_hex = [](char ch) -> bool {
+		return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+	};
+
+	if (str.empty()) {
+		return false;
+	}
+	int has_braces = 0;
+	if (str.front() == '{') {
+		has_braces = 1;
+	}
+	if (has_braces && str.back() != '}') {
+		return false;
+	}
+
+	result.lower = 0;
+	result.upper = 0;
+	size_t count = 0;
+	for (size_t i = has_braces; i < str.size() - has_braces; ++i) {
+		if (str[i] == '-') {
+			continue;
+		}
+		if (count >= 32 || !is_hex(str[i])) {
+			return false;
+		}
+		if (count >= 16) {
+			result.lower = (result.lower << 4) | hex2char(str[i]);
+		} else {
+			result.upper = (result.upper << 4) | hex2char(str[i]);
+		}
+		count++;
+	}
+	// Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
+	result.upper ^= (int64_t(1) << 63);
+	return count == 32;
+}
+
+void UUID::ToString(hugeint_t input, char *buf) {
+	auto byte_to_hex = [](char byte_val, char *buf, idx_t &pos) {
+		static char const HEX_DIGITS[] = "0123456789abcdef";
+		buf[pos++] = HEX_DIGITS[(byte_val >> 4) & 0xf];
+		buf[pos++] = HEX_DIGITS[byte_val & 0xf];
+	};
+
+	// Flip back before convert to string
+	int64_t upper = input.upper ^ (int64_t(1) << 63);
+	idx_t pos = 0;
+	byte_to_hex(upper >> 56 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 48 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 40 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 32 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(upper >> 24 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 16 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(upper >> 8 & 0xFF, buf, pos);
+	byte_to_hex(upper & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(input.lower >> 56 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 48 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(input.lower >> 40 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 32 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 24 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 16 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 8 & 0xFF, buf, pos);
+	byte_to_hex(input.lower & 0xFF, buf, pos);
+}
+
+hugeint_t UUID::GenerateRandomUUID(RandomEngine &engine) {
+	uint8_t bytes[16];
+	for (int i = 0; i < 16; i += 4) {
+		*reinterpret_cast<uint32_t *>(bytes + i) = engine.NextRandomInteger();
+	}
+	// variant must be 10xxxxxx
+	bytes[8] &= 0xBF;
+	bytes[8] |= 0x80;
+	// version must be 0100xxxx
+	bytes[6] &= 0x4F;
+	bytes[6] |= 0x40;
+
+	hugeint_t result;
+	result.upper = 0;
+	result.upper |= ((int64_t)bytes[0] << 56);
+	result.upper |= ((int64_t)bytes[1] << 48);
+	result.upper |= ((int64_t)bytes[3] << 40);
+	result.upper |= ((int64_t)bytes[4] << 32);
+	result.upper |= ((int64_t)bytes[5] << 24);
+	result.upper |= ((int64_t)bytes[6] << 16);
+	result.upper |= ((int64_t)bytes[7] << 8);
+	result.upper |= bytes[8];
+	result.lower = 0;
+	result.lower |= ((uint64_t)bytes[8] << 56);
+	result.lower |= ((uint64_t)bytes[9] << 48);
+	result.lower |= ((uint64_t)bytes[10] << 40);
+	result.lower |= ((uint64_t)bytes[11] << 32);
+	result.lower |= ((uint64_t)bytes[12] << 24);
+	result.lower |= ((uint64_t)bytes[13] << 16);
+	result.lower |= ((uint64_t)bytes[14] << 8);
+	result.lower |= bytes[15];
+	return result;
+}
+
+hugeint_t UUID::GenerateRandomUUID() {
+	RandomEngine engine;
+	return GenerateRandomUUID(engine);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ValidityData::ValidityData(idx_t count) : TemplatedValidityData(count) {
+}
+ValidityData::ValidityData(const ValidityMask &original, idx_t count)
+    : TemplatedValidityData(original.GetData(), count) {
+}
+
+void ValidityMask::Combine(const ValidityMask &other, idx_t count) {
+	if (other.AllValid()) {
+		// X & 1 = X
+		return;
+	}
+	if (AllValid()) {
+		// 1 & Y = Y
+		Initialize(other);
+		return;
+	}
+	if (validity_mask == other.validity_mask) {
+		// X & X == X
+		return;
+	}
+	// have to merge
+	// create a new validity mask that contains the combined mask
+	auto owned_data = move(validity_data);
+	auto data = GetData();
+	auto other_data = other.GetData();
+
+	Initialize(count);
+	auto result_data = GetData();
+
+	auto entry_count = ValidityData::EntryCount(count);
+	for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+		result_data[entry_idx] = data[entry_idx] & other_data[entry_idx];
+	}
+}
+
+// LCOV_EXCL_START
+string ValidityMask::ToString(idx_t count) const {
+	string result = "Validity Mask (" + to_string(count) + ") [";
+	for (idx_t i = 0; i < count; i++) {
+		result += RowIsValid(i) ? "." : "X";
+	}
+	result += "]";
+	return result;
+}
+// LCOV_EXCL_STOP
+
+void ValidityMask::Resize(idx_t old_size, idx_t new_size) {
+	if (validity_mask) {
+		auto new_size_count = EntryCount(new_size);
+		auto old_size_count = EntryCount(old_size);
+		auto new_owned_data = unique_ptr<validity_t[]>(new validity_t[new_size_count]);
+		for (idx_t entry_idx = 0; entry_idx < old_size_count; entry_idx++) {
+			new_owned_data[entry_idx] = validity_mask[entry_idx];
+		}
+		for (idx_t entry_idx = old_size_count; entry_idx < new_size_count; entry_idx++) {
+			new_owned_data[entry_idx] = ValidityData::MAX_ENTRY;
+		}
+		validity_data->owned_data = move(new_owned_data);
+		validity_mask = validity_data->owned_data.get();
+	} else {
+		Initialize(new_size);
+	}
+}
+
+void ValidityMask::Slice(const ValidityMask &other, idx_t offset) {
+	if (other.AllValid()) {
+		validity_mask = nullptr;
+		validity_data.reset();
+		return;
+	}
+	if (offset == 0) {
+		Initialize(other);
+		return;
+	}
+	ValidityMask new_mask(STANDARD_VECTOR_SIZE);
+
+// FIXME THIS NEEDS FIXING!
+#if 1
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		new_mask.Set(i - offset, other.RowIsValid(i));
+	}
+	Initialize(new_mask);
+#else
+	// first shift the "whole" units
+	idx_t entire_units = offset / BITS_PER_VALUE;
+	idx_t sub_units = offset - entire_units * BITS_PER_VALUE;
+	if (entire_units > 0) {
+		idx_t validity_idx;
+		for (validity_idx = 0; validity_idx + entire_units < STANDARD_ENTRY_COUNT; validity_idx++) {
+			new_mask.validity_mask[validity_idx] = other.validity_mask[validity_idx + entire_units];
+		}
+	}
+	// now we shift the remaining sub units
+	// this gets a bit more complicated because we have to shift over the borders of the entries
+	// e.g. suppose we have 2 entries of length 4 and we left-shift by two
+	// 0101|1010
+	// a regular left-shift of both gets us:
+	// 0100|1000
+	// we then OR the overflow (right-shifted by BITS_PER_VALUE - offset) together to get the correct result
+	// 0100|1000 ->
+	// 0110|1000
+	if (sub_units > 0) {
+		idx_t validity_idx;
+		for (validity_idx = 0; validity_idx + 1 < STANDARD_ENTRY_COUNT; validity_idx++) {
+			new_mask.validity_mask[validity_idx] =
+			    (other.validity_mask[validity_idx] >> sub_units) |
+			    (other.validity_mask[validity_idx + 1] << (BITS_PER_VALUE - sub_units));
+		}
+		new_mask.validity_mask[validity_idx] >>= sub_units;
+	}
+#ifdef DEBUG
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		D_ASSERT(new_mask.RowIsValid(i - offset) == other.RowIsValid(i));
+	}
+	Initialize(new_mask);
+#endif
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <utility>
+#include <cmath>
+
+namespace duckdb {
+
+Value::Value(LogicalType type) : type_(move(type)), is_null(true) {
+}
+
+Value::Value(int32_t val) : type_(LogicalType::INTEGER), is_null(false) {
+	value_.integer = val;
+}
+
+Value::Value(int64_t val) : type_(LogicalType::BIGINT), is_null(false) {
+	value_.bigint = val;
+}
+
+Value::Value(float val) : type_(LogicalType::FLOAT), is_null(false) {
+	value_.float_ = val;
+}
+
+Value::Value(double val) : type_(LogicalType::DOUBLE), is_null(false) {
+	value_.double_ = val;
+}
+
+Value::Value(const char *val) : Value(val ? string(val) : string()) {
+}
+
+Value::Value(std::nullptr_t val) : Value(LogicalType::VARCHAR) {
+}
+
+Value::Value(string_t val) : Value(string(val.GetDataUnsafe(), val.GetSize())) {
+}
+
+Value::Value(string val) : type_(LogicalType::VARCHAR), is_null(false), str_value(move(val)) {
+	if (!Value::StringIsValid(str_value.c_str(), str_value.size())) {
+		throw Exception("String value is not valid UTF8");
+	}
+}
+
+Value::~Value() {
+}
+
+Value::Value(const Value &other)
+    : type_(other.type_), is_null(other.is_null), value_(other.value_), str_value(other.str_value),
+      struct_value(other.struct_value), list_value(other.list_value) {
+}
+
+Value::Value(Value &&other) noexcept
+    : type_(move(other.type_)), is_null(other.is_null), value_(other.value_), str_value(move(other.str_value)),
+      struct_value(move(other.struct_value)), list_value(move(other.list_value)) {
+}
+
+Value &Value::operator=(const Value &other) {
+	type_ = other.type_;
+	is_null = other.is_null;
+	value_ = other.value_;
+	str_value = other.str_value;
+	struct_value = other.struct_value;
+	list_value = other.list_value;
+	return *this;
+}
+
+Value &Value::operator=(Value &&other) noexcept {
+	type_ = move(other.type_);
+	is_null = other.is_null;
+	value_ = other.value_;
+	str_value = move(other.str_value);
+	struct_value = move(other.struct_value);
+	list_value = move(other.list_value);
+	return *this;
+}
+
+Value Value::MinimumValue(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(false);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(NumericLimits<int8_t>::Minimum());
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(NumericLimits<int16_t>::Minimum());
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::SQLNULL:
+		return Value::INTEGER(NumericLimits<int32_t>::Minimum());
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(NumericLimits<int64_t>::Minimum());
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(NumericLimits<hugeint_t>::Minimum());
+	case LogicalTypeId::UUID:
+		return Value::UUID(NumericLimits<hugeint_t>::Minimum());
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(NumericLimits<uint8_t>::Minimum());
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(NumericLimits<uint16_t>::Minimum());
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(NumericLimits<uint32_t>::Minimum());
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(NumericLimits<uint64_t>::Minimum());
+	case LogicalTypeId::DATE:
+		return Value::DATE(Date::FromDate(Date::DATE_MIN_YEAR, Date::DATE_MIN_MONTH, Date::DATE_MIN_DAY));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(0));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY),
+		                        dtime_t(0));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return MinimumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_S);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return MinimumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_MS);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(NumericLimits<int64_t>::Minimum()));
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(0));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(Timestamp::FromDatetime(
+		    Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY), dtime_t(0)));
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(NumericLimits<float>::Minimum());
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(NumericLimits<double>::Minimum());
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(int16_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(int32_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(int64_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(-Hugeint::POWERS_OF_TEN[width] + 1, width, scale);
+		default:
+			throw InternalException("Unknown decimal type");
+		}
+	}
+	case LogicalTypeId::ENUM:
+		return Value::ENUM(0, type);
+	default:
+		throw InvalidTypeException(type, "MinimumValue requires numeric type");
+	}
+}
+
+Value Value::MaximumValue(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(true);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(NumericLimits<int8_t>::Maximum());
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(NumericLimits<int16_t>::Maximum());
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::SQLNULL:
+		return Value::INTEGER(NumericLimits<int32_t>::Maximum());
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(NumericLimits<int64_t>::Maximum());
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(NumericLimits<hugeint_t>::Maximum());
+	case LogicalTypeId::UUID:
+		return Value::UUID(NumericLimits<hugeint_t>::Maximum());
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(NumericLimits<uint8_t>::Maximum());
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(NumericLimits<uint16_t>::Maximum());
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(NumericLimits<uint32_t>::Maximum());
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(NumericLimits<uint64_t>::Maximum());
+	case LogicalTypeId::DATE:
+		return Value::DATE(Date::FromDate(Date::DATE_MAX_YEAR, Date::DATE_MAX_MONTH, Date::DATE_MAX_DAY));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(Interval::SECS_PER_DAY * Interval::MICROS_PER_SEC - 1));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(timestamp_t(NumericLimits<int64_t>::Maximum() - 1));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return MaximumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_MS);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(NumericLimits<int64_t>::Maximum() - 1));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return MaximumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_S);
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(Interval::SECS_PER_DAY * Interval::MICROS_PER_SEC - 1));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return MaximumValue(LogicalType::TIMESTAMP);
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(NumericLimits<float>::Maximum());
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(NumericLimits<double>::Maximum());
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(int16_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(int32_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(int64_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(Hugeint::POWERS_OF_TEN[width] - 1, width, scale);
+		default:
+			throw InternalException("Unknown decimal type");
+		}
+	}
+	case LogicalTypeId::ENUM:
+		return Value::ENUM(EnumType::GetSize(type) - 1, type);
+	default:
+		throw InvalidTypeException(type, "MaximumValue requires numeric type");
+	}
+}
+
+Value Value::BOOLEAN(int8_t value) {
+	Value result(LogicalType::BOOLEAN);
+	result.value_.boolean = value ? true : false;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TINYINT(int8_t value) {
+	Value result(LogicalType::TINYINT);
+	result.value_.tinyint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::SMALLINT(int16_t value) {
+	Value result(LogicalType::SMALLINT);
+	result.value_.smallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::INTEGER(int32_t value) {
+	Value result(LogicalType::INTEGER);
+	result.value_.integer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::BIGINT(int64_t value) {
+	Value result(LogicalType::BIGINT);
+	result.value_.bigint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::HUGEINT(hugeint_t value) {
+	Value result(LogicalType::HUGEINT);
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UUID(hugeint_t value) {
+	Value result(LogicalType::UUID);
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UUID(const string &value) {
+	Value result(LogicalType::UUID);
+	result.value_.hugeint = UUID::FromString(value);
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UTINYINT(uint8_t value) {
+	Value result(LogicalType::UTINYINT);
+	result.value_.utinyint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::USMALLINT(uint16_t value) {
+	Value result(LogicalType::USMALLINT);
+	result.value_.usmallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UINTEGER(uint32_t value) {
+	Value result(LogicalType::UINTEGER);
+	result.value_.uinteger = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UBIGINT(uint64_t value) {
+	Value result(LogicalType::UBIGINT);
+	result.value_.ubigint = value;
+	result.is_null = false;
+	return result;
+}
+
+bool Value::FloatIsFinite(float value) {
+	return !(std::isnan(value) || std::isinf(value));
+}
+
+bool Value::DoubleIsFinite(double value) {
+	return !(std::isnan(value) || std::isinf(value));
+}
+
+template <>
+bool Value::IsNan(float input) {
+	return std::isnan(input);
+}
+
+template <>
+bool Value::IsNan(double input) {
+	return std::isnan(input);
+}
+
+template <>
+bool Value::IsFinite(float input) {
+	return Value::FloatIsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(double input) {
+	return Value::DoubleIsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(date_t input) {
+	return Date::IsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(timestamp_t input) {
+	return Timestamp::IsFinite(input);
+}
+
+bool Value::StringIsValid(const char *str, idx_t length) {
+	auto utf_type = Utf8Proc::Analyze(str, length);
+	return utf_type != UnicodeType::INVALID;
+}
+
+Value Value::DECIMAL(int16_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width <= Decimal::MAX_WIDTH_INT16);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.smallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(int32_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT16 && width <= Decimal::MAX_WIDTH_INT32);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.integer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(int64_t value, uint8_t width, uint8_t scale) {
+	auto decimal_type = LogicalType::DECIMAL(width, scale);
+	Value result(decimal_type);
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		result.value_.smallint = value;
+		break;
+	case PhysicalType::INT32:
+		result.value_.integer = value;
+		break;
+	case PhysicalType::INT64:
+		result.value_.bigint = value;
+		break;
+	default:
+		result.value_.hugeint = value;
+		break;
+	}
+	result.type_.Verify();
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(hugeint_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT64 && width <= Decimal::MAX_WIDTH_INT128);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::FLOAT(float value) {
+	Value result(LogicalType::FLOAT);
+	result.value_.float_ = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DOUBLE(double value) {
+	Value result(LogicalType::DOUBLE);
+	result.value_.double_ = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::HASH(hash_t value) {
+	Value result(LogicalType::HASH);
+	result.value_.hash = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::POINTER(uintptr_t value) {
+	Value result(LogicalType::POINTER);
+	result.value_.pointer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DATE(date_t value) {
+	Value result(LogicalType::DATE);
+	result.value_.date = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DATE(int32_t year, int32_t month, int32_t day) {
+	return Value::DATE(Date::FromDate(year, month, day));
+}
+
+Value Value::TIME(dtime_t value) {
+	Value result(LogicalType::TIME);
+	result.value_.time = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMETZ(dtime_t value) {
+	Value result(LogicalType::TIME_TZ);
+	result.value_.time = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIME(int32_t hour, int32_t min, int32_t sec, int32_t micros) {
+	return Value::TIME(Time::FromTime(hour, min, sec, micros));
+}
+
+Value Value::TIMESTAMP(timestamp_t value) {
+	Value result(LogicalType::TIMESTAMP);
+	result.value_.timestamp = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPTZ(timestamp_t value) {
+	Value result(LogicalType::TIMESTAMP_TZ);
+	result.value_.timestamp = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPNS(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_NS);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPMS(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_MS);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPSEC(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_S);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMP(date_t date, dtime_t time) {
+	return Value::TIMESTAMP(Timestamp::FromDatetime(date, time));
+}
+
+Value Value::TIMESTAMP(int32_t year, int32_t month, int32_t day, int32_t hour, int32_t min, int32_t sec,
+                       int32_t micros) {
+	auto val = Value::TIMESTAMP(Date::FromDate(year, month, day), Time::FromTime(hour, min, sec, micros));
+	val.type_ = LogicalType::TIMESTAMP;
+	return val;
+}
+
+Value Value::STRUCT(child_list_t<Value> values) {
+	Value result;
+	child_list_t<LogicalType> child_types;
+	for (auto &child : values) {
+		child_types.push_back(make_pair(move(child.first), child.second.type()));
+		result.struct_value.push_back(move(child.second));
+	}
+	result.type_ = LogicalType::STRUCT(move(child_types));
+
+	result.is_null = false;
+	return result;
+}
+
+Value Value::MAP(Value key, Value value) {
+	Value result;
+	child_list_t<LogicalType> child_types;
+	child_types.push_back({"key", key.type()});
+	child_types.push_back({"value", value.type()});
+
+	result.type_ = LogicalType::MAP(move(child_types));
+
+	result.struct_value.push_back(move(key));
+	result.struct_value.push_back(move(value));
+	result.is_null = false;
+	return result;
+}
+
+Value Value::LIST(vector<Value> values) {
+	if (values.empty()) {
+		throw InternalException("Value::LIST requires a non-empty list of values. Use Value::EMPTYLIST instead.");
+	}
+#ifdef DEBUG
+	for (idx_t i = 1; i < values.size(); i++) {
+		D_ASSERT(values[i].type() == values[0].type());
+	}
+#endif
+	Value result;
+	result.type_ = LogicalType::LIST(values[0].type());
+	result.list_value = move(values);
+	result.is_null = false;
+	return result;
+}
+
+Value Value::LIST(LogicalType child_type, vector<Value> values) {
+	if (values.empty()) {
+		return Value::EMPTYLIST(move(child_type));
+	}
+	for (auto &val : values) {
+		val = val.CastAs(child_type);
+	}
+	return Value::LIST(move(values));
+}
+
+Value Value::EMPTYLIST(LogicalType child_type) {
+	Value result;
+	result.type_ = LogicalType::LIST(move(child_type));
+	result.is_null = false;
+	return result;
+}
+
+Value Value::BLOB(const_data_ptr_t data, idx_t len) {
+	Value result(LogicalType::BLOB);
+	result.is_null = false;
+	result.str_value = string((const char *)data, len);
+	return result;
+}
+
+Value Value::BLOB(const string &data) {
+	Value result(LogicalType::BLOB);
+	result.is_null = false;
+	result.str_value = Blob::ToBlob(string_t(data));
+	return result;
+}
+
+Value Value::JSON(const char *val) {
+	auto result = Value(val);
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::JSON(string_t val) {
+	auto result = Value(val);
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::JSON(string val) {
+	auto result = Value(move(val));
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::ENUM(uint64_t value, const LogicalType &original_type) {
+	D_ASSERT(original_type.id() == LogicalTypeId::ENUM);
+	Value result(original_type);
+	switch (original_type.InternalType()) {
+	case PhysicalType::UINT8:
+		result.value_.utinyint = value;
+		break;
+	case PhysicalType::UINT16:
+		result.value_.usmallint = value;
+		break;
+	case PhysicalType::UINT32:
+		result.value_.uinteger = value;
+		break;
+	case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+		result.value_.ubigint = value;
+		break;
+	default:
+		throw InternalException("Incorrect Physical Type for ENUM");
+	}
+	result.is_null = false;
+	return result;
+}
+
+Value Value::INTERVAL(int32_t months, int32_t days, int64_t micros) {
+	Value result(LogicalType::INTERVAL);
+	result.is_null = false;
+	result.value_.interval.months = months;
+	result.value_.interval.days = days;
+	result.value_.interval.micros = micros;
+	return result;
+}
+
+Value Value::INTERVAL(interval_t interval) {
+	return Value::INTERVAL(interval.months, interval.days, interval.micros);
+}
+
+//===--------------------------------------------------------------------===//
+// CreateValue
+//===--------------------------------------------------------------------===//
+template <>
+Value Value::CreateValue(bool value) {
+	return Value::BOOLEAN(value);
+}
+
+template <>
+Value Value::CreateValue(int8_t value) {
+	return Value::TINYINT(value);
+}
+
+template <>
+Value Value::CreateValue(int16_t value) {
+	return Value::SMALLINT(value);
+}
+
+template <>
+Value Value::CreateValue(int32_t value) {
+	return Value::INTEGER(value);
+}
+
+template <>
+Value Value::CreateValue(int64_t value) {
+	return Value::BIGINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint8_t value) {
+	return Value::UTINYINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint16_t value) {
+	return Value::USMALLINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint32_t value) {
+	return Value::UINTEGER(value);
+}
+
+template <>
+Value Value::CreateValue(uint64_t value) {
+	return Value::UBIGINT(value);
+}
+
+template <>
+Value Value::CreateValue(hugeint_t value) {
+	return Value::HUGEINT(value);
+}
+
+template <>
+Value Value::CreateValue(date_t value) {
+	return Value::DATE(value);
+}
+
+template <>
+Value Value::CreateValue(dtime_t value) {
+	return Value::TIME(value);
+}
+
+template <>
+Value Value::CreateValue(timestamp_t value) {
+	return Value::TIMESTAMP(value);
+}
+
+template <>
+Value Value::CreateValue(const char *value) {
+	return Value(string(value));
+}
+
+template <>
+Value Value::CreateValue(string value) { // NOLINT: required for templating
+	return Value::BLOB(value);
+}
+
+template <>
+Value Value::CreateValue(string_t value) {
+	return Value(value);
+}
+
+template <>
+Value Value::CreateValue(float value) {
+	return Value::FLOAT(value);
+}
+
+template <>
+Value Value::CreateValue(double value) {
+	return Value::DOUBLE(value);
+}
+
+template <>
+Value Value::CreateValue(interval_t value) {
+	return Value::INTERVAL(value);
+}
+
+template <>
+Value Value::CreateValue(Value value) {
+	return value;
+}
+
+//===--------------------------------------------------------------------===//
+// GetValue
+//===--------------------------------------------------------------------===//
+template <class T>
+T Value::GetValueInternal() const {
+	if (IsNull()) {
+		return NullValue<T>();
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Cast::Operation<bool, T>(value_.boolean);
+	case LogicalTypeId::TINYINT:
+		return Cast::Operation<int8_t, T>(value_.tinyint);
+	case LogicalTypeId::SMALLINT:
+		return Cast::Operation<int16_t, T>(value_.smallint);
+	case LogicalTypeId::INTEGER:
+		return Cast::Operation<int32_t, T>(value_.integer);
+	case LogicalTypeId::BIGINT:
+		return Cast::Operation<int64_t, T>(value_.bigint);
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return Cast::Operation<hugeint_t, T>(value_.hugeint);
+	case LogicalTypeId::DATE:
+		return Cast::Operation<date_t, T>(value_.date);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return Cast::Operation<dtime_t, T>(value_.time);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Cast::Operation<timestamp_t, T>(value_.timestamp);
+	case LogicalTypeId::UTINYINT:
+		return Cast::Operation<uint8_t, T>(value_.utinyint);
+	case LogicalTypeId::USMALLINT:
+		return Cast::Operation<uint16_t, T>(value_.usmallint);
+	case LogicalTypeId::UINTEGER:
+		return Cast::Operation<uint32_t, T>(value_.uinteger);
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::UBIGINT:
+		return Cast::Operation<uint64_t, T>(value_.ubigint);
+	case LogicalTypeId::FLOAT:
+		return Cast::Operation<float, T>(value_.float_);
+	case LogicalTypeId::DOUBLE:
+		return Cast::Operation<double, T>(value_.double_);
+	case LogicalTypeId::VARCHAR:
+		return Cast::Operation<string_t, T>(str_value.c_str());
+	case LogicalTypeId::INTERVAL:
+		return Cast::Operation<interval_t, T>(value_.interval);
+	case LogicalTypeId::DECIMAL:
+		return CastAs(LogicalType::DOUBLE).GetValueInternal<T>();
+	case LogicalTypeId::ENUM: {
+		switch (type_.InternalType()) {
+		case PhysicalType::UINT8:
+			return Cast::Operation<uint8_t, T>(value_.utinyint);
+		case PhysicalType::UINT16:
+			return Cast::Operation<uint16_t, T>(value_.usmallint);
+		case PhysicalType::UINT32:
+			return Cast::Operation<uint32_t, T>(value_.uinteger);
+		default:
+			throw InternalException("Invalid Internal Type for ENUMs");
+		}
+	}
+
+	default:
+		throw NotImplementedException("Unimplemented type \"%s\" for GetValue()", type_.ToString());
+	}
+}
+
+template <>
+bool Value::GetValue() const {
+	return GetValueInternal<int8_t>();
+}
+template <>
+int8_t Value::GetValue() const {
+	return GetValueInternal<int8_t>();
+}
+template <>
+int16_t Value::GetValue() const {
+	return GetValueInternal<int16_t>();
+}
+template <>
+int32_t Value::GetValue() const {
+	if (type_.id() == LogicalTypeId::DATE) {
+		return value_.integer;
+	}
+	return GetValueInternal<int32_t>();
+}
+template <>
+int64_t Value::GetValue() const {
+	switch (type_.id()) {
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return value_.bigint;
+	default:
+		return GetValueInternal<int64_t>();
+	}
+}
+template <>
+hugeint_t Value::GetValue() const {
+	return GetValueInternal<hugeint_t>();
+}
+template <>
+uint8_t Value::GetValue() const {
+	return GetValueInternal<uint8_t>();
+}
+template <>
+uint16_t Value::GetValue() const {
+	return GetValueInternal<uint16_t>();
+}
+template <>
+uint32_t Value::GetValue() const {
+	return GetValueInternal<uint32_t>();
+}
+template <>
+uint64_t Value::GetValue() const {
+	return GetValueInternal<uint64_t>();
+}
+template <>
+string Value::GetValue() const {
+	return ToString();
+}
+template <>
+float Value::GetValue() const {
+	return GetValueInternal<float>();
+}
+template <>
+double Value::GetValue() const {
+	return GetValueInternal<double>();
+}
+template <>
+date_t Value::GetValue() const {
+	return GetValueInternal<date_t>();
+}
+template <>
+dtime_t Value::GetValue() const {
+	return GetValueInternal<dtime_t>();
+}
+template <>
+timestamp_t Value::GetValue() const {
+	return GetValueInternal<timestamp_t>();
+}
+
+template <>
+DUCKDB_API interval_t Value::GetValue() const {
+	return GetValueInternal<interval_t>();
+}
+
+template <>
+DUCKDB_API Value Value::GetValue() const {
+	return Value(*this);
+}
+
+uintptr_t Value::GetPointer() const {
+	D_ASSERT(type() == LogicalType::POINTER);
+	return value_.pointer;
+}
+
+Value Value::Numeric(const LogicalType &type, int64_t value) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		D_ASSERT(value == 0 || value == 1);
+		return Value::BOOLEAN(value ? 1 : 0);
+	case LogicalTypeId::TINYINT:
+		D_ASSERT(value >= NumericLimits<int8_t>::Minimum() && value <= NumericLimits<int8_t>::Maximum());
+		return Value::TINYINT((int8_t)value);
+	case LogicalTypeId::SMALLINT:
+		D_ASSERT(value >= NumericLimits<int16_t>::Minimum() && value <= NumericLimits<int16_t>::Maximum());
+		return Value::SMALLINT((int16_t)value);
+	case LogicalTypeId::INTEGER:
+		D_ASSERT(value >= NumericLimits<int32_t>::Minimum() && value <= NumericLimits<int32_t>::Maximum());
+		return Value::INTEGER((int32_t)value);
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(value);
+	case LogicalTypeId::UTINYINT:
+		D_ASSERT(value >= NumericLimits<uint8_t>::Minimum() && value <= NumericLimits<uint8_t>::Maximum());
+		return Value::UTINYINT((uint8_t)value);
+	case LogicalTypeId::USMALLINT:
+		D_ASSERT(value >= NumericLimits<uint16_t>::Minimum() && value <= NumericLimits<uint16_t>::Maximum());
+		return Value::USMALLINT((uint16_t)value);
+	case LogicalTypeId::UINTEGER:
+		D_ASSERT(value >= NumericLimits<uint32_t>::Minimum() && value <= NumericLimits<uint32_t>::Maximum());
+		return Value::UINTEGER((uint32_t)value);
+	case LogicalTypeId::UBIGINT:
+		D_ASSERT(value >= 0);
+		return Value::UBIGINT(value);
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(value);
+	case LogicalTypeId::DECIMAL:
+		return Value::DECIMAL(value, DecimalType::GetWidth(type), DecimalType::GetScale(type));
+	case LogicalTypeId::FLOAT:
+		return Value((float)value);
+	case LogicalTypeId::DOUBLE:
+		return Value((double)value);
+	case LogicalTypeId::POINTER:
+		return Value::POINTER(value);
+	case LogicalTypeId::DATE:
+		D_ASSERT(value >= NumericLimits<int32_t>::Minimum() && value <= NumericLimits<int32_t>::Maximum());
+		return Value::DATE(date_t(value));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(value));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Value::TIMESTAMPMS(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Value::TIMESTAMPSEC(timestamp_t(value));
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(value));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(timestamp_t(value));
+	case LogicalTypeId::ENUM:
+		switch (type.InternalType()) {
+		case PhysicalType::UINT8:
+			D_ASSERT(value >= NumericLimits<uint8_t>::Minimum() && value <= NumericLimits<uint8_t>::Maximum());
+			return Value::UTINYINT((uint8_t)value);
+		case PhysicalType::UINT16:
+			D_ASSERT(value >= NumericLimits<uint16_t>::Minimum() && value <= NumericLimits<uint16_t>::Maximum());
+			return Value::USMALLINT((uint16_t)value);
+		case PhysicalType::UINT32:
+			D_ASSERT(value >= NumericLimits<uint32_t>::Minimum() && value <= NumericLimits<uint32_t>::Maximum());
+			return Value::UINTEGER((uint32_t)value);
+		default:
+			throw InternalException("Enum doesn't accept this physical type");
+		}
+	default:
+		throw InvalidTypeException(type, "Numeric requires numeric type");
+	}
+}
+
+Value Value::Numeric(const LogicalType &type, hugeint_t value) {
+#ifdef DEBUG
+	// perform a throwing cast to verify that the type fits
+	Value::HUGEINT(value).CastAs(type);
+#endif
+	switch (type.id()) {
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(value);
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(Hugeint::Cast<uint64_t>(value));
+	default:
+		return Value::Numeric(type, Hugeint::Cast<int64_t>(value));
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// GetValueUnsafe
+//===--------------------------------------------------------------------===//
+template <>
+DUCKDB_API bool Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::BOOL);
+	return value_.boolean;
+}
+
+template <>
+int8_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT8 || type_.InternalType() == PhysicalType::BOOL);
+	return value_.tinyint;
+}
+
+template <>
+int16_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT16);
+	return value_.smallint;
+}
+
+template <>
+int32_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.integer;
+}
+
+template <>
+int64_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.bigint;
+}
+
+template <>
+hugeint_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT128);
+	return value_.hugeint;
+}
+
+template <>
+uint8_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT8);
+	return value_.utinyint;
+}
+
+template <>
+uint16_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT16);
+	return value_.usmallint;
+}
+
+template <>
+uint32_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT32);
+	return value_.uinteger;
+}
+
+template <>
+uint64_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT64);
+	return value_.ubigint;
+}
+
+template <>
+string Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::VARCHAR);
+	return str_value;
+}
+
+template <>
+DUCKDB_API string_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::VARCHAR);
+	return string_t(str_value);
+}
+
+template <>
+float Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::FLOAT);
+	return value_.float_;
+}
+
+template <>
+double Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::DOUBLE);
+	return value_.double_;
+}
+
+template <>
+date_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.date;
+}
+
+template <>
+dtime_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.time;
+}
+
+template <>
+timestamp_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.timestamp;
+}
+
+template <>
+interval_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INTERVAL);
+	return value_.interval;
+}
+
+//===--------------------------------------------------------------------===//
+// GetReferenceUnsafe
+//===--------------------------------------------------------------------===//
+template <>
+int8_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT8 || type_.InternalType() == PhysicalType::BOOL);
+	return value_.tinyint;
+}
+
+template <>
+int16_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT16);
+	return value_.smallint;
+}
+
+template <>
+int32_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.integer;
+}
+
+template <>
+int64_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.bigint;
+}
+
+template <>
+hugeint_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT128);
+	return value_.hugeint;
+}
+
+template <>
+uint8_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT8);
+	return value_.utinyint;
+}
+
+template <>
+uint16_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT16);
+	return value_.usmallint;
+}
+
+template <>
+uint32_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT32);
+	return value_.uinteger;
+}
+
+template <>
+uint64_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT64);
+	return value_.ubigint;
+}
+
+template <>
+float &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::FLOAT);
+	return value_.float_;
+}
+
+template <>
+double &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::DOUBLE);
+	return value_.double_;
+}
+
+template <>
+date_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.date;
+}
+
+template <>
+dtime_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.time;
+}
+
+template <>
+timestamp_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.timestamp;
+}
+
+template <>
+interval_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INTERVAL);
+	return value_.interval;
+}
+
+//===--------------------------------------------------------------------===//
+// Hash
+//===--------------------------------------------------------------------===//
+hash_t Value::Hash() const {
+	if (IsNull()) {
+		return 0;
+	}
+	switch (type_.InternalType()) {
+	case PhysicalType::BOOL:
+		return duckdb::Hash(value_.boolean);
+	case PhysicalType::INT8:
+		return duckdb::Hash(value_.tinyint);
+	case PhysicalType::INT16:
+		return duckdb::Hash(value_.smallint);
+	case PhysicalType::INT32:
+		return duckdb::Hash(value_.integer);
+	case PhysicalType::INT64:
+		return duckdb::Hash(value_.bigint);
+	case PhysicalType::UINT8:
+		return duckdb::Hash(value_.utinyint);
+	case PhysicalType::UINT16:
+		return duckdb::Hash(value_.usmallint);
+	case PhysicalType::UINT32:
+		return duckdb::Hash(value_.uinteger);
+	case PhysicalType::UINT64:
+		return duckdb::Hash(value_.ubigint);
+	case PhysicalType::INT128:
+		return duckdb::Hash(value_.hugeint);
+	case PhysicalType::FLOAT:
+		return duckdb::Hash(value_.float_);
+	case PhysicalType::DOUBLE:
+		return duckdb::Hash(value_.double_);
+	case PhysicalType::INTERVAL:
+		return duckdb::Hash(value_.interval);
+	case PhysicalType::VARCHAR:
+		return duckdb::Hash(string_t(StringValue::Get(*this)));
+	case PhysicalType::STRUCT: {
+		auto &struct_children = StructValue::GetChildren(*this);
+		hash_t hash = 0;
+		for (auto &entry : struct_children) {
+			hash ^= entry.Hash();
+		}
+		return hash;
+	}
+	case PhysicalType::LIST: {
+		auto &list_children = ListValue::GetChildren(*this);
+		hash_t hash = 0;
+		for (auto &entry : list_children) {
+			hash ^= entry.Hash();
+		}
+		return hash;
+	}
+	default:
+		throw InternalException("Unimplemented type for value hash");
+	}
+}
+
+string Value::ToString() const {
+	if (IsNull()) {
+		return "NULL";
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return value_.boolean ? "True" : "False";
+	case LogicalTypeId::TINYINT:
+		return to_string(value_.tinyint);
+	case LogicalTypeId::SMALLINT:
+		return to_string(value_.smallint);
+	case LogicalTypeId::INTEGER:
+		return to_string(value_.integer);
+	case LogicalTypeId::BIGINT:
+		return to_string(value_.bigint);
+	case LogicalTypeId::UTINYINT:
+		return to_string(value_.utinyint);
+	case LogicalTypeId::USMALLINT:
+		return to_string(value_.usmallint);
+	case LogicalTypeId::UINTEGER:
+		return to_string(value_.uinteger);
+	case LogicalTypeId::UBIGINT:
+		return to_string(value_.ubigint);
+	case LogicalTypeId::HUGEINT:
+		return Hugeint::ToString(value_.hugeint);
+	case LogicalTypeId::UUID:
+		return UUID::ToString(value_.hugeint);
+	case LogicalTypeId::FLOAT:
+		return duckdb_fmt::format("{}", value_.float_);
+	case LogicalTypeId::DOUBLE:
+		return duckdb_fmt::format("{}", value_.double_);
+	case LogicalTypeId::DECIMAL: {
+		auto internal_type = type_.InternalType();
+		auto scale = DecimalType::GetScale(type_);
+		if (internal_type == PhysicalType::INT16) {
+			return Decimal::ToString(value_.smallint, scale);
+		} else if (internal_type == PhysicalType::INT32) {
+			return Decimal::ToString(value_.integer, scale);
+		} else if (internal_type == PhysicalType::INT64) {
+			return Decimal::ToString(value_.bigint, scale);
+		} else {
+			D_ASSERT(internal_type == PhysicalType::INT128);
+			return Decimal::ToString(value_.hugeint, scale);
+		}
+	}
+	case LogicalTypeId::DATE:
+		return Date::ToString(value_.date);
+	case LogicalTypeId::TIME:
+		return Time::ToString(value_.time);
+	case LogicalTypeId::TIMESTAMP:
+		return Timestamp::ToString(value_.timestamp);
+	case LogicalTypeId::TIME_TZ:
+		return Time::ToString(value_.time) + Time::ToUTCOffset(0, 0);
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		// Infinite TSTZ values do not display offsets in PG.
+		auto ret = Timestamp::ToString(value_.timestamp);
+		if (Timestamp::IsFinite(value_.timestamp)) {
+			ret += Time::ToUTCOffset(0, 0);
+		}
+		return ret;
+	}
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Timestamp::ToString(Timestamp::FromEpochSeconds(value_.timestamp.value));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Timestamp::ToString(Timestamp::FromEpochMs(value_.timestamp.value));
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Timestamp::ToString(Timestamp::FromEpochNanoSeconds(value_.timestamp.value));
+	case LogicalTypeId::INTERVAL:
+		return Interval::ToString(value_.interval);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		return str_value;
+	case LogicalTypeId::BLOB:
+		return Blob::ToString(string_t(str_value));
+	case LogicalTypeId::POINTER:
+		return to_string(value_.pointer);
+	case LogicalTypeId::STRUCT: {
+		string ret = "{";
+		auto &child_types = StructType::GetChildTypes(type_);
+		for (size_t i = 0; i < struct_value.size(); i++) {
+			auto &name = child_types[i].first;
+			auto &child = struct_value[i];
+			ret += "'" + name + "': " + child.ToString();
+			if (i < struct_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::LIST: {
+		string ret = "[";
+		for (size_t i = 0; i < list_value.size(); i++) {
+			auto &child = list_value[i];
+			ret += child.ToString();
+			if (i < list_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "]";
+		return ret;
+	}
+	case LogicalTypeId::MAP: {
+		string ret = "{";
+		auto &key_list = struct_value[0].list_value;
+		auto &value_list = struct_value[1].list_value;
+		for (size_t i = 0; i < key_list.size(); i++) {
+			ret += key_list[i].ToString() + "=" + value_list[i].ToString();
+			if (i < key_list.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::ENUM: {
+		auto &values_insert_order = EnumType::GetValuesInsertOrder(type_);
+		uint64_t enum_idx;
+		switch (type_.InternalType()) {
+		case PhysicalType::UINT8:
+			enum_idx = value_.utinyint;
+			break;
+		case PhysicalType::UINT16:
+			enum_idx = value_.usmallint;
+			break;
+		case PhysicalType::UINT32:
+			enum_idx = value_.uinteger;
+			break;
+		case PhysicalType::UINT64:
+			return string((const char *)value_.bigint);
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+		return values_insert_order.GetValue(enum_idx).ToString();
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for printing: %s", type_.ToString());
+	}
+}
+
+string Value::ToSQLString() const {
+	if (IsNull()) {
+		return ToString();
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::UUID:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::INTERVAL:
+	case LogicalTypeId::BLOB:
+		return "'" + ToString() + "'::" + type_.ToString();
+	case LogicalTypeId::VARCHAR:
+		return "'" + StringUtil::Replace(ToString(), "'", "''") + "'";
+	case LogicalTypeId::STRUCT: {
+		string ret = "{";
+		auto &child_types = StructType::GetChildTypes(type_);
+		for (size_t i = 0; i < struct_value.size(); i++) {
+			auto &name = child_types[i].first;
+			auto &child = struct_value[i];
+			ret += "'" + name + "': " + child.ToSQLString();
+			if (i < struct_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::FLOAT:
+		if (!FloatIsFinite(FloatValue::Get(*this))) {
+			return "'" + ToString() + "'::" + type_.ToString();
+		}
+		return ToString();
+	case LogicalTypeId::DOUBLE: {
+		double val = DoubleValue::Get(*this);
+		if (!DoubleIsFinite(val)) {
+			if (!Value::IsNan(val)) {
+				// to infinity and beyond
+				return val < 0 ? "-1e1000" : "1e1000";
+			}
+			return "'" + ToString() + "'::" + type_.ToString();
+		}
+		return ToString();
+	}
+	case LogicalTypeId::LIST: {
+		string ret = "[";
+		for (size_t i = 0; i < list_value.size(); i++) {
+			auto &child = list_value[i];
+			ret += child.ToSQLString();
+			if (i < list_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "]";
+		return ret;
+	}
+	default:
+		return ToString();
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Type-specific getters
+//===--------------------------------------------------------------------===//
+bool BooleanValue::Get(const Value &value) {
+	return value.GetValueUnsafe<bool>();
+}
+
+int8_t TinyIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int8_t>();
+}
+
+int16_t SmallIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int16_t>();
+}
+
+int32_t IntegerValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int32_t>();
+}
+
+int64_t BigIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int64_t>();
+}
+
+hugeint_t HugeIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<hugeint_t>();
+}
+
+uint8_t UTinyIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint8_t>();
+}
+
+uint16_t USmallIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint16_t>();
+}
+
+uint32_t UIntegerValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint32_t>();
+}
+
+uint64_t UBigIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint64_t>();
+}
+
+float FloatValue::Get(const Value &value) {
+	return value.GetValueUnsafe<float>();
+}
+
+double DoubleValue::Get(const Value &value) {
+	return value.GetValueUnsafe<double>();
+}
+
+const string &StringValue::Get(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::VARCHAR);
+	return value.str_value;
+}
+
+date_t DateValue::Get(const Value &value) {
+	return value.GetValueUnsafe<date_t>();
+}
+
+dtime_t TimeValue::Get(const Value &value) {
+	return value.GetValueUnsafe<dtime_t>();
+}
+
+timestamp_t TimestampValue::Get(const Value &value) {
+	return value.GetValueUnsafe<timestamp_t>();
+}
+
+interval_t IntervalValue::Get(const Value &value) {
+	return value.GetValueUnsafe<interval_t>();
+}
+
+const vector<Value> &StructValue::GetChildren(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::STRUCT);
+	return value.struct_value;
+}
+
+const vector<Value> &ListValue::GetChildren(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::LIST);
+	return value.list_value;
+}
+
+hugeint_t IntegralValue::Get(const Value &value) {
+	switch (value.type().InternalType()) {
+	case PhysicalType::INT8:
+		return TinyIntValue::Get(value);
+	case PhysicalType::INT16:
+		return SmallIntValue::Get(value);
+	case PhysicalType::INT32:
+		return IntegerValue::Get(value);
+	case PhysicalType::INT64:
+		return BigIntValue::Get(value);
+	case PhysicalType::INT128:
+		return HugeIntValue::Get(value);
+	case PhysicalType::UINT8:
+		return UTinyIntValue::Get(value);
+	case PhysicalType::UINT16:
+		return USmallIntValue::Get(value);
+	case PhysicalType::UINT32:
+		return UIntegerValue::Get(value);
+	case PhysicalType::UINT64:
+		return UBigIntValue::Get(value);
+	default:
+		throw InternalException("Invalid internal type \"%s\" for IntegralValue::Get", value.type().ToString());
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Comparison Operators
+//===--------------------------------------------------------------------===//
+bool Value::operator==(const Value &rhs) const {
+	return ValueOperations::Equals(*this, rhs);
+}
+
+bool Value::operator!=(const Value &rhs) const {
+	return ValueOperations::NotEquals(*this, rhs);
+}
+
+bool Value::operator<(const Value &rhs) const {
+	return ValueOperations::LessThan(*this, rhs);
+}
+
+bool Value::operator>(const Value &rhs) const {
+	return ValueOperations::GreaterThan(*this, rhs);
+}
+
+bool Value::operator<=(const Value &rhs) const {
+	return ValueOperations::LessThanEquals(*this, rhs);
+}
+
+bool Value::operator>=(const Value &rhs) const {
+	return ValueOperations::GreaterThanEquals(*this, rhs);
+}
+
+bool Value::operator==(const int64_t &rhs) const {
+	return *this == Value::Numeric(type_, rhs);
+}
+
+bool Value::operator!=(const int64_t &rhs) const {
+	return *this != Value::Numeric(type_, rhs);
+}
+
+bool Value::operator<(const int64_t &rhs) const {
+	return *this < Value::Numeric(type_, rhs);
+}
+
+bool Value::operator>(const int64_t &rhs) const {
+	return *this > Value::Numeric(type_, rhs);
+}
+
+bool Value::operator<=(const int64_t &rhs) const {
+	return *this <= Value::Numeric(type_, rhs);
+}
+
+bool Value::operator>=(const int64_t &rhs) const {
+	return *this >= Value::Numeric(type_, rhs);
+}
+
+bool Value::TryCastAs(const LogicalType &target_type, Value &new_value, string *error_message, bool strict) const {
+	if (type_ == target_type) {
+		new_value = Copy();
+		return true;
+	}
+	Vector input(*this);
+	Vector result(target_type);
+	if (!VectorOperations::TryCast(input, result, 1, error_message, strict)) {
+		return false;
+	}
+	new_value = result.GetValue(0);
+	return true;
+}
+
+Value Value::CastAs(const LogicalType &target_type, bool strict) const {
+	Value new_value;
+	string error_message;
+	if (!TryCastAs(target_type, new_value, &error_message, strict)) {
+		throw InvalidInputException("Failed to cast value: %s", error_message);
+	}
+	return new_value;
+}
+
+bool Value::TryCastAs(const LogicalType &target_type, bool strict) {
+	Value new_value;
+	string error_message;
+	if (!TryCastAs(target_type, new_value, &error_message, strict)) {
+		return false;
+	}
+	type_ = target_type;
+	is_null = new_value.is_null;
+	value_ = new_value.value_;
+	str_value = new_value.str_value;
+	struct_value = new_value.struct_value;
+	list_value = new_value.list_value;
+	return true;
+}
+
+void Value::Serialize(Serializer &main_serializer) const {
+	FieldWriter writer(main_serializer);
+	writer.WriteSerializable(type_);
+	writer.WriteField<bool>(IsNull());
+	if (!IsNull()) {
+		auto &serializer = writer.GetSerializer();
+		switch (type_.InternalType()) {
+		case PhysicalType::BOOL:
+			serializer.Write<int8_t>(value_.boolean);
+			break;
+		case PhysicalType::INT8:
+			serializer.Write<int8_t>(value_.tinyint);
+			break;
+		case PhysicalType::INT16:
+			serializer.Write<int16_t>(value_.smallint);
+			break;
+		case PhysicalType::INT32:
+			serializer.Write<int32_t>(value_.integer);
+			break;
+		case PhysicalType::INT64:
+			serializer.Write<int64_t>(value_.bigint);
+			break;
+		case PhysicalType::UINT8:
+			serializer.Write<uint8_t>(value_.utinyint);
+			break;
+		case PhysicalType::UINT16:
+			serializer.Write<uint16_t>(value_.usmallint);
+			break;
+		case PhysicalType::UINT32:
+			serializer.Write<uint32_t>(value_.uinteger);
+			break;
+		case PhysicalType::UINT64:
+			serializer.Write<uint64_t>(value_.ubigint);
+			break;
+		case PhysicalType::INT128:
+			serializer.Write<hugeint_t>(value_.hugeint);
+			break;
+		case PhysicalType::FLOAT:
+			serializer.Write<float>(value_.float_);
+			break;
+		case PhysicalType::DOUBLE:
+			serializer.Write<double>(value_.double_);
+			break;
+		case PhysicalType::INTERVAL:
+			serializer.Write<interval_t>(value_.interval);
+			break;
+		case PhysicalType::VARCHAR:
+			serializer.WriteString(str_value);
+			break;
+		default: {
+			Vector v(*this);
+			v.Serialize(1, serializer);
+			break;
+		}
+		}
+	}
+	writer.Finalize();
+}
+
+Value Value::Deserialize(Deserializer &main_source) {
+	FieldReader reader(main_source);
+	auto type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	auto is_null = reader.ReadRequired<bool>();
+	Value new_value = Value(type);
+	if (is_null) {
+		reader.Finalize();
+		return new_value;
+	}
+	new_value.is_null = false;
+	auto &source = reader.GetSource();
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+		new_value.value_.boolean = source.Read<int8_t>();
+		break;
+	case PhysicalType::INT8:
+		new_value.value_.tinyint = source.Read<int8_t>();
+		break;
+	case PhysicalType::INT16:
+		new_value.value_.smallint = source.Read<int16_t>();
+		break;
+	case PhysicalType::INT32:
+		new_value.value_.integer = source.Read<int32_t>();
+		break;
+	case PhysicalType::INT64:
+		new_value.value_.bigint = source.Read<int64_t>();
+		break;
+	case PhysicalType::UINT8:
+		new_value.value_.utinyint = source.Read<uint8_t>();
+		break;
+	case PhysicalType::UINT16:
+		new_value.value_.usmallint = source.Read<uint16_t>();
+		break;
+	case PhysicalType::UINT32:
+		new_value.value_.uinteger = source.Read<uint32_t>();
+		break;
+	case PhysicalType::UINT64:
+		new_value.value_.ubigint = source.Read<uint64_t>();
+		break;
+	case PhysicalType::INT128:
+		new_value.value_.hugeint = source.Read<hugeint_t>();
+		break;
+	case PhysicalType::FLOAT:
+		new_value.value_.float_ = source.Read<float>();
+		break;
+	case PhysicalType::DOUBLE:
+		new_value.value_.double_ = source.Read<double>();
+		break;
+	case PhysicalType::INTERVAL:
+		new_value.value_.interval = source.Read<interval_t>();
+		break;
+	case PhysicalType::VARCHAR:
+		new_value.str_value = source.Read<string>();
+		break;
+	default: {
+		Vector v(type);
+		v.Deserialize(1, source);
+		new_value = v.GetValue(0);
+		break;
+	}
+	}
+	reader.Finalize();
+	return new_value;
+}
+
+void Value::Print() const {
+	Printer::Print(ToString());
+}
+
+bool Value::NotDistinctFrom(const Value &lvalue, const Value &rvalue) {
+	return ValueOperations::NotDistinctFrom(lvalue, rvalue);
+}
+
+bool Value::ValuesAreEqual(const Value &result_value, const Value &value) {
+	if (result_value.IsNull() != value.IsNull()) {
+		return false;
+	}
+	if (result_value.IsNull() && value.IsNull()) {
+		// NULL = NULL in checking code
+		return true;
+	}
+	switch (value.type_.id()) {
+	case LogicalTypeId::FLOAT: {
+		auto other = result_value.CastAs(LogicalType::FLOAT);
+		float ldecimal = value.value_.float_;
+		float rdecimal = other.value_.float_;
+		return ApproxEqual(ldecimal, rdecimal);
+	}
+	case LogicalTypeId::DOUBLE: {
+		auto other = result_value.CastAs(LogicalType::DOUBLE);
+		double ldecimal = value.value_.double_;
+		double rdecimal = other.value_.double_;
+		return ApproxEqual(ldecimal, rdecimal);
+	}
+	case LogicalTypeId::VARCHAR: {
+		auto other = result_value.CastAs(LogicalType::VARCHAR);
+		// some results might contain padding spaces, e.g. when rendering
+		// VARCHAR(10) and the string only has 6 characters, they will be padded
+		// with spaces to 10 in the rendering. We don't do that here yet as we
+		// are looking at internal structures. So just ignore any extra spaces
+		// on the right
+		string left = other.str_value;
+		string right = value.str_value;
+		StringUtil::RTrim(left);
+		StringUtil::RTrim(right);
+		return left == right;
+	}
+	default:
+		if (result_value.type_.id() == LogicalTypeId::FLOAT || result_value.type_.id() == LogicalTypeId::DOUBLE) {
+			return Value::ValuesAreEqual(value, result_value);
+		}
+		return value == result_value;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstring> // strlen() on Solaris
+
+namespace duckdb {
+
+Vector::Vector(LogicalType type_p, bool create_data, bool zero_data, idx_t capacity)
+    : vector_type(VectorType::FLAT_VECTOR), type(move(type_p)), data(nullptr) {
+	if (create_data) {
+		Initialize(zero_data, capacity);
+	}
+}
+
+Vector::Vector(LogicalType type_p, idx_t capacity) : Vector(move(type_p), true, false, capacity) {
+}
+
+Vector::Vector(LogicalType type_p, data_ptr_t dataptr)
+    : vector_type(VectorType::FLAT_VECTOR), type(move(type_p)), data(dataptr) {
+	if (dataptr && type.id() == LogicalTypeId::INVALID) {
+		throw InternalException("Cannot create a vector of type INVALID!");
+	}
+}
+
+Vector::Vector(const VectorCache &cache) : type(cache.GetType()) {
+	ResetFromCache(cache);
+}
+
+Vector::Vector(Vector &other) : type(other.type) {
+	Reference(other);
+}
+
+Vector::Vector(Vector &other, const SelectionVector &sel, idx_t count) : type(other.type) {
+	Slice(other, sel, count);
+}
+
+Vector::Vector(Vector &other, idx_t offset) : type(other.type) {
+	Slice(other, offset);
+}
+
+Vector::Vector(const Value &value) : type(value.type()) {
+	Reference(value);
+}
+
+Vector::Vector(Vector &&other) noexcept
+    : vector_type(other.vector_type), type(move(other.type)), data(other.data), validity(move(other.validity)),
+      buffer(move(other.buffer)), auxiliary(move(other.auxiliary)) {
+}
+
+void Vector::Reference(const Value &value) {
+	D_ASSERT(GetType().id() == value.type().id());
+	this->vector_type = VectorType::CONSTANT_VECTOR;
+	buffer = VectorBuffer::CreateConstantVector(value.type());
+	auto internal_type = value.type().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		auto struct_buffer = make_unique<VectorStructBuffer>();
+		auto &child_types = StructType::GetChildTypes(value.type());
+		auto &child_vectors = struct_buffer->GetChildren();
+		auto &value_children = StructValue::GetChildren(value);
+		for (idx_t i = 0; i < child_types.size(); i++) {
+			auto vector = make_unique<Vector>(value.IsNull() ? Value(child_types[i].second) : value_children[i]);
+			child_vectors.push_back(move(vector));
+		}
+		auxiliary = move(struct_buffer);
+		if (value.IsNull()) {
+			SetValue(0, value);
+		}
+	} else if (internal_type == PhysicalType::LIST) {
+		auto list_buffer = make_unique<VectorListBuffer>(value.type());
+		auxiliary = move(list_buffer);
+		data = buffer->GetData();
+		SetValue(0, value);
+	} else {
+		auxiliary.reset();
+		data = buffer->GetData();
+		SetValue(0, value);
+	}
+}
+
+void Vector::Reference(Vector &other) {
+	D_ASSERT(other.GetType() == GetType());
+	Reinterpret(other);
+}
+
+void Vector::ReferenceAndSetType(Vector &other) {
+	type = other.GetType();
+	Reference(other);
+}
+
+void Vector::Reinterpret(Vector &other) {
+	vector_type = other.vector_type;
+	AssignSharedPointer(buffer, other.buffer);
+	AssignSharedPointer(auxiliary, other.auxiliary);
+	data = other.data;
+	validity = other.validity;
+}
+
+void Vector::ResetFromCache(const VectorCache &cache) {
+	cache.ResetFromCache(*this);
+}
+
+void Vector::Slice(Vector &other, idx_t offset) {
+	if (other.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		Reference(other);
+		return;
+	}
+	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	auto internal_type = GetType().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		Vector new_vector(GetType());
+		auto &entries = StructVector::GetEntries(new_vector);
+		auto &other_entries = StructVector::GetEntries(other);
+		D_ASSERT(entries.size() == other_entries.size());
+		for (idx_t i = 0; i < entries.size(); i++) {
+			entries[i]->Slice(*other_entries[i], offset);
+		}
+		if (offset > 0) {
+			new_vector.validity.Slice(other.validity, offset);
+		} else {
+			new_vector.validity = other.validity;
+		}
+		Reference(new_vector);
+	} else {
+		Reference(other);
+		if (offset > 0) {
+			data = data + GetTypeIdSize(internal_type) * offset;
+			validity.Slice(other.validity, offset);
+		}
+	}
+}
+
+void Vector::Slice(Vector &other, const SelectionVector &sel, idx_t count) {
+	Reference(other);
+	Slice(sel, count);
+}
+
+void Vector::Slice(const SelectionVector &sel, idx_t count) {
+	if (GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// dictionary on a constant is just a constant
+		return;
+	}
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// already a dictionary, slice the current dictionary
+		auto &current_sel = DictionaryVector::SelVector(*this);
+		auto sliced_dictionary = current_sel.Slice(sel, count);
+		buffer = make_buffer<DictionaryBuffer>(move(sliced_dictionary));
+		if (GetType().InternalType() == PhysicalType::STRUCT) {
+			auto &child_vector = DictionaryVector::Child(*this);
+
+			Vector new_child(child_vector);
+			new_child.auxiliary = make_buffer<VectorStructBuffer>(new_child, sel, count);
+			auxiliary = make_buffer<VectorChildBuffer>(move(new_child));
+		}
+		return;
+	}
+	Vector child_vector(*this);
+	auto internal_type = GetType().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		child_vector.auxiliary = make_buffer<VectorStructBuffer>(*this, sel, count);
+	}
+	auto child_ref = make_buffer<VectorChildBuffer>(move(child_vector));
+	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
+	vector_type = VectorType::DICTIONARY_VECTOR;
+	buffer = move(dict_buffer);
+	auxiliary = move(child_ref);
+}
+
+void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR && GetType().InternalType() != PhysicalType::STRUCT) {
+		// dictionary vector: need to merge dictionaries
+		// check if we have a cached entry
+		auto &current_sel = DictionaryVector::SelVector(*this);
+		auto target_data = current_sel.data();
+		auto entry = cache.cache.find(target_data);
+		if (entry != cache.cache.end()) {
+			// cached entry exists: use that
+			this->buffer = make_buffer<DictionaryBuffer>(((DictionaryBuffer &)*entry->second).GetSelVector());
+			vector_type = VectorType::DICTIONARY_VECTOR;
+		} else {
+			Slice(sel, count);
+			cache.cache[target_data] = this->buffer;
+		}
+	} else {
+		Slice(sel, count);
+	}
+}
+
+void Vector::Initialize(bool zero_data, idx_t capacity) {
+	auxiliary.reset();
+	validity.Reset();
+	auto &type = GetType();
+	auto internal_type = type.InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		auto struct_buffer = make_unique<VectorStructBuffer>(type, capacity);
+		auxiliary = move(struct_buffer);
+	} else if (internal_type == PhysicalType::LIST) {
+		auto list_buffer = make_unique<VectorListBuffer>(type, capacity);
+		auxiliary = move(list_buffer);
+	}
+	auto type_size = GetTypeIdSize(internal_type);
+	if (type_size > 0) {
+		buffer = VectorBuffer::CreateStandardVector(type, capacity);
+		data = buffer->GetData();
+		if (zero_data) {
+			memset(data, 0, capacity * type_size);
+		}
+	}
+}
+
+struct DataArrays {
+	Vector &vec;
+	data_ptr_t data;
+	VectorBuffer *buffer;
+	idx_t type_size;
+	bool is_nested;
+	DataArrays(Vector &vec, data_ptr_t data, VectorBuffer *buffer, idx_t type_size, bool is_nested)
+	    : vec(vec), data(data), buffer(buffer), type_size(type_size), is_nested(is_nested) {};
+};
+
+void FindChildren(std::vector<DataArrays> &to_resize, VectorBuffer &auxiliary) {
+	if (auxiliary.GetBufferType() == VectorBufferType::LIST_BUFFER) {
+		auto &buffer = (VectorListBuffer &)auxiliary;
+		auto &child = buffer.GetChild();
+		auto data = child.GetData();
+		if (!data) {
+			//! Nested type
+			DataArrays arrays(child, data, child.GetBuffer().get(), GetTypeIdSize(child.GetType().InternalType()),
+			                  true);
+			to_resize.emplace_back(arrays);
+			FindChildren(to_resize, *child.GetAuxiliary());
+		} else {
+			DataArrays arrays(child, data, child.GetBuffer().get(), GetTypeIdSize(child.GetType().InternalType()),
+			                  false);
+			to_resize.emplace_back(arrays);
+		}
+	} else if (auxiliary.GetBufferType() == VectorBufferType::STRUCT_BUFFER) {
+		auto &buffer = (VectorStructBuffer &)auxiliary;
+		auto &children = buffer.GetChildren();
+		for (auto &child : children) {
+			auto data = child->GetData();
+			if (!data) {
+				//! Nested type
+				DataArrays arrays(*child, data, child->GetBuffer().get(),
+				                  GetTypeIdSize(child->GetType().InternalType()), true);
+				to_resize.emplace_back(arrays);
+				FindChildren(to_resize, *child->GetAuxiliary());
+			} else {
+				DataArrays arrays(*child, data, child->GetBuffer().get(),
+				                  GetTypeIdSize(child->GetType().InternalType()), false);
+				to_resize.emplace_back(arrays);
+			}
+		}
+	}
+}
+void Vector::Resize(idx_t cur_size, idx_t new_size) {
+	std::vector<DataArrays> to_resize;
+	if (!buffer) {
+		buffer = make_unique<VectorBuffer>(0);
+	}
+	if (!data) {
+		//! this is a nested structure
+		DataArrays arrays(*this, data, buffer.get(), GetTypeIdSize(GetType().InternalType()), true);
+		to_resize.emplace_back(arrays);
+		FindChildren(to_resize, *auxiliary);
+	} else {
+		DataArrays arrays(*this, data, buffer.get(), GetTypeIdSize(GetType().InternalType()), false);
+		to_resize.emplace_back(arrays);
+	}
+	for (auto &data_to_resize : to_resize) {
+		if (!data_to_resize.is_nested) {
+			auto new_data = unique_ptr<data_t[]>(new data_t[new_size * data_to_resize.type_size]);
+			memcpy(new_data.get(), data_to_resize.data, cur_size * data_to_resize.type_size * sizeof(data_t));
+			data_to_resize.buffer->SetData(move(new_data));
+			data_to_resize.vec.data = data_to_resize.buffer->GetData();
+		}
+		data_to_resize.vec.validity.Resize(cur_size, new_size);
+	}
+}
+
+void Vector::SetValue(idx_t index, const Value &val) {
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// dictionary: apply dictionary and forward to child
+		auto &sel_vector = DictionaryVector::SelVector(*this);
+		auto &child = DictionaryVector::Child(*this);
+		return child.SetValue(sel_vector.get_index(index), val);
+	}
+	if (val.type().InternalType() != GetType().InternalType()) {
+		SetValue(index, val.CastAs(GetType()));
+		return;
+	}
+
+	validity.EnsureWritable();
+	validity.Set(index, !val.IsNull());
+	if (val.IsNull() && GetType().InternalType() != PhysicalType::STRUCT) {
+		// for structs we still need to set the child-entries to NULL
+		// so we do not bail out yet
+		return;
+	}
+
+	switch (GetType().InternalType()) {
+	case PhysicalType::BOOL:
+		((bool *)data)[index] = val.GetValueUnsafe<bool>();
+		break;
+	case PhysicalType::INT8:
+		((int8_t *)data)[index] = val.GetValueUnsafe<int8_t>();
+		break;
+	case PhysicalType::INT16:
+		((int16_t *)data)[index] = val.GetValueUnsafe<int16_t>();
+		break;
+	case PhysicalType::INT32:
+		((int32_t *)data)[index] = val.GetValueUnsafe<int32_t>();
+		break;
+	case PhysicalType::INT64:
+		((int64_t *)data)[index] = val.GetValueUnsafe<int64_t>();
+		break;
+	case PhysicalType::INT128:
+		((hugeint_t *)data)[index] = val.GetValueUnsafe<hugeint_t>();
+		break;
+	case PhysicalType::UINT8:
+		((uint8_t *)data)[index] = val.GetValueUnsafe<uint8_t>();
+		break;
+	case PhysicalType::UINT16:
+		((uint16_t *)data)[index] = val.GetValueUnsafe<uint16_t>();
+		break;
+	case PhysicalType::UINT32:
+		((uint32_t *)data)[index] = val.GetValueUnsafe<uint32_t>();
+		break;
+	case PhysicalType::UINT64:
+		((uint64_t *)data)[index] = val.GetValueUnsafe<uint64_t>();
+		break;
+	case PhysicalType::FLOAT:
+		((float *)data)[index] = val.GetValueUnsafe<float>();
+		break;
+	case PhysicalType::DOUBLE:
+		((double *)data)[index] = val.GetValueUnsafe<double>();
+		break;
+	case PhysicalType::INTERVAL:
+		((interval_t *)data)[index] = val.GetValueUnsafe<interval_t>();
+		break;
+	case PhysicalType::VARCHAR:
+		((string_t *)data)[index] = StringVector::AddStringOrBlob(*this, StringValue::Get(val));
+		break;
+	case PhysicalType::STRUCT: {
+		D_ASSERT(GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR);
+
+		auto &children = StructVector::GetEntries(*this);
+		auto &val_children = StructValue::GetChildren(val);
+		D_ASSERT(val.IsNull() || children.size() == val_children.size());
+		for (size_t i = 0; i < children.size(); i++) {
+			auto &vec_child = children[i];
+			if (!val.IsNull()) {
+				auto &struct_child = val_children[i];
+				vec_child->SetValue(index, struct_child);
+			} else {
+				vec_child->SetValue(index, Value());
+			}
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		auto offset = ListVector::GetListSize(*this);
+		auto &val_children = ListValue::GetChildren(val);
+		if (!val_children.empty()) {
+			for (idx_t i = 0; i < val_children.size(); i++) {
+				ListVector::PushBack(*this, val_children[i]);
+			}
+		}
+		//! now set the pointer
+		auto &entry = ((list_entry_t *)data)[index];
+		entry.length = val_children.size();
+		entry.offset = offset;
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for Vector::SetValue");
+	}
+}
+
+Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
+	const Vector *vector = &v_p;
+	idx_t index = index_p;
+	bool finished = false;
+	while (!finished) {
+		switch (vector->GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR:
+			index = 0;
+			finished = true;
+			break;
+		case VectorType::FLAT_VECTOR:
+			finished = true;
+			break;
+			// dictionary: apply dictionary and forward to child
+		case VectorType::DICTIONARY_VECTOR: {
+			auto &sel_vector = DictionaryVector::SelVector(*vector);
+			auto &child = DictionaryVector::Child(*vector);
+			vector = &child;
+			index = sel_vector.get_index(index);
+			break;
+		}
+		case VectorType::SEQUENCE_VECTOR: {
+			int64_t start, increment;
+			SequenceVector::GetSequence(*vector, start, increment);
+			return Value::Numeric(vector->GetType(), start + increment * index);
+		}
+		default:
+			throw InternalException("Unimplemented vector type for Vector::GetValue");
+		}
+	}
+	auto data = vector->data;
+	auto &validity = vector->validity;
+	auto &type = vector->GetType();
+
+	if (!validity.RowIsValid(index)) {
+		return Value(vector->GetType());
+	}
+	switch (vector->GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(((bool *)data)[index]);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(((int8_t *)data)[index]);
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(((int16_t *)data)[index]);
+	case LogicalTypeId::INTEGER:
+		return Value::INTEGER(((int32_t *)data)[index]);
+	case LogicalTypeId::DATE:
+		return Value::DATE(((date_t *)data)[index]);
+	case LogicalTypeId::TIME:
+		return Value::TIME(((dtime_t *)data)[index]);
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(((dtime_t *)data)[index]);
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(((int64_t *)data)[index]);
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(((uint8_t *)data)[index]);
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(((uint16_t *)data)[index]);
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(((uint32_t *)data)[index]);
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(((uint64_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Value::TIMESTAMPMS(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Value::TIMESTAMPSEC(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(((timestamp_t *)data)[index]);
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(((hugeint_t *)data)[index]);
+	case LogicalTypeId::UUID:
+		return Value::UUID(((hugeint_t *)data)[index]);
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(((int16_t *)data)[index], width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(((int32_t *)data)[index], width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(((int64_t *)data)[index], width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(((hugeint_t *)data)[index], width, scale);
+		default:
+			throw InternalException("Widths bigger than 38 are not supported");
+		}
+	}
+	case LogicalTypeId::ENUM: {
+		switch (type.InternalType()) {
+		case PhysicalType::UINT8:
+			return Value::ENUM(((uint8_t *)data)[index], type);
+		case PhysicalType::UINT16:
+			return Value::ENUM(((uint16_t *)data)[index], type);
+		case PhysicalType::UINT32:
+			return Value::ENUM(((uint32_t *)data)[index], type);
+		case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+			return Value::ENUM(((uint64_t *)data)[index], type);
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+	}
+	case LogicalTypeId::POINTER:
+		return Value::POINTER(((uintptr_t *)data)[index]);
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(((float *)data)[index]);
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(((double *)data)[index]);
+	case LogicalTypeId::INTERVAL:
+		return Value::INTERVAL(((interval_t *)data)[index]);
+	case LogicalTypeId::VARCHAR: {
+		auto str = ((string_t *)data)[index];
+		return Value(str.GetString());
+	}
+	case LogicalTypeId::JSON: {
+		auto str = ((string_t *)data)[index];
+		return Value::JSON(str.GetString());
+	}
+	case LogicalTypeId::AGGREGATE_STATE:
+	case LogicalTypeId::BLOB: {
+		auto str = ((string_t *)data)[index];
+		return Value::BLOB((const_data_ptr_t)str.GetDataUnsafe(), str.GetSize());
+	}
+	case LogicalTypeId::MAP: {
+		auto &child_entries = StructVector::GetEntries(*vector);
+		Value key = child_entries[0]->GetValue(index);
+		Value value = child_entries[1]->GetValue(index);
+		return Value::MAP(move(key), move(value));
+	}
+	case LogicalTypeId::STRUCT: {
+		// we can derive the value schema from the vector schema
+		auto &child_entries = StructVector::GetEntries(*vector);
+		child_list_t<Value> children;
+		for (idx_t child_idx = 0; child_idx < child_entries.size(); child_idx++) {
+			auto &struct_child = child_entries[child_idx];
+			children.push_back(make_pair(StructType::GetChildName(type, child_idx), struct_child->GetValue(index_p)));
+		}
+		return Value::STRUCT(move(children));
+	}
+	case LogicalTypeId::LIST: {
+		auto offlen = ((list_entry_t *)data)[index];
+		auto &child_vec = ListVector::GetEntry(*vector);
+		std::vector<Value> children;
+		for (idx_t i = offlen.offset; i < offlen.offset + offlen.length; i++) {
+			children.push_back(child_vec.GetValue(i));
+		}
+		return Value::LIST(ListType::GetChildType(type), move(children));
+	}
+	default:
+		throw InternalException("Unimplemented type for value access");
+	}
+}
+
+Value Vector::GetValue(idx_t index) const {
+	return GetValue(*this, index);
+}
+
+// LCOV_EXCL_START
+string VectorTypeToString(VectorType type) {
+	switch (type) {
+	case VectorType::FLAT_VECTOR:
+		return "FLAT";
+	case VectorType::SEQUENCE_VECTOR:
+		return "SEQUENCE";
+	case VectorType::DICTIONARY_VECTOR:
+		return "DICTIONARY";
+	case VectorType::CONSTANT_VECTOR:
+		return "CONSTANT";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+string Vector::ToString(idx_t count) const {
+	string retval =
+	    VectorTypeToString(GetVectorType()) + " " + GetType().ToString() + ": " + to_string(count) + " = [ ";
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+	case VectorType::DICTIONARY_VECTOR:
+		for (idx_t i = 0; i < count; i++) {
+			retval += GetValue(i).ToString() + (i == count - 1 ? "" : ", ");
+		}
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		retval += GetValue(0).ToString();
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+		for (idx_t i = 0; i < count; i++) {
+			retval += to_string(start + increment * i) + (i == count - 1 ? "" : ", ");
+		}
+		break;
+	}
+	default:
+		retval += "UNKNOWN VECTOR TYPE";
+		break;
+	}
+	retval += "]";
+	return retval;
+}
+
+void Vector::Print(idx_t count) {
+	Printer::Print(ToString(count));
+}
+
+string Vector::ToString() const {
+	string retval = VectorTypeToString(GetVectorType()) + " " + GetType().ToString() + ": (UNKNOWN COUNT) [ ";
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+	case VectorType::DICTIONARY_VECTOR:
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		retval += GetValue(0).ToString();
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		break;
+	}
+	default:
+		retval += "UNKNOWN VECTOR TYPE";
+		break;
+	}
+	retval += "]";
+	return retval;
+}
+
+void Vector::Print() {
+	Printer::Print(ToString());
+}
+// LCOV_EXCL_STOP
+
+template <class T>
+static void TemplatedFlattenConstantVector(data_ptr_t data, data_ptr_t old_data, idx_t count) {
+	auto constant = Load<T>(old_data);
+	auto output = (T *)data;
+	for (idx_t i = 0; i < count; i++) {
+		output[i] = constant;
+	}
+}
+
+void Vector::Normalify(idx_t count) {
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		// already a flat vector
+		break;
+	case VectorType::DICTIONARY_VECTOR: {
+		// create a new flat vector of this type
+		Vector other(GetType(), count);
+		// now copy the data of this vector to the other vector, removing the selection vector in the process
+		VectorOperations::Copy(*this, other, count, 0, 0);
+		// create a reference to the data in the other vector
+		this->Reference(other);
+		break;
+	}
+	case VectorType::CONSTANT_VECTOR: {
+		bool is_null = ConstantVector::IsNull(*this);
+		// allocate a new buffer for the vector
+		auto old_buffer = move(buffer);
+		auto old_data = data;
+		buffer = VectorBuffer::CreateStandardVector(type, MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count));
+		data = buffer->GetData();
+		vector_type = VectorType::FLAT_VECTOR;
+		if (is_null) {
+			// constant NULL, set nullmask
+			validity.EnsureWritable();
+			validity.SetAllInvalid(count);
+			return;
+		}
+		// non-null constant: have to repeat the constant
+		switch (GetType().InternalType()) {
+		case PhysicalType::BOOL:
+			TemplatedFlattenConstantVector<bool>(data, old_data, count);
+			break;
+		case PhysicalType::INT8:
+			TemplatedFlattenConstantVector<int8_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT16:
+			TemplatedFlattenConstantVector<int16_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT32:
+			TemplatedFlattenConstantVector<int32_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT64:
+			TemplatedFlattenConstantVector<int64_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedFlattenConstantVector<uint8_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedFlattenConstantVector<uint16_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedFlattenConstantVector<uint32_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedFlattenConstantVector<uint64_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT128:
+			TemplatedFlattenConstantVector<hugeint_t>(data, old_data, count);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedFlattenConstantVector<float>(data, old_data, count);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedFlattenConstantVector<double>(data, old_data, count);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedFlattenConstantVector<interval_t>(data, old_data, count);
+			break;
+		case PhysicalType::VARCHAR:
+			TemplatedFlattenConstantVector<string_t>(data, old_data, count);
+			break;
+		case PhysicalType::LIST: {
+			TemplatedFlattenConstantVector<list_entry_t>(data, old_data, count);
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto normalified_buffer = make_unique<VectorStructBuffer>();
+
+			auto &new_children = normalified_buffer->GetChildren();
+
+			auto &child_entries = StructVector::GetEntries(*this);
+			for (auto &child : child_entries) {
+				D_ASSERT(child->GetVectorType() == VectorType::CONSTANT_VECTOR);
+				auto vector = make_unique<Vector>(*child);
+				vector->Normalify(count);
+				new_children.push_back(move(vector));
+			}
+			auxiliary = move(normalified_buffer);
+		} break;
+		default:
+			throw InternalException("Unimplemented type for VectorOperations::Normalify");
+		}
+		break;
+	}
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+
+		buffer = VectorBuffer::CreateStandardVector(GetType());
+		data = buffer->GetData();
+		VectorOperations::GenerateSequence(*this, count, start, increment);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for normalify");
+	}
+}
+
+void Vector::Normalify(const SelectionVector &sel, idx_t count) {
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		// already a flat vector
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+
+		buffer = VectorBuffer::CreateStandardVector(GetType());
+		data = buffer->GetData();
+		VectorOperations::GenerateSequence(*this, count, sel, start, increment);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for normalify with selection vector");
+	}
+}
+
+void Vector::Orrify(idx_t count, VectorData &data) {
+	switch (GetVectorType()) {
+	case VectorType::DICTIONARY_VECTOR: {
+		auto &sel = DictionaryVector::SelVector(*this);
+		auto &child = DictionaryVector::Child(*this);
+		if (child.GetVectorType() == VectorType::FLAT_VECTOR) {
+			data.sel = &sel;
+			data.data = FlatVector::GetData(child);
+			data.validity = FlatVector::Validity(child);
+		} else {
+			// dictionary with non-flat child: create a new reference to the child and normalify it
+			Vector child_vector(child);
+			child_vector.Normalify(sel, count);
+			auto new_aux = make_buffer<VectorChildBuffer>(move(child_vector));
+
+			data.sel = &sel;
+			data.data = FlatVector::GetData(new_aux->data);
+			data.validity = FlatVector::Validity(new_aux->data);
+			this->auxiliary = move(new_aux);
+		}
+		break;
+	}
+	case VectorType::CONSTANT_VECTOR:
+		data.sel = ConstantVector::ZeroSelectionVector(count, data.owned_sel);
+		data.data = ConstantVector::GetData(*this);
+		data.validity = ConstantVector::Validity(*this);
+		break;
+	default:
+		Normalify(count);
+		data.sel = FlatVector::IncrementalSelectionVector();
+		data.data = FlatVector::GetData(*this);
+		data.validity = FlatVector::Validity(*this);
+		break;
+	}
+}
+
+void Vector::Sequence(int64_t start, int64_t increment) {
+	this->vector_type = VectorType::SEQUENCE_VECTOR;
+	this->buffer = make_buffer<VectorBuffer>(sizeof(int64_t) * 2);
+	auto data = (int64_t *)buffer->GetData();
+	data[0] = start;
+	data[1] = increment;
+	validity.Reset();
+	auxiliary.reset();
+}
+
+void Vector::Serialize(idx_t count, Serializer &serializer) {
+	auto &type = GetType();
+
+	VectorData vdata;
+	Orrify(count, vdata);
+
+	const auto write_validity = (count > 0) && !vdata.validity.AllValid();
+	serializer.Write<bool>(write_validity);
+	if (write_validity) {
+		ValidityMask flat_mask(count);
+		for (idx_t i = 0; i < count; ++i) {
+			auto row_idx = vdata.sel->get_index(i);
+			flat_mask.Set(i, vdata.validity.RowIsValid(row_idx));
+		}
+		serializer.WriteData((const_data_ptr_t)flat_mask.GetData(), flat_mask.ValidityMaskSize(count));
+	}
+	if (TypeIsConstantSize(type.InternalType())) {
+		// constant size type: simple copy
+		idx_t write_size = GetTypeIdSize(type.InternalType()) * count;
+		auto ptr = unique_ptr<data_t[]>(new data_t[write_size]);
+		VectorOperations::WriteToStorage(*this, count, ptr.get());
+		serializer.WriteData(ptr.get(), write_size);
+	} else {
+		switch (type.InternalType()) {
+		case PhysicalType::VARCHAR: {
+			auto strings = (string_t *)vdata.data;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = vdata.sel->get_index(i);
+				auto source = !vdata.validity.RowIsValid(idx) ? NullValue<string_t>() : strings[idx];
+				serializer.WriteStringLen((const_data_ptr_t)source.GetDataUnsafe(), source.GetSize());
+			}
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			Normalify(count);
+			auto &entries = StructVector::GetEntries(*this);
+			for (auto &entry : entries) {
+				entry->Serialize(count, serializer);
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			auto &child = ListVector::GetEntry(*this);
+			auto list_size = ListVector::GetListSize(*this);
+
+			// serialize the list entries in a flat array
+			auto data = unique_ptr<list_entry_t[]>(new list_entry_t[count]);
+			auto source_array = (list_entry_t *)vdata.data;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = vdata.sel->get_index(i);
+				auto source = source_array[idx];
+				data[i].offset = source.offset;
+				data[i].length = source.length;
+			}
+
+			// write the list size
+			serializer.Write<idx_t>(list_size);
+			serializer.WriteData((data_ptr_t)data.get(), count * sizeof(list_entry_t));
+
+			child.Serialize(list_size, serializer);
+			break;
+		}
+		default:
+			throw InternalException("Unimplemented variable width type for Vector::Serialize!");
+		}
+	}
+}
+
+void Vector::Deserialize(idx_t count, Deserializer &source) {
+	auto &type = GetType();
+
+	auto &validity = FlatVector::Validity(*this);
+	validity.Reset();
+	const auto has_validity = source.Read<bool>();
+	if (has_validity) {
+		validity.Initialize(count);
+		source.ReadData((data_ptr_t)validity.GetData(), validity.ValidityMaskSize(count));
+	}
+
+	if (TypeIsConstantSize(type.InternalType())) {
+		// constant size type: read fixed amount of data from
+		auto column_size = GetTypeIdSize(type.InternalType()) * count;
+		auto ptr = unique_ptr<data_t[]>(new data_t[column_size]);
+		source.ReadData(ptr.get(), column_size);
+
+		VectorOperations::ReadFromStorage(ptr.get(), count, *this);
+	} else {
+		switch (type.InternalType()) {
+		case PhysicalType::VARCHAR: {
+			auto strings = FlatVector::GetData<string_t>(*this);
+			for (idx_t i = 0; i < count; i++) {
+				// read the strings
+				auto str = source.Read<string>();
+				// now add the string to the StringHeap of the vector
+				// and write the pointer into the vector
+				if (validity.RowIsValid(i)) {
+					strings[i] = StringVector::AddStringOrBlob(*this, str);
+				}
+			}
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto &entries = StructVector::GetEntries(*this);
+			for (auto &entry : entries) {
+				entry->Deserialize(count, source);
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			// read the list size
+			auto list_size = source.Read<idx_t>();
+			ListVector::Reserve(*this, list_size);
+			ListVector::SetListSize(*this, list_size);
+
+			// read the list entry
+			auto list_entries = FlatVector::GetData(*this);
+			source.ReadData(list_entries, count * sizeof(list_entry_t));
+
+			// deserialize the child vector
+			auto &child = ListVector::GetEntry(*this);
+			child.Deserialize(list_size, source);
+
+			break;
+		}
+		default:
+			throw InternalException("Unimplemented variable width type for Vector::Deserialize!");
+		}
+	}
+}
+
+void Vector::SetVectorType(VectorType vector_type_p) {
+	this->vector_type = vector_type_p;
+	if (TypeIsConstantSize(GetType().InternalType()) &&
+	    (GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR)) {
+		auxiliary.reset();
+	}
+	if (vector_type == VectorType::CONSTANT_VECTOR && GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &entries = StructVector::GetEntries(*this);
+		for (auto &entry : entries) {
+			entry->SetVectorType(vector_type);
+		}
+	}
+}
+
+void Vector::UTFVerify(const SelectionVector &sel, idx_t count) {
+#ifdef DEBUG
+	if (count == 0) {
+		return;
+	}
+	if (GetType().InternalType() == PhysicalType::VARCHAR) {
+		// we just touch all the strings and let the sanitizer figure out if any
+		// of them are deallocated/corrupt
+		switch (GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR: {
+			auto string = ConstantVector::GetData<string_t>(*this);
+			if (!ConstantVector::IsNull(*this)) {
+				string->Verify();
+			}
+			break;
+		}
+		case VectorType::FLAT_VECTOR: {
+			auto strings = FlatVector::GetData<string_t>(*this);
+			for (idx_t i = 0; i < count; i++) {
+				auto oidx = sel.get_index(i);
+				if (validity.RowIsValid(oidx)) {
+					strings[oidx].Verify();
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+#endif
+}
+
+void Vector::UTFVerify(idx_t count) {
+	auto flat_sel = FlatVector::IncrementalSelectionVector();
+
+	UTFVerify(*flat_sel, count);
+}
+
+void Vector::VerifyMap(Vector &vector_p, const SelectionVector &sel_p, idx_t count) {
+#ifdef DEBUG
+	D_ASSERT(vector_p.GetType().id() == LogicalTypeId::MAP);
+	auto valid_check = CheckMapValidity(vector_p, count, sel_p);
+	D_ASSERT(valid_check == MapInvalidReason::VALID);
+#endif // DEBUG
+}
+
+void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count) {
+#ifdef DEBUG
+	if (count == 0) {
+		return;
+	}
+	Vector *vector = &vector_p;
+	const SelectionVector *sel = &sel_p;
+	SelectionVector owned_sel;
+	auto &type = vector->GetType();
+	auto vtype = vector->GetVectorType();
+	if (vector->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(*vector);
+		D_ASSERT(child.GetVectorType() != VectorType::DICTIONARY_VECTOR);
+		auto &dict_sel = DictionaryVector::SelVector(*vector);
+		// merge the selection vectors and verify the child
+		auto new_buffer = dict_sel.Slice(*sel, count);
+		owned_sel.Initialize(new_buffer);
+		sel = &owned_sel;
+		vector = &child;
+		vtype = vector->GetVectorType();
+	}
+	if (TypeIsConstantSize(type.InternalType()) &&
+	    (vtype == VectorType::CONSTANT_VECTOR || vtype == VectorType::FLAT_VECTOR)) {
+		D_ASSERT(!vector->auxiliary);
+	}
+	if (type.id() == LogicalTypeId::VARCHAR || type.id() == LogicalTypeId::JSON) {
+		// verify that there are no '\0' bytes in string values
+		switch (vtype) {
+		case VectorType::FLAT_VECTOR: {
+			auto &validity = FlatVector::Validity(*vector);
+			auto strings = FlatVector::GetData<string_t>(*vector);
+			for (idx_t i = 0; i < count; i++) {
+				auto oidx = sel->get_index(i);
+				if (validity.RowIsValid(oidx)) {
+					strings[oidx].VerifyNull();
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		auto &child_types = StructType::GetChildTypes(type);
+		D_ASSERT(!child_types.empty());
+		// create a selection vector of the non-null entries of the struct vector
+		auto &children = StructVector::GetEntries(*vector);
+		D_ASSERT(child_types.size() == children.size());
+		for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+			D_ASSERT(children[child_idx]->GetType() == child_types[child_idx].second);
+			Vector::Verify(*children[child_idx], sel_p, count);
+			if (vtype == VectorType::CONSTANT_VECTOR) {
+				D_ASSERT(children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR);
+				if (ConstantVector::IsNull(*vector)) {
+					D_ASSERT(ConstantVector::IsNull(*children[child_idx]));
+				}
+			}
+			if (vtype != VectorType::FLAT_VECTOR) {
+				continue;
+			}
+			ValidityMask *child_validity;
+			SelectionVector owned_child_sel;
+			const SelectionVector *child_sel = &owned_child_sel;
+			if (children[child_idx]->GetVectorType() == VectorType::FLAT_VECTOR) {
+				child_sel = FlatVector::IncrementalSelectionVector();
+				child_validity = &FlatVector::Validity(*children[child_idx]);
+			} else if (children[child_idx]->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+				auto &child = DictionaryVector::Child(*children[child_idx]);
+				if (child.GetVectorType() != VectorType::FLAT_VECTOR) {
+					continue;
+				}
+				child_validity = &FlatVector::Validity(child);
+				child_sel = &DictionaryVector::SelVector(*children[child_idx]);
+			} else if (children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				child_sel = ConstantVector::ZeroSelectionVector(count, owned_child_sel);
+				child_validity = &ConstantVector::Validity(*children[child_idx]);
+			} else {
+				continue;
+			}
+			// for any NULL entry in the struct, the child should be NULL as well
+			auto &validity = FlatVector::Validity(*vector);
+			for (idx_t i = 0; i < count; i++) {
+				auto index = sel->get_index(i);
+				if (!validity.RowIsValid(index)) {
+					auto child_index = child_sel->get_index(sel_p.get_index(i));
+					D_ASSERT(!child_validity->RowIsValid(child_index));
+				}
+			}
+		}
+		if (vector->GetType().id() == LogicalTypeId::MAP) {
+			VerifyMap(*vector, *sel, count);
+		}
+	}
+
+	if (type.InternalType() == PhysicalType::LIST) {
+		if (vtype == VectorType::CONSTANT_VECTOR) {
+			if (!ConstantVector::IsNull(*vector)) {
+				auto &child = ListVector::GetEntry(*vector);
+				SelectionVector child_sel(ListVector::GetListSize(*vector));
+				idx_t child_count = 0;
+				auto le = ConstantVector::GetData<list_entry_t>(*vector);
+				D_ASSERT(le->offset + le->length <= ListVector::GetListSize(*vector));
+				for (idx_t k = 0; k < le->length; k++) {
+					child_sel.set_index(child_count++, le->offset + k);
+				}
+				Vector::Verify(child, child_sel, child_count);
+			}
+		} else if (vtype == VectorType::FLAT_VECTOR) {
+			auto &validity = FlatVector::Validity(*vector);
+			auto &child = ListVector::GetEntry(*vector);
+			auto child_size = ListVector::GetListSize(*vector);
+			auto list_data = FlatVector::GetData<list_entry_t>(*vector);
+			idx_t total_size = 0;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = sel->get_index(i);
+				auto &le = list_data[idx];
+				if (validity.RowIsValid(idx)) {
+					D_ASSERT(le.offset + le.length <= child_size);
+					total_size += le.length;
+				}
+			}
+			SelectionVector child_sel(total_size);
+			idx_t child_count = 0;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = sel->get_index(i);
+				auto &le = list_data[idx];
+				if (validity.RowIsValid(idx)) {
+					D_ASSERT(le.offset + le.length <= child_size);
+					for (idx_t k = 0; k < le.length; k++) {
+						child_sel.set_index(child_count++, le.offset + k);
+					}
+				}
+			}
+			Vector::Verify(child, child_sel, child_count);
+		}
+	}
+#endif
+}
+
+void Vector::Verify(idx_t count) {
+	auto flat_sel = FlatVector::IncrementalSelectionVector();
+	Verify(*this, *flat_sel, count);
+}
+
+void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+	vector.validity.Set(idx, !is_null);
+	if (is_null && vector.GetType().InternalType() == PhysicalType::STRUCT) {
+		// set all child entries to null as well
+		auto &entries = StructVector::GetEntries(vector);
+		for (auto &entry : entries) {
+			FlatVector::SetNull(*entry, idx, is_null);
+		}
+	}
+}
+
+void ConstantVector::SetNull(Vector &vector, bool is_null) {
+	D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	vector.validity.Set(0, !is_null);
+	if (is_null && vector.GetType().InternalType() == PhysicalType::STRUCT) {
+		// set all child entries to null as well
+		auto &entries = StructVector::GetEntries(vector);
+		for (auto &entry : entries) {
+			entry->SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(*entry, is_null);
+		}
+	}
+}
+
+const SelectionVector *ConstantVector::ZeroSelectionVector(idx_t count, SelectionVector &owned_sel) {
+	if (count <= STANDARD_VECTOR_SIZE) {
+		return ConstantVector::ZeroSelectionVector();
+	}
+	owned_sel.Initialize(count);
+	for (idx_t i = 0; i < count; i++) {
+		owned_sel.set_index(i, 0);
+	}
+	return &owned_sel;
+}
+
+void ConstantVector::Reference(Vector &vector, Vector &source, idx_t position, idx_t count) {
+	auto &source_type = source.GetType();
+	switch (source_type.InternalType()) {
+	case PhysicalType::LIST: {
+		// retrieve the list entry from the source vector
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		auto list_index = vdata.sel->get_index(position);
+		if (!vdata.validity.RowIsValid(list_index)) {
+			// list is null: create null value
+			Value null_value(source_type);
+			vector.Reference(null_value);
+			break;
+		}
+
+		auto list_data = (list_entry_t *)vdata.data;
+		auto list_entry = list_data[list_index];
+
+		// add the list entry as the first element of "vector"
+		// FIXME: we only need to allocate space for 1 tuple here
+		auto target_data = FlatVector::GetData<list_entry_t>(vector);
+		target_data[0] = list_entry;
+
+		// create a reference to the child list of the source vector
+		auto &child = ListVector::GetEntry(vector);
+		child.Reference(ListVector::GetEntry(source));
+
+		ListVector::SetListSize(vector, ListVector::GetListSize(source));
+		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		auto struct_index = vdata.sel->get_index(position);
+		if (!vdata.validity.RowIsValid(struct_index)) {
+			// null struct: create null value
+			Value null_value(source_type);
+			vector.Reference(null_value);
+			break;
+		}
+
+		// struct: pass constant reference into child entries
+		auto &source_entries = StructVector::GetEntries(source);
+		auto &target_entries = StructVector::GetEntries(vector);
+		for (idx_t i = 0; i < source_entries.size(); i++) {
+			ConstantVector::Reference(*target_entries[i], *source_entries[i], position, count);
+		}
+		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		break;
+	}
+	default:
+		// default behavior: get a value from the vector and reference it
+		// this is not that expensive for scalar types
+		auto value = source.GetValue(position);
+		vector.Reference(value);
+		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+		break;
+	}
+}
+
+string_t StringVector::AddString(Vector &vector, const char *data, idx_t len) {
+	return StringVector::AddString(vector, string_t(data, len));
+}
+
+string_t StringVector::AddStringOrBlob(Vector &vector, const char *data, idx_t len) {
+	return StringVector::AddStringOrBlob(vector, string_t(data, len));
+}
+
+string_t StringVector::AddString(Vector &vector, const char *data) {
+	return StringVector::AddString(vector, string_t(data, strlen(data)));
+}
+
+string_t StringVector::AddString(Vector &vector, const string &data) {
+	return StringVector::AddString(vector, string_t(data.c_str(), data.size()));
+}
+
+string_t StringVector::AddString(Vector &vector, string_t data) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::VARCHAR || vector.GetType().id() == LogicalTypeId::JSON);
+	if (data.IsInlined()) {
+		// string will be inlined: no need to store in string heap
+		return data;
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.AddString(data);
+}
+
+string_t StringVector::AddStringOrBlob(Vector &vector, string_t data) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (data.IsInlined()) {
+		// string will be inlined: no need to store in string heap
+		return data;
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.AddBlob(data);
+}
+
+string_t StringVector::EmptyString(Vector &vector, idx_t len) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (len < string_t::INLINE_LENGTH) {
+		return string_t(len);
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.EmptyString(len);
+}
+
+void StringVector::AddHandle(Vector &vector, unique_ptr<BufferHandle> handle) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	string_buffer.AddHeapReference(make_buffer<ManagedVectorBuffer>(move(handle)));
+}
+
+void StringVector::AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(buffer.get() != vector.auxiliary.get());
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	string_buffer.AddHeapReference(move(buffer));
+}
+
+void StringVector::AddHeapReference(Vector &vector, Vector &other) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(other.GetType().InternalType() == PhysicalType::VARCHAR);
+
+	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		StringVector::AddHeapReference(vector, DictionaryVector::Child(other));
+		return;
+	}
+	if (!other.auxiliary) {
+		return;
+	}
+	StringVector::AddBuffer(vector, other.auxiliary);
+}
+
+vector<unique_ptr<Vector>> &StructVector::GetEntries(Vector &vector) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::STRUCT || vector.GetType().id() == LogicalTypeId::MAP);
+	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vector);
+		return StructVector::GetEntries(child);
+	}
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRUCT_BUFFER);
+	return ((VectorStructBuffer *)vector.auxiliary.get())->GetChildren();
+}
+
+const vector<unique_ptr<Vector>> &StructVector::GetEntries(const Vector &vector) {
+	return GetEntries((Vector &)vector);
+}
+
+const Vector &ListVector::GetEntry(const Vector &vector) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vector);
+		return ListVector::GetEntry(child);
+	}
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	return ((VectorListBuffer *)vector.auxiliary.get())->GetChild();
+}
+
+Vector &ListVector::GetEntry(Vector &vector) {
+	const Vector &cvector = vector;
+	return const_cast<Vector &>(ListVector::GetEntry(cvector));
+}
+
+void ListVector::Reserve(Vector &vector, idx_t required_capacity) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	auto &child_buffer = *((VectorListBuffer *)vector.auxiliary.get());
+	child_buffer.Reserve(required_capacity);
+}
+
+template <class T>
+void TemplatedSearchInMap(Vector &list, T key, vector<idx_t> &offsets, bool is_key_null, idx_t offset, idx_t length) {
+	auto &list_vector = ListVector::GetEntry(list);
+	VectorData vector_data;
+	list_vector.Orrify(ListVector::GetListSize(list), vector_data);
+	auto data = (T *)vector_data.data;
+	auto validity_mask = vector_data.validity;
+
+	if (is_key_null) {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				offsets.push_back(i);
+			}
+		}
+	} else {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				continue;
+			}
+			if (key == data[i]) {
+				offsets.push_back(i);
+			}
+		}
+	}
+}
+
+template <class T>
+void TemplatedSearchInMap(Vector &list, const Value &key, vector<idx_t> &offsets, bool is_key_null, idx_t offset,
+                          idx_t length) {
+	TemplatedSearchInMap<T>(list, key.template GetValueUnsafe<T>(), offsets, is_key_null, offset, length);
+}
+
+void SearchStringInMap(Vector &list, const string &key, vector<idx_t> &offsets, bool is_key_null, idx_t offset,
+                       idx_t length) {
+	auto &list_vector = ListVector::GetEntry(list);
+	VectorData vector_data;
+	list_vector.Orrify(ListVector::GetListSize(list), vector_data);
+	auto data = (string_t *)vector_data.data;
+	auto validity_mask = vector_data.validity;
+	if (is_key_null) {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				offsets.push_back(i);
+			}
+		}
+	} else {
+		string_t key_str_t(key);
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				continue;
+			}
+			if (Equals::Operation<string_t>(data[i], key_str_t)) {
+				offsets.push_back(i);
+			}
+		}
+	}
+}
+
+vector<idx_t> ListVector::Search(Vector &list, const Value &key, idx_t row) {
+	vector<idx_t> offsets;
+
+	auto &list_vector = ListVector::GetEntry(list);
+	auto &entry = ((list_entry_t *)list.GetData())[row];
+
+	switch (list_vector.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedSearchInMap<int8_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT16:
+		TemplatedSearchInMap<int16_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT32:
+		TemplatedSearchInMap<int32_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT64:
+		TemplatedSearchInMap<int64_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT128:
+		TemplatedSearchInMap<hugeint_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedSearchInMap<uint8_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedSearchInMap<uint16_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedSearchInMap<uint32_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedSearchInMap<uint64_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedSearchInMap<float>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedSearchInMap<double>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::VARCHAR:
+		SearchStringInMap(list, StringValue::Get(key), offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	default:
+		throw InvalidTypeException(list.GetType().id(), "Invalid type for List Vector Search");
+	}
+	return offsets;
+}
+
+Value ListVector::GetValuesFromOffsets(Vector &list, vector<idx_t> &offsets) {
+	auto &child_vec = ListVector::GetEntry(list);
+	vector<Value> list_values;
+	list_values.reserve(offsets.size());
+	for (auto &offset : offsets) {
+		list_values.push_back(child_vec.GetValue(offset));
+	}
+	return Value::LIST(ListType::GetChildType(list.GetType()), move(list_values));
+}
+
+idx_t ListVector::GetListSize(const Vector &vec) {
+	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vec);
+		return ListVector::GetListSize(child);
+	}
+	D_ASSERT(vec.auxiliary);
+	return ((VectorListBuffer &)*vec.auxiliary).size;
+}
+
+void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(other.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR || other.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	vector.auxiliary = other.auxiliary;
+}
+
+void ListVector::SetListSize(Vector &vec, idx_t size) {
+	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vec);
+		ListVector::SetListSize(child, size);
+	}
+	((VectorListBuffer &)*vec.auxiliary).size = size;
+}
+
+void ListVector::Append(Vector &target, const Vector &source, idx_t source_size, idx_t source_offset) {
+	if (source_size - source_offset == 0) {
+		//! Nothing to add
+		return;
+	}
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.Append(source, source_size, source_offset);
+}
+
+void ListVector::Append(Vector &target, const Vector &source, const SelectionVector &sel, idx_t source_size,
+                        idx_t source_offset) {
+	if (source_size - source_offset == 0) {
+		//! Nothing to add
+		return;
+	}
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.Append(source, sel, source_size, source_offset);
+}
+
+void ListVector::PushBack(Vector &target, const Value &insert) {
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.PushBack(insert);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, idx_t capacity) {
+	return make_buffer<VectorBuffer>(capacity * GetTypeIdSize(type));
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
+	return make_buffer<VectorBuffer>(GetTypeIdSize(type));
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(const LogicalType &type) {
+	return VectorBuffer::CreateConstantVector(type.InternalType());
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &type, idx_t capacity) {
+	return VectorBuffer::CreateStandardVector(type.InternalType(), capacity);
+}
+
+VectorStringBuffer::VectorStringBuffer() : VectorBuffer(VectorBufferType::STRING_BUFFER) {
+}
+
+VectorStructBuffer::VectorStructBuffer() : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+}
+
+VectorStructBuffer::VectorStructBuffer(const LogicalType &type, idx_t capacity)
+    : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+	auto &child_types = StructType::GetChildTypes(type);
+	for (auto &child_type : child_types) {
+		auto vector = make_unique<Vector>(child_type.second, capacity);
+		children.push_back(move(vector));
+	}
+}
+
+VectorStructBuffer::VectorStructBuffer(Vector &other, const SelectionVector &sel, idx_t count)
+    : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+	auto &other_vector = StructVector::GetEntries(other);
+	for (auto &child_vector : other_vector) {
+		auto vector = make_unique<Vector>(*child_vector, sel, count);
+		children.push_back(move(vector));
+	}
+}
+
+VectorStructBuffer::~VectorStructBuffer() {
+}
+
+VectorListBuffer::VectorListBuffer(unique_ptr<Vector> vector, idx_t initial_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(initial_capacity), child(move(vector)) {
+}
+
+VectorListBuffer::VectorListBuffer(const LogicalType &list_type, idx_t initial_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(initial_capacity),
+      child(make_unique<Vector>(ListType::GetChildType(list_type), initial_capacity)) {
+}
+
+void VectorListBuffer::Reserve(idx_t to_reserve) {
+	if (to_reserve > capacity) {
+		idx_t new_capacity = NextPowerOfTwo(to_reserve);
+		D_ASSERT(new_capacity >= to_reserve);
+		child->Resize(capacity, new_capacity);
+		capacity = new_capacity;
+	}
+}
+
+void VectorListBuffer::Append(const Vector &to_append, idx_t to_append_size, idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::Append(const Vector &to_append, const SelectionVector &sel, idx_t to_append_size,
+                              idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, sel, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::PushBack(const Value &insert) {
+	if (size + 1 > capacity) {
+		child->Resize(capacity, capacity * 2);
+		capacity *= 2;
+	}
+	child->SetValue(size++, insert);
+}
+
+VectorListBuffer::~VectorListBuffer() {
+}
+
+ManagedVectorBuffer::ManagedVectorBuffer(unique_ptr<BufferHandle> handle)
+    : VectorBuffer(VectorBufferType::MANAGED_BUFFER), handle(move(handle)) {
+}
+
+ManagedVectorBuffer::~ManagedVectorBuffer() {
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+class VectorCacheBuffer : public VectorBuffer {
+public:
+	explicit VectorCacheBuffer(const LogicalType &type_p)
+	    : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), type(type_p) {
+		auto internal_type = type.InternalType();
+		switch (internal_type) {
+		case PhysicalType::LIST: {
+			// memory for the list offsets
+			owned_data = unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * GetTypeIdSize(internal_type)]);
+			// child data of the list
+			auto &child_type = ListType::GetChildType(type);
+			child_caches.push_back(make_buffer<VectorCacheBuffer>(child_type));
+			auto child_vector = make_unique<Vector>(child_type, false, false);
+			auxiliary = make_unique<VectorListBuffer>(move(child_vector));
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto &child_types = StructType::GetChildTypes(type);
+			for (auto &child_type : child_types) {
+				child_caches.push_back(make_buffer<VectorCacheBuffer>(child_type.second));
+			}
+			auto struct_buffer = make_unique<VectorStructBuffer>(type);
+			auxiliary = move(struct_buffer);
+			break;
+		}
+		default:
+			owned_data = unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * GetTypeIdSize(internal_type)]);
+			break;
+		}
+	}
+
+	void ResetFromCache(Vector &result, const buffer_ptr<VectorBuffer> &buffer) {
+		D_ASSERT(type == result.GetType());
+		auto internal_type = type.InternalType();
+		result.vector_type = VectorType::FLAT_VECTOR;
+		AssignSharedPointer(result.buffer, buffer);
+		result.validity.Reset();
+		switch (internal_type) {
+		case PhysicalType::LIST: {
+			result.data = owned_data.get();
+			// reinitialize the VectorListBuffer
+			AssignSharedPointer(result.auxiliary, auxiliary);
+			// propagate through child
+			auto &list_buffer = (VectorListBuffer &)*result.auxiliary;
+			list_buffer.capacity = STANDARD_VECTOR_SIZE;
+			list_buffer.size = 0;
+
+			auto &list_child = list_buffer.GetChild();
+			auto &child_cache = (VectorCacheBuffer &)*child_caches[0];
+			child_cache.ResetFromCache(list_child, child_caches[0]);
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			// struct does not have data
+			result.data = nullptr;
+			// reinitialize the VectorStructBuffer
+			AssignSharedPointer(result.auxiliary, auxiliary);
+			// propagate through children
+			auto &children = ((VectorStructBuffer &)*result.auxiliary).GetChildren();
+			for (idx_t i = 0; i < children.size(); i++) {
+				auto &child_cache = (VectorCacheBuffer &)*child_caches[i];
+				child_cache.ResetFromCache(*children[i], child_caches[i]);
+			}
+			break;
+		}
+		default:
+			// regular type: no aux data and reset data to cached data
+			result.data = owned_data.get();
+			result.auxiliary.reset();
+			break;
+		}
+	}
+
+	const LogicalType &GetType() {
+		return type;
+	}
+
+private:
+	//! The type of the vector cache
+	LogicalType type;
+	//! Owned data
+	unique_ptr<data_t[]> owned_data;
+	//! Child caches (if any). Used for nested types.
+	vector<buffer_ptr<VectorBuffer>> child_caches;
+	//! Aux data for the vector (if any)
+	buffer_ptr<VectorBuffer> auxiliary;
+};
+
+VectorCache::VectorCache(const LogicalType &type_p) {
+	buffer = make_unique<VectorCacheBuffer>(type_p);
+}
+
+void VectorCache::ResetFromCache(Vector &result) const {
+	D_ASSERT(buffer);
+	auto &vcache = (VectorCacheBuffer &)*buffer;
+	vcache.ResetFromCache(result, buffer);
+}
+
+const LogicalType &VectorCache::GetType() const {
+	auto &vcache = (VectorCacheBuffer &)*buffer;
+	return vcache.GetType();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+const SelectionVector *ConstantVector::ZeroSelectionVector() {
+	static const SelectionVector ZERO_SELECTION_VECTOR = SelectionVector((sel_t *)ConstantVector::ZERO_VECTOR);
+	return &ZERO_SELECTION_VECTOR;
+}
+
+const SelectionVector *FlatVector::IncrementalSelectionVector() {
+	static const SelectionVector INCREMENTAL_SELECTION_VECTOR;
+	return &INCREMENTAL_SELECTION_VECTOR;
+}
+
+const sel_t ConstantVector::ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+LogicalType::LogicalType() : LogicalType(LogicalTypeId::INVALID) {
+}
+
+LogicalType::LogicalType(LogicalTypeId id) : id_(id) {
+	physical_type_ = GetInternalType();
+}
+LogicalType::LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info_p)
+    : id_(id), type_info_(move(type_info_p)) {
+	physical_type_ = GetInternalType();
+}
+
+LogicalType::LogicalType(const LogicalType &other)
+    : id_(other.id_), physical_type_(other.physical_type_), type_info_(other.type_info_) {
+}
+
+LogicalType::LogicalType(LogicalType &&other) noexcept
+    : id_(other.id_), physical_type_(other.physical_type_), type_info_(move(other.type_info_)) {
+}
+
+hash_t LogicalType::Hash() const {
+	return duckdb::Hash<uint8_t>((uint8_t)id_);
+}
+
+PhysicalType LogicalType::GetInternalType() {
+	switch (id_) {
+	case LogicalTypeId::BOOLEAN:
+		return PhysicalType::BOOL;
+	case LogicalTypeId::TINYINT:
+		return PhysicalType::INT8;
+	case LogicalTypeId::UTINYINT:
+		return PhysicalType::UINT8;
+	case LogicalTypeId::SMALLINT:
+		return PhysicalType::INT16;
+	case LogicalTypeId::USMALLINT:
+		return PhysicalType::UINT16;
+	case LogicalTypeId::SQLNULL:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::INTEGER:
+		return PhysicalType::INT32;
+	case LogicalTypeId::UINTEGER:
+		return PhysicalType::UINT32;
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return PhysicalType::INT64;
+	case LogicalTypeId::UBIGINT:
+		return PhysicalType::UINT64;
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return PhysicalType::INT128;
+	case LogicalTypeId::FLOAT:
+		return PhysicalType::FLOAT;
+	case LogicalTypeId::DOUBLE:
+		return PhysicalType::DOUBLE;
+	case LogicalTypeId::DECIMAL: {
+		if (!type_info_) {
+			return PhysicalType::INVALID;
+		}
+		auto width = DecimalType::GetWidth(*this);
+		if (width <= Decimal::MAX_WIDTH_INT16) {
+			return PhysicalType::INT16;
+		} else if (width <= Decimal::MAX_WIDTH_INT32) {
+			return PhysicalType::INT32;
+		} else if (width <= Decimal::MAX_WIDTH_INT64) {
+			return PhysicalType::INT64;
+		} else if (width <= Decimal::MAX_WIDTH_INT128) {
+			return PhysicalType::INT128;
+		} else {
+			throw InternalException("Widths bigger than %d are not supported", DecimalType::MaxWidth());
+		}
+	}
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::CHAR:
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::JSON:
+		return PhysicalType::VARCHAR;
+	case LogicalTypeId::INTERVAL:
+		return PhysicalType::INTERVAL;
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::STRUCT:
+		return PhysicalType::STRUCT;
+	case LogicalTypeId::LIST:
+		return PhysicalType::LIST;
+	case LogicalTypeId::POINTER:
+		// LCOV_EXCL_START
+		if (sizeof(uintptr_t) == sizeof(uint32_t)) {
+			return PhysicalType::UINT32;
+		} else if (sizeof(uintptr_t) == sizeof(uint64_t)) {
+			return PhysicalType::UINT64;
+		} else {
+			throw InternalException("Unsupported pointer size");
+		}
+		// LCOV_EXCL_STOP
+	case LogicalTypeId::VALIDITY:
+		return PhysicalType::BIT;
+	case LogicalTypeId::ENUM: {
+		D_ASSERT(type_info_);
+		return EnumType::GetPhysicalType(*this);
+	}
+	case LogicalTypeId::TABLE:
+	case LogicalTypeId::ANY:
+	case LogicalTypeId::INVALID:
+	case LogicalTypeId::UNKNOWN:
+		return PhysicalType::INVALID;
+	case LogicalTypeId::USER:
+		return PhysicalType::UNKNOWN;
+	case LogicalTypeId::AGGREGATE_STATE:
+		return PhysicalType::VARCHAR;
+	default:
+		throw InternalException("Invalid LogicalType %s", ToString());
+	}
+}
+
+constexpr const LogicalTypeId LogicalType::INVALID;
+constexpr const LogicalTypeId LogicalType::SQLNULL;
+constexpr const LogicalTypeId LogicalType::BOOLEAN;
+constexpr const LogicalTypeId LogicalType::TINYINT;
+constexpr const LogicalTypeId LogicalType::UTINYINT;
+constexpr const LogicalTypeId LogicalType::SMALLINT;
+constexpr const LogicalTypeId LogicalType::USMALLINT;
+constexpr const LogicalTypeId LogicalType::INTEGER;
+constexpr const LogicalTypeId LogicalType::UINTEGER;
+constexpr const LogicalTypeId LogicalType::BIGINT;
+constexpr const LogicalTypeId LogicalType::UBIGINT;
+constexpr const LogicalTypeId LogicalType::HUGEINT;
+constexpr const LogicalTypeId LogicalType::UUID;
+constexpr const LogicalTypeId LogicalType::FLOAT;
+constexpr const LogicalTypeId LogicalType::DOUBLE;
+constexpr const LogicalTypeId LogicalType::DATE;
+
+constexpr const LogicalTypeId LogicalType::TIMESTAMP;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_MS;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_NS;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_S;
+
+constexpr const LogicalTypeId LogicalType::TIME;
+
+constexpr const LogicalTypeId LogicalType::TIME_TZ;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_TZ;
+
+constexpr const LogicalTypeId LogicalType::HASH;
+constexpr const LogicalTypeId LogicalType::POINTER;
+
+constexpr const LogicalTypeId LogicalType::VARCHAR;
+constexpr const LogicalTypeId LogicalType::JSON;
+
+constexpr const LogicalTypeId LogicalType::BLOB;
+constexpr const LogicalTypeId LogicalType::INTERVAL;
+constexpr const LogicalTypeId LogicalType::ROW_TYPE;
+
+// TODO these are incomplete and should maybe not exist as such
+constexpr const LogicalTypeId LogicalType::TABLE;
+
+constexpr const LogicalTypeId LogicalType::ANY;
+
+const vector<LogicalType> LogicalType::Numeric() {
+	vector<LogicalType> types = {LogicalType::TINYINT,   LogicalType::SMALLINT,  LogicalType::INTEGER,
+	                             LogicalType::BIGINT,    LogicalType::HUGEINT,   LogicalType::FLOAT,
+	                             LogicalType::DOUBLE,    LogicalTypeId::DECIMAL, LogicalType::UTINYINT,
+	                             LogicalType::USMALLINT, LogicalType::UINTEGER,  LogicalType::UBIGINT};
+	return types;
+}
+
+const vector<LogicalType> LogicalType::Integral() {
+	vector<LogicalType> types = {LogicalType::TINYINT,   LogicalType::SMALLINT, LogicalType::INTEGER,
+	                             LogicalType::BIGINT,    LogicalType::HUGEINT,  LogicalType::UTINYINT,
+	                             LogicalType::USMALLINT, LogicalType::UINTEGER, LogicalType::UBIGINT};
+	return types;
+}
+
+const vector<LogicalType> LogicalType::AllTypes() {
+	vector<LogicalType> types = {
+	    LogicalType::BOOLEAN,  LogicalType::TINYINT,   LogicalType::SMALLINT,     LogicalType::INTEGER,
+	    LogicalType::BIGINT,   LogicalType::DATE,      LogicalType::TIMESTAMP,    LogicalType::DOUBLE,
+	    LogicalType::FLOAT,    LogicalType::VARCHAR,   LogicalType::BLOB,         LogicalType::INTERVAL,
+	    LogicalType::HUGEINT,  LogicalTypeId::DECIMAL, LogicalType::UTINYINT,     LogicalType::USMALLINT,
+	    LogicalType::UINTEGER, LogicalType::UBIGINT,   LogicalType::TIME,         LogicalTypeId::LIST,
+	    LogicalTypeId::STRUCT, LogicalType::TIME_TZ,   LogicalType::TIMESTAMP_TZ, LogicalTypeId::MAP,
+	    LogicalType::UUID,     LogicalType::JSON};
+	return types;
+}
+
+const PhysicalType ROW_TYPE = PhysicalType::INT64;
+
+// LCOV_EXCL_START
+string TypeIdToString(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+		return "BOOL";
+	case PhysicalType::INT8:
+		return "INT8";
+	case PhysicalType::INT16:
+		return "INT16";
+	case PhysicalType::INT32:
+		return "INT32";
+	case PhysicalType::INT64:
+		return "INT64";
+	case PhysicalType::UINT8:
+		return "UINT8";
+	case PhysicalType::UINT16:
+		return "UINT16";
+	case PhysicalType::UINT32:
+		return "UINT32";
+	case PhysicalType::UINT64:
+		return "UINT64";
+	case PhysicalType::INT128:
+		return "INT128";
+	case PhysicalType::FLOAT:
+		return "FLOAT";
+	case PhysicalType::DOUBLE:
+		return "DOUBLE";
+	case PhysicalType::VARCHAR:
+		return "VARCHAR";
+	case PhysicalType::INTERVAL:
+		return "INTERVAL";
+	case PhysicalType::STRUCT:
+		return "STRUCT";
+	case PhysicalType::LIST:
+		return "LIST";
+	case PhysicalType::INVALID:
+		return "INVALID";
+	case PhysicalType::BIT:
+		return "BIT";
+	case PhysicalType::NA:
+		return "NA";
+	case PhysicalType::HALF_FLOAT:
+		return "HALF_FLOAT";
+	case PhysicalType::STRING:
+		return "ARROW_STRING";
+	case PhysicalType::BINARY:
+		return "BINARY";
+	case PhysicalType::FIXED_SIZE_BINARY:
+		return "FIXED_SIZE_BINARY";
+	case PhysicalType::DATE32:
+		return "DATE32";
+	case PhysicalType::DATE64:
+		return "DATE64";
+	case PhysicalType::TIMESTAMP:
+		return "TIMESTAMP";
+	case PhysicalType::TIME32:
+		return "TIME32";
+	case PhysicalType::TIME64:
+		return "TIME64";
+	case PhysicalType::UNION:
+		return "UNION";
+	case PhysicalType::DICTIONARY:
+		return "DICTIONARY";
+	case PhysicalType::MAP:
+		return "MAP";
+	case PhysicalType::EXTENSION:
+		return "EXTENSION";
+	case PhysicalType::FIXED_SIZE_LIST:
+		return "FIXED_SIZE_LIST";
+	case PhysicalType::DURATION:
+		return "DURATION";
+	case PhysicalType::LARGE_STRING:
+		return "LARGE_STRING";
+	case PhysicalType::LARGE_BINARY:
+		return "LARGE_BINARY";
+	case PhysicalType::LARGE_LIST:
+		return "LARGE_LIST";
+	case PhysicalType::UNKNOWN:
+		return "UNKNOWN";
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+idx_t GetTypeIdSize(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+	case PhysicalType::BOOL:
+		return sizeof(bool);
+	case PhysicalType::INT8:
+		return sizeof(int8_t);
+	case PhysicalType::INT16:
+		return sizeof(int16_t);
+	case PhysicalType::INT32:
+		return sizeof(int32_t);
+	case PhysicalType::INT64:
+		return sizeof(int64_t);
+	case PhysicalType::UINT8:
+		return sizeof(uint8_t);
+	case PhysicalType::UINT16:
+		return sizeof(uint16_t);
+	case PhysicalType::UINT32:
+		return sizeof(uint32_t);
+	case PhysicalType::UINT64:
+		return sizeof(uint64_t);
+	case PhysicalType::INT128:
+		return sizeof(hugeint_t);
+	case PhysicalType::FLOAT:
+		return sizeof(float);
+	case PhysicalType::DOUBLE:
+		return sizeof(double);
+	case PhysicalType::VARCHAR:
+		return sizeof(string_t);
+	case PhysicalType::INTERVAL:
+		return sizeof(interval_t);
+	case PhysicalType::STRUCT:
+	case PhysicalType::UNKNOWN:
+		return 0; // no own payload
+	case PhysicalType::LIST:
+		return sizeof(list_entry_t); // offset + len
+	default:
+		throw InternalException("Invalid PhysicalType for GetTypeIdSize");
+	}
+}
+
+bool TypeIsConstantSize(PhysicalType type) {
+	return (type >= PhysicalType::BOOL && type <= PhysicalType::DOUBLE) ||
+	       (type >= PhysicalType::FIXED_SIZE_BINARY && type <= PhysicalType::INTERVAL) ||
+	       type == PhysicalType::INTERVAL || type == PhysicalType::INT128;
+}
+bool TypeIsIntegral(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::INT64) || type == PhysicalType::INT128;
+}
+bool TypeIsNumeric(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::DOUBLE) || type == PhysicalType::INT128;
+}
+bool TypeIsInteger(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::INT64) || type == PhysicalType::INT128;
+}
+
+// LCOV_EXCL_START
+string LogicalTypeIdToString(LogicalTypeId id) {
+	switch (id) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+		return "TINYINT";
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+		return "BIGINT";
+	case LogicalTypeId::HUGEINT:
+		return "HUGEINT";
+	case LogicalTypeId::UUID:
+		return "UUID";
+	case LogicalTypeId::UTINYINT:
+		return "UTINYINT";
+	case LogicalTypeId::USMALLINT:
+		return "USMALLINT";
+	case LogicalTypeId::UINTEGER:
+		return "UINTEGER";
+	case LogicalTypeId::UBIGINT:
+		return "UBIGINT";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIME:
+		return "TIME";
+	case LogicalTypeId::TIMESTAMP:
+		return "TIMESTAMP";
+	case LogicalTypeId::TIMESTAMP_MS:
+		return "TIMESTAMP_MS";
+	case LogicalTypeId::TIMESTAMP_NS:
+		return "TIMESTAMP_NS";
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return "TIMESTAMP_S";
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return "TIMESTAMP WITH TIME ZONE";
+	case LogicalTypeId::TIME_TZ:
+		return "TIME WITH TIME ZONE";
+	case LogicalTypeId::FLOAT:
+		return "FLOAT";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE";
+	case LogicalTypeId::DECIMAL:
+		return "DECIMAL";
+	case LogicalTypeId::VARCHAR:
+		return "VARCHAR";
+	case LogicalTypeId::BLOB:
+		return "BLOB";
+	case LogicalTypeId::CHAR:
+		return "CHAR";
+	case LogicalTypeId::INTERVAL:
+		return "INTERVAL";
+	case LogicalTypeId::SQLNULL:
+		return "NULL";
+	case LogicalTypeId::ANY:
+		return "ANY";
+	case LogicalTypeId::VALIDITY:
+		return "VALIDITY";
+	case LogicalTypeId::STRUCT:
+		return "STRUCT";
+	case LogicalTypeId::LIST:
+		return "LIST";
+	case LogicalTypeId::MAP:
+		return "MAP";
+	case LogicalTypeId::POINTER:
+		return "POINTER";
+	case LogicalTypeId::TABLE:
+		return "TABLE";
+	case LogicalTypeId::INVALID:
+		return "INVALID";
+	case LogicalTypeId::UNKNOWN:
+		return "UNKNOWN";
+	case LogicalTypeId::ENUM:
+		return "ENUM";
+	case LogicalTypeId::AGGREGATE_STATE:
+		return "AGGREGATE_STATE";
+	case LogicalTypeId::USER:
+		return "USER";
+	case LogicalTypeId::JSON:
+		return "JSON";
+	}
+	return "UNDEFINED";
+}
+
+string LogicalType::ToString() const {
+	auto alias = GetAlias();
+	if (!alias.empty()) {
+		return alias;
+	}
+	switch (id_) {
+	case LogicalTypeId::STRUCT: {
+		if (!type_info_) {
+			return "STRUCT";
+		}
+		auto &child_types = StructType::GetChildTypes(*this);
+		string ret = "STRUCT(";
+		for (size_t i = 0; i < child_types.size(); i++) {
+			ret += child_types[i].first + " " + child_types[i].second.ToString();
+			if (i < child_types.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += ")";
+		return ret;
+	}
+	case LogicalTypeId::LIST: {
+		if (!type_info_) {
+			return "LIST";
+		}
+		return ListType::GetChildType(*this).ToString() + "[]";
+	}
+	case LogicalTypeId::MAP: {
+		if (!type_info_) {
+			return "MAP";
+		}
+		auto &child_types = StructType::GetChildTypes(*this);
+		if (child_types.empty()) {
+			return "MAP(?)";
+		}
+		if (child_types.size() != 2) {
+			throw InternalException("Map needs exactly two child elements");
+		}
+		return "MAP(" + ListType::GetChildType(child_types[0].second).ToString() + ", " +
+		       ListType::GetChildType(child_types[1].second).ToString() + ")";
+	}
+	case LogicalTypeId::DECIMAL: {
+		if (!type_info_) {
+			return "DECIMAL";
+		}
+		auto width = DecimalType::GetWidth(*this);
+		auto scale = DecimalType::GetScale(*this);
+		if (width == 0) {
+			return "DECIMAL";
+		}
+		return StringUtil::Format("DECIMAL(%d,%d)", width, scale);
+	}
+	case LogicalTypeId::ENUM: {
+		return KeywordHelper::WriteOptionallyQuoted(EnumType::GetTypeName(*this));
+	}
+	case LogicalTypeId::USER: {
+		return KeywordHelper::WriteOptionallyQuoted(UserType::GetTypeName(*this));
+	}
+	case LogicalTypeId::AGGREGATE_STATE: {
+		return AggregateStateType::GetTypeName(*this);
+	}
+	default:
+		return LogicalTypeIdToString(id_);
+	}
+}
+// LCOV_EXCL_STOP
+
+LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
+	auto type = DefaultTypeGenerator::GetDefaultType(str);
+	if (type == LogicalTypeId::INVALID) {
+		// This is a User Type, at this point we don't know if its one of the User Defined Types or an error
+		// It is checked in the binder
+		type = LogicalTypeId::USER;
+	}
+	return type;
+}
+
+LogicalType TransformStringToLogicalType(const string &str) {
+	if (StringUtil::Lower(str) == "null") {
+		return LogicalType::SQLNULL;
+	}
+	return Parser::ParseColumnList("dummy " + str)[0].Type();
+}
+
+bool LogicalType::IsIntegral() const {
+	switch (id_) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::HUGEINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool LogicalType::IsNumeric() const {
+	switch (id_) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool LogicalType::GetDecimalProperties(uint8_t &width, uint8_t &scale) const {
+	switch (id_) {
+	case LogicalTypeId::SQLNULL:
+		width = 0;
+		scale = 0;
+		break;
+	case LogicalTypeId::BOOLEAN:
+		width = 1;
+		scale = 0;
+		break;
+	case LogicalTypeId::TINYINT:
+		// tinyint: [-127, 127] = DECIMAL(3,0)
+		width = 3;
+		scale = 0;
+		break;
+	case LogicalTypeId::SMALLINT:
+		// smallint: [-32767, 32767] = DECIMAL(5,0)
+		width = 5;
+		scale = 0;
+		break;
+	case LogicalTypeId::INTEGER:
+		// integer: [-2147483647, 2147483647] = DECIMAL(10,0)
+		width = 10;
+		scale = 0;
+		break;
+	case LogicalTypeId::BIGINT:
+		// bigint: [-9223372036854775807, 9223372036854775807] = DECIMAL(19,0)
+		width = 19;
+		scale = 0;
+		break;
+	case LogicalTypeId::UTINYINT:
+		// UInt8 — [0 : 255]
+		width = 3;
+		scale = 0;
+		break;
+	case LogicalTypeId::USMALLINT:
+		// UInt16 — [0 : 65535]
+		width = 5;
+		scale = 0;
+		break;
+	case LogicalTypeId::UINTEGER:
+		// UInt32 — [0 : 4294967295]
+		width = 10;
+		scale = 0;
+		break;
+	case LogicalTypeId::UBIGINT:
+		// UInt64 — [0 : 18446744073709551615]
+		width = 20;
+		scale = 0;
+		break;
+	case LogicalTypeId::HUGEINT:
+		// hugeint: max size decimal (38, 0)
+		// note that a hugeint is not guaranteed to fit in this
+		width = 38;
+		scale = 0;
+		break;
+	case LogicalTypeId::DECIMAL:
+		width = DecimalType::GetWidth(*this);
+		scale = DecimalType::GetScale(*this);
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+LogicalType LogicalType::MaxLogicalType(const LogicalType &left, const LogicalType &right) {
+	if (left.id() < right.id()) {
+		return right;
+	} else if (right.id() < left.id()) {
+		return left;
+	} else {
+		// Since both left and right are equal we get the left type as our type_id for checks
+		auto type_id = left.id();
+		if (type_id == LogicalTypeId::ENUM) {
+			// If both types are different ENUMs we do a string comparison.
+			return left == right ? left : LogicalType::VARCHAR;
+		}
+		if (type_id == LogicalTypeId::VARCHAR) {
+			// varchar: use type that has collation (if any)
+			if (StringType::GetCollation(right).empty()) {
+				return left;
+			} else {
+				return right;
+			}
+		} else if (type_id == LogicalTypeId::DECIMAL) {
+			// unify the width/scale so that the resulting decimal always fits
+			// "width - scale" gives us the number of digits on the left side of the decimal point
+			// "scale" gives us the number of digits allowed on the right of the deciaml point
+			// using the max of these of the two types gives us the new decimal size
+			auto extra_width_left = DecimalType::GetWidth(left) - DecimalType::GetScale(left);
+			auto extra_width_right = DecimalType::GetWidth(right) - DecimalType::GetScale(right);
+			auto extra_width = MaxValue<uint8_t>(extra_width_left, extra_width_right);
+			auto scale = MaxValue<uint8_t>(DecimalType::GetScale(left), DecimalType::GetScale(right));
+			auto width = extra_width + scale;
+			if (width > DecimalType::MaxWidth()) {
+				// if the resulting decimal does not fit, we truncate the scale
+				width = DecimalType::MaxWidth();
+				scale = width - extra_width;
+			}
+			return LogicalType::DECIMAL(width, scale);
+		} else if (type_id == LogicalTypeId::LIST) {
+			// list: perform max recursively on child type
+			auto new_child = MaxLogicalType(ListType::GetChildType(left), ListType::GetChildType(right));
+			return LogicalType::LIST(move(new_child));
+		} else if (type_id == LogicalTypeId::STRUCT) {
+			// struct: perform recursively
+			auto &left_child_types = StructType::GetChildTypes(left);
+			auto &right_child_types = StructType::GetChildTypes(right);
+			if (left_child_types.size() != right_child_types.size()) {
+				// child types are not of equal size, we can't cast anyway
+				// just return the left child
+				return left;
+			}
+			child_list_t<LogicalType> child_types;
+			for (idx_t i = 0; i < left_child_types.size(); i++) {
+				auto child_type = MaxLogicalType(left_child_types[i].second, right_child_types[i].second);
+				child_types.push_back(make_pair(left_child_types[i].first, move(child_type)));
+			}
+			return LogicalType::STRUCT(move(child_types));
+		} else {
+			// types are equal but no extra specifier: just return the type
+			return left;
+		}
+	}
+}
+
+void LogicalType::Verify() const {
+#ifdef DEBUG
+	if (id_ == LogicalTypeId::DECIMAL) {
+		D_ASSERT(DecimalType::GetWidth(*this) >= 1 && DecimalType::GetWidth(*this) <= Decimal::MAX_WIDTH_DECIMAL);
+		D_ASSERT(DecimalType::GetScale(*this) >= 0 && DecimalType::GetScale(*this) <= DecimalType::GetWidth(*this));
+	}
+#endif
+}
+
+bool ApproxEqual(float ldecimal, float rdecimal) {
+	if (Value::IsNan(ldecimal) && Value::IsNan(rdecimal)) {
+		return true;
+	}
+	if (!Value::FloatIsFinite(ldecimal) || !Value::FloatIsFinite(rdecimal)) {
+		return ldecimal == rdecimal;
+	}
+	float epsilon = std::fabs(rdecimal) * 0.01 + 0.00000001;
+	return std::fabs(ldecimal - rdecimal) <= epsilon;
+}
+
+bool ApproxEqual(double ldecimal, double rdecimal) {
+	if (Value::IsNan(ldecimal) && Value::IsNan(rdecimal)) {
+		return true;
+	}
+	if (!Value::DoubleIsFinite(ldecimal) || !Value::DoubleIsFinite(rdecimal)) {
+		return ldecimal == rdecimal;
+	}
+	double epsilon = std::fabs(rdecimal) * 0.01 + 0.00000001;
+	return std::fabs(ldecimal - rdecimal) <= epsilon;
+}
+
+//===--------------------------------------------------------------------===//
+// Extra Type Info
+//===--------------------------------------------------------------------===//
+enum class ExtraTypeInfoType : uint8_t {
+	INVALID_TYPE_INFO = 0,
+	GENERIC_TYPE_INFO = 1,
+	DECIMAL_TYPE_INFO = 2,
+	STRING_TYPE_INFO = 3,
+	LIST_TYPE_INFO = 4,
+	STRUCT_TYPE_INFO = 5,
+	ENUM_TYPE_INFO = 6,
+	USER_TYPE_INFO = 7,
+	AGGREGATE_STATE_TYPE_INFO = 8
+};
+
+struct ExtraTypeInfo {
+	explicit ExtraTypeInfo(ExtraTypeInfoType type) : type(type) {
+	}
+	explicit ExtraTypeInfo(ExtraTypeInfoType type, string alias) : type(type), alias(move(alias)) {
+	}
+	virtual ~ExtraTypeInfo() {
+	}
+
+	ExtraTypeInfoType type;
+	string alias;
+	TypeCatalogEntry *catalog_entry = nullptr;
+
+public:
+	bool Equals(ExtraTypeInfo *other_p) const {
+		if (type == ExtraTypeInfoType::INVALID_TYPE_INFO || type == ExtraTypeInfoType::STRING_TYPE_INFO ||
+		    type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
+			if (!other_p) {
+				if (!alias.empty()) {
+					return false;
+				}
+				return true;
+			}
+			if (alias != other_p->alias) {
+				return false;
+			}
+			return true;
+		}
+		if (!other_p) {
+			return false;
+		}
+		if (type != other_p->type) {
+			return false;
+		}
+		auto &other = (ExtraTypeInfo &)*other_p;
+		return alias == other.alias && EqualsInternal(other_p);
+	}
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	virtual void Serialize(FieldWriter &writer) const {};
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	static void Serialize(ExtraTypeInfo *info, FieldWriter &writer);
+	//! Deserializes a blob back into an ExtraTypeInfo
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader);
+
+protected:
+	virtual bool EqualsInternal(ExtraTypeInfo *other_p) const {
+		// Do nothing
+		return true;
+	}
+};
+
+void LogicalType::SetAlias(string &alias) {
+	if (!type_info_) {
+		type_info_ = make_shared<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, alias);
+	} else {
+		type_info_->alias = alias;
+	}
+}
+
+string LogicalType::GetAlias() const {
+	if (!type_info_) {
+		return string();
+	} else {
+		return type_info_->alias;
+	}
+}
+
+void LogicalType::SetCatalog(LogicalType &type, TypeCatalogEntry *catalog_entry) {
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	((ExtraTypeInfo &)*info).catalog_entry = catalog_entry;
+}
+TypeCatalogEntry *LogicalType::GetCatalog(const LogicalType &type) {
+	auto info = type.AuxInfo();
+	if (!info) {
+		return nullptr;
+	}
+	return ((ExtraTypeInfo &)*info).catalog_entry;
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal Type
+//===--------------------------------------------------------------------===//
+struct DecimalTypeInfo : public ExtraTypeInfo {
+	DecimalTypeInfo(uint8_t width_p, uint8_t scale_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::DECIMAL_TYPE_INFO), width(width_p), scale(scale_p) {
+	}
+
+	uint8_t width;
+	uint8_t scale;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteField<uint8_t>(width);
+		writer.WriteField<uint8_t>(scale);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto width = reader.ReadRequired<uint8_t>();
+		auto scale = reader.ReadRequired<uint8_t>();
+		return make_shared<DecimalTypeInfo>(width, scale);
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (DecimalTypeInfo &)*other_p;
+		return width == other.width && scale == other.scale;
+	}
+};
+
+uint8_t DecimalType::GetWidth(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((DecimalTypeInfo &)*info).width;
+}
+
+uint8_t DecimalType::GetScale(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((DecimalTypeInfo &)*info).scale;
+}
+
+uint8_t DecimalType::MaxWidth() {
+	return 38;
+}
+
+LogicalType LogicalType::DECIMAL(int width, int scale) {
+	auto type_info = make_shared<DecimalTypeInfo>(width, scale);
+	return LogicalType(LogicalTypeId::DECIMAL, move(type_info));
+}
+
+//===--------------------------------------------------------------------===//
+// String Type
+//===--------------------------------------------------------------------===//
+struct StringTypeInfo : public ExtraTypeInfo {
+	explicit StringTypeInfo(string collation_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::STRING_TYPE_INFO), collation(move(collation_p)) {
+	}
+
+	string collation;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteString(collation);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto collation = reader.ReadRequired<string>();
+		return make_shared<StringTypeInfo>(move(collation));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		// collation info has no impact on equality
+		return true;
+	}
+};
+
+string StringType::GetCollation(const LogicalType &type) {
+	if (type.id() != LogicalTypeId::VARCHAR) {
+		return string();
+	}
+	auto info = type.AuxInfo();
+	if (!info) {
+		return string();
+	}
+	if (info->type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
+		return string();
+	}
+	return ((StringTypeInfo &)*info).collation;
+}
+
+LogicalType LogicalType::VARCHAR_COLLATION(string collation) { // NOLINT
+	auto string_info = make_shared<StringTypeInfo>(move(collation));
+	return LogicalType(LogicalTypeId::VARCHAR, move(string_info));
+}
+
+//===--------------------------------------------------------------------===//
+// List Type
+//===--------------------------------------------------------------------===//
+struct ListTypeInfo : public ExtraTypeInfo {
+	explicit ListTypeInfo(LogicalType child_type_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::LIST_TYPE_INFO), child_type(move(child_type_p)) {
+	}
+
+	LogicalType child_type;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteSerializable(child_type);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto child_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+		return make_shared<ListTypeInfo>(move(child_type));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (ListTypeInfo &)*other_p;
+		return child_type == other.child_type;
+	}
+};
+
+const LogicalType &ListType::GetChildType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::LIST);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((ListTypeInfo &)*info).child_type;
+}
+
+LogicalType LogicalType::LIST(LogicalType child) {
+	auto info = make_shared<ListTypeInfo>(move(child));
+	return LogicalType(LogicalTypeId::LIST, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Struct Type
+//===--------------------------------------------------------------------===//
+struct StructTypeInfo : public ExtraTypeInfo {
+	explicit StructTypeInfo(child_list_t<LogicalType> child_types_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::STRUCT_TYPE_INFO), child_types(move(child_types_p)) {
+	}
+
+	child_list_t<LogicalType> child_types;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteField<uint32_t>(child_types.size());
+		auto &serializer = writer.GetSerializer();
+		for (idx_t i = 0; i < child_types.size(); i++) {
+			serializer.WriteString(child_types[i].first);
+			child_types[i].second.Serialize(serializer);
+		}
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		child_list_t<LogicalType> child_list;
+		auto child_types_size = reader.ReadRequired<uint32_t>();
+		auto &source = reader.GetSource();
+		for (uint32_t i = 0; i < child_types_size; i++) {
+			auto name = source.Read<string>();
+			auto type = LogicalType::Deserialize(source);
+			child_list.push_back(make_pair(move(name), move(type)));
+		}
+		return make_shared<StructTypeInfo>(move(child_list));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (StructTypeInfo &)*other_p;
+		return child_types == other.child_types;
+	}
+};
+
+struct AggregateStateTypeInfo : public ExtraTypeInfo {
+	explicit AggregateStateTypeInfo(aggregate_state_t state_type_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::AGGREGATE_STATE_TYPE_INFO), state_type(move(state_type_p)) {
+	}
+
+	aggregate_state_t state_type;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		auto &serializer = writer.GetSerializer();
+		writer.WriteString(state_type.function_name);
+		state_type.return_type.Serialize(serializer);
+		writer.WriteField<uint32_t>(state_type.bound_argument_types.size());
+		for (idx_t i = 0; i < state_type.bound_argument_types.size(); i++) {
+			state_type.bound_argument_types[i].Serialize(serializer);
+		}
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto &source = reader.GetSource();
+
+		auto function_name = reader.ReadRequired<string>();
+		auto return_type = LogicalType::Deserialize(source);
+		auto bound_argument_types_size = reader.ReadRequired<uint32_t>();
+		vector<LogicalType> bound_argument_types;
+
+		for (uint32_t i = 0; i < bound_argument_types_size; i++) {
+			auto type = LogicalType::Deserialize(source);
+			bound_argument_types.push_back(move(type));
+		}
+		return make_shared<AggregateStateTypeInfo>(
+		    aggregate_state_t(move(function_name), move(return_type), move(bound_argument_types)));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (AggregateStateTypeInfo &)*other_p;
+		return state_type.function_name == other.state_type.function_name &&
+		       state_type.return_type == other.state_type.return_type &&
+		       state_type.bound_argument_types == other.state_type.bound_argument_types;
+	}
+};
+
+const aggregate_state_t &AggregateStateType::GetStateType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::AGGREGATE_STATE);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((AggregateStateTypeInfo &)*info).state_type;
+}
+
+const string AggregateStateType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::AGGREGATE_STATE);
+	auto info = type.AuxInfo();
+	if (!info) {
+		return "AGGREGATE_STATE<?>";
+	}
+	auto aggr_state = ((AggregateStateTypeInfo &)*info).state_type;
+	return "AGGREGATE_STATE<" + aggr_state.function_name + "(" +
+	       StringUtil::Join(aggr_state.bound_argument_types, aggr_state.bound_argument_types.size(), ", ",
+	                        [](const LogicalType &arg_type) { return arg_type.ToString(); }) +
+	       ")" + "::" + aggr_state.return_type.ToString() + ">";
+}
+
+const child_list_t<LogicalType> &StructType::GetChildTypes(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::MAP);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((StructTypeInfo &)*info).child_types;
+}
+
+const LogicalType &StructType::GetChildType(const LogicalType &type, idx_t index) {
+	auto &child_types = StructType::GetChildTypes(type);
+	D_ASSERT(index < child_types.size());
+	return child_types[index].second;
+}
+
+const string &StructType::GetChildName(const LogicalType &type, idx_t index) {
+	auto &child_types = StructType::GetChildTypes(type);
+	D_ASSERT(index < child_types.size());
+	return child_types[index].first;
+}
+
+idx_t StructType::GetChildCount(const LogicalType &type) {
+	return StructType::GetChildTypes(type).size();
+}
+
+LogicalType LogicalType::STRUCT(child_list_t<LogicalType> children) {
+	auto info = make_shared<StructTypeInfo>(move(children));
+	return LogicalType(LogicalTypeId::STRUCT, move(info));
+}
+
+LogicalType LogicalType::AGGREGATE_STATE(aggregate_state_t state_type) { // NOLINT
+	auto info = make_shared<AggregateStateTypeInfo>(move(state_type));
+	return LogicalType(LogicalTypeId::AGGREGATE_STATE, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Map Type
+//===--------------------------------------------------------------------===//
+LogicalType LogicalType::MAP(child_list_t<LogicalType> children) {
+	auto info = make_shared<StructTypeInfo>(move(children));
+	return LogicalType(LogicalTypeId::MAP, move(info));
+}
+
+LogicalType LogicalType::MAP(LogicalType key, LogicalType value) {
+	child_list_t<LogicalType> child_types;
+	child_types.push_back({"key", LogicalType::LIST(move(key))});
+	child_types.push_back({"value", LogicalType::LIST(move(value))});
+	return LogicalType::MAP(move(child_types));
+}
+
+const LogicalType &MapType::KeyType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::MAP);
+	return ListType::GetChildType(StructType::GetChildTypes(type)[0].second);
+}
+
+const LogicalType &MapType::ValueType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::MAP);
+	return ListType::GetChildType(StructType::GetChildTypes(type)[1].second);
+}
+
+//===--------------------------------------------------------------------===//
+// User Type
+//===--------------------------------------------------------------------===//
+struct UserTypeInfo : public ExtraTypeInfo {
+	explicit UserTypeInfo(string name_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::USER_TYPE_INFO), user_type_name(move(name_p)) {
+	}
+
+	string user_type_name;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteString(user_type_name);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto enum_name = reader.ReadRequired<string>();
+		return make_shared<UserTypeInfo>(move(enum_name));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (UserTypeInfo &)*other_p;
+		return other.user_type_name == user_type_name;
+	}
+};
+
+const string &UserType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::USER);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((UserTypeInfo &)*info).user_type_name;
+}
+
+LogicalType LogicalType::USER(const string &user_type_name) {
+	auto info = make_shared<UserTypeInfo>(user_type_name);
+	return LogicalType(LogicalTypeId::USER, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Enum Type
+//===--------------------------------------------------------------------===//
+
+enum EnumDictType : uint8_t { INVALID = 0, VECTOR_DICT = 1, DEDUP_POINTER = 2 };
+
+struct EnumTypeInfo : public ExtraTypeInfo {
+	explicit EnumTypeInfo(string enum_name_p, Vector &values_insert_order_p, idx_t dict_size_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::ENUM_TYPE_INFO), dict_type(EnumDictType::VECTOR_DICT),
+	      enum_name(move(enum_name_p)), values_insert_order(values_insert_order_p), dict_size(dict_size_p) {
+	}
+	explicit EnumTypeInfo()
+	    : ExtraTypeInfo(ExtraTypeInfoType::ENUM_TYPE_INFO), dict_type(EnumDictType::DEDUP_POINTER),
+	      enum_name("dedup_pointer"), values_insert_order(Vector(LogicalType::VARCHAR)), dict_size(0) {
+	}
+	EnumDictType dict_type;
+	string enum_name;
+	Vector values_insert_order;
+	idx_t dict_size;
+
+protected:
+	// Equalities are only used in enums with different catalog entries
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (EnumTypeInfo &)*other_p;
+		if (dict_type != other.dict_type) {
+			return false;
+		}
+		if (dict_type == EnumDictType::DEDUP_POINTER) {
+			return true;
+		}
+		D_ASSERT(dict_type == EnumDictType::VECTOR_DICT);
+		// We must check if both enums have the same size
+		if (other.dict_size != dict_size) {
+			return false;
+		}
+		auto other_vector_ptr = FlatVector::GetData<string_t>(other.values_insert_order);
+		auto this_vector_ptr = FlatVector::GetData<string_t>(values_insert_order);
+
+		// Now we must check if all strings are the same
+		for (idx_t i = 0; i < dict_size; i++) {
+			if (!Equals::Operation(other_vector_ptr[i], this_vector_ptr[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void Serialize(FieldWriter &writer) const override {
+		if (dict_type != EnumDictType::VECTOR_DICT) {
+			throw InternalException("Cannot serialize non-vector dictionary ENUM types");
+		}
+		writer.WriteField<uint32_t>(dict_size);
+		writer.WriteString(enum_name);
+		((Vector &)values_insert_order).Serialize(dict_size, writer.GetSerializer());
+	}
+};
+
+template <class T>
+struct EnumTypeInfoTemplated : public EnumTypeInfo {
+	explicit EnumTypeInfoTemplated(const string &enum_name_p, Vector &values_insert_order_p, idx_t size_p)
+	    : EnumTypeInfo(enum_name_p, values_insert_order_p, size_p) {
+		for (idx_t count = 0; count < size_p; count++) {
+			values[values_insert_order_p.GetValue(count).ToString()] = count;
+		}
+	}
+
+	static shared_ptr<EnumTypeInfoTemplated> Deserialize(FieldReader &reader, uint32_t size) {
+		auto enum_name = reader.ReadRequired<string>();
+		Vector values_insert_order(LogicalType::VARCHAR, size);
+		values_insert_order.Deserialize(size, reader.GetSource());
+		return make_shared<EnumTypeInfoTemplated>(move(enum_name), values_insert_order, size);
+	}
+	unordered_map<string, T> values;
+};
+
+const string &EnumType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).enum_name;
+}
+
+static PhysicalType EnumVectorDictType(idx_t size) {
+	if (size <= NumericLimits<uint8_t>::Maximum()) {
+		return PhysicalType::UINT8;
+	} else if (size <= NumericLimits<uint16_t>::Maximum()) {
+		return PhysicalType::UINT16;
+	} else if (size <= NumericLimits<uint32_t>::Maximum()) {
+		return PhysicalType::UINT32;
+	} else {
+		throw InternalException("Enum size must be lower than " + std::to_string(NumericLimits<uint32_t>::Maximum()));
+	}
+}
+
+LogicalType LogicalType::ENUM(const string &enum_name, Vector &ordered_data, idx_t size) {
+	// Generate EnumTypeInfo
+	shared_ptr<ExtraTypeInfo> info;
+	auto enum_internal_type = EnumVectorDictType(size);
+	switch (enum_internal_type) {
+	case PhysicalType::UINT8:
+		info = make_shared<EnumTypeInfoTemplated<uint8_t>>(enum_name, ordered_data, size);
+		break;
+	case PhysicalType::UINT16:
+		info = make_shared<EnumTypeInfoTemplated<uint16_t>>(enum_name, ordered_data, size);
+		break;
+	case PhysicalType::UINT32:
+		info = make_shared<EnumTypeInfoTemplated<uint32_t>>(enum_name, ordered_data, size);
+		break;
+	default:
+		throw InternalException("Invalid Physical Type for ENUMs");
+	}
+	// Generate Actual Enum Type
+	return LogicalType(LogicalTypeId::ENUM, info);
+}
+
+LogicalType LogicalType::DEDUP_POINTER_ENUM() { // NOLINT
+	auto info = make_shared<EnumTypeInfo>();
+	D_ASSERT(info->dict_type == EnumDictType::DEDUP_POINTER);
+	return LogicalType(LogicalTypeId::ENUM, info);
+}
+
+template <class T>
+int64_t TemplatedGetPos(unordered_map<string, T> &map, const string &key) {
+	auto it = map.find(key);
+	if (it == map.end()) {
+		return -1;
+	}
+	return it->second;
+}
+int64_t EnumType::GetPos(const LogicalType &type, const string &key) {
+	auto info = type.AuxInfo();
+	switch (type.InternalType()) {
+	case PhysicalType::UINT8:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint8_t> &)*info).values, key);
+	case PhysicalType::UINT16:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint16_t> &)*info).values, key);
+	case PhysicalType::UINT32:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint32_t> &)*info).values, key);
+	default:
+		throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+	}
+}
+
+const string EnumType::GetValue(const Value &val) {
+	auto info = val.type().AuxInfo();
+	auto &enum_info = ((EnumTypeInfo &)*info);
+	if (enum_info.dict_type == EnumDictType::DEDUP_POINTER) {
+		return (const char *)val.GetValue<uint64_t>();
+	}
+	auto &values_insert_order = ((EnumTypeInfo &)*info).values_insert_order;
+	return StringValue::Get(values_insert_order.GetValue(val.GetValue<uint32_t>()));
+}
+
+Vector &EnumType::GetValuesInsertOrder(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).values_insert_order;
+}
+
+idx_t EnumType::GetSize(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).dict_size;
+}
+
+void EnumType::SetCatalog(LogicalType &type, TypeCatalogEntry *catalog_entry) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	((EnumTypeInfo &)*info).catalog_entry = catalog_entry;
+}
+TypeCatalogEntry *EnumType::GetCatalog(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).catalog_entry;
+}
+
+PhysicalType EnumType::GetPhysicalType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto aux_info = type.AuxInfo();
+	D_ASSERT(aux_info);
+	auto &info = (EnumTypeInfo &)*aux_info;
+
+	if (info.dict_type == EnumDictType::DEDUP_POINTER) {
+		return PhysicalType::UINT64; // for pointer enum types
+	}
+	D_ASSERT(info.dict_type == EnumDictType::VECTOR_DICT);
+	return EnumVectorDictType(info.dict_size);
+}
+
+//===--------------------------------------------------------------------===//
+// Extra Type Info
+//===--------------------------------------------------------------------===//
+void ExtraTypeInfo::Serialize(ExtraTypeInfo *info, FieldWriter &writer) {
+	if (!info) {
+		writer.WriteField<ExtraTypeInfoType>(ExtraTypeInfoType::INVALID_TYPE_INFO);
+		writer.WriteString(string());
+	} else {
+		writer.WriteField<ExtraTypeInfoType>(info->type);
+		info->Serialize(writer);
+		writer.WriteString(info->alias);
+	}
+}
+shared_ptr<ExtraTypeInfo> ExtraTypeInfo::Deserialize(FieldReader &reader) {
+	auto type = reader.ReadRequired<ExtraTypeInfoType>();
+	shared_ptr<ExtraTypeInfo> extra_info;
+	switch (type) {
+	case ExtraTypeInfoType::INVALID_TYPE_INFO: {
+		auto alias = reader.ReadField<string>(string());
+		if (!alias.empty()) {
+			return make_shared<ExtraTypeInfo>(type, alias);
+		}
+		return nullptr;
+	} break;
+	case ExtraTypeInfoType::GENERIC_TYPE_INFO: {
+		extra_info = make_shared<ExtraTypeInfo>(type);
+	} break;
+	case ExtraTypeInfoType::DECIMAL_TYPE_INFO:
+		extra_info = DecimalTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::STRING_TYPE_INFO:
+		extra_info = StringTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::LIST_TYPE_INFO:
+		extra_info = ListTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::STRUCT_TYPE_INFO:
+		extra_info = StructTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::USER_TYPE_INFO:
+		extra_info = UserTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::ENUM_TYPE_INFO: {
+		auto enum_size = reader.ReadRequired<uint32_t>();
+		auto enum_internal_type = EnumVectorDictType(enum_size);
+		switch (enum_internal_type) {
+		case PhysicalType::UINT8:
+			extra_info = EnumTypeInfoTemplated<uint8_t>::Deserialize(reader, enum_size);
+			break;
+		case PhysicalType::UINT16:
+			extra_info = EnumTypeInfoTemplated<uint16_t>::Deserialize(reader, enum_size);
+			break;
+		case PhysicalType::UINT32:
+			extra_info = EnumTypeInfoTemplated<uint32_t>::Deserialize(reader, enum_size);
+			break;
+		default:
+			throw InternalException("Invalid Physical Type for ENUMs");
+		}
+	} break;
+	case ExtraTypeInfoType::AGGREGATE_STATE_TYPE_INFO:
+		extra_info = AggregateStateTypeInfo::Deserialize(reader);
+		break;
+
+	default:
+		throw InternalException("Unimplemented type info in ExtraTypeInfo::Deserialize");
+	}
+	auto alias = reader.ReadField<string>(string());
+	extra_info->alias = alias;
+	return extra_info;
+}
+
+//===--------------------------------------------------------------------===//
+// Logical Type
+//===--------------------------------------------------------------------===//
+
+// the destructor needs to know about the extra type info
+LogicalType::~LogicalType() {
+}
+
+void LogicalType::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<LogicalTypeId>(id_);
+	ExtraTypeInfo::Serialize(type_info_.get(), writer);
+	writer.Finalize();
+}
+
+LogicalType LogicalType::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto id = reader.ReadRequired<LogicalTypeId>();
+	auto info = ExtraTypeInfo::Deserialize(reader);
+	reader.Finalize();
+
+	return LogicalType(id, move(info));
+}
+
+bool LogicalType::operator==(const LogicalType &rhs) const {
+	if (id_ != rhs.id_) {
+		return false;
+	}
+	if (type_info_.get() == rhs.type_info_.get()) {
+		return true;
+	}
+	if (type_info_) {
+		return type_info_->Equals(rhs.type_info_.get());
+	} else {
+		D_ASSERT(rhs.type_info_);
+		return rhs.type_info_->Equals(type_info_.get());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Comparison Operations
+//===--------------------------------------------------------------------===//
+
+struct ValuePositionComparator {
+	// Return true if the positional Values definitely match.
+	// Default to the same as the final value
+	template <typename OP>
+	static inline bool Definite(const Value &lhs, const Value &rhs) {
+		return Final<OP>(lhs, rhs);
+	}
+
+	// Select the positional Values that need further testing.
+	// Usually this means Is Not Distinct, as those are the semantics used by Postges
+	template <typename OP>
+	static inline bool Possible(const Value &lhs, const Value &rhs) {
+		return ValueOperations::NotDistinctFrom(lhs, rhs);
+	}
+
+	// Return true if the positional Values definitely match in the final position
+	// This needs to be specialised.
+	template <typename OP>
+	static inline bool Final(const Value &lhs, const Value &rhs) {
+		return false;
+	}
+
+	// Tie-break based on length when one of the sides has been exhausted, returning true if the LHS matches.
+	// This essentially means that the existing positions compare equal.
+	// Default to the same semantics as the OP for idx_t. This works in most cases.
+	template <typename OP>
+	static inline bool TieBreak(const idx_t lpos, const idx_t rpos) {
+		return OP::Operation(lpos, rpos);
+	}
+};
+
+// Equals must always check every column
+template <>
+inline bool ValuePositionComparator::Definite<duckdb::Equals>(const Value &lhs, const Value &rhs) {
+	return false;
+}
+
+template <>
+inline bool ValuePositionComparator::Final<duckdb::Equals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::NotDistinctFrom(lhs, rhs);
+}
+
+// NotEquals must check everything that matched
+template <>
+inline bool ValuePositionComparator::Possible<duckdb::NotEquals>(const Value &lhs, const Value &rhs) {
+	return true;
+}
+
+template <>
+inline bool ValuePositionComparator::Final<duckdb::NotEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::NotDistinctFrom(lhs, rhs);
+}
+
+// Non-strict inequalities must use strict comparisons for Definite
+template <>
+bool ValuePositionComparator::Definite<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThanEquals(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Definite<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThanEquals(lhs, rhs);
+}
+
+// Strict inequalities just use strict for both Definite and Final
+template <>
+bool ValuePositionComparator::Final<duckdb::LessThan>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::GreaterThan>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThan(lhs, rhs);
+}
+
+template <class OP>
+static bool TemplatedBooleanOperation(const Value &left, const Value &right) {
+	const auto &left_type = left.type();
+	const auto &right_type = right.type();
+	if (left_type != right_type) {
+		Value left_copy = left;
+		Value right_copy = right;
+
+		LogicalType comparison_type = BoundComparisonExpression::BindComparison(left_type, right_type);
+		if (!left_copy.TryCastAs(comparison_type) || !right_copy.TryCastAs(comparison_type)) {
+			return false;
+		}
+		D_ASSERT(left_copy.type() == right_copy.type());
+		return TemplatedBooleanOperation<OP>(left_copy, right_copy);
+	}
+	switch (left_type.InternalType()) {
+	case PhysicalType::BOOL:
+		return OP::Operation(left.GetValueUnsafe<bool>(), right.GetValueUnsafe<bool>());
+	case PhysicalType::INT8:
+		return OP::Operation(left.GetValueUnsafe<int8_t>(), right.GetValueUnsafe<int8_t>());
+	case PhysicalType::INT16:
+		return OP::Operation(left.GetValueUnsafe<int16_t>(), right.GetValueUnsafe<int16_t>());
+	case PhysicalType::INT32:
+		return OP::Operation(left.GetValueUnsafe<int32_t>(), right.GetValueUnsafe<int32_t>());
+	case PhysicalType::INT64:
+		return OP::Operation(left.GetValueUnsafe<int64_t>(), right.GetValueUnsafe<int64_t>());
+	case PhysicalType::UINT8:
+		return OP::Operation(left.GetValueUnsafe<uint8_t>(), right.GetValueUnsafe<uint8_t>());
+	case PhysicalType::UINT16:
+		return OP::Operation(left.GetValueUnsafe<uint16_t>(), right.GetValueUnsafe<uint16_t>());
+	case PhysicalType::UINT32:
+		return OP::Operation(left.GetValueUnsafe<uint32_t>(), right.GetValueUnsafe<uint32_t>());
+	case PhysicalType::UINT64:
+		return OP::Operation(left.GetValueUnsafe<uint64_t>(), right.GetValueUnsafe<uint64_t>());
+	case PhysicalType::INT128:
+		return OP::Operation(left.GetValueUnsafe<hugeint_t>(), right.GetValueUnsafe<hugeint_t>());
+	case PhysicalType::FLOAT:
+		return OP::Operation(left.GetValueUnsafe<float>(), right.GetValueUnsafe<float>());
+	case PhysicalType::DOUBLE:
+		return OP::Operation(left.GetValueUnsafe<double>(), right.GetValueUnsafe<double>());
+	case PhysicalType::INTERVAL:
+		return OP::Operation(left.GetValueUnsafe<interval_t>(), right.GetValueUnsafe<interval_t>());
+	case PhysicalType::VARCHAR:
+		return OP::Operation(StringValue::Get(left), StringValue::Get(right));
+	case PhysicalType::STRUCT: {
+		auto &left_children = StructValue::GetChildren(left);
+		auto &right_children = StructValue::GetChildren(right);
+		// this should be enforced by the type
+		D_ASSERT(left_children.size() == right_children.size());
+		idx_t i = 0;
+		for (; i < left_children.size() - 1; ++i) {
+			if (ValuePositionComparator::Definite<OP>(left_children[i], right_children[i])) {
+				return true;
+			}
+			if (!ValuePositionComparator::Possible<OP>(left_children[i], right_children[i])) {
+				return false;
+			}
+		}
+		return ValuePositionComparator::Final<OP>(left_children[i], right_children[i]);
+	}
+	case PhysicalType::LIST: {
+		auto &left_children = ListValue::GetChildren(left);
+		auto &right_children = ListValue::GetChildren(right);
+		for (idx_t pos = 0;; ++pos) {
+			if (pos == left_children.size() || pos == right_children.size()) {
+				return ValuePositionComparator::TieBreak<OP>(left_children.size(), right_children.size());
+			}
+			if (ValuePositionComparator::Definite<OP>(left_children[pos], right_children[pos])) {
+				return true;
+			}
+			if (!ValuePositionComparator::Possible<OP>(left_children[pos], right_children[pos])) {
+				return false;
+			}
+		}
+		return false;
+	}
+	default:
+		throw InternalException("Unimplemented type for value comparison");
+	}
+}
+
+bool ValueOperations::Equals(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::Equals>(left, right);
+}
+
+bool ValueOperations::NotEquals(const Value &left, const Value &right) {
+	return !ValueOperations::Equals(left, right);
+}
+
+bool ValueOperations::GreaterThan(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThan>(left, right);
+}
+
+bool ValueOperations::GreaterThanEquals(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThanEquals>(left, right);
+}
+
+bool ValueOperations::LessThan(const Value &left, const Value &right) {
+	return ValueOperations::GreaterThan(right, left);
+}
+
+bool ValueOperations::LessThanEquals(const Value &left, const Value &right) {
+	return ValueOperations::GreaterThanEquals(right, left);
+}
+
+bool ValueOperations::NotDistinctFrom(const Value &left, const Value &right) {
+	if (left.IsNull() && right.IsNull()) {
+		return true;
+	}
+	if (left.IsNull() != right.IsNull()) {
+		return false;
+	}
+	return TemplatedBooleanOperation<duckdb::Equals>(left, right);
+}
+
+bool ValueOperations::DistinctFrom(const Value &left, const Value &right) {
+	return !ValueOperations::NotDistinctFrom(left, right);
+}
+
+bool ValueOperations::DistinctGreaterThan(const Value &left, const Value &right) {
+	if (left.IsNull() && right.IsNull()) {
+		return false;
+	} else if (right.IsNull()) {
+		return false;
+	} else if (left.IsNull()) {
+		return true;
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThan>(left, right);
+}
+
+bool ValueOperations::DistinctGreaterThanEquals(const Value &left, const Value &right) {
+	if (left.IsNull()) {
+		return true;
+	} else if (right.IsNull()) {
+		return false;
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThanEquals>(left, right);
+}
+
+bool ValueOperations::DistinctLessThan(const Value &left, const Value &right) {
+	return ValueOperations::DistinctGreaterThan(right, left);
+}
+
+bool ValueOperations::DistinctLessThanEquals(const Value &left, const Value &right) {
+	return ValueOperations::DistinctGreaterThanEquals(right, left);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// boolean_operators.cpp
+// Description: This file contains the implementation of the boolean
+// operations AND OR !
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// AND/OR
+//===--------------------------------------------------------------------===//
+template <class OP>
+static void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t count) {
+	D_ASSERT(left.GetType().id() == LogicalTypeId::BOOLEAN && right.GetType().id() == LogicalTypeId::BOOLEAN &&
+	         result.GetType().id() == LogicalTypeId::BOOLEAN);
+
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// operation on two constants, result is constant vector
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto ldata = ConstantVector::GetData<uint8_t>(left);
+		auto rdata = ConstantVector::GetData<uint8_t>(right);
+		auto result_data = ConstantVector::GetData<bool>(result);
+
+		bool is_null = OP::Operation(*ldata > 0, *rdata > 0, ConstantVector::IsNull(left),
+		                             ConstantVector::IsNull(right), *result_data);
+		ConstantVector::SetNull(result, is_null);
+	} else {
+		// perform generic loop
+		VectorData ldata, rdata;
+		left.Orrify(count, ldata);
+		right.Orrify(count, rdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto left_data = (uint8_t *)ldata.data; // we use uint8 to avoid load of gunk bools
+		auto right_data = (uint8_t *)rdata.data;
+		auto result_data = FlatVector::GetData<bool>(result);
+		auto &result_mask = FlatVector::Validity(result);
+		if (!ldata.validity.AllValid() || !rdata.validity.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				auto lidx = ldata.sel->get_index(i);
+				auto ridx = rdata.sel->get_index(i);
+				bool is_null =
+				    OP::Operation(left_data[lidx] > 0, right_data[ridx] > 0, !ldata.validity.RowIsValid(lidx),
+				                  !rdata.validity.RowIsValid(ridx), result_data[i]);
+				result_mask.Set(i, !is_null);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				auto lidx = ldata.sel->get_index(i);
+				auto ridx = rdata.sel->get_index(i);
+				result_data[i] = OP::SimpleOperation(left_data[lidx], right_data[ridx]);
+			}
+		}
+	}
+}
+
+/*
+SQL AND Rules:
+
+TRUE  AND TRUE   = TRUE
+TRUE  AND FALSE  = FALSE
+TRUE  AND NULL   = NULL
+FALSE AND TRUE   = FALSE
+FALSE AND FALSE  = FALSE
+FALSE AND NULL   = FALSE
+NULL  AND TRUE   = NULL
+NULL  AND FALSE  = FALSE
+NULL  AND NULL   = NULL
+
+Basically:
+- Only true if both are true
+- False if either is false (regardless of NULLs)
+- NULL otherwise
+*/
+struct TernaryAnd {
+	static bool SimpleOperation(bool left, bool right) {
+		return left && right;
+	}
+	static bool Operation(bool left, bool right, bool left_null, bool right_null, bool &result) {
+		if (left_null && right_null) {
+			// both NULL:
+			// result is NULL
+			return true;
+		} else if (left_null) {
+			// left is NULL:
+			// result is FALSE if right is false
+			// result is NULL if right is true
+			result = right;
+			return right;
+		} else if (right_null) {
+			// right is NULL:
+			// result is FALSE if left is false
+			// result is NULL if left is true
+			result = left;
+			return left;
+		} else {
+			// no NULL: perform the AND
+			result = left && right;
+			return false;
+		}
+	}
+};
+
+void VectorOperations::And(Vector &left, Vector &right, Vector &result, idx_t count) {
+	TemplatedBooleanNullmask<TernaryAnd>(left, right, result, count);
+}
+
+/*
+SQL OR Rules:
+
+OR
+TRUE  OR TRUE  = TRUE
+TRUE  OR FALSE = TRUE
+TRUE  OR NULL  = TRUE
+FALSE OR TRUE  = TRUE
+FALSE OR FALSE = FALSE
+FALSE OR NULL  = NULL
+NULL  OR TRUE  = TRUE
+NULL  OR FALSE = NULL
+NULL  OR NULL  = NULL
+
+Basically:
+- Only false if both are false
+- True if either is true (regardless of NULLs)
+- NULL otherwise
+*/
+
+struct TernaryOr {
+	static bool SimpleOperation(bool left, bool right) {
+		return left || right;
+	}
+	static bool Operation(bool left, bool right, bool left_null, bool right_null, bool &result) {
+		if (left_null && right_null) {
+			// both NULL:
+			// result is NULL
+			return true;
+		} else if (left_null) {
+			// left is NULL:
+			// result is TRUE if right is true
+			// result is NULL if right is false
+			result = right;
+			return !right;
+		} else if (right_null) {
+			// right is NULL:
+			// result is TRUE if left is true
+			// result is NULL if left is false
+			result = left;
+			return !left;
+		} else {
+			// no NULL: perform the OR
+			result = left || right;
+			return false;
+		}
+	}
+};
+
+void VectorOperations::Or(Vector &left, Vector &right, Vector &result, idx_t count) {
+	TemplatedBooleanNullmask<TernaryOr>(left, right, result, count);
+}
+
+struct NotOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return !left;
+	}
+};
+
+void VectorOperations::Not(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType() == LogicalType::BOOLEAN && result.GetType() == LogicalType::BOOLEAN);
+	UnaryExecutor::Execute<bool, bool, NotOperator>(input, result, count);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// comparison_operators.cpp
+// Description: This file contains the implementation of the comparison
+// operations == != >= <= > <
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+bool EqualsFloat(T left, T right) {
+	if (DUCKDB_UNLIKELY(Value::IsNan(left) && Value::IsNan(right))) {
+		return true;
+	}
+	return left == right;
+}
+
+template <>
+bool Equals::Operation(float left, float right) {
+	return EqualsFloat<float>(left, right);
+}
+
+template <>
+bool Equals::Operation(double left, double right) {
+	return EqualsFloat<double>(left, right);
+}
+
+template <class T>
+bool GreaterThanFloat(T left, T right) {
+	// handle nans
+	// nan is always bigger than everything else
+	bool left_is_nan = Value::IsNan(left);
+	bool right_is_nan = Value::IsNan(right);
+	// if right is nan, there is no number that is bigger than right
+	if (DUCKDB_UNLIKELY(right_is_nan)) {
+		return false;
+	}
+	// if left is nan, but right is not, left is always bigger
+	if (DUCKDB_UNLIKELY(left_is_nan)) {
+		return true;
+	}
+	return left > right;
+}
+
+template <>
+bool GreaterThan::Operation(float left, float right) {
+	return GreaterThanFloat<float>(left, right);
+}
+
+template <>
+bool GreaterThan::Operation(double left, double right) {
+	return GreaterThanFloat<double>(left, right);
+}
+
+template <class T>
+bool GreaterThanEqualsFloat(T left, T right) {
+	// handle nans
+	// nan is always bigger than everything else
+	bool left_is_nan = Value::IsNan(left);
+	bool right_is_nan = Value::IsNan(right);
+	// if right is nan, there is no bigger number
+	// we only return true if left is also nan (in which case the numbers are equal)
+	if (DUCKDB_UNLIKELY(right_is_nan)) {
+		return left_is_nan;
+	}
+	// if left is nan, but right is not, left is always bigger
+	if (DUCKDB_UNLIKELY(left_is_nan)) {
+		return true;
+	}
+	return left >= right;
+}
+
+template <>
+bool GreaterThanEquals::Operation(float left, float right) {
+	return GreaterThanEqualsFloat<float>(left, right);
+}
+
+template <>
+bool GreaterThanEquals::Operation(double left, double right) {
+	return GreaterThanEqualsFloat<double>(left, right);
+}
+
+struct ComparisonSelector {
+	template <typename OP>
+	static idx_t Select(Vector &left, Vector &right, const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+	                    SelectionVector *false_sel) {
+		throw NotImplementedException("Unknown comparison operation!");
+	}
+};
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::Equals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                        idx_t count, SelectionVector *true_sel,
+                                                        SelectionVector *false_sel) {
+	return VectorOperations::Equals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::NotEquals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                           idx_t count, SelectionVector *true_sel,
+                                                           SelectionVector *false_sel) {
+	return VectorOperations::NotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::GreaterThan>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                             idx_t count, SelectionVector *true_sel,
+                                                             SelectionVector *false_sel) {
+	return VectorOperations::GreaterThan(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::GreaterThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector *sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector *false_sel) {
+	return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::LessThan>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                          idx_t count, SelectionVector *true_sel,
+                                                          SelectionVector *false_sel) {
+	return VectorOperations::LessThan(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::LessThanEquals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                                idx_t count, SelectionVector *true_sel,
+                                                                SelectionVector *false_sel) {
+	return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+static void ComparesNotNull(VectorData &ldata, VectorData &rdata, ValidityMask &vresult, idx_t count) {
+	for (idx_t i = 0; i < count; ++i) {
+		auto lidx = ldata.sel->get_index(i);
+		auto ridx = rdata.sel->get_index(i);
+		if (!ldata.validity.RowIsValid(lidx) || !rdata.validity.RowIsValid(ridx)) {
+			vresult.SetInvalid(i);
+		}
+	}
+}
+
+template <typename OP>
+static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result, idx_t count) {
+	const auto left_constant = left.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	const auto right_constant = right.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+	if ((left_constant && ConstantVector::IsNull(left)) || (right_constant && ConstantVector::IsNull(right))) {
+		// either left or right is constant NULL: result is constant NULL
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+
+	if (left_constant && right_constant) {
+		// both sides are constant, and neither is NULL so just compare one element.
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		SelectionVector true_sel(1);
+		auto match_count = ComparisonSelector::Select<OP>(left, right, nullptr, 1, &true_sel, nullptr);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		result_data[0] = match_count > 0;
+		return;
+	}
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<bool>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	VectorData leftv, rightv;
+	left.Orrify(count, leftv);
+	right.Orrify(count, rightv);
+	if (!leftv.validity.AllValid() || !rightv.validity.AllValid()) {
+		ComparesNotNull(leftv, rightv, result_validity, count);
+	}
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+	idx_t match_count = ComparisonSelector::Select<OP>(left, right, nullptr, count, &true_sel, &false_sel);
+
+	for (idx_t i = 0; i < match_count; ++i) {
+		const auto idx = true_sel.get_index(i);
+		result_data[idx] = true;
+	}
+
+	const idx_t no_match_count = count - match_count;
+	for (idx_t i = 0; i < no_match_count; ++i) {
+		const auto idx = false_sel.get_index(i);
+		result_data[idx] = false;
+	}
+}
+
+struct ComparisonExecutor {
+private:
+	template <class T, class OP>
+	static inline void TemplatedExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::Execute<T, T, bool, OP>(left, right, result, count);
+	}
+
+public:
+	template <class OP>
+	static inline void Execute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		D_ASSERT(left.GetType() == right.GetType() && result.GetType() == LogicalType::BOOLEAN);
+		// the inplace loops take the result as the last parameter
+		switch (left.GetType().InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			TemplatedExecute<int8_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT16:
+			TemplatedExecute<int16_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT32:
+			TemplatedExecute<int32_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT64:
+			TemplatedExecute<int64_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedExecute<uint8_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedExecute<uint16_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedExecute<uint32_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedExecute<uint64_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT128:
+			TemplatedExecute<hugeint_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedExecute<float, OP>(left, right, result, count);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedExecute<double, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedExecute<interval_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::VARCHAR:
+			TemplatedExecute<string_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::LIST:
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			NestedComparisonExecutor<OP>(left, right, result, count);
+			break;
+		default:
+			throw InternalException("Invalid type for comparison");
+		}
+	}
+};
+
+void VectorOperations::Equals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::Equals>(left, right, result, count);
+}
+
+void VectorOperations::NotEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::NotEquals>(left, right, result, count);
+}
+
+void VectorOperations::GreaterThanEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::GreaterThanEquals>(left, right, result, count);
+}
+
+void VectorOperations::LessThanEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::LessThanEquals>(left, right, result, count);
+}
+
+void VectorOperations::GreaterThan(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::GreaterThan>(left, right, result, count);
+}
+
+void VectorOperations::LessThan(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::LessThan>(left, right, result, count);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// generators.cpp
+// Description: This file contains the implementation of different generators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+void TemplatedGenerateSequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
+	D_ASSERT(result.GetType().IsNumeric());
+	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
+		throw Exception("Sequence start or increment out of type range");
+	}
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<T>(result);
+	auto value = (T)start;
+	for (idx_t i = 0; i < count; i++) {
+		if (i > 0) {
+			value += increment;
+		}
+		result_data[i] = value;
+	}
+}
+
+void VectorOperations::GenerateSequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
+	if (!result.GetType().IsNumeric()) {
+		throw InvalidTypeException(result.GetType(), "Can only generate sequences for numeric values!");
+	}
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedGenerateSequence<int8_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateSequence<int16_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateSequence<int32_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateSequence<int64_t>(result, count, start, increment);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateSequence<float>(result, count, start, increment);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateSequence<double>(result, count, start, increment);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for generate sequence");
+	}
+}
+
+template <class T>
+void TemplatedGenerateSequence(Vector &result, idx_t count, const SelectionVector &sel, int64_t start,
+                               int64_t increment) {
+	D_ASSERT(result.GetType().IsNumeric());
+	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
+		throw Exception("Sequence start or increment out of type range");
+	}
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<T>(result);
+	auto value = (T)start;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		result_data[idx] = value + increment * idx;
+	}
+}
+
+void VectorOperations::GenerateSequence(Vector &result, idx_t count, const SelectionVector &sel, int64_t start,
+                                        int64_t increment) {
+	if (!result.GetType().IsNumeric()) {
+		throw InvalidTypeException(result.GetType(), "Can only generate sequences for numeric values!");
+	}
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedGenerateSequence<int8_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateSequence<int16_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateSequence<int32_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateSequence<int64_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateSequence<float>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateSequence<double>(result, count, sel, start, increment);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for generate sequence");
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct DistinctBinaryLambdaWrapper {
+	template <class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static inline RESULT_TYPE Operation(LEFT_TYPE left, RIGHT_TYPE right, bool is_left_null, bool is_right_null) {
+		return OP::template Operation<LEFT_TYPE>(left, right, is_left_null, is_right_null);
+	}
+};
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteGenericLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                       RESULT_TYPE *__restrict result_data, const SelectionVector *__restrict lsel,
+                                       const SelectionVector *__restrict rsel, idx_t count, ValidityMask &lmask,
+                                       ValidityMask &rmask, ValidityMask &result_mask) {
+	for (idx_t i = 0; i < count; i++) {
+		auto lindex = lsel->get_index(i);
+		auto rindex = rsel->get_index(i);
+		auto lentry = ldata[lindex];
+		auto rentry = rdata[rindex];
+		result_data[i] =
+		    OP::template Operation<LEFT_TYPE>(lentry, rentry, !lmask.RowIsValid(lindex), !rmask.RowIsValid(rindex));
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteConstant(Vector &left, Vector &right, Vector &result) {
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+	auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
+	auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
+	auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
+	*result_data =
+	    OP::template Operation<LEFT_TYPE>(*ldata, *rdata, ConstantVector::IsNull(left), ConstantVector::IsNull(right));
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteGeneric(Vector &left, Vector &right, Vector &result, idx_t count) {
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		DistinctExecuteConstant<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result);
+	} else {
+		VectorData ldata, rdata;
+
+		left.Orrify(count, ldata);
+		right.Orrify(count, rdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<RESULT_TYPE>(result);
+		DistinctExecuteGenericLoop<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(
+		    (LEFT_TYPE *)ldata.data, (RIGHT_TYPE *)rdata.data, result_data, ldata.sel, rdata.sel, count, ldata.validity,
+		    rdata.validity, FlatVector::Validity(result));
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteSwitch(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecuteGeneric<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, count);
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, count);
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t
+DistinctSelectGenericLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                          const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                          const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                          ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto result_idx = result_sel->get_index(i);
+		auto lindex = lsel->get_index(i);
+		auto rindex = rsel->get_index(i);
+		if (NO_NULL) {
+			if (OP::Operation(ldata[lindex], rdata[rindex], false, false)) {
+				if (HAS_TRUE_SEL) {
+					true_sel->set_index(true_count++, result_idx);
+				}
+			} else {
+				if (HAS_FALSE_SEL) {
+					false_sel->set_index(false_count++, result_idx);
+				}
+			}
+		} else {
+			if (OP::Operation(ldata[lindex], rdata[rindex], !lmask.RowIsValid(lindex), !rmask.RowIsValid(rindex))) {
+				if (HAS_TRUE_SEL) {
+					true_sel->set_index(true_count++, result_idx);
+				}
+			} else {
+				if (HAS_FALSE_SEL) {
+					false_sel->set_index(false_count++, result_idx);
+				}
+			}
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL>
+static inline idx_t
+DistinctSelectGenericLoopSelSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                   const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                                   const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                                   ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else if (true_sel) {
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, false>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, false, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static inline idx_t
+DistinctSelectGenericLoopSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                                const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                                ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (!lmask.AllValid() || !rmask.AllValid()) {
+		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelectGeneric(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	VectorData ldata, rdata;
+
+	left.Orrify(count, ldata);
+	right.Orrify(count, rdata);
+
+	return DistinctSelectGenericLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP>((LEFT_TYPE *)ldata.data, (RIGHT_TYPE *)rdata.data,
+	                                                                  ldata.sel, rdata.sel, sel, count, ldata.validity,
+	                                                                  rdata.validity, true_sel, false_sel);
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT, bool NO_NULL,
+          bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t DistinctSelectFlatLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                           const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                           ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		idx_t result_idx = sel->get_index(i);
+		idx_t lidx = LEFT_CONSTANT ? 0 : i;
+		idx_t ridx = RIGHT_CONSTANT ? 0 : i;
+		const bool lnull = !lmask.RowIsValid(lidx);
+		const bool rnull = !rmask.RowIsValid(ridx);
+		bool comparison_result = OP::Operation(ldata[lidx], rdata[ridx], lnull, rnull);
+		if (HAS_TRUE_SEL) {
+			true_sel->set_index(true_count, result_idx);
+			true_count += comparison_result;
+		}
+		if (HAS_FALSE_SEL) {
+			false_sel->set_index(false_count, result_idx);
+			false_count += !comparison_result;
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT, bool NO_NULL>
+static inline idx_t DistinctSelectFlatLoopSelSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                                    const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                                    ValidityMask &rmask, SelectionVector *true_sel,
+                                                    SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, true, true>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	} else if (true_sel) {
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, true, false>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, false, true>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+static inline idx_t DistinctSelectFlatLoopSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                                 const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                                 ValidityMask &rmask, SelectionVector *true_sel,
+                                                 SelectionVector *false_sel) {
+	return DistinctSelectFlatLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, true>(
+	    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+static idx_t DistinctSelectFlat(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                SelectionVector *true_sel, SelectionVector *false_sel) {
+	auto ldata = FlatVector::GetData<LEFT_TYPE>(left);
+	auto rdata = FlatVector::GetData<RIGHT_TYPE>(right);
+	if (LEFT_CONSTANT) {
+		ValidityMask validity;
+		if (ConstantVector::IsNull(left)) {
+			validity.SetAllInvalid(1);
+		}
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, validity, FlatVector::Validity(right), true_sel, false_sel);
+	} else if (RIGHT_CONSTANT) {
+		ValidityMask validity;
+		if (ConstantVector::IsNull(right)) {
+			validity.SetAllInvalid(1);
+		}
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, FlatVector::Validity(left), validity, true_sel, false_sel);
+	} else {
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, FlatVector::Validity(left), FlatVector::Validity(right), true_sel, false_sel);
+	}
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelectConstant(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
+	auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
+
+	// both sides are constant, return either 0 or the count
+	// in this case we do not fill in the result selection vector at all
+	if (!OP::Operation(*ldata, *rdata, ConstantVector::IsNull(left), ConstantVector::IsNull(right))) {
+		if (false_sel) {
+			for (idx_t i = 0; i < count; i++) {
+				false_sel->set_index(i, sel->get_index(i));
+			}
+		}
+		return 0;
+	} else {
+		if (true_sel) {
+			for (idx_t i = 0; i < count; i++) {
+				true_sel->set_index(i, sel->get_index(i));
+			}
+		}
+		return count;
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelect(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                            SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return DistinctSelectConstant<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+	           right.GetVectorType() == VectorType::FLAT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::FLAT_VECTOR &&
+	           right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::FLAT_VECTOR && right.GetVectorType() == VectorType::FLAT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, sel, count, true_sel,
+		                                                                   false_sel);
+	} else {
+		return DistinctSelectGeneric<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectNotNull(Vector &left, Vector &right, const idx_t count, idx_t &true_count,
+                                   const SelectionVector &sel, SelectionVector &maybe_vec, OptionalSelection &true_opt,
+                                   OptionalSelection &false_opt) {
+	VectorData lvdata, rvdata;
+	left.Orrify(count, lvdata);
+	right.Orrify(count, rvdata);
+
+	auto &lmask = lvdata.validity;
+	auto &rmask = rvdata.validity;
+
+	idx_t remaining = 0;
+	if (lmask.AllValid() && rmask.AllValid()) {
+		//	None are NULL, distinguish values.
+		for (idx_t i = 0; i < count; ++i) {
+			const auto idx = sel.get_index(i);
+			maybe_vec.set_index(remaining++, idx);
+		}
+		return remaining;
+	}
+
+	// Slice the Vectors down to the rows that are not determined (i.e., neither is NULL)
+	SelectionVector slicer(count);
+	true_count = 0;
+	idx_t false_count = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto result_idx = sel.get_index(i);
+		const auto lidx = lvdata.sel->get_index(i);
+		const auto ridx = rvdata.sel->get_index(i);
+		const auto lnull = !lmask.RowIsValid(lidx);
+		const auto rnull = !rmask.RowIsValid(ridx);
+		if (lnull || rnull) {
+			// If either is NULL then we can major distinguish them
+			if (!OP::Operation(false, false, lnull, rnull)) {
+				false_opt.Append(false_count, result_idx);
+			} else {
+				true_opt.Append(true_count, result_idx);
+			}
+		} else {
+			//	Neither is NULL, distinguish values.
+			slicer.set_index(remaining, i);
+			maybe_vec.set_index(remaining++, result_idx);
+		}
+	}
+
+	true_opt.Advance(true_count);
+	false_opt.Advance(false_count);
+
+	if (remaining && remaining < count) {
+		left.Slice(slicer, remaining);
+		right.Slice(slicer, remaining);
+	}
+
+	return remaining;
+}
+
+struct PositionComparator {
+	// Select the rows that definitely match.
+	// Default to the same as the final row
+	template <typename OP>
+	static idx_t Definite(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+	                      SelectionVector *true_sel, SelectionVector &false_sel) {
+		return Final<OP>(left, right, sel, count, true_sel, &false_sel);
+	}
+
+	// Select the possible rows that need further testing.
+	// Usually this means Is Not Distinct, as those are the semantics used by Postges
+	template <typename OP>
+	static idx_t Possible(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+	                      SelectionVector &true_sel, SelectionVector *false_sel) {
+		return VectorOperations::NestedEquals(left, right, sel, count, &true_sel, false_sel);
+	}
+
+	// Select the matching rows for the final position.
+	// This needs to be specialised.
+	template <typename OP>
+	static idx_t Final(Vector &left, Vector &right, const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                   SelectionVector *false_sel) {
+		return 0;
+	}
+
+	// Tie-break based on length when one of the sides has been exhausted, returning true if the LHS matches.
+	// This essentially means that the existing positions compare equal.
+	// Default to the same semantics as the OP for idx_t. This works in most cases.
+	template <typename OP>
+	static bool TieBreak(const idx_t lpos, const idx_t rpos) {
+		return OP::Operation(lpos, rpos, false, false);
+	}
+};
+
+// NotDistinctFrom must always check every column
+template <>
+idx_t PositionComparator::Definite<duckdb::NotDistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                            idx_t count, SelectionVector *true_sel,
+                                                            SelectionVector &false_sel) {
+	return 0;
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::NotDistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                         idx_t count, SelectionVector *true_sel,
+                                                         SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+// DistinctFrom must check everything that matched
+template <>
+idx_t PositionComparator::Possible<duckdb::DistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                         idx_t count, SelectionVector &true_sel,
+                                                         SelectionVector *false_sel) {
+	return count;
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                      idx_t count, SelectionVector *true_sel,
+                                                      SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+// Non-strict inequalities must use strict comparisons for Definite
+template <>
+idx_t PositionComparator::Definite<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector &sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector &false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, &false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                                idx_t count, SelectionVector *true_sel,
+                                                                SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t PositionComparator::Definite<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
+                                                                      const SelectionVector &sel, idx_t count,
+                                                                      SelectionVector *true_sel,
+                                                                      SelectionVector &false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, &false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector &sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+// Strict inequalities just use strict for both Definite and Final
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                          idx_t count, SelectionVector *true_sel,
+                                                          SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                             idx_t count, SelectionVector *true_sel,
+                                                             SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+using StructEntries = vector<unique_ptr<Vector>>;
+
+static void ExtractNestedSelection(const SelectionVector &slice_sel, const idx_t count, const SelectionVector &sel,
+                                   OptionalSelection &opt) {
+
+	for (idx_t i = 0; i < count;) {
+		const auto slice_idx = slice_sel.get_index(i);
+		const auto result_idx = sel.get_index(slice_idx);
+		opt.Append(i, result_idx);
+	}
+	opt.Advance(count);
+}
+
+static void DensifyNestedSelection(const SelectionVector &dense_sel, const idx_t count, SelectionVector &slice_sel) {
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, dense_sel.get_index(i));
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectStruct(Vector &left, Vector &right, idx_t count, const SelectionVector &sel,
+                                  OptionalSelection &true_opt, OptionalSelection &false_opt) {
+	if (count == 0) {
+		return 0;
+	}
+
+	// Avoid allocating in the 99% of the cases where we don't need to.
+	StructEntries lsliced, rsliced;
+	auto &lchildren = StructVector::GetEntries(left);
+	auto &rchildren = StructVector::GetEntries(right);
+	D_ASSERT(lchildren.size() == rchildren.size());
+
+	// In order to reuse the comparators, we have to track what passed and failed internally.
+	// To do that, we need local SVs that we then merge back into the real ones after every pass.
+	const auto vcount = count;
+	SelectionVector slice_sel(count);
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, i);
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	idx_t match_count = 0;
+	for (idx_t col_no = 0; col_no < lchildren.size(); ++col_no) {
+		// Slice the children to maintain density
+		Vector lchild(*lchildren[col_no]);
+		lchild.Normalify(vcount);
+		lchild.Slice(slice_sel, count);
+
+		Vector rchild(*rchildren[col_no]);
+		rchild.Normalify(vcount);
+		rchild.Slice(slice_sel, count);
+
+		// Find everything that definitely matches
+		auto true_count = PositionComparator::Definite<OP>(lchild, rchild, slice_sel, count, &true_sel, false_sel);
+		if (true_count > 0) {
+			auto false_count = count - true_count;
+
+			// Extract the definite matches into the true result
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+
+			// Remove the definite matches from the slicing vector
+			DensifyNestedSelection(false_sel, false_count, slice_sel);
+
+			match_count += true_count;
+			count -= true_count;
+		}
+
+		if (col_no != lchildren.size() - 1) {
+			// Find what might match on the next position
+			true_count = PositionComparator::Possible<OP>(lchild, rchild, slice_sel, count, true_sel, &false_sel);
+			auto false_count = count - true_count;
+
+			// Extract the definite failures into the false result
+			ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+			// Remove any definite failures from the slicing vector
+			if (false_count) {
+				DensifyNestedSelection(true_sel, true_count, slice_sel);
+			}
+
+			count = true_count;
+		} else {
+			true_count = PositionComparator::Final<OP>(lchild, rchild, slice_sel, count, &true_sel, &false_sel);
+			auto false_count = count - true_count;
+
+			// Extract the definite matches into the true result
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+
+			// Extract the definite failures into the false result
+			ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+			match_count += true_count;
+		}
+	}
+	return match_count;
+}
+
+static void PositionListCursor(SelectionVector &cursor, VectorData &vdata, const idx_t pos,
+                               const SelectionVector &slice_sel, const idx_t count) {
+	const auto data = (const list_entry_t *)vdata.data;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto slice_idx = slice_sel.get_index(i);
+
+		const auto lidx = vdata.sel->get_index(slice_idx);
+		const auto &entry = data[lidx];
+		cursor.set_index(i, entry.offset + pos);
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectList(Vector &left, Vector &right, idx_t count, const SelectionVector &sel,
+                                OptionalSelection &true_opt, OptionalSelection &false_opt) {
+	if (count == 0) {
+		return count;
+	}
+
+	// Create dictionary views of the children so we can vectorise the positional comparisons.
+	SelectionVector lcursor(count);
+	SelectionVector rcursor(count);
+
+	ListVector::GetEntry(left).Normalify(count);
+	ListVector::GetEntry(right).Normalify(count);
+	Vector lchild(ListVector::GetEntry(left), lcursor, count);
+	Vector rchild(ListVector::GetEntry(right), rcursor, count);
+
+	// To perform the positional comparison, we use a vectorisation of the following algorithm:
+	// bool CompareLists(T *left, idx_t nleft, T *right, nright) {
+	// 	for (idx_t pos = 0; ; ++pos) {
+	// 		if (nleft == pos || nright == pos)
+	// 			return OP::TieBreak(nleft, nright);
+	// 		if (OP::Definite(*left, *right))
+	// 			return true;
+	// 		if (!OP::Maybe(*left, *right))
+	// 			return false;
+	// 		}
+	//	 	++left, ++right;
+	// 	}
+	// }
+
+	// Get pointers to the list entries
+	VectorData lvdata;
+	left.Orrify(count, lvdata);
+	const auto ldata = (const list_entry_t *)lvdata.data;
+
+	VectorData rvdata;
+	right.Orrify(count, rvdata);
+	const auto rdata = (const list_entry_t *)rvdata.data;
+
+	// In order to reuse the comparators, we have to track what passed and failed internally.
+	// To do that, we need local SVs that we then merge back into the real ones after every pass.
+	SelectionVector slice_sel(count);
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, i);
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	idx_t match_count = 0;
+	for (idx_t pos = 0; count > 0; ++pos) {
+		// Set up the cursors for the current position
+		PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+		PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+
+		// Tie-break the pairs where one of the LISTs is exhausted.
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+		idx_t maybe_count = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto slice_idx = slice_sel.get_index(i);
+			const auto lidx = lvdata.sel->get_index(slice_idx);
+			const auto &lentry = ldata[lidx];
+			const auto ridx = rvdata.sel->get_index(slice_idx);
+			const auto &rentry = rdata[ridx];
+			if (lentry.length == pos || rentry.length == pos) {
+				const auto idx = sel.get_index(slice_idx);
+				if (PositionComparator::TieBreak<OP>(lentry.length, rentry.length)) {
+					true_opt.Append(true_count, idx);
+				} else {
+					false_opt.Append(false_count, idx);
+				}
+			} else {
+				true_sel.set_index(maybe_count++, slice_idx);
+			}
+		}
+		true_opt.Advance(true_count);
+		false_opt.Advance(false_count);
+		match_count += true_count;
+
+		// Redensify the list cursors
+		if (maybe_count < count) {
+			count = maybe_count;
+			DensifyNestedSelection(true_sel, count, slice_sel);
+			PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+			PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+		}
+
+		// Find everything that definitely matches
+		true_count = PositionComparator::Definite<OP>(lchild, rchild, slice_sel, count, &true_sel, false_sel);
+		if (true_count) {
+			false_count = count - true_count;
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+			match_count += true_count;
+
+			// Redensify the list cursors
+			count -= true_count;
+			DensifyNestedSelection(false_sel, count, slice_sel);
+			PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+			PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+		}
+
+		// Find what might match on the next position
+		true_count = PositionComparator::Possible<OP>(lchild, rchild, slice_sel, count, true_sel, &false_sel);
+		false_count = count - true_count;
+		ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+		if (false_count) {
+			DensifyNestedSelection(true_sel, true_count, slice_sel);
+		}
+		count = true_count;
+	}
+
+	return match_count;
+}
+
+template <class OP, class OPNESTED>
+static idx_t DistinctSelectNested(Vector &left, Vector &right, const SelectionVector *sel, const idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	// The Select operations all use a dense pair of input vectors to partition
+	// a selection vector in a single pass. But to implement progressive comparisons,
+	// we have to make multiple passes, so we need to keep track of the original input positions
+	// and then scatter the output selections when we are done.
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+
+	// Make buffered selections for progressive comparisons
+	// TODO: Remove unnecessary allocations
+	SelectionVector true_vec(count);
+	OptionalSelection true_opt(&true_vec);
+
+	SelectionVector false_vec(count);
+	OptionalSelection false_opt(&false_vec);
+
+	SelectionVector maybe_vec(count);
+
+	// Handle NULL nested values
+	Vector l_not_null(left);
+	Vector r_not_null(right);
+
+	idx_t match_count = 0;
+	auto unknown =
+	    DistinctSelectNotNull<OP>(l_not_null, r_not_null, count, match_count, *sel, maybe_vec, true_opt, false_opt);
+
+	if (PhysicalType::LIST == left.GetType().InternalType()) {
+		match_count += DistinctSelectList<OPNESTED>(l_not_null, r_not_null, unknown, maybe_vec, true_opt, false_opt);
+	} else {
+		match_count += DistinctSelectStruct<OPNESTED>(l_not_null, r_not_null, unknown, maybe_vec, true_opt, false_opt);
+	}
+
+	// Copy the buffered selections to the output selections
+	if (true_sel) {
+		DensifyNestedSelection(true_vec, match_count, *true_sel);
+	}
+
+	if (false_sel) {
+		DensifyNestedSelection(false_vec, count - match_count, *false_sel);
+	}
+
+	return match_count;
+}
+
+template <typename OP>
+static void NestedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count);
+
+template <class T, class OP>
+static inline void TemplatedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecute<T, T, bool, OP>(left, right, result, count);
+}
+template <class OP>
+static void ExecuteDistinct(Vector &left, Vector &right, Vector &result, idx_t count) {
+	D_ASSERT(left.GetType() == right.GetType() && result.GetType() == LogicalType::BOOLEAN);
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedDistinctExecute<int8_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedDistinctExecute<int16_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedDistinctExecute<int32_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedDistinctExecute<int64_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedDistinctExecute<uint8_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedDistinctExecute<uint16_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedDistinctExecute<uint32_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedDistinctExecute<uint64_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedDistinctExecute<hugeint_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedDistinctExecute<float, OP>(left, right, result, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedDistinctExecute<double, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedDistinctExecute<interval_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedDistinctExecute<string_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		NestedDistinctExecute<OP>(left, right, result, count);
+		break;
+	default:
+		throw InternalException("Invalid type for distinct comparison");
+	}
+}
+
+template <class OP, class OPNESTED = OP>
+static idx_t TemplatedDistinctSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                              SelectionVector *true_sel, SelectionVector *false_sel) {
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return DistinctSelect<int8_t, int8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT16:
+		return DistinctSelect<int16_t, int16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT32:
+		return DistinctSelect<int32_t, int32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT64:
+		return DistinctSelect<int64_t, int64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT8:
+		return DistinctSelect<uint8_t, uint8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT16:
+		return DistinctSelect<uint16_t, uint16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT32:
+		return DistinctSelect<uint32_t, uint32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT64:
+		return DistinctSelect<uint64_t, uint64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT128:
+		return DistinctSelect<hugeint_t, hugeint_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::FLOAT:
+		return DistinctSelect<float, float, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return DistinctSelect<double, double, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INTERVAL:
+		return DistinctSelect<interval_t, interval_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::VARCHAR:
+		return DistinctSelect<string_t, string_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+		return DistinctSelectNested<OP, OPNESTED>(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Invalid type for distinct selection");
+	}
+}
+
+template <typename OP>
+static void NestedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	const auto left_constant = left.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	const auto right_constant = right.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+	if (left_constant && right_constant) {
+		// both sides are constant, so just compare one element.
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		SelectionVector true_sel(1);
+		auto match_count = TemplatedDistinctSelectOperation<OP>(left, right, nullptr, 1, &true_sel, nullptr);
+		result_data[0] = match_count > 0;
+		return;
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	// DISTINCT is either true or false
+	idx_t match_count = TemplatedDistinctSelectOperation<OP>(left, right, nullptr, count, &true_sel, &false_sel);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<bool>(result);
+
+	for (idx_t i = 0; i < match_count; ++i) {
+		const auto idx = true_sel.get_index(i);
+		result_data[idx] = true;
+	}
+
+	const idx_t no_match_count = count - match_count;
+	for (idx_t i = 0; i < no_match_count; ++i) {
+		const auto idx = false_sel.get_index(i);
+		result_data[idx] = false;
+	}
+}
+
+void VectorOperations::DistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ExecuteDistinct<duckdb::DistinctFrom>(left, right, result, count);
+}
+
+void VectorOperations::NotDistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ExecuteDistinct<duckdb::NotDistinctFrom>(left, right, result, count);
+}
+
+// true := A != B with nulls being equal
+idx_t VectorOperations::DistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                     SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctFrom>(left, right, sel, count, true_sel, false_sel);
+}
+// true := A == B with nulls being equal
+idx_t VectorOperations::NotDistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::NotDistinctFrom>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A > B with nulls being maximal
+idx_t VectorOperations::DistinctGreaterThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                            SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A > B with nulls being minimal
+idx_t VectorOperations::DistinctGreaterThanNullsFirst(Vector &left, Vector &right, const SelectionVector *sel,
+                                                      idx_t count, SelectionVector *true_sel,
+                                                      SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst, duckdb::DistinctGreaterThan>(
+	    left, right, sel, count, true_sel, false_sel);
+}
+// true := A >= B with nulls being maximal
+idx_t VectorOperations::DistinctGreaterThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanEquals>(left, right, sel, count, true_sel,
+	                                                                           false_sel);
+}
+// true := A < B with nulls being maximal
+idx_t VectorOperations::DistinctLessThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                         SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A < B with nulls being minimal
+idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThanNullsFirst, duckdb::DistinctLessThan>(
+	    left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A <= B with nulls being maximal
+idx_t VectorOperations::DistinctLessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThanEquals>(left, right, sel, count, true_sel,
+	                                                                        false_sel);
+}
+
+// true := A != B with nulls being equal, inputs selected
+idx_t VectorOperations::NestedNotEquals(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctFrom>(left, right, &sel, count, true_sel, false_sel);
+}
+// true := A == B with nulls being equal, inputs selected
+idx_t VectorOperations::NestedEquals(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                     SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::NotDistinctFrom>(left, right, &sel, count, true_sel, false_sel);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// null_operators.cpp
+// Description: This file contains the implementation of the
+// IS NULL/NOT IS NULL operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+namespace duckdb {
+
+template <bool INVERSE>
+void IsNullLoop(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(result.GetType() == LogicalType::BOOLEAN);
+
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		*result_data = INVERSE ? !ConstantVector::IsNull(input) : ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<bool>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			result_data[i] = INVERSE ? data.validity.RowIsValid(idx) : !data.validity.RowIsValid(idx);
+		}
+	}
+}
+
+void VectorOperations::IsNotNull(Vector &input, Vector &result, idx_t count) {
+	IsNullLoop<true>(input, result, count);
+}
+
+void VectorOperations::IsNull(Vector &input, Vector &result, idx_t count) {
+	IsNullLoop<false>(input, result, count);
+}
+
+bool VectorOperations::HasNotNull(Vector &input, idx_t count) {
+	if (count == 0) {
+		return false;
+	}
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return !ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		if (data.validity.AllValid()) {
+			return true;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			if (data.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+bool VectorOperations::HasNull(Vector &input, idx_t count) {
+	if (count == 0) {
+		return false;
+	}
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		if (data.validity.AllValid()) {
+			return false;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			if (!data.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+idx_t VectorOperations::CountNotNull(Vector &input, const idx_t count) {
+	idx_t valid = 0;
+
+	VectorData vdata;
+	input.Orrify(count, vdata);
+	if (vdata.validity.AllValid()) {
+		return count;
+	}
+	switch (input.GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		valid += vdata.validity.CountValid(count);
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		valid += vdata.validity.CountValid(1) * count;
+		break;
+	default:
+		for (idx_t i = 0; i < count; ++i) {
+			const auto row_idx = vdata.sel->get_index(i);
+			valid += int(vdata.validity.RowIsValid(row_idx));
+		}
+		break;
+	}
+
+	return valid;
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// numeric_inplace_operators.cpp
+// Description: This file contains the implementation of numeric inplace ops
+// += *= /= -= %=
+//===--------------------------------------------------------------------===//
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// In-Place Addition
+//===--------------------------------------------------------------------===//
+
+void VectorOperations::AddInPlace(Vector &input, int64_t right, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::POINTER);
+	if (right == 0) {
+		return;
+	}
+	switch (input.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		D_ASSERT(!ConstantVector::IsNull(input));
+		auto data = ConstantVector::GetData<uintptr_t>(input);
+		*data += right;
+		break;
+	}
+	default: {
+		D_ASSERT(input.GetVectorType() == VectorType::FLAT_VECTOR);
+		auto data = FlatVector::GetData<uintptr_t>(input);
+		for (idx_t i = 0; i < count; i++) {
+			data[i] += right;
+		}
+		break;
+	}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct VectorStringCastOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto result = (Vector *)dataptr;
+		return OP::template Operation<INPUT_TYPE>(input, *result);
+	}
+};
+
+struct VectorTryCastData {
+	VectorTryCastData(Vector &result_p, string *error_message_p, bool strict_p)
+	    : result(result_p), error_message(error_message_p), strict(strict_p) {
+	}
+
+	Vector &result;
+	string *error_message;
+	bool strict;
+	bool all_converted = true;
+};
+
+template <class OP>
+struct VectorTryCastOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output))) {
+			return output;
+		}
+		auto data = (VectorTryCastData *)dataptr;
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastStrictOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->strict))) {
+			return output;
+		}
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastErrorOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(
+		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->error_message, data->strict))) {
+			return output;
+		}
+		bool has_error = data->error_message && !data->error_message->empty();
+		return HandleVectorCastError::Operation<RESULT_TYPE>(
+		    has_error ? *data->error_message : CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask, idx,
+		    data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastStringOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result,
+		                                                                  data->error_message, data->strict))) {
+			return output;
+		}
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class SRC, class DST, class OP>
+static bool TemplatedVectorTryCastLoop(Vector &source, Vector &result, idx_t count, bool strict,
+                                       string *error_message) {
+	VectorTryCastData input(result, error_message, strict);
+	UnaryExecutor::GenericExecute<SRC, DST, OP>(source, result, count, &input, error_message);
+	return input.all_converted;
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastLoop(Vector &source, Vector &result, idx_t count, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastOperator<OP>>(source, result, count, false, error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastStrictLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastStrictOperator<OP>>(source, result, count, strict,
+	                                                                             error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastErrorLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastErrorOperator<OP>>(source, result, count, strict,
+	                                                                            error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastStringLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastStringOperator<OP>>(source, result, count, strict,
+	                                                                             error_message);
+}
+
+template <class SRC, class OP>
+static void VectorStringCast(Vector &source, Vector &result, idx_t count) {
+	D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
+	UnaryExecutor::GenericExecute<SRC, string_t, VectorStringCastOperator<OP>>(source, result, count, (void *)&result);
+}
+
+template <class SRC>
+static bool NumericCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return VectorTryCastLoop<SRC, bool, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::TINYINT:
+		return VectorTryCastLoop<SRC, int8_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::SMALLINT:
+		return VectorTryCastLoop<SRC, int16_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::INTEGER:
+		return VectorTryCastLoop<SRC, int32_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::BIGINT:
+		return VectorTryCastLoop<SRC, int64_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UTINYINT:
+		return VectorTryCastLoop<SRC, uint8_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::USMALLINT:
+		return VectorTryCastLoop<SRC, uint16_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UINTEGER:
+		return VectorTryCastLoop<SRC, uint32_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UBIGINT:
+		return VectorTryCastLoop<SRC, uint64_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::HUGEINT:
+		return VectorTryCastLoop<SRC, hugeint_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::FLOAT:
+		return VectorTryCastLoop<SRC, float, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::DOUBLE:
+		return VectorTryCastLoop<SRC, double, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::DECIMAL:
+		return ToDecimalCast<SRC>(source, result, count, error_message);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		VectorStringCast<SRC, duckdb::StringCast>(source, result, count);
+		return true;
+	}
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+template <class T>
+bool FillEnum(string_t *source_data, ValidityMask &source_mask, const LogicalType &source_type, T *result_data,
+              ValidityMask &result_mask, const LogicalType &result_type, idx_t count, string *error_message,
+              const SelectionVector *sel) {
+	bool all_converted = true;
+	for (idx_t i = 0; i < count; i++) {
+		idx_t source_idx = i;
+		if (sel) {
+			source_idx = sel->get_index(i);
+		}
+		if (source_mask.RowIsValid(source_idx)) {
+			auto string_value = source_data[source_idx].GetString();
+			auto pos = EnumType::GetPos(result_type, string_value);
+			if (pos == -1) {
+				result_data[i] =
+				    HandleVectorCastError::Operation<T>(CastExceptionText<string_t, T>(source_data[source_idx]),
+				                                        result_mask, i, error_message, all_converted);
+			} else {
+				result_data[i] = pos;
+			}
+		} else {
+			result_mask.SetInvalid(i);
+		}
+	}
+	return all_converted;
+}
+
+template <class T>
+bool TransformEnum(Vector &source, Vector &result, idx_t count, string *error_message) {
+	D_ASSERT(source.GetType().id() == LogicalTypeId::VARCHAR);
+	auto enum_name = EnumType::GetTypeName(result.GetType());
+	switch (source.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+		auto source_data = ConstantVector::GetData<string_t>(source);
+		auto source_mask = ConstantVector::Validity(source);
+		auto result_data = ConstantVector::GetData<T>(result);
+		auto &result_mask = ConstantVector::Validity(result);
+
+		return FillEnum(source_data, source_mask, source.GetType(), result_data, result_mask, result.GetType(), 1,
+		                error_message, nullptr);
+	}
+	default: {
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+
+		auto source_data = (string_t *)vdata.data;
+		auto source_sel = vdata.sel;
+		auto source_mask = vdata.validity;
+		auto result_data = FlatVector::GetData<T>(result);
+		auto &result_mask = FlatVector::Validity(result);
+
+		return FillEnum(source_data, source_mask, source.GetType(), result_data, result_mask, result.GetType(), count,
+		                error_message, source_sel);
+	}
+	}
+}
+static bool VectorStringCastNumericSwitch(Vector &source, Vector &result, idx_t count, bool strict,
+                                          string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::ENUM: {
+		switch (result.GetType().InternalType()) {
+		case PhysicalType::UINT8:
+			return TransformEnum<uint8_t>(source, result, count, error_message);
+		case PhysicalType::UINT16:
+			return TransformEnum<uint16_t>(source, result, count, error_message);
+		case PhysicalType::UINT32:
+			return TransformEnum<uint32_t>(source, result, count, error_message);
+		default:
+			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+		}
+	}
+	case LogicalTypeId::BOOLEAN:
+		return VectorTryCastStrictLoop<string_t, bool, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::TINYINT:
+		return VectorTryCastStrictLoop<string_t, int8_t, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::SMALLINT:
+		return VectorTryCastStrictLoop<string_t, int16_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::INTEGER:
+		return VectorTryCastStrictLoop<string_t, int32_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::BIGINT:
+		return VectorTryCastStrictLoop<string_t, int64_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::UTINYINT:
+		return VectorTryCastStrictLoop<string_t, uint8_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::USMALLINT:
+		return VectorTryCastStrictLoop<string_t, uint16_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::UINTEGER:
+		return VectorTryCastStrictLoop<string_t, uint32_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::UBIGINT:
+		return VectorTryCastStrictLoop<string_t, uint64_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::HUGEINT:
+		return VectorTryCastStrictLoop<string_t, hugeint_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                     error_message);
+	case LogicalTypeId::FLOAT:
+		return VectorTryCastStrictLoop<string_t, float, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::DOUBLE:
+		return VectorTryCastStrictLoop<string_t, double, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::INTERVAL:
+		return VectorTryCastErrorLoop<string_t, interval_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                                 error_message);
+	case LogicalTypeId::DECIMAL:
+		return ToDecimalCast<string_t>(source, result, count, error_message);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool StringCastSwitch(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::DATE:
+		return VectorTryCastErrorLoop<string_t, date_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                             error_message);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return VectorTryCastErrorLoop<string_t, dtime_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                              error_message);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return VectorTryCastErrorLoop<string_t, timestamp_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                                  error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampNS>(source, result, count,
+		                                                                                    strict, error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampSec>(source, result, count,
+		                                                                                     strict, error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampMS>(source, result, count,
+		                                                                                    strict, error_message);
+	case LogicalTypeId::BLOB:
+		return VectorTryCastStringLoop<string_t, string_t, duckdb::TryCastToBlob>(source, result, count, strict,
+		                                                                          error_message);
+	case LogicalTypeId::UUID:
+		return VectorTryCastStringLoop<string_t, hugeint_t, duckdb::TryCastToUUID>(source, result, count, strict,
+		                                                                           error_message);
+	case LogicalTypeId::SQLNULL:
+		return TryVectorNullCast(source, result, count, error_message);
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		result.Reinterpret(source);
+		return true;
+	default:
+		return VectorStringCastNumericSwitch(source, result, count, strict, error_message);
+	}
+}
+
+static bool DateCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// date to varchar
+		VectorStringCast<date_t, duckdb::StringCast>(source, result, count);
+		return true;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		// date to timestamp
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCast>(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampNS>(source, result, count,
+		                                                                            error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>(source, result, count,
+		                                                                             error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>(source, result, count,
+		                                                                            error_message);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimeCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time to varchar
+		VectorStringCast<dtime_t, duckdb::StringCast>(source, result, count);
+		return true;
+	case LogicalTypeId::TIME_TZ:
+		// time to time with time zone
+		UnaryExecutor::Execute<dtime_t, dtime_t, duckdb::Cast>(source, result, count);
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimeTzCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time with time zone to varchar
+		VectorStringCast<dtime_t, duckdb::StringCastTZ>(source, result, count);
+		return true;
+	case LogicalTypeId::TIME:
+		// time with time zone to time
+		UnaryExecutor::Execute<dtime_t, dtime_t, duckdb::Cast>(source, result, count);
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimestampCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp to varchar
+		VectorStringCast<timestamp_t, duckdb::StringCast>(source, result, count);
+		break;
+	case LogicalTypeId::DATE:
+		// timestamp to date
+		UnaryExecutor::Execute<timestamp_t, date_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		// timestamp to time
+		UnaryExecutor::Execute<timestamp_t, dtime_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		// timestamp (us) to timestamp with time zone
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		// timestamp (us) to timestamp (ns)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_MS:
+		// timestamp (us) to timestamp (ms)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		// timestamp (us) to timestamp (s)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampTzCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp with time zone to varchar
+		VectorStringCast<timestamp_t, duckdb::StringCastTZ>(source, result, count);
+		break;
+	case LogicalTypeId::TIME_TZ:
+		// timestamp with time zone to time with time zone.
+		// TODO: set the offset to +00
+		UnaryExecutor::Execute<timestamp_t, dtime_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp with time zone to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::Cast>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampNsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (ns) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampNS>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (ns) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampMsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (ms) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampMS>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (ms) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampSecCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (sec) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampSec>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (s) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool IntervalCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time to varchar
+		VectorStringCast<interval_t, duckdb::StringCast>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool UUIDCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// uuid to varchar
+		VectorStringCast<hugeint_t, duckdb::CastFromUUID>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool BlobCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// blob to varchar
+		VectorStringCast<string_t, duckdb::CastFromBlob>(source, result, count);
+		break;
+	case LogicalTypeId::AGGREGATE_STATE:
+		result.Reinterpret(source);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool ValueStringCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+		} else {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto src_val = source.GetValue(i);
+			if (src_val.IsNull()) {
+				result.SetValue(i, Value(result.GetType()));
+			} else {
+				auto str_val = src_val.ToString();
+				result.SetValue(i, Value(str_val));
+			}
+		}
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool ListCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::LIST: {
+		// only handle constant and flat vectors here for now
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+			ConstantVector::SetNull(result, ConstantVector::IsNull(source));
+
+			auto ldata = ConstantVector::GetData<list_entry_t>(source);
+			auto tdata = ConstantVector::GetData<list_entry_t>(result);
+			*tdata = *ldata;
+		} else {
+			source.Normalify(count);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			FlatVector::SetValidity(result, FlatVector::Validity(source));
+
+			auto ldata = FlatVector::GetData<list_entry_t>(source);
+			auto tdata = FlatVector::GetData<list_entry_t>(result);
+			for (idx_t i = 0; i < count; i++) {
+				tdata[i] = ldata[i];
+			}
+		}
+		auto &source_cc = ListVector::GetEntry(source);
+		auto source_size = ListVector::GetListSize(source);
+
+		ListVector::Reserve(result, source_size);
+		auto &append_vector = ListVector::GetEntry(result);
+
+		VectorOperations::Cast(source_cc, append_vector, source_size);
+		ListVector::SetListSize(result, source_size);
+		D_ASSERT(ListVector::GetListSize(result) == source_size);
+		return true;
+	}
+	default:
+		return ValueStringCastSwitch(source, result, count, error_message);
+	}
+}
+
+template <class SRC_TYPE, class RES_TYPE>
+bool FillEnum(Vector &source, Vector &result, idx_t count, string *error_message) {
+	bool all_converted = true;
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+	auto str_vec_ptr = FlatVector::GetData<string_t>(str_vec);
+
+	auto res_enum_type = result.GetType();
+
+	VectorData vdata;
+	source.Orrify(count, vdata);
+
+	auto source_data = (SRC_TYPE *)vdata.data;
+	auto source_sel = vdata.sel;
+	auto source_mask = vdata.validity;
+
+	auto result_data = FlatVector::GetData<RES_TYPE>(result);
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto src_idx = source_sel->get_index(i);
+		if (!source_mask.RowIsValid(src_idx)) {
+			result_mask.SetInvalid(i);
+			continue;
+		}
+		auto str = str_vec_ptr[source_data[src_idx]].GetString();
+		auto key = EnumType::GetPos(res_enum_type, str);
+		if (key == -1) {
+			// key doesn't exist on result enum
+			if (!error_message) {
+				result_data[i] = HandleVectorCastError::Operation<RES_TYPE>(
+				    CastExceptionText<SRC_TYPE, RES_TYPE>(source_data[src_idx]), result_mask, i, error_message,
+				    all_converted);
+			} else {
+				result_mask.SetInvalid(i);
+			}
+			continue;
+		}
+		result_data[i] = key;
+	}
+	return all_converted;
+}
+
+template <class SRC_TYPE>
+bool FillEnumResultTemplate(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		return FillEnum<SRC_TYPE, uint8_t>(source, result, count, error_message);
+	case PhysicalType::UINT16:
+		return FillEnum<SRC_TYPE, uint16_t>(source, result, count, error_message);
+	case PhysicalType::UINT32:
+		return FillEnum<SRC_TYPE, uint32_t>(source, result, count, error_message);
+	default:
+		throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+	}
+}
+
+void EnumToVarchar(Vector &source, Vector &result, idx_t count, PhysicalType enum_physical_type) {
+	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(source.GetVectorType());
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	auto &str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+	auto str_vec_ptr = FlatVector::GetData<string_t>(str_vec);
+	auto res_vec_ptr = FlatVector::GetData<string_t>(result);
+
+	// TODO remove value api from this loop
+	for (idx_t i = 0; i < count; i++) {
+		auto src_val = source.GetValue(i);
+		if (src_val.IsNull()) {
+			result.SetValue(i, Value());
+			continue;
+		}
+
+		uint64_t enum_idx;
+		switch (enum_physical_type) {
+		case PhysicalType::UINT8:
+			enum_idx = UTinyIntValue::Get(src_val);
+			break;
+		case PhysicalType::UINT16:
+			enum_idx = USmallIntValue::Get(src_val);
+			break;
+		case PhysicalType::UINT32:
+			enum_idx = UIntegerValue::Get(src_val);
+			break;
+		case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+		{
+			res_vec_ptr[i] = (const char *)UBigIntValue::Get(src_val);
+			continue;
+		}
+
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+		res_vec_ptr[i] = str_vec_ptr[enum_idx];
+	}
+}
+
+static bool EnumCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	auto enum_physical_type = source.GetType().InternalType();
+	switch (result.GetType().id()) {
+	case LogicalTypeId::ENUM: {
+		// This means they are both ENUMs, but of different types.
+		switch (enum_physical_type) {
+		case PhysicalType::UINT8:
+			return FillEnumResultTemplate<uint8_t>(source, result, count, error_message);
+		case PhysicalType::UINT16:
+			return FillEnumResultTemplate<uint16_t>(source, result, count, error_message);
+		case PhysicalType::UINT32:
+			return FillEnumResultTemplate<uint32_t>(source, result, count, error_message);
+		default:
+			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+		}
+	}
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		EnumToVarchar(source, result, count, enum_physical_type);
+		break;
+	}
+	default: {
+		// Cast to varchar
+		Vector varchar_cast(LogicalType::VARCHAR, count);
+		EnumToVarchar(source, varchar_cast, count, enum_physical_type);
+		// Try to cast from varchar to whatever we wanted before
+		VectorOperations::TryCast(varchar_cast, result, count, error_message, strict);
+		break;
+	}
+	}
+	return true;
+}
+
+static bool AggregateStateToBlobCast(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	if (result.GetType().id() != LogicalTypeId::BLOB) {
+		throw TypeMismatchException(source.GetType(), result.GetType(),
+		                            "Cannot cast AGGREGATE_STATE to anything but BLOB");
+	}
+	result.Reinterpret(source);
+	return true;
+}
+
+static bool StructCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP: {
+		auto &source_child_types = StructType::GetChildTypes(source.GetType());
+		auto &result_child_types = StructType::GetChildTypes(result.GetType());
+		if (source_child_types.size() != result_child_types.size()) {
+			throw TypeMismatchException(source.GetType(), result.GetType(), "Cannot cast STRUCTs of different size");
+		}
+		auto &source_children = StructVector::GetEntries(source);
+		D_ASSERT(source_children.size() == source_child_types.size());
+
+		auto &result_children = StructVector::GetEntries(result);
+		for (idx_t c_idx = 0; c_idx < result_child_types.size(); c_idx++) {
+			auto &result_child_vector = result_children[c_idx];
+			auto &source_child_vector = *source_children[c_idx];
+			if (result_child_vector->GetType() != source_child_vector.GetType()) {
+				VectorOperations::Cast(source_child_vector, *result_child_vector, count, false);
+			} else {
+				result_child_vector->Reference(source_child_vector);
+			}
+		}
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, ConstantVector::IsNull(source));
+		} else {
+			source.Normalify(count);
+			FlatVector::Validity(result) = FlatVector::Validity(source);
+		}
+		return true;
+	}
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+		} else {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto src_val = source.GetValue(i);
+			auto str_val = src_val.ToString();
+			result.SetValue(i, Value(str_val));
+		}
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+bool VectorOperations::TryCast(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	D_ASSERT(source.GetType() != result.GetType());
+	// first switch on source type
+	switch (source.GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return NumericCastSwitch<bool>(source, result, count, error_message);
+	case LogicalTypeId::TINYINT:
+		return NumericCastSwitch<int8_t>(source, result, count, error_message);
+	case LogicalTypeId::SMALLINT:
+		return NumericCastSwitch<int16_t>(source, result, count, error_message);
+	case LogicalTypeId::INTEGER:
+		return NumericCastSwitch<int32_t>(source, result, count, error_message);
+	case LogicalTypeId::BIGINT:
+		return NumericCastSwitch<int64_t>(source, result, count, error_message);
+	case LogicalTypeId::UTINYINT:
+		return NumericCastSwitch<uint8_t>(source, result, count, error_message);
+	case LogicalTypeId::USMALLINT:
+		return NumericCastSwitch<uint16_t>(source, result, count, error_message);
+	case LogicalTypeId::UINTEGER:
+		return NumericCastSwitch<uint32_t>(source, result, count, error_message);
+	case LogicalTypeId::UBIGINT:
+		return NumericCastSwitch<uint64_t>(source, result, count, error_message);
+	case LogicalTypeId::HUGEINT:
+		return NumericCastSwitch<hugeint_t>(source, result, count, error_message);
+	case LogicalTypeId::UUID:
+		return UUIDCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::DECIMAL:
+		return DecimalCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::FLOAT:
+		return NumericCastSwitch<float>(source, result, count, error_message);
+	case LogicalTypeId::DOUBLE:
+		return NumericCastSwitch<double>(source, result, count, error_message);
+	case LogicalTypeId::DATE:
+		return DateCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIME:
+		return TimeCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIME_TZ:
+		return TimeTzCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP:
+		return TimestampCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return TimestampTzCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return TimestampNsCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return TimestampMsCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return TimestampSecCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::INTERVAL:
+		return IntervalCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		return StringCastSwitch(source, result, count, strict, error_message);
+	case LogicalTypeId::BLOB:
+		return BlobCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::SQLNULL: {
+		// cast a NULL to another type, just copy the properties and change the type
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return true;
+	}
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::STRUCT:
+		return StructCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::LIST:
+		return ListCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::ENUM:
+		return EnumCastSwitch(source, result, count, error_message, strict);
+	case LogicalTypeId::AGGREGATE_STATE:
+		return AggregateStateToBlobCast(source, result, count, error_message, strict);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+void VectorOperations::Cast(Vector &source, Vector &result, idx_t count, bool strict) {
+	VectorOperations::TryCast(source, result, count, nullptr, strict);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// copy.cpp
+// Description: This file contains the implementation of the different copy
+// functions
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static void TemplatedCopy(const Vector &source, const SelectionVector &sel, Vector &target, idx_t source_offset,
+                          idx_t target_offset, idx_t copy_count) {
+	auto ldata = FlatVector::GetData<T>(source);
+	auto tdata = FlatVector::GetData<T>(target);
+	for (idx_t i = 0; i < copy_count; i++) {
+		auto source_idx = sel.get_index(source_offset + i);
+		tdata[target_offset + i] = ldata[source_idx];
+	}
+}
+
+void VectorOperations::Copy(const Vector &source_p, Vector &target, const SelectionVector &sel_p, idx_t source_count,
+                            idx_t source_offset, idx_t target_offset) {
+	D_ASSERT(source_offset <= source_count);
+	D_ASSERT(source_p.GetType() == target.GetType());
+	idx_t copy_count = source_count - source_offset;
+
+	SelectionVector owned_sel;
+	const SelectionVector *sel = &sel_p;
+
+	const Vector *source = &source_p;
+	bool finished = false;
+	while (!finished) {
+		switch (source->GetVectorType()) {
+		case VectorType::DICTIONARY_VECTOR: {
+			// dictionary vector: merge selection vectors
+			auto &child = DictionaryVector::Child(*source);
+			auto &dict_sel = DictionaryVector::SelVector(*source);
+			// merge the selection vectors and verify the child
+			auto new_buffer = dict_sel.Slice(*sel, source_count);
+			owned_sel.Initialize(new_buffer);
+			sel = &owned_sel;
+			source = &child;
+			break;
+		}
+		case VectorType::SEQUENCE_VECTOR: {
+			int64_t start, increment;
+			Vector seq(source->GetType());
+			SequenceVector::GetSequence(*source, start, increment);
+			VectorOperations::GenerateSequence(seq, source_count, *sel, start, increment);
+			VectorOperations::Copy(seq, target, *sel, source_count, source_offset, target_offset);
+			return;
+		}
+		case VectorType::CONSTANT_VECTOR:
+			sel = ConstantVector::ZeroSelectionVector(copy_count, owned_sel);
+			finished = true;
+			break;
+		case VectorType::FLAT_VECTOR:
+			finished = true;
+			break;
+		default:
+			throw NotImplementedException("FIXME unimplemented vector type for VectorOperations::Copy");
+		}
+	}
+
+	if (copy_count == 0) {
+		return;
+	}
+
+	// Allow copying of a single value to constant vectors
+	const auto target_vector_type = target.GetVectorType();
+	if (copy_count == 1 && target_vector_type == VectorType::CONSTANT_VECTOR) {
+		target_offset = 0;
+		target.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	D_ASSERT(target.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	// first copy the nullmask
+	auto &tmask = FlatVector::Validity(target);
+	if (source->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		const bool valid = !ConstantVector::IsNull(*source);
+		for (idx_t i = 0; i < copy_count; i++) {
+			tmask.Set(target_offset + i, valid);
+		}
+	} else {
+		auto &smask = FlatVector::Validity(*source);
+		if (smask.IsMaskSet()) {
+			for (idx_t i = 0; i < copy_count; i++) {
+				auto idx = sel->get_index(source_offset + i);
+
+				if (smask.RowIsValid(idx)) {
+					// set valid
+					if (!tmask.AllValid()) {
+						tmask.SetValidUnsafe(target_offset + i);
+					}
+				} else {
+					// set invalid
+					if (tmask.AllValid()) {
+						auto init_size = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, target_offset + copy_count);
+						tmask.Initialize(init_size);
+					}
+					tmask.SetInvalidUnsafe(target_offset + i);
+				}
+			}
+		}
+	}
+
+	D_ASSERT(sel);
+
+	// now copy over the data
+	switch (source->GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedCopy<int8_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedCopy<int16_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedCopy<int32_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedCopy<int64_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedCopy<uint8_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedCopy<uint16_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedCopy<uint32_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedCopy<uint64_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedCopy<hugeint_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedCopy<float>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedCopy<double>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedCopy<interval_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::VARCHAR: {
+		auto ldata = FlatVector::GetData<string_t>(*source);
+		auto tdata = FlatVector::GetData<string_t>(target);
+		for (idx_t i = 0; i < copy_count; i++) {
+			auto source_idx = sel->get_index(source_offset + i);
+			auto target_idx = target_offset + i;
+			if (tmask.RowIsValid(target_idx)) {
+				tdata[target_idx] = StringVector::AddStringOrBlob(target, ldata[source_idx]);
+			}
+		}
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		auto &source_children = StructVector::GetEntries(*source);
+		auto &target_children = StructVector::GetEntries(target);
+		D_ASSERT(source_children.size() == target_children.size());
+		for (idx_t i = 0; i < source_children.size(); i++) {
+			VectorOperations::Copy(*source_children[i], *target_children[i], sel_p, source_count, source_offset,
+			                       target_offset);
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		D_ASSERT(target.GetType().InternalType() == PhysicalType::LIST);
+
+		auto &source_child = ListVector::GetEntry(*source);
+		auto sdata = FlatVector::GetData<list_entry_t>(*source);
+		auto tdata = FlatVector::GetData<list_entry_t>(target);
+
+		if (target_vector_type == VectorType::CONSTANT_VECTOR) {
+			// If we are only writing one value, then the copied values (if any) are contiguous
+			// and we can just Append from the offset position
+			if (!tmask.RowIsValid(target_offset)) {
+				break;
+			}
+			auto source_idx = sel->get_index(source_offset);
+			auto &source_entry = sdata[source_idx];
+			const idx_t source_child_size = source_entry.length + source_entry.offset;
+
+			//! overwrite constant target vectors.
+			ListVector::SetListSize(target, 0);
+			ListVector::Append(target, source_child, source_child_size, source_entry.offset);
+
+			auto &target_entry = tdata[target_offset];
+			target_entry.length = source_entry.length;
+			target_entry.offset = 0;
+		} else {
+			//! if the source has list offsets, we need to append them to the target
+			//! build a selection vector for the copied child elements
+			vector<sel_t> child_rows;
+			for (idx_t i = 0; i < copy_count; ++i) {
+				if (tmask.RowIsValid(target_offset + i)) {
+					auto source_idx = sel->get_index(source_offset + i);
+					auto &source_entry = sdata[source_idx];
+					for (idx_t j = 0; j < source_entry.length; ++j) {
+						child_rows.emplace_back(source_entry.offset + j);
+					}
+				}
+			}
+			idx_t source_child_size = child_rows.size();
+			SelectionVector child_sel(child_rows.data());
+
+			idx_t old_target_child_len = ListVector::GetListSize(target);
+
+			//! append to list itself
+			ListVector::Append(target, source_child, child_sel, source_child_size);
+
+			//! now write the list offsets
+			for (idx_t i = 0; i < copy_count; i++) {
+				auto source_idx = sel->get_index(source_offset + i);
+				auto &source_entry = sdata[source_idx];
+				auto &target_entry = tdata[target_offset + i];
+
+				target_entry.length = source_entry.length;
+				target_entry.offset = old_target_child_len;
+				if (tmask.RowIsValid(target_offset + i)) {
+					old_target_child_len += target_entry.length;
+				}
+			}
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type '%s' for copy!",
+		                              TypeIdToString(source->GetType().InternalType()));
+	}
+
+	if (target_vector_type != VectorType::FLAT_VECTOR) {
+		target.SetVectorType(target_vector_type);
+	}
+}
+
+void VectorOperations::Copy(const Vector &source, Vector &target, idx_t source_count, idx_t source_offset,
+                            idx_t target_offset) {
+	VectorOperations::Copy(source, target, *FlatVector::IncrementalSelectionVector(), source_count, source_offset,
+	                       target_offset);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// hash.cpp
+// Description: This file contains the vectorized hash implementations
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct HashOp {
+	static const hash_t NULL_HASH = 0xbf58476d1ce4e5b9;
+
+	template <class T>
+	static inline hash_t Operation(T input, bool is_null) {
+		return is_null ? NULL_HASH : duckdb::Hash<T>(input);
+	}
+};
+
+static inline hash_t CombineHashScalar(hash_t a, hash_t b) {
+	return (a * UINT64_C(0xbf58476d1ce4e5b9)) ^ b;
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopHash(T *__restrict ldata, hash_t *__restrict result_data, const SelectionVector *rsel,
+                                 idx_t count, const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			result_data[ridx] = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			result_data[ridx] = duckdb::Hash<T>(ldata[idx]);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TemplatedLoopHash(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+		auto ldata = ConstantVector::GetData<T>(input);
+		auto result_data = ConstantVector::GetData<hash_t>(result);
+		*result_data = HashOp::Operation(*ldata, ConstantVector::IsNull(input));
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+
+		VectorData idata;
+		input.Orrify(count, idata);
+
+		TightLoopHash<HAS_RSEL, T>((T *)idata.data, FlatVector::GetData<hash_t>(result), rsel, count, idata.sel,
+		                           idata.validity);
+	}
+}
+
+template <bool HAS_RSEL, bool FIRST_HASH>
+static inline void StructLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	auto &children = StructVector::GetEntries(input);
+
+	D_ASSERT(!children.empty());
+	idx_t col_no = 0;
+	if (HAS_RSEL) {
+		if (FIRST_HASH) {
+			VectorOperations::Hash(*children[col_no++], hashes, *rsel, count);
+		} else {
+			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+		}
+		while (col_no < children.size()) {
+			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+		}
+	} else {
+		if (FIRST_HASH) {
+			VectorOperations::Hash(*children[col_no++], hashes, count);
+		} else {
+			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+		}
+		while (col_no < children.size()) {
+			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+		}
+	}
+}
+
+template <bool HAS_RSEL, bool FIRST_HASH>
+static inline void ListLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	auto hdata = FlatVector::GetData<hash_t>(hashes);
+
+	VectorData idata;
+	input.Orrify(count, idata);
+	const auto ldata = (const list_entry_t *)idata.data;
+
+	// Hash the children into a temporary
+	auto &child = ListVector::GetEntry(input);
+	const auto child_count = ListVector::GetListSize(input);
+
+	Vector child_hashes(LogicalType::HASH, child_count);
+	VectorOperations::Hash(child, child_hashes, child_count);
+	auto chdata = FlatVector::GetData<hash_t>(child_hashes);
+
+	// Reduce the number of entries to check to the non-empty ones
+	SelectionVector unprocessed(count);
+	SelectionVector cursor(HAS_RSEL ? STANDARD_VECTOR_SIZE : count);
+	idx_t remaining = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const idx_t ridx = HAS_RSEL ? rsel->get_index(i) : i;
+		const auto lidx = idata.sel->get_index(ridx);
+		const auto &entry = ldata[lidx];
+		if (idata.validity.RowIsValid(lidx) && entry.length > 0) {
+			unprocessed.set_index(remaining++, ridx);
+			cursor.set_index(ridx, entry.offset);
+		} else if (FIRST_HASH) {
+			hdata[ridx] = HashOp::NULL_HASH;
+		}
+		// Empty or NULL non-first elements have no effect.
+	}
+
+	count = remaining;
+	if (count == 0) {
+		return;
+	}
+
+	// Merge the first position hash into the main hash
+	idx_t position = 1;
+	if (FIRST_HASH) {
+		remaining = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto ridx = unprocessed.get_index(i);
+			const auto cidx = cursor.get_index(ridx);
+			hdata[ridx] = chdata[cidx];
+
+			const auto lidx = idata.sel->get_index(ridx);
+			const auto &entry = ldata[lidx];
+			if (entry.length > position) {
+				// Entry still has values to hash
+				unprocessed.set_index(remaining++, ridx);
+				cursor.set_index(ridx, cidx + 1);
+			}
+		}
+		count = remaining;
+		if (count == 0) {
+			return;
+		}
+		++position;
+	}
+
+	// Combine the hashes for the remaining positions until there are none left
+	for (;; ++position) {
+		remaining = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto ridx = unprocessed.get_index(i);
+			const auto cidx = cursor.get_index(ridx);
+			hdata[ridx] = CombineHashScalar(hdata[ridx], chdata[cidx]);
+
+			const auto lidx = idata.sel->get_index(ridx);
+			const auto &entry = ldata[lidx];
+			if (entry.length > position) {
+				// Entry still has values to hash
+				unprocessed.set_index(remaining++, ridx);
+				cursor.set_index(ridx, cidx + 1);
+			}
+		}
+
+		count = remaining;
+		if (count == 0) {
+			break;
+		}
+	}
+}
+
+template <bool HAS_RSEL>
+static inline void HashTypeSwitch(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedLoopHash<HAS_RSEL, int8_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedLoopHash<HAS_RSEL, int16_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedLoopHash<HAS_RSEL, int32_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedLoopHash<HAS_RSEL, int64_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedLoopHash<HAS_RSEL, uint8_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedLoopHash<HAS_RSEL, uint16_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedLoopHash<HAS_RSEL, uint32_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedLoopHash<HAS_RSEL, uint64_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedLoopHash<HAS_RSEL, hugeint_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedLoopHash<HAS_RSEL, float>(input, result, rsel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedLoopHash<HAS_RSEL, double>(input, result, rsel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedLoopHash<HAS_RSEL, interval_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedLoopHash<HAS_RSEL, string_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		StructLoopHash<HAS_RSEL, true>(input, result, rsel, count);
+		break;
+	case PhysicalType::LIST:
+		ListLoopHash<HAS_RSEL, true>(input, result, rsel, count);
+		break;
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for hash");
+	}
+}
+
+void VectorOperations::Hash(Vector &input, Vector &result, idx_t count) {
+	HashTypeSwitch<false>(input, result, nullptr, count);
+}
+
+void VectorOperations::Hash(Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
+	HashTypeSwitch<true>(input, result, &sel, count);
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopCombineHashConstant(T *__restrict ldata, hash_t constant_hash, hash_t *__restrict hash_data,
+                                                const SelectionVector *rsel, idx_t count,
+                                                const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+			hash_data[ridx] = CombineHashScalar(constant_hash, other_hash);
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = duckdb::Hash<T>(ldata[idx]);
+			hash_data[ridx] = CombineHashScalar(constant_hash, other_hash);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopCombineHash(T *__restrict ldata, hash_t *__restrict hash_data, const SelectionVector *rsel,
+                                        idx_t count, const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+			hash_data[ridx] = CombineHashScalar(hash_data[ridx], other_hash);
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = duckdb::Hash<T>(ldata[idx]);
+			hash_data[ridx] = CombineHashScalar(hash_data[ridx], other_hash);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+void TemplatedLoopCombineHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR && hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto ldata = ConstantVector::GetData<T>(input);
+		auto hash_data = ConstantVector::GetData<hash_t>(hashes);
+
+		auto other_hash = HashOp::Operation(*ldata, ConstantVector::IsNull(input));
+		*hash_data = CombineHashScalar(*hash_data, other_hash);
+	} else {
+		VectorData idata;
+		input.Orrify(count, idata);
+		if (hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			// mix constant with non-constant, first get the constant value
+			auto constant_hash = *ConstantVector::GetData<hash_t>(hashes);
+			// now re-initialize the hashes vector to an empty flat vector
+			hashes.SetVectorType(VectorType::FLAT_VECTOR);
+			TightLoopCombineHashConstant<HAS_RSEL, T>((T *)idata.data, constant_hash,
+			                                          FlatVector::GetData<hash_t>(hashes), rsel, count, idata.sel,
+			                                          idata.validity);
+		} else {
+			D_ASSERT(hashes.GetVectorType() == VectorType::FLAT_VECTOR);
+			TightLoopCombineHash<HAS_RSEL, T>((T *)idata.data, FlatVector::GetData<hash_t>(hashes), rsel, count,
+			                                  idata.sel, idata.validity);
+		}
+	}
+}
+
+template <bool HAS_RSEL>
+static inline void CombineHashTypeSwitch(Vector &hashes, Vector &input, const SelectionVector *rsel, idx_t count) {
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedLoopCombineHash<HAS_RSEL, int8_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedLoopCombineHash<HAS_RSEL, int16_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedLoopCombineHash<HAS_RSEL, int32_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedLoopCombineHash<HAS_RSEL, int64_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedLoopCombineHash<HAS_RSEL, uint8_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedLoopCombineHash<HAS_RSEL, uint16_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedLoopCombineHash<HAS_RSEL, uint32_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedLoopCombineHash<HAS_RSEL, uint64_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedLoopCombineHash<HAS_RSEL, hugeint_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedLoopCombineHash<HAS_RSEL, float>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedLoopCombineHash<HAS_RSEL, double>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedLoopCombineHash<HAS_RSEL, interval_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedLoopCombineHash<HAS_RSEL, string_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		StructLoopHash<HAS_RSEL, false>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::LIST:
+		ListLoopHash<HAS_RSEL, false>(input, hashes, rsel, count);
+		break;
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for hash");
+	}
+}
+
+void VectorOperations::CombineHash(Vector &hashes, Vector &input, idx_t count) {
+	CombineHashTypeSwitch<false>(hashes, input, nullptr, count);
+}
+
+void VectorOperations::CombineHash(Vector &hashes, Vector &input, const SelectionVector &rsel, idx_t count) {
+	CombineHashTypeSwitch<true>(hashes, input, &rsel, count);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static void CopyToStorageLoop(VectorData &vdata, idx_t count, data_ptr_t target) {
+	auto ldata = (T *)vdata.data;
+	auto result_data = (T *)target;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (!vdata.validity.RowIsValid(idx)) {
+			result_data[i] = NullValue<T>();
+		} else {
+			result_data[i] = ldata[idx];
+		}
+	}
+}
+
+void VectorOperations::WriteToStorage(Vector &source, idx_t count, data_ptr_t target) {
+	if (count == 0) {
+		return;
+	}
+	VectorData vdata;
+	source.Orrify(count, vdata);
+
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		CopyToStorageLoop<int8_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT16:
+		CopyToStorageLoop<int16_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT32:
+		CopyToStorageLoop<int32_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT64:
+		CopyToStorageLoop<int64_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT8:
+		CopyToStorageLoop<uint8_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT16:
+		CopyToStorageLoop<uint16_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT32:
+		CopyToStorageLoop<uint32_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT64:
+		CopyToStorageLoop<uint64_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT128:
+		CopyToStorageLoop<hugeint_t>(vdata, count, target);
+		break;
+	case PhysicalType::FLOAT:
+		CopyToStorageLoop<float>(vdata, count, target);
+		break;
+	case PhysicalType::DOUBLE:
+		CopyToStorageLoop<double>(vdata, count, target);
+		break;
+	case PhysicalType::INTERVAL:
+		CopyToStorageLoop<interval_t>(vdata, count, target);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for WriteToStorage");
+	}
+}
+
+template <class T>
+static void ReadFromStorageLoop(data_ptr_t source, idx_t count, Vector &result) {
+	auto ldata = (T *)source;
+	auto result_data = FlatVector::GetData<T>(result);
+	for (idx_t i = 0; i < count; i++) {
+		result_data[i] = ldata[i];
+	}
+}
+
+void VectorOperations::ReadFromStorage(data_ptr_t source, idx_t count, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		ReadFromStorageLoop<int8_t>(source, count, result);
+		break;
+	case PhysicalType::INT16:
+		ReadFromStorageLoop<int16_t>(source, count, result);
+		break;
+	case PhysicalType::INT32:
+		ReadFromStorageLoop<int32_t>(source, count, result);
+		break;
+	case PhysicalType::INT64:
+		ReadFromStorageLoop<int64_t>(source, count, result);
+		break;
+	case PhysicalType::UINT8:
+		ReadFromStorageLoop<uint8_t>(source, count, result);
+		break;
+	case PhysicalType::UINT16:
+		ReadFromStorageLoop<uint16_t>(source, count, result);
+		break;
+	case PhysicalType::UINT32:
+		ReadFromStorageLoop<uint32_t>(source, count, result);
+		break;
+	case PhysicalType::UINT64:
+		ReadFromStorageLoop<uint64_t>(source, count, result);
+		break;
+	case PhysicalType::INT128:
+		ReadFromStorageLoop<hugeint_t>(source, count, result);
+		break;
+	case PhysicalType::FLOAT:
+		ReadFromStorageLoop<float>(source, count, result);
+		break;
+	case PhysicalType::DOUBLE:
+		ReadFromStorageLoop<double>(source, count, result);
+		break;
+	case PhysicalType::INTERVAL:
+		ReadFromStorageLoop<interval_t>(source, count, result);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for ReadFromStorage");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+VirtualFileSystem::VirtualFileSystem() : default_fs(FileSystem::CreateLocal()) {
+	RegisterSubSystem(FileCompressionType::GZIP, make_unique<GZipFileSystem>());
+}
+
+unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
+                                                   FileCompressionType compression, FileOpener *opener) {
+	if (compression == FileCompressionType::AUTO_DETECT) {
+		// auto detect compression settings based on file name
+		auto lower_path = StringUtil::Lower(path);
+		if (StringUtil::EndsWith(lower_path, ".gz")) {
+			compression = FileCompressionType::GZIP;
+		} else if (StringUtil::EndsWith(lower_path, ".zst")) {
+			compression = FileCompressionType::ZSTD;
+		} else {
+			compression = FileCompressionType::UNCOMPRESSED;
+		}
+	}
+	// open the base file handle
+	auto file_handle = FindFileSystem(path)->OpenFile(path, flags, lock, FileCompressionType::UNCOMPRESSED, opener);
+	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
+		file_handle = PipeFileSystem::OpenPipe(move(file_handle));
+	} else if (compression != FileCompressionType::UNCOMPRESSED) {
+		auto entry = compressed_fs.find(compression);
+		if (entry == compressed_fs.end()) {
+			throw NotImplementedException(
+			    "Attempting to open a compressed file, but the compression type is not supported");
+		}
+		file_handle = entry->second->OpenCompressedFile(move(file_handle), flags & FileFlags::FILE_FLAGS_WRITE);
+	}
+	return file_handle;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+#ifdef DUCKDB_WINDOWS
+
+std::wstring WindowsUtil::UTF8ToUnicode(const char *input) {
+	idx_t result_size;
+
+	result_size = MultiByteToWideChar(CP_UTF8, 0, input, -1, nullptr, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in MultiByteToWideChar");
+	}
+	auto buffer = unique_ptr<wchar_t[]>(new wchar_t[result_size]);
+	result_size = MultiByteToWideChar(CP_UTF8, 0, input, -1, buffer.get(), result_size);
+	if (result_size == 0) {
+		throw IOException("Failure in MultiByteToWideChar");
+	}
+	return std::wstring(buffer.get(), result_size);
+}
+
+static string WideCharToMultiByteWrapper(LPCWSTR input, uint32_t code_page) {
+	idx_t result_size;
+
+	result_size = WideCharToMultiByte(code_page, 0, input, -1, 0, 0, 0, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in WideCharToMultiByte");
+	}
+	auto buffer = unique_ptr<char[]>(new char[result_size]);
+	result_size = WideCharToMultiByte(code_page, 0, input, -1, buffer.get(), result_size, 0, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in WideCharToMultiByte");
+	}
+	return string(buffer.get(), result_size - 1);
+}
+
+string WindowsUtil::UnicodeToUTF8(LPCWSTR input) {
+	return WideCharToMultiByteWrapper(input, CP_UTF8);
+}
+
+static string WindowsUnicodeToMBCS(LPCWSTR unicode_text, int use_ansi) {
+	uint32_t code_page = use_ansi ? CP_ACP : CP_OEMCP;
+	return WideCharToMultiByteWrapper(unicode_text, code_page);
+}
+
+string WindowsUtil::UTF8ToMBCS(const char *input, bool use_ansi) {
+	auto unicode = WindowsUtil::UTF8ToUnicode(input);
+	return WindowsUnicodeToMBCS(unicode.c_str(), use_ansi);
+}
+
+#endif
+
+} // namespace duckdb
+
+
+
+#include <vector>
+
+namespace duckdb {
+
+AdaptiveFilter::AdaptiveFilter(const Expression &expr)
+    : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
+	auto &conj_expr = (const BoundConjunctionExpression &)expr;
+	D_ASSERT(conj_expr.children.size() > 1);
+	for (idx_t idx = 0; idx < conj_expr.children.size(); idx++) {
+		permutation.push_back(idx);
+		if (idx != conj_expr.children.size() - 1) {
+			swap_likeliness.push_back(100);
+		}
+	}
+	right_random_border = 100 * (conj_expr.children.size() - 1);
+}
+
+AdaptiveFilter::AdaptiveFilter(TableFilterSet *table_filters)
+    : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
+	for (auto &table_filter : table_filters->filters) {
+		permutation.push_back(table_filter.first);
+		swap_likeliness.push_back(100);
+	}
+	swap_likeliness.pop_back();
+	right_random_border = 100 * (table_filters->filters.size() - 1);
+}
+void AdaptiveFilter::AdaptRuntimeStatistics(double duration) {
+	iteration_count++;
+	runtime_sum += duration;
+
+	if (!warmup) {
+		// the last swap was observed
+		if (observe && iteration_count == observe_interval) {
+			// keep swap if runtime decreased, else reverse swap
+			if (prev_mean - (runtime_sum / iteration_count) <= 0) {
+				// reverse swap because runtime didn't decrease
+				std::swap(permutation[swap_idx], permutation[swap_idx + 1]);
+
+				// decrease swap likeliness, but make sure there is always a small likeliness left
+				if (swap_likeliness[swap_idx] > 1) {
+					swap_likeliness[swap_idx] /= 2;
+				}
+			} else {
+				// keep swap because runtime decreased, reset likeliness
+				swap_likeliness[swap_idx] = 100;
+			}
+			observe = false;
+
+			// reset values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+		} else if (!observe && iteration_count == execute_interval) {
+			// save old mean to evaluate swap
+			prev_mean = runtime_sum / iteration_count;
+
+			// get swap index and swap likeliness
+			std::uniform_int_distribution<int> distribution(1, right_random_border); // a <= i <= b
+			idx_t random_number = distribution(generator) - 1;
+
+			swap_idx = random_number / 100;                    // index to be swapped
+			idx_t likeliness = random_number - 100 * swap_idx; // random number between [0, 100)
+
+			// check if swap is going to happen
+			if (swap_likeliness[swap_idx] > likeliness) { // always true for the first swap of an index
+				// swap
+				std::swap(permutation[swap_idx], permutation[swap_idx + 1]);
+
+				// observe whether swap will be applied
+				observe = true;
+			}
+
+			// reset values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+		}
+	} else {
+		if (iteration_count == 5) {
+			// initially set all values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+			observe = false;
+			warmup = false;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types,
+                                                     vector<LogicalType> payload_types,
+                                                     const vector<BoundAggregateExpression *> &bindings,
+                                                     HtEntryType entry_type)
+    : GroupedAggregateHashTable(buffer_manager, move(group_types), move(payload_types),
+                                AggregateObject::CreateAggregateObjects(bindings), entry_type) {
+}
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types)
+    : GroupedAggregateHashTable(buffer_manager, move(group_types), {}, vector<AggregateObject>()) {
+}
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types_p,
+                                                     vector<LogicalType> payload_types_p,
+                                                     vector<AggregateObject> aggregate_objects_p,
+                                                     HtEntryType entry_type)
+    : BaseAggregateHashTable(buffer_manager, move(payload_types_p)), entry_type(entry_type), capacity(0), entries(0),
+      payload_page_offset(0), is_finalized(false), ht_offsets(LogicalTypeId::BIGINT),
+      hash_salts(LogicalTypeId::SMALLINT), group_compare_vector(STANDARD_VECTOR_SIZE),
+      no_match_vector(STANDARD_VECTOR_SIZE), empty_vector(STANDARD_VECTOR_SIZE) {
+
+	// Append hash column to the end and initialise the row layout
+	group_types_p.emplace_back(LogicalType::HASH);
+	layout.Initialize(move(group_types_p), move(aggregate_objects_p));
+
+	// HT layout
+	hash_offset = layout.GetOffsets()[layout.ColumnCount() - 1];
+
+	tuple_size = layout.GetRowWidth();
+
+	D_ASSERT(tuple_size <= Storage::BLOCK_SIZE);
+	tuples_per_block = Storage::BLOCK_SIZE / tuple_size;
+	hashes_hdl = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+	hashes_hdl_ptr = hashes_hdl->Ptr();
+
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_64: {
+		hash_prefix_shift = (HASH_WIDTH - sizeof(aggr_ht_entry_64::salt)) * 8;
+		Resize<aggr_ht_entry_64>(STANDARD_VECTOR_SIZE * 2);
+		break;
+	}
+	case HtEntryType::HT_WIDTH_32: {
+		hash_prefix_shift = (HASH_WIDTH - sizeof(aggr_ht_entry_32::salt)) * 8;
+		Resize<aggr_ht_entry_32>(STANDARD_VECTOR_SIZE * 2);
+		break;
+	}
+	default:
+		throw InternalException("Unknown HT entry width");
+	}
+
+	// create additional hash tables for distinct aggrs
+	auto &aggregates = layout.GetAggregates();
+	distinct_hashes.resize(aggregates.size());
+
+	idx_t payload_idx = 0;
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggr = aggregates[i];
+		if (aggr.distinct) {
+			// layout types minus hash column plus aggr return type
+			vector<LogicalType> distinct_group_types(layout.GetTypes());
+			(void)distinct_group_types.pop_back();
+			for (idx_t child_idx = 0; child_idx < aggr.child_count; child_idx++) {
+				distinct_group_types.push_back(payload_types[payload_idx + child_idx]);
+			}
+			distinct_hashes[i] = make_unique<GroupedAggregateHashTable>(buffer_manager, distinct_group_types);
+		}
+		payload_idx += aggr.child_count;
+	}
+	predicates.resize(layout.ColumnCount() - 1, ExpressionType::COMPARE_EQUAL);
+	string_heap = make_unique<RowDataCollection>(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+}
+
+GroupedAggregateHashTable::~GroupedAggregateHashTable() {
+	Destroy();
+}
+
+template <class FUNC>
+void GroupedAggregateHashTable::PayloadApply(FUNC fun) {
+	if (entries == 0) {
+		return;
+	}
+	idx_t apply_entries = entries;
+	idx_t page_nr = 0;
+	idx_t page_offset = 0;
+
+	for (auto &payload_chunk_ptr : payload_hds_ptrs) {
+		auto this_entries = MinValue(tuples_per_block, apply_entries);
+		page_offset = 0;
+		for (data_ptr_t ptr = payload_chunk_ptr, end = payload_chunk_ptr + this_entries * tuple_size; ptr < end;
+		     ptr += tuple_size) {
+			fun(page_nr, page_offset++, ptr);
+		}
+		apply_entries -= this_entries;
+		page_nr++;
+	}
+	D_ASSERT(apply_entries == 0);
+}
+
+void GroupedAggregateHashTable::NewBlock() {
+	auto pin = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+	payload_hds.push_back(move(pin));
+	payload_hds_ptrs.push_back(payload_hds.back()->Ptr());
+	payload_page_offset = 0;
+}
+
+void GroupedAggregateHashTable::Destroy() {
+	// check if there is a destructor
+	bool has_destructor = false;
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			has_destructor = true;
+		}
+	}
+	if (!has_destructor) {
+		return;
+	}
+	// there are aggregates with destructors: loop over the hash table
+	// and call the destructor method for each of the aggregates
+	data_ptr_t data_pointers[STANDARD_VECTOR_SIZE];
+	Vector state_vector(LogicalType::POINTER, (data_ptr_t)data_pointers);
+	idx_t count = 0;
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		data_pointers[count++] = ptr;
+		if (count == STANDARD_VECTOR_SIZE) {
+			RowOperations::DestroyStates(layout, state_vector, count);
+			count = 0;
+		}
+	});
+	RowOperations::DestroyStates(layout, state_vector, count);
+}
+
+template <class ENTRY>
+void GroupedAggregateHashTable::VerifyInternal() {
+	auto hashes_ptr = (ENTRY *)hashes_hdl_ptr;
+	D_ASSERT(payload_hds.size() == payload_hds_ptrs.size());
+	idx_t count = 0;
+	for (idx_t i = 0; i < capacity; i++) {
+		if (hashes_ptr[i].page_nr > 0) {
+			D_ASSERT(hashes_ptr[i].page_offset < tuples_per_block);
+			D_ASSERT(hashes_ptr[i].page_nr <= payload_hds.size());
+			auto ptr = payload_hds_ptrs[hashes_ptr[i].page_nr - 1] + ((hashes_ptr[i].page_offset) * tuple_size);
+			auto hash = Load<hash_t>(ptr + hash_offset);
+			D_ASSERT((hashes_ptr[i].salt) == (hash >> hash_prefix_shift));
+
+			count++;
+		}
+	}
+	D_ASSERT(count == entries);
+}
+
+idx_t GroupedAggregateHashTable::MaxCapacity() {
+	idx_t max_pages = 0;
+	idx_t max_tuples = 0;
+
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_32:
+		max_pages = NumericLimits<uint8_t>::Maximum();
+		max_tuples = NumericLimits<uint16_t>::Maximum();
+		break;
+	default:
+		D_ASSERT(entry_type == HtEntryType::HT_WIDTH_64);
+		max_pages = NumericLimits<uint32_t>::Maximum();
+		max_tuples = NumericLimits<uint16_t>::Maximum();
+		break;
+	}
+
+	return max_pages * MinValue(max_tuples, (idx_t)Storage::BLOCK_SIZE / tuple_size);
+}
+
+void GroupedAggregateHashTable::Verify() {
+#ifdef DEBUG
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_32:
+		VerifyInternal<aggr_ht_entry_32>();
+		break;
+	case HtEntryType::HT_WIDTH_64:
+		VerifyInternal<aggr_ht_entry_64>();
+		break;
+	}
+#endif
+}
+
+template <class ENTRY>
+void GroupedAggregateHashTable::Resize(idx_t size) {
+	Verify();
+
+	D_ASSERT(!is_finalized);
+
+	if (size <= capacity) {
+		throw InternalException("Cannot downsize a hash table!");
+	}
+	D_ASSERT(size >= STANDARD_VECTOR_SIZE);
+
+	// size needs to be a power of 2
+	D_ASSERT((size & (size - 1)) == 0);
+	bitmask = size - 1;
+
+	auto byte_size = size * sizeof(ENTRY);
+	if (byte_size > (idx_t)Storage::BLOCK_SIZE) {
+		hashes_hdl = buffer_manager.Allocate(byte_size);
+		hashes_hdl_ptr = hashes_hdl->Ptr();
+	}
+	memset(hashes_hdl_ptr, 0, byte_size);
+	hashes_end_ptr = hashes_hdl_ptr + byte_size;
+	capacity = size;
+
+	auto hashes_arr = (ENTRY *)hashes_hdl_ptr;
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+		D_ASSERT((hash & bitmask) == (hash % capacity));
+		auto entry_idx = (idx_t)hash & bitmask;
+		while (hashes_arr[entry_idx].page_nr > 0) {
+			entry_idx++;
+			if (entry_idx >= capacity) {
+				entry_idx = 0;
+			}
+		}
+
+		D_ASSERT(!hashes_arr[entry_idx].page_nr);
+		D_ASSERT(hash >> hash_prefix_shift <= NumericLimits<uint16_t>::Maximum());
+
+		hashes_arr[entry_idx].salt = hash >> hash_prefix_shift;
+		hashes_arr[entry_idx].page_nr = page_nr + 1;
+		hashes_arr[entry_idx].page_offset = page_offset;
+	});
+
+	Verify();
+}
+
+idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, DataChunk &payload) {
+	Vector hashes(LogicalType::HASH);
+	groups.Hash(hashes);
+
+	return AddChunk(groups, hashes, payload);
+}
+
+idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashes, DataChunk &payload) {
+	D_ASSERT(!is_finalized);
+
+	if (groups.size() == 0) {
+		return 0;
+	}
+	// dummy
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		D_ASSERT(groups.GetTypes()[i] == layout.GetTypes()[i]);
+	}
+
+	Vector addresses(LogicalType::POINTER);
+	auto new_group_count = FindOrCreateGroups(groups, group_hashes, addresses, new_groups);
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), payload.size());
+
+	// now every cell has an entry
+	// update the aggregates
+	idx_t payload_idx = 0;
+
+	auto &aggregates = layout.GetAggregates();
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		// for any entries for which a group was found, update the aggregate
+		auto &aggr = aggregates[aggr_idx];
+		if (aggr.distinct) {
+			// construct chunk for secondary hash table probing
+			vector<LogicalType> probe_types(groups.GetTypes());
+			for (idx_t i = 0; i < aggr.child_count; i++) {
+				probe_types.push_back(payload_types[payload_idx + i]);
+			}
+			DataChunk probe_chunk;
+			probe_chunk.Initialize(probe_types);
+			for (idx_t group_idx = 0; group_idx < groups.ColumnCount(); group_idx++) {
+				probe_chunk.data[group_idx].Reference(groups.data[group_idx]);
+			}
+			for (idx_t i = 0; i < aggr.child_count; i++) {
+				probe_chunk.data[groups.ColumnCount() + i].Reference(payload.data[payload_idx + i]);
+			}
+			probe_chunk.SetCardinality(groups);
+			probe_chunk.Verify();
+
+			Vector dummy_addresses(LogicalType::POINTER);
+			// this is the actual meat, find out which groups plus payload
+			// value have not been seen yet
+			idx_t new_group_count =
+			    distinct_hashes[aggr_idx]->FindOrCreateGroups(probe_chunk, dummy_addresses, new_groups);
+			if (new_group_count > 0) {
+				// now fix up the payload and addresses accordingly by creating
+				// a selection vector
+				DataChunk distinct_payload;
+				distinct_payload.Initialize(payload.GetTypes());
+				distinct_payload.Slice(payload, new_groups, new_group_count);
+				distinct_payload.Verify();
+
+				Vector distinct_addresses(addresses, new_groups, new_group_count);
+				distinct_addresses.Verify(new_group_count);
+
+				if (aggr.filter) {
+					distinct_addresses.Normalify(new_group_count);
+					RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
+				} else {
+					RowOperations::UpdateStates(aggr, distinct_addresses, distinct_payload, payload_idx,
+					                            new_group_count);
+				}
+			}
+		} else if (aggr.filter) {
+			RowOperations::UpdateFilteredStates(aggr, addresses, payload, payload_idx);
+		} else {
+			RowOperations::UpdateStates(aggr, addresses, payload, payload_idx, payload.size());
+		}
+
+		// move to the next aggregate
+		payload_idx += aggr.child_count;
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, payload.size());
+	}
+
+	Verify();
+	return new_group_count;
+}
+
+void GroupedAggregateHashTable::FetchAggregates(DataChunk &groups, DataChunk &result) {
+	groups.Verify();
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	for (idx_t i = 0; i < result.ColumnCount(); i++) {
+		D_ASSERT(result.data[i].GetType() == payload_types[i]);
+	}
+	result.SetCardinality(groups);
+	if (groups.size() == 0) {
+		return;
+	}
+	// find the groups associated with the addresses
+	// FIXME: this should not use the FindOrCreateGroups, creating them is unnecessary
+	Vector addresses(LogicalType::POINTER);
+	FindOrCreateGroups(groups, addresses);
+	// now fetch the aggregates
+	RowOperations::FinalizeStates(layout, addresses, result, 0);
+}
+
+template <class ENTRY>
+idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, Vector &group_hashes, Vector &addresses,
+                                                            SelectionVector &new_groups_out) {
+	D_ASSERT(!is_finalized);
+
+	if (entries + groups.size() > MaxCapacity()) {
+		throw InternalException("Hash table capacity reached");
+	}
+
+	// resize at 50% capacity, also need to fit the entire vector
+	if (capacity - entries <= groups.size() || entries > capacity / LOAD_FACTOR) {
+		Resize<ENTRY>(capacity * 2);
+	}
+
+	D_ASSERT(capacity - entries >= groups.size());
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	// we need to be able to fit at least one vector of data
+	D_ASSERT(capacity - entries >= groups.size());
+	D_ASSERT(group_hashes.GetType() == LogicalType::HASH);
+
+	group_hashes.Normalify(groups.size());
+	auto group_hashes_ptr = FlatVector::GetData<hash_t>(group_hashes);
+
+	D_ASSERT(ht_offsets.GetVectorType() == VectorType::FLAT_VECTOR);
+	D_ASSERT(ht_offsets.GetType() == LogicalType::BIGINT);
+
+	D_ASSERT(addresses.GetType() == LogicalType::POINTER);
+	addresses.Normalify(groups.size());
+	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+
+	// now compute the entry in the table based on the hash using a modulo
+	UnaryExecutor::Execute<hash_t, uint64_t>(group_hashes, ht_offsets, groups.size(), [&](hash_t element) {
+		D_ASSERT((element & bitmask) == (element % capacity));
+		return (element & bitmask);
+	});
+	auto ht_offsets_ptr = FlatVector::GetData<uint64_t>(ht_offsets);
+
+	// precompute the hash salts for faster comparison below
+	D_ASSERT(hash_salts.GetType() == LogicalType::SMALLINT);
+	UnaryExecutor::Execute<hash_t, uint16_t>(group_hashes, hash_salts, groups.size(),
+	                                         [&](hash_t element) { return (element >> hash_prefix_shift); });
+	auto hash_salts_ptr = FlatVector::GetData<uint16_t>(hash_salts);
+
+	// we start out with all entries [0, 1, 2, ..., groups.size()]
+	const SelectionVector *sel_vector = FlatVector::IncrementalSelectionVector();
+
+	idx_t remaining_entries = groups.size();
+
+	// make a chunk that references the groups and the hashes
+	DataChunk group_chunk;
+	group_chunk.InitializeEmpty(layout.GetTypes());
+	for (idx_t grp_idx = 0; grp_idx < groups.ColumnCount(); grp_idx++) {
+		group_chunk.data[grp_idx].Reference(groups.data[grp_idx]);
+	}
+	group_chunk.data[groups.ColumnCount()].Reference(group_hashes);
+	group_chunk.SetCardinality(groups);
+
+	// orrify all the groups
+	auto group_data = group_chunk.Orrify();
+
+	idx_t new_group_count = 0;
+	while (remaining_entries > 0) {
+		idx_t new_entry_count = 0;
+		idx_t need_compare_count = 0;
+		idx_t no_match_count = 0;
+
+		// first figure out for each remaining whether or not it belongs to a full or empty group
+		for (idx_t i = 0; i < remaining_entries; i++) {
+			const idx_t index = sel_vector->get_index(i);
+			const auto ht_entry_ptr = ((ENTRY *)this->hashes_hdl_ptr) + ht_offsets_ptr[index];
+			if (ht_entry_ptr->page_nr == 0) { // we use page number 0 as a "unused marker"
+				// cell is empty; setup the new entry
+				if (payload_page_offset == tuples_per_block || payload_hds.empty()) {
+					NewBlock();
+				}
+
+				auto entry_payload_ptr = payload_hds_ptrs.back() + (payload_page_offset * tuple_size);
+
+				D_ASSERT(group_hashes_ptr[index] >> hash_prefix_shift <= NumericLimits<uint16_t>::Maximum());
+				D_ASSERT(payload_page_offset < tuples_per_block);
+				D_ASSERT(payload_hds.size() < NumericLimits<uint32_t>::Maximum());
+				D_ASSERT(payload_page_offset + 1 < NumericLimits<uint16_t>::Maximum());
+
+				ht_entry_ptr->salt = group_hashes_ptr[index] >> hash_prefix_shift;
+
+				// page numbers start at one so we can use 0 as empty flag
+				// GetPtr undoes this
+				ht_entry_ptr->page_nr = payload_hds.size();
+				ht_entry_ptr->page_offset = payload_page_offset++;
+
+				// update selection lists for outer loops
+				empty_vector.set_index(new_entry_count++, index);
+				new_groups_out.set_index(new_group_count++, index);
+				entries++;
+
+				addresses_ptr[index] = entry_payload_ptr;
+
+			} else {
+				// cell is occupied: add to check list
+				// only need to check if hash salt in ptr == prefix of hash in payload
+				if (ht_entry_ptr->salt == hash_salts_ptr[index]) {
+					group_compare_vector.set_index(need_compare_count++, index);
+
+					auto page_ptr = payload_hds_ptrs[ht_entry_ptr->page_nr - 1];
+					auto page_offset = ht_entry_ptr->page_offset * tuple_size;
+					addresses_ptr[index] = page_ptr + page_offset;
+
+				} else {
+					no_match_vector.set_index(no_match_count++, index);
+				}
+			}
+		}
+
+		// for each of the locations that are empty, serialize the group columns to the locations
+		RowOperations::Scatter(group_chunk, group_data.get(), layout, addresses, *string_heap, empty_vector,
+		                       new_entry_count);
+		RowOperations::InitializeStates(layout, addresses, empty_vector, new_entry_count);
+
+		// now we have only the tuples remaining that might match to an existing group
+		// start performing comparisons with each of the groups
+		RowOperations::Match(group_chunk, group_data.get(), layout, addresses, predicates, group_compare_vector,
+		                     need_compare_count, &no_match_vector, no_match_count);
+
+		// each of the entries that do not match we move them to the next entry in the HT
+		for (idx_t i = 0; i < no_match_count; i++) {
+			idx_t index = no_match_vector.get_index(i);
+			ht_offsets_ptr[index]++;
+			if (ht_offsets_ptr[index] >= capacity) {
+				ht_offsets_ptr[index] = 0;
+			}
+		}
+		sel_vector = &no_match_vector;
+		remaining_entries = no_match_count;
+	}
+
+	return new_group_count;
+}
+
+// this is to support distinct aggregations where we need to record whether we
+// have already seen a value for a group
+idx_t GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &group_hashes, Vector &addresses_out,
+                                                    SelectionVector &new_groups_out) {
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_64:
+		return FindOrCreateGroupsInternal<aggr_ht_entry_64>(groups, group_hashes, addresses_out, new_groups_out);
+	case HtEntryType::HT_WIDTH_32:
+		return FindOrCreateGroupsInternal<aggr_ht_entry_32>(groups, group_hashes, addresses_out, new_groups_out);
+	default:
+		throw InternalException("Unknown HT entry width");
+	}
+}
+
+void GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &addresses) {
+	// create a dummy new_groups sel vector
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+	FindOrCreateGroups(groups, addresses, new_groups);
+}
+
+idx_t GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &addresses_out,
+                                                    SelectionVector &new_groups_out) {
+	Vector hashes(LogicalType::HASH);
+	groups.Hash(hashes);
+	return FindOrCreateGroups(groups, hashes, addresses_out, new_groups_out);
+}
+
+void GroupedAggregateHashTable::FlushMove(Vector &source_addresses, Vector &source_hashes, idx_t count) {
+	D_ASSERT(source_addresses.GetType() == LogicalType::POINTER);
+	D_ASSERT(source_hashes.GetType() == LogicalType::HASH);
+
+	DataChunk groups;
+	groups.Initialize(vector<LogicalType>(layout.GetTypes().begin(), layout.GetTypes().end() - 1));
+	groups.SetCardinality(count);
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		auto &column = groups.data[i];
+		const auto col_offset = layout.GetOffsets()[i];
+		RowOperations::Gather(source_addresses, *FlatVector::IncrementalSelectionVector(), column,
+		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, i);
+	}
+
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+	Vector group_addresses(LogicalType::POINTER);
+	SelectionVector new_groups_sel(STANDARD_VECTOR_SIZE);
+
+	FindOrCreateGroups(groups, source_hashes, group_addresses, new_groups_sel);
+
+	RowOperations::CombineStates(layout, source_addresses, group_addresses, count);
+}
+
+void GroupedAggregateHashTable::Combine(GroupedAggregateHashTable &other) {
+
+	D_ASSERT(!is_finalized);
+
+	D_ASSERT(other.layout.GetAggrWidth() == layout.GetAggrWidth());
+	D_ASSERT(other.layout.GetDataWidth() == layout.GetDataWidth());
+	D_ASSERT(other.layout.GetRowWidth() == layout.GetRowWidth());
+	D_ASSERT(other.tuples_per_block == tuples_per_block);
+
+	if (other.entries == 0) {
+		return;
+	}
+
+	Vector addresses(LogicalType::POINTER);
+	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+
+	Vector hashes(LogicalType::HASH);
+	auto hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+
+	idx_t group_idx = 0;
+
+	other.PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+
+		hashes_ptr[group_idx] = hash;
+		addresses_ptr[group_idx] = ptr;
+		group_idx++;
+		if (group_idx == STANDARD_VECTOR_SIZE) {
+			FlushMove(addresses, hashes, group_idx);
+			group_idx = 0;
+		}
+	});
+	FlushMove(addresses, hashes, group_idx);
+	string_heap->Merge(*other.string_heap);
+	Verify();
+}
+
+struct PartitionInfo {
+	PartitionInfo() : addresses(LogicalType::POINTER), hashes(LogicalType::HASH), group_count(0) {
+		addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+		hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+	};
+	Vector addresses;
+	Vector hashes;
+	idx_t group_count;
+	data_ptr_t *addresses_ptr;
+	hash_t *hashes_ptr;
+};
+
+void GroupedAggregateHashTable::Partition(vector<GroupedAggregateHashTable *> &partition_hts, hash_t mask,
+                                          idx_t shift) {
+	D_ASSERT(partition_hts.size() > 1);
+	vector<PartitionInfo> partition_info(partition_hts.size());
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+
+		idx_t partition = (hash & mask) >> shift;
+		D_ASSERT(partition < partition_hts.size());
+
+		auto &info = partition_info[partition];
+
+		info.hashes_ptr[info.group_count] = hash;
+		info.addresses_ptr[info.group_count] = ptr;
+		info.group_count++;
+		if (info.group_count == STANDARD_VECTOR_SIZE) {
+			D_ASSERT(partition_hts[partition]);
+			partition_hts[partition]->FlushMove(info.addresses, info.hashes, info.group_count);
+			info.group_count = 0;
+		}
+	});
+
+	idx_t info_idx = 0;
+	idx_t total_count = 0;
+	for (auto &partition_entry : partition_hts) {
+		auto &info = partition_info[info_idx++];
+		partition_entry->FlushMove(info.addresses, info.hashes, info.group_count);
+
+		partition_entry->string_heap->Merge(*string_heap);
+		partition_entry->Verify();
+		total_count += partition_entry->Size();
+	}
+	D_ASSERT(total_count == entries);
+}
+
+idx_t GroupedAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
+	Vector addresses(LogicalType::POINTER);
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+
+	auto remaining = entries - scan_position;
+	if (remaining == 0) {
+		return 0;
+	}
+	auto this_n = MinValue((idx_t)STANDARD_VECTOR_SIZE, remaining);
+
+	auto chunk_idx = scan_position / tuples_per_block;
+	auto chunk_offset = (scan_position % tuples_per_block) * tuple_size;
+	D_ASSERT(chunk_offset + tuple_size <= Storage::BLOCK_SIZE);
+
+	auto read_ptr = payload_hds_ptrs[chunk_idx++];
+	for (idx_t i = 0; i < this_n; i++) {
+		data_pointers[i] = read_ptr + chunk_offset;
+		chunk_offset += tuple_size;
+		if (chunk_offset >= tuples_per_block * tuple_size) {
+			read_ptr = payload_hds_ptrs[chunk_idx++];
+			chunk_offset = 0;
+		}
+	}
+
+	result.SetCardinality(this_n);
+	// fetch the group columns (ignoring the final hash column
+	const auto group_cols = layout.ColumnCount() - 1;
+	for (idx_t i = 0; i < group_cols; i++) {
+		auto &column = result.data[i];
+		const auto col_offset = layout.GetOffsets()[i];
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), column,
+		                      *FlatVector::IncrementalSelectionVector(), result.size(), col_offset, i);
+	}
+
+	RowOperations::FinalizeStates(layout, addresses, result, group_cols);
+
+	scan_position += this_n;
+	return this_n;
+}
+
+void GroupedAggregateHashTable::Finalize() {
+	if (is_finalized) {
+		return;
+	}
+
+	// early release hashes, not needed for partition/scan
+	hashes_hdl.reset();
+	is_finalized = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BaseAggregateHashTable::BaseAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> payload_types_p)
+    : buffer_manager(buffer_manager), payload_types(move(payload_types_p)) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnBindingResolver::ColumnBindingResolver() {
+}
+
+void ColumnBindingResolver::VisitOperator(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		// special case: comparison join
+		auto &comp_join = (LogicalComparisonJoin &)op;
+		// first get the bindings of the LHS and resolve the LHS expressions
+		VisitOperator(*comp_join.children[0]);
+		for (auto &cond : comp_join.conditions) {
+			VisitExpression(&cond.left);
+		}
+		if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+			// visit the duplicate eliminated columns on the LHS, if any
+			auto &delim_join = (LogicalDelimJoin &)op;
+			for (auto &expr : delim_join.duplicate_eliminated_columns) {
+				VisitExpression(&expr);
+			}
+		}
+		// then get the bindings of the RHS and resolve the RHS expressions
+		VisitOperator(*comp_join.children[1]);
+		for (auto &cond : comp_join.conditions) {
+			VisitExpression(&cond.right);
+		}
+		// finally update the bindings with the result bindings of the join
+		bindings = op.GetColumnBindings();
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_ANY_JOIN) {
+		// ANY join, this join is different because we evaluate the expression on the bindings of BOTH join sides at
+		// once i.e. we set the bindings first to the bindings of the entire join, and then resolve the expressions of
+		// this operator
+		VisitOperatorChildren(op);
+		bindings = op.GetColumnBindings();
+		VisitOperatorExpressions(op);
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_CREATE_INDEX) {
+		// CREATE INDEX statement, add the columns of the table with table index 0 to the binding set
+		// afterwards bind the expressions of the CREATE INDEX statement
+		auto &create_index = (LogicalCreateIndex &)op;
+		bindings = LogicalOperator::GenerateColumnBindings(0, create_index.table.columns.size());
+		VisitOperatorExpressions(op);
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		//! We first need to update the current set of bindings and then visit operator expressions
+		bindings = op.GetColumnBindings();
+		VisitOperatorExpressions(op);
+		return;
+	}
+	// general case
+	// first visit the children of this operator
+	VisitOperatorChildren(op);
+	// now visit the expressions of this operator to resolve any bound column references
+	VisitOperatorExpressions(op);
+	// finally update the current set of bindings to the current set of column bindings
+	bindings = op.GetColumnBindings();
+}
+
+unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpression &expr,
+                                                           unique_ptr<Expression> *expr_ptr) {
+	D_ASSERT(expr.depth == 0);
+	// check the current set of column bindings to see which index corresponds to the column reference
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		if (expr.binding == bindings[i]) {
+			return make_unique<BoundReferenceExpression>(expr.alias, expr.return_type, i);
+		}
+	}
+	// LCOV_EXCL_START
+	// could not bind the column reference, this should never happen and indicates a bug in the code
+	// generate an error message
+	string bound_columns = "[";
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		if (i != 0) {
+			bound_columns += " ";
+		}
+		bound_columns += to_string(bindings[i].table_index) + "." + to_string(bindings[i].column_index);
+	}
+	bound_columns += "]";
+
+	throw InternalException("Failed to bind column reference \"%s\" [%d.%d] (bindings: %s)", expr.alias,
+	                        expr.binding.table_index, expr.binding.column_index, bound_columns);
+	// LCOV_EXCL_STOP
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BothInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThanEquals::Operation<T>(input, lower) && LessThanEquals::Operation<T>(input, upper);
+	}
+};
+
+struct LowerInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThanEquals::Operation<T>(input, lower) && LessThan::Operation<T>(input, upper);
+	}
+};
+
+struct UpperInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThan::Operation<T>(input, lower) && LessThanEquals::Operation<T>(input, upper);
+	}
+};
+
+struct ExclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThan::Operation<T>(input, lower) && LessThan::Operation<T>(input, upper);
+	}
+};
+
+template <class OP>
+static idx_t BetweenLoopTypeSwitch(Vector &input, Vector &lower, Vector &upper, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TernaryExecutor::Select<int8_t, int8_t, int8_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	case PhysicalType::INT16:
+		return TernaryExecutor::Select<int16_t, int16_t, int16_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT32:
+		return TernaryExecutor::Select<int32_t, int32_t, int32_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT64:
+		return TernaryExecutor::Select<int64_t, int64_t, int64_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT128:
+		return TernaryExecutor::Select<hugeint_t, hugeint_t, hugeint_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                    false_sel);
+	case PhysicalType::UINT8:
+		return TernaryExecutor::Select<uint8_t, uint8_t, uint8_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::UINT16:
+		return TernaryExecutor::Select<uint16_t, uint16_t, uint16_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::UINT32:
+		return TernaryExecutor::Select<uint32_t, uint32_t, uint32_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::UINT64:
+		return TernaryExecutor::Select<uint64_t, uint64_t, uint64_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::FLOAT:
+		return TernaryExecutor::Select<float, float, float, OP>(input, lower, upper, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return TernaryExecutor::Select<double, double, double, OP>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	case PhysicalType::VARCHAR:
+		return TernaryExecutor::Select<string_t, string_t, string_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for BETWEEN");
+	}
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundBetweenExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.input.get());
+	result->AddChild(expr.lower.get());
+	result->AddChild(expr.upper.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+
+	auto &input = state->intermediate_chunk.data[0];
+	auto &lower = state->intermediate_chunk.data[1];
+	auto &upper = state->intermediate_chunk.data[2];
+
+	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
+	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
+	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);
+
+	Vector intermediate1(LogicalType::BOOLEAN);
+	Vector intermediate2(LogicalType::BOOLEAN);
+
+	if (expr.upper_inclusive && expr.lower_inclusive) {
+		VectorOperations::GreaterThanEquals(input, lower, intermediate1, count);
+		VectorOperations::LessThanEquals(input, upper, intermediate2, count);
+	} else if (expr.lower_inclusive) {
+		VectorOperations::GreaterThanEquals(input, lower, intermediate1, count);
+		VectorOperations::LessThan(input, upper, intermediate2, count);
+	} else if (expr.upper_inclusive) {
+		VectorOperations::GreaterThan(input, lower, intermediate1, count);
+		VectorOperations::LessThanEquals(input, upper, intermediate2, count);
+	} else {
+		VectorOperations::GreaterThan(input, lower, intermediate1, count);
+		VectorOperations::LessThan(input, upper, intermediate2, count);
+	}
+	VectorOperations::And(intermediate1, intermediate2, result, count);
+}
+
+idx_t ExpressionExecutor::Select(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	// resolve the children
+	Vector input(state->intermediate_chunk.data[0]);
+	Vector lower(state->intermediate_chunk.data[1]);
+	Vector upper(state->intermediate_chunk.data[2]);
+
+	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
+	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
+	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);
+
+	if (expr.upper_inclusive && expr.lower_inclusive) {
+		return BetweenLoopTypeSwitch<BothInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	} else if (expr.lower_inclusive) {
+		return BetweenLoopTypeSwitch<LowerInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                            false_sel);
+	} else if (expr.upper_inclusive) {
+		return BetweenLoopTypeSwitch<UpperInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                            false_sel);
+	} else {
+		return BetweenLoopTypeSwitch<ExclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel, false_sel);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct CaseExpressionState : public ExpressionState {
+	CaseExpressionState(const Expression &expr, ExpressionExecutorState &root)
+	    : ExpressionState(expr, root), true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE) {
+	}
+
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+};
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCaseExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<CaseExpressionState>(expr, root);
+	for (auto &case_check : expr.case_checks) {
+		result->AddChild(case_check.when_expr.get());
+		result->AddChild(case_check.then_expr.get());
+	}
+	result->AddChild(expr.else_expr.get());
+	result->Finalize();
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundCaseExpression &expr, ExpressionState *state_p, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	auto state = (CaseExpressionState *)state_p;
+
+	state->intermediate_chunk.Reset();
+
+	// first execute the check expression
+	auto current_true_sel = &state->true_sel;
+	auto current_false_sel = &state->false_sel;
+	auto current_sel = sel;
+	idx_t current_count = count;
+	for (idx_t i = 0; i < expr.case_checks.size(); i++) {
+		auto &case_check = expr.case_checks[i];
+		auto &intermediate_result = state->intermediate_chunk.data[i * 2 + 1];
+		auto check_state = state->child_states[i * 2].get();
+		auto then_state = state->child_states[i * 2 + 1].get();
+
+		idx_t tcount =
+		    Select(*case_check.when_expr, check_state, current_sel, current_count, current_true_sel, current_false_sel);
+		if (tcount == 0) {
+			// everything is false: do nothing
+			continue;
+		}
+		idx_t fcount = current_count - tcount;
+		if (fcount == 0 && current_count == count) {
+			// everything is true in the first CHECK statement
+			// we can skip the entire case and only execute the TRUE side
+			Execute(*case_check.then_expr, then_state, sel, count, result);
+			return;
+		} else {
+			// we need to execute and then fill in the desired tuples in the result
+			Execute(*case_check.then_expr, then_state, current_true_sel, tcount, intermediate_result);
+			FillSwitch(intermediate_result, result, *current_true_sel, tcount);
+		}
+		// continue with the false tuples
+		current_sel = current_false_sel;
+		current_count = fcount;
+		if (fcount == 0) {
+			// everything is true: we are done
+			break;
+		}
+	}
+	if (current_count > 0) {
+		auto else_state = state->child_states.back().get();
+		if (current_count == count) {
+			// everything was false, we can just evaluate the else expression directly
+			Execute(*expr.else_expr, else_state, sel, count, result);
+			return;
+		} else {
+			auto &intermediate_result = state->intermediate_chunk.data[expr.case_checks.size() * 2];
+
+			D_ASSERT(current_sel);
+			Execute(*expr.else_expr, else_state, current_sel, current_count, intermediate_result);
+			FillSwitch(intermediate_result, result, *current_sel, current_count);
+		}
+	}
+	if (sel) {
+		result.Slice(*sel, count);
+	}
+}
+
+template <class T>
+void TemplatedFillLoop(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto res = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+	if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto data = ConstantVector::GetData<T>(vector);
+		if (ConstantVector::IsNull(vector)) {
+			for (idx_t i = 0; i < count; i++) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				res[sel.get_index(i)] = *data;
+			}
+		}
+	} else {
+		VectorData vdata;
+		vector.Orrify(count, vdata);
+		auto data = (T *)vdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = vdata.sel->get_index(i);
+			auto res_idx = sel.get_index(i);
+
+			res[res_idx] = data[source_idx];
+			result_mask.Set(res_idx, vdata.validity.RowIsValid(source_idx));
+		}
+	}
+}
+
+void ValidityFillLoop(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_mask = FlatVector::Validity(result);
+	if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		if (ConstantVector::IsNull(vector)) {
+			for (idx_t i = 0; i < count; i++) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		}
+	} else {
+		VectorData vdata;
+		vector.Orrify(count, vdata);
+		if (vdata.validity.AllValid()) {
+			return;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = vdata.sel->get_index(i);
+			if (!vdata.validity.RowIsValid(source_idx)) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		}
+	}
+}
+
+void ExpressionExecutor::FillSwitch(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedFillLoop<int8_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFillLoop<int16_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFillLoop<int32_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFillLoop<int64_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedFillLoop<uint8_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFillLoop<uint16_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFillLoop<uint32_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFillLoop<uint64_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedFillLoop<hugeint_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedFillLoop<float>(vector, result, sel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedFillLoop<double>(vector, result, sel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedFillLoop<interval_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedFillLoop<string_t>(vector, result, sel, count);
+		StringVector::AddHeapReference(result, vector);
+		break;
+	case PhysicalType::STRUCT: {
+		auto &vector_entries = StructVector::GetEntries(vector);
+		auto &result_entries = StructVector::GetEntries(result);
+		ValidityFillLoop(vector, result, sel, count);
+		D_ASSERT(vector_entries.size() == result_entries.size());
+		for (idx_t i = 0; i < vector_entries.size(); i++) {
+			FillSwitch(*vector_entries[i], *result_entries[i], sel, count);
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		idx_t offset = ListVector::GetListSize(result);
+		auto &list_child = ListVector::GetEntry(vector);
+		ListVector::Append(result, list_child, ListVector::GetListSize(vector));
+
+		// all the false offsets need to be incremented by true_child.count
+		TemplatedFillLoop<list_entry_t>(vector, result, sel, count);
+		if (offset == 0) {
+			break;
+		}
+
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto result_idx = sel.get_index(i);
+			result_data[result_idx].offset += offset;
+		}
+
+		Vector::Verify(result, sel, count);
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for case expression: %s", result.GetType().ToString());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCastExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.child.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	// resolve the child
+	state->intermediate_chunk.Reset();
+
+	auto &child = state->intermediate_chunk.data[0];
+	auto child_state = state->child_states[0].get();
+
+	Execute(*expr.child, child_state, sel, count, child);
+	if (expr.try_cast) {
+		string error_message;
+		VectorOperations::TryCast(child, result, count, &error_message);
+	} else {
+		// cast it to the type specified by the cast expression
+		D_ASSERT(result.GetType() == expr.return_type);
+		VectorOperations::Cast(child, result, count);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundComparisonExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.left.get());
+	result->AddChild(expr.right.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundComparisonExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+	auto &left = state->intermediate_chunk.data[0];
+	auto &right = state->intermediate_chunk.data[1];
+
+	Execute(*expr.left, state->child_states[0].get(), sel, count, left);
+	Execute(*expr.right, state->child_states[1].get(), sel, count, right);
+
+	switch (expr.type) {
+	case ExpressionType::COMPARE_EQUAL:
+		VectorOperations::Equals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		VectorOperations::NotEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		VectorOperations::LessThan(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		VectorOperations::GreaterThan(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		VectorOperations::LessThanEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		VectorOperations::GreaterThanEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		VectorOperations::DistinctFrom(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		VectorOperations::NotDistinctFrom(left, right, result, count);
+		break;
+	default:
+		throw InternalException("Unknown comparison type!");
+	}
+}
+
+template <typename OP>
+static idx_t NestedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel);
+
+template <class OP>
+static idx_t TemplatedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                      SelectionVector *true_sel, SelectionVector *false_sel) {
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return BinaryExecutor::Select<int8_t, int8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT16:
+		return BinaryExecutor::Select<int16_t, int16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT32:
+		return BinaryExecutor::Select<int32_t, int32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT64:
+		return BinaryExecutor::Select<int64_t, int64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT8:
+		return BinaryExecutor::Select<uint8_t, uint8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT16:
+		return BinaryExecutor::Select<uint16_t, uint16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT32:
+		return BinaryExecutor::Select<uint32_t, uint32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT64:
+		return BinaryExecutor::Select<uint64_t, uint64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT128:
+		return BinaryExecutor::Select<hugeint_t, hugeint_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::FLOAT:
+		return BinaryExecutor::Select<float, float, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return BinaryExecutor::Select<double, double, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INTERVAL:
+		return BinaryExecutor::Select<interval_t, interval_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::VARCHAR:
+		return BinaryExecutor::Select<string_t, string_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		return NestedSelectOperation<OP>(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Invalid type for comparison");
+	}
+}
+
+struct NestedSelector {
+	// Select the matching rows for the values of a nested type that are not both NULL.
+	// Those semantics are the same as the corresponding non-distinct comparator
+	template <typename OP>
+	static idx_t Select(Vector &left, Vector &right, const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                    SelectionVector *false_sel) {
+		throw InvalidTypeException(left.GetType(), "Invalid operation for nested SELECT");
+	}
+};
+
+template <>
+idx_t NestedSelector::Select<duckdb::Equals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                             SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::NotEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                                SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::LessThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::LessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                     idx_t count, SelectionVector *true_sel,
+                                                     SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::GreaterThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::GreaterThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                        idx_t count, SelectionVector *true_sel,
+                                                        SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+static inline idx_t SelectNotNull(Vector &left, Vector &right, const idx_t count, const SelectionVector &sel,
+                                  SelectionVector &maybe_vec, OptionalSelection &false_opt) {
+
+	VectorData lvdata, rvdata;
+	left.Orrify(count, lvdata);
+	right.Orrify(count, rvdata);
+
+	auto &lmask = lvdata.validity;
+	auto &rmask = rvdata.validity;
+
+	// For top-level comparisons, NULL semantics are in effect,
+	// so filter out any NULLs
+	idx_t remaining = 0;
+	if (lmask.AllValid() && rmask.AllValid()) {
+		//	None are NULL, distinguish values.
+		for (idx_t i = 0; i < count; ++i) {
+			const auto idx = sel.get_index(i);
+			maybe_vec.set_index(remaining++, idx);
+		}
+		return remaining;
+	}
+
+	// Slice the Vectors down to the rows that are not determined (i.e., neither is NULL)
+	SelectionVector slicer(count);
+	idx_t false_count = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto result_idx = sel.get_index(i);
+		const auto lidx = lvdata.sel->get_index(i);
+		const auto ridx = rvdata.sel->get_index(i);
+		if (!lmask.RowIsValid(lidx) || !rmask.RowIsValid(ridx)) {
+			false_opt.Append(false_count, result_idx);
+		} else {
+			//	Neither is NULL, distinguish values.
+			slicer.set_index(remaining, i);
+			maybe_vec.set_index(remaining++, result_idx);
+		}
+	}
+	false_opt.Advance(false_count);
+
+	if (remaining && remaining < count) {
+		left.Slice(slicer, remaining);
+		right.Slice(slicer, remaining);
+	}
+
+	return remaining;
+}
+
+static void ScatterSelection(SelectionVector *target, const idx_t count, const SelectionVector &dense_vec) {
+	if (target) {
+		for (idx_t i = 0; i < count; ++i) {
+			target->set_index(i, dense_vec.get_index(i));
+		}
+	}
+}
+
+template <typename OP>
+static idx_t NestedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	// The Select operations all use a dense pair of input vectors to partition
+	// a selection vector in a single pass. But to implement progressive comparisons,
+	// we have to make multiple passes, so we need to keep track of the original input positions
+	// and then scatter the output selections when we are done.
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+
+	// Make buffered selections for progressive comparisons
+	// TODO: Remove unnecessary allocations
+	SelectionVector true_vec(count);
+	OptionalSelection true_opt(&true_vec);
+
+	SelectionVector false_vec(count);
+	OptionalSelection false_opt(&false_vec);
+
+	SelectionVector maybe_vec(count);
+
+	// Handle NULL nested values
+	Vector l_not_null(left);
+	Vector r_not_null(right);
+
+	auto match_count = SelectNotNull(l_not_null, r_not_null, count, *sel, maybe_vec, false_opt);
+	auto no_match_count = count - match_count;
+	count = match_count;
+
+	//	Now that we have handled the NULLs, we can use the recursive nested comparator for the rest.
+	match_count = NestedSelector::Select<OP>(l_not_null, r_not_null, maybe_vec, count, true_opt, false_opt);
+	no_match_count += (count - match_count);
+
+	// Copy the buffered selections to the output selections
+	ScatterSelection(true_sel, match_count, true_vec);
+	ScatterSelection(false_sel, no_match_count, false_vec);
+
+	return match_count;
+}
+
+idx_t VectorOperations::Equals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::Equals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::NotEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::NotEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::GreaterThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::GreaterThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::GreaterThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                          SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::GreaterThanEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::LessThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                 SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::LessThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::LessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                       SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::LessThanEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t ExpressionExecutor::Select(const BoundComparisonExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                 SelectionVector *false_sel) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+	auto &left = state->intermediate_chunk.data[0];
+	auto &right = state->intermediate_chunk.data[1];
+
+	Execute(*expr.left, state->child_states[0].get(), sel, count, left);
+	Execute(*expr.right, state->child_states[1].get(), sel, count, right);
+
+	switch (expr.type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return VectorOperations::Equals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return VectorOperations::NotEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return VectorOperations::LessThan(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return VectorOperations::GreaterThan(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return VectorOperations::DistinctFrom(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return VectorOperations::NotDistinctFrom(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Unknown comparison type!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <random>
+
+namespace duckdb {
+
+struct ConjunctionState : public ExpressionState {
+	ConjunctionState(const Expression &expr, ExpressionExecutorState &root) : ExpressionState(expr, root) {
+		adaptive_filter = make_unique<AdaptiveFilter>(expr);
+	}
+	unique_ptr<AdaptiveFilter> adaptive_filter;
+};
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConjunctionExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ConjunctionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundConjunctionExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// execute the children
+	state->intermediate_chunk.Reset();
+	for (idx_t i = 0; i < expr.children.size(); i++) {
+		auto &current_result = state->intermediate_chunk.data[i];
+		Execute(*expr.children[i], state->child_states[i].get(), sel, count, current_result);
+		if (i == 0) {
+			// move the result
+			result.Reference(current_result);
+		} else {
+			Vector intermediate(LogicalType::BOOLEAN);
+			// AND/OR together
+			switch (expr.type) {
+			case ExpressionType::CONJUNCTION_AND:
+				VectorOperations::And(current_result, result, intermediate, count);
+				break;
+			case ExpressionType::CONJUNCTION_OR:
+				VectorOperations::Or(current_result, result, intermediate, count);
+				break;
+			default:
+				throw InternalException("Unknown conjunction type!");
+			}
+			result.Reference(intermediate);
+		}
+	}
+}
+
+idx_t ExpressionExecutor::Select(const BoundConjunctionExpression &expr, ExpressionState *state_p,
+                                 const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                 SelectionVector *false_sel) {
+	auto state = (ConjunctionState *)state_p;
+
+	if (expr.type == ExpressionType::CONJUNCTION_AND) {
+		// get runtime statistics
+		auto start_time = high_resolution_clock::now();
+
+		const SelectionVector *current_sel = sel;
+		idx_t current_count = count;
+		idx_t false_count = 0;
+
+		unique_ptr<SelectionVector> temp_true, temp_false;
+		if (false_sel) {
+			temp_false = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+		}
+		if (!true_sel) {
+			temp_true = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+			true_sel = temp_true.get();
+		}
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, true_sel, temp_false.get());
+			idx_t fcount = current_count - tcount;
+			if (fcount > 0 && false_sel) {
+				// move failing tuples into the false_sel
+				// tuples passed, move them into the actual result vector
+				for (idx_t i = 0; i < fcount; i++) {
+					false_sel->set_index(false_count++, temp_false->get_index(i));
+				}
+			}
+			current_count = tcount;
+			if (current_count == 0) {
+				break;
+			}
+			if (current_count < count) {
+				// tuples were filtered out: move on to using the true_sel to only evaluate passing tuples in subsequent
+				// iterations
+				current_sel = true_sel;
+			}
+		}
+
+		// adapt runtime statistics
+		auto end_time = high_resolution_clock::now();
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
+		return current_count;
+	} else {
+		// get runtime statistics
+		auto start_time = high_resolution_clock::now();
+
+		const SelectionVector *current_sel = sel;
+		idx_t current_count = count;
+		idx_t result_count = 0;
+
+		unique_ptr<SelectionVector> temp_true, temp_false;
+		if (true_sel) {
+			temp_true = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+		}
+		if (!false_sel) {
+			temp_false = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+			false_sel = temp_false.get();
+		}
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, temp_true.get(), false_sel);
+			if (tcount > 0) {
+				if (true_sel) {
+					// tuples passed, move them into the actual result vector
+					for (idx_t i = 0; i < tcount; i++) {
+						true_sel->set_index(result_count++, temp_true->get_index(i));
+					}
+				}
+				// now move on to check only the non-passing tuples
+				current_count -= tcount;
+				current_sel = false_sel;
+			}
+		}
+
+		// adapt runtime statistics
+		auto end_time = high_resolution_clock::now();
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
+		return result_count;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConstantExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundConstantExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.value.type() == expr.return_type);
+	result.Reference(expr.value);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+ExecuteFunctionState::ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root)
+    : ExpressionState(expr, root) {
+}
+
+ExecuteFunctionState::~ExecuteFunctionState() {
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunctionExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExecuteFunctionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	if (expr.function.init_local_state) {
+		result->local_state = expr.function.init_local_state(expr, expr.bind_info.get());
+	}
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	state->intermediate_chunk.Reset();
+	auto &arguments = state->intermediate_chunk;
+	if (!state->types.empty()) {
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			D_ASSERT(state->types[i] == expr.children[i]->return_type);
+			Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
+#ifdef DEBUG
+			if (expr.children[i]->return_type.id() == LogicalTypeId::VARCHAR) {
+				arguments.data[i].UTFVerify(count);
+			}
+#endif
+		}
+		arguments.Verify();
+	}
+	arguments.SetCardinality(count);
+	state->profiler.BeginSample();
+	expr.function.function(arguments, *state, result);
+	state->profiler.EndSample(count);
+	D_ASSERT(result.GetType() == expr.return_type);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundOperatorExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// special handling for special snowflake 'IN'
+	// IN has n children
+	if (expr.type == ExpressionType::COMPARE_IN || expr.type == ExpressionType::COMPARE_NOT_IN) {
+		if (expr.children.size() < 2) {
+			throw Exception("IN needs at least two children");
+		}
+
+		Vector left(expr.children[0]->return_type);
+		// eval left side
+		Execute(*expr.children[0], state->child_states[0].get(), sel, count, left);
+
+		// init result to false
+		Vector intermediate(LogicalType::BOOLEAN);
+		Value false_val = Value::BOOLEAN(false);
+		intermediate.Reference(false_val);
+
+		// in rhs is a list of constants
+		// for every child, OR the result of the comparision with the left
+		// to get the overall result.
+		for (idx_t child = 1; child < expr.children.size(); child++) {
+			Vector vector_to_check(expr.children[child]->return_type);
+			Vector comp_res(LogicalType::BOOLEAN);
+
+			Execute(*expr.children[child], state->child_states[child].get(), sel, count, vector_to_check);
+			VectorOperations::Equals(left, vector_to_check, comp_res, count);
+
+			if (child == 1) {
+				// first child: move to result
+				intermediate.Reference(comp_res);
+			} else {
+				// otherwise OR together
+				Vector new_result(LogicalType::BOOLEAN, true, false);
+				VectorOperations::Or(intermediate, comp_res, new_result, count);
+				intermediate.Reference(new_result);
+			}
+		}
+		if (expr.type == ExpressionType::COMPARE_NOT_IN) {
+			// NOT IN: invert result
+			VectorOperations::Not(intermediate, result, count);
+		} else {
+			// directly use the result
+			result.Reference(intermediate);
+		}
+	} else if (expr.type == ExpressionType::OPERATOR_COALESCE) {
+		SelectionVector sel_a(count);
+		SelectionVector sel_b(count);
+		SelectionVector slice_sel(count);
+		SelectionVector result_sel(count);
+		SelectionVector *next_sel = &sel_a;
+		const SelectionVector *current_sel = sel;
+		idx_t remaining_count = count;
+		idx_t next_count;
+		for (idx_t child = 0; child < expr.children.size(); child++) {
+			Vector vector_to_check(expr.children[child]->return_type);
+			Execute(*expr.children[child], state->child_states[child].get(), current_sel, remaining_count,
+			        vector_to_check);
+
+			VectorData vdata;
+			vector_to_check.Orrify(remaining_count, vdata);
+
+			idx_t result_count = 0;
+			next_count = 0;
+			for (idx_t i = 0; i < remaining_count; i++) {
+				auto base_idx = current_sel ? current_sel->get_index(i) : i;
+				auto idx = vdata.sel->get_index(i);
+				if (vdata.validity.RowIsValid(idx)) {
+					slice_sel.set_index(result_count, i);
+					result_sel.set_index(result_count++, base_idx);
+				} else {
+					next_sel->set_index(next_count++, base_idx);
+				}
+			}
+			if (result_count > 0) {
+				vector_to_check.Slice(slice_sel, result_count);
+				FillSwitch(vector_to_check, result, result_sel, result_count);
+			}
+			current_sel = next_sel;
+			next_sel = next_sel == &sel_a ? &sel_b : &sel_a;
+			remaining_count = next_count;
+			if (next_count == 0) {
+				break;
+			}
+		}
+		if (remaining_count > 0) {
+			for (idx_t i = 0; i < remaining_count; i++) {
+				FlatVector::SetNull(result, current_sel->get_index(i), true);
+			}
+		}
+		if (sel) {
+			result.Slice(*sel, count);
+		} else if (count == 1) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+	} else if (expr.children.size() == 1) {
+		state->intermediate_chunk.Reset();
+		auto &child = state->intermediate_chunk.data[0];
+
+		Execute(*expr.children[0], state->child_states[0].get(), sel, count, child);
+		switch (expr.type) {
+		case ExpressionType::OPERATOR_NOT: {
+			VectorOperations::Not(child, result, count);
+			break;
+		}
+		case ExpressionType::OPERATOR_IS_NULL: {
+			VectorOperations::IsNull(child, result, count);
+			break;
+		}
+		case ExpressionType::OPERATOR_IS_NOT_NULL: {
+			VectorOperations::IsNotNull(child, result, count);
+			break;
+		}
+		default:
+			throw NotImplementedException("Unsupported operator type with 1 child!");
+		}
+	} else {
+		throw NotImplementedException("operator");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundParameterExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundParameterExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.value);
+	D_ASSERT(expr.value->type() == expr.return_type);
+	result.Reference(*expr.value);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundReferenceExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundReferenceExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.index != DConstants::INVALID_INDEX);
+	D_ASSERT(expr.index < chunk->ColumnCount());
+	if (sel) {
+		result.Slice(chunk->data[expr.index], *sel, count);
+	} else {
+		result.Reference(chunk->data[expr.index]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ExpressionExecutor::ExpressionExecutor() {
+}
+
+ExpressionExecutor::ExpressionExecutor(const Expression *expression) : ExpressionExecutor() {
+	D_ASSERT(expression);
+	AddExpression(*expression);
+}
+
+ExpressionExecutor::ExpressionExecutor(const Expression &expression) : ExpressionExecutor() {
+	AddExpression(expression);
+}
+
+ExpressionExecutor::ExpressionExecutor(const vector<unique_ptr<Expression>> &exprs) : ExpressionExecutor() {
+	D_ASSERT(exprs.size() > 0);
+	for (auto &expr : exprs) {
+		AddExpression(*expr);
+	}
+}
+
+void ExpressionExecutor::AddExpression(const Expression &expr) {
+	expressions.push_back(&expr);
+	auto state = make_unique<ExpressionExecutorState>(expr.ToString());
+	Initialize(expr, *state);
+	states.push_back(move(state));
+}
+
+void ExpressionExecutor::Initialize(const Expression &expression, ExpressionExecutorState &state) {
+	state.root_state = InitializeState(expression, state);
+	state.executor = this;
+}
+
+void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
+	SetChunk(input);
+	D_ASSERT(expressions.size() == result.ColumnCount());
+	D_ASSERT(!expressions.empty());
+
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		ExecuteExpression(i, result.data[i]);
+	}
+	result.SetCardinality(input ? input->size() : 1);
+	result.Verify();
+}
+
+void ExpressionExecutor::ExecuteExpression(DataChunk &input, Vector &result) {
+	SetChunk(&input);
+	ExecuteExpression(result);
+}
+
+idx_t ExpressionExecutor::SelectExpression(DataChunk &input, SelectionVector &sel) {
+	D_ASSERT(expressions.size() == 1);
+	SetChunk(&input);
+	states[0]->profiler.BeginSample();
+	idx_t selected_tuples = Select(*expressions[0], states[0]->root_state.get(), nullptr, input.size(), &sel, nullptr);
+	states[0]->profiler.EndSample(chunk ? chunk->size() : 0);
+	return selected_tuples;
+}
+
+void ExpressionExecutor::ExecuteExpression(Vector &result) {
+	D_ASSERT(expressions.size() == 1);
+	ExecuteExpression(0, result);
+}
+
+void ExpressionExecutor::ExecuteExpression(idx_t expr_idx, Vector &result) {
+	D_ASSERT(expr_idx < expressions.size());
+	D_ASSERT(result.GetType().id() == expressions[expr_idx]->return_type.id());
+	states[expr_idx]->profiler.BeginSample();
+	Execute(*expressions[expr_idx], states[expr_idx]->root_state.get(), nullptr, chunk ? chunk->size() : 1, result);
+	states[expr_idx]->profiler.EndSample(chunk ? chunk->size() : 0);
+}
+
+Value ExpressionExecutor::EvaluateScalar(const Expression &expr) {
+	D_ASSERT(expr.IsFoldable());
+	D_ASSERT(expr.IsScalar());
+	// use an ExpressionExecutor to execute the expression
+	ExpressionExecutor executor(expr);
+
+	Vector result(expr.return_type);
+	executor.ExecuteExpression(result);
+
+	D_ASSERT(result.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	auto result_value = result.GetValue(0);
+	D_ASSERT(result_value.type().InternalType() == expr.return_type.InternalType());
+	return result_value;
+}
+
+bool ExpressionExecutor::TryEvaluateScalar(const Expression &expr, Value &result) {
+	try {
+		result = EvaluateScalar(expr);
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
+
+void ExpressionExecutor::Verify(const Expression &expr, Vector &vector, idx_t count) {
+	D_ASSERT(expr.return_type.id() == vector.GetType().id());
+	vector.Verify(count);
+	if (expr.verification_stats) {
+		expr.verification_stats->Verify(vector, count);
+	}
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const Expression &expr,
+                                                                ExpressionExecutorState &state) {
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_REF:
+		return InitializeState((const BoundReferenceExpression &)expr, state);
+	case ExpressionClass::BOUND_BETWEEN:
+		return InitializeState((const BoundBetweenExpression &)expr, state);
+	case ExpressionClass::BOUND_CASE:
+		return InitializeState((const BoundCaseExpression &)expr, state);
+	case ExpressionClass::BOUND_CAST:
+		return InitializeState((const BoundCastExpression &)expr, state);
+	case ExpressionClass::BOUND_COMPARISON:
+		return InitializeState((const BoundComparisonExpression &)expr, state);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return InitializeState((const BoundConjunctionExpression &)expr, state);
+	case ExpressionClass::BOUND_CONSTANT:
+		return InitializeState((const BoundConstantExpression &)expr, state);
+	case ExpressionClass::BOUND_FUNCTION:
+		return InitializeState((const BoundFunctionExpression &)expr, state);
+	case ExpressionClass::BOUND_OPERATOR:
+		return InitializeState((const BoundOperatorExpression &)expr, state);
+	case ExpressionClass::BOUND_PARAMETER:
+		return InitializeState((const BoundParameterExpression &)expr, state);
+	default:
+		throw InternalException("Attempting to initialize state of expression of unknown type!");
+	}
+}
+
+void ExpressionExecutor::Execute(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+#ifdef DEBUG
+	if (result.GetVectorType() == VectorType::FLAT_VECTOR) {
+		D_ASSERT(FlatVector::Validity(result).CheckAllValid(count));
+	}
+#endif
+
+	if (count == 0) {
+		return;
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_BETWEEN:
+		Execute((const BoundBetweenExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_REF:
+		Execute((const BoundReferenceExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CASE:
+		Execute((const BoundCaseExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CAST:
+		Execute((const BoundCastExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_COMPARISON:
+		Execute((const BoundComparisonExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CONJUNCTION:
+		Execute((const BoundConjunctionExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CONSTANT:
+		Execute((const BoundConstantExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_FUNCTION:
+		Execute((const BoundFunctionExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_OPERATOR:
+		Execute((const BoundOperatorExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_PARAMETER:
+		Execute((const BoundParameterExpression &)expr, state, sel, count, result);
+		break;
+	default:
+		throw InternalException("Attempting to execute expression of unknown type!");
+	}
+	Verify(expr, result, count);
+}
+
+idx_t ExpressionExecutor::Select(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (count == 0) {
+		return 0;
+	}
+	D_ASSERT(true_sel || false_sel);
+	D_ASSERT(expr.return_type.id() == LogicalTypeId::BOOLEAN);
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_BETWEEN:
+		return Select((BoundBetweenExpression &)expr, state, sel, count, true_sel, false_sel);
+	case ExpressionClass::BOUND_COMPARISON:
+		return Select((BoundComparisonExpression &)expr, state, sel, count, true_sel, false_sel);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return Select((BoundConjunctionExpression &)expr, state, sel, count, true_sel, false_sel);
+	default:
+		return DefaultSelect(expr, state, sel, count, true_sel, false_sel);
+	}
+}
+
+template <bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t DefaultSelectLoop(const SelectionVector *bsel, uint8_t *__restrict bdata, ValidityMask &mask,
+                                      const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                      SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto bidx = bsel->get_index(i);
+		auto result_idx = sel->get_index(i);
+		if (bdata[bidx] > 0 && (NO_NULL || mask.RowIsValid(bidx))) {
+			if (HAS_TRUE_SEL) {
+				true_sel->set_index(true_count++, result_idx);
+			}
+		} else {
+			if (HAS_FALSE_SEL) {
+				false_sel->set_index(false_count++, result_idx);
+			}
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+
+template <bool NO_NULL>
+static inline idx_t DefaultSelectSwitch(VectorData &idata, const SelectionVector *sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DefaultSelectLoop<NO_NULL, true, true>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                              true_sel, false_sel);
+	} else if (true_sel) {
+		return DefaultSelectLoop<NO_NULL, true, false>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                               true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DefaultSelectLoop<NO_NULL, false, true>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                               true_sel, false_sel);
+	}
+}
+
+idx_t ExpressionExecutor::DefaultSelect(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                        idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	// generic selection of boolean expression:
+	// resolve the true/false expression first
+	// then use that to generate the selection vector
+	bool intermediate_bools[STANDARD_VECTOR_SIZE];
+	Vector intermediate(LogicalType::BOOLEAN, (data_ptr_t)intermediate_bools);
+	Execute(expr, state, sel, count, intermediate);
+
+	VectorData idata;
+	intermediate.Orrify(count, idata);
+
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+	if (!idata.validity.AllValid()) {
+		return DefaultSelectSwitch<false>(idata, sel, count, true_sel, false_sel);
+	} else {
+		return DefaultSelectSwitch<true>(idata, sel, count, true_sel, false_sel);
+	}
+}
+
+vector<unique_ptr<ExpressionExecutorState>> &ExpressionExecutor::GetStates() {
+	return states;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+void ExpressionState::AddChild(Expression *expr) {
+	types.push_back(expr->return_type);
+	child_states.push_back(ExpressionExecutor::InitializeState(*expr, root));
+}
+
+void ExpressionState::Finalize() {
+	if (!types.empty()) {
+		intermediate_chunk.Initialize(types);
+	}
+}
+ExpressionState::ExpressionState(const Expression &expr, ExpressionExecutorState &root)
+    : expr(expr), root(root), name(expr.ToString()) {
+}
+
+ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler(), name(name) {
+}
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cstring>
+#include <ctgmath>
+
+namespace duckdb {
+
+ART::ART(const vector<column_t> &column_ids, const vector<unique_ptr<Expression>> &unbound_expressions,
+         IndexConstraintType constraint_type)
+    : Index(IndexType::ART, column_ids, unbound_expressions, constraint_type) {
+	tree = nullptr;
+	expression_result.Initialize(logical_types);
+	is_little_endian = Radix::IsLittleEndian();
+	for (idx_t i = 0; i < types.size(); i++) {
+		switch (types[i]) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+		case PhysicalType::INT16:
+		case PhysicalType::INT32:
+		case PhysicalType::INT64:
+		case PhysicalType::INT128:
+		case PhysicalType::UINT8:
+		case PhysicalType::UINT16:
+		case PhysicalType::UINT32:
+		case PhysicalType::UINT64:
+		case PhysicalType::FLOAT:
+		case PhysicalType::DOUBLE:
+		case PhysicalType::VARCHAR:
+			break;
+		default:
+			throw InvalidTypeException(logical_types[i], "Invalid type for index");
+		}
+	}
+}
+
+ART::~ART() {
+}
+
+bool ART::LeafMatches(Node *node, Key &key, unsigned depth) {
+	auto leaf = static_cast<Leaf *>(node);
+	Key &leaf_key = *leaf->value;
+	for (idx_t i = depth; i < leaf_key.len; i++) {
+		if (leaf_key[i] != key[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+unique_ptr<IndexScanState> ART::InitializeScanSinglePredicate(Transaction &transaction, Value value,
+                                                              ExpressionType expression_type) {
+	auto result = make_unique<ARTIndexScanState>();
+	result->values[0] = value;
+	result->expressions[0] = expression_type;
+	return move(result);
+}
+
+unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transaction, Value low_value,
+                                                            ExpressionType low_expression_type, Value high_value,
+                                                            ExpressionType high_expression_type) {
+	auto result = make_unique<ARTIndexScanState>();
+	result->values[0] = low_value;
+	result->expressions[0] = low_expression_type;
+	result->values[1] = high_value;
+	result->expressions[1] = high_expression_type;
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Insert
+//===--------------------------------------------------------------------===//
+template <class T>
+static void TemplatedGenerateKeys(Vector &input, idx_t count, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
+	VectorData idata;
+	input.Orrify(count, idata);
+
+	auto input_data = (T *)idata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (idata.validity.RowIsValid(idx)) {
+			keys.push_back(Key::CreateKey<T>(input_data[idx], is_little_endian));
+		} else {
+			keys.push_back(nullptr);
+		}
+	}
+}
+
+template <class T>
+static void ConcatenateKeys(Vector &input, idx_t count, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
+	VectorData idata;
+	input.Orrify(count, idata);
+
+	auto input_data = (T *)idata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (!idata.validity.RowIsValid(idx) || !keys[i]) {
+			// either this column is NULL, or the previous column is NULL!
+			keys[i] = nullptr;
+		} else {
+			// concatenate the keys
+			auto old_key = move(keys[i]);
+			auto new_key = Key::CreateKey<T>(input_data[idx], is_little_endian);
+			auto key_len = old_key->len + new_key->len;
+			auto compound_data = unique_ptr<data_t[]>(new data_t[key_len]);
+			memcpy(compound_data.get(), old_key->data.get(), old_key->len);
+			memcpy(compound_data.get() + old_key->len, new_key->data.get(), new_key->len);
+			keys[i] = make_unique<Key>(move(compound_data), key_len);
+		}
+	}
+}
+
+void ART::GenerateKeys(DataChunk &input, vector<unique_ptr<Key>> &keys) {
+	keys.reserve(STANDARD_VECTOR_SIZE);
+	// generate keys for the first input column
+	switch (input.data[0].GetType().InternalType()) {
+	case PhysicalType::BOOL:
+		TemplatedGenerateKeys<bool>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT8:
+		TemplatedGenerateKeys<int8_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateKeys<int16_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateKeys<int32_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateKeys<int64_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT128:
+		TemplatedGenerateKeys<hugeint_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedGenerateKeys<uint8_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedGenerateKeys<uint16_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedGenerateKeys<uint32_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedGenerateKeys<uint64_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateKeys<float>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateKeys<double>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedGenerateKeys<string_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	default:
+		throw InternalException("Invalid type for index");
+	}
+
+	for (idx_t i = 1; i < input.ColumnCount(); i++) {
+		// for each of the remaining columns, concatenate
+		switch (input.data[i].GetType().InternalType()) {
+		case PhysicalType::BOOL:
+			ConcatenateKeys<bool>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT8:
+			ConcatenateKeys<int8_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT16:
+			ConcatenateKeys<int16_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT32:
+			ConcatenateKeys<int32_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT64:
+			ConcatenateKeys<int64_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT128:
+			ConcatenateKeys<hugeint_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT8:
+			ConcatenateKeys<uint8_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT16:
+			ConcatenateKeys<uint16_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT32:
+			ConcatenateKeys<uint32_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT64:
+			ConcatenateKeys<uint64_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::FLOAT:
+			ConcatenateKeys<float>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::DOUBLE:
+			ConcatenateKeys<double>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::VARCHAR:
+			ConcatenateKeys<string_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		default:
+			throw InternalException("Invalid type for index");
+		}
+	}
+}
+
+bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
+	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
+	D_ASSERT(logical_types[0] == input.data[0].GetType());
+
+	// generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(input, keys);
+
+	// now insert the elements into the index
+	row_ids.Normalify(input.size());
+	auto row_identifiers = FlatVector::GetData<row_t>(row_ids);
+	idx_t failed_index = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < input.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+
+		row_t row_id = row_identifiers[i];
+		if (!Insert(tree, move(keys[i]), 0, row_id)) {
+			// failed to insert because of constraint violation
+			failed_index = i;
+			break;
+		}
+	}
+	if (failed_index != DConstants::INVALID_INDEX) {
+		// failed to insert because of constraint violation: remove previously inserted entries
+		// generate keys again
+		keys.clear();
+		GenerateKeys(input, keys);
+		unique_ptr<Key> key;
+
+		// now erase the entries
+		for (idx_t i = 0; i < failed_index; i++) {
+			if (!keys[i]) {
+				continue;
+			}
+			row_t row_id = row_identifiers[i];
+			Erase(tree, *keys[i], 0, row_id);
+		}
+		return false;
+	}
+	return true;
+}
+
+bool ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifiers) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// first resolve the expressions for the index
+	ExecuteExpressions(appended_data, expression_result);
+
+	// now insert into the index
+	return Insert(lock, expression_result, row_identifiers);
+}
+
+void ART::VerifyAppend(DataChunk &chunk) {
+	VerifyExistence(chunk, VerifyExistenceType::APPEND);
+}
+
+void ART::VerifyAppendForeignKey(DataChunk &chunk, string *err_msg_ptr) {
+	VerifyExistence(chunk, VerifyExistenceType::APPEND_FK, err_msg_ptr);
+}
+
+void ART::VerifyDeleteForeignKey(DataChunk &chunk, string *err_msg_ptr) {
+	VerifyExistence(chunk, VerifyExistenceType::DELETE_FK, err_msg_ptr);
+}
+
+bool ART::InsertToLeaf(Leaf &leaf, row_t row_id) {
+	if (IsUnique() && leaf.num_elements != 0) {
+		return false;
+	}
+	leaf.Insert(row_id);
+	return true;
+}
+
+bool ART::Insert(unique_ptr<Node> &node, unique_ptr<Key> value, unsigned depth, row_t row_id) {
+	Key &key = *value;
+	if (!node) {
+		// node is currently empty, create a leaf here with the key
+		node = make_unique<Leaf>(*this, move(value), row_id);
+		return true;
+	}
+
+	if (node->type == NodeType::NLeaf) {
+		// Replace leaf with Node4 and store both leaves in it
+		auto leaf = static_cast<Leaf *>(node.get());
+
+		Key &existing_key = *leaf->value;
+		uint32_t new_prefix_length = 0;
+		// Leaf node is already there, update row_id vector
+		if (depth + new_prefix_length == existing_key.len && existing_key.len == key.len) {
+			return InsertToLeaf(*leaf, row_id);
+		}
+		while (existing_key[depth + new_prefix_length] == key[depth + new_prefix_length]) {
+			new_prefix_length++;
+			// Leaf node is already there, update row_id vector
+			if (depth + new_prefix_length == existing_key.len && existing_key.len == key.len) {
+				return InsertToLeaf(*leaf, row_id);
+			}
+		}
+
+		unique_ptr<Node> new_node = make_unique<Node4>(*this, new_prefix_length);
+		new_node->prefix_length = new_prefix_length;
+		memcpy(new_node->prefix.get(), &key[depth], new_prefix_length);
+		Node4::Insert(*this, new_node, existing_key[depth + new_prefix_length], node);
+		unique_ptr<Node> leaf_node = make_unique<Leaf>(*this, move(value), row_id);
+		Node4::Insert(*this, new_node, key[depth + new_prefix_length], leaf_node);
+		node = move(new_node);
+		return true;
+	}
+
+	// Handle prefix of inner node
+	if (node->prefix_length) {
+		uint32_t mismatch_pos = Node::PrefixMismatch(*this, node.get(), key, depth);
+		if (mismatch_pos != node->prefix_length) {
+			// Prefix differs, create new node
+			unique_ptr<Node> new_node = make_unique<Node4>(*this, mismatch_pos);
+			new_node->prefix_length = mismatch_pos;
+			memcpy(new_node->prefix.get(), node->prefix.get(), mismatch_pos);
+			// Break up prefix
+			auto node_ptr = node.get();
+			Node4::Insert(*this, new_node, node->prefix[mismatch_pos], node);
+			node_ptr->prefix_length -= (mismatch_pos + 1);
+			memmove(node_ptr->prefix.get(), node_ptr->prefix.get() + mismatch_pos + 1, node_ptr->prefix_length);
+			unique_ptr<Node> leaf_node = make_unique<Leaf>(*this, move(value), row_id);
+			Node4::Insert(*this, new_node, key[depth + mismatch_pos], leaf_node);
+			node = move(new_node);
+			return true;
+		}
+		depth += node->prefix_length;
+	}
+
+	// Recurse
+	idx_t pos = node->GetChildPos(key[depth]);
+	if (pos != DConstants::INVALID_INDEX) {
+		auto child = node->GetChild(pos);
+		return Insert(*child, move(value), depth + 1, row_id);
+	}
+	unique_ptr<Node> new_node = make_unique<Leaf>(*this, move(value), row_id);
+	Node::InsertLeaf(*this, node, key[depth], new_node);
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Delete
+//===--------------------------------------------------------------------===//
+void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// first resolve the expressions
+	ExecuteExpressions(input, expression_result);
+
+	// then generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(expression_result, keys);
+
+	// now erase the elements from the database
+	row_ids.Normalify(input.size());
+	auto row_identifiers = FlatVector::GetData<row_t>(row_ids);
+
+	for (idx_t i = 0; i < input.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+		Erase(tree, *keys[i], 0, row_identifiers[i]);
+#ifdef DEBUG
+		auto node = Lookup(tree, *keys[i], 0);
+		if (node) {
+			auto leaf = static_cast<Leaf *>(node);
+			for (idx_t k = 0; k < leaf->num_elements; k++) {
+				D_ASSERT(leaf->GetRowId(k) != row_identifiers[i]);
+			}
+		}
+#endif
+	}
+}
+
+void ART::Erase(unique_ptr<Node> &node, Key &key, unsigned depth, row_t row_id) {
+	if (!node) {
+		return;
+	}
+	// Delete a leaf from a tree
+	if (node->type == NodeType::NLeaf) {
+		// Make sure we have the right leaf
+		if (ART::LeafMatches(node.get(), key, depth)) {
+			auto leaf = static_cast<Leaf *>(node.get());
+			leaf->Remove(row_id);
+			if (leaf->num_elements == 0) {
+				node.reset();
+			}
+		}
+		return;
+	}
+
+	// Handle prefix
+	if (node->prefix_length) {
+		if (Node::PrefixMismatch(*this, node.get(), key, depth) != node->prefix_length) {
+			return;
+		}
+		depth += node->prefix_length;
+	}
+	idx_t pos = node->GetChildPos(key[depth]);
+	if (pos != DConstants::INVALID_INDEX) {
+		auto child = node->GetChild(pos);
+		D_ASSERT(child);
+
+		unique_ptr<Node> &child_ref = *child;
+		if (child_ref->type == NodeType::NLeaf && LeafMatches(child_ref.get(), key, depth)) {
+			// Leaf found, remove entry
+			auto leaf = static_cast<Leaf *>(child_ref.get());
+			leaf->Remove(row_id);
+			if (leaf->num_elements == 0) {
+				// Leaf is empty, delete leaf, decrement node counter and maybe shrink node
+				Node::Erase(*this, node, pos);
+			}
+		} else {
+			// Recurse
+			Erase(*child, key, depth + 1, row_id);
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Point Query
+//===--------------------------------------------------------------------===//
+static unique_ptr<Key> CreateKey(ART &art, PhysicalType type, Value &value) {
+	D_ASSERT(type == value.type().InternalType());
+	switch (type) {
+	case PhysicalType::BOOL:
+		return Key::CreateKey<bool>(value, art.is_little_endian);
+	case PhysicalType::INT8:
+		return Key::CreateKey<int8_t>(value, art.is_little_endian);
+	case PhysicalType::INT16:
+		return Key::CreateKey<int16_t>(value, art.is_little_endian);
+	case PhysicalType::INT32:
+		return Key::CreateKey<int32_t>(value, art.is_little_endian);
+	case PhysicalType::INT64:
+		return Key::CreateKey<int64_t>(value, art.is_little_endian);
+	case PhysicalType::UINT8:
+		return Key::CreateKey<uint8_t>(value, art.is_little_endian);
+	case PhysicalType::UINT16:
+		return Key::CreateKey<uint16_t>(value, art.is_little_endian);
+	case PhysicalType::UINT32:
+		return Key::CreateKey<uint32_t>(value, art.is_little_endian);
+	case PhysicalType::UINT64:
+		return Key::CreateKey<uint64_t>(value, art.is_little_endian);
+	case PhysicalType::INT128:
+		return Key::CreateKey<hugeint_t>(value, art.is_little_endian);
+	case PhysicalType::FLOAT:
+		return Key::CreateKey<float>(value, art.is_little_endian);
+	case PhysicalType::DOUBLE:
+		return Key::CreateKey<double>(value, art.is_little_endian);
+	case PhysicalType::VARCHAR:
+		return Key::CreateKey<string_t>(value, art.is_little_endian);
+	default:
+		throw InternalException("Invalid type for index");
+	}
+}
+
+bool ART::SearchEqual(ARTIndexScanState *state, idx_t max_count, vector<row_t> &result_ids) {
+	auto key = CreateKey(*this, types[0], state->values[0]);
+	auto leaf = static_cast<Leaf *>(Lookup(tree, *key, 0));
+	if (!leaf) {
+		return true;
+	}
+	if (leaf->num_elements > max_count) {
+		return false;
+	}
+	for (idx_t i = 0; i < leaf->num_elements; i++) {
+		row_t row_id = leaf->GetRowId(i);
+		result_ids.push_back(row_id);
+	}
+	return true;
+}
+
+void ART::SearchEqualJoinNoFetch(Value &equal_value, idx_t &result_size) {
+	//! We need to look for a leaf
+	auto key = CreateKey(*this, types[0], equal_value);
+	auto leaf = static_cast<Leaf *>(Lookup(tree, *key, 0));
+	if (!leaf) {
+		return;
+	}
+	result_size = leaf->num_elements;
+}
+
+Node *ART::Lookup(unique_ptr<Node> &node, Key &key, unsigned depth) {
+	auto node_val = node.get();
+
+	while (node_val) {
+		if (node_val->type == NodeType::NLeaf) {
+			auto leaf = static_cast<Leaf *>(node_val);
+			Key &leaf_key = *leaf->value;
+			//! Check leaf
+			for (idx_t i = depth; i < leaf_key.len; i++) {
+				if (leaf_key[i] != key[i]) {
+					return nullptr;
+				}
+			}
+			return node_val;
+		}
+		if (node_val->prefix_length) {
+			for (idx_t pos = 0; pos < node_val->prefix_length; pos++) {
+				if (key[depth + pos] != node_val->prefix[pos]) {
+					return nullptr;
+				}
+			}
+			depth += node_val->prefix_length;
+		}
+		idx_t pos = node_val->GetChildPos(key[depth]);
+		if (pos == DConstants::INVALID_INDEX) {
+			return nullptr;
+		}
+		node_val = node_val->GetChild(pos)->get();
+		D_ASSERT(node_val);
+
+		depth++;
+	}
+
+	return nullptr;
+}
+
+//===--------------------------------------------------------------------===//
+// Iterator scans
+//===--------------------------------------------------------------------===//
+template <bool HAS_BOUND, bool INCLUSIVE>
+bool ART::IteratorScan(ARTIndexScanState *state, Iterator *it, Key *bound, idx_t max_count, vector<row_t> &result_ids) {
+	bool has_next;
+	do {
+		if (HAS_BOUND) {
+			D_ASSERT(bound);
+			if (INCLUSIVE) {
+				if (*it->node->value > *bound) {
+					break;
+				}
+			} else {
+				if (*it->node->value >= *bound) {
+					break;
+				}
+			}
+		}
+		if (result_ids.size() + it->node->num_elements > max_count) {
+			// adding these elements would exceed the max count
+			return false;
+		}
+		for (idx_t i = 0; i < it->node->num_elements; i++) {
+			row_t row_id = it->node->GetRowId(i);
+			result_ids.push_back(row_id);
+		}
+		has_next = ART::IteratorNext(*it);
+	} while (has_next);
+	return true;
+}
+
+void Iterator::SetEntry(idx_t entry_depth, IteratorEntry entry) {
+	if (stack.size() < entry_depth + 1) {
+		stack.resize(MaxValue<idx_t>(8, MaxValue<idx_t>(entry_depth + 1, stack.size() * 2)));
+	}
+	stack[entry_depth] = entry;
+}
+
+bool ART::IteratorNext(Iterator &it) {
+	// Skip leaf
+	if ((it.depth) && ((it.stack[it.depth - 1].node)->type == NodeType::NLeaf)) {
+		it.depth--;
+	}
+
+	// Look for the next leaf
+	while (it.depth > 0) {
+		auto &top = it.stack[it.depth - 1];
+		Node *node = top.node;
+
+		if (node->type == NodeType::NLeaf) {
+			// found a leaf: move to next node
+			it.node = (Leaf *)node;
+			return true;
+		}
+
+		// Find next node
+		top.pos = node->GetNextPos(top.pos);
+		if (top.pos != DConstants::INVALID_INDEX) {
+			// next node found: go there
+			it.SetEntry(it.depth, IteratorEntry(node->GetChild(top.pos)->get(), DConstants::INVALID_INDEX));
+			it.depth++;
+		} else {
+			// no node found: move up the tree
+			it.depth--;
+		}
+	}
+	return false;
+}
+
+//===--------------------------------------------------------------------===//
+// Greater Than
+// Returns: True (If found leaf >= key)
+//          False (Otherwise)
+//===--------------------------------------------------------------------===//
+bool ART::Bound(unique_ptr<Node> &n, Key &key, Iterator &it, bool inclusive) {
+	it.depth = 0;
+	bool equal = false;
+	if (!n) {
+		return false;
+	}
+	Node *node = n.get();
+
+	idx_t depth = 0;
+	while (true) {
+		it.SetEntry(it.depth, IteratorEntry(node, 0));
+		auto &top = it.stack[it.depth];
+		it.depth++;
+		if (!equal) {
+			while (node->type != NodeType::NLeaf) {
+				node = node->GetChild(node->GetMin())->get();
+				auto &c_top = it.stack[it.depth];
+				c_top.node = node;
+				it.depth++;
+			}
+		}
+		if (node->type == NodeType::NLeaf) {
+			// found a leaf node: check if it is bigger or equal than the current key
+			auto leaf = static_cast<Leaf *>(node);
+			it.node = leaf;
+			// if the search is not inclusive the leaf node could still be equal to the current value
+			// check if leaf is equal to the current key
+			if (*leaf->value == key) {
+				// if its not inclusive check if there is a next leaf
+				if (!inclusive && !IteratorNext(it)) {
+					return false;
+				} else {
+					return true;
+				}
+			}
+
+			if (*leaf->value > key) {
+				return true;
+			}
+			// Leaf is lower than key
+			// Check if next leaf is still lower than key
+			while (IteratorNext(it)) {
+				if (*it.node->value == key) {
+					// if its not inclusive check if there is a next leaf
+					if (!inclusive && !IteratorNext(it)) {
+						return false;
+					} else {
+						return true;
+					}
+				} else if (*it.node->value > key) {
+					// if its not inclusive check if there is a next leaf
+					return true;
+				}
+			}
+			return false;
+		}
+		uint32_t mismatch_pos = Node::PrefixMismatch(*this, node, key, depth);
+		if (mismatch_pos != node->prefix_length) {
+			if (node->prefix[mismatch_pos] < key[depth + mismatch_pos]) {
+				// Less
+				it.depth--;
+				return IteratorNext(it);
+			} else {
+				// Greater
+				top.pos = DConstants::INVALID_INDEX;
+				return IteratorNext(it);
+			}
+		}
+		// prefix matches, search inside the child for the key
+		depth += node->prefix_length;
+
+		top.pos = node->GetChildGreaterEqual(key[depth], equal);
+		if (top.pos == DConstants::INVALID_INDEX) {
+			// Find min leaf
+			top.pos = node->GetMin();
+		}
+		node = node->GetChild(top.pos)->get();
+		//! This means all children of this node qualify as geq
+
+		depth++;
+	}
+}
+
+bool ART::SearchGreater(ARTIndexScanState *state, bool inclusive, idx_t max_count, vector<row_t> &result_ids) {
+	Iterator *it = &state->iterator;
+	auto key = CreateKey(*this, types[0], state->values[0]);
+
+	// greater than scan: first set the iterator to the node at which we will start our scan by finding the lowest node
+	// that satisfies our requirement
+	if (!it->start) {
+		bool found = ART::Bound(tree, *key, *it, inclusive);
+		if (!found) {
+			return true;
+		}
+		it->start = true;
+	}
+	// after that we continue the scan; we don't need to check the bounds as any value following this value is
+	// automatically bigger and hence satisfies our predicate
+	return IteratorScan<false, false>(state, it, nullptr, max_count, result_ids);
+}
+
+//===--------------------------------------------------------------------===//
+// Less Than
+//===--------------------------------------------------------------------===//
+static Leaf &FindMinimum(Iterator &it, Node &node) {
+	Node *next = nullptr;
+	idx_t pos = 0;
+	switch (node.type) {
+	case NodeType::NLeaf:
+		it.node = (Leaf *)&node;
+		return (Leaf &)node;
+	case NodeType::N4:
+		next = ((Node4 &)node).child[0].get();
+		break;
+	case NodeType::N16:
+		next = ((Node16 &)node).child[0].get();
+		break;
+	case NodeType::N48: {
+		auto &n48 = (Node48 &)node;
+		while (n48.child_index[pos] == Node::EMPTY_MARKER) {
+			pos++;
+		}
+		next = n48.child[n48.child_index[pos]].get();
+		break;
+	}
+	case NodeType::N256: {
+		auto &n256 = (Node256 &)node;
+		while (!n256.child[pos]) {
+			pos++;
+		}
+		next = n256.child[pos].get();
+		break;
+	}
+	}
+	it.SetEntry(it.depth, IteratorEntry(&node, pos));
+	it.depth++;
+	return FindMinimum(it, *next);
+}
+
+bool ART::SearchLess(ARTIndexScanState *state, bool inclusive, idx_t max_count, vector<row_t> &result_ids) {
+	if (!tree) {
+		return true;
+	}
+
+	Iterator *it = &state->iterator;
+	auto upper_bound = CreateKey(*this, types[0], state->values[0]);
+
+	if (!it->start) {
+		// first find the minimum value in the ART: we start scanning from this value
+		auto &minimum = FindMinimum(state->iterator, *tree);
+		// early out min value higher than upper bound query
+		if (*minimum.value > *upper_bound) {
+			return true;
+		}
+		it->start = true;
+	}
+	// now continue the scan until we reach the upper bound
+	if (inclusive) {
+		return IteratorScan<true, true>(state, it, upper_bound.get(), max_count, result_ids);
+	} else {
+		return IteratorScan<true, false>(state, it, upper_bound.get(), max_count, result_ids);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Closed Range Query
+//===--------------------------------------------------------------------===//
+bool ART::SearchCloseRange(ARTIndexScanState *state, bool left_inclusive, bool right_inclusive, idx_t max_count,
+                           vector<row_t> &result_ids) {
+	auto lower_bound = CreateKey(*this, types[0], state->values[0]);
+	auto upper_bound = CreateKey(*this, types[0], state->values[1]);
+	Iterator *it = &state->iterator;
+	// first find the first node that satisfies the left predicate
+	if (!it->start) {
+		bool found = ART::Bound(tree, *lower_bound, *it, left_inclusive);
+		if (!found) {
+			return true;
+		}
+		it->start = true;
+	}
+	// now continue the scan until we reach the upper bound
+	if (right_inclusive) {
+		return IteratorScan<true, true>(state, it, upper_bound.get(), max_count, result_ids);
+	} else {
+		return IteratorScan<true, false>(state, it, upper_bound.get(), max_count, result_ids);
+	}
+}
+
+bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table_state, idx_t max_count,
+               vector<row_t> &result_ids) {
+	auto state = (ARTIndexScanState *)&table_state;
+
+	D_ASSERT(state->values[0].type().InternalType() == types[0]);
+
+	vector<row_t> row_ids;
+	bool success = true;
+	if (state->values[1].IsNull()) {
+		lock_guard<mutex> l(lock);
+		// single predicate
+		switch (state->expressions[0]) {
+		case ExpressionType::COMPARE_EQUAL:
+			success = SearchEqual(state, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			success = SearchGreater(state, true, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			success = SearchGreater(state, false, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			success = SearchLess(state, true, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+			success = SearchLess(state, false, max_count, row_ids);
+			break;
+		default:
+			throw InternalException("Operation not implemented");
+		}
+	} else {
+		lock_guard<mutex> l(lock);
+		// two predicates
+		D_ASSERT(state->values[1].type().InternalType() == types[0]);
+		bool left_inclusive = state->expressions[0] == ExpressionType ::COMPARE_GREATERTHANOREQUALTO;
+		bool right_inclusive = state->expressions[1] == ExpressionType ::COMPARE_LESSTHANOREQUALTO;
+		success = SearchCloseRange(state, left_inclusive, right_inclusive, max_count, row_ids);
+	}
+	if (!success) {
+		return false;
+	}
+	if (row_ids.empty()) {
+		return true;
+	}
+	// sort the row ids
+	sort(row_ids.begin(), row_ids.end());
+	// duplicate eliminate the row ids and append them to the row ids of the state
+	result_ids.reserve(row_ids.size());
+
+	result_ids.push_back(row_ids[0]);
+	for (idx_t i = 1; i < row_ids.size(); i++) {
+		if (row_ids[i] != row_ids[i - 1]) {
+			result_ids.push_back(row_ids[i]);
+		}
+	}
+	return true;
+}
+
+void ART::VerifyExistence(DataChunk &chunk, VerifyExistenceType verify_type, string *err_msg_ptr) {
+	if (verify_type != VerifyExistenceType::DELETE_FK && !IsUnique()) {
+		return;
+	}
+
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// unique index, check
+	lock_guard<mutex> l(lock);
+	// first resolve the expressions for the index
+	ExecuteExpressions(chunk, expression_result);
+
+	// generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(expression_result, keys);
+
+	for (idx_t i = 0; i < chunk.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+		Node *node_ptr = Lookup(tree, *keys[i], 0);
+		bool throw_exception =
+		    verify_type == VerifyExistenceType::APPEND_FK ? node_ptr == nullptr : node_ptr != nullptr;
+		if (!throw_exception) {
+			continue;
+		}
+		string key_name;
+		for (idx_t k = 0; k < expression_result.ColumnCount(); k++) {
+			if (k > 0) {
+				key_name += ", ";
+			}
+			key_name += unbound_expressions[k]->GetName() + ": " + expression_result.data[k].GetValue(i).ToString();
+		}
+		string exception_msg;
+		switch (verify_type) {
+		case VerifyExistenceType::APPEND: {
+			// node already exists in tree
+			string type = IsPrimary() ? "primary key" : "unique";
+			exception_msg = "duplicate key \"" + key_name + "\" violates ";
+			exception_msg += type + " constraint";
+			break;
+		}
+		case VerifyExistenceType::APPEND_FK: {
+			// found node no exists in tree
+			exception_msg =
+			    "violates foreign key constraint because key \"" + key_name + "\" does not exist in referenced table";
+			break;
+		}
+		case VerifyExistenceType::DELETE_FK: {
+			// found node exists in tree
+			exception_msg =
+			    "violates foreign key constraint because key \"" + key_name + "\" exist in table has foreign key";
+			break;
+		}
+		}
+		if (err_msg_ptr) {
+			err_msg_ptr[i] = exception_msg;
+		} else {
+			throw ConstraintException(exception_msg);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Key::Key(unique_ptr<data_t[]> data, idx_t len) : len(len), data(move(data)) {
+}
+
+template <>
+unique_ptr<Key> Key::CreateKey(string_t value, bool is_little_endian) {
+	idx_t len = value.GetSize() + 1;
+	auto data = unique_ptr<data_t[]>(new data_t[len]);
+	memcpy(data.get(), value.GetDataUnsafe(), len - 1);
+	data[len - 1] = '\0';
+	return make_unique<Key>(move(data), len);
+}
+
+template <>
+unique_ptr<Key> Key::CreateKey(const char *value, bool is_little_endian) {
+	return Key::CreateKey(string_t(value, strlen(value)), is_little_endian);
+}
+
+bool Key::operator>(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] > k.data[i]) {
+			return true;
+		} else if (data[i] < k.data[i]) {
+			return false;
+		}
+	}
+	return len > k.len;
+}
+
+bool Key::operator<(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] < k.data[i]) {
+			return true;
+		} else if (data[i] > k.data[i]) {
+			return false;
+		}
+	}
+	return len < k.len;
+}
+
+bool Key::operator>=(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] > k.data[i]) {
+			return true;
+		} else if (data[i] < k.data[i]) {
+			return false;
+		}
+	}
+	return len >= k.len;
+}
+
+bool Key::operator==(const Key &k) const {
+	if (len != k.len) {
+		return false;
+	}
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] != k.data[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+} // namespace duckdb
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+Leaf::Leaf(ART &art, unique_ptr<Key> value, row_t row_id) : Node(art, NodeType::NLeaf, 0) {
+	this->value = move(value);
+	this->capacity = 1;
+	this->row_ids = unique_ptr<row_t[]>(new row_t[this->capacity]);
+	this->row_ids[0] = row_id;
+	this->num_elements = 1;
+}
+
+void Leaf::Insert(row_t row_id) {
+	// Grow array
+	if (num_elements == capacity) {
+		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity * 2]);
+		memcpy(new_row_id.get(), row_ids.get(), capacity * sizeof(row_t));
+		capacity *= 2;
+		row_ids = move(new_row_id);
+	}
+	row_ids[num_elements++] = row_id;
+}
+
+void Leaf::Remove(row_t row_id) {
+	idx_t entry_offset = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < num_elements; i++) {
+		if (row_ids[i] == row_id) {
+			entry_offset = i;
+			break;
+		}
+	}
+	if (entry_offset == DConstants::INVALID_INDEX) {
+		return;
+	}
+	num_elements--;
+	if (capacity > 2 && num_elements < capacity / 2) {
+		// Shrink array, if less than half full
+		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity / 2]);
+		memcpy(new_row_id.get(), row_ids.get(), entry_offset * sizeof(row_t));
+		memcpy(new_row_id.get() + entry_offset, row_ids.get() + entry_offset + 1,
+		       (num_elements - entry_offset) * sizeof(row_t));
+		capacity /= 2;
+		row_ids = move(new_row_id);
+	} else {
+		// Copy the rest
+		for (idx_t j = entry_offset; j < num_elements; j++) {
+			row_ids[j] = row_ids[j + 1];
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node::Node(ART &art, NodeType type, size_t compressed_prefix_size) : prefix_length(0), count(0), type(type) {
+	this->prefix = unique_ptr<uint8_t[]>(new uint8_t[compressed_prefix_size]);
+}
+
+void Node::CopyPrefix(ART &art, Node *src, Node *dst) {
+	dst->prefix_length = src->prefix_length;
+	memcpy(dst->prefix.get(), src->prefix.get(), src->prefix_length);
+}
+
+// LCOV_EXCL_START
+unique_ptr<Node> *Node::GetChild(idx_t pos) {
+	D_ASSERT(0);
+	return nullptr;
+}
+
+idx_t Node::GetMin() {
+	D_ASSERT(0);
+	return 0;
+}
+// LCOV_EXCL_STOP
+
+uint32_t Node::PrefixMismatch(ART &art, Node *node, Key &key, uint64_t depth) {
+	uint64_t pos;
+	for (pos = 0; pos < node->prefix_length; pos++) {
+		if (key[depth + pos] != node->prefix[pos]) {
+			return pos;
+		}
+	}
+	return pos;
+}
+
+void Node::InsertLeaf(ART &art, unique_ptr<Node> &node, uint8_t key, unique_ptr<Node> &new_node) {
+	switch (node->type) {
+	case NodeType::N4:
+		Node4::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N16:
+		Node16::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N48:
+		Node48::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N256:
+		Node256::Insert(art, node, key, new_node);
+		break;
+	default:
+		throw InternalException("Unrecognized leaf type for insert");
+	}
+}
+
+void Node::Erase(ART &art, unique_ptr<Node> &node, idx_t pos) {
+	switch (node->type) {
+	case NodeType::N4: {
+		Node4::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N16: {
+		Node16::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N48: {
+		Node48::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N256:
+		Node256::Erase(art, node, pos);
+		break;
+	default:
+		throw InternalException("Unrecognized leaf type for erase");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+Node16::Node16(ART &art, size_t compression_length) : Node(art, NodeType::N16, compression_length) {
+	memset(key, 16, sizeof(key));
+}
+
+idx_t Node16::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] == k) {
+			return pos;
+		}
+	}
+	return Node::GetChildPos(k);
+}
+
+idx_t Node16::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] >= k) {
+			if (key[pos] == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node16::GetNextPos(idx_t pos) {
+	if (pos == DConstants::INVALID_INDEX) {
+		return 0;
+	}
+	pos++;
+	return pos < count ? pos : DConstants::INVALID_INDEX;
+}
+
+unique_ptr<Node> *Node16::GetChild(idx_t pos) {
+	D_ASSERT(pos < count);
+	return &child[pos];
+}
+
+idx_t Node16::GetMin() {
+	return 0;
+}
+
+void Node16::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node16 *n = static_cast<Node16 *>(node.get());
+
+	if (n->count < 16) {
+		// Insert element
+		idx_t pos = 0;
+		while (pos < node->count && n->key[pos] < key_byte) {
+			pos++;
+		}
+		if (n->child[pos] != nullptr) {
+			for (idx_t i = n->count; i > pos; i--) {
+				n->key[i] = n->key[i - 1];
+				n->child[i] = move(n->child[i - 1]);
+			}
+		}
+		n->key[pos] = key_byte;
+		n->child[pos] = move(child);
+		n->count++;
+	} else {
+		// Grow to Node48
+		auto new_node = make_unique<Node48>(art, n->prefix_length);
+		for (idx_t i = 0; i < node->count; i++) {
+			new_node->child_index[n->key[i]] = i;
+			new_node->child[i] = move(n->child[i]);
+		}
+		CopyPrefix(art, n, new_node.get());
+		new_node->count = node->count;
+		node = move(new_node);
+
+		Node48::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node16::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node16 *n = static_cast<Node16 *>(node.get());
+	// erase the child and decrease the count
+	n->child[pos].reset();
+	n->count--;
+	// potentially move any children backwards
+	for (; pos < n->count; pos++) {
+		n->key[pos] = n->key[pos + 1];
+		n->child[pos] = move(n->child[pos + 1]);
+	}
+	if (node->count <= 3) {
+		// Shrink node
+		auto new_node = make_unique<Node4>(art, n->prefix_length);
+		for (unsigned i = 0; i < n->count; i++) {
+			new_node->key[new_node->count] = n->key[i];
+			new_node->child[new_node->count++] = move(n->child[i]);
+		}
+		CopyPrefix(art, n, new_node.get());
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+Node256::Node256(ART &art, size_t compression_length) : Node(art, NodeType::N256, compression_length) {
+}
+
+idx_t Node256::GetChildPos(uint8_t k) {
+	if (child[k]) {
+		return k;
+	} else {
+		return DConstants::INVALID_INDEX;
+	}
+}
+
+idx_t Node256::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = k; pos < 256; pos++) {
+		if (child[pos]) {
+			if (pos == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+idx_t Node256::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
+		if (child[i]) {
+			return i;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+idx_t Node256::GetNextPos(idx_t pos) {
+	for (pos == DConstants::INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
+		if (child[pos]) {
+			return pos;
+		}
+	}
+	return Node::GetNextPos(pos);
+}
+
+unique_ptr<Node> *Node256::GetChild(idx_t pos) {
+	D_ASSERT(child[pos]);
+	return &child[pos];
+}
+
+void Node256::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node256 *n = static_cast<Node256 *>(node.get());
+
+	n->count++;
+	n->child[key_byte] = move(child);
+}
+
+void Node256::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node256 *n = static_cast<Node256 *>(node.get());
+
+	n->child[pos].reset();
+	n->count--;
+	if (node->count <= 36) {
+		auto new_node = make_unique<Node48>(art, n->prefix_length);
+		CopyPrefix(art, n, new_node.get());
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child[i]) {
+				new_node->child_index[i] = new_node->count;
+				new_node->child[new_node->count] = move(n->child[i]);
+				new_node->count++;
+			}
+		}
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node4::Node4(ART &art, size_t compression_length) : Node(art, NodeType::N4, compression_length) {
+	memset(key, 0, sizeof(key));
+}
+
+idx_t Node4::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] == k) {
+			return pos;
+		}
+	}
+	return Node::GetChildPos(k);
+}
+
+idx_t Node4::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] >= k) {
+			if (key[pos] == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node4::GetMin() {
+	return 0;
+}
+
+idx_t Node4::GetNextPos(idx_t pos) {
+	if (pos == DConstants::INVALID_INDEX) {
+		return 0;
+	}
+	pos++;
+	return pos < count ? pos : DConstants::INVALID_INDEX;
+}
+
+unique_ptr<Node> *Node4::GetChild(idx_t pos) {
+	D_ASSERT(pos < count);
+	return &child[pos];
+}
+
+void Node4::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node4 *n = static_cast<Node4 *>(node.get());
+
+	// Insert leaf into inner node
+	if (node->count < 4) {
+		// Insert element
+		idx_t pos = 0;
+		while ((pos < node->count) && (n->key[pos] < key_byte)) {
+			pos++;
+		}
+		if (n->child[pos] != nullptr) {
+			for (idx_t i = n->count; i > pos; i--) {
+				n->key[i] = n->key[i - 1];
+				n->child[i] = move(n->child[i - 1]);
+			}
+		}
+		n->key[pos] = key_byte;
+		n->child[pos] = move(child);
+		n->count++;
+	} else {
+		// Grow to Node16
+		auto new_node = make_unique<Node16>(art, n->prefix_length);
+		new_node->count = 4;
+		CopyPrefix(art, node.get(), new_node.get());
+		for (idx_t i = 0; i < 4; i++) {
+			new_node->key[i] = n->key[i];
+			new_node->child[i] = move(n->child[i]);
+		}
+		node = move(new_node);
+		Node16::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node4::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node4 *n = static_cast<Node4 *>(node.get());
+	D_ASSERT(pos < n->count);
+
+	// erase the child and decrease the count
+	n->child[pos].reset();
+	n->count--;
+	// potentially move any children backwards
+	for (; pos < n->count; pos++) {
+		n->key[pos] = n->key[pos + 1];
+		n->child[pos] = move(n->child[pos + 1]);
+	}
+
+	// This is a one way node
+	if (n->count == 1) {
+		auto childref = n->child[0].get();
+		//! concatenate prefixes
+		auto new_length = node->prefix_length + childref->prefix_length + 1;
+		//! have to allocate space in our prefix array
+		unique_ptr<uint8_t[]> new_prefix = unique_ptr<uint8_t[]>(new uint8_t[new_length]);
+
+		//! first move the existing prefix (if any)
+		for (uint32_t i = 0; i < childref->prefix_length; i++) {
+			new_prefix[new_length - (i + 1)] = childref->prefix[childref->prefix_length - (i + 1)];
+		}
+		//! now move the current key as part of the prefix
+		new_prefix[node->prefix_length] = n->key[0];
+		//! finally add the old prefix
+		for (uint32_t i = 0; i < node->prefix_length; i++) {
+			new_prefix[i] = node->prefix[i];
+		}
+		//! set new prefix and move the child
+		childref->prefix = move(new_prefix);
+		childref->prefix_length = new_length;
+		node = move(n->child[0]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node48::Node48(ART &art, size_t compression_length) : Node(art, NodeType::N48, compression_length) {
+	for (idx_t i = 0; i < 256; i++) {
+		child_index[i] = Node::EMPTY_MARKER;
+	}
+}
+
+idx_t Node48::GetChildPos(uint8_t k) {
+	if (child_index[k] == Node::EMPTY_MARKER) {
+		return DConstants::INVALID_INDEX;
+	} else {
+		return k;
+	}
+}
+
+idx_t Node48::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = k; pos < 256; pos++) {
+		if (child_index[pos] != Node::EMPTY_MARKER) {
+			if (pos == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node48::GetNextPos(idx_t pos) {
+	for (pos == DConstants::INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
+		if (child_index[pos] != Node::EMPTY_MARKER) {
+			return pos;
+		}
+	}
+	return Node::GetNextPos(pos);
+}
+
+unique_ptr<Node> *Node48::GetChild(idx_t pos) {
+	D_ASSERT(child_index[pos] != Node::EMPTY_MARKER);
+	return &child[child_index[pos]];
+}
+
+idx_t Node48::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
+		if (child_index[i] != Node::EMPTY_MARKER) {
+			return i;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+void Node48::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node48 *n = static_cast<Node48 *>(node.get());
+
+	// Insert leaf into inner node
+	if (node->count < 48) {
+		// Insert element
+		idx_t pos = n->count;
+		if (n->child[pos]) {
+			// find an empty position in the node list if the current position is occupied
+			pos = 0;
+			while (n->child[pos]) {
+				pos++;
+			}
+		}
+		n->child[pos] = move(child);
+		n->child_index[key_byte] = pos;
+		n->count++;
+	} else {
+		// Grow to Node256
+		auto new_node = make_unique<Node256>(art, n->prefix_length);
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child_index[i] != Node::EMPTY_MARKER) {
+				new_node->child[i] = move(n->child[n->child_index[i]]);
+			}
+		}
+		new_node->count = n->count;
+		CopyPrefix(art, n, new_node.get());
+		node = move(new_node);
+		Node256::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node48::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node48 *n = static_cast<Node48 *>(node.get());
+
+	n->child[n->child_index[pos]].reset();
+	n->child_index[pos] = Node::EMPTY_MARKER;
+	n->count--;
+	if (node->count <= 12) {
+		auto new_node = make_unique<Node16>(art, n->prefix_length);
+		CopyPrefix(art, n, new_node.get());
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child_index[i] != Node::EMPTY_MARKER) {
+				new_node->key[new_node->count] = i;
+				new_node->child[new_node->count++] = move(n->child[n->child_index[i]]);
+			}
+		}
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = JoinHashTable::ValidityBytes;
+using ScanStructure = JoinHashTable::ScanStructure;
+
+JoinHashTable::JoinHashTable(BufferManager &buffer_manager, const vector<JoinCondition> &conditions,
+                             vector<LogicalType> btypes, JoinType type)
+    : buffer_manager(buffer_manager), build_types(move(btypes)), entry_size(0), tuple_size(0),
+      vfound(Value::BOOLEAN(false)), join_type(type), finalized(false), has_null(false) {
+	for (auto &condition : conditions) {
+		D_ASSERT(condition.left->return_type == condition.right->return_type);
+		auto type = condition.left->return_type;
+		if (condition.comparison == ExpressionType::COMPARE_EQUAL ||
+		    condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM ||
+		    condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
+			// all equality conditions should be at the front
+			// all other conditions at the back
+			// this assert checks that
+			D_ASSERT(equality_types.size() == condition_types.size());
+			equality_types.push_back(type);
+		}
+
+		predicates.push_back(condition.comparison);
+		null_values_are_equal.push_back(condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
+		                                condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+
+		condition_types.push_back(type);
+	}
+	// at least one equality is necessary
+	D_ASSERT(!equality_types.empty());
+
+	// Types for the layout
+	vector<LogicalType> layout_types(condition_types);
+	layout_types.insert(layout_types.end(), build_types.begin(), build_types.end());
+	if (IsRightOuterJoin(join_type)) {
+		// full/right outer joins need an extra bool to keep track of whether or not a tuple has found a matching entry
+		// we place the bool before the NEXT pointer
+		layout_types.emplace_back(LogicalType::BOOLEAN);
+	}
+	layout_types.emplace_back(LogicalType::HASH);
+	layout.Initialize(layout_types, false);
+
+	const auto &offsets = layout.GetOffsets();
+	tuple_size = offsets[condition_types.size() + build_types.size()];
+	pointer_offset = offsets.back();
+	entry_size = layout.GetRowWidth();
+
+	// compute the per-block capacity of this HT
+	idx_t block_capacity = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, (Storage::BLOCK_SIZE / entry_size) + 1);
+	block_collection = make_unique<RowDataCollection>(buffer_manager, block_capacity, entry_size);
+	string_heap = make_unique<RowDataCollection>(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+}
+
+JoinHashTable::~JoinHashTable() {
+}
+
+void JoinHashTable::ApplyBitmask(Vector &hashes, idx_t count) {
+	if (hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		D_ASSERT(!ConstantVector::IsNull(hashes));
+		auto indices = ConstantVector::GetData<hash_t>(hashes);
+		*indices = *indices & bitmask;
+	} else {
+		hashes.Normalify(count);
+		auto indices = FlatVector::GetData<hash_t>(hashes);
+		for (idx_t i = 0; i < count; i++) {
+			indices[i] &= bitmask;
+		}
+	}
+}
+
+void JoinHashTable::ApplyBitmask(Vector &hashes, const SelectionVector &sel, idx_t count, Vector &pointers) {
+	VectorData hdata;
+	hashes.Orrify(count, hdata);
+
+	auto hash_data = (hash_t *)hdata.data;
+	auto result_data = FlatVector::GetData<data_ptr_t *>(pointers);
+	auto main_ht = (data_ptr_t *)hash_map->node->buffer;
+	for (idx_t i = 0; i < count; i++) {
+		auto rindex = sel.get_index(i);
+		auto hindex = hdata.sel->get_index(rindex);
+		auto hash = hash_data[hindex];
+		result_data[rindex] = main_ht + (hash & bitmask);
+	}
+}
+
+void JoinHashTable::Hash(DataChunk &keys, const SelectionVector &sel, idx_t count, Vector &hashes) {
+	if (count == keys.size()) {
+		// no null values are filtered: use regular hash functions
+		VectorOperations::Hash(keys.data[0], hashes, keys.size());
+		for (idx_t i = 1; i < equality_types.size(); i++) {
+			VectorOperations::CombineHash(hashes, keys.data[i], keys.size());
+		}
+	} else {
+		// null values were filtered: use selection vector
+		VectorOperations::Hash(keys.data[0], hashes, sel, count);
+		for (idx_t i = 1; i < equality_types.size(); i++) {
+			VectorOperations::CombineHash(hashes, keys.data[i], sel, count);
+		}
+	}
+}
+
+static idx_t FilterNullValues(VectorData &vdata, const SelectionVector &sel, idx_t count, SelectionVector &result) {
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto key_idx = vdata.sel->get_index(idx);
+		if (vdata.validity.RowIsValid(key_idx)) {
+			result.set_index(result_count++, idx);
+		}
+	}
+	return result_count;
+}
+
+idx_t JoinHashTable::PrepareKeys(DataChunk &keys, unique_ptr<VectorData[]> &key_data,
+                                 const SelectionVector *&current_sel, SelectionVector &sel, bool build_side) {
+	key_data = keys.Orrify();
+
+	// figure out which keys are NULL, and create a selection vector out of them
+	current_sel = FlatVector::IncrementalSelectionVector();
+	idx_t added_count = keys.size();
+	if (build_side && IsRightOuterJoin(join_type)) {
+		// in case of a right or full outer join, we cannot remove NULL keys from the build side
+		return added_count;
+	}
+	for (idx_t i = 0; i < keys.ColumnCount(); i++) {
+		if (!null_values_are_equal[i]) {
+			if (key_data[i].validity.AllValid()) {
+				continue;
+			}
+			added_count = FilterNullValues(key_data[i], *current_sel, added_count, sel);
+			// null values are NOT equal for this column, filter them out
+			current_sel = &sel;
+		}
+	}
+	return added_count;
+}
+
+void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
+	D_ASSERT(!finalized);
+	D_ASSERT(keys.size() == payload.size());
+	if (keys.size() == 0) {
+		return;
+	}
+	// special case: correlated mark join
+	if (join_type == JoinType::MARK && !correlated_mark_join_info.correlated_types.empty()) {
+		auto &info = correlated_mark_join_info;
+		lock_guard<mutex> mj_lock(info.mj_lock);
+		// Correlated MARK join
+		// for the correlated mark join we need to keep track of COUNT(*) and COUNT(COLUMN) for each of the correlated
+		// columns push into the aggregate hash table
+		D_ASSERT(info.correlated_counts);
+		info.group_chunk.SetCardinality(keys);
+		for (idx_t i = 0; i < info.correlated_types.size(); i++) {
+			info.group_chunk.data[i].Reference(keys.data[i]);
+		}
+		if (info.correlated_payload.data.empty()) {
+			vector<LogicalType> types;
+			types.push_back(keys.data[info.correlated_types.size()].GetType());
+			info.correlated_payload.InitializeEmpty(types);
+		}
+		info.correlated_payload.SetCardinality(keys);
+		info.correlated_payload.data[0].Reference(keys.data[info.correlated_types.size()]);
+		info.correlated_counts->AddChunk(info.group_chunk, info.correlated_payload);
+	}
+
+	// prepare the keys for processing
+	unique_ptr<VectorData[]> key_data;
+	const SelectionVector *current_sel;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	idx_t added_count = PrepareKeys(keys, key_data, current_sel, sel, true);
+	if (added_count < keys.size()) {
+		has_null = true;
+	}
+	if (added_count == 0) {
+		return;
+	}
+
+	// build out the buffer space
+	Vector addresses(LogicalType::POINTER);
+	auto key_locations = FlatVector::GetData<data_ptr_t>(addresses);
+	auto handles = block_collection->Build(added_count, key_locations, nullptr, current_sel);
+
+	// hash the keys and obtain an entry in the list
+	// note that we only hash the keys used in the equality comparison
+	Vector hash_values(LogicalType::HASH);
+	Hash(keys, *current_sel, added_count, hash_values);
+
+	// build a chunk so we can handle nested types that need more than Orrification
+	DataChunk source_chunk;
+	source_chunk.InitializeEmpty(layout.GetTypes());
+
+	vector<VectorData> source_data;
+	source_data.reserve(layout.ColumnCount());
+
+	// serialize the keys to the key locations
+	for (idx_t i = 0; i < keys.ColumnCount(); i++) {
+		source_chunk.data[i].Reference(keys.data[i]);
+		source_data.emplace_back(move(key_data[i]));
+	}
+	// now serialize the payload
+	D_ASSERT(build_types.size() == payload.ColumnCount());
+	for (idx_t i = 0; i < payload.ColumnCount(); i++) {
+		source_chunk.data[source_data.size()].Reference(payload.data[i]);
+		VectorData pdata;
+		payload.data[i].Orrify(payload.size(), pdata);
+		source_data.emplace_back(move(pdata));
+	}
+	if (IsRightOuterJoin(join_type)) {
+		// for FULL/RIGHT OUTER joins initialize the "found" boolean to false
+		source_chunk.data[source_data.size()].Reference(vfound);
+		VectorData fdata;
+		vfound.Orrify(keys.size(), fdata);
+		source_data.emplace_back(move(fdata));
+	}
+
+	// serialise the hashes at the end
+	source_chunk.data[source_data.size()].Reference(hash_values);
+	VectorData hdata;
+	hash_values.Orrify(keys.size(), hdata);
+	source_data.emplace_back(move(hdata));
+
+	source_chunk.SetCardinality(keys);
+
+	RowOperations::Scatter(source_chunk, source_data.data(), layout, addresses, *string_heap, *current_sel,
+	                       added_count);
+}
+
+void JoinHashTable::InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_locations[]) {
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
+
+	// use bitmask to get position in array
+	ApplyBitmask(hashes, count);
+
+	hashes.Normalify(count);
+
+	D_ASSERT(hashes.GetVectorType() == VectorType::FLAT_VECTOR);
+	auto pointers = (data_ptr_t *)hash_map->node->buffer;
+	auto indices = FlatVector::GetData<hash_t>(hashes);
+	for (idx_t i = 0; i < count; i++) {
+		auto index = indices[i];
+		// set prev in current key to the value (NOTE: this will be nullptr if
+		// there is none)
+		Store<data_ptr_t>(pointers[index], key_locations[i] + pointer_offset);
+
+		// set pointer to current tuple
+		pointers[index] = key_locations[i];
+	}
+}
+
+void JoinHashTable::Finalize() {
+	// the build has finished, now iterate over all the nodes and construct the final hash table
+	// select a HT that has at least 50% empty space
+	idx_t capacity = NextPowerOfTwo(MaxValue<idx_t>(Count() * 2, (Storage::BLOCK_SIZE / sizeof(data_ptr_t)) + 1));
+	// size needs to be a power of 2
+	D_ASSERT((capacity & (capacity - 1)) == 0);
+	bitmask = capacity - 1;
+
+	// allocate the HT and initialize it with all-zero entries
+	hash_map = buffer_manager.Allocate(capacity * sizeof(data_ptr_t));
+	memset(hash_map->node->buffer, 0, capacity * sizeof(data_ptr_t));
+
+	Vector hashes(LogicalType::HASH);
+	auto hash_data = FlatVector::GetData<hash_t>(hashes);
+	data_ptr_t key_locations[STANDARD_VECTOR_SIZE];
+	// now construct the actual hash table; scan the nodes
+	// as we can the nodes we pin all the blocks of the HT and keep them pinned until the HT is destroyed
+	// this is so that we can keep pointers around to the blocks
+	// FIXME: if we cannot keep everything pinned in memory, we could switch to an out-of-memory merge join or so
+	for (auto &block : block_collection->blocks) {
+		auto handle = buffer_manager.Pin(block.block);
+		data_ptr_t dataptr = handle->node->buffer;
+		idx_t entry = 0;
+		while (entry < block.count) {
+			// fetch the next vector of entries from the blocks
+			idx_t next = MinValue<idx_t>(STANDARD_VECTOR_SIZE, block.count - entry);
+			for (idx_t i = 0; i < next; i++) {
+				hash_data[i] = Load<hash_t>((data_ptr_t)(dataptr + pointer_offset));
+				key_locations[i] = dataptr;
+				dataptr += entry_size;
+			}
+			// now insert into the hash table
+			InsertHashes(hashes, next, key_locations);
+
+			entry += next;
+		}
+		pinned_handles.push_back(move(handle));
+	}
+
+	finalized = true;
+}
+
+unique_ptr<ScanStructure> JoinHashTable::Probe(DataChunk &keys) {
+	D_ASSERT(Count() > 0); // should be handled before
+	D_ASSERT(finalized);
+
+	// set up the scan structure
+	auto ss = make_unique<ScanStructure>(*this);
+
+	if (join_type != JoinType::INNER) {
+		ss->found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+		memset(ss->found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+	}
+
+	// first prepare the keys for probing
+	const SelectionVector *current_sel;
+	ss->count = PrepareKeys(keys, ss->key_data, current_sel, ss->sel_vector, false);
+	if (ss->count == 0) {
+		return ss;
+	}
+
+	// hash all the keys
+	Vector hashes(LogicalType::HASH);
+	Hash(keys, *current_sel, ss->count, hashes);
+
+	// now initialize the pointers of the scan structure based on the hashes
+	ApplyBitmask(hashes, *current_sel, ss->count, ss->pointers);
+
+	// create the selection vector linking to only non-empty entries
+	idx_t count = 0;
+	auto pointers = FlatVector::GetData<data_ptr_t>(ss->pointers);
+	for (idx_t i = 0; i < ss->count; i++) {
+		auto idx = current_sel->get_index(i);
+		pointers[idx] = Load<data_ptr_t>(pointers[idx]);
+		if (pointers[idx]) {
+			ss->sel_vector.set_index(count++, idx);
+		}
+	}
+	ss->count = count;
+	return ss;
+}
+
+ScanStructure::ScanStructure(JoinHashTable &ht)
+    : pointers(LogicalType::POINTER), sel_vector(STANDARD_VECTOR_SIZE), ht(ht), finished(false) {
+}
+
+void ScanStructure::Next(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	if (finished) {
+		return;
+	}
+
+	switch (ht.join_type) {
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+		NextInnerJoin(keys, left, result);
+		break;
+	case JoinType::SEMI:
+		NextSemiJoin(keys, left, result);
+		break;
+	case JoinType::MARK:
+		NextMarkJoin(keys, left, result);
+		break;
+	case JoinType::ANTI:
+		NextAntiJoin(keys, left, result);
+		break;
+	case JoinType::OUTER:
+	case JoinType::LEFT:
+		NextLeftJoin(keys, left, result);
+		break;
+	case JoinType::SINGLE:
+		NextSingleJoin(keys, left, result);
+		break;
+	default:
+		throw InternalException("Unhandled join type in JoinHashTable");
+	}
+}
+
+idx_t ScanStructure::ResolvePredicates(DataChunk &keys, SelectionVector &match_sel, SelectionVector *no_match_sel) {
+	// Start with the scan selection
+	for (idx_t i = 0; i < this->count; ++i) {
+		match_sel.set_index(i, this->sel_vector.get_index(i));
+	}
+	idx_t no_match_count = 0;
+
+	return RowOperations::Match(keys, key_data.get(), ht.layout, pointers, ht.predicates, match_sel, this->count,
+	                            no_match_sel, no_match_count);
+}
+
+idx_t ScanStructure::ScanInnerJoin(DataChunk &keys, SelectionVector &result_vector) {
+	while (true) {
+		// resolve the predicates for this set of keys
+		idx_t result_count = ResolvePredicates(keys, result_vector, nullptr);
+
+		// after doing all the comparisons set the found_match vector
+		if (found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				auto idx = result_vector.get_index(i);
+				found_match[idx] = true;
+			}
+		}
+		if (result_count > 0) {
+			return result_count;
+		}
+		// no matches found: check the next set of pointers
+		AdvancePointers();
+		if (this->count == 0) {
+			return 0;
+		}
+	}
+}
+
+void ScanStructure::AdvancePointers(const SelectionVector &sel, idx_t sel_count) {
+	// now for all the pointers, we move on to the next set of pointers
+	idx_t new_count = 0;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(this->pointers);
+	for (idx_t i = 0; i < sel_count; i++) {
+		auto idx = sel.get_index(i);
+		ptrs[idx] = Load<data_ptr_t>(ptrs[idx] + ht.pointer_offset);
+		if (ptrs[idx]) {
+			this->sel_vector.set_index(new_count++, idx);
+		}
+	}
+	this->count = new_count;
+}
+
+void ScanStructure::AdvancePointers() {
+	AdvancePointers(this->sel_vector, this->count);
+}
+
+void ScanStructure::GatherResult(Vector &result, const SelectionVector &result_vector,
+                                 const SelectionVector &sel_vector, const idx_t count, const idx_t col_no) {
+	const auto col_offset = ht.layout.GetOffsets()[col_no];
+	RowOperations::Gather(pointers, sel_vector, result, result_vector, count, col_offset, col_no);
+}
+
+void ScanStructure::GatherResult(Vector &result, const SelectionVector &sel_vector, const idx_t count,
+                                 const idx_t col_idx) {
+	GatherResult(result, *FlatVector::IncrementalSelectionVector(), sel_vector, count, col_idx);
+}
+
+void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	D_ASSERT(result.ColumnCount() == left.ColumnCount() + ht.build_types.size());
+	if (this->count == 0) {
+		// no pointers left to chase
+		return;
+	}
+
+	SelectionVector result_vector(STANDARD_VECTOR_SIZE);
+
+	idx_t result_count = ScanInnerJoin(keys, result_vector);
+	if (result_count > 0) {
+		if (IsRightOuterJoin(ht.join_type)) {
+			// full/right outer join: mark join matches as FOUND in the HT
+			auto ptrs = FlatVector::GetData<data_ptr_t>(pointers);
+			for (idx_t i = 0; i < result_count; i++) {
+				auto idx = result_vector.get_index(i);
+				// NOTE: threadsan reports this as a data race because this can be set concurrently by separate threads
+				// Technically it is, but it does not matter, since the only value that can be written is "true"
+				Store<bool>(true, ptrs[idx] + ht.tuple_size);
+			}
+		}
+		// matches were found
+		// construct the result
+		// on the LHS, we create a slice using the result vector
+		result.Slice(left, result_vector, result_count);
+
+		// on the RHS, we need to fetch the data from the hash table
+		for (idx_t i = 0; i < ht.build_types.size(); i++) {
+			auto &vector = result.data[left.ColumnCount() + i];
+			D_ASSERT(vector.GetType() == ht.build_types[i]);
+			GatherResult(vector, result_vector, result_count, i + ht.condition_types.size());
+		}
+		AdvancePointers();
+	}
+}
+
+void ScanStructure::ScanKeyMatches(DataChunk &keys) {
+	// the semi-join, anti-join and mark-join we handle a differently from the inner join
+	// since there can be at most STANDARD_VECTOR_SIZE results
+	// we handle the entire chunk in one call to Next().
+	// for every pointer, we keep chasing pointers and doing comparisons.
+	// this results in a boolean array indicating whether or not the tuple has a match
+	SelectionVector match_sel(STANDARD_VECTOR_SIZE), no_match_sel(STANDARD_VECTOR_SIZE);
+	while (this->count > 0) {
+		// resolve the predicates for the current set of pointers
+		idx_t match_count = ResolvePredicates(keys, match_sel, &no_match_sel);
+		idx_t no_match_count = this->count - match_count;
+
+		// mark each of the matches as found
+		for (idx_t i = 0; i < match_count; i++) {
+			found_match[match_sel.get_index(i)] = true;
+		}
+		// continue searching for the ones where we did not find a match yet
+		AdvancePointers(no_match_sel, no_match_count);
+	}
+}
+
+template <bool MATCH>
+void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	D_ASSERT(left.ColumnCount() == result.ColumnCount());
+	D_ASSERT(keys.size() == left.size());
+	// create the selection vector from the matches that were found
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < keys.size(); i++) {
+		if (found_match[i] == MATCH) {
+			// part of the result
+			sel.set_index(result_count++, i);
+		}
+	}
+	// construct the final result
+	if (result_count > 0) {
+		// we only return the columns on the left side
+		// reference the columns of the left side from the result
+		result.Slice(left, sel, result_count);
+	} else {
+		D_ASSERT(result.size() == 0);
+	}
+}
+
+void ScanStructure::NextSemiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// first scan for key matches
+	ScanKeyMatches(keys);
+	// then construct the result from all tuples with a match
+	NextSemiOrAntiJoin<true>(keys, left, result);
+
+	finished = true;
+}
+
+void ScanStructure::NextAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// first scan for key matches
+	ScanKeyMatches(keys);
+	// then construct the result from all tuples that did not find a match
+	NextSemiOrAntiJoin<false>(keys, left, result);
+
+	finished = true;
+}
+
+void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &child, DataChunk &result) {
+	// for the initial set of columns we just reference the left side
+	result.SetCardinality(child);
+	for (idx_t i = 0; i < child.ColumnCount(); i++) {
+		result.data[i].Reference(child.data[i]);
+	}
+	auto &mark_vector = result.data.back();
+	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	// first we set the NULL values from the join keys
+	// if there is any NULL in the keys, the result is NULL
+	auto bool_result = FlatVector::GetData<bool>(mark_vector);
+	auto &mask = FlatVector::Validity(mark_vector);
+	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
+		if (ht.null_values_are_equal[col_idx]) {
+			continue;
+		}
+		VectorData jdata;
+		join_keys.data[col_idx].Orrify(join_keys.size(), jdata);
+		if (!jdata.validity.AllValid()) {
+			for (idx_t i = 0; i < join_keys.size(); i++) {
+				auto jidx = jdata.sel->get_index(i);
+				mask.Set(i, jdata.validity.RowIsValidUnsafe(jidx));
+			}
+		}
+	}
+	// now set the remaining entries to either true or false based on whether a match was found
+	if (found_match) {
+		for (idx_t i = 0; i < child.size(); i++) {
+			bool_result[i] = found_match[i];
+		}
+	} else {
+		memset(bool_result, 0, sizeof(bool) * child.size());
+	}
+	// if the right side contains NULL values, the result of any FALSE becomes NULL
+	if (ht.has_null) {
+		for (idx_t i = 0; i < child.size(); i++) {
+			if (!bool_result[i]) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+void ScanStructure::NextMarkJoin(DataChunk &keys, DataChunk &input, DataChunk &result) {
+	D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
+	D_ASSERT(result.data.back().GetType() == LogicalType::BOOLEAN);
+	// this method should only be called for a non-empty HT
+	D_ASSERT(ht.Count() > 0);
+
+	ScanKeyMatches(keys);
+	if (ht.correlated_mark_join_info.correlated_types.empty()) {
+		ConstructMarkJoinResult(keys, input, result);
+	} else {
+		auto &info = ht.correlated_mark_join_info;
+		// there are correlated columns
+		// first we fetch the counts from the aggregate hashtable corresponding to these entries
+		D_ASSERT(keys.ColumnCount() == info.group_chunk.ColumnCount() + 1);
+		info.group_chunk.SetCardinality(keys);
+		for (idx_t i = 0; i < info.group_chunk.ColumnCount(); i++) {
+			info.group_chunk.data[i].Reference(keys.data[i]);
+		}
+		info.correlated_counts->FetchAggregates(info.group_chunk, info.result_chunk);
+
+		// for the initial set of columns we just reference the left side
+		result.SetCardinality(input);
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// create the result matching vector
+		auto &last_key = keys.data.back();
+		auto &result_vector = result.data.back();
+		// first set the nullmask based on whether or not there were NULL values in the join key
+		result_vector.SetVectorType(VectorType::FLAT_VECTOR);
+		auto bool_result = FlatVector::GetData<bool>(result_vector);
+		auto &mask = FlatVector::Validity(result_vector);
+		switch (last_key.GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR:
+			if (ConstantVector::IsNull(last_key)) {
+				mask.SetAllInvalid(input.size());
+			}
+			break;
+		case VectorType::FLAT_VECTOR:
+			mask.Copy(FlatVector::Validity(last_key), input.size());
+			break;
+		default: {
+			VectorData kdata;
+			last_key.Orrify(keys.size(), kdata);
+			for (idx_t i = 0; i < input.size(); i++) {
+				auto kidx = kdata.sel->get_index(i);
+				mask.Set(i, kdata.validity.RowIsValid(kidx));
+			}
+			break;
+		}
+		}
+
+		auto count_star = FlatVector::GetData<int64_t>(info.result_chunk.data[0]);
+		auto count = FlatVector::GetData<int64_t>(info.result_chunk.data[1]);
+		// set the entries to either true or false based on whether a match was found
+		for (idx_t i = 0; i < input.size(); i++) {
+			D_ASSERT(count_star[i] >= count[i]);
+			bool_result[i] = found_match ? found_match[i] : false;
+			if (!bool_result[i] && count_star[i] > count[i]) {
+				// RHS has NULL value and result is false: set to null
+				mask.SetInvalid(i);
+			}
+			if (count_star[i] == 0) {
+				// count == 0, set nullmask to false (we know the result is false now)
+				mask.SetValid(i);
+			}
+		}
+	}
+	finished = true;
+}
+
+void ScanStructure::NextLeftJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// a LEFT OUTER JOIN is identical to an INNER JOIN except all tuples that do
+	// not have a match must return at least one tuple (with the right side set
+	// to NULL in every column)
+	NextInnerJoin(keys, left, result);
+	if (result.size() == 0) {
+		// no entries left from the normal join
+		// fill in the result of the remaining left tuples
+		// together with NULL values on the right-hand side
+		idx_t remaining_count = 0;
+		SelectionVector sel(STANDARD_VECTOR_SIZE);
+		for (idx_t i = 0; i < left.size(); i++) {
+			if (!found_match[i]) {
+				sel.set_index(remaining_count++, i);
+			}
+		}
+		if (remaining_count > 0) {
+			// have remaining tuples
+			// slice the left side with tuples that did not find a match
+			result.Slice(left, sel, remaining_count);
+
+			// now set the right side to NULL
+			for (idx_t i = left.ColumnCount(); i < result.ColumnCount(); i++) {
+				Vector &vec = result.data[i];
+				vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(vec, true);
+			}
+		}
+		finished = true;
+	}
+}
+
+void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &input, DataChunk &result) {
+	// single join
+	// this join is similar to the semi join except that
+	// (1) we actually return data from the RHS and
+	// (2) we return NULL for that data if there is no match
+	idx_t result_count = 0;
+	SelectionVector result_sel(STANDARD_VECTOR_SIZE);
+	SelectionVector match_sel(STANDARD_VECTOR_SIZE), no_match_sel(STANDARD_VECTOR_SIZE);
+	while (this->count > 0) {
+		// resolve the predicates for the current set of pointers
+		idx_t match_count = ResolvePredicates(keys, match_sel, &no_match_sel);
+		idx_t no_match_count = this->count - match_count;
+
+		// mark each of the matches as found
+		for (idx_t i = 0; i < match_count; i++) {
+			// found a match for this index
+			auto index = match_sel.get_index(i);
+			found_match[index] = true;
+			result_sel.set_index(result_count++, index);
+		}
+		// continue searching for the ones where we did not find a match yet
+		AdvancePointers(no_match_sel, no_match_count);
+	}
+	// reference the columns of the left side from the result
+	D_ASSERT(input.ColumnCount() > 0);
+	for (idx_t i = 0; i < input.ColumnCount(); i++) {
+		result.data[i].Reference(input.data[i]);
+	}
+	// now fetch the data from the RHS
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto &vector = result.data[input.ColumnCount() + i];
+		// set NULL entries for every entry that was not found
+		auto &mask = FlatVector::Validity(vector);
+		mask.SetAllInvalid(input.size());
+		for (idx_t j = 0; j < result_count; j++) {
+			mask.SetValid(result_sel.get_index(j));
+		}
+		// for the remaining values we fetch the values
+		GatherResult(vector, result_sel, result_sel, result_count, i + ht.condition_types.size());
+	}
+	result.SetCardinality(input.size());
+
+	// like the SEMI, ANTI and MARK join types, the SINGLE join only ever does one pass over the HT per input chunk
+	finished = true;
+}
+
+void JoinHashTable::ScanFullOuter(DataChunk &result, JoinHTScanState &state) {
+	// scan the HT starting from the current position and check which rows from the build side did not find a match
+	Vector addresses(LogicalType::POINTER);
+	auto key_locations = FlatVector::GetData<data_ptr_t>(addresses);
+	idx_t found_entries = 0;
+	{
+		lock_guard<mutex> state_lock(state.lock);
+		for (; state.block_position < block_collection->blocks.size(); state.block_position++, state.position = 0) {
+			auto &block = block_collection->blocks[state.block_position];
+			auto &handle = pinned_handles[state.block_position];
+			auto baseptr = handle->node->buffer;
+			for (; state.position < block.count; state.position++) {
+				auto tuple_base = baseptr + state.position * entry_size;
+				auto found_match = Load<bool>(tuple_base + tuple_size);
+				if (!found_match) {
+					key_locations[found_entries++] = tuple_base;
+					if (found_entries == STANDARD_VECTOR_SIZE) {
+						state.position++;
+						break;
+					}
+				}
+			}
+			if (found_entries == STANDARD_VECTOR_SIZE) {
+				break;
+			}
+		}
+	}
+	result.SetCardinality(found_entries);
+	if (found_entries > 0) {
+		idx_t left_column_count = result.ColumnCount() - build_types.size();
+		const auto &sel_vector = *FlatVector::IncrementalSelectionVector();
+		// set the left side as a constant NULL
+		for (idx_t i = 0; i < left_column_count; i++) {
+			Vector &vec = result.data[i];
+			vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(vec, true);
+		}
+		// gather the values from the RHS
+		for (idx_t i = 0; i < build_types.size(); i++) {
+			auto &vector = result.data[left_column_count + i];
+			D_ASSERT(vector.GetType() == build_types[i]);
+			const auto col_no = condition_types.size() + i;
+			const auto col_offset = layout.GetOffsets()[col_no];
+			RowOperations::Gather(addresses, sel_vector, vector, sel_vector, found_entries, col_offset, col_no);
+		}
+	}
+}
+
+idx_t JoinHashTable::FillWithHTOffsets(data_ptr_t *key_locations, JoinHTScanState &state) {
+
+	// iterate over blocks
+	idx_t key_count = 0;
+	while (state.block_position < block_collection->blocks.size()) {
+		auto &block = block_collection->blocks[state.block_position];
+		auto handle = buffer_manager.Pin(block.block);
+		auto base_ptr = handle->node->buffer;
+		// go through all the tuples within this block
+		while (state.position < block.count) {
+			auto tuple_base = base_ptr + state.position * entry_size;
+			// store its locations
+			key_locations[key_count++] = tuple_base;
+			state.position++;
+		}
+		state.block_position++;
+		state.position = 0;
+	}
+	return key_count;
+}
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-3.cpp
+++ b/velox/external/duckdb/duckdb-3.cpp
@@ -1,0 +1,16677 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct ComparisonOperationWrapper {
+	template <class T>
+	static inline bool Operation(T left, T right, bool left_is_null, bool right_is_null) {
+		if (left_is_null || right_is_null) {
+			return false;
+		}
+		return OP::Operation(left, right);
+	}
+};
+
+struct InitialNestedLoopJoin {
+	template <class T, class OP>
+	static idx_t Operation(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos, idx_t &rpos,
+	                       SelectionVector &lvector, SelectionVector &rvector, idx_t current_match_count) {
+		// initialize phase of nested loop join
+		// fill lvector and rvector with matches from the base vectors
+		VectorData left_data, right_data;
+		left.Orrify(left_size, left_data);
+		right.Orrify(right_size, right_data);
+
+		auto ldata = (T *)left_data.data;
+		auto rdata = (T *)right_data.data;
+		idx_t result_count = 0;
+		for (; rpos < right_size; rpos++) {
+			idx_t right_position = right_data.sel->get_index(rpos);
+			bool right_is_valid = right_data.validity.RowIsValid(right_position);
+			for (; lpos < left_size; lpos++) {
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					return result_count;
+				}
+				idx_t left_position = left_data.sel->get_index(lpos);
+				bool left_is_valid = left_data.validity.RowIsValid(left_position);
+				if (OP::Operation(ldata[left_position], rdata[right_position], !left_is_valid, !right_is_valid)) {
+					// emit tuple
+					lvector.set_index(result_count, lpos);
+					rvector.set_index(result_count, rpos);
+					result_count++;
+				}
+			}
+			lpos = 0;
+		}
+		return result_count;
+	}
+};
+
+struct RefineNestedLoopJoin {
+	template <class T, class OP>
+	static idx_t Operation(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos, idx_t &rpos,
+	                       SelectionVector &lvector, SelectionVector &rvector, idx_t current_match_count) {
+		VectorData left_data, right_data;
+		left.Orrify(left_size, left_data);
+		right.Orrify(right_size, right_data);
+
+		// refine phase of the nested loop join
+		// refine lvector and rvector based on matches of subsequent conditions (in case there are multiple conditions
+		// in the join)
+		D_ASSERT(current_match_count > 0);
+		auto ldata = (T *)left_data.data;
+		auto rdata = (T *)right_data.data;
+		idx_t result_count = 0;
+		for (idx_t i = 0; i < current_match_count; i++) {
+			auto lidx = lvector.get_index(i);
+			auto ridx = rvector.get_index(i);
+			auto left_idx = left_data.sel->get_index(lidx);
+			auto right_idx = right_data.sel->get_index(ridx);
+			bool left_is_valid = left_data.validity.RowIsValid(left_idx);
+			bool right_is_valid = right_data.validity.RowIsValid(right_idx);
+			if (OP::Operation(ldata[left_idx], rdata[right_idx], !left_is_valid, !right_is_valid)) {
+				lvector.set_index(result_count, lidx);
+				rvector.set_index(result_count, ridx);
+				result_count++;
+			}
+		}
+		return result_count;
+	}
+};
+
+template <class NLTYPE, class OP>
+static idx_t NestedLoopJoinTypeSwitch(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos,
+                                      idx_t &rpos, SelectionVector &lvector, SelectionVector &rvector,
+                                      idx_t current_match_count) {
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return NLTYPE::template Operation<int8_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                              current_match_count);
+	case PhysicalType::INT16:
+		return NLTYPE::template Operation<int16_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::INT32:
+		return NLTYPE::template Operation<int32_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::INT64:
+		return NLTYPE::template Operation<int64_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::UINT8:
+		return NLTYPE::template Operation<uint8_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::UINT16:
+		return NLTYPE::template Operation<uint16_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::UINT32:
+		return NLTYPE::template Operation<uint32_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::UINT64:
+		return NLTYPE::template Operation<uint64_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::INT128:
+		return NLTYPE::template Operation<hugeint_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                 rvector, current_match_count);
+	case PhysicalType::FLOAT:
+		return NLTYPE::template Operation<float, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                             current_match_count);
+	case PhysicalType::DOUBLE:
+		return NLTYPE::template Operation<double, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                              current_match_count);
+	case PhysicalType::INTERVAL:
+		return NLTYPE::template Operation<interval_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                  rvector, current_match_count);
+	case PhysicalType::VARCHAR:
+		return NLTYPE::template Operation<string_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	default:
+		throw InternalException("Unimplemented type for join!");
+	}
+}
+
+template <class NLTYPE>
+idx_t NestedLoopJoinComparisonSwitch(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos,
+                                     idx_t &rpos, SelectionVector &lvector, SelectionVector &rvector,
+                                     idx_t current_match_count, ExpressionType comparison_type) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::Equals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::NotEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::LessThan>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::GreaterThan>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::LessThanEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::GreaterThanEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return NestedLoopJoinTypeSwitch<NLTYPE, duckdb::DistinctFrom>(left, right, left_size, right_size, lpos, rpos,
+		                                                              lvector, rvector, current_match_count);
+	default:
+		throw NotImplementedException("Unimplemented comparison type for join!");
+	}
+}
+
+idx_t NestedLoopJoinInner::Perform(idx_t &lpos, idx_t &rpos, DataChunk &left_conditions, DataChunk &right_conditions,
+                                   SelectionVector &lvector, SelectionVector &rvector,
+                                   const vector<JoinCondition> &conditions) {
+	D_ASSERT(left_conditions.ColumnCount() == right_conditions.ColumnCount());
+	if (lpos >= left_conditions.size() || rpos >= right_conditions.size()) {
+		return 0;
+	}
+	// for the first condition, lvector and rvector are not set yet
+	// we initialize them using the InitialNestedLoopJoin
+	idx_t match_count = NestedLoopJoinComparisonSwitch<InitialNestedLoopJoin>(
+	    left_conditions.data[0], right_conditions.data[0], left_conditions.size(), right_conditions.size(), lpos, rpos,
+	    lvector, rvector, 0, conditions[0].comparison);
+	// now resolve the rest of the conditions
+	for (idx_t i = 1; i < conditions.size(); i++) {
+		// check if we have run out of tuples to compare
+		if (match_count == 0) {
+			return 0;
+		}
+		// if not, get the vectors to compare
+		Vector &l = left_conditions.data[i];
+		Vector &r = right_conditions.data[i];
+		// then we refine the currently obtained results using the RefineNestedLoopJoin
+		match_count = NestedLoopJoinComparisonSwitch<RefineNestedLoopJoin>(
+		    l, r, left_conditions.size(), right_conditions.size(), lpos, rpos, lvector, rvector, match_count,
+		    conditions[i].comparison);
+	}
+	return match_count;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T, class OP>
+static void TemplatedMarkJoin(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[]) {
+	VectorData left_data, right_data;
+	left.Orrify(lcount, left_data);
+	right.Orrify(rcount, right_data);
+
+	auto ldata = (T *)left_data.data;
+	auto rdata = (T *)right_data.data;
+	for (idx_t i = 0; i < lcount; i++) {
+		if (found_match[i]) {
+			continue;
+		}
+		auto lidx = left_data.sel->get_index(i);
+		if (!left_data.validity.RowIsValid(lidx)) {
+			continue;
+		}
+		for (idx_t j = 0; j < rcount; j++) {
+			auto ridx = right_data.sel->get_index(j);
+			if (!right_data.validity.RowIsValid(ridx)) {
+				continue;
+			}
+			if (OP::Operation(ldata[lidx], rdata[ridx])) {
+				found_match[i] = true;
+				break;
+			}
+		}
+	}
+}
+
+template <class OP>
+static void MarkJoinSwitch(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[]) {
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedMarkJoin<int8_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT16:
+		return TemplatedMarkJoin<int16_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT32:
+		return TemplatedMarkJoin<int32_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT64:
+		return TemplatedMarkJoin<int64_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT128:
+		return TemplatedMarkJoin<hugeint_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT8:
+		return TemplatedMarkJoin<uint8_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT16:
+		return TemplatedMarkJoin<uint16_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT32:
+		return TemplatedMarkJoin<uint32_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT64:
+		return TemplatedMarkJoin<uint64_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::FLOAT:
+		return TemplatedMarkJoin<float, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::DOUBLE:
+		return TemplatedMarkJoin<double, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::VARCHAR:
+		return TemplatedMarkJoin<string_t, OP>(left, right, lcount, rcount, found_match);
+	default:
+		throw NotImplementedException("Unimplemented type for mark join!");
+	}
+}
+
+static void MarkJoinComparisonSwitch(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[],
+                                     ExpressionType comparison_type) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return MarkJoinSwitch<duckdb::Equals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return MarkJoinSwitch<duckdb::NotEquals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return MarkJoinSwitch<duckdb::LessThan>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return MarkJoinSwitch<duckdb::GreaterThan>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return MarkJoinSwitch<duckdb::LessThanEquals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return MarkJoinSwitch<duckdb::GreaterThanEquals>(left, right, lcount, rcount, found_match);
+	default:
+		throw NotImplementedException("Unimplemented comparison type for join!");
+	}
+}
+
+void NestedLoopJoinMark::Perform(DataChunk &left, ChunkCollection &right, bool found_match[],
+                                 const vector<JoinCondition> &conditions) {
+	// initialize a new temporary selection vector for the left chunk
+	// loop over all chunks in the RHS
+	for (idx_t chunk_idx = 0; chunk_idx < right.ChunkCount(); chunk_idx++) {
+		DataChunk &right_chunk = right.GetChunk(chunk_idx);
+		for (idx_t i = 0; i < conditions.size(); i++) {
+			MarkJoinComparisonSwitch(left.data[i], right_chunk.data[i], left.size(), right_chunk.size(), found_match,
+			                         conditions[i].comparison);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), {}, estimated_cardinality, type) {
+}
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions,
+                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), move(groups_p), {}, {}, estimated_cardinality,
+                            type) {
+}
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions,
+                                             vector<unique_ptr<Expression>> groups_p,
+                                             vector<GroupingSet> grouping_sets_p,
+                                             vector<vector<idx_t>> grouping_functions_p, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), groups(move(groups_p)),
+      grouping_sets(move(grouping_sets_p)), grouping_functions(move(grouping_functions_p)), any_distinct(false) {
+	// get a list of all aggregates to be computed
+	for (auto &expr : groups) {
+		group_types.push_back(expr->return_type);
+	}
+	if (grouping_sets.empty()) {
+		GroupingSet set;
+		for (idx_t i = 0; i < group_types.size(); i++) {
+			set.insert(i);
+		}
+		grouping_sets.push_back(move(set));
+	}
+	vector<LogicalType> payload_types_filters;
+	for (auto &expr : expressions) {
+		D_ASSERT(expr->expression_class == ExpressionClass::BOUND_AGGREGATE);
+		D_ASSERT(expr->IsAggregate());
+		auto &aggr = (BoundAggregateExpression &)*expr;
+		bindings.push_back(&aggr);
+
+		if (aggr.distinct) {
+			any_distinct = true;
+		}
+
+		aggregate_return_types.push_back(aggr.return_type);
+		for (auto &child : aggr.children) {
+			payload_types.push_back(child->return_type);
+		}
+		if (aggr.filter) {
+			payload_types_filters.push_back(aggr.filter->return_type);
+		}
+		if (!aggr.function.combine) {
+			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
+		}
+		aggregates.push_back(move(expr));
+	}
+
+	for (const auto &pay_filters : payload_types_filters) {
+		payload_types.push_back(pay_filters);
+	}
+
+	// filter_indexes must be pre-built, not lazily instantiated in parallel...
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		aggregate_input_idx += aggr.children.size();
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto &bound_ref_expr = (BoundReferenceExpression &)*aggr.filter;
+			auto it = filter_indexes.find(aggr.filter.get());
+			if (it == filter_indexes.end()) {
+				filter_indexes[aggr.filter.get()] = bound_ref_expr.index;
+				bound_ref_expr.index = aggregate_input_idx++;
+			} else {
+				++aggregate_input_idx;
+			}
+		}
+	}
+
+	for (auto &grouping_set : grouping_sets) {
+		radix_tables.emplace_back(grouping_set, *this);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class HashAggregateGlobalState : public GlobalSinkState {
+public:
+	HashAggregateGlobalState(const PhysicalHashAggregate &op, ClientContext &context) {
+		radix_states.reserve(op.radix_tables.size());
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetGlobalSinkState(context));
+		}
+	}
+
+	vector<unique_ptr<GlobalSinkState>> radix_states;
+};
+
+class HashAggregateLocalState : public LocalSinkState {
+public:
+	HashAggregateLocalState(const PhysicalHashAggregate &op, ExecutionContext &context) {
+		if (!op.payload_types.empty()) {
+			aggregate_input_chunk.InitializeEmpty(op.payload_types);
+		}
+
+		radix_states.reserve(op.radix_tables.size());
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetLocalSinkState(context));
+		}
+	}
+
+	DataChunk aggregate_input_chunk;
+
+	vector<unique_ptr<LocalSinkState>> radix_states;
+};
+
+void PhysicalHashAggregate::SetMultiScan(GlobalSinkState &state) {
+	auto &gstate = (HashAggregateGlobalState &)state;
+	for (auto &radix_state : gstate.radix_states) {
+		RadixPartitionedHashTable::SetMultiScan(*radix_state);
+	}
+}
+
+unique_ptr<GlobalSinkState> PhysicalHashAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<HashAggregateGlobalState>(*this, context);
+}
+
+unique_ptr<LocalSinkState> PhysicalHashAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<HashAggregateLocalState>(*this, context);
+}
+
+SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                           DataChunk &input) const {
+	auto &llstate = (HashAggregateLocalState &)lstate;
+	auto &gstate = (HashAggregateGlobalState &)state;
+
+	DataChunk &aggregate_input_chunk = llstate.aggregate_input_chunk;
+
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		for (auto &child_expr : aggr.children) {
+			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
+			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			D_ASSERT(bound_ref_expr.index < input.data.size());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
+		}
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto it = filter_indexes.find(aggr.filter.get());
+			D_ASSERT(it != filter_indexes.end());
+			D_ASSERT(it->second < input.data.size());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[it->second]);
+		}
+	}
+
+	aggregate_input_chunk.SetCardinality(input.size());
+	aggregate_input_chunk.Verify();
+
+	for (idx_t i = 0; i < radix_tables.size(); i++) {
+		radix_tables[i].Sink(context, *gstate.radix_states[i], *llstate.radix_states[i], input, aggregate_input_chunk);
+	}
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalHashAggregate::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
+	auto &gstate = (HashAggregateGlobalState &)state;
+	auto &llstate = (HashAggregateLocalState &)lstate;
+
+	for (idx_t i = 0; i < radix_tables.size(); i++) {
+		radix_tables[i].Combine(context, *gstate.radix_states[i], *llstate.radix_states[i]);
+	}
+}
+
+class HashAggregateFinalizeEvent : public Event {
+public:
+	HashAggregateFinalizeEvent(const PhysicalHashAggregate &op_p, HashAggregateGlobalState &gstate_p,
+	                           Pipeline *pipeline_p)
+	    : Event(pipeline_p->executor), op(op_p), gstate(gstate_p), pipeline(pipeline_p) {
+	}
+
+	const PhysicalHashAggregate &op;
+	HashAggregateGlobalState &gstate;
+	Pipeline *pipeline;
+
+public:
+	void Schedule() override {
+		vector<unique_ptr<Task>> tasks;
+		for (idx_t i = 0; i < op.radix_tables.size(); i++) {
+			op.radix_tables[i].ScheduleTasks(pipeline->executor, shared_from_this(), *gstate.radix_states[i], tasks);
+		}
+		D_ASSERT(!tasks.empty());
+		SetTasks(move(tasks));
+	}
+};
+
+SinkFinalizeType PhysicalHashAggregate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                 GlobalSinkState &gstate_p) const {
+	auto &gstate = (HashAggregateGlobalState &)gstate_p;
+	bool any_partitioned = false;
+	for (idx_t i = 0; i < gstate.radix_states.size(); i++) {
+		bool is_partitioned = radix_tables[i].Finalize(context, *gstate.radix_states[i]);
+		if (is_partitioned) {
+			any_partitioned = true;
+		}
+	}
+	if (any_partitioned) {
+		auto new_event = make_shared<HashAggregateFinalizeEvent>(*this, gstate, &pipeline);
+		event.InsertEvent(move(new_event));
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PhysicalHashAggregateState : public GlobalSourceState {
+public:
+	explicit PhysicalHashAggregateState(const PhysicalHashAggregate &op) : scan_index(0) {
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetGlobalSourceState());
+		}
+	}
+
+	idx_t scan_index;
+
+	vector<unique_ptr<GlobalSourceState>> radix_states;
+};
+
+unique_ptr<GlobalSourceState> PhysicalHashAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalHashAggregateState>(*this);
+}
+
+void PhysicalHashAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                    LocalSourceState &lstate) const {
+	auto &gstate = (HashAggregateGlobalState &)*sink_state;
+	auto &state = (PhysicalHashAggregateState &)gstate_p;
+	while (state.scan_index < state.radix_states.size()) {
+		radix_tables[state.scan_index].GetData(context, chunk, *gstate.radix_states[state.scan_index],
+		                                       *state.radix_states[state.scan_index]);
+		if (chunk.size() != 0) {
+			return;
+		}
+
+		state.scan_index++;
+	}
+}
+
+string PhysicalHashAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (i > 0 || !groups.empty()) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(ClientContext &context, vector<LogicalType> types_p,
+                                                           vector<unique_ptr<Expression>> aggregates_p,
+                                                           vector<unique_ptr<Expression>> groups_p,
+                                                           vector<unique_ptr<BaseStatistics>> group_stats,
+                                                           vector<idx_t> required_bits_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p), estimated_cardinality),
+      groups(move(groups_p)), aggregates(move(aggregates_p)), required_bits(move(required_bits_p)) {
+	D_ASSERT(groups.size() == group_stats.size());
+	group_minima.reserve(group_stats.size());
+	for (auto &stats : group_stats) {
+		D_ASSERT(stats);
+		auto &nstats = (NumericStatistics &)*stats;
+		D_ASSERT(!nstats.min.IsNull());
+		group_minima.push_back(move(nstats.min));
+	}
+	for (auto &expr : groups) {
+		group_types.push_back(expr->return_type);
+	}
+
+	vector<BoundAggregateExpression *> bindings;
+	vector<LogicalType> payload_types_filters;
+	for (auto &expr : aggregates) {
+		D_ASSERT(expr->expression_class == ExpressionClass::BOUND_AGGREGATE);
+		D_ASSERT(expr->IsAggregate());
+		auto &aggr = (BoundAggregateExpression &)*expr;
+		bindings.push_back(&aggr);
+
+		D_ASSERT(!aggr.distinct);
+		D_ASSERT(aggr.function.combine);
+		for (auto &child : aggr.children) {
+			payload_types.push_back(child->return_type);
+		}
+		if (aggr.filter) {
+			payload_types_filters.push_back(aggr.filter->return_type);
+		}
+	}
+	for (const auto &pay_filters : payload_types_filters) {
+		payload_types.push_back(pay_filters);
+	}
+	aggregate_objects = AggregateObject::CreateAggregateObjects(bindings);
+
+	// filter_indexes must be pre-built, not lazily instantiated in parallel...
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		aggregate_input_idx += aggr.children.size();
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto &bound_ref_expr = (BoundReferenceExpression &)*aggr.filter;
+			auto it = filter_indexes.find(aggr.filter.get());
+			if (it == filter_indexes.end()) {
+				filter_indexes[aggr.filter.get()] = bound_ref_expr.index;
+				bound_ref_expr.index = aggregate_input_idx++;
+			} else {
+				++aggregate_input_idx;
+			}
+		}
+	}
+}
+
+unique_ptr<PerfectAggregateHashTable> PhysicalPerfectHashAggregate::CreateHT(ClientContext &context) const {
+	return make_unique<PerfectAggregateHashTable>(BufferManager::GetBufferManager(context), group_types, payload_types,
+	                                              aggregate_objects, group_minima, required_bits);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class PerfectHashAggregateGlobalState : public GlobalSinkState {
+public:
+	PerfectHashAggregateGlobalState(const PhysicalPerfectHashAggregate &op, ClientContext &context)
+	    : ht(op.CreateHT(context)) {
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The global aggregate hash table
+	unique_ptr<PerfectAggregateHashTable> ht;
+};
+
+class PerfectHashAggregateLocalState : public LocalSinkState {
+public:
+	PerfectHashAggregateLocalState(const PhysicalPerfectHashAggregate &op, ClientContext &context)
+	    : ht(op.CreateHT(context)) {
+		group_chunk.InitializeEmpty(op.group_types);
+		if (!op.payload_types.empty()) {
+			aggregate_input_chunk.InitializeEmpty(op.payload_types);
+		}
+	}
+
+	//! The local aggregate hash table
+	unique_ptr<PerfectAggregateHashTable> ht;
+	DataChunk group_chunk;
+	DataChunk aggregate_input_chunk;
+};
+
+unique_ptr<GlobalSinkState> PhysicalPerfectHashAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<PerfectHashAggregateGlobalState>(*this, context);
+}
+
+unique_ptr<LocalSinkState> PhysicalPerfectHashAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<PerfectHashAggregateLocalState>(*this, context.client);
+}
+
+SinkResultType PhysicalPerfectHashAggregate::Sink(ExecutionContext &context, GlobalSinkState &state,
+                                                  LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &lstate = (PerfectHashAggregateLocalState &)lstate_p;
+	DataChunk &group_chunk = lstate.group_chunk;
+	DataChunk &aggregate_input_chunk = lstate.aggregate_input_chunk;
+
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		auto &group = groups[group_idx];
+		D_ASSERT(group->type == ExpressionType::BOUND_REF);
+		auto &bound_ref_expr = (BoundReferenceExpression &)*group;
+		group_chunk.data[group_idx].Reference(input.data[bound_ref_expr.index]);
+	}
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		for (auto &child_expr : aggr.children) {
+			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
+			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
+		}
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto it = filter_indexes.find(aggr.filter.get());
+			D_ASSERT(it != filter_indexes.end());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[it->second]);
+		}
+	}
+
+	group_chunk.SetCardinality(input.size());
+
+	aggregate_input_chunk.SetCardinality(input.size());
+
+	group_chunk.Verify();
+	aggregate_input_chunk.Verify();
+	D_ASSERT(aggregate_input_chunk.ColumnCount() == 0 || group_chunk.size() == aggregate_input_chunk.size());
+
+	lstate.ht->AddChunk(group_chunk, aggregate_input_chunk);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+void PhysicalPerfectHashAggregate::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                           LocalSinkState &lstate_p) const {
+	auto &lstate = (PerfectHashAggregateLocalState &)lstate_p;
+	auto &gstate = (PerfectHashAggregateGlobalState &)gstate_p;
+
+	lock_guard<mutex> l(gstate.lock);
+	gstate.ht->Combine(*lstate.ht);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PerfectHashAggregateState : public GlobalSourceState {
+public:
+	PerfectHashAggregateState() : ht_scan_position(0) {
+	}
+
+	//! The current position to scan the HT for output tuples
+	idx_t ht_scan_position;
+};
+
+unique_ptr<GlobalSourceState> PhysicalPerfectHashAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PerfectHashAggregateState>();
+}
+
+void PhysicalPerfectHashAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                           LocalSourceState &lstate) const {
+	auto &state = (PerfectHashAggregateState &)gstate_p;
+	auto &gstate = (PerfectHashAggregateGlobalState &)*sink_state;
+
+	gstate.ht->Scan(state.ht_scan_position, chunk);
+}
+
+string PhysicalPerfectHashAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		if (i > 0 || !groups.empty()) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+                                                 idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types), estimated_cardinality),
+      aggregates(move(expressions)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+struct AggregateState {
+	explicit AggregateState(const vector<unique_ptr<Expression>> &aggregate_expressions) {
+		for (auto &aggregate : aggregate_expressions) {
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*aggregate;
+			auto state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size()]);
+			aggr.function.initialize(state.get());
+			aggregates.push_back(move(state));
+			destructors.push_back(aggr.function.destructor);
+		}
+	}
+	~AggregateState() {
+		D_ASSERT(destructors.size() == aggregates.size());
+		for (idx_t i = 0; i < destructors.size(); i++) {
+			if (!destructors[i]) {
+				continue;
+			}
+			Vector state_vector(Value::POINTER((uintptr_t)aggregates[i].get()));
+			state_vector.SetVectorType(VectorType::FLAT_VECTOR);
+
+			destructors[i](state_vector, 1);
+		}
+	}
+
+	void Move(AggregateState &other) {
+		other.aggregates = move(aggregates);
+		other.destructors = move(destructors);
+	}
+
+	//! The aggregate values
+	vector<unique_ptr<data_t[]>> aggregates;
+	// The destructors
+	vector<aggregate_destructor_t> destructors;
+};
+
+class SimpleAggregateGlobalState : public GlobalSinkState {
+public:
+	explicit SimpleAggregateGlobalState(const vector<unique_ptr<Expression>> &aggregates)
+	    : state(aggregates), finished(false) {
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The global aggregate state
+	AggregateState state;
+	//! Whether or not the aggregate is finished
+	bool finished;
+};
+
+class SimpleAggregateLocalState : public LocalSinkState {
+public:
+	explicit SimpleAggregateLocalState(const vector<unique_ptr<Expression>> &aggregates) : state(aggregates) {
+		vector<LogicalType> payload_types;
+		for (auto &aggregate : aggregates) {
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*aggregate;
+			// initialize the payload chunk
+			if (!aggr.children.empty()) {
+				for (auto &child : aggr.children) {
+					payload_types.push_back(child->return_type);
+					child_executor.AddExpression(*child);
+				}
+			}
+		}
+		if (!payload_types.empty()) { // for select count(*) from t; there is no payload at all
+			payload_chunk.Initialize(payload_types);
+		}
+	}
+	void Reset() {
+		payload_chunk.Reset();
+	}
+
+	//! The local aggregate state
+	AggregateState state;
+	//! The executor
+	ExpressionExecutor child_executor;
+	//! The payload chunk
+	DataChunk payload_chunk;
+};
+
+unique_ptr<GlobalSinkState> PhysicalSimpleAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<SimpleAggregateGlobalState>(aggregates);
+}
+
+unique_ptr<LocalSinkState> PhysicalSimpleAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<SimpleAggregateLocalState>(aggregates);
+}
+
+SinkResultType PhysicalSimpleAggregate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &sink = (SimpleAggregateLocalState &)lstate;
+	// perform the aggregation inside the local state
+	idx_t payload_idx = 0, payload_expr_idx = 0;
+	sink.Reset();
+
+	DataChunk &payload_chunk = sink.payload_chunk;
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		DataChunk filtered_input;
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+		idx_t payload_cnt = 0;
+		// resolve the filter (if any)
+		if (aggregate.filter) {
+			ExpressionExecutor filter_execution(aggregate.filter.get());
+			SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+			auto count = filter_execution.SelectExpression(input, true_sel);
+			auto input_types = input.GetTypes();
+			filtered_input.Initialize(input_types);
+			filtered_input.Slice(input, true_sel, count);
+			sink.child_executor.SetChunk(filtered_input);
+			payload_chunk.SetCardinality(count);
+		} else {
+			sink.child_executor.SetChunk(input);
+			payload_chunk.SetCardinality(input);
+		}
+		// resolve the child expressions of the aggregate (if any)
+		if (!aggregate.children.empty()) {
+			for (idx_t i = 0; i < aggregate.children.size(); ++i) {
+				sink.child_executor.ExecuteExpression(payload_expr_idx, payload_chunk.data[payload_idx + payload_cnt]);
+				payload_expr_idx++;
+				payload_cnt++;
+			}
+		}
+
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.simple_update(payload_cnt == 0 ? nullptr : &payload_chunk.data[payload_idx], aggr_input_data,
+		                                 payload_cnt, sink.state.aggregates[aggr_idx].get(), payload_chunk.size());
+		payload_idx += payload_cnt;
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+void PhysicalSimpleAggregate::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
+	auto &gstate = (SimpleAggregateGlobalState &)state;
+	auto &source = (SimpleAggregateLocalState &)lstate;
+	D_ASSERT(!gstate.finished);
+
+	// finalize: combine the local state into the global state
+	// all aggregates are combinable: we might be doing a parallel aggregate
+	// use the combine method to combine the partial aggregates
+	lock_guard<mutex> glock(gstate.lock);
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+		Vector source_state(Value::POINTER((uintptr_t)source.state.aggregates[aggr_idx].get()));
+		Vector dest_state(Value::POINTER((uintptr_t)gstate.state.aggregates[aggr_idx].get()));
+
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.combine(source_state, dest_state, aggr_input_data, 1);
+	}
+
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &source.child_executor, "child_executor", 0);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+SinkFinalizeType PhysicalSimpleAggregate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                   GlobalSinkState &gstate_p) const {
+	auto &gstate = (SimpleAggregateGlobalState &)gstate_p;
+
+	D_ASSERT(!gstate.finished);
+	gstate.finished = true;
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class SimpleAggregateState : public GlobalSourceState {
+public:
+	SimpleAggregateState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalSimpleAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<SimpleAggregateState>();
+}
+
+void PhysicalSimpleAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                      LocalSourceState &lstate) const {
+	auto &gstate = (SimpleAggregateGlobalState &)*sink_state;
+	auto &state = (SimpleAggregateState &)gstate_p;
+	D_ASSERT(gstate.finished);
+	if (state.finished) {
+		return;
+	}
+
+	// initialize the result chunk with the aggregate values
+	chunk.SetCardinality(1);
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+
+		Vector state_vector(Value::POINTER((uintptr_t)gstate.state.aggregates[aggr_idx].get()));
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.finalize(state_vector, aggr_input_data, chunk.data[aggr_idx], 1, 0);
+	}
+	state.finished = true;
+}
+
+string PhysicalSimpleAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (i > 0) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalStreamingWindow::PhysicalStreamingWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                                                 idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(move(select_list)) {
+}
+
+class StreamingWindowGlobalState : public GlobalOperatorState {
+public:
+	StreamingWindowGlobalState() : row_number(1) {
+	}
+
+	//! The next row number.
+	std::atomic<int64_t> row_number;
+};
+
+class StreamingWindowState : public OperatorState {
+public:
+	StreamingWindowState() : initialized(false) {
+	}
+
+	void Initialize(DataChunk &input, const vector<unique_ptr<Expression>> &expressions) {
+		for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
+			auto &expr = *expressions[expr_idx];
+			switch (expr.GetExpressionType()) {
+			case ExpressionType::WINDOW_FIRST_VALUE: {
+				auto &wexpr = (BoundWindowExpression &)expr;
+				auto &ref = (BoundReferenceExpression &)*wexpr.children[0];
+				const_vectors.push_back(make_unique<Vector>(input.data[ref.index].GetValue(0)));
+				break;
+			}
+			case ExpressionType::WINDOW_PERCENT_RANK: {
+				const_vectors.push_back(make_unique<Vector>(Value((double)0)));
+				break;
+			}
+			case ExpressionType::WINDOW_RANK:
+			case ExpressionType::WINDOW_RANK_DENSE: {
+				const_vectors.push_back(make_unique<Vector>(Value((int64_t)1)));
+				break;
+			}
+			default:
+				const_vectors.push_back(nullptr);
+			}
+		}
+		initialized = true;
+	}
+
+public:
+	bool initialized;
+	vector<unique_ptr<Vector>> const_vectors;
+};
+
+unique_ptr<GlobalOperatorState> PhysicalStreamingWindow::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<StreamingWindowGlobalState>();
+}
+
+unique_ptr<OperatorState> PhysicalStreamingWindow::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingWindowState>();
+}
+
+OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (StreamingWindowGlobalState &)gstate_p;
+	auto &state = (StreamingWindowState &)state_p;
+	if (!state.initialized) {
+		state.Initialize(input, select_list);
+	}
+	// Put payload columns in place
+	for (idx_t col_idx = 0; col_idx < input.data.size(); col_idx++) {
+		chunk.data[col_idx].Reference(input.data[col_idx]);
+	}
+	// Compute window function
+	const idx_t count = input.size();
+	for (idx_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
+		idx_t col_idx = input.data.size() + expr_idx;
+		auto &expr = *select_list[expr_idx];
+		switch (expr.GetExpressionType()) {
+		case ExpressionType::WINDOW_FIRST_VALUE:
+		case ExpressionType::WINDOW_PERCENT_RANK:
+		case ExpressionType::WINDOW_RANK:
+		case ExpressionType::WINDOW_RANK_DENSE: {
+			// Reference constant vector
+			chunk.data[col_idx].Reference(*state.const_vectors[expr_idx]);
+			break;
+		}
+		case ExpressionType::WINDOW_ROW_NUMBER: {
+			// Set row numbers
+			auto rdata = FlatVector::GetData<int64_t>(chunk.data[col_idx]);
+			for (idx_t i = 0; i < count; i++) {
+				rdata[i] = gstate.row_number + i;
+			}
+			break;
+		}
+		default:
+			throw NotImplementedException("%s for StreamingWindow", ExpressionTypeToString(expr.GetExpressionType()));
+		}
+	}
+	gstate.row_number += count;
+	chunk.SetCardinality(count);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalStreamingWindow::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += select_list[i]->GetName();
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace duckdb {
+
+using counts_t = std::vector<size_t>;
+
+//	Global sink state
+class WindowGlobalState : public GlobalSinkState {
+public:
+	WindowGlobalState(const PhysicalWindow &op_p, ClientContext &context)
+	    : op(op_p), buffer_manager(BufferManager::GetBufferManager(context)),
+	      mode(DBConfig::GetConfig(context).window_mode) {
+	}
+	const PhysicalWindow &op;
+	BufferManager &buffer_manager;
+	mutex lock;
+	ChunkCollection chunks;
+	ChunkCollection over_collection;
+	ChunkCollection hash_collection;
+	counts_t counts;
+	WindowAggregationMode mode;
+};
+
+//	Per-thread sink state
+class WindowLocalState : public LocalSinkState {
+public:
+	explicit WindowLocalState(const PhysicalWindow &op_p, const unsigned partition_bits = 10)
+	    : op(op_p), partition_count(size_t(1) << partition_bits) {
+	}
+
+	const PhysicalWindow &op;
+	ChunkCollection chunks;
+	ChunkCollection over_collection;
+	ChunkCollection hash_collection;
+	const size_t partition_count;
+	counts_t counts;
+};
+
+// Per-thread read state
+class WindowOperatorState : public LocalSourceState {
+public:
+	WindowOperatorState(const PhysicalWindow &op, ExecutionContext &context)
+	    : buffer_manager(BufferManager::GetBufferManager(context.client)) {
+		auto &gstate = (WindowGlobalState &)*op.sink_state;
+		// initialize thread-local operator state
+		partitions = gstate.counts.size();
+		next_part = 0;
+		position = 0;
+	}
+
+	//! The number of partitions to process (0 if there is no partitioning)
+	size_t partitions;
+	//! The output read position.
+	size_t next_part;
+	//! The generated input chunks
+	ChunkCollection chunks;
+	//! The generated output chunks
+	ChunkCollection window_results;
+	//! The read cursor
+	idx_t position;
+
+	BufferManager &buffer_manager;
+	unique_ptr<GlobalSortState> global_sort_state;
+};
+
+// this implements a sorted window functions variant
+PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(move(select_list)) {
+}
+
+template <typename INPUT_TYPE>
+struct ChunkIterator {
+
+	ChunkIterator(ChunkCollection &collection, const idx_t col_idx)
+	    : collection(collection), col_idx(col_idx), chunk_begin(0), chunk_end(0), ch_idx(0), data(nullptr),
+	      validity(nullptr) {
+		Update(0);
+	}
+
+	inline void Update(idx_t r) {
+		if (r >= chunk_end) {
+			ch_idx = collection.LocateChunk(r);
+			auto &ch = collection.GetChunk(ch_idx);
+			chunk_begin = ch_idx * STANDARD_VECTOR_SIZE;
+			chunk_end = chunk_begin + ch.size();
+			auto &vector = ch.data[col_idx];
+			data = FlatVector::GetData<INPUT_TYPE>(vector);
+			validity = &FlatVector::Validity(vector);
+		}
+	}
+
+	inline bool IsValid(idx_t r) {
+		return validity->RowIsValid(r - chunk_begin);
+	}
+
+	inline INPUT_TYPE GetValue(idx_t r) {
+		return data[r - chunk_begin];
+	}
+
+private:
+	ChunkCollection &collection;
+	idx_t col_idx;
+	idx_t chunk_begin;
+	idx_t chunk_end;
+	idx_t ch_idx;
+	const INPUT_TYPE *data;
+	ValidityMask *validity;
+};
+
+template <typename INPUT_TYPE>
+static void MaskTypedColumn(ValidityMask &mask, ChunkCollection &over_collection, const idx_t c) {
+	ChunkIterator<INPUT_TYPE> ci(over_collection, c);
+
+	//	Record the first value
+	idx_t r = 0;
+	auto prev_valid = ci.IsValid(r);
+	auto prev = ci.GetValue(r);
+
+	//	Process complete blocks
+	const auto count = over_collection.Count();
+	const auto entry_count = mask.EntryCount(count);
+	for (idx_t entry_idx = 0; entry_idx < entry_count; ++entry_idx) {
+		auto validity_entry = mask.GetValidityEntry(entry_idx);
+
+		//	Skip the block if it is all boundaries.
+		idx_t next = MinValue<idx_t>(r + ValidityMask::BITS_PER_VALUE, count);
+		if (ValidityMask::AllValid(validity_entry)) {
+			r = next;
+			continue;
+		}
+
+		//	Scan the rows in the complete block
+		idx_t start = r;
+		for (; r < next; ++r) {
+			//	Update the chunk for this row
+			ci.Update(r);
+
+			auto curr_valid = ci.IsValid(r);
+			auto curr = ci.GetValue(r);
+			if (!ValidityMask::RowIsValid(validity_entry, r - start)) {
+				if (curr_valid != prev_valid || (curr_valid && !Equals::Operation(curr, prev))) {
+					mask.SetValidUnsafe(r);
+				}
+			}
+			prev_valid = curr_valid;
+			prev = curr;
+		}
+	}
+}
+
+static void MaskColumn(ValidityMask &mask, ChunkCollection &over_collection, const idx_t c) {
+	auto &vector = over_collection.GetChunk(0).data[c];
+	switch (vector.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		MaskTypedColumn<int8_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT16:
+		MaskTypedColumn<int16_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT32:
+		MaskTypedColumn<int32_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT64:
+		MaskTypedColumn<int64_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT8:
+		MaskTypedColumn<uint8_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT16:
+		MaskTypedColumn<uint16_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT32:
+		MaskTypedColumn<uint32_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT64:
+		MaskTypedColumn<uint64_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT128:
+		MaskTypedColumn<hugeint_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::FLOAT:
+		MaskTypedColumn<float>(mask, over_collection, c);
+		break;
+	case PhysicalType::DOUBLE:
+		MaskTypedColumn<double>(mask, over_collection, c);
+		break;
+	case PhysicalType::VARCHAR:
+		MaskTypedColumn<string_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INTERVAL:
+		MaskTypedColumn<interval_t>(mask, over_collection, c);
+		break;
+	default:
+		throw NotImplementedException("Type for comparison");
+		break;
+	}
+}
+
+static idx_t FindNextStart(const ValidityMask &mask, idx_t l, const idx_t r, idx_t &n) {
+	if (mask.AllValid()) {
+		auto start = MinValue(l + n - 1, r);
+		n -= MinValue(n, r - l);
+		return start;
+	}
+
+	while (l < r) {
+		//	If l is aligned with the start of a block, and the block is blank, then skip forward one block.
+		idx_t entry_idx;
+		idx_t shift;
+		mask.GetEntryIndex(l, entry_idx, shift);
+
+		const auto block = mask.GetValidityEntry(entry_idx);
+		if (mask.NoneValid(block) && !shift) {
+			l += ValidityMask::BITS_PER_VALUE;
+			continue;
+		}
+
+		// Loop over the block
+		for (; shift < ValidityMask::BITS_PER_VALUE && l < r; ++shift, ++l) {
+			if (mask.RowIsValid(block, shift) && --n == 0) {
+				return MinValue(l, r);
+			}
+		}
+	}
+
+	//	Didn't find a start so return the end of the range
+	return r;
+}
+
+static idx_t FindPrevStart(const ValidityMask &mask, const idx_t l, idx_t r, idx_t &n) {
+	if (mask.AllValid()) {
+		auto start = (r <= l + n) ? l : r - n;
+		n -= r - start;
+		return start;
+	}
+
+	while (l < r) {
+		// If r is aligned with the start of a block, and the previous block is blank,
+		// then skip backwards one block.
+		idx_t entry_idx;
+		idx_t shift;
+		mask.GetEntryIndex(r - 1, entry_idx, shift);
+
+		const auto block = mask.GetValidityEntry(entry_idx);
+		if (mask.NoneValid(block) && (shift + 1 == ValidityMask::BITS_PER_VALUE)) {
+			// r is nonzero (> l) and word aligned, so this will not underflow.
+			r -= ValidityMask::BITS_PER_VALUE;
+			continue;
+		}
+
+		// Loop backwards over the block
+		// shift is probing r-1 >= l >= 0
+		for (++shift; shift-- > 0; --r) {
+			if (mask.RowIsValid(block, shift) && --n == 0) {
+				return MaxValue(l, r - 1);
+			}
+		}
+	}
+
+	//	Didn't find a start so return the start of the range
+	return l;
+}
+
+static void MaterializeExpressions(Expression **exprs, idx_t expr_count, ChunkCollection &input,
+                                   ChunkCollection &output, bool scalar = false) {
+	if (expr_count == 0) {
+		return;
+	}
+
+	vector<LogicalType> types;
+	ExpressionExecutor executor;
+	for (idx_t expr_idx = 0; expr_idx < expr_count; ++expr_idx) {
+		types.push_back(exprs[expr_idx]->return_type);
+		executor.AddExpression(*exprs[expr_idx]);
+	}
+
+	for (idx_t i = 0; i < input.ChunkCount(); i++) {
+		DataChunk chunk;
+		chunk.Initialize(types);
+
+		executor.Execute(input.GetChunk(i), chunk);
+
+		chunk.Verify();
+		output.Append(chunk);
+
+		if (scalar) {
+			break;
+		}
+	}
+}
+
+static void MaterializeExpression(Expression *expr, ChunkCollection &input, ChunkCollection &output,
+                                  bool scalar = false) {
+	MaterializeExpressions(&expr, 1, input, output, scalar);
+}
+
+static void SortCollectionForPartition(WindowOperatorState &state, BoundWindowExpression *wexpr, ChunkCollection &input,
+                                       ChunkCollection &over, ChunkCollection *hashes, const hash_t hash_bin,
+                                       const hash_t hash_mask) {
+	if (input.Count() == 0) {
+		return;
+	}
+
+	vector<BoundOrderByNode> orders;
+	// we sort by both 1) partition by expression list and 2) order by expressions
+	for (idx_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
+		if (wexpr->partitions_stats.empty() || !wexpr->partitions_stats[prt_idx]) {
+			orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, wexpr->partitions[prt_idx]->Copy(),
+			                    nullptr);
+		} else {
+			orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, wexpr->partitions[prt_idx]->Copy(),
+			                    wexpr->partitions_stats[prt_idx]->Copy());
+		}
+	}
+	for (const auto &order : wexpr->orders) {
+		orders.push_back(order.Copy());
+	}
+
+	// fuse input and sort collection into one
+	// (sorting columns are not decoded, and we need them later)
+	auto payload_types = input.Types();
+	payload_types.insert(payload_types.end(), over.Types().begin(), over.Types().end());
+	DataChunk payload_chunk;
+	payload_chunk.InitializeEmpty(payload_types);
+
+	// initialise partitioning memory
+	// to minimise copying, we fill up a chunk and then sink it.
+	SelectionVector sel;
+	DataChunk over_partition;
+	DataChunk payload_partition;
+	if (hashes) {
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		over_partition.Initialize(over.Types());
+		payload_partition.Initialize(payload_types);
+	}
+
+	// initialize row layout for sorting
+	RowLayout payload_layout;
+	payload_layout.Initialize(payload_types);
+
+	// initialize sorting states
+	state.global_sort_state = make_unique<GlobalSortState>(state.buffer_manager, orders, payload_layout);
+	auto &global_sort_state = *state.global_sort_state;
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(global_sort_state, state.buffer_manager);
+
+	// sink collection chunks into row format
+	const idx_t chunk_count = over.ChunkCount();
+	for (idx_t i = 0; i < chunk_count; i++) {
+		auto &input_chunk = *input.Chunks()[i];
+		for (idx_t col_idx = 0; col_idx < input_chunk.ColumnCount(); ++col_idx) {
+			payload_chunk.data[col_idx].Reference(input_chunk.data[col_idx]);
+		}
+		auto &over_chunk = *over.Chunks()[i];
+		for (idx_t col_idx = 0; col_idx < over_chunk.ColumnCount(); ++col_idx) {
+			payload_chunk.data[input_chunk.ColumnCount() + col_idx].Reference(over_chunk.data[col_idx]);
+		}
+		payload_chunk.SetCardinality(input_chunk);
+
+		// Extract the hash partition, if any
+		if (hashes) {
+			auto &hash_chunk = *hashes->Chunks()[i];
+			auto hash_size = hash_chunk.size();
+			auto hash_data = FlatVector::GetData<hash_t>(hash_chunk.data[0]);
+			idx_t bin_size = 0;
+			for (idx_t i = 0; i < hash_size; ++i) {
+				if ((hash_data[i] & hash_mask) == hash_bin) {
+					sel.set_index(bin_size++, i);
+				}
+			}
+
+			// Flush the partition chunks if we would overflow
+			if (over_partition.size() + bin_size > STANDARD_VECTOR_SIZE) {
+				local_sort_state.SinkChunk(over_partition, payload_partition);
+				over_partition.Reset();
+				payload_partition.Reset();
+			}
+
+			// Copy the data for each collection.
+			if (bin_size) {
+				over_partition.Append(over_chunk, false, &sel, bin_size);
+				payload_partition.Append(payload_chunk, false, &sel, bin_size);
+			}
+		} else {
+			local_sort_state.SinkChunk(over_chunk, payload_chunk);
+		}
+	}
+
+	// Flush any ragged partition chunks
+	if (over_partition.size() > 0) {
+		local_sort_state.SinkChunk(over_partition, payload_partition);
+		over_partition.Reset();
+		payload_partition.Reset();
+	}
+
+	// If there are no hashes, release the input to save memory.
+	if (!hashes) {
+		over.Reset();
+		input.Reset();
+	}
+
+	// add local state to global state, which sorts the data
+	global_sort_state.AddLocalState(local_sort_state);
+	// Prepare for merge phase (in this case we never have a merge phase, but this call is still needed)
+	global_sort_state.PrepareMergePhase();
+}
+
+static void ScanSortedPartition(WindowOperatorState &state, ChunkCollection &input,
+                                const vector<LogicalType> &input_types, ChunkCollection &over,
+                                const vector<LogicalType> &over_types) {
+	auto &global_sort_state = *state.global_sort_state;
+
+	auto payload_types = input_types;
+	payload_types.insert(payload_types.end(), over_types.begin(), over_types.end());
+
+	// scan the sorted row data
+	PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+	for (;;) {
+		DataChunk payload_chunk;
+		payload_chunk.Initialize(payload_types);
+		payload_chunk.SetCardinality(0);
+		scanner.Scan(payload_chunk);
+		if (payload_chunk.size() == 0) {
+			break;
+		}
+
+		// split into two
+		DataChunk over_chunk;
+		payload_chunk.Split(over_chunk, input_types.size());
+
+		// append back to collection
+		input.Append(payload_chunk);
+		over.Append(over_chunk);
+	}
+}
+
+static void HashChunk(counts_t &counts, DataChunk &hash_chunk, DataChunk &sort_chunk, const idx_t partition_cols) {
+	const vector<LogicalType> hash_types(1, LogicalType::HASH);
+	hash_chunk.Initialize(hash_types);
+	hash_chunk.SetCardinality(sort_chunk);
+	auto &hash_vector = hash_chunk.data[0];
+
+	const auto count = sort_chunk.size();
+	VectorOperations::Hash(sort_chunk.data[0], hash_vector, count);
+	for (idx_t prt_idx = 1; prt_idx < partition_cols; ++prt_idx) {
+		VectorOperations::CombineHash(hash_vector, sort_chunk.data[prt_idx], count);
+	}
+
+	const auto partition_mask = hash_t(counts.size() - 1);
+	auto hashes = FlatVector::GetData<hash_t>(hash_vector);
+	if (hash_vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		const auto bin = (hashes[0] & partition_mask);
+		counts[bin] += count;
+	} else {
+		for (idx_t i = 0; i < count; ++i) {
+			const auto bin = (hashes[i] & partition_mask);
+			++counts[bin];
+		}
+	}
+}
+
+static void MaterializeOverForWindow(BoundWindowExpression *wexpr, DataChunk &input_chunk, DataChunk &over_chunk) {
+	vector<LogicalType> over_types;
+	ExpressionExecutor executor;
+
+	// we sort by both 1) partition by expression list and 2) order by expressions
+	for (idx_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
+		auto &pexpr = wexpr->partitions[prt_idx];
+		over_types.push_back(pexpr->return_type);
+		executor.AddExpression(*pexpr);
+	}
+
+	for (idx_t ord_idx = 0; ord_idx < wexpr->orders.size(); ord_idx++) {
+		auto &oexpr = wexpr->orders[ord_idx].expression;
+		over_types.push_back(oexpr->return_type);
+		executor.AddExpression(*oexpr);
+	}
+
+	D_ASSERT(!over_types.empty());
+
+	over_chunk.Initialize(over_types);
+	executor.Execute(input_chunk, over_chunk);
+
+	over_chunk.Verify();
+}
+
+static inline bool BoundaryNeedsPeer(const WindowBoundary &boundary) {
+	switch (boundary) {
+	case WindowBoundary::CURRENT_ROW_RANGE:
+	case WindowBoundary::EXPR_PRECEDING_RANGE:
+	case WindowBoundary::EXPR_FOLLOWING_RANGE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+struct WindowBoundariesState {
+	static inline bool IsScalar(const unique_ptr<Expression> &expr) {
+		return expr ? expr->IsScalar() : true;
+	}
+
+	explicit WindowBoundariesState(BoundWindowExpression *wexpr)
+	    : type(wexpr->type), start_boundary(wexpr->start), end_boundary(wexpr->end),
+	      partition_count(wexpr->partitions.size()), order_count(wexpr->orders.size()),
+	      range_sense(wexpr->orders.empty() ? OrderType::INVALID : wexpr->orders[0].type),
+	      scalar_start(IsScalar(wexpr->start_expr)), scalar_end(IsScalar(wexpr->end_expr)),
+	      has_preceding_range(wexpr->start == WindowBoundary::EXPR_PRECEDING_RANGE ||
+	                          wexpr->end == WindowBoundary::EXPR_PRECEDING_RANGE),
+	      has_following_range(wexpr->start == WindowBoundary::EXPR_FOLLOWING_RANGE ||
+	                          wexpr->end == WindowBoundary::EXPR_FOLLOWING_RANGE),
+	      needs_peer(BoundaryNeedsPeer(wexpr->end) || wexpr->type == ExpressionType::WINDOW_CUME_DIST) {
+	}
+
+	// Cached lookups
+	const ExpressionType type;
+	const WindowBoundary start_boundary;
+	const WindowBoundary end_boundary;
+	const idx_t partition_count;
+	const idx_t order_count;
+	const OrderType range_sense;
+	const bool scalar_start;
+	const bool scalar_end;
+	const bool has_preceding_range;
+	const bool has_following_range;
+	const bool needs_peer;
+
+	idx_t partition_start = 0;
+	idx_t partition_end = 0;
+	idx_t peer_start = 0;
+	idx_t peer_end = 0;
+	idx_t valid_start = 0;
+	idx_t valid_end = 0;
+	int64_t window_start = -1;
+	int64_t window_end = -1;
+	bool is_same_partition = false;
+	bool is_peer = false;
+};
+
+static bool WindowNeedsRank(BoundWindowExpression *wexpr) {
+	return wexpr->type == ExpressionType::WINDOW_PERCENT_RANK || wexpr->type == ExpressionType::WINDOW_RANK ||
+	       wexpr->type == ExpressionType::WINDOW_RANK_DENSE || wexpr->type == ExpressionType::WINDOW_CUME_DIST;
+}
+
+template <typename T>
+static T GetCell(ChunkCollection &collection, idx_t column, idx_t index) {
+	D_ASSERT(collection.ColumnCount() > column);
+	auto &chunk = collection.GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	const auto data = FlatVector::GetData<T>(source);
+	return data[source_offset];
+}
+
+static bool CellIsNull(ChunkCollection &collection, idx_t column, idx_t index) {
+	D_ASSERT(collection.ColumnCount() > column);
+	auto &chunk = collection.GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	return FlatVector::IsNull(source, source_offset);
+}
+
+template <typename T>
+struct ChunkCollectionIterator {
+	using iterator = ChunkCollectionIterator<T>;
+	using iterator_category = std::forward_iterator_tag;
+	using difference_type = std::ptrdiff_t;
+	using value_type = T;
+	using reference = T;
+	using pointer = idx_t;
+
+	ChunkCollectionIterator(ChunkCollection &coll_p, idx_t col_no_p, pointer pos_p = 0)
+	    : coll(&coll_p), col_no(col_no_p), pos(pos_p) {
+	}
+
+	inline reference operator*() const {
+		return GetCell<T>(*coll, col_no, pos);
+	}
+	inline explicit operator pointer() const {
+		return pos;
+	}
+
+	inline iterator &operator++() {
+		++pos;
+		return *this;
+	}
+	inline iterator operator++(int) {
+		auto result = *this;
+		++(*this);
+		return result;
+	}
+
+	friend inline bool operator==(const iterator &a, const iterator &b) {
+		return a.pos == b.pos;
+	}
+	friend inline bool operator!=(const iterator &a, const iterator &b) {
+		return a.pos != b.pos;
+	}
+
+private:
+	ChunkCollection *coll;
+	idx_t col_no;
+	pointer pos;
+};
+
+template <typename T, typename OP>
+struct OperationCompare : public std::function<bool(T, T)> {
+	inline bool operator()(const T &lhs, const T &val) const {
+		return OP::template Operation(lhs, val);
+	}
+};
+
+template <typename T, typename OP, bool FROM>
+static idx_t FindTypedRangeBound(ChunkCollection &over, const idx_t order_col, const idx_t order_begin,
+                                 const idx_t order_end, ChunkCollection &boundary, const idx_t boundary_row) {
+	D_ASSERT(!CellIsNull(boundary, 0, boundary_row));
+	const auto val = GetCell<T>(boundary, 0, boundary_row);
+
+	OperationCompare<T, OP> comp;
+	ChunkCollectionIterator<T> begin(over, order_col, order_begin);
+	ChunkCollectionIterator<T> end(over, order_col, order_end);
+	if (FROM) {
+		return idx_t(std::lower_bound(begin, end, val, comp));
+	} else {
+		return idx_t(std::upper_bound(begin, end, val, comp));
+	}
+}
+
+template <typename OP, bool FROM>
+static idx_t FindRangeBound(ChunkCollection &over, const idx_t order_col, const idx_t order_begin,
+                            const idx_t order_end, ChunkCollection &boundary, const idx_t expr_idx) {
+	const auto &over_types = over.Types();
+	D_ASSERT(over_types.size() > order_col);
+	D_ASSERT(boundary.Types().size() == 1);
+	D_ASSERT(boundary.Types()[0] == over_types[order_col]);
+
+	switch (over_types[order_col].InternalType()) {
+	case PhysicalType::INT8:
+		return FindTypedRangeBound<int8_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT16:
+		return FindTypedRangeBound<int16_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT32:
+		return FindTypedRangeBound<int32_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT64:
+		return FindTypedRangeBound<int64_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT8:
+		return FindTypedRangeBound<uint8_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT16:
+		return FindTypedRangeBound<uint16_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT32:
+		return FindTypedRangeBound<uint32_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT64:
+		return FindTypedRangeBound<uint64_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT128:
+		return FindTypedRangeBound<hugeint_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::FLOAT:
+		return FindTypedRangeBound<float, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::DOUBLE:
+		return FindTypedRangeBound<double, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INTERVAL:
+		return FindTypedRangeBound<interval_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	default:
+		throw InternalException("Unsupported column type for RANGE");
+	}
+}
+
+template <bool FROM>
+static idx_t FindOrderedRangeBound(ChunkCollection &over, const idx_t order_col, const OrderType range_sense,
+                                   const idx_t order_begin, const idx_t order_end, ChunkCollection &boundary,
+                                   const idx_t expr_idx) {
+	switch (range_sense) {
+	case OrderType::ASCENDING:
+		return FindRangeBound<LessThan, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case OrderType::DESCENDING:
+		return FindRangeBound<GreaterThan, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	default:
+		throw InternalException("Unsupported ORDER BY sense for RANGE");
+	}
+}
+
+static void UpdateWindowBoundaries(WindowBoundariesState &bounds, const idx_t input_size, const idx_t row_idx,
+                                   ChunkCollection &over_collection, ChunkCollection &boundary_start_collection,
+                                   ChunkCollection &boundary_end_collection, const ValidityMask &partition_mask,
+                                   const ValidityMask &order_mask) {
+
+	// RANGE sorting parameters
+	const auto order_col = bounds.partition_count;
+
+	if (bounds.partition_count + bounds.order_count > 0) {
+
+		// determine partition and peer group boundaries to ultimately figure out window size
+		bounds.is_same_partition = !partition_mask.RowIsValidUnsafe(row_idx);
+		bounds.is_peer = !order_mask.RowIsValidUnsafe(row_idx);
+
+		// when the partition changes, recompute the boundaries
+		if (!bounds.is_same_partition) {
+			bounds.partition_start = row_idx;
+			bounds.peer_start = row_idx;
+
+			// find end of partition
+			bounds.partition_end = input_size;
+			if (bounds.partition_count) {
+				idx_t n = 1;
+				bounds.partition_end = FindNextStart(partition_mask, bounds.partition_start + 1, input_size, n);
+			}
+
+			// Find valid ordering values for the new partition
+			// so we can exclude NULLs from RANGE expression computations
+			bounds.valid_start = bounds.partition_start;
+			bounds.valid_end = bounds.partition_end;
+
+			if ((bounds.valid_start < bounds.valid_end) && bounds.has_preceding_range) {
+				// Exclude any leading NULLs
+				if (CellIsNull(over_collection, order_col, bounds.valid_start)) {
+					idx_t n = 1;
+					bounds.valid_start = FindNextStart(order_mask, bounds.valid_start + 1, bounds.valid_end, n);
+				}
+			}
+
+			if ((bounds.valid_start < bounds.valid_end) && bounds.has_following_range) {
+				// Exclude any trailing NULLs
+				if (CellIsNull(over_collection, order_col, bounds.valid_end - 1)) {
+					idx_t n = 1;
+					bounds.valid_end = FindPrevStart(order_mask, bounds.valid_start, bounds.valid_end, n);
+				}
+			}
+
+		} else if (!bounds.is_peer) {
+			bounds.peer_start = row_idx;
+		}
+
+		if (bounds.needs_peer) {
+			bounds.peer_end = bounds.partition_end;
+			if (bounds.order_count) {
+				idx_t n = 1;
+				bounds.peer_end = FindNextStart(order_mask, bounds.peer_start + 1, bounds.partition_end, n);
+			}
+		}
+
+	} else {
+		bounds.is_same_partition = false;
+		bounds.is_peer = true;
+		bounds.partition_end = input_size;
+		bounds.peer_end = bounds.partition_end;
+	}
+
+	// determine window boundaries depending on the type of expression
+	bounds.window_start = -1;
+	bounds.window_end = -1;
+
+	switch (bounds.start_boundary) {
+	case WindowBoundary::UNBOUNDED_PRECEDING:
+		bounds.window_start = bounds.partition_start;
+		break;
+	case WindowBoundary::CURRENT_ROW_ROWS:
+		bounds.window_start = row_idx;
+		break;
+	case WindowBoundary::CURRENT_ROW_RANGE:
+		bounds.window_start = bounds.peer_start;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_ROWS: {
+		bounds.window_start =
+		    (int64_t)row_idx - GetCell<int64_t>(boundary_start_collection, 0, bounds.scalar_start ? 0 : row_idx);
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_ROWS: {
+		bounds.window_start =
+		    row_idx + GetCell<int64_t>(boundary_start_collection, 0, bounds.scalar_start ? 0 : row_idx);
+		break;
+	}
+	case WindowBoundary::EXPR_PRECEDING_RANGE: {
+		const auto expr_idx = bounds.scalar_start ? 0 : row_idx;
+		if (CellIsNull(boundary_start_collection, 0, expr_idx)) {
+			bounds.window_start = bounds.peer_start;
+		} else {
+			bounds.window_start =
+			    FindOrderedRangeBound<true>(over_collection, order_col, bounds.range_sense, bounds.valid_start, row_idx,
+			                                boundary_start_collection, expr_idx);
+		}
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_RANGE: {
+		const auto expr_idx = bounds.scalar_start ? 0 : row_idx;
+		if (CellIsNull(boundary_start_collection, 0, expr_idx)) {
+			bounds.window_start = bounds.peer_start;
+		} else {
+			bounds.window_start = FindOrderedRangeBound<true>(over_collection, order_col, bounds.range_sense, row_idx,
+			                                                  bounds.valid_end, boundary_start_collection, expr_idx);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unsupported window start boundary");
+	}
+
+	switch (bounds.end_boundary) {
+	case WindowBoundary::CURRENT_ROW_ROWS:
+		bounds.window_end = row_idx + 1;
+		break;
+	case WindowBoundary::CURRENT_ROW_RANGE:
+		bounds.window_end = bounds.peer_end;
+		break;
+	case WindowBoundary::UNBOUNDED_FOLLOWING:
+		bounds.window_end = bounds.partition_end;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_ROWS:
+		bounds.window_end =
+		    (int64_t)row_idx - GetCell<int64_t>(boundary_end_collection, 0, bounds.scalar_end ? 0 : row_idx) + 1;
+		break;
+	case WindowBoundary::EXPR_FOLLOWING_ROWS:
+		bounds.window_end = row_idx + GetCell<int64_t>(boundary_end_collection, 0, bounds.scalar_end ? 0 : row_idx) + 1;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_RANGE: {
+		const auto expr_idx = bounds.scalar_end ? 0 : row_idx;
+		if (CellIsNull(boundary_end_collection, 0, expr_idx)) {
+			bounds.window_end = bounds.peer_end;
+		} else {
+			bounds.window_end =
+			    FindOrderedRangeBound<false>(over_collection, order_col, bounds.range_sense, bounds.valid_start,
+			                                 row_idx, boundary_end_collection, expr_idx);
+		}
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_RANGE: {
+		const auto expr_idx = bounds.scalar_end ? 0 : row_idx;
+		if (CellIsNull(boundary_end_collection, 0, expr_idx)) {
+			bounds.window_end = bounds.peer_end;
+		} else {
+			bounds.window_end = FindOrderedRangeBound<false>(over_collection, order_col, bounds.range_sense, row_idx,
+			                                                 bounds.valid_end, boundary_end_collection, expr_idx);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unsupported window end boundary");
+	}
+
+	// clamp windows to partitions if they should exceed
+	if (bounds.window_start < (int64_t)bounds.partition_start) {
+		bounds.window_start = bounds.partition_start;
+	}
+	if (bounds.window_start > (int64_t)bounds.partition_end) {
+		bounds.window_start = bounds.partition_end;
+	}
+	if (bounds.window_end < (int64_t)bounds.partition_start) {
+		bounds.window_end = bounds.partition_start;
+	}
+	if (bounds.window_end > (int64_t)bounds.partition_end) {
+		bounds.window_end = bounds.partition_end;
+	}
+
+	if (bounds.window_start < 0 || bounds.window_end < 0) {
+		throw InternalException("Failed to compute window boundaries");
+	}
+}
+
+static void ComputeWindowExpression(BoundWindowExpression *wexpr, ChunkCollection &input, ChunkCollection &output,
+                                    ChunkCollection &over, const ValidityMask &partition_mask,
+                                    const ValidityMask &order_mask, WindowAggregationMode mode) {
+
+	// TODO we could evaluate those expressions in parallel
+
+	// evaluate inner expressions of window functions, could be more complex
+	ChunkCollection payload_collection;
+	vector<Expression *> exprs;
+	for (auto &child : wexpr->children) {
+		exprs.push_back(child.get());
+	}
+	// TODO: child may be a scalar, don't need to materialize the whole collection then
+	MaterializeExpressions(exprs.data(), exprs.size(), input, payload_collection);
+
+	ChunkCollection leadlag_offset_collection;
+	ChunkCollection leadlag_default_collection;
+	if (wexpr->type == ExpressionType::WINDOW_LEAD || wexpr->type == ExpressionType::WINDOW_LAG) {
+		if (wexpr->offset_expr) {
+			MaterializeExpression(wexpr->offset_expr.get(), input, leadlag_offset_collection,
+			                      wexpr->offset_expr->IsScalar());
+		}
+		if (wexpr->default_expr) {
+			MaterializeExpression(wexpr->default_expr.get(), input, leadlag_default_collection,
+			                      wexpr->default_expr->IsScalar());
+		}
+	}
+
+	// evaluate the FILTER clause and stuff it into a large mask for compactness and reuse
+	ValidityMask filter_mask;
+	vector<validity_t> filter_bits;
+	if (wexpr->filter_expr) {
+		// 	Start with all invalid and set the ones that pass
+		filter_bits.resize(ValidityMask::ValidityMaskSize(input.Count()), 0);
+		filter_mask.Initialize(filter_bits.data());
+		ExpressionExecutor filter_execution(*wexpr->filter_expr);
+		SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+		idx_t base_idx = 0;
+		for (auto &chunk : input.Chunks()) {
+			const auto filtered = filter_execution.SelectExpression(*chunk, true_sel);
+			for (idx_t f = 0; f < filtered; ++f) {
+				filter_mask.SetValid(base_idx + true_sel[f]);
+			}
+			base_idx += chunk->size();
+		}
+	}
+
+	// evaluate boundaries if present. Parser has checked boundary types.
+	ChunkCollection boundary_start_collection;
+	if (wexpr->start_expr) {
+		MaterializeExpression(wexpr->start_expr.get(), input, boundary_start_collection, wexpr->start_expr->IsScalar());
+	}
+
+	ChunkCollection boundary_end_collection;
+	if (wexpr->end_expr) {
+		MaterializeExpression(wexpr->end_expr.get(), input, boundary_end_collection, wexpr->end_expr->IsScalar());
+	}
+
+	// Set up a validity mask for IGNORE NULLS
+	ValidityMask ignore_nulls;
+	if (wexpr->ignore_nulls) {
+		switch (wexpr->type) {
+		case ExpressionType::WINDOW_LEAD:
+		case ExpressionType::WINDOW_LAG:
+		case ExpressionType::WINDOW_FIRST_VALUE:
+		case ExpressionType::WINDOW_LAST_VALUE:
+		case ExpressionType::WINDOW_NTH_VALUE: {
+			idx_t pos = 0;
+			for (auto &chunk : payload_collection.Chunks()) {
+				const auto count = chunk->size();
+				VectorData vdata;
+				chunk->data[0].Orrify(count, vdata);
+				if (!vdata.validity.AllValid()) {
+					//	Lazily materialise the contents when we find the first NULL
+					if (ignore_nulls.AllValid()) {
+						ignore_nulls.Initialize(payload_collection.Count());
+					}
+					// Write to the current position
+					// Chunks in a collection are full, so we don't have to worry about raggedness
+					auto dst = ignore_nulls.GetData() + ignore_nulls.EntryCount(pos);
+					auto src = vdata.validity.GetData();
+					for (auto entry_count = vdata.validity.EntryCount(count); entry_count-- > 0;) {
+						*dst++ = *src++;
+					}
+				}
+				pos += count;
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	// build a segment tree for frame-adhering aggregates
+	// see http://www.vldb.org/pvldb/vol8/p1058-leis.pdf
+	unique_ptr<WindowSegmentTree> segment_tree = nullptr;
+
+	if (wexpr->aggregate) {
+		segment_tree = make_unique<WindowSegmentTree>(*(wexpr->aggregate), wexpr->bind_info.get(), wexpr->return_type,
+		                                              &payload_collection, filter_mask, mode);
+	}
+
+	WindowBoundariesState bounds(wexpr);
+	uint64_t dense_rank = 1, rank_equal = 0, rank = 1;
+
+	// this is the main loop, go through all sorted rows and compute window function result
+	const vector<LogicalType> output_types(1, wexpr->return_type);
+	DataChunk output_chunk;
+	output_chunk.Initialize(output_types);
+	for (idx_t row_idx = 0; row_idx < input.Count(); row_idx++) {
+		// Grow the chunk if necessary.
+		const auto output_offset = row_idx % STANDARD_VECTOR_SIZE;
+		if (output_offset == 0) {
+			output.Append(output_chunk);
+			output_chunk.Reset();
+			output_chunk.SetCardinality(MinValue(idx_t(STANDARD_VECTOR_SIZE), input.Count() - row_idx));
+		}
+		auto &result = output_chunk.data[0];
+
+		// special case, OVER (), aggregate over everything
+		UpdateWindowBoundaries(bounds, input.Count(), row_idx, over, boundary_start_collection, boundary_end_collection,
+		                       partition_mask, order_mask);
+		if (WindowNeedsRank(wexpr)) {
+			if (!bounds.is_same_partition || row_idx == 0) { // special case for first row, need to init
+				dense_rank = 1;
+				rank = 1;
+				rank_equal = 0;
+			} else if (!bounds.is_peer) {
+				dense_rank++;
+				rank += rank_equal;
+				rank_equal = 0;
+			}
+			rank_equal++;
+		}
+
+		// if no values are read for window, result is NULL
+		if (bounds.window_start >= bounds.window_end) {
+			FlatVector::SetNull(result, output_offset, true);
+			continue;
+		}
+
+		switch (wexpr->type) {
+		case ExpressionType::WINDOW_AGGREGATE: {
+			segment_tree->Compute(result, output_offset, bounds.window_start, bounds.window_end);
+			break;
+		}
+		case ExpressionType::WINDOW_ROW_NUMBER: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = row_idx - bounds.partition_start + 1;
+			break;
+		}
+		case ExpressionType::WINDOW_RANK_DENSE: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = dense_rank;
+			break;
+		}
+		case ExpressionType::WINDOW_RANK: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = rank;
+			break;
+		}
+		case ExpressionType::WINDOW_PERCENT_RANK: {
+			int64_t denom = (int64_t)bounds.partition_end - bounds.partition_start - 1;
+			double percent_rank = denom > 0 ? ((double)rank - 1) / denom : 0;
+			auto rdata = FlatVector::GetData<double>(result);
+			rdata[output_offset] = percent_rank;
+			break;
+		}
+		case ExpressionType::WINDOW_CUME_DIST: {
+			int64_t denom = (int64_t)bounds.partition_end - bounds.partition_start;
+			double cume_dist = denom > 0 ? ((double)(bounds.peer_end - bounds.partition_start)) / denom : 0;
+			auto rdata = FlatVector::GetData<double>(result);
+			rdata[output_offset] = cume_dist;
+			break;
+		}
+		case ExpressionType::WINDOW_NTILE: {
+			D_ASSERT(payload_collection.ColumnCount() == 1);
+			auto n_param = GetCell<int64_t>(payload_collection, 0, row_idx);
+			// With thanks from SQLite's ntileValueFunc()
+			int64_t n_total = bounds.partition_end - bounds.partition_start;
+			if (n_param > n_total) {
+				// more groups allowed than we have values
+				// map every entry to a unique group
+				n_param = n_total;
+			}
+			int64_t n_size = (n_total / n_param);
+			// find the row idx within the group
+			D_ASSERT(row_idx >= bounds.partition_start);
+			int64_t adjusted_row_idx = row_idx - bounds.partition_start;
+			// now compute the ntile
+			int64_t n_large = n_total - n_param * n_size;
+			int64_t i_small = n_large * (n_size + 1);
+			int64_t result_ntile;
+
+			D_ASSERT((n_large * (n_size + 1) + (n_param - n_large) * n_size) == n_total);
+
+			if (adjusted_row_idx < i_small) {
+				result_ntile = 1 + adjusted_row_idx / (n_size + 1);
+			} else {
+				result_ntile = 1 + n_large + (adjusted_row_idx - i_small) / n_size;
+			}
+			// result has to be between [1, NTILE]
+			D_ASSERT(result_ntile >= 1 && result_ntile <= n_param);
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = result_ntile;
+			break;
+		}
+		case ExpressionType::WINDOW_LEAD:
+		case ExpressionType::WINDOW_LAG: {
+			int64_t offset = 1;
+			if (wexpr->offset_expr) {
+				offset = GetCell<int64_t>(leadlag_offset_collection, 0, wexpr->offset_expr->IsScalar() ? 0 : row_idx);
+			}
+			int64_t val_idx = (int64_t)row_idx;
+			if (wexpr->type == ExpressionType::WINDOW_LEAD) {
+				val_idx += offset;
+			} else {
+				val_idx -= offset;
+			}
+
+			idx_t delta = 0;
+			if (val_idx < (int64_t)row_idx) {
+				// Count backwards
+				delta = idx_t(row_idx - val_idx);
+				val_idx = FindPrevStart(ignore_nulls, bounds.partition_start, row_idx, delta);
+			} else if (val_idx > (int64_t)row_idx) {
+				delta = idx_t(val_idx - row_idx);
+				val_idx = FindNextStart(ignore_nulls, row_idx + 1, bounds.partition_end, delta);
+			}
+			// else offset is zero, so don't move.
+
+			if (!delta) {
+				payload_collection.CopyCell(0, val_idx, result, output_offset);
+			} else if (wexpr->default_expr) {
+				const auto source_row = wexpr->default_expr->IsScalar() ? 0 : row_idx;
+				leadlag_default_collection.CopyCell(0, source_row, result, output_offset);
+			} else {
+				FlatVector::SetNull(result, output_offset, true);
+			}
+			break;
+		}
+		case ExpressionType::WINDOW_FIRST_VALUE: {
+			idx_t n = 1;
+			const auto first_idx = FindNextStart(ignore_nulls, bounds.window_start, bounds.window_end, n);
+			payload_collection.CopyCell(0, first_idx, result, output_offset);
+			break;
+		}
+		case ExpressionType::WINDOW_LAST_VALUE: {
+			idx_t n = 1;
+			payload_collection.CopyCell(0, FindPrevStart(ignore_nulls, bounds.window_start, bounds.window_end, n),
+			                            result, output_offset);
+			break;
+		}
+		case ExpressionType::WINDOW_NTH_VALUE: {
+			D_ASSERT(payload_collection.ColumnCount() == 2);
+			// Returns value evaluated at the row that is the n'th row of the window frame (counting from 1);
+			// returns NULL if there is no such row.
+			if (CellIsNull(payload_collection, 1, row_idx)) {
+				FlatVector::SetNull(result, output_offset, true);
+			} else {
+				auto n_param = GetCell<int64_t>(payload_collection, 1, row_idx);
+				if (n_param < 1) {
+					FlatVector::SetNull(result, output_offset, true);
+				} else {
+					auto n = idx_t(n_param);
+					const auto nth_index = FindNextStart(ignore_nulls, bounds.window_start, bounds.window_end, n);
+					if (!n) {
+						payload_collection.CopyCell(0, nth_index, result, output_offset);
+					} else {
+						FlatVector::SetNull(result, output_offset, true);
+					}
+				}
+			}
+			break;
+		}
+		default:
+			throw InternalException("Window aggregate type %s", ExpressionTypeToString(wexpr->type));
+		}
+	}
+
+	// Push the last chunk
+	output.Append(output_chunk);
+}
+
+using WindowExpressions = vector<BoundWindowExpression *>;
+
+static void ComputeWindowExpressions(WindowExpressions &window_exprs, ChunkCollection &input,
+                                     ChunkCollection &window_results, ChunkCollection &over,
+                                     WindowAggregationMode mode) {
+	//	Idempotency
+	if (input.Count() == 0) {
+		return;
+	}
+	//	Pick out a function for the OVER clause
+	auto over_expr = window_exprs[0];
+
+	//	Set bits for the start of each partition
+	vector<validity_t> partition_bits(ValidityMask::EntryCount(input.Count()), 0);
+	ValidityMask partition_mask(partition_bits.data());
+	partition_mask.SetValid(0);
+
+	for (idx_t c = 0; c < over_expr->partitions.size(); ++c) {
+		MaskColumn(partition_mask, over, c);
+	}
+
+	//	Set bits for the start of each peer group.
+	//	Partitions also break peer groups, so start with the partition bits.
+	const auto sort_col_count = over_expr->partitions.size() + over_expr->orders.size();
+	ValidityMask order_mask(partition_mask, input.Count());
+	for (idx_t c = over_expr->partitions.size(); c < sort_col_count; ++c) {
+		MaskColumn(order_mask, over, c);
+	}
+
+	//	Compute the functions columnwise
+	for (idx_t expr_idx = 0; expr_idx < window_exprs.size(); ++expr_idx) {
+		ChunkCollection output;
+		ComputeWindowExpression(window_exprs[expr_idx], input, output, over, partition_mask, order_mask, mode);
+		window_results.Fuse(output);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+static void GeneratePartition(WindowOperatorState &state, WindowGlobalState &gstate, const idx_t hash_bin) {
+	auto &op = (PhysicalWindow &)gstate.op;
+	WindowExpressions window_exprs;
+	for (idx_t expr_idx = 0; expr_idx < op.select_list.size(); ++expr_idx) {
+		D_ASSERT(op.select_list[expr_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
+		auto wexpr = reinterpret_cast<BoundWindowExpression *>(op.select_list[expr_idx].get());
+		window_exprs.emplace_back(wexpr);
+	}
+
+	//	Get rid of any stale data
+	state.chunks.Reset();
+	state.window_results.Reset();
+	state.position = 0;
+	state.global_sort_state = nullptr;
+
+	//	Pick out a function for the OVER clause
+	auto over_expr = window_exprs[0];
+
+	// There are three types of partitions:
+	// 1. No partition (no sorting)
+	// 2. One partition (sorting, but no hashing)
+	// 3. Multiple partitions (sorting and hashing)
+	const auto input_types = gstate.chunks.Types();
+	const auto over_types = gstate.over_collection.Types();
+
+	if (gstate.counts.empty() && hash_bin == 0) {
+		ChunkCollection &input = gstate.chunks;
+		ChunkCollection output;
+		ChunkCollection &over = gstate.over_collection;
+
+		const auto has_sorting = over_expr->partitions.size() + over_expr->orders.size();
+		if (has_sorting && input.Count() > 0) {
+			// 2. One partition
+			SortCollectionForPartition(state, over_expr, input, over, nullptr, 0, 0);
+
+			// Overwrite the collections with the sorted data
+			ScanSortedPartition(state, input, input_types, over, over_types);
+		}
+
+		ComputeWindowExpressions(window_exprs, input, output, over, gstate.mode);
+		state.chunks.Merge(input);
+		state.window_results.Merge(output);
+
+	} else if (hash_bin < gstate.counts.size() && gstate.counts[hash_bin] > 0) {
+		// 3. Multiple partitions
+		const auto hash_mask = hash_t(gstate.counts.size() - 1);
+		SortCollectionForPartition(state, over_expr, gstate.chunks, gstate.over_collection, &gstate.hash_collection,
+		                           hash_bin, hash_mask);
+
+		// Scan the sorted data into new Collections
+		ChunkCollection input;
+		ChunkCollection output;
+		ChunkCollection over;
+		ScanSortedPartition(state, input, input_types, over, over_types);
+
+		ComputeWindowExpressions(window_exprs, input, output, over, gstate.mode);
+		state.chunks.Merge(input);
+		state.window_results.Merge(output);
+	}
+}
+
+static void Scan(WindowOperatorState &state, DataChunk &chunk) {
+	ChunkCollection &big_data = state.chunks;
+	ChunkCollection &window_results = state.window_results;
+
+	if (state.position >= big_data.Count()) {
+		return;
+	}
+
+	// just return what was computed before, appending the result cols of the window expressions at the end
+	auto &proj_ch = big_data.GetChunkForRow(state.position);
+	auto &wind_ch = window_results.GetChunkForRow(state.position);
+
+	idx_t out_idx = 0;
+	D_ASSERT(proj_ch.size() == wind_ch.size());
+	chunk.SetCardinality(proj_ch);
+	for (idx_t col_idx = 0; col_idx < proj_ch.ColumnCount(); col_idx++) {
+		chunk.data[out_idx++].Reference(proj_ch.data[col_idx]);
+	}
+	for (idx_t col_idx = 0; col_idx < wind_ch.ColumnCount(); col_idx++) {
+		chunk.data[out_idx++].Reference(wind_ch.data[col_idx]);
+	}
+	chunk.Verify();
+
+	state.position += STANDARD_VECTOR_SIZE;
+}
+
+SinkResultType PhysicalWindow::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                    DataChunk &input) const {
+	auto &lstate = (WindowLocalState &)lstate_p;
+	lstate.chunks.Append(input);
+
+	// Compute the over columns and the hash values for this block (if any)
+	const auto over_idx = 0;
+	auto over_expr = reinterpret_cast<BoundWindowExpression *>(select_list[over_idx].get());
+
+	const auto sort_col_count = over_expr->partitions.size() + over_expr->orders.size();
+	if (sort_col_count > 0) {
+		DataChunk over_chunk;
+		MaterializeOverForWindow(over_expr, input, over_chunk);
+
+		if (!over_expr->partitions.empty()) {
+			if (lstate.counts.empty()) {
+				lstate.counts.resize(lstate.partition_count, 0);
+			}
+
+			DataChunk hash_chunk;
+			HashChunk(lstate.counts, hash_chunk, over_chunk, over_expr->partitions.size());
+			lstate.hash_collection.Append(hash_chunk);
+			D_ASSERT(lstate.chunks.Count() == lstate.hash_collection.Count());
+		}
+
+		lstate.over_collection.Append(over_chunk);
+		D_ASSERT(lstate.chunks.Count() == lstate.over_collection.Count());
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalWindow::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &lstate = (WindowLocalState &)lstate_p;
+	if (lstate.chunks.Count() == 0) {
+		return;
+	}
+	auto &gstate = (WindowGlobalState &)gstate_p;
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.chunks.Merge(lstate.chunks);
+	gstate.over_collection.Merge(lstate.over_collection);
+	gstate.hash_collection.Merge(lstate.hash_collection);
+	if (gstate.counts.empty()) {
+		gstate.counts = lstate.counts;
+	} else {
+		D_ASSERT(gstate.counts.size() == lstate.counts.size());
+		for (idx_t i = 0; i < gstate.counts.size(); ++i) {
+			gstate.counts[i] += lstate.counts[i];
+		}
+	}
+}
+
+unique_ptr<LocalSinkState> PhysicalWindow::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<WindowLocalState>(*this);
+}
+
+unique_ptr<GlobalSinkState> PhysicalWindow::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<WindowGlobalState>(*this, context);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class WindowGlobalSourceState : public GlobalSourceState {
+public:
+	explicit WindowGlobalSourceState(const PhysicalWindow &op) : op(op), next_part(0) {
+	}
+
+	const PhysicalWindow &op;
+	//! The output read position.
+	atomic<idx_t> next_part;
+
+public:
+	idx_t MaxThreads() override {
+		auto &state = (WindowGlobalState &)*op.sink_state;
+
+		// If there is only one partition, we have to process it on one thread.
+		if (state.counts.empty()) {
+			return 1;
+		}
+
+		idx_t max_threads = 0;
+		for (const auto count : state.counts) {
+			if (count > 0) {
+				max_threads++;
+			}
+		}
+
+		return max_threads;
+	}
+};
+
+unique_ptr<LocalSourceState> PhysicalWindow::GetLocalSourceState(ExecutionContext &context,
+                                                                 GlobalSourceState &gstate) const {
+	return make_unique<WindowOperatorState>(*this, context);
+}
+
+unique_ptr<GlobalSourceState> PhysicalWindow::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<WindowGlobalSourceState>(*this);
+}
+
+void PhysicalWindow::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                             LocalSourceState &lstate_p) const {
+	auto &state = (WindowOperatorState &)lstate_p;
+	auto &global_source = (WindowGlobalSourceState &)gstate_p;
+	auto &gstate = (WindowGlobalState &)*sink_state;
+
+	do {
+		if (state.position >= state.chunks.Count()) {
+			auto hash_bin = global_source.next_part++;
+			for (; hash_bin < state.partitions; hash_bin = global_source.next_part++) {
+				if (gstate.counts[hash_bin] > 0) {
+					break;
+				}
+			}
+			GeneratePartition(state, gstate, hash_bin);
+		}
+		Scan(state, chunk);
+		if (chunk.size() != 0) {
+			return;
+		} else {
+			break;
+		}
+	} while (true);
+	D_ASSERT(chunk.size() == 0);
+}
+
+string PhysicalWindow::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += select_list[i]->GetName();
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types), estimated_cardinality) {
+	D_ASSERT(select_list.size() > 0);
+	if (select_list.size() > 1) {
+		// create a big AND out of the expressions
+		auto conjunction = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+		for (auto &expr : select_list) {
+			conjunction->children.push_back(move(expr));
+		}
+		expression = move(conjunction);
+	} else {
+		expression = move(select_list[0]);
+	}
+}
+
+class FilterState : public OperatorState {
+public:
+	explicit FilterState(Expression &expr) : executor(expr), sel(STANDARD_VECTOR_SIZE) {
+	}
+
+	ExpressionExecutor executor;
+	SelectionVector sel;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &executor, "filter", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalFilter::GetOperatorState(ClientContext &context) const {
+	return make_unique<FilterState>(*expression);
+}
+
+OperatorResultType PhysicalFilter::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (FilterState &)state_p;
+	idx_t result_count = state.executor.SelectExpression(input, state.sel);
+	if (result_count == input.size()) {
+		// nothing was filtered: skip adding any selection vectors
+		chunk.Reference(input);
+	} else {
+		chunk.Slice(input, state.sel, result_count);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalFilter::ParamsToString() const {
+	return expression->GetName();
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalBatchCollector::PhysicalBatchCollector(PreparedStatementData &data) : PhysicalResultCollector(data) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class BatchCollectorGlobalState : public GlobalSinkState {
+public:
+	mutex glock;
+	BatchedChunkCollection data;
+	unique_ptr<MaterializedQueryResult> result;
+};
+
+class BatchCollectorLocalState : public LocalSinkState {
+public:
+	BatchedChunkCollection data;
+};
+
+SinkResultType PhysicalBatchCollector::Sink(ExecutionContext &context, GlobalSinkState &gstate,
+                                            LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &state = (BatchCollectorLocalState &)lstate_p;
+	state.data.Append(input, state.batch_index);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalBatchCollector::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                     LocalSinkState &lstate_p) const {
+	auto &gstate = (BatchCollectorGlobalState &)gstate_p;
+	auto &state = (BatchCollectorLocalState &)lstate_p;
+
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.data.Merge(state.data);
+}
+
+SinkFinalizeType PhysicalBatchCollector::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (BatchCollectorGlobalState &)gstate_p;
+	auto result =
+	    make_unique<MaterializedQueryResult>(statement_type, properties, types, names, context.shared_from_this());
+	DataChunk output;
+	output.Initialize(types);
+
+	BatchedChunkScanState state;
+	gstate.data.InitializeScan(state);
+	while (true) {
+		output.Reset();
+		gstate.data.Scan(state, output);
+		if (output.size() == 0) {
+			break;
+		}
+		result->collection.Append(output);
+	}
+
+	gstate.result = move(result);
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalBatchCollector::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<BatchCollectorLocalState>();
+}
+
+unique_ptr<GlobalSinkState> PhysicalBatchCollector::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<BatchCollectorGlobalState>();
+}
+
+unique_ptr<QueryResult> PhysicalBatchCollector::GetResult(GlobalSinkState &state) {
+	auto &gstate = (BatchCollectorGlobalState &)state;
+	D_ASSERT(gstate.result);
+	return move(gstate.result);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+PhysicalExecute::PhysicalExecute(PhysicalOperator *plan)
+    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types, -1), plan(plan) {
+}
+
+vector<PhysicalOperator *> PhysicalExecute::GetChildren() const {
+	return {plan};
+}
+
+void PhysicalExecute::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// EXECUTE statement: build pipeline on child
+	plan->BuildPipelines(executor, current, state);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class ExplainAnalyzeStateGlobalState : public GlobalSinkState {
+public:
+	string analyzed_plan;
+};
+
+SinkResultType PhysicalExplainAnalyze::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                            DataChunk &input) const {
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+SinkFinalizeType PhysicalExplainAnalyze::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (ExplainAnalyzeStateGlobalState &)gstate_p;
+	auto &profiler = QueryProfiler::Get(context);
+	gstate.analyzed_plan = profiler.ToString();
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<GlobalSinkState> PhysicalExplainAnalyze::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<ExplainAnalyzeStateGlobalState>();
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class ExplainAnalyzeState : public GlobalSourceState {
+public:
+	ExplainAnalyzeState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalExplainAnalyze::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<ExplainAnalyzeState>();
+}
+
+void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &source_state,
+                                     LocalSourceState &lstate) const {
+	auto &state = (ExplainAnalyzeState &)source_state;
+	auto &gstate = (ExplainAnalyzeStateGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	chunk.SetValue(0, 0, Value("analyzed_plan"));
+	chunk.SetValue(1, 0, Value(gstate.analyzed_plan));
+	chunk.SetCardinality(1);
+
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalLimit::PhysicalLimit(vector<LogicalType> types, idx_t limit, idx_t offset,
+                             unique_ptr<Expression> limit_expression, unique_ptr<Expression> offset_expression,
+                             idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types), estimated_cardinality), limit_value(limit),
+      offset_value(offset), limit_expression(move(limit_expression)), offset_expression(move(offset_expression)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class LimitGlobalState : public GlobalSinkState {
+public:
+	explicit LimitGlobalState(const PhysicalLimit &op) {
+		limit = 0;
+		offset = 0;
+	}
+
+	mutex glock;
+	idx_t limit;
+	idx_t offset;
+	BatchedChunkCollection data;
+};
+
+class LimitLocalState : public LocalSinkState {
+public:
+	explicit LimitLocalState(const PhysicalLimit &op) : current_offset(0) {
+		this->limit = op.limit_expression ? DConstants::INVALID_INDEX : op.limit_value;
+		this->offset = op.offset_expression ? DConstants::INVALID_INDEX : op.offset_value;
+	}
+
+	idx_t current_offset;
+	idx_t limit;
+	idx_t offset;
+	BatchedChunkCollection data;
+};
+
+unique_ptr<GlobalSinkState> PhysicalLimit::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<LimitGlobalState>(*this);
+}
+
+unique_ptr<LocalSinkState> PhysicalLimit::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<LimitLocalState>(*this);
+}
+
+bool PhysicalLimit::ComputeOffset(DataChunk &input, idx_t &limit, idx_t &offset, idx_t current_offset,
+                                  idx_t &max_element, Expression *limit_expression, Expression *offset_expression) {
+	if (limit != DConstants::INVALID_INDEX && offset != DConstants::INVALID_INDEX) {
+		max_element = limit + offset;
+		if ((limit == 0 || current_offset >= max_element) && !(limit_expression || offset_expression)) {
+			return false;
+		}
+	}
+
+	// get the next chunk from the child
+	if (limit == DConstants::INVALID_INDEX) {
+		limit = 1ULL << 62ULL;
+		Value val = GetDelimiter(input, limit_expression);
+		if (!val.IsNull()) {
+			limit = val.GetValue<idx_t>();
+		}
+		if (limit > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", limit, 1ULL << 62ULL);
+		}
+	}
+	if (offset == DConstants::INVALID_INDEX) {
+		offset = 0;
+		Value val = GetDelimiter(input, offset_expression);
+		if (!val.IsNull()) {
+			offset = val.GetValue<idx_t>();
+		}
+		if (offset > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", offset, 1ULL << 62ULL);
+		}
+	}
+	max_element = limit + offset;
+	if (limit == 0 || current_offset >= max_element) {
+		return false;
+	}
+	return true;
+}
+
+SinkResultType PhysicalLimit::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                   DataChunk &input) const {
+
+	D_ASSERT(input.size() > 0);
+	auto &state = (LimitLocalState &)lstate;
+	auto &limit = state.limit;
+	auto &offset = state.offset;
+
+	idx_t max_element;
+	if (!ComputeOffset(input, limit, offset, state.current_offset, max_element, limit_expression.get(),
+	                   offset_expression.get())) {
+		return SinkResultType::FINISHED;
+	}
+	state.data.Append(input, lstate.batch_index);
+	state.current_offset += input.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalLimit::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (LimitGlobalState &)gstate_p;
+	auto &state = (LimitLocalState &)lstate_p;
+
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.limit = state.limit;
+	gstate.offset = state.offset;
+	gstate.data.Merge(state.data);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class LimitSourceState : public GlobalSourceState {
+public:
+	LimitSourceState() {
+		initialized = false;
+		current_offset = 0;
+	}
+
+	bool initialized;
+	idx_t current_offset;
+	BatchedChunkScanState scan_state;
+};
+
+unique_ptr<GlobalSourceState> PhysicalLimit::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<LimitSourceState>();
+}
+
+void PhysicalLimit::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                            LocalSourceState &lstate) const {
+	auto &gstate = (LimitGlobalState &)*sink_state;
+	auto &state = (LimitSourceState &)gstate_p;
+	while (state.current_offset < gstate.limit + gstate.offset) {
+		if (!state.initialized) {
+			gstate.data.InitializeScan(state.scan_state);
+			state.initialized = true;
+		}
+		gstate.data.Scan(state.scan_state, chunk);
+		if (chunk.size() == 0) {
+			break;
+		}
+		if (HandleOffset(chunk, state.current_offset, gstate.offset, gstate.limit)) {
+			break;
+		}
+	}
+}
+
+bool PhysicalLimit::HandleOffset(DataChunk &input, idx_t &current_offset, idx_t offset, idx_t limit) {
+	idx_t max_element = limit + offset;
+	if (limit == DConstants::INVALID_INDEX) {
+		max_element = DConstants::INVALID_INDEX;
+	}
+	idx_t input_size = input.size();
+	if (current_offset < offset) {
+		// we are not yet at the offset point
+		if (current_offset + input.size() > offset) {
+			// however we will reach it in this chunk
+			// we have to copy part of the chunk with an offset
+			idx_t start_position = offset - current_offset;
+			auto chunk_count = MinValue<idx_t>(limit, input.size() - start_position);
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = 0; i < chunk_count; i++) {
+				sel.set_index(i, start_position + i);
+			}
+			// set up a slice of the input chunks
+			input.Slice(input, sel, chunk_count);
+		} else {
+			current_offset += input_size;
+			return false;
+		}
+	} else {
+		// have to copy either the entire chunk or part of it
+		idx_t chunk_count;
+		if (current_offset + input.size() >= max_element) {
+			// have to limit the count of the chunk
+			chunk_count = max_element - current_offset;
+		} else {
+			// we copy the entire chunk
+			chunk_count = input.size();
+		}
+		// instead of copying we just change the pointer in the current chunk
+		input.Reference(input);
+		input.SetCardinality(chunk_count);
+	}
+
+	current_offset += input_size;
+	return true;
+}
+
+Value PhysicalLimit::GetDelimiter(DataChunk &input, Expression *expr) {
+	DataChunk limit_chunk;
+	vector<LogicalType> types {expr->return_type};
+	limit_chunk.Initialize(types);
+	ExpressionExecutor limit_executor(expr);
+	auto input_size = input.size();
+	input.SetCardinality(1);
+	limit_executor.Execute(input, limit_chunk);
+	input.SetCardinality(input_size);
+	auto limit_value = limit_chunk.GetValue(0, 0);
+	return limit_value;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class LimitPercentGlobalState : public GlobalSinkState {
+public:
+	explicit LimitPercentGlobalState(const PhysicalLimitPercent &op) : current_offset(0) {
+		if (!op.limit_expression) {
+			this->limit_percent = op.limit_percent;
+			is_limit_percent_delimited = true;
+		} else {
+			this->limit_percent = 100.0;
+		}
+
+		if (!op.offset_expression) {
+			this->offset = op.offset_value;
+			is_offset_delimited = true;
+		} else {
+			this->offset = 0;
+		}
+	}
+
+	idx_t current_offset;
+	double limit_percent;
+	idx_t offset;
+	ChunkCollection data;
+
+	bool is_limit_percent_delimited = false;
+	bool is_offset_delimited = false;
+};
+
+unique_ptr<GlobalSinkState> PhysicalLimitPercent::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<LimitPercentGlobalState>(*this);
+}
+
+SinkResultType PhysicalLimitPercent::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                          DataChunk &input) const {
+	D_ASSERT(input.size() > 0);
+	auto &state = (LimitPercentGlobalState &)gstate;
+	auto &limit_percent = state.limit_percent;
+	auto &offset = state.offset;
+
+	// get the next chunk from the child
+	if (!state.is_limit_percent_delimited) {
+		Value val = PhysicalLimit::GetDelimiter(input, limit_expression.get());
+		if (!val.IsNull()) {
+			limit_percent = val.GetValue<double>();
+		}
+		if (limit_percent < 0.0) {
+			throw BinderException("Percentage value(%f) can't be negative", limit_percent);
+		}
+		state.is_limit_percent_delimited = true;
+	}
+	if (!state.is_offset_delimited) {
+		Value val = PhysicalLimit::GetDelimiter(input, offset_expression.get());
+		if (!val.IsNull()) {
+			offset = val.GetValue<idx_t>();
+		}
+		if (offset > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", offset, 1ULL << 62ULL);
+		}
+		state.is_offset_delimited = true;
+	}
+
+	if (!PhysicalLimit::HandleOffset(input, state.current_offset, offset, DConstants::INVALID_INDEX)) {
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	state.data.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class LimitPercentOperatorState : public GlobalSourceState {
+public:
+	LimitPercentOperatorState() : chunk_idx(0), limit(DConstants::INVALID_INDEX), current_offset(0) {
+	}
+
+	idx_t chunk_idx;
+	idx_t limit;
+	idx_t current_offset;
+};
+
+unique_ptr<GlobalSourceState> PhysicalLimitPercent::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<LimitPercentOperatorState>();
+}
+
+void PhysicalLimitPercent::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                   LocalSourceState &lstate) const {
+	auto &gstate = (LimitPercentGlobalState &)*sink_state;
+	auto &state = (LimitPercentOperatorState &)gstate_p;
+	auto &limit_percent = gstate.limit_percent;
+	auto &offset = gstate.offset;
+	auto &limit = state.limit;
+	auto &current_offset = state.current_offset;
+
+	if (gstate.is_limit_percent_delimited && limit == DConstants::INVALID_INDEX) {
+		idx_t count = gstate.data.Count();
+		if (count > 0) {
+			count += offset;
+		}
+		limit = MinValue((idx_t)(limit_percent / 100 * count), count);
+		if (limit == 0) {
+			return;
+		}
+	}
+
+	if (current_offset >= limit || state.chunk_idx >= gstate.data.ChunkCount()) {
+		return;
+	}
+
+	DataChunk &input = gstate.data.GetChunk(state.chunk_idx);
+	state.chunk_idx++;
+	if (PhysicalLimit::HandleOffset(input, current_offset, 0, limit)) {
+		chunk.Reference(input);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalLoad::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                           LocalSourceState &lstate) const {
+	auto &db = DatabaseInstance::GetDatabase(context.client);
+	if (info->load_type == LoadType::INSTALL || info->load_type == LoadType::FORCE_INSTALL) {
+		ExtensionHelper::InstallExtension(db, info->filename, info->load_type == LoadType::FORCE_INSTALL);
+	} else {
+		ExtensionHelper::LoadExternalExtension(db, info->filename);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalMaterializedCollector::PhysicalMaterializedCollector(PreparedStatementData &data, bool parallel)
+    : PhysicalResultCollector(data), parallel(parallel) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class MaterializedCollectorGlobalState : public GlobalSinkState {
+public:
+	mutex glock;
+	unique_ptr<MaterializedQueryResult> result;
+};
+
+SinkResultType PhysicalMaterializedCollector::Sink(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                   LocalSinkState &lstate, DataChunk &input) const {
+	auto &gstate = (MaterializedCollectorGlobalState &)gstate_p;
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.result->collection.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalMaterializedCollector::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<MaterializedCollectorGlobalState>();
+	state->result =
+	    make_unique<MaterializedQueryResult>(statement_type, properties, types, names, context.shared_from_this());
+	return move(state);
+}
+
+unique_ptr<QueryResult> PhysicalMaterializedCollector::GetResult(GlobalSinkState &state) {
+	auto &gstate = (MaterializedCollectorGlobalState &)state;
+	D_ASSERT(gstate.result);
+	return move(gstate.result);
+}
+
+bool PhysicalMaterializedCollector::ParallelSink() const {
+	return parallel;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalPragma::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                             LocalSourceState &lstate) const {
+	auto &client = context.client;
+	FunctionParameters parameters {info.parameters, info.named_parameters};
+	function.function(client, parameters);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalPrepare::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                              LocalSourceState &lstate) const {
+	auto &client = context.client;
+
+	// store the prepared statement in the context
+	ClientData::Get(client).prepared_statements[name] = prepared;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class SampleGlobalSinkState : public GlobalSinkState {
+public:
+	explicit SampleGlobalSinkState(SampleOptions &options) {
+		if (options.is_percentage) {
+			auto percentage = options.sample_size.GetValue<double>();
+			if (percentage == 0) {
+				return;
+			}
+			sample = make_unique<ReservoirSamplePercentage>(percentage, options.seed);
+		} else {
+			auto size = options.sample_size.GetValue<int64_t>();
+			if (size == 0) {
+				return;
+			}
+			sample = make_unique<ReservoirSample>(size, options.seed);
+		}
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The reservoir sample
+	unique_ptr<BlockingSample> sample;
+};
+
+unique_ptr<GlobalSinkState> PhysicalReservoirSample::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<SampleGlobalSinkState>(*options);
+}
+
+SinkResultType PhysicalReservoirSample::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &gstate = (SampleGlobalSinkState &)state;
+	if (!gstate.sample) {
+		return SinkResultType::FINISHED;
+	}
+	// we implement reservoir sampling without replacement and exponential jumps here
+	// the algorithm is adopted from the paper Weighted random sampling with a reservoir by Pavlos S. Efraimidis et al.
+	// note that the original algorithm is about weighted sampling; this is a simplified approach for uniform sampling
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.sample->AddToReservoir(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+void PhysicalReservoirSample::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	auto &sink = (SampleGlobalSinkState &)*this->sink_state;
+	if (!sink.sample) {
+		return;
+	}
+	auto sample_chunk = sink.sample->GetChunk();
+	if (!sample_chunk) {
+		return;
+	}
+	chunk.Move(*sample_chunk);
+}
+
+string PhysicalReservoirSample::ParamsToString() const {
+	return options->sample_size.ToString() + (options->is_percentage ? "%" : " rows");
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalResultCollector::PhysicalResultCollector(PreparedStatementData &data)
+    : PhysicalOperator(PhysicalOperatorType::RESULT_COLLECTOR, {LogicalType::BOOLEAN}, 0),
+      statement_type(data.statement_type), properties(data.properties), plan(data.plan.get()), names(data.names) {
+	this->types = data.types;
+}
+
+unique_ptr<PhysicalResultCollector> PhysicalResultCollector::GetResultCollector(ClientContext &context,
+                                                                                PreparedStatementData &data) {
+	auto &config = DBConfig::GetConfig(context);
+	bool use_materialized_collector = !config.preserve_insertion_order || !data.plan->AllSourcesSupportBatchIndex();
+	if (use_materialized_collector) {
+		// parallel materialized collector only if we don't care about maintaining insertion order
+		return make_unique_base<PhysicalResultCollector, PhysicalMaterializedCollector>(
+		    data, !config.preserve_insertion_order);
+	} else {
+		// we care about maintaining insertion order and the sources all support batch indexes
+		// use a batch collector
+		return make_unique_base<PhysicalResultCollector, PhysicalBatchCollector>(data);
+	}
+}
+
+vector<PhysicalOperator *> PhysicalResultCollector::GetChildren() const {
+	return {plan};
+}
+
+void PhysicalResultCollector::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// operator is a sink, build a pipeline
+	sink_state.reset();
+
+	// single operator:
+	// the operator becomes the data source of the current pipeline
+	state.SetPipelineSource(current, this);
+	// we create a new pipeline starting from the child
+	D_ASSERT(children.size() == 0);
+	D_ASSERT(plan);
+
+	BuildChildPipeline(executor, current, state, plan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void PhysicalSet::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                          LocalSourceState &lstate) const {
+	auto option = DBConfig::GetOptionByName(name);
+	if (!option) {
+		// check if this is an extra extension variable
+		auto &config = DBConfig::GetConfig(context.client);
+		auto entry = config.extension_parameters.find(name);
+		if (entry == config.extension_parameters.end()) {
+			// it is not!
+			// get a list of all options
+			vector<string> potential_names;
+			for (idx_t i = 0, option_count = DBConfig::GetOptionCount(); i < option_count; i++) {
+				potential_names.emplace_back(DBConfig::GetOptionByIndex(i)->name);
+			}
+			for (auto &entry : config.extension_parameters) {
+				potential_names.push_back(entry.first);
+			}
+
+			throw CatalogException("unrecognized configuration parameter \"%s\"\n%s", name,
+			                       StringUtil::CandidatesErrorMessage(potential_names, name, "Did you mean"));
+		}
+		//! it is!
+		auto &extension_option = entry->second;
+		auto &target_type = extension_option.type;
+		Value target_value = value.CastAs(target_type);
+		if (extension_option.set_function) {
+			extension_option.set_function(context.client, scope, target_value);
+		}
+		if (scope == SetScope::GLOBAL) {
+			config.set_variables[name] = move(target_value);
+		} else {
+			auto &client_config = ClientConfig::GetConfig(context.client);
+			client_config.set_variables[name] = move(target_value);
+		}
+		return;
+	}
+	SetScope variable_scope = scope;
+	if (variable_scope == SetScope::AUTOMATIC) {
+		if (option->set_local) {
+			variable_scope = SetScope::SESSION;
+		} else {
+			D_ASSERT(option->set_global);
+			variable_scope = SetScope::GLOBAL;
+		}
+	}
+
+	Value input = value.CastAs(option->parameter_type);
+	switch (variable_scope) {
+	case SetScope::GLOBAL: {
+		if (!option->set_global) {
+			throw CatalogException("option \"%s\" cannot be set globally", name);
+		}
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		auto &config = DBConfig::GetConfig(context.client);
+		option->set_global(&db, config, input);
+		break;
+	}
+	case SetScope::SESSION:
+		if (!option->set_local) {
+			throw CatalogException("option \"%s\" cannot be set locally", name);
+		}
+		option->set_local(context.client, input);
+		break;
+	default:
+		throw InternalException("Unsupported SetScope for variable");
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalStreamingLimit::PhysicalStreamingLimit(vector<LogicalType> types, idx_t limit, idx_t offset,
+                                               unique_ptr<Expression> limit_expression,
+                                               unique_ptr<Expression> offset_expression, idx_t estimated_cardinality,
+                                               bool parallel)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_LIMIT, move(types), estimated_cardinality), limit_value(limit),
+      offset_value(offset), limit_expression(move(limit_expression)), offset_expression(move(offset_expression)),
+      parallel(parallel) {
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class StreamingLimitOperatorState : public OperatorState {
+public:
+	explicit StreamingLimitOperatorState(const PhysicalStreamingLimit &op) {
+		this->limit = op.limit_expression ? DConstants::INVALID_INDEX : op.limit_value;
+		this->offset = op.offset_expression ? DConstants::INVALID_INDEX : op.offset_value;
+	}
+
+	idx_t limit;
+	idx_t offset;
+};
+
+class StreamingLimitGlobalState : public GlobalOperatorState {
+public:
+	StreamingLimitGlobalState() : current_offset(0) {
+	}
+
+	std::atomic<idx_t> current_offset;
+};
+
+unique_ptr<OperatorState> PhysicalStreamingLimit::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingLimitOperatorState>(*this);
+}
+
+unique_ptr<GlobalOperatorState> PhysicalStreamingLimit::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<StreamingLimitGlobalState>();
+}
+
+OperatorResultType PhysicalStreamingLimit::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (StreamingLimitGlobalState &)gstate_p;
+	auto &state = (StreamingLimitOperatorState &)state_p;
+	auto &limit = state.limit;
+	auto &offset = state.offset;
+	idx_t current_offset = gstate.current_offset.fetch_add(input.size());
+	idx_t max_element;
+	if (!PhysicalLimit::ComputeOffset(input, limit, offset, current_offset, max_element, limit_expression.get(),
+	                                  offset_expression.get())) {
+		return OperatorResultType::FINISHED;
+	}
+	if (PhysicalLimit::HandleOffset(input, current_offset, offset, limit)) {
+		chunk.Reference(input);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+bool PhysicalStreamingLimit::IsOrderDependent() const {
+	return !parallel;
+}
+
+bool PhysicalStreamingLimit::ParallelOperator() const {
+	return parallel;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage,
+                                                 int64_t seed, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types), estimated_cardinality), method(method),
+      percentage(percentage / 100), seed(seed) {
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class StreamingSampleOperatorState : public OperatorState {
+public:
+	explicit StreamingSampleOperatorState(int64_t seed) : random(seed) {
+	}
+
+	RandomEngine random;
+};
+
+void PhysicalStreamingSample::SystemSample(DataChunk &input, DataChunk &result, OperatorState &state_p) const {
+	// system sampling: we throw one dice per chunk
+	auto &state = (StreamingSampleOperatorState &)state_p;
+	double rand = state.random.NextRandom();
+	if (rand <= percentage) {
+		// rand is smaller than sample_size: output chunk
+		result.Reference(input);
+	}
+}
+
+void PhysicalStreamingSample::BernoulliSample(DataChunk &input, DataChunk &result, OperatorState &state_p) const {
+	// bernoulli sampling: we throw one dice per tuple
+	// then slice the result chunk
+	auto &state = (StreamingSampleOperatorState &)state_p;
+	idx_t result_count = 0;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < input.size(); i++) {
+		double rand = state.random.NextRandom();
+		if (rand <= percentage) {
+			sel.set_index(result_count++, i);
+		}
+	}
+	if (result_count > 0) {
+		result.Slice(input, sel, result_count);
+	}
+}
+
+unique_ptr<OperatorState> PhysicalStreamingSample::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingSampleOperatorState>(seed);
+}
+
+OperatorResultType PhysicalStreamingSample::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate, OperatorState &state) const {
+	switch (method) {
+	case SampleMethod::BERNOULLI_SAMPLE:
+		BernoulliSample(input, chunk, state);
+		break;
+	case SampleMethod::SYSTEM_SAMPLE:
+		SystemSample(input, chunk, state);
+		break;
+	default:
+		throw InternalException("Unsupported sample method for streaming sample");
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalStreamingSample::ParamsToString() const {
+	return SampleMethodToString(method) + ": " + to_string(100 * percentage) + "%";
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalTransaction::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &client = context.client;
+
+	switch (info->type) {
+	case TransactionType::BEGIN_TRANSACTION: {
+		if (client.transaction.IsAutoCommit()) {
+			// start the active transaction
+			// if autocommit is active, we have already called
+			// BeginTransaction by setting autocommit to false we
+			// prevent it from being closed after this query, hence
+			// preserving the transaction context for the next query
+			client.transaction.SetAutoCommit(false);
+		} else {
+			throw TransactionException("cannot start a transaction within a transaction");
+		}
+		break;
+	}
+	case TransactionType::COMMIT: {
+		if (client.transaction.IsAutoCommit()) {
+			throw TransactionException("cannot commit - no transaction is active");
+		} else {
+			// explicitly commit the current transaction
+			client.transaction.Commit();
+		}
+		break;
+	}
+	case TransactionType::ROLLBACK: {
+		if (client.transaction.IsAutoCommit()) {
+			throw TransactionException("cannot rollback - no transaction is active");
+		} else {
+			// explicitly rollback the current transaction
+			client.transaction.Rollback();
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unrecognized transaction type!");
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalVacuum::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	// NOP
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PerfectHashJoinExecutor::PerfectHashJoinExecutor(const PhysicalHashJoin &join_p, JoinHashTable &ht_p,
+                                                 PerfectHashJoinStats perfect_join_stats)
+    : join(join_p), ht(ht_p), perfect_join_statistics(move(perfect_join_stats)) {
+}
+
+bool PerfectHashJoinExecutor::CanDoPerfectHashJoin() {
+	return perfect_join_statistics.is_build_small;
+}
+
+//===--------------------------------------------------------------------===//
+// Build
+//===--------------------------------------------------------------------===//
+bool PerfectHashJoinExecutor::BuildPerfectHashTable(LogicalType &key_type) {
+	// First, allocate memory for each build column
+	auto build_size = perfect_join_statistics.build_range + 1;
+	for (const auto &type : ht.build_types) {
+		perfect_hash_table.emplace_back(type, build_size);
+	}
+	// and for duplicate_checking
+	bitmap_build_idx = unique_ptr<bool[]>(new bool[build_size]);
+	memset(bitmap_build_idx.get(), 0, sizeof(bool) * build_size); // set false
+
+	// Now fill columns with build data
+	JoinHTScanState join_ht_state;
+	return FullScanHashTable(join_ht_state, key_type);
+}
+
+bool PerfectHashJoinExecutor::FullScanHashTable(JoinHTScanState &state, LogicalType &key_type) {
+	Vector tuples_addresses(LogicalType::POINTER, ht.Count());              // allocate space for all the tuples
+	auto key_locations = FlatVector::GetData<data_ptr_t>(tuples_addresses); // get a pointer to vector data
+	// TODO: In a parallel finalize: One should exclusively lock and each thread should do one part of the code below.
+	// Go through all the blocks and fill the keys addresses
+	auto keys_count = ht.FillWithHTOffsets(key_locations, state);
+	// Scan the build keys in the hash table
+	Vector build_vector(key_type, keys_count);
+	RowOperations::FullScanColumn(ht.layout, tuples_addresses, build_vector, keys_count, 0);
+	// Now fill the selection vector using the build keys and create a sequential vector
+	// todo: add check for fast pass when probe is part of build domain
+	SelectionVector sel_build(keys_count + 1);
+	SelectionVector sel_tuples(keys_count + 1);
+	bool success = FillSelectionVectorSwitchBuild(build_vector, sel_build, sel_tuples, keys_count);
+	// early out
+	if (!success) {
+		return false;
+	}
+	if (unique_keys == perfect_join_statistics.build_range + 1 && !ht.has_null) {
+		perfect_join_statistics.is_build_dense = true;
+	}
+	keys_count = unique_keys; // do not consider keys out of the range
+	// Full scan the remaining build columns and fill the perfect hash table
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto build_size = perfect_join_statistics.build_range + 1;
+		auto &vector = perfect_hash_table[i];
+		D_ASSERT(vector.GetType() == ht.build_types[i]);
+		const auto col_no = ht.condition_types.size() + i;
+		const auto col_offset = ht.layout.GetOffsets()[col_no];
+		RowOperations::Gather(tuples_addresses, sel_tuples, vector, sel_build, keys_count, col_offset, col_no,
+		                      build_size);
+	}
+	return true;
+}
+
+bool PerfectHashJoinExecutor::FillSelectionVectorSwitchBuild(Vector &source, SelectionVector &sel_vec,
+                                                             SelectionVector &seq_sel_vec, idx_t count) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		return TemplatedFillSelectionVectorBuild<int8_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT16:
+		return TemplatedFillSelectionVectorBuild<int16_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT32:
+		return TemplatedFillSelectionVectorBuild<int32_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT64:
+		return TemplatedFillSelectionVectorBuild<int64_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT8:
+		return TemplatedFillSelectionVectorBuild<uint8_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT16:
+		return TemplatedFillSelectionVectorBuild<uint16_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT32:
+		return TemplatedFillSelectionVectorBuild<uint32_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT64:
+		return TemplatedFillSelectionVectorBuild<uint64_t>(source, sel_vec, seq_sel_vec, count);
+	default:
+		throw NotImplementedException("Type not supported for perfect hash join");
+	}
+}
+
+template <typename T>
+bool PerfectHashJoinExecutor::TemplatedFillSelectionVectorBuild(Vector &source, SelectionVector &sel_vec,
+                                                                SelectionVector &seq_sel_vec, idx_t count) {
+	if (perfect_join_statistics.build_min.IsNull() || perfect_join_statistics.build_max.IsNull()) {
+		return false;
+	}
+	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
+	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
+	VectorData vector_data;
+	source.Orrify(count, vector_data);
+	auto data = reinterpret_cast<T *>(vector_data.data);
+	// generate the selection vector
+	for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+		auto data_idx = vector_data.sel->get_index(i);
+		auto input_value = data[data_idx];
+		// add index to selection vector if value in the range
+		if (min_value <= input_value && input_value <= max_value) {
+			auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+			sel_vec.set_index(sel_idx, idx);
+			if (bitmap_build_idx[idx]) {
+				return false;
+			} else {
+				bitmap_build_idx[idx] = true;
+				unique_keys++;
+			}
+			seq_sel_vec.set_index(sel_idx++, i);
+		}
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Probe
+//===--------------------------------------------------------------------===//
+class PerfectHashJoinState : public OperatorState {
+public:
+	DataChunk join_keys;
+	ExpressionExecutor probe_executor;
+	SelectionVector build_sel_vec;
+	SelectionVector probe_sel_vec;
+	SelectionVector seq_sel_vec;
+};
+
+unique_ptr<OperatorState> PerfectHashJoinExecutor::GetOperatorState(ClientContext &context) {
+	auto state = make_unique<PerfectHashJoinState>();
+	state->join_keys.Initialize(join.condition_types);
+	for (auto &cond : join.conditions) {
+		state->probe_executor.AddExpression(*cond.left);
+	}
+	state->build_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	state->probe_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	state->seq_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	return move(state);
+}
+
+OperatorResultType PerfectHashJoinExecutor::ProbePerfectHashTable(ExecutionContext &context, DataChunk &input,
+                                                                  DataChunk &result, OperatorState &state_p) {
+	auto &state = (PerfectHashJoinState &)state_p;
+	// keeps track of how many probe keys have a match
+	idx_t probe_sel_count = 0;
+
+	// fetch the join keys from the chunk
+	state.join_keys.Reset();
+	state.probe_executor.Execute(input, state.join_keys);
+	// select the keys that are in the min-max range
+	auto &keys_vec = state.join_keys.data[0];
+	auto keys_count = state.join_keys.size();
+	// todo: add check for fast pass when probe is part of build domain
+	FillSelectionVectorSwitchProbe(keys_vec, state.build_sel_vec, state.probe_sel_vec, keys_count, probe_sel_count);
+
+	// If build is dense and probe is in build's domain, just reference probe
+	if (perfect_join_statistics.is_build_dense && keys_count == probe_sel_count) {
+		result.Reference(input);
+	} else {
+		// otherwise, filter it out the values that do not match
+		result.Slice(input, state.probe_sel_vec, probe_sel_count, 0);
+	}
+	// on the build side, we need to fetch the data and build dictionary vectors with the sel_vec
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto &result_vector = result.data[input.ColumnCount() + i];
+		D_ASSERT(result_vector.GetType() == ht.build_types[i]);
+		auto &build_vec = perfect_hash_table[i];
+		result_vector.Reference(build_vec);
+		result_vector.Slice(state.build_sel_vec, probe_sel_count);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+void PerfectHashJoinExecutor::FillSelectionVectorSwitchProbe(Vector &source, SelectionVector &build_sel_vec,
+                                                             SelectionVector &probe_sel_vec, idx_t count,
+                                                             idx_t &probe_sel_count) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedFillSelectionVectorProbe<int8_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFillSelectionVectorProbe<int16_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFillSelectionVectorProbe<int32_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFillSelectionVectorProbe<int64_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedFillSelectionVectorProbe<uint8_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFillSelectionVectorProbe<uint16_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFillSelectionVectorProbe<uint32_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFillSelectionVectorProbe<uint64_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	default:
+		throw NotImplementedException("Type not supported");
+	}
+}
+
+template <typename T>
+void PerfectHashJoinExecutor::TemplatedFillSelectionVectorProbe(Vector &source, SelectionVector &build_sel_vec,
+                                                                SelectionVector &probe_sel_vec, idx_t count,
+                                                                idx_t &probe_sel_count) {
+	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
+	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
+
+	VectorData vector_data;
+	source.Orrify(count, vector_data);
+	auto data = reinterpret_cast<T *>(vector_data.data);
+	auto validity_mask = &vector_data.validity;
+	// build selection vector for non-dense build
+	if (validity_mask->AllValid()) {
+		for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+			// retrieve value from vector
+			auto data_idx = vector_data.sel->get_index(i);
+			auto input_value = data[data_idx];
+			// add index to selection vector if value in the range
+			if (min_value <= input_value && input_value <= max_value) {
+				auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+				                                             // check for matches in the build
+				if (bitmap_build_idx[idx]) {
+					build_sel_vec.set_index(sel_idx, idx);
+					probe_sel_vec.set_index(sel_idx++, i);
+					probe_sel_count++;
+				}
+			}
+		}
+	} else {
+		for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+			// retrieve value from vector
+			auto data_idx = vector_data.sel->get_index(i);
+			if (!validity_mask->RowIsValid(data_idx)) {
+				continue;
+			}
+			auto input_value = data[data_idx];
+			// add index to selection vector if value in the range
+			if (min_value <= input_value && input_value <= max_value) {
+				auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+				                                             // check for matches in the build
+				if (bitmap_build_idx[idx]) {
+					build_sel_vec.set_index(sel_idx, idx);
+					probe_sel_vec.set_index(sel_idx++, i);
+					probe_sel_count++;
+				}
+			}
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                                 unique_ptr<PhysicalOperator> right, unique_ptr<Expression> condition,
+                                                 JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
+      condition(move(condition)) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+	// MARK and SINGLE joins not handled
+	D_ASSERT(join_type != JoinType::MARK);
+	D_ASSERT(join_type != JoinType::SINGLE);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinLocalState : public LocalSinkState {
+public:
+	BlockwiseNLJoinLocalState() {
+	}
+};
+
+class BlockwiseNLJoinGlobalState : public GlobalSinkState {
+public:
+	mutex lock;
+	ChunkCollection right_chunks;
+	//! Whether or not a tuple on the RHS has found a match, only used for FULL OUTER joins
+	unique_ptr<bool[]> rhs_found_match;
+};
+
+unique_ptr<GlobalSinkState> PhysicalBlockwiseNLJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalBlockwiseNLJoin::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<BlockwiseNLJoinLocalState>();
+}
+
+SinkResultType PhysicalBlockwiseNLJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &gstate = (BlockwiseNLJoinGlobalState &)state;
+	lock_guard<mutex> nl_lock(gstate.lock);
+	gstate.right_chunks.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalBlockwiseNLJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                   GlobalSinkState &gstate_p) const {
+	auto &gstate = (BlockwiseNLJoinGlobalState &)gstate_p;
+	if (IsRightOuterJoin(join_type)) {
+		gstate.rhs_found_match = unique_ptr<bool[]>(new bool[gstate.right_chunks.Count()]);
+		memset(gstate.rhs_found_match.get(), 0, sizeof(bool) * gstate.right_chunks.Count());
+	}
+	if (gstate.right_chunks.Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinState : public OperatorState {
+public:
+	explicit BlockwiseNLJoinState(const PhysicalBlockwiseNLJoin &op)
+	    : left_position(0), right_position(0), executor(*op.condition) {
+		if (IsLeftOuterJoin(op.join_type)) {
+			left_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+	}
+
+	//! Whether or not a tuple on the LHS has found a match, only used for LEFT OUTER and FULL OUTER joins
+	unique_ptr<bool[]> left_found_match;
+	idx_t left_position;
+	idx_t right_position;
+	ExpressionExecutor executor;
+};
+
+unique_ptr<OperatorState> PhysicalBlockwiseNLJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinState>(*this);
+}
+
+OperatorResultType PhysicalBlockwiseNLJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	D_ASSERT(input.size() > 0);
+	auto &state = (BlockwiseNLJoinState &)state_p;
+	auto &gstate = (BlockwiseNLJoinGlobalState &)*sink_state;
+
+	if (gstate.right_chunks.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			PhysicalComparisonJoin::ConstructEmptyJoinResult(join_type, false, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	// now perform the actual join
+	// we construct a combined DataChunk by referencing the LHS and the RHS
+	// every step that we do not have output results we shift the vectors of the RHS one up or down
+	// this creates a new "alignment" between the tuples, exhausting all possible O(n^2) combinations
+	// while allowing us to use vectorized execution for every step
+	idx_t result_count = 0;
+	do {
+		if (state.left_position >= input.size()) {
+			// exhausted LHS, have to pull new LHS chunk
+			if (state.left_found_match) {
+				// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+				// have a match found
+				PhysicalJoin::ConstructLeftJoinResult(input, chunk, state.left_found_match.get());
+				memset(state.left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+			}
+			state.left_position = 0;
+			state.right_position = 0;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		auto &lchunk = input;
+		auto &rchunk = gstate.right_chunks.GetChunk(state.right_position);
+
+		// fill in the current element of the LHS into the chunk
+		D_ASSERT(chunk.ColumnCount() == lchunk.ColumnCount() + rchunk.ColumnCount());
+		for (idx_t i = 0; i < lchunk.ColumnCount(); i++) {
+			ConstantVector::Reference(chunk.data[i], lchunk.data[i], state.left_position, lchunk.size());
+		}
+		// for the RHS we just reference the entire vector
+		for (idx_t i = 0; i < rchunk.ColumnCount(); i++) {
+			chunk.data[lchunk.ColumnCount() + i].Reference(rchunk.data[i]);
+		}
+		chunk.SetCardinality(rchunk.size());
+
+		// now perform the computation
+		SelectionVector match_sel(STANDARD_VECTOR_SIZE);
+		result_count = state.executor.SelectExpression(chunk, match_sel);
+		if (result_count > 0) {
+			// found a match!
+			// set the match flags in the LHS
+			if (state.left_found_match) {
+				state.left_found_match[state.left_position] = true;
+			}
+			// set the match flags in the RHS
+			if (gstate.rhs_found_match) {
+				for (idx_t i = 0; i < result_count; i++) {
+					auto idx = match_sel.get_index(i);
+					gstate.rhs_found_match[state.right_position * STANDARD_VECTOR_SIZE + idx] = true;
+				}
+			}
+			chunk.Slice(match_sel, result_count);
+		} else {
+			// no result: reset the chunk
+			chunk.Reset();
+		}
+		// move to the next tuple on the LHS
+		state.left_position++;
+		if (state.left_position >= input.size()) {
+			// exhausted the current chunk, move to the next RHS chunk
+			state.right_position++;
+			if (state.right_position < gstate.right_chunks.ChunkCount()) {
+				// we still have chunks left! start over on the LHS
+				state.left_position = 0;
+			}
+		}
+	} while (result_count == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+string PhysicalBlockwiseNLJoin::ParamsToString() const {
+	string extra_info = JoinTypeToString(join_type) + "\n";
+	extra_info += condition->GetName();
+	return extra_info;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinScanState : public GlobalSourceState {
+public:
+	explicit BlockwiseNLJoinScanState(const PhysicalBlockwiseNLJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalBlockwiseNLJoin &op;
+	//! The position in the RHS in the final scan of the FULL OUTER JOIN
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (BlockwiseNLJoinGlobalState &)*op.sink_state;
+		return sink.right_chunks.Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalBlockwiseNLJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinScanState>(*this);
+}
+
+void PhysicalBlockwiseNLJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (BlockwiseNLJoinGlobalState &)*sink_state;
+	auto &state = (BlockwiseNLJoinScanState &)gstate;
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	lock_guard<mutex> l(state.lock);
+	PhysicalComparisonJoin::ConstructFullOuterJoinResult(sink.rhs_found_match.get(), sink.right_chunks, chunk,
+	                                                     state.right_outer_position);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type,
+                                               vector<JoinCondition> conditions_p, JoinType join_type,
+                                               idx_t estimated_cardinality)
+    : PhysicalJoin(op, type, join_type, estimated_cardinality) {
+	conditions.resize(conditions_p.size());
+	// we reorder conditions so the ones with COMPARE_EQUAL occur first
+	idx_t equal_position = 0;
+	idx_t other_position = conditions_p.size() - 1;
+	for (idx_t i = 0; i < conditions_p.size(); i++) {
+		if (conditions_p[i].comparison == ExpressionType::COMPARE_EQUAL ||
+		    conditions_p[i].comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			// COMPARE_EQUAL and COMPARE_NOT_DISTINCT_FROM, move to the start
+			conditions[equal_position++] = std::move(conditions_p[i]);
+		} else {
+			// other expression, move to the end
+			conditions[other_position--] = std::move(conditions_p[i]);
+		}
+	}
+}
+
+string PhysicalComparisonJoin::ParamsToString() const {
+	string extra_info = JoinTypeToString(join_type) + "\n";
+	for (auto &it : conditions) {
+		string op = ExpressionTypeToOperator(it.comparison);
+		extra_info += it.left->GetName() + " " + op + " " + it.right->GetName() + "\n";
+	}
+	return extra_info;
+}
+
+void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool has_null, DataChunk &input,
+                                                      DataChunk &result) {
+	// empty hash table, special case
+	if (join_type == JoinType::ANTI) {
+		// anti join with empty hash table, NOP join
+		// return the input
+		D_ASSERT(input.ColumnCount() == result.ColumnCount());
+		result.Reference(input);
+	} else if (join_type == JoinType::MARK) {
+		// MARK join with empty hash table
+		D_ASSERT(join_type == JoinType::MARK);
+		D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
+		auto &result_vector = result.data.back();
+		D_ASSERT(result_vector.GetType() == LogicalType::BOOLEAN);
+		// for every data vector, we just reference the child chunk
+		result.SetCardinality(input);
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// for the MARK vector:
+		// if the HT has no NULL values (i.e. empty result set), return a vector that has false for every input
+		// entry if the HT has NULL values (i.e. result set had values, but all were NULL), return a vector that
+		// has NULL for every input entry
+		if (!has_null) {
+			auto bool_result = FlatVector::GetData<bool>(result_vector);
+			for (idx_t i = 0; i < result.size(); i++) {
+				bool_result[i] = false;
+			}
+		} else {
+			FlatVector::Validity(result_vector).SetAllInvalid(result.size());
+		}
+	} else if (join_type == JoinType::LEFT || join_type == JoinType::OUTER || join_type == JoinType::SINGLE) {
+		// LEFT/FULL OUTER/SINGLE join and build side is empty
+		// for the LHS we reference the data
+		result.SetCardinality(input.size());
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// for the RHS
+		for (idx_t k = input.ColumnCount(); k < result.ColumnCount(); k++) {
+			result.data[k].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[k], true);
+		}
+	}
+}
+
+void PhysicalComparisonJoin::ConstructFullOuterJoinResult(bool *found_match, ChunkCollection &input, DataChunk &result,
+                                                          idx_t &scan_position) {
+	// fill in NULL values for the LHS
+	SelectionVector rsel(STANDARD_VECTOR_SIZE);
+	while (scan_position < input.Count()) {
+		auto &rhs_chunk = input.GetChunk(scan_position / STANDARD_VECTOR_SIZE);
+		idx_t result_count = 0;
+		// figure out which tuples didn't find a match in the RHS
+		for (idx_t i = 0; i < rhs_chunk.size(); i++) {
+			if (!found_match[scan_position + i]) {
+				rsel.set_index(result_count++, i);
+			}
+		}
+		scan_position += STANDARD_VECTOR_SIZE;
+		if (result_count > 0) {
+			// if there were any tuples that didn't find a match, output them
+			idx_t left_column_count = result.ColumnCount() - input.ColumnCount();
+			for (idx_t i = 0; i < left_column_count; i++) {
+				result.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result.data[i], true);
+			}
+			for (idx_t col_idx = 0; col_idx < rhs_chunk.ColumnCount(); col_idx++) {
+				result.data[left_column_count + col_idx].Slice(rhs_chunk.data[col_idx], rsel, result_count);
+			}
+			result.SetCardinality(result_count);
+			return;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCrossProduct::PhysicalCrossProduct(vector<LogicalType> types, unique_ptr<PhysicalOperator> left,
+                                           unique_ptr<PhysicalOperator> right, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CROSS_PRODUCT, move(types), estimated_cardinality) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class CrossProductGlobalState : public GlobalSinkState {
+public:
+	CrossProductGlobalState() {
+	}
+
+	ChunkCollection rhs_materialized;
+	mutex rhs_lock;
+};
+
+unique_ptr<GlobalSinkState> PhysicalCrossProduct::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<CrossProductGlobalState>();
+}
+
+SinkResultType PhysicalCrossProduct::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                          DataChunk &input) const {
+	auto &sink = (CrossProductGlobalState &)state;
+	lock_guard<mutex> client_guard(sink.rhs_lock);
+	sink.rhs_materialized.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class CrossProductOperatorState : public OperatorState {
+public:
+	CrossProductOperatorState() : right_position(0) {
+	}
+
+	idx_t right_position;
+};
+
+unique_ptr<OperatorState> PhysicalCrossProduct::GetOperatorState(ClientContext &context) const {
+	return make_unique<CrossProductOperatorState>();
+}
+
+OperatorResultType PhysicalCrossProduct::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                 GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (CrossProductOperatorState &)state_p;
+	auto &sink = (CrossProductGlobalState &)*sink_state;
+	auto &right_collection = sink.rhs_materialized;
+
+	if (sink.rhs_materialized.Count() == 0) {
+		// no RHS: empty result
+		return OperatorResultType::FINISHED;
+	}
+	if (state.right_position >= right_collection.Count()) {
+		// ran out of entries on the RHS
+		// reset the RHS and move to the next chunk on the LHS
+		state.right_position = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	auto &left_chunk = input;
+	// now match the current vector of the left relation with the current row
+	// from the right relation
+	chunk.SetCardinality(left_chunk.size());
+	// create a reference to the vectors of the left column
+	for (idx_t i = 0; i < left_chunk.ColumnCount(); i++) {
+		chunk.data[i].Reference(left_chunk.data[i]);
+	}
+	// duplicate the values on the right side
+	auto &right_chunk = right_collection.GetChunkForRow(state.right_position);
+	auto row_in_chunk = state.right_position % STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < right_collection.ColumnCount(); i++) {
+		ConstantVector::Reference(chunk.data[left_chunk.ColumnCount() + i], right_chunk.data[i], row_in_chunk,
+		                          right_chunk.size());
+	}
+
+	// for the next iteration, move to the next position on the right side
+	state.right_position++;
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalCrossProduct::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	PhysicalJoin::BuildJoinPipelines(executor, current, state, *this);
+}
+
+vector<const PhysicalOperator *> PhysicalCrossProduct::GetSources() const {
+	return children[0]->GetSources();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<PhysicalOperator> original_join,
+                                     vector<PhysicalOperator *> delim_scans, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::DELIM_JOIN, move(types), estimated_cardinality), join(move(original_join)),
+      delim_scans(move(delim_scans)) {
+	D_ASSERT(join->children.size() == 2);
+	// now for the original join
+	// we take its left child, this is the side that we will duplicate eliminate
+	children.push_back(move(join->children[0]));
+
+	// we replace it with a PhysicalChunkCollectionScan, that scans the ChunkCollection that we keep cached
+	// the actual chunk collection to scan will be created in the DelimJoinGlobalState
+	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN,
+	                                                        estimated_cardinality);
+	join->children[0] = move(cached_chunk_scan);
+}
+
+vector<PhysicalOperator *> PhysicalDelimJoin::GetChildren() const {
+	vector<PhysicalOperator *> result;
+	for (auto &child : children) {
+		result.push_back(child.get());
+	}
+	result.push_back(join.get());
+	result.push_back(distinct.get());
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class DelimJoinGlobalState : public GlobalSinkState {
+public:
+	explicit DelimJoinGlobalState(const PhysicalDelimJoin *delim_join) {
+		D_ASSERT(delim_join->delim_scans.size() > 0);
+		// set up the delim join chunk to scan in the original join
+		auto &cached_chunk_scan = (PhysicalChunkScan &)*delim_join->join->children[0];
+		cached_chunk_scan.collection = &lhs_data;
+	}
+
+	ChunkCollection lhs_data;
+	mutex lhs_lock;
+
+	void Merge(ChunkCollection &input) {
+		lock_guard<mutex> guard(lhs_lock);
+		lhs_data.Append(input);
+	}
+};
+
+class DelimJoinLocalState : public LocalSinkState {
+public:
+	unique_ptr<LocalSinkState> distinct_state;
+	ChunkCollection lhs_data;
+
+	void Append(DataChunk &input) {
+		lhs_data.Append(input);
+	}
+};
+
+unique_ptr<GlobalSinkState> PhysicalDelimJoin::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<DelimJoinGlobalState>(this);
+	distinct->sink_state = distinct->GetGlobalSinkState(context);
+	if (delim_scans.size() > 1) {
+		PhysicalHashAggregate::SetMultiScan(*distinct->sink_state);
+	}
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalDelimJoin::GetLocalSinkState(ExecutionContext &context) const {
+	auto state = make_unique<DelimJoinLocalState>();
+	state->distinct_state = distinct->GetLocalSinkState(context);
+	return move(state);
+}
+
+SinkResultType PhysicalDelimJoin::Sink(ExecutionContext &context, GlobalSinkState &state_p, LocalSinkState &lstate_p,
+                                       DataChunk &input) const {
+	auto &lstate = (DelimJoinLocalState &)lstate_p;
+	lstate.lhs_data.Append(input);
+	distinct->Sink(context, *distinct->sink_state, *lstate.distinct_state, input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalDelimJoin::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+	auto &lstate = (DelimJoinLocalState &)lstate_p;
+	auto &gstate = (DelimJoinGlobalState &)state;
+	gstate.Merge(lstate.lhs_data);
+	distinct->Combine(context, *distinct->sink_state, *lstate.distinct_state);
+}
+
+SinkFinalizeType PhysicalDelimJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &client,
+                                             GlobalSinkState &gstate) const {
+	// finalize the distinct HT
+	D_ASSERT(distinct);
+	distinct->Finalize(pipeline, event, client, *distinct->sink_state);
+	return SinkFinalizeType::READY;
+}
+
+string PhysicalDelimJoin::ParamsToString() const {
+	return join->ParamsToString();
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalDelimJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	sink_state.reset();
+
+	// duplicate eliminated join
+	auto pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*pipeline, this);
+	current.AddDependency(pipeline);
+
+	// recurse into the pipeline child
+	children[0]->BuildPipelines(executor, *pipeline, state);
+	if (type == PhysicalOperatorType::DELIM_JOIN) {
+		// recurse into the actual join
+		// any pipelines in there depend on the main pipeline
+		// any scan of the duplicate eliminated data on the RHS depends on this pipeline
+		// we add an entry to the mapping of (PhysicalOperator*) -> (Pipeline*)
+		for (auto &delim_scan : delim_scans) {
+			state.delim_join_dependencies[delim_scan] = pipeline.get();
+		}
+		join->BuildPipelines(executor, current, state);
+	}
+	if (!state.recursive_cte) {
+		// regular pipeline: schedule it
+		state.AddPipeline(executor, move(pipeline));
+	} else {
+		// CTE pipeline! add it to the CTE pipelines
+		auto &cte = (PhysicalRecursiveCTE &)*state.recursive_cte;
+		cte.pipelines.push_back(move(pipeline));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                   const vector<idx_t> &left_projection_map,
+                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types,
+                                   idx_t estimated_cardinality, PerfectHashJoinStats perfect_join_stats)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type, estimated_cardinality),
+      right_projection_map(right_projection_map_p), delim_types(move(delim_types)),
+      perfect_join_statistics(move(perfect_join_stats)) {
+
+	children.push_back(move(left));
+	children.push_back(move(right));
+
+	D_ASSERT(left_projection_map.empty());
+	for (auto &condition : conditions) {
+		condition_types.push_back(condition.left->return_type);
+	}
+
+	// for ANTI, SEMI and MARK join, we only need to store the keys, so for these the build types are empty
+	if (join_type != JoinType::ANTI && join_type != JoinType::SEMI && join_type != JoinType::MARK) {
+		build_types = LogicalOperator::MapTypes(children[1]->GetTypes(), right_projection_map);
+	}
+}
+
+PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                   idx_t estimated_cardinality, PerfectHashJoinStats perfect_join_state)
+    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {}, estimated_cardinality,
+                       std::move(perfect_join_state)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class HashJoinLocalState : public LocalSinkState {
+public:
+	DataChunk build_chunk;
+	DataChunk join_keys;
+	ExpressionExecutor build_executor;
+};
+
+class HashJoinGlobalState : public GlobalSinkState {
+public:
+	HashJoinGlobalState() {
+	}
+
+	//! The HT used by the join
+	unique_ptr<JoinHashTable> hash_table;
+	//! The perfect hash join executor (if any)
+	unique_ptr<PerfectHashJoinExecutor> perfect_join_executor;
+	//! Whether or not the hash table has been finalized
+	bool finalized = false;
+};
+
+unique_ptr<GlobalSinkState> PhysicalHashJoin::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<HashJoinGlobalState>();
+	state->hash_table =
+	    make_unique<JoinHashTable>(BufferManager::GetBufferManager(context), conditions, build_types, join_type);
+	if (!delim_types.empty() && join_type == JoinType::MARK) {
+		// correlated MARK join
+		if (delim_types.size() + 1 == conditions.size()) {
+			// the correlated MARK join has one more condition than the amount of correlated columns
+			// this is the case in a correlated ANY() expression
+			// in this case we need to keep track of additional entries, namely:
+			// - (1) the total amount of elements per group
+			// - (2) the amount of non-null elements per group
+			// we need these to correctly deal with the cases of either:
+			// - (1) the group being empty [in which case the result is always false, even if the comparison is NULL]
+			// - (2) the group containing a NULL value [in which case FALSE becomes NULL]
+			auto &info = state->hash_table->correlated_mark_join_info;
+
+			vector<LogicalType> payload_types;
+			vector<BoundAggregateExpression *> correlated_aggregates;
+			unique_ptr<BoundAggregateExpression> aggr;
+
+			// jury-rigging the GroupedAggregateHashTable
+			// we need a count_star and a count to get counts with and without NULLs
+			aggr = AggregateFunction::BindAggregateFunction(context, CountStarFun::GetFunction(), {}, nullptr, false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
+			auto count_fun = CountFun::GetFunction();
+			vector<unique_ptr<Expression>> children;
+			// this is a dummy but we need it to make the hash table understand whats going on
+			children.push_back(make_unique_base<Expression, BoundReferenceExpression>(count_fun.return_type, 0));
+			aggr = AggregateFunction::BindAggregateFunction(context, count_fun, move(children), nullptr, false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
+			info.correlated_counts = make_unique<GroupedAggregateHashTable>(
+			    BufferManager::GetBufferManager(context), delim_types, payload_types, correlated_aggregates);
+			info.correlated_types = delim_types;
+			info.group_chunk.Initialize(delim_types);
+			info.result_chunk.Initialize(payload_types);
+		}
+	}
+	// for perfect hash join
+	state->perfect_join_executor =
+	    make_unique<PerfectHashJoinExecutor>(*this, *state->hash_table, perfect_join_statistics);
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalHashJoin::GetLocalSinkState(ExecutionContext &context) const {
+	auto state = make_unique<HashJoinLocalState>();
+	if (!right_projection_map.empty()) {
+		state->build_chunk.Initialize(build_types);
+	}
+	for (auto &cond : conditions) {
+		state->build_executor.AddExpression(*cond.right);
+	}
+	state->join_keys.Initialize(condition_types);
+	return move(state);
+}
+
+SinkResultType PhysicalHashJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                      DataChunk &input) const {
+	auto &sink = (HashJoinGlobalState &)state;
+	auto &lstate = (HashJoinLocalState &)lstate_p;
+	// resolve the join keys for the right chunk
+	lstate.join_keys.Reset();
+	lstate.build_executor.Execute(input, lstate.join_keys);
+	// TODO: add statement to check for possible per
+	// build the HT
+	if (!right_projection_map.empty()) {
+		// there is a projection map: fill the build chunk with the projected columns
+		lstate.build_chunk.Reset();
+		lstate.build_chunk.SetCardinality(input);
+		for (idx_t i = 0; i < right_projection_map.size(); i++) {
+			lstate.build_chunk.data[i].Reference(input.data[right_projection_map[i]]);
+		}
+		sink.hash_table->Build(lstate.join_keys, lstate.build_chunk);
+	} else if (!build_types.empty()) {
+		// there is not a projected map: place the entire right chunk in the HT
+		sink.hash_table->Build(lstate.join_keys, input);
+	} else {
+		// there are only keys: place an empty chunk in the payload
+		lstate.build_chunk.SetCardinality(input.size());
+		sink.hash_table->Build(lstate.join_keys, lstate.build_chunk);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalHashJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (HashJoinLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.build_executor, "build_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                            GlobalSinkState &gstate) const {
+	auto &sink = (HashJoinGlobalState &)gstate;
+	// check for possible perfect hash table
+	auto use_perfect_hash = sink.perfect_join_executor->CanDoPerfectHashJoin();
+	if (use_perfect_hash) {
+		D_ASSERT(sink.hash_table->equality_types.size() == 1);
+		auto key_type = sink.hash_table->equality_types[0];
+		use_perfect_hash = sink.perfect_join_executor->BuildPerfectHashTable(key_type);
+	}
+	// In case of a large build side or duplicates, use regular hash join
+	if (!use_perfect_hash) {
+		sink.perfect_join_executor.reset();
+		sink.hash_table->Finalize();
+	}
+	sink.finalized = true;
+	if (sink.hash_table->Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PhysicalHashJoinState : public OperatorState {
+public:
+	DataChunk join_keys;
+	ExpressionExecutor probe_executor;
+	unique_ptr<JoinHashTable::ScanStructure> scan_structure;
+	unique_ptr<OperatorState> perfect_hash_join_state;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &probe_executor, "probe_executor", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ClientContext &context) const {
+	auto state = make_unique<PhysicalHashJoinState>();
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	if (sink.perfect_join_executor) {
+		state->perfect_hash_join_state = sink.perfect_join_executor->GetOperatorState(context);
+	} else {
+		state->join_keys.Initialize(condition_types);
+		for (auto &cond : conditions) {
+			state->probe_executor.AddExpression(*cond.left);
+		}
+	}
+	return move(state);
+}
+
+OperatorResultType PhysicalHashJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                             GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (PhysicalHashJoinState &)state_p;
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	D_ASSERT(sink.finalized);
+
+	if (sink.hash_table->Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return OperatorResultType::FINISHED;
+	}
+	if (sink.perfect_join_executor) {
+		return sink.perfect_join_executor->ProbePerfectHashTable(context, input, chunk, *state.perfect_hash_join_state);
+	}
+
+	if (state.scan_structure) {
+		// still have elements remaining from the previous probe (i.e. we got
+		// >1024 elements in the previous probe)
+		state.scan_structure->Next(state.join_keys, input, chunk);
+		if (chunk.size() > 0) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+		state.scan_structure = nullptr;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	// probe the HT
+	if (sink.hash_table->Count() == 0) {
+		ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, input, chunk);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	// resolve the join keys for the left chunk
+	state.join_keys.Reset();
+	state.probe_executor.Execute(input, state.join_keys);
+
+	// perform the actual probe
+	state.scan_structure = sink.hash_table->Probe(state.join_keys);
+	state.scan_structure->Next(state.join_keys, input, chunk);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class HashJoinScanState : public GlobalSourceState {
+public:
+	explicit HashJoinScanState(const PhysicalHashJoin &op) : op(op) {
+	}
+
+	const PhysicalHashJoin &op;
+	//! Only used for FULL OUTER JOIN: scan state of the final scan to find unmatched tuples in the build-side
+	JoinHTScanState ht_scan_state;
+
+	idx_t MaxThreads() override {
+		auto &sink = (HashJoinGlobalState &)*op.sink_state;
+		return sink.hash_table->Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalHashJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<HashJoinScanState>(*this);
+}
+
+void PhysicalHashJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                               LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	auto &state = (HashJoinScanState &)gstate;
+	sink.hash_table->ScanFullOuter(chunk, state.ht_scan_state);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <thread>
+
+namespace duckdb {
+
+PhysicalIEJoin::PhysicalIEJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                               unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                               idx_t estimated_cardinality)
+    : PhysicalRangeJoin(op, PhysicalOperatorType::IE_JOIN, move(left), move(right), move(cond), join_type,
+                        estimated_cardinality) {
+
+	// 1. let L1 (resp. L2) be the array of column X (resp. Y)
+	D_ASSERT(conditions.size() >= 2);
+	lhs_orders.resize(2);
+	rhs_orders.resize(2);
+	for (idx_t i = 0; i < 2; ++i) {
+		auto &cond = conditions[i];
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+
+		// Convert the conditions to sort orders
+		auto left = cond.left->Copy();
+		auto right = cond.right->Copy();
+		auto sense = OrderType::INVALID;
+
+		// 2. if (op1 ∈ {>, ≥}) sort L1 in descending order
+		// 3. else if (op1 ∈ {<, ≤}) sort L1 in ascending order
+		// 4. if (op2 ∈ {>, ≥}) sort L2 in ascending order
+		// 5. else if (op2 ∈ {<, ≤}) sort L2 in descending order
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			sense = i ? OrderType::ASCENDING : OrderType::DESCENDING;
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			sense = i ? OrderType::DESCENDING : OrderType::ASCENDING;
+			break;
+		default:
+			throw NotImplementedException("Unimplemented join type for IEJoin");
+		}
+		lhs_orders[i].emplace_back(BoundOrderByNode(sense, OrderByNullType::NULLS_LAST, move(left)));
+		rhs_orders[i].emplace_back(BoundOrderByNode(sense, OrderByNullType::NULLS_LAST, move(right)));
+	}
+
+	for (idx_t i = 2; i < conditions.size(); ++i) {
+		auto &cond = conditions[i];
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class IEJoinLocalState : public LocalSinkState {
+public:
+	using LocalSortedTable = PhysicalRangeJoin::LocalSortedTable;
+
+	IEJoinLocalState(const PhysicalRangeJoin &op, const idx_t child) : table(op, child) {
+	}
+
+	//! The local sort state
+	LocalSortedTable table;
+};
+
+class IEJoinGlobalState : public GlobalSinkState {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	IEJoinGlobalState(ClientContext &context, const PhysicalIEJoin &op) : child(0) {
+		tables.resize(2);
+		RowLayout lhs_layout;
+		lhs_layout.Initialize(op.children[0]->types);
+		vector<BoundOrderByNode> lhs_order;
+		lhs_order.emplace_back(op.lhs_orders[0][0].Copy());
+		tables[0] = make_unique<GlobalSortedTable>(context, lhs_order, lhs_layout);
+
+		RowLayout rhs_layout;
+		rhs_layout.Initialize(op.children[1]->types);
+		vector<BoundOrderByNode> rhs_order;
+		rhs_order.emplace_back(op.rhs_orders[0][0].Copy());
+		tables[1] = make_unique<GlobalSortedTable>(context, rhs_order, rhs_layout);
+	}
+
+	IEJoinGlobalState(IEJoinGlobalState &prev)
+	    : GlobalSinkState(prev), tables(move(prev.tables)), child(prev.child + 1) {
+	}
+
+	void Sink(DataChunk &input, IEJoinLocalState &lstate) {
+		auto &table = *tables[child];
+		auto &global_sort_state = table.global_sort_state;
+		auto &local_sort_state = lstate.table.local_sort_state;
+
+		// Sink the data into the local sort state
+		lstate.table.Sink(input, global_sort_state);
+
+		// When sorting data reaches a certain size, we sort it
+		if (local_sort_state.SizeInBytes() >= table.memory_per_thread) {
+			local_sort_state.Sort(global_sort_state, true);
+		}
+	}
+
+	vector<unique_ptr<GlobalSortedTable>> tables;
+	size_t child;
+};
+
+unique_ptr<GlobalSinkState> PhysicalIEJoin::GetGlobalSinkState(ClientContext &context) const {
+	D_ASSERT(!sink_state);
+	return make_unique<IEJoinGlobalState>(context, *this);
+}
+
+unique_ptr<LocalSinkState> PhysicalIEJoin::GetLocalSinkState(ExecutionContext &context) const {
+	idx_t sink_child = 0;
+	if (sink_state) {
+		const auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+		sink_child = ie_sink.child;
+	}
+	return make_unique<IEJoinLocalState>(*this, sink_child);
+}
+
+SinkResultType PhysicalIEJoin::Sink(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p,
+                                    DataChunk &input) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &lstate = (IEJoinLocalState &)lstate_p;
+
+	gstate.Sink(input, lstate);
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalIEJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &lstate = (IEJoinLocalState &)lstate_p;
+	gstate.tables[gstate.child]->Combine(lstate.table);
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &lstate.table.executor, gstate.child ? "rhs_executor" : "lhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalIEJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                          GlobalSinkState &gstate_p) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &table = *gstate.tables[gstate.child];
+	auto &global_sort_state = table.global_sort_state;
+
+	if ((gstate.child == 1 && IsRightOuterJoin(join_type)) || (gstate.child == 0 && IsLeftOuterJoin(join_type))) {
+		// for FULL/LEFT/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		table.IntializeMatches();
+	}
+	if (gstate.child == 1 && global_sort_state.sorted_blocks.empty() && EmptyResultIfRHSIsEmpty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Sort the current input child
+	table.Finalize(pipeline, event);
+
+	// Move to the next input child
+	++gstate.child;
+
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+OperatorResultType PhysicalIEJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state) const {
+	return OperatorResultType::FINISHED;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+struct SBIterator {
+	static int ComparisonValue(ExpressionType comparison) {
+		switch (comparison) {
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_GREATERTHAN:
+			return -1;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			return 0;
+		default:
+			throw InternalException("Unimplemented comparison type for IEJoin!");
+		}
+	}
+
+	explicit SBIterator(GlobalSortState &gss, ExpressionType comparison, idx_t entry_idx_p = 0)
+	    : sort_layout(gss.sort_layout), block_count(gss.sorted_blocks[0]->radix_sorting_data.size()),
+	      block_capacity(gss.block_capacity), cmp_size(sort_layout.comparison_size), entry_size(sort_layout.entry_size),
+	      all_constant(sort_layout.all_constant), external(gss.external), cmp(ComparisonValue(comparison)),
+	      scan(gss.buffer_manager, gss), block_ptr(nullptr), entry_ptr(nullptr) {
+
+		scan.sb = gss.sorted_blocks[0].get();
+		scan.block_idx = block_count;
+		SetIndex(entry_idx_p);
+	}
+
+	inline idx_t GetIndex() const {
+		return entry_idx;
+	}
+
+	inline void SetIndex(idx_t entry_idx_p) {
+		const auto new_block_idx = entry_idx_p / block_capacity;
+		if (new_block_idx != scan.block_idx) {
+			scan.SetIndices(new_block_idx, 0);
+			if (new_block_idx < block_count) {
+				scan.PinRadix(scan.block_idx);
+				block_ptr = scan.RadixPtr();
+				if (!all_constant) {
+					scan.PinData(*scan.sb->blob_sorting_data);
+				}
+			}
+		}
+
+		scan.entry_idx = entry_idx_p % block_capacity;
+		entry_ptr = block_ptr + scan.entry_idx * entry_size;
+		entry_idx = entry_idx_p;
+	}
+
+	inline SBIterator &operator++() {
+		if (++scan.entry_idx < block_capacity) {
+			entry_ptr += entry_size;
+			++entry_idx;
+		} else {
+			SetIndex(entry_idx + 1);
+		}
+
+		return *this;
+	}
+
+	inline SBIterator &operator--() {
+		if (scan.entry_idx) {
+			--scan.entry_idx;
+			--entry_idx;
+			entry_ptr -= entry_size;
+		} else {
+			SetIndex(entry_idx - 1);
+		}
+
+		return *this;
+	}
+
+	inline bool Compare(const SBIterator &other) const {
+		int comp_res;
+		if (all_constant) {
+			comp_res = FastMemcmp(entry_ptr, other.entry_ptr, cmp_size);
+		} else {
+			comp_res = Comparators::CompareTuple(scan, other.scan, entry_ptr, other.entry_ptr, sort_layout, external);
+		}
+
+		return comp_res <= cmp;
+	}
+
+	// Fixed comparison parameters
+	const SortLayout &sort_layout;
+	const idx_t block_count;
+	const idx_t block_capacity;
+	const size_t cmp_size;
+	const size_t entry_size;
+	const bool all_constant;
+	const bool external;
+	const int cmp;
+
+	// Iteration state
+	SBScanState scan;
+	idx_t entry_idx;
+	data_ptr_t block_ptr;
+	data_ptr_t entry_ptr;
+};
+
+struct IEJoinUnion {
+	using SortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+	static idx_t AppendKey(SortedTable &table, ExpressionExecutor &executor, SortedTable &marked, int64_t increment,
+	                       int64_t base, const idx_t block_idx);
+
+	static void Sort(SortedTable &table) {
+		auto &global_sort_state = table.global_sort_state;
+		global_sort_state.PrepareMergePhase();
+		while (global_sort_state.sorted_blocks.size() > 1) {
+			global_sort_state.InitializeMergeRound();
+			MergeSorter merge_sorter(global_sort_state, global_sort_state.buffer_manager);
+			merge_sorter.PerformInMergeRound();
+			global_sort_state.CompleteMergeRound(true);
+		}
+	}
+
+	template <typename T>
+	static vector<T> ExtractColumn(SortedTable &table, idx_t col_idx) {
+		vector<T> result;
+		result.reserve(table.count);
+
+		auto &gstate = table.global_sort_state;
+		auto &blocks = *gstate.sorted_blocks[0]->payload_data;
+		PayloadScanner scanner(blocks, gstate, false);
+
+		DataChunk payload;
+		payload.Initialize(gstate.payload_layout.GetTypes());
+		for (;;) {
+			scanner.Scan(payload);
+			const auto count = payload.size();
+			if (!count) {
+				break;
+			}
+
+			const auto data_ptr = FlatVector::GetData<T>(payload.data[col_idx]);
+			result.insert(result.end(), data_ptr, data_ptr + count);
+		}
+
+		return result;
+	}
+
+	IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, SortedTable &t1, const idx_t b1, SortedTable &t2,
+	            const idx_t b2);
+
+	idx_t SearchL1(idx_t pos);
+	bool NextRow();
+
+	//! Inverted loop
+	idx_t JoinComplexBlocks(SelectionVector &lsel, SelectionVector &rsel);
+
+	//! L1
+	unique_ptr<SortedTable> l1;
+	//! L2
+	unique_ptr<SortedTable> l2;
+
+	//! Li
+	vector<int64_t> li;
+	//! P
+	vector<idx_t> p;
+
+	//! B
+	vector<validity_t> bit_array;
+	ValidityMask bit_mask;
+
+	//! Bloom Filter
+	static constexpr idx_t BLOOM_CHUNK_BITS = 1024;
+	idx_t bloom_count;
+	vector<validity_t> bloom_array;
+	ValidityMask bloom_filter;
+
+	//! Iteration state
+	idx_t n;
+	idx_t i;
+	idx_t j;
+	unique_ptr<SBIterator> op1;
+	unique_ptr<SBIterator> off1;
+	unique_ptr<SBIterator> op2;
+	unique_ptr<SBIterator> off2;
+	int64_t lrid;
+};
+
+idx_t IEJoinUnion::AppendKey(SortedTable &table, ExpressionExecutor &executor, SortedTable &marked, int64_t increment,
+                             int64_t base, const idx_t block_idx) {
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(marked.global_sort_state, marked.global_sort_state.buffer_manager);
+
+	// Reading
+	const auto valid = table.count - table.has_null;
+	auto &gstate = table.global_sort_state;
+	PayloadScanner scanner(gstate, block_idx);
+	auto table_idx = block_idx * gstate.block_capacity;
+
+	DataChunk scanned;
+	scanned.Initialize(scanner.GetPayloadTypes());
+
+	// Writing
+	auto types = local_sort_state.sort_layout->logical_types;
+	const idx_t payload_idx = types.size();
+
+	const auto &payload_types = local_sort_state.payload_layout->GetTypes();
+	types.insert(types.end(), payload_types.begin(), payload_types.end());
+	const idx_t rid_idx = types.size() - 1;
+
+	DataChunk keys;
+	DataChunk payload;
+	keys.Initialize(types);
+
+	idx_t inserted = 0;
+	for (auto rid = base; table_idx < valid;) {
+		scanner.Scan(scanned);
+
+		// NULLs are at the end, so stop when we reach them
+		auto scan_count = scanned.size();
+		if (table_idx + scan_count > valid) {
+			scan_count = valid - table_idx;
+			scanned.SetCardinality(scan_count);
+		}
+		if (scan_count == 0) {
+			break;
+		}
+		table_idx += scan_count;
+
+		// Compute the input columns from the payload
+		keys.Reset();
+		keys.Split(payload, rid_idx);
+		executor.Execute(scanned, keys);
+
+		// Mark the rid column
+		payload.data[0].Sequence(rid, increment);
+		payload.SetCardinality(scan_count);
+		keys.Fuse(payload);
+		rid += increment * scan_count;
+
+		// Sort on the sort columns (which will no longer be needed)
+		keys.Split(payload, payload_idx);
+		local_sort_state.SinkChunk(keys, payload);
+		inserted += scan_count;
+		keys.Fuse(payload);
+
+		// Flush when we have enough data
+		if (local_sort_state.SizeInBytes() >= marked.memory_per_thread) {
+			local_sort_state.Sort(marked.global_sort_state, true);
+		}
+	}
+	marked.global_sort_state.AddLocalState(local_sort_state);
+	marked.count += inserted;
+
+	return inserted;
+}
+
+IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, SortedTable &t1, const idx_t b1,
+                         SortedTable &t2, const idx_t b2)
+    : n(0), i(0) {
+	// input : query Q with 2 join predicates t1.X op1 t2.X' and t1.Y op2 t2.Y', tables T, T' of sizes m and n resp.
+	// output: a list of tuple pairs (ti , tj)
+	// Note that T/T' are already sorted on X/X' and contain the payload data
+	// We only join the two block numbers and use the sizes of the blocks as the counts
+
+	// 0. Filter out tables with no overlap
+	if (!t1.BlockSize(b1) || !t2.BlockSize(b2)) {
+		return;
+	}
+
+	const auto &cmp1 = op.conditions[0].comparison;
+	SBIterator bounds1(t1.global_sort_state, cmp1);
+	SBIterator bounds2(t2.global_sort_state, cmp1);
+
+	// t1.X[0] op1 t2.X'[-1]
+	bounds1.SetIndex(bounds1.block_capacity * b1);
+	bounds2.SetIndex(bounds2.block_capacity * b2 + t2.BlockSize(b2) - 1);
+	if (!bounds1.Compare(bounds2)) {
+		return;
+	}
+
+	// 1. let L1 (resp. L2) be the array of column X (resp. Y )
+	const auto &order1 = op.lhs_orders[0][0];
+	const auto &order2 = op.lhs_orders[1][0];
+
+	// 2. if (op1 ∈ {>, ≥}) sort L1 in descending order
+	// 3. else if (op1 ∈ {<, ≤}) sort L1 in ascending order
+
+	// For the union algorithm, we make a unified table with the keys and the rids as the payload:
+	//		X/X', Y/Y', R/R'/Li
+	// The first position is the sort key.
+	vector<LogicalType> types;
+	types.emplace_back(order2.expression->return_type);
+	types.emplace_back(LogicalType::BIGINT);
+	RowLayout payload_layout;
+	payload_layout.Initialize(types);
+
+	// Sort on the first expression
+	auto ref = make_unique<BoundReferenceExpression>(order1.expression->return_type, 0);
+	vector<BoundOrderByNode> orders;
+	orders.emplace_back(BoundOrderByNode(order1.type, order1.null_order, move(ref)));
+
+	l1 = make_unique<SortedTable>(context, orders, payload_layout);
+
+	// LHS has positive rids
+	ExpressionExecutor l_executor;
+	l_executor.AddExpression(*order1.expression);
+	l_executor.AddExpression(*order2.expression);
+	AppendKey(t1, l_executor, *l1, 1, 1, b1);
+
+	// RHS has negative rids
+	ExpressionExecutor r_executor;
+	r_executor.AddExpression(*op.rhs_orders[0][0].expression);
+	r_executor.AddExpression(*op.rhs_orders[1][0].expression);
+	AppendKey(t2, r_executor, *l1, -1, -1, b2);
+
+	Sort(*l1);
+
+	op1 = make_unique<SBIterator>(l1->global_sort_state, cmp1);
+	off1 = make_unique<SBIterator>(l1->global_sort_state, cmp1);
+
+	// We don't actually need the L1 column, just its sort key, which is in the sort blocks
+	li = ExtractColumn<int64_t>(*l1, types.size() - 1);
+
+	// 4. if (op2 ∈ {>, ≥}) sort L2 in ascending order
+	// 5. else if (op2 ∈ {<, ≤}) sort L2 in descending order
+
+	// We sort on Y/Y' to obtain the sort keys and the permutation array.
+	// For this we just need a two-column table of Y, P
+	types.clear();
+	types.emplace_back(LogicalType::BIGINT);
+	payload_layout.Initialize(types);
+
+	// Sort on the first expression
+	orders.clear();
+	ref = make_unique<BoundReferenceExpression>(order2.expression->return_type, 0);
+	orders.emplace_back(BoundOrderByNode(order2.type, order2.null_order, move(ref)));
+
+	ExpressionExecutor executor;
+	executor.AddExpression(*orders[0].expression);
+
+	l2 = make_unique<SortedTable>(context, orders, payload_layout);
+	for (idx_t base = 0, block_idx = 0; block_idx < l1->BlockCount(); ++block_idx) {
+		base += AppendKey(*l1, executor, *l2, 1, base, block_idx);
+	}
+
+	Sort(*l2);
+
+	// We don't actually need the L2 column, just its sort key, which is in the sort blocks
+
+	// 6. compute the permutation array P of L2 w.r.t. L1
+	p = ExtractColumn<idx_t>(*l2, types.size() - 1);
+
+	// 7. initialize bit-array B (|B| = n), and set all bits to 0
+	n = l2->count.load();
+	bit_array.resize(ValidityMask::EntryCount(n), 0);
+	bit_mask.Initialize(bit_array.data());
+
+	// Bloom filter
+	bloom_count = (n + (BLOOM_CHUNK_BITS - 1)) / BLOOM_CHUNK_BITS;
+	bloom_array.resize(ValidityMask::EntryCount(bloom_count), 0);
+	bloom_filter.Initialize(bloom_array.data());
+
+	// 11. for(i←1 to n) do
+	const auto &cmp2 = op.conditions[1].comparison;
+	op2 = make_unique<SBIterator>(l2->global_sort_state, cmp2);
+	off2 = make_unique<SBIterator>(l2->global_sort_state, cmp2);
+	i = 0;
+	j = 0;
+	(void)NextRow();
+}
+
+idx_t IEJoinUnion::SearchL1(idx_t pos) {
+	// Perform an exponential search in the appropriate direction
+	op1->SetIndex(pos);
+
+	idx_t step = 1;
+	auto hi = pos;
+	auto lo = pos;
+	if (!op1->cmp) {
+		// Scan left for loose inequality
+		lo -= MinValue(step, lo);
+		step *= 2;
+		off1->SetIndex(lo);
+		while (lo > 0 && op1->Compare(*off1)) {
+			hi = lo;
+			lo -= MinValue(step, lo);
+			step *= 2;
+			off1->SetIndex(lo);
+		}
+	} else {
+		// Scan right for strict inequality
+		hi += MinValue(step, n - hi);
+		step *= 2;
+		off1->SetIndex(hi);
+		while (hi < n && !op1->Compare(*off1)) {
+			lo = hi;
+			hi += MinValue(step, n - hi);
+			step *= 2;
+			off1->SetIndex(hi);
+		}
+	}
+
+	// Binary search the target area
+	while (lo < hi) {
+		const auto mid = lo + (hi - lo) / 2;
+		off1->SetIndex(mid);
+		if (op1->Compare(*off1)) {
+			hi = mid;
+		} else {
+			lo = mid + 1;
+		}
+	}
+
+	off1->SetIndex(lo);
+
+	return lo;
+}
+
+bool IEJoinUnion::NextRow() {
+	for (; i < n; ++i) {
+		// 12. pos ← P[i]
+		auto pos = p[i];
+		lrid = li[pos];
+		if (lrid < 0) {
+			continue;
+		}
+
+		// 16. B[pos] ← 1
+		op2->SetIndex(i);
+		for (; off2->GetIndex() < n; ++(*off2)) {
+			if (!off2->Compare(*op2)) {
+				break;
+			}
+			const auto p2 = p[off2->GetIndex()];
+			if (li[p2] < 0) {
+				// Only mark rhs matches.
+				bit_mask.SetValid(p2);
+				bloom_filter.SetValid(p2 / BLOOM_CHUNK_BITS);
+			}
+		}
+
+		// 9.  if (op1 ∈ {≤,≥} and op2 ∈ {≤,≥}) eqOff = 0
+		// 10. else eqOff = 1
+		// No, because there could be more than one equal value.
+		// Find the leftmost off1 where L1[pos] op1 L1[off1..n]
+		// These are the rows that satisfy the op1 condition
+		// and that is where we should start scanning B from
+		j = SearchL1(pos);
+
+		return true;
+	}
+	return false;
+}
+
+static idx_t NextValid(const ValidityMask &bits, idx_t j, const idx_t n) {
+	if (j >= n) {
+		return n;
+	}
+
+	// We can do a first approximation by checking entries one at a time
+	// which gives 64:1.
+	idx_t entry_idx, idx_in_entry;
+	bits.GetEntryIndex(j, entry_idx, idx_in_entry);
+	auto entry = bits.GetValidityEntry(entry_idx++);
+
+	// Trim the bits before the start position
+	entry &= (ValidityMask::ValidityBuffer::MAX_ENTRY << idx_in_entry);
+
+	// Check the non-ragged entries
+	for (const auto entry_count = bits.EntryCount(n); entry_idx < entry_count; ++entry_idx) {
+		if (entry) {
+			for (; idx_in_entry < bits.BITS_PER_VALUE; ++idx_in_entry, ++j) {
+				if (bits.RowIsValid(entry, idx_in_entry)) {
+					return j;
+				}
+			}
+		} else {
+			j += bits.BITS_PER_VALUE - idx_in_entry;
+		}
+
+		entry = bits.GetValidityEntry(entry_idx);
+		idx_in_entry = 0;
+	}
+
+	// Check the final entry
+	for (; j < n; ++idx_in_entry, ++j) {
+		if (bits.RowIsValid(entry, idx_in_entry)) {
+			return j;
+		}
+	}
+
+	return j;
+}
+
+idx_t IEJoinUnion::JoinComplexBlocks(SelectionVector &lsel, SelectionVector &rsel) {
+	// 8. initialize join result as an empty list for tuple pairs
+	idx_t result_count = 0;
+
+	// 11. for(i←1 to n) do
+	while (i < n) {
+		// 13. for (j ← pos+eqOff to n) do
+		for (;;) {
+			// 14. if B[j] = 1 then
+
+			//	Use the Bloom filter to find candidate blocks
+			while (j < n) {
+				auto bloom_begin = NextValid(bloom_filter, j / BLOOM_CHUNK_BITS, bloom_count) * BLOOM_CHUNK_BITS;
+				auto bloom_end = MinValue<idx_t>(n, bloom_begin + BLOOM_CHUNK_BITS);
+
+				j = MaxValue<idx_t>(j, bloom_begin);
+				j = NextValid(bit_mask, j, bloom_end);
+				if (j < bloom_end) {
+					break;
+				}
+			}
+
+			if (j >= n) {
+				break;
+			}
+
+			// Filter out tuples with the same sign (they come from the same table)
+			const auto rrid = li[j];
+			++j;
+
+			// 15. add tuples w.r.t. (L1[j], L1[i]) to join result
+			if (lrid > 0 && rrid < 0) {
+				lsel.set_index(result_count, sel_t(+lrid - 1));
+				rsel.set_index(result_count, sel_t(-rrid - 1));
+				++result_count;
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					return result_count;
+				}
+			}
+		}
+		++i;
+
+		if (!NextRow()) {
+			break;
+		}
+	}
+
+	return result_count;
+}
+
+class IEJoinState : public OperatorState {
+public:
+	explicit IEJoinState(const PhysicalIEJoin &op) : local_left(op, 0) {};
+
+	IEJoinLocalState local_left;
+};
+
+class IEJoinLocalSourceState : public LocalSourceState {
+public:
+	explicit IEJoinLocalSourceState(const PhysicalIEJoin &op)
+	    : op(op), true_sel(STANDARD_VECTOR_SIZE), left_matches(nullptr), right_matches(nullptr) {
+
+		if (op.conditions.size() < 3) {
+			return;
+		}
+
+		vector<LogicalType> left_types;
+		vector<LogicalType> right_types;
+		for (idx_t i = 2; i < op.conditions.size(); ++i) {
+			const auto &cond = op.conditions[i];
+
+			left_types.push_back(cond.left->return_type);
+			left_executor.AddExpression(*cond.left);
+
+			right_types.push_back(cond.left->return_type);
+			right_executor.AddExpression(*cond.right);
+		}
+
+		left_keys.Initialize(left_types);
+		right_keys.Initialize(right_types);
+	}
+
+	idx_t SelectOuterRows(bool *matches) {
+		idx_t count = 0;
+		for (; outer_idx < outer_count; ++outer_idx) {
+			if (!matches[outer_idx]) {
+				true_sel.set_index(count++, outer_idx);
+				if (count >= STANDARD_VECTOR_SIZE) {
+					break;
+				}
+			}
+		}
+
+		return count;
+	}
+
+	const PhysicalIEJoin &op;
+
+	// Joining
+	unique_ptr<IEJoinUnion> joiner;
+
+	idx_t left_base;
+	idx_t left_block_index;
+
+	idx_t right_base;
+	idx_t right_block_index;
+
+	// Trailing predicates
+	SelectionVector true_sel;
+
+	ExpressionExecutor left_executor;
+	DataChunk left_keys;
+
+	ExpressionExecutor right_executor;
+	DataChunk right_keys;
+
+	// Outer joins
+	idx_t outer_idx;
+	idx_t outer_count;
+	bool *left_matches;
+	bool *right_matches;
+};
+
+void PhysicalIEJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &chunk, LocalSourceState &state_p) const {
+	auto &state = (IEJoinLocalSourceState &)state_p;
+	auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+	auto &left_table = *ie_sink.tables[0];
+	auto &right_table = *ie_sink.tables[1];
+
+	const auto left_cols = children[0]->GetTypes().size();
+	do {
+		SelectionVector lsel(STANDARD_VECTOR_SIZE);
+		SelectionVector rsel(STANDARD_VECTOR_SIZE);
+		auto result_count = state.joiner->JoinComplexBlocks(lsel, rsel);
+		if (result_count == 0) {
+			// exhausted this pair
+			return;
+		}
+
+		// found matches: extract them
+		chunk.Reset();
+		SliceSortedPayload(chunk, left_table.global_sort_state, state.left_block_index, lsel, result_count, 0);
+		SliceSortedPayload(chunk, right_table.global_sort_state, state.right_block_index, rsel, result_count,
+		                   left_cols);
+		chunk.SetCardinality(result_count);
+
+		auto sel = FlatVector::IncrementalSelectionVector();
+		if (conditions.size() > 2) {
+			// If there are more expressions to compute,
+			// split the result chunk into the left and right halves
+			// so we can compute the values for comparison.
+			const auto tail_cols = conditions.size() - 2;
+
+			DataChunk right_chunk;
+			chunk.Split(right_chunk, left_cols);
+			state.left_executor.SetChunk(chunk);
+			state.right_executor.SetChunk(right_chunk);
+
+			auto tail_count = result_count;
+			auto true_sel = &state.true_sel;
+			for (size_t cmp_idx = 0; cmp_idx < tail_cols; ++cmp_idx) {
+				auto &left = state.left_keys.data[cmp_idx];
+				state.left_executor.ExecuteExpression(cmp_idx, left);
+
+				auto &right = state.right_keys.data[cmp_idx];
+				state.right_executor.ExecuteExpression(cmp_idx, right);
+
+				if (tail_count < result_count) {
+					left.Slice(*sel, tail_count);
+					right.Slice(*sel, tail_count);
+				}
+				tail_count = SelectJoinTail(conditions[cmp_idx + 2].comparison, left, right, sel, tail_count, true_sel);
+				sel = true_sel;
+			}
+			chunk.Fuse(right_chunk);
+
+			if (tail_count < result_count) {
+				result_count = tail_count;
+				chunk.Slice(*sel, result_count);
+			}
+		}
+
+		// found matches: mark the found matches if required
+		if (left_table.found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				left_table.found_match[state.left_base + lsel[sel->get_index(i)]] = true;
+			}
+		}
+		if (right_table.found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				right_table.found_match[state.right_base + rsel[sel->get_index(i)]] = true;
+			}
+		}
+		chunk.Verify();
+	} while (chunk.size() == 0);
+}
+
+class IEJoinGlobalSourceState : public GlobalSourceState {
+public:
+	explicit IEJoinGlobalSourceState(const PhysicalIEJoin &op)
+	    : op(op), initialized(false), next_pair(0), completed(0), left_outers(0), next_left(0), right_outers(0),
+	      next_right(0) {
+	}
+
+	void Initialize(IEJoinGlobalState &sink_state) {
+		lock_guard<mutex> initializing(lock);
+		if (initialized) {
+			return;
+		}
+
+		// Compute the starting row for reach block
+		// (In theory these are all the same size, but you never know...)
+		auto &left_table = *sink_state.tables[0];
+		const auto left_blocks = left_table.BlockCount();
+		idx_t left_base = 0;
+
+		for (size_t lhs = 0; lhs < left_blocks; ++lhs) {
+			left_bases.emplace_back(left_base);
+			left_base += left_table.BlockSize(lhs);
+		}
+
+		auto &right_table = *sink_state.tables[1];
+		const auto right_blocks = right_table.BlockCount();
+		idx_t right_base = 0;
+		for (size_t rhs = 0; rhs < right_blocks; ++rhs) {
+			right_bases.emplace_back(right_base);
+			right_base += right_table.BlockSize(rhs);
+		}
+
+		// Outer join block counts
+		if (left_table.found_match) {
+			left_outers = left_blocks;
+		}
+
+		if (right_table.found_match) {
+			right_outers = right_blocks;
+		}
+
+		// Ready for action
+		initialized = true;
+	}
+
+public:
+	idx_t MaxThreads() override {
+		// We can't leverage any more threads than block pairs.
+		const auto &sink_state = ((IEJoinGlobalState &)*op.sink_state);
+		return sink_state.tables[0]->BlockCount() * sink_state.tables[1]->BlockCount();
+	}
+
+	void GetNextPair(ClientContext &client, IEJoinGlobalState &gstate, IEJoinLocalSourceState &lstate) {
+		auto &left_table = *gstate.tables[0];
+		auto &right_table = *gstate.tables[1];
+
+		const auto left_blocks = left_table.BlockCount();
+		const auto right_blocks = right_table.BlockCount();
+		const auto pair_count = left_blocks * right_blocks;
+
+		// Regular block
+		const auto i = next_pair++;
+		if (i < pair_count) {
+			const auto b1 = i / right_blocks;
+			const auto b2 = i % right_blocks;
+
+			lstate.left_block_index = b1;
+			lstate.left_base = left_bases[b1];
+
+			lstate.right_block_index = b2;
+			lstate.right_base = right_bases[b2];
+
+			lstate.joiner = make_unique<IEJoinUnion>(client, op, left_table, b1, right_table, b2);
+			return;
+		} else {
+			--next_pair;
+		}
+
+		// Outer joins
+		if (!left_outers && !right_outers) {
+			return;
+		}
+
+		// Spin wait for regular blocks to finish(!)
+		while (completed < pair_count) {
+			std::this_thread::yield();
+		}
+
+		// Left outer blocks
+		const auto l = next_left++;
+		if (l < left_outers) {
+			lstate.left_block_index = l;
+			lstate.left_base = left_bases[l];
+
+			lstate.left_matches = left_table.found_match.get() + lstate.left_base;
+			lstate.outer_idx = 0;
+			lstate.outer_count = left_table.BlockSize(l);
+			return;
+		} else {
+			lstate.left_matches = nullptr;
+			--next_left;
+		}
+
+		// Right outer block
+		const auto r = next_right++;
+		if (r < right_outers) {
+			lstate.right_block_index = r;
+			lstate.right_base = right_bases[r];
+
+			lstate.right_matches = right_table.found_match.get() + lstate.right_base;
+			lstate.outer_idx = 0;
+			lstate.outer_count = right_table.BlockSize(r);
+			return;
+		} else {
+			lstate.right_matches = nullptr;
+			--next_right;
+		}
+	}
+
+	void PairCompleted(ClientContext &client, IEJoinGlobalState &gstate, IEJoinLocalSourceState &lstate) {
+		lstate.joiner.reset();
+		++completed;
+		GetNextPair(client, gstate, lstate);
+	}
+
+	const PhysicalIEJoin &op;
+
+	mutex lock;
+	bool initialized;
+
+	// Join queue state
+	std::atomic<size_t> next_pair;
+	std::atomic<size_t> completed;
+
+	// Block base row number
+	vector<idx_t> left_bases;
+	vector<idx_t> right_bases;
+
+	// Outer joins
+	idx_t left_outers;
+	std::atomic<idx_t> next_left;
+
+	idx_t right_outers;
+	std::atomic<idx_t> next_right;
+};
+
+unique_ptr<GlobalSourceState> PhysicalIEJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<IEJoinGlobalSourceState>(*this);
+}
+
+unique_ptr<LocalSourceState> PhysicalIEJoin::GetLocalSourceState(ExecutionContext &context,
+                                                                 GlobalSourceState &gstate) const {
+	return make_unique<IEJoinLocalSourceState>(*this);
+}
+
+void PhysicalIEJoin::GetData(ExecutionContext &context, DataChunk &result, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+	auto &ie_gstate = (IEJoinGlobalSourceState &)gstate;
+	auto &ie_lstate = (IEJoinLocalSourceState &)lstate;
+
+	ie_gstate.Initialize(ie_sink);
+
+	if (!ie_lstate.joiner) {
+		ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+	}
+
+	// Process INNER results
+	while (ie_lstate.joiner) {
+		ResolveComplexJoin(context, result, ie_lstate);
+
+		if (result.size()) {
+			return;
+		}
+
+		ie_gstate.PairCompleted(context.client, ie_sink, ie_lstate);
+	}
+
+	// Process LEFT OUTER results
+	const auto left_cols = children[0]->GetTypes().size();
+	while (ie_lstate.left_matches) {
+		const idx_t count = ie_lstate.SelectOuterRows(ie_lstate.left_matches);
+		if (!count) {
+			ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+			continue;
+		}
+
+		SliceSortedPayload(result, ie_sink.tables[0]->global_sort_state, ie_lstate.left_base, ie_lstate.true_sel,
+		                   count);
+
+		// Fill in NULLs to the right
+		for (auto col_idx = left_cols; col_idx < result.ColumnCount(); ++col_idx) {
+			result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[col_idx], true);
+		}
+
+		result.SetCardinality(count);
+		result.Verify();
+
+		return;
+	}
+
+	// Process RIGHT OUTER results
+	while (ie_lstate.right_matches) {
+		const idx_t count = ie_lstate.SelectOuterRows(ie_lstate.right_matches);
+		if (!count) {
+			ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+			continue;
+		}
+
+		SliceSortedPayload(result, ie_sink.tables[1]->global_sort_state, ie_lstate.right_base, ie_lstate.true_sel,
+		                   count, left_cols);
+
+		// Fill in NULLs to the left
+		for (idx_t col_idx = 0; col_idx < left_cols; ++col_idx) {
+			result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[col_idx], true);
+		}
+
+		result.SetCardinality(count);
+		result.Verify();
+
+		return;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalIEJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	D_ASSERT(children.size() == 2);
+	if (state.recursive_cte) {
+		throw NotImplementedException("IEJoins are not supported in recursive CTEs yet");
+	}
+
+	// Build the LHS
+	auto lhs_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*lhs_pipeline, this);
+	D_ASSERT(children[0].get());
+	children[0]->BuildPipelines(executor, *lhs_pipeline, state);
+
+	// Build the RHS
+	auto rhs_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*rhs_pipeline, this);
+	D_ASSERT(children[1].get());
+	children[1]->BuildPipelines(executor, *rhs_pipeline, state);
+
+	// RHS => LHS => current
+	current.AddDependency(rhs_pipeline);
+	rhs_pipeline->AddDependency(lhs_pipeline);
+
+	state.AddPipeline(executor, move(lhs_pipeline));
+	state.AddPipeline(executor, move(rhs_pipeline));
+
+	// Now build both and scan
+	state.SetPipelineSource(current, this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class IndexJoinOperatorState : public OperatorState {
+public:
+	explicit IndexJoinOperatorState(const PhysicalIndexJoin &op) {
+		rhs_rows.resize(STANDARD_VECTOR_SIZE);
+		result_sizes.resize(STANDARD_VECTOR_SIZE);
+
+		join_keys.Initialize(op.condition_types);
+		for (auto &cond : op.conditions) {
+			probe_executor.AddExpression(*cond.left);
+		}
+		if (!op.fetch_types.empty()) {
+			rhs_chunk.Initialize(op.fetch_types);
+		}
+		rhs_sel.Initialize(STANDARD_VECTOR_SIZE);
+	}
+
+	bool first_fetch = true;
+	idx_t lhs_idx = 0;
+	idx_t rhs_idx = 0;
+	idx_t result_size = 0;
+	vector<idx_t> result_sizes;
+	DataChunk join_keys;
+	DataChunk rhs_chunk;
+	SelectionVector rhs_sel;
+	//! Vector of rows that mush be fetched for every LHS key
+	vector<vector<row_t>> rhs_rows;
+	ExpressionExecutor probe_executor;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &probe_executor, "probe_executor", 0);
+	}
+};
+
+PhysicalIndexJoin::PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                     unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                     const vector<idx_t> &left_projection_map_p, vector<idx_t> right_projection_map_p,
+                                     vector<column_t> column_ids_p, Index *index_p, bool lhs_first,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types), estimated_cardinality),
+      left_projection_map(left_projection_map_p), right_projection_map(move(right_projection_map_p)), index(index_p),
+      conditions(move(cond)), join_type(join_type), lhs_first(lhs_first) {
+	column_ids = move(column_ids_p);
+	children.push_back(move(left));
+	children.push_back(move(right));
+	for (auto &condition : conditions) {
+		condition_types.push_back(condition.left->return_type);
+	}
+	//! Only add to fetch_ids columns that are not indexed
+	for (auto &index_id : index->column_ids) {
+		index_ids.insert(index_id);
+	}
+	for (idx_t column_id = 0; column_id < column_ids.size(); column_id++) {
+		auto it = index_ids.find(column_ids[column_id]);
+		if (it == index_ids.end()) {
+			fetch_ids.push_back(column_ids[column_id]);
+			fetch_types.push_back(children[1]->types[column_id]);
+		}
+	}
+	if (right_projection_map.empty()) {
+		for (column_t i = 0; i < column_ids.size(); i++) {
+			right_projection_map.push_back(i);
+		}
+	}
+	if (left_projection_map.empty()) {
+		for (column_t i = 0; i < children[0]->types.size(); i++) {
+			left_projection_map.push_back(i);
+		}
+	}
+}
+
+unique_ptr<OperatorState> PhysicalIndexJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<IndexJoinOperatorState>(*this);
+}
+
+void PhysicalIndexJoin::Output(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                               OperatorState &state_p) const {
+	auto &transaction = Transaction::GetTransaction(context.client);
+	auto &phy_tbl_scan = (PhysicalTableScan &)*children[1];
+	auto &bind_tbl = (TableScanBindData &)*phy_tbl_scan.bind_data;
+	auto &state = (IndexJoinOperatorState &)state_p;
+
+	auto tbl = bind_tbl.table->storage.get();
+	idx_t output_sel_idx = 0;
+	vector<row_t> fetch_rows;
+
+	while (output_sel_idx < STANDARD_VECTOR_SIZE && state.lhs_idx < input.size()) {
+		if (state.rhs_idx < state.result_sizes[state.lhs_idx]) {
+			state.rhs_sel.set_index(output_sel_idx++, state.lhs_idx);
+			if (!fetch_types.empty()) {
+				//! We need to collect the rows we want to fetch
+				fetch_rows.push_back(state.rhs_rows[state.lhs_idx][state.rhs_idx]);
+			}
+			state.rhs_idx++;
+		} else {
+			//! We are done with the matches from this LHS Key
+			state.rhs_idx = 0;
+			state.lhs_idx++;
+		}
+	}
+	//! Now we fetch the RHS data
+	if (!fetch_types.empty()) {
+		if (fetch_rows.empty()) {
+			return;
+		}
+		state.rhs_chunk.Reset();
+		ColumnFetchState fetch_state;
+		Vector row_ids(LogicalType::ROW_TYPE, (data_ptr_t)&fetch_rows[0]);
+		tbl->Fetch(transaction, state.rhs_chunk, fetch_ids, row_ids, output_sel_idx, fetch_state);
+	}
+
+	//! Now we actually produce our result chunk
+	idx_t left_offset = lhs_first ? 0 : right_projection_map.size();
+	idx_t right_offset = lhs_first ? left_projection_map.size() : 0;
+	idx_t rhs_column_idx = 0;
+	for (idx_t i = 0; i < right_projection_map.size(); i++) {
+		auto it = index_ids.find(column_ids[right_projection_map[i]]);
+		if (it == index_ids.end()) {
+			chunk.data[right_offset + i].Reference(state.rhs_chunk.data[rhs_column_idx++]);
+		} else {
+			chunk.data[right_offset + i].Slice(state.join_keys.data[0], state.rhs_sel, output_sel_idx);
+		}
+	}
+	for (idx_t i = 0; i < left_projection_map.size(); i++) {
+		chunk.data[left_offset + i].Slice(input.data[left_projection_map[i]], state.rhs_sel, output_sel_idx);
+	}
+
+	state.result_size = output_sel_idx;
+	chunk.SetCardinality(state.result_size);
+}
+
+void PhysicalIndexJoin::GetRHSMatches(ExecutionContext &context, DataChunk &input, OperatorState &state_p) const {
+	auto &state = (IndexJoinOperatorState &)state_p;
+	auto &art = (ART &)*index;
+	auto &transaction = Transaction::GetTransaction(context.client);
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto equal_value = state.join_keys.GetValue(0, i);
+		auto index_state = art.InitializeScanSinglePredicate(transaction, equal_value, ExpressionType::COMPARE_EQUAL);
+		state.rhs_rows[i].clear();
+		if (!equal_value.IsNull()) {
+			if (fetch_types.empty()) {
+				IndexLock lock;
+				index->InitializeLock(lock);
+				art.SearchEqualJoinNoFetch(equal_value, state.result_sizes[i]);
+			} else {
+				IndexLock lock;
+				index->InitializeLock(lock);
+				art.SearchEqual((ARTIndexScanState *)index_state.get(), (idx_t)-1, state.rhs_rows[i]);
+				state.result_sizes[i] = state.rhs_rows[i].size();
+			}
+		} else {
+			//! This is null so no matches
+			state.result_sizes[i] = 0;
+		}
+	}
+	for (idx_t i = input.size(); i < STANDARD_VECTOR_SIZE; i++) {
+		//! No LHS chunk value so result size is empty
+		state.result_sizes[i] = 0;
+	}
+}
+
+OperatorResultType PhysicalIndexJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                              GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (IndexJoinOperatorState &)state_p;
+
+	state.result_size = 0;
+	if (state.first_fetch) {
+		state.probe_executor.Execute(input, state.join_keys);
+
+		//! Fill Matches for the current LHS chunk
+		GetRHSMatches(context, input, state_p);
+		state.first_fetch = false;
+	}
+	//! Check if we need to get a new LHS chunk
+	if (state.lhs_idx >= input.size()) {
+		state.lhs_idx = 0;
+		state.rhs_idx = 0;
+		state.first_fetch = true;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	//! Output vectors
+	if (state.lhs_idx < input.size()) {
+		Output(context, input, chunk, state_p);
+	}
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalIndexJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// index join: we only continue into the LHS
+	// the right side is probed by the index join
+	// so we don't need to do anything in the pipeline with this child
+	state.AddPipelineOperator(current, this);
+	children[0]->BuildPipelines(executor, current, state);
+}
+
+vector<const PhysicalOperator *> PhysicalIndexJoin::GetSources() const {
+	return children[0]->GetSources();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
+                           idx_t estimated_cardinality)
+    : PhysicalOperator(type, op.types, estimated_cardinality), join_type(join_type) {
+}
+
+bool PhysicalJoin::EmptyResultIfRHSIsEmpty() const {
+	// empty RHS with INNER, RIGHT or SEMI join means empty result set
+	switch (join_type) {
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+	case JoinType::SEMI:
+		return true;
+	default:
+		return false;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalJoin::BuildJoinPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state,
+                                      PhysicalOperator &op) {
+	op.op_state.reset();
+	op.sink_state.reset();
+
+	// on the LHS (probe child), the operator becomes a regular operator
+	state.AddPipelineOperator(current, &op);
+	if (op.IsSource()) {
+		// FULL or RIGHT outer join
+		// schedule a scan of the node as a child pipeline
+		// this scan has to be performed AFTER all the probing has happened
+		if (state.recursive_cte) {
+			throw NotImplementedException("FULL and RIGHT outer joins are not supported in recursive CTEs yet");
+		}
+		state.AddChildPipeline(executor, current);
+	}
+	// continue building the pipeline on this child
+	op.children[0]->BuildPipelines(executor, current, state);
+
+	// on the RHS (build side), we construct a new child pipeline with this pipeline as its source
+	op.BuildChildPipeline(executor, current, state, op.children[1].get());
+}
+
+void PhysicalJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	PhysicalJoin::BuildJoinPipelines(executor, current, state, *this);
+}
+
+vector<const PhysicalOperator *> PhysicalJoin::GetSources() const {
+	auto result = children[0]->GetSources();
+	if (IsSource()) {
+		result.push_back(this);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                               unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
+                                               JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type, estimated_cardinality) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+static bool HasNullValues(DataChunk &chunk) {
+	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+		VectorData vdata;
+		chunk.data[col_idx].Orrify(chunk.size(), vdata);
+
+		if (vdata.validity.AllValid()) {
+			continue;
+		}
+		for (idx_t i = 0; i < chunk.size(); i++) {
+			auto idx = vdata.sel->get_index(i);
+			if (!vdata.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+template <bool MATCH>
+static void ConstructSemiOrAntiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	D_ASSERT(left.ColumnCount() == result.ColumnCount());
+	// create the selection vector from the matches that were found
+	idx_t result_count = 0;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < left.size(); i++) {
+		if (found_match[i] == MATCH) {
+			sel.set_index(result_count++, i);
+		}
+	}
+	// construct the final result
+	if (result_count > 0) {
+		// we only return the columns on the left side
+		// project them using the result selection vector
+		// reference the columns of the left side from the result
+		result.Slice(left, sel, result_count);
+	} else {
+		result.SetCardinality(0);
+	}
+}
+
+void PhysicalJoin::ConstructSemiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	ConstructSemiOrAntiJoinResult<true>(left, result, found_match);
+}
+
+void PhysicalJoin::ConstructAntiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	ConstructSemiOrAntiJoinResult<false>(left, result, found_match);
+}
+
+void PhysicalJoin::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &left, DataChunk &result, bool found_match[],
+                                           bool has_null) {
+	// for the initial set of columns we just reference the left side
+	result.SetCardinality(left);
+	for (idx_t i = 0; i < left.ColumnCount(); i++) {
+		result.data[i].Reference(left.data[i]);
+	}
+	auto &mark_vector = result.data.back();
+	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	// first we set the NULL values from the join keys
+	// if there is any NULL in the keys, the result is NULL
+	auto bool_result = FlatVector::GetData<bool>(mark_vector);
+	auto &mask = FlatVector::Validity(mark_vector);
+	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
+		VectorData jdata;
+		join_keys.data[col_idx].Orrify(join_keys.size(), jdata);
+		if (!jdata.validity.AllValid()) {
+			for (idx_t i = 0; i < join_keys.size(); i++) {
+				auto jidx = jdata.sel->get_index(i);
+				mask.Set(i, jdata.validity.RowIsValid(jidx));
+			}
+		}
+	}
+	// now set the remaining entries to either true or false based on whether a match was found
+	if (found_match) {
+		for (idx_t i = 0; i < left.size(); i++) {
+			bool_result[i] = found_match[i];
+		}
+	} else {
+		memset(bool_result, 0, sizeof(bool) * left.size());
+	}
+	// if the right side contains NULL values, the result of any FALSE becomes NULL
+	if (has_null) {
+		for (idx_t i = 0; i < left.size(); i++) {
+			if (!bool_result[i]) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class NestedLoopJoinLocalState : public LocalSinkState {
+public:
+	explicit NestedLoopJoinLocalState(const vector<JoinCondition> &conditions) {
+		vector<LogicalType> condition_types;
+		for (auto &cond : conditions) {
+			rhs_executor.AddExpression(*cond.right);
+			condition_types.push_back(cond.right->return_type);
+		}
+		right_condition.Initialize(condition_types);
+	}
+
+	//! The chunk holding the right condition
+	DataChunk right_condition;
+	//! The executor of the RHS condition
+	ExpressionExecutor rhs_executor;
+};
+
+class NestedLoopJoinGlobalState : public GlobalSinkState {
+public:
+	NestedLoopJoinGlobalState() : has_null(false) {
+	}
+
+	mutex nj_lock;
+	//! Materialized data of the RHS
+	ChunkCollection right_data;
+	//! Materialized join condition of the RHS
+	ChunkCollection right_chunks;
+	//! Whether or not the RHS of the nested loop join has NULL values
+	bool has_null;
+	//! A bool indicating for each tuple in the RHS if they found a match (only used in FULL OUTER JOIN)
+	unique_ptr<bool[]> right_found_match;
+};
+
+SinkResultType PhysicalNestedLoopJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                            DataChunk &input) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)state;
+	auto &nlj_state = (NestedLoopJoinLocalState &)lstate;
+
+	// resolve the join expression of the right side
+	nlj_state.right_condition.Reset();
+	nlj_state.rhs_executor.Execute(input, nlj_state.right_condition);
+
+	// if we have not seen any NULL values yet, and we are performing a MARK join, check if there are NULL values in
+	// this chunk
+	if (join_type == JoinType::MARK && !gstate.has_null) {
+		if (HasNullValues(nlj_state.right_condition)) {
+			gstate.has_null = true;
+		}
+	}
+
+	// append the data and the
+	lock_guard<mutex> nj_guard(gstate.nj_lock);
+	gstate.right_data.Append(input);
+	gstate.right_chunks.Append(nlj_state.right_condition);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalNestedLoopJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (NestedLoopJoinLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &state.rhs_executor, "rhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+SinkFinalizeType PhysicalNestedLoopJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)gstate_p;
+	if (join_type == JoinType::OUTER || join_type == JoinType::RIGHT) {
+		// for FULL/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		gstate.right_found_match = unique_ptr<bool[]>(new bool[gstate.right_data.Count()]);
+		memset(gstate.right_found_match.get(), 0, sizeof(bool) * gstate.right_data.Count());
+	}
+	if (gstate.right_chunks.Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<GlobalSinkState> PhysicalNestedLoopJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<NestedLoopJoinGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalNestedLoopJoin::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<NestedLoopJoinLocalState>(conditions);
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PhysicalNestedLoopJoinState : public OperatorState {
+public:
+	PhysicalNestedLoopJoinState(const PhysicalNestedLoopJoin &op, const vector<JoinCondition> &conditions)
+	    : fetch_next_left(true), fetch_next_right(false), right_chunk(0), left_tuple(0), right_tuple(0) {
+		vector<LogicalType> condition_types;
+		for (auto &cond : conditions) {
+			lhs_executor.AddExpression(*cond.left);
+			condition_types.push_back(cond.left->return_type);
+		}
+		left_condition.Initialize(condition_types);
+		if (IsLeftOuterJoin(op.join_type)) {
+			left_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+	}
+
+	bool fetch_next_left;
+	bool fetch_next_right;
+	idx_t right_chunk;
+	DataChunk left_condition;
+	//! The executor of the LHS condition
+	ExpressionExecutor lhs_executor;
+
+	idx_t left_tuple;
+	idx_t right_tuple;
+
+	unique_ptr<bool[]> left_found_match;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &lhs_executor, "lhs_executor", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalNestedLoopJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<PhysicalNestedLoopJoinState>(*this, conditions);
+}
+
+OperatorResultType PhysicalNestedLoopJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	if (gstate.right_chunks.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			ConstructEmptyJoinResult(join_type, gstate.has_null, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	switch (join_type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+		// simple joins can have max STANDARD_VECTOR_SIZE matches per chunk
+		ResolveSimpleJoin(context, input, chunk, state_p);
+		return OperatorResultType::NEED_MORE_INPUT;
+	case JoinType::LEFT:
+	case JoinType::INNER:
+	case JoinType::OUTER:
+	case JoinType::RIGHT:
+		return ResolveComplexJoin(context, input, chunk, state_p);
+	default:
+		throw NotImplementedException("Unimplemented type for nested loop join!");
+	}
+}
+
+void PhysicalNestedLoopJoin::ResolveSimpleJoin(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                               OperatorState &state_p) const {
+	auto &state = (PhysicalNestedLoopJoinState &)state_p;
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	// resolve the left join condition for the current chunk
+	state.lhs_executor.Execute(input, state.left_condition);
+
+	bool found_match[STANDARD_VECTOR_SIZE] = {false};
+	NestedLoopJoinMark::Perform(state.left_condition, gstate.right_chunks, found_match, conditions);
+	switch (join_type) {
+	case JoinType::MARK:
+		// now construct the mark join result from the found matches
+		PhysicalJoin::ConstructMarkJoinResult(state.left_condition, input, chunk, found_match, gstate.has_null);
+		break;
+	case JoinType::SEMI:
+		// construct the semi join result from the found matches
+		PhysicalJoin::ConstructSemiJoinResult(input, chunk, found_match);
+		break;
+	case JoinType::ANTI:
+		// construct the anti join result from the found matches
+		PhysicalJoin::ConstructAntiJoinResult(input, chunk, found_match);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for simple nested loop join!");
+	}
+}
+
+void PhysicalJoin::ConstructLeftJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	SelectionVector remaining_sel(STANDARD_VECTOR_SIZE);
+	idx_t remaining_count = 0;
+	for (idx_t i = 0; i < left.size(); i++) {
+		if (!found_match[i]) {
+			remaining_sel.set_index(remaining_count++, i);
+		}
+	}
+	if (remaining_count > 0) {
+		result.Slice(left, remaining_sel, remaining_count);
+		for (idx_t idx = left.ColumnCount(); idx < result.ColumnCount(); idx++) {
+			result.data[idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[idx], true);
+		}
+	}
+}
+
+OperatorResultType PhysicalNestedLoopJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &input,
+                                                              DataChunk &chunk, OperatorState &state_p) const {
+	auto &state = (PhysicalNestedLoopJoinState &)state_p;
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	idx_t match_count;
+	do {
+		if (state.fetch_next_right) {
+			// we exhausted the chunk on the right: move to the next chunk on the right
+			state.right_chunk++;
+			state.left_tuple = 0;
+			state.right_tuple = 0;
+			state.fetch_next_right = false;
+			// check if we exhausted all chunks on the RHS
+			if (state.right_chunk >= gstate.right_chunks.ChunkCount()) {
+				state.fetch_next_left = true;
+				// we exhausted all chunks on the right: move to the next chunk on the left
+				if (IsLeftOuterJoin(join_type)) {
+					// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+					// have a match found
+					PhysicalJoin::ConstructLeftJoinResult(input, chunk, state.left_found_match.get());
+					memset(state.left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+				}
+				return OperatorResultType::NEED_MORE_INPUT;
+			}
+		}
+		if (state.fetch_next_left) {
+			// resolve the left join condition for the current chunk
+			state.left_condition.Reset();
+			state.lhs_executor.Execute(input, state.left_condition);
+
+			state.left_tuple = 0;
+			state.right_tuple = 0;
+			state.right_chunk = 0;
+			state.fetch_next_left = false;
+		}
+		// now we have a left and a right chunk that we can join together
+		// note that we only get here in the case of a LEFT, INNER or FULL join
+		auto &left_chunk = input;
+		auto &right_chunk = gstate.right_chunks.GetChunk(state.right_chunk);
+		auto &right_data = gstate.right_data.GetChunk(state.right_chunk);
+
+		// sanity check
+		left_chunk.Verify();
+		right_chunk.Verify();
+		right_data.Verify();
+
+		// now perform the join
+		SelectionVector lvector(STANDARD_VECTOR_SIZE), rvector(STANDARD_VECTOR_SIZE);
+		match_count = NestedLoopJoinInner::Perform(state.left_tuple, state.right_tuple, state.left_condition,
+		                                           right_chunk, lvector, rvector, conditions);
+		// we have finished resolving the join conditions
+		if (match_count > 0) {
+			// we have matching tuples!
+			// construct the result
+			if (state.left_found_match) {
+				for (idx_t i = 0; i < match_count; i++) {
+					state.left_found_match[lvector.get_index(i)] = true;
+				}
+			}
+			if (gstate.right_found_match) {
+				for (idx_t i = 0; i < match_count; i++) {
+					gstate.right_found_match[state.right_chunk * STANDARD_VECTOR_SIZE + rvector.get_index(i)] = true;
+				}
+			}
+			chunk.Slice(input, lvector, match_count);
+			chunk.Slice(right_data, rvector, match_count, input.ColumnCount());
+		}
+
+		// check if we exhausted the RHS, if we did we need to move to the next right chunk in the next iteration
+		if (state.right_tuple >= right_chunk.size()) {
+			state.fetch_next_right = true;
+		}
+	} while (match_count == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class NestedLoopJoinScanState : public GlobalSourceState {
+public:
+	explicit NestedLoopJoinScanState(const PhysicalNestedLoopJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalNestedLoopJoin &op;
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (NestedLoopJoinGlobalState &)*op.sink_state;
+		return sink.right_chunks.Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalNestedLoopJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<NestedLoopJoinScanState>(*this);
+}
+
+void PhysicalNestedLoopJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (NestedLoopJoinGlobalState &)*sink_state;
+	auto &state = (NestedLoopJoinScanState &)gstate;
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	lock_guard<mutex> l(state.lock);
+	ConstructFullOuterJoinResult(sink.right_found_match.get(), sink.right_data, chunk, state.right_outer_position);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                                       unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
+                                                       JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalRangeJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(left), move(right), move(cond), join_type,
+                        estimated_cardinality) {
+
+	for (auto &cond : conditions) {
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+
+		// Convert the conditions to sort orders
+		auto left = cond.left->Copy();
+		auto right = cond.right->Copy();
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			// Allowed in multi-predicate joins, but can't be first/sort.
+			D_ASSERT(!lhs_orders.empty());
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::INVALID, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::INVALID, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+
+		default:
+			// COMPARE EQUAL not supported with merge join
+			throw NotImplementedException("Unimplemented join type for merge join");
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class MergeJoinLocalState : public LocalSinkState {
+public:
+	explicit MergeJoinLocalState(const PhysicalRangeJoin &op, const idx_t child) : table(op, child) {
+	}
+
+	//! The local sort state
+	PhysicalRangeJoin::LocalSortedTable table;
+};
+
+class MergeJoinGlobalState : public GlobalSinkState {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	MergeJoinGlobalState(ClientContext &context, const PhysicalPiecewiseMergeJoin &op) {
+		RowLayout rhs_layout;
+		rhs_layout.Initialize(op.children[1]->types);
+		vector<BoundOrderByNode> rhs_order;
+		rhs_order.emplace_back(op.rhs_orders[0].Copy());
+		table = make_unique<GlobalSortedTable>(context, rhs_order, rhs_layout);
+	}
+
+	inline idx_t Count() const {
+		return table->count;
+	}
+
+	void Sink(DataChunk &input, MergeJoinLocalState &lstate) {
+		auto &global_sort_state = table->global_sort_state;
+		auto &local_sort_state = lstate.table.local_sort_state;
+
+		// Sink the data into the local sort state
+		lstate.table.Sink(input, global_sort_state);
+
+		// When sorting data reaches a certain size, we sort it
+		if (local_sort_state.SizeInBytes() >= table->memory_per_thread) {
+			local_sort_state.Sort(global_sort_state, true);
+		}
+	}
+
+	unique_ptr<GlobalSortedTable> table;
+};
+
+unique_ptr<GlobalSinkState> PhysicalPiecewiseMergeJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<MergeJoinGlobalState>(context, *this);
+}
+
+unique_ptr<LocalSinkState> PhysicalPiecewiseMergeJoin::GetLocalSinkState(ExecutionContext &context) const {
+	// We only sink the RHS
+	return make_unique<MergeJoinLocalState>(*this, 1);
+}
+
+SinkResultType PhysicalPiecewiseMergeJoin::Sink(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &lstate = (MergeJoinLocalState &)lstate_p;
+
+	gstate.Sink(input, lstate);
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalPiecewiseMergeJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                         LocalSinkState &lstate_p) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &lstate = (MergeJoinLocalState &)lstate_p;
+	gstate.table->Combine(lstate.table);
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &lstate.table.executor, "rhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalPiecewiseMergeJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                      GlobalSinkState &gstate_p) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &global_sort_state = gstate.table->global_sort_state;
+
+	if (IsRightOuterJoin(join_type)) {
+		// for FULL/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		gstate.table->IntializeMatches();
+	}
+	if (global_sort_state.sorted_blocks.empty() && EmptyResultIfRHSIsEmpty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Sort the current input child
+	gstate.table->Finalize(pipeline, event);
+
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PiecewiseMergeJoinState : public OperatorState {
+public:
+	using LocalSortedTable = PhysicalRangeJoin::LocalSortedTable;
+
+	explicit PiecewiseMergeJoinState(const PhysicalPiecewiseMergeJoin &op, BufferManager &buffer_manager,
+	                                 bool force_external)
+	    : op(op), buffer_manager(buffer_manager), force_external(force_external), left_position(0), first_fetch(true),
+	      finished(true), right_position(0), right_chunk_index(0) {
+		vector<LogicalType> condition_types;
+		for (auto &order : op.lhs_orders) {
+			condition_types.push_back(order.expression->return_type);
+		}
+		if (IsLeftOuterJoin(op.join_type)) {
+			lhs_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(lhs_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+		lhs_layout.Initialize(op.children[0]->types);
+		lhs_payload.Initialize(op.children[0]->types);
+
+		lhs_order.emplace_back(op.lhs_orders[0].Copy());
+
+		// Set up shared data for multiple predicates
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		condition_types.clear();
+		for (auto &order : op.rhs_orders) {
+			rhs_executor.AddExpression(*order.expression);
+			condition_types.push_back(order.expression->return_type);
+		}
+		rhs_keys.Initialize(condition_types);
+	}
+
+	const PhysicalPiecewiseMergeJoin &op;
+	BufferManager &buffer_manager;
+	bool force_external;
+
+	// Block sorting
+	DataChunk lhs_payload;
+	unique_ptr<bool[]> lhs_found_match;
+	vector<BoundOrderByNode> lhs_order;
+	RowLayout lhs_layout;
+	unique_ptr<LocalSortedTable> lhs_local_table;
+	unique_ptr<GlobalSortState> lhs_global_state;
+
+	// Simple scans
+	idx_t left_position;
+
+	// Complex scans
+	bool first_fetch;
+	bool finished;
+	idx_t right_position;
+	idx_t right_chunk_index;
+	idx_t right_base;
+
+	// Secondary predicate shared data
+	SelectionVector sel;
+	DataChunk rhs_keys;
+	DataChunk rhs_input;
+	ExpressionExecutor rhs_executor;
+
+public:
+	void ResolveJoinKeys(DataChunk &input) {
+		// sort by join key
+		lhs_global_state = make_unique<GlobalSortState>(buffer_manager, lhs_order, lhs_layout);
+		lhs_local_table = make_unique<LocalSortedTable>(op, 0);
+		lhs_local_table->Sink(input, *lhs_global_state);
+
+		// Set external (can be forced with the PRAGMA)
+		lhs_global_state->external = force_external;
+		lhs_global_state->AddLocalState(lhs_local_table->local_sort_state);
+		lhs_global_state->PrepareMergePhase();
+		while (lhs_global_state->sorted_blocks.size() > 1) {
+			MergeSorter merge_sorter(*lhs_global_state, buffer_manager);
+			merge_sorter.PerformInMergeRound();
+			lhs_global_state->CompleteMergeRound();
+		}
+
+		// Scan the sorted payload
+		D_ASSERT(lhs_global_state->sorted_blocks.size() == 1);
+
+		PayloadScanner scanner(*lhs_global_state->sorted_blocks[0]->payload_data, *lhs_global_state);
+		lhs_payload.Reset();
+		scanner.Scan(lhs_payload);
+
+		// Recompute the sorted keys from the sorted input
+		lhs_local_table->keys.Reset();
+		lhs_local_table->executor.Execute(lhs_payload, lhs_local_table->keys);
+	}
+
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		if (lhs_local_table) {
+			context.thread.profiler.Flush(op, &lhs_local_table->executor, "lhs_executor", 0);
+		}
+	}
+};
+
+unique_ptr<OperatorState> PhysicalPiecewiseMergeJoin::GetOperatorState(ClientContext &context) const {
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	auto &config = ClientConfig::GetConfig(context);
+	return make_unique<PiecewiseMergeJoinState>(*this, buffer_manager, config.force_external);
+}
+
+static inline idx_t SortedBlockNotNull(const idx_t base, const idx_t count, const idx_t not_null) {
+	return MinValue(base + count, MaxValue(base, not_null)) - base;
+}
+
+static int MergeJoinComparisonValue(ExpressionType comparison) {
+	switch (comparison) {
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return -1;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return 0;
+	default:
+		throw InternalException("Unimplemented comparison type for merge join!");
+	}
+}
+
+struct BlockMergeInfo {
+	GlobalSortState &state;
+	//! The block being scanned
+	const idx_t block_idx;
+	//! The number of not-NULL values in the block (they are at the end)
+	const idx_t not_null;
+	//! The current offset in the block
+	idx_t &entry_idx;
+	SelectionVector result;
+
+	BlockMergeInfo(GlobalSortState &state, idx_t block_idx, idx_t &entry_idx, idx_t not_null)
+	    : state(state), block_idx(block_idx), not_null(not_null), entry_idx(entry_idx), result(STANDARD_VECTOR_SIZE) {
+	}
+};
+
+static void MergeJoinPinSortingBlock(SBScanState &scan, const idx_t block_idx) {
+	scan.SetIndices(block_idx, 0);
+	scan.PinRadix(block_idx);
+
+	auto &sd = *scan.sb->blob_sorting_data;
+	if (block_idx < sd.data_blocks.size()) {
+		scan.PinData(sd);
+	}
+}
+
+static data_ptr_t MergeJoinRadixPtr(SBScanState &scan, const idx_t entry_idx) {
+	scan.entry_idx = entry_idx;
+	return scan.RadixPtr();
+}
+
+static idx_t MergeJoinSimpleBlocks(PiecewiseMergeJoinState &lstate, MergeJoinGlobalState &rstate, bool *found_match,
+                                   const ExpressionType comparison) {
+	const auto cmp = MergeJoinComparisonValue(comparison);
+
+	// The sort parameters should all be the same
+	auto &lsort = *lstate.lhs_global_state;
+	auto &rsort = rstate.table->global_sort_state;
+	D_ASSERT(lsort.sort_layout.all_constant == rsort.sort_layout.all_constant);
+	const auto all_constant = lsort.sort_layout.all_constant;
+	D_ASSERT(lsort.external == rsort.external);
+	const auto external = lsort.external;
+
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(lsort.sorted_blocks.size() == 1);
+	SBScanState lread(lsort.buffer_manager, lsort);
+	lread.sb = lsort.sorted_blocks[0].get();
+
+	const idx_t l_block_idx = 0;
+	idx_t l_entry_idx = 0;
+	const auto lhs_not_null = lstate.lhs_local_table->count - lstate.lhs_local_table->has_null;
+	MergeJoinPinSortingBlock(lread, l_block_idx);
+	auto l_ptr = MergeJoinRadixPtr(lread, l_entry_idx);
+
+	D_ASSERT(rsort.sorted_blocks.size() == 1);
+	SBScanState rread(rsort.buffer_manager, rsort);
+	rread.sb = rsort.sorted_blocks[0].get();
+
+	const auto cmp_size = lsort.sort_layout.comparison_size;
+	const auto entry_size = lsort.sort_layout.entry_size;
+
+	idx_t right_base = 0;
+	for (idx_t r_block_idx = 0; r_block_idx < rread.sb->radix_sorting_data.size(); r_block_idx++) {
+		// we only care about the BIGGEST value in each of the RHS data blocks
+		// because we want to figure out if the LHS values are less than [or equal] to ANY value
+		// get the biggest value from the RHS chunk
+		MergeJoinPinSortingBlock(rread, r_block_idx);
+
+		auto &rblock = rread.sb->radix_sorting_data[r_block_idx];
+		const auto r_not_null =
+		    SortedBlockNotNull(right_base, rblock.count, rstate.table->count - rstate.table->has_null);
+		if (r_not_null == 0) {
+			break;
+		}
+		const auto r_entry_idx = r_not_null - 1;
+		right_base += rblock.count;
+
+		auto r_ptr = MergeJoinRadixPtr(rread, r_entry_idx);
+
+		// now we start from the current lpos value and check if we found a new value that is [<= OR <] the max RHS
+		// value
+		while (true) {
+			int comp_res;
+			if (all_constant) {
+				comp_res = FastMemcmp(l_ptr, r_ptr, cmp_size);
+			} else {
+				lread.entry_idx = l_entry_idx;
+				rread.entry_idx = r_entry_idx;
+				comp_res = Comparators::CompareTuple(lread, rread, l_ptr, r_ptr, lsort.sort_layout, external);
+			}
+
+			if (comp_res <= cmp) {
+				// found a match for lpos, set it in the found_match vector
+				found_match[l_entry_idx] = true;
+				l_entry_idx++;
+				l_ptr += entry_size;
+				if (l_entry_idx >= lhs_not_null) {
+					// early out: we exhausted the entire LHS and they all match
+					return 0;
+				}
+			} else {
+				// we found no match: any subsequent value from the LHS we scan now will be bigger and thus also not
+				// match move to the next RHS chunk
+				break;
+			}
+		}
+	}
+	return 0;
+}
+
+void PhysicalPiecewiseMergeJoin::ResolveSimpleJoin(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   OperatorState &state_p) const {
+	auto &state = (PiecewiseMergeJoinState &)state_p;
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+
+	state.ResolveJoinKeys(input);
+	auto &lhs_table = *state.lhs_local_table;
+
+	// perform the actual join
+	bool found_match[STANDARD_VECTOR_SIZE];
+	memset(found_match, 0, sizeof(found_match));
+	MergeJoinSimpleBlocks(state, gstate, found_match, conditions[0].comparison);
+
+	// use the sorted payload
+	const auto lhs_not_null = lhs_table.count - lhs_table.has_null;
+	auto &payload = state.lhs_payload;
+
+	// now construct the result based on the join result
+	switch (join_type) {
+	case JoinType::MARK: {
+		// The only part of the join keys that is actually used is the validity mask.
+		// Since the payload is sorted, we can just set the tail end of the validity masks to invalid.
+		for (auto &key : lhs_table.keys.data) {
+			key.Normalify(lhs_table.keys.size());
+			auto &mask = FlatVector::Validity(key);
+			if (mask.AllValid()) {
+				continue;
+			}
+			mask.SetAllValid(lhs_not_null);
+			for (idx_t i = lhs_not_null; i < lhs_table.count; ++i) {
+				mask.SetInvalid(i);
+			}
+		}
+		// So we make a set of keys that have the validity mask set for the
+		PhysicalJoin::ConstructMarkJoinResult(lhs_table.keys, payload, chunk, found_match, gstate.table->has_null);
+		break;
+	}
+	case JoinType::SEMI:
+		PhysicalJoin::ConstructSemiJoinResult(payload, chunk, found_match);
+		break;
+	case JoinType::ANTI:
+		PhysicalJoin::ConstructAntiJoinResult(payload, chunk, found_match);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented join type for merge join");
+	}
+}
+
+static idx_t MergeJoinComplexBlocks(BlockMergeInfo &l, BlockMergeInfo &r, const ExpressionType comparison) {
+	const auto cmp = MergeJoinComparisonValue(comparison);
+
+	// The sort parameters should all be the same
+	D_ASSERT(l.state.sort_layout.all_constant == r.state.sort_layout.all_constant);
+	const auto all_constant = r.state.sort_layout.all_constant;
+	D_ASSERT(l.state.external == r.state.external);
+	const auto external = l.state.external;
+
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(l.state.sorted_blocks.size() == 1);
+	SBScanState lread(l.state.buffer_manager, l.state);
+	lread.sb = l.state.sorted_blocks[0].get();
+	D_ASSERT(lread.sb->radix_sorting_data.size() == 1);
+	MergeJoinPinSortingBlock(lread, l.block_idx);
+	auto l_start = MergeJoinRadixPtr(lread, 0);
+	auto l_ptr = MergeJoinRadixPtr(lread, l.entry_idx);
+
+	D_ASSERT(r.state.sorted_blocks.size() == 1);
+	SBScanState rread(r.state.buffer_manager, r.state);
+	rread.sb = r.state.sorted_blocks[0].get();
+
+	if (r.entry_idx >= r.not_null) {
+		return 0;
+	}
+
+	MergeJoinPinSortingBlock(rread, r.block_idx);
+	auto r_ptr = MergeJoinRadixPtr(rread, r.entry_idx);
+
+	const auto cmp_size = l.state.sort_layout.comparison_size;
+	const auto entry_size = l.state.sort_layout.entry_size;
+
+	idx_t result_count = 0;
+	while (true) {
+		if (l.entry_idx < l.not_null) {
+			int comp_res;
+			if (all_constant) {
+				comp_res = FastMemcmp(l_ptr, r_ptr, cmp_size);
+			} else {
+				lread.entry_idx = l.entry_idx;
+				rread.entry_idx = r.entry_idx;
+				comp_res = Comparators::CompareTuple(lread, rread, l_ptr, r_ptr, l.state.sort_layout, external);
+			}
+
+			if (comp_res <= cmp) {
+				// left side smaller: found match
+				l.result.set_index(result_count, sel_t(l.entry_idx));
+				r.result.set_index(result_count, sel_t(r.entry_idx));
+				result_count++;
+				// move left side forward
+				l.entry_idx++;
+				l_ptr += entry_size;
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					break;
+				}
+				continue;
+			}
+		}
+		// right side smaller or equal, or left side exhausted: move
+		// right pointer forward reset left side to start
+		r.entry_idx++;
+		if (r.entry_idx >= r.not_null) {
+			break;
+		}
+		r_ptr += entry_size;
+
+		l_ptr = l_start;
+		l.entry_idx = 0;
+	}
+
+	return result_count;
+}
+
+OperatorResultType PhysicalPiecewiseMergeJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &input,
+                                                                  DataChunk &chunk, OperatorState &state_p) const {
+	auto &state = (PiecewiseMergeJoinState &)state_p;
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+	auto &rsorted = *gstate.table->global_sort_state.sorted_blocks[0];
+	const auto left_cols = input.ColumnCount();
+	const auto tail_cols = conditions.size() - 1;
+	do {
+		if (state.first_fetch) {
+			state.ResolveJoinKeys(input);
+
+			state.right_chunk_index = 0;
+			state.right_base = 0;
+			state.left_position = 0;
+			state.right_position = 0;
+			state.first_fetch = false;
+			state.finished = false;
+		}
+		if (state.finished) {
+			if (IsLeftOuterJoin(join_type)) {
+				// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+				// have a match found
+				PhysicalJoin::ConstructLeftJoinResult(state.lhs_payload, chunk, state.lhs_found_match.get());
+				memset(state.lhs_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+			}
+			state.first_fetch = true;
+			state.finished = false;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+
+		auto &lhs_table = *state.lhs_local_table;
+		const auto lhs_not_null = lhs_table.count - lhs_table.has_null;
+		BlockMergeInfo left_info(*state.lhs_global_state, 0, state.left_position, lhs_not_null);
+
+		const auto &rblock = rsorted.radix_sorting_data[state.right_chunk_index];
+		const auto rhs_not_null =
+		    SortedBlockNotNull(state.right_base, rblock.count, gstate.table->count - gstate.table->has_null);
+		BlockMergeInfo right_info(gstate.table->global_sort_state, state.right_chunk_index, state.right_position,
+		                          rhs_not_null);
+
+		idx_t result_count = MergeJoinComplexBlocks(left_info, right_info, conditions[0].comparison);
+		if (result_count == 0) {
+			// exhausted this chunk on the right side
+			// move to the next right chunk
+			state.left_position = 0;
+			state.right_position = 0;
+			state.right_base += rsorted.radix_sorting_data[state.right_chunk_index].count;
+			state.right_chunk_index++;
+			if (state.right_chunk_index >= rsorted.radix_sorting_data.size()) {
+				state.finished = true;
+			}
+		} else {
+			// found matches: extract them
+			chunk.Reset();
+			for (idx_t c = 0; c < state.lhs_payload.ColumnCount(); ++c) {
+				chunk.data[c].Slice(state.lhs_payload.data[c], left_info.result, result_count);
+			}
+			SliceSortedPayload(chunk, right_info.state, right_info.block_idx, right_info.result, result_count,
+			                   left_cols);
+			chunk.SetCardinality(result_count);
+
+			auto sel = FlatVector::IncrementalSelectionVector();
+			if (tail_cols) {
+				// If there are more expressions to compute,
+				// split the result chunk into the left and right halves
+				// so we can compute the values for comparison.
+				chunk.Split(state.rhs_input, left_cols);
+				state.rhs_executor.SetChunk(state.rhs_input);
+				state.rhs_keys.Reset();
+
+				auto tail_count = result_count;
+				for (size_t cmp_idx = 1; cmp_idx < conditions.size(); ++cmp_idx) {
+					Vector left(lhs_table.keys.data[cmp_idx]);
+					left.Slice(left_info.result, result_count);
+
+					auto &right = state.rhs_keys.data[cmp_idx];
+					state.rhs_executor.ExecuteExpression(cmp_idx, right);
+
+					if (tail_count < result_count) {
+						left.Slice(*sel, tail_count);
+						right.Slice(*sel, tail_count);
+					}
+					tail_count =
+					    SelectJoinTail(conditions[cmp_idx].comparison, left, right, sel, tail_count, &state.sel);
+					sel = &state.sel;
+				}
+				chunk.Fuse(state.rhs_input);
+
+				if (tail_count < result_count) {
+					result_count = tail_count;
+					chunk.Slice(*sel, result_count);
+				}
+			}
+
+			// found matches: mark the found matches if required
+			if (state.lhs_found_match) {
+				for (idx_t i = 0; i < result_count; i++) {
+					state.lhs_found_match[left_info.result[sel->get_index(i)]] = true;
+				}
+			}
+			if (gstate.table->found_match) {
+				//	Absolute position of the block + start position inside that block
+				for (idx_t i = 0; i < result_count; i++) {
+					gstate.table->found_match[state.right_base + right_info.result[sel->get_index(i)]] = true;
+				}
+			}
+			chunk.SetCardinality(result_count);
+			chunk.Verify();
+		}
+	} while (chunk.size() == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+OperatorResultType PhysicalPiecewiseMergeJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state) const {
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+
+	if (gstate.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			ConstructEmptyJoinResult(join_type, gstate.table->has_null, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	input.Verify();
+	switch (join_type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+		// simple joins can have max STANDARD_VECTOR_SIZE matches per chunk
+		ResolveSimpleJoin(context, input, chunk, state);
+		return OperatorResultType::NEED_MORE_INPUT;
+	case JoinType::LEFT:
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+	case JoinType::OUTER:
+		return ResolveComplexJoin(context, input, chunk, state);
+	default:
+		throw NotImplementedException("Unimplemented type for piecewise merge loop join!");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PiecewiseJoinScanState : public GlobalSourceState {
+public:
+	explicit PiecewiseJoinScanState(const PhysicalPiecewiseMergeJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalPiecewiseMergeJoin &op;
+	unique_ptr<PayloadScanner> scanner;
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (MergeJoinGlobalState &)*op.sink_state;
+		return sink.Count() / (STANDARD_VECTOR_SIZE * idx_t(10));
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalPiecewiseMergeJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PiecewiseJoinScanState>(*this);
+}
+
+void PhysicalPiecewiseMergeJoin::GetData(ExecutionContext &context, DataChunk &result, GlobalSourceState &gstate,
+                                         LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (MergeJoinGlobalState &)*sink_state;
+	auto &state = (PiecewiseJoinScanState &)gstate;
+
+	lock_guard<mutex> l(state.lock);
+	if (!state.scanner) {
+		// Initialize scanner (if not yet initialized)
+		auto &sort_state = sink.table->global_sort_state;
+		if (sort_state.sorted_blocks.empty()) {
+			return;
+		}
+		state.scanner = make_unique<PayloadScanner>(*sort_state.sorted_blocks[0]->payload_data, sort_state);
+	}
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	const auto found_match = sink.table->found_match.get();
+
+	// ConstructFullOuterJoinResult(sink.table->found_match.get(), sink.right_chunks, chunk,
+	// state.right_outer_position);
+	DataChunk rhs_chunk;
+	rhs_chunk.Initialize(sink.table->global_sort_state.payload_layout.GetTypes());
+	SelectionVector rsel(STANDARD_VECTOR_SIZE);
+	for (;;) {
+		// Read the next sorted chunk
+		state.scanner->Scan(rhs_chunk);
+
+		const auto count = rhs_chunk.size();
+		if (count == 0) {
+			return;
+		}
+
+		idx_t result_count = 0;
+		// figure out which tuples didn't find a match in the RHS
+		for (idx_t i = 0; i < count; i++) {
+			if (!found_match[state.right_outer_position + i]) {
+				rsel.set_index(result_count++, i);
+			}
+		}
+		state.right_outer_position += count;
+
+		if (result_count > 0) {
+			// if there were any tuples that didn't find a match, output them
+			const idx_t left_column_count = children[0]->types.size();
+			for (idx_t col_idx = 0; col_idx < left_column_count; ++col_idx) {
+				result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result.data[col_idx], true);
+			}
+			const idx_t right_column_count = children[1]->types.size();
+			;
+			for (idx_t col_idx = 0; col_idx < right_column_count; ++col_idx) {
+				result.data[left_column_count + col_idx].Slice(rhs_chunk.data[col_idx], rsel, result_count);
+			}
+			result.SetCardinality(result_count);
+			return;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <thread>
+
+namespace duckdb {
+
+PhysicalRangeJoin::LocalSortedTable::LocalSortedTable(const PhysicalRangeJoin &op, const idx_t child)
+    : op(op), has_null(0), count(0) {
+	// Initialize order clause expression executor and key DataChunk
+	vector<LogicalType> types;
+	for (const auto &cond : op.conditions) {
+		const auto &expr = child ? cond.right : cond.left;
+		executor.AddExpression(*expr);
+
+		types.push_back(expr->return_type);
+	}
+	keys.Initialize(types);
+}
+
+void PhysicalRangeJoin::LocalSortedTable::Sink(DataChunk &input, GlobalSortState &global_sort_state) {
+	// Initialize local state (if necessary)
+	if (!local_sort_state.initialized) {
+		local_sort_state.Initialize(global_sort_state, global_sort_state.buffer_manager);
+	}
+
+	// Obtain sorting columns
+	keys.Reset();
+	executor.Execute(input, keys);
+
+	// Count the NULLs so we can exclude them later
+	has_null += MergeNulls(op.conditions);
+	count += keys.size();
+
+	//	Only sort the primary key
+	DataChunk join_head;
+	join_head.data.emplace_back(Vector(keys.data[0]));
+	join_head.SetCardinality(keys.size());
+
+	// Sink the data into the local sort state
+	local_sort_state.SinkChunk(join_head, input);
+}
+
+PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &context, const vector<BoundOrderByNode> &orders,
+                                                        RowLayout &payload_layout)
+    : global_sort_state(BufferManager::GetBufferManager(context), orders, payload_layout), has_null(0), count(0),
+      memory_per_thread(0) {
+	D_ASSERT(orders.size() == 1);
+
+	// Set external (can be force with the PRAGMA)
+	auto &config = ClientConfig::GetConfig(context);
+	global_sort_state.external = config.force_external;
+	// Memory usage per thread should scale with max mem / num threads
+	// We take 1/4th of this, to be conservative
+	idx_t max_memory = global_sort_state.buffer_manager.GetMaxMemory();
+	idx_t num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	memory_per_thread = (max_memory / num_threads) / 4;
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Combine(LocalSortedTable &ltable) {
+	global_sort_state.AddLocalState(ltable.local_sort_state);
+	has_null += ltable.has_null;
+	count += ltable.count;
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::IntializeMatches() {
+	found_match = unique_ptr<bool[]>(new bool[Count()]);
+	memset(found_match.get(), 0, sizeof(bool) * Count());
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Print() {
+	global_sort_state.Print();
+}
+
+class RangeJoinMergeTask : public ExecutorTask {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	RangeJoinMergeTask(shared_ptr<Event> event_p, ClientContext &context, GlobalSortedTable &table)
+	    : ExecutorTask(context), event(move(event_p)), context(context), table(table) {
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		// Initialize iejoin sorted and iterate until done
+		auto &global_sort_state = table.global_sort_state;
+		MergeSorter merge_sorter(global_sort_state, BufferManager::GetBufferManager(context));
+		merge_sorter.PerformInMergeRound();
+		event->FinishTask();
+
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	ClientContext &context;
+	GlobalSortedTable &table;
+};
+
+class RangeJoinMergeEvent : public Event {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	RangeJoinMergeEvent(GlobalSortedTable &table_p, Pipeline &pipeline_p)
+	    : Event(pipeline_p.executor), table(table_p), pipeline(pipeline_p) {
+	}
+
+	GlobalSortedTable &table;
+	Pipeline &pipeline;
+
+public:
+	void Schedule() override {
+		auto &context = pipeline.GetClientContext();
+
+		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
+		auto &ts = TaskScheduler::GetScheduler(context);
+		idx_t num_threads = ts.NumberOfThreads();
+
+		vector<unique_ptr<Task>> iejoin_tasks;
+		for (idx_t tnum = 0; tnum < num_threads; tnum++) {
+			iejoin_tasks.push_back(make_unique<RangeJoinMergeTask>(shared_from_this(), context, table));
+		}
+		SetTasks(move(iejoin_tasks));
+	}
+
+	void FinishEvent() override {
+		auto &global_sort_state = table.global_sort_state;
+
+		global_sort_state.CompleteMergeRound(true);
+		if (global_sort_state.sorted_blocks.size() > 1) {
+			// Multiple blocks remaining: Schedule the next round
+			table.ScheduleMergeTasks(pipeline, *this);
+		}
+	}
+};
+
+void PhysicalRangeJoin::GlobalSortedTable::ScheduleMergeTasks(Pipeline &pipeline, Event &event) {
+	// Initialize global sort state for a round of merging
+	global_sort_state.InitializeMergeRound();
+	auto new_event = make_shared<RangeJoinMergeEvent>(*this, pipeline);
+	event.InsertEvent(move(new_event));
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Finalize(Pipeline &pipeline, Event &event) {
+	// Prepare for merge sort phase
+	global_sort_state.PrepareMergePhase();
+
+	// Start the merge phase or finish if a merge is not necessary
+	if (global_sort_state.sorted_blocks.size() > 1) {
+		ScheduleMergeTasks(pipeline, event);
+	}
+}
+
+PhysicalRangeJoin::PhysicalRangeJoin(LogicalOperator &op, PhysicalOperatorType type, unique_ptr<PhysicalOperator> left,
+                                     unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                     idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, type, move(cond), join_type, estimated_cardinality) {
+	// Reorder the conditions so that ranges are at the front.
+	// TODO: use stats to improve the choice?
+	// TODO: Prefer fixed length types?
+	if (conditions.size() > 1) {
+		auto conditions_p = std::move(conditions);
+		conditions.resize(conditions_p.size());
+		idx_t range_position = 0;
+		idx_t other_position = conditions_p.size();
+		for (idx_t i = 0; i < conditions_p.size(); ++i) {
+			switch (conditions_p[i].comparison) {
+			case ExpressionType::COMPARE_LESSTHAN:
+			case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			case ExpressionType::COMPARE_GREATERTHAN:
+			case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+				conditions[range_position++] = std::move(conditions_p[i]);
+				break;
+			default:
+				conditions[--other_position] = std::move(conditions_p[i]);
+				break;
+			}
+		}
+	}
+
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+idx_t PhysicalRangeJoin::LocalSortedTable::MergeNulls(const vector<JoinCondition> &conditions) {
+	// Merge the validity masks of the comparison keys into the primary
+	// Return the number of NULLs in the resulting chunk
+	D_ASSERT(keys.ColumnCount() > 0);
+	const auto count = keys.size();
+
+	size_t all_constant = 0;
+	for (auto &v : keys.data) {
+		if (v.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			++all_constant;
+		}
+	}
+
+	auto &primary = keys.data[0];
+	if (all_constant == keys.data.size()) {
+		//	Either all NULL or no NULLs
+		for (auto &v : keys.data) {
+			if (ConstantVector::IsNull(v)) {
+				ConstantVector::SetNull(primary, true);
+				return count;
+			}
+		}
+		return 0;
+	} else if (keys.ColumnCount() > 1) {
+		//	Normalify the primary, as it will need to merge arbitrary validity masks
+		primary.Normalify(count);
+		auto &pvalidity = FlatVector::Validity(primary);
+		D_ASSERT(keys.ColumnCount() == conditions.size());
+		for (size_t c = 1; c < keys.data.size(); ++c) {
+			// Skip comparisons that accept NULLs
+			if (conditions[c].comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
+				continue;
+			}
+			//	Orrify the rest, as the sort code will do this anyway.
+			auto &v = keys.data[c];
+			VectorData vdata;
+			v.Orrify(count, vdata);
+			auto &vvalidity = vdata.validity;
+			if (vvalidity.AllValid()) {
+				continue;
+			}
+			pvalidity.EnsureWritable();
+			switch (v.GetVectorType()) {
+			case VectorType::FLAT_VECTOR: {
+				// Merge entire entries
+				auto pmask = pvalidity.GetData();
+				const auto entry_count = pvalidity.EntryCount(count);
+				for (idx_t entry_idx = 0; entry_idx < entry_count; ++entry_idx) {
+					pmask[entry_idx] &= vvalidity.GetValidityEntry(entry_idx);
+				}
+				break;
+			}
+			case VectorType::CONSTANT_VECTOR:
+				// All or nothing
+				if (ConstantVector::IsNull(v)) {
+					pvalidity.SetAllInvalid(count);
+					return count;
+				}
+				break;
+			default:
+				// One by one
+				for (idx_t i = 0; i < count; ++i) {
+					const auto idx = vdata.sel->get_index(i);
+					if (!vvalidity.RowIsValidUnsafe(idx)) {
+						pvalidity.SetInvalidUnsafe(i);
+					}
+				}
+				break;
+			}
+		}
+		return count - pvalidity.CountValid(count);
+	} else {
+		return count - VectorOperations::CountNotNull(primary, count);
+	}
+}
+
+void PhysicalRangeJoin::SliceSortedPayload(DataChunk &payload, GlobalSortState &state, const idx_t block_idx,
+                                           const SelectionVector &result, const idx_t result_count,
+                                           const idx_t left_cols) {
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(state.sorted_blocks.size() == 1);
+	SBScanState read_state(state.buffer_manager, state);
+	read_state.sb = state.sorted_blocks[0].get();
+	auto &sorted_data = *read_state.sb->payload_data;
+
+	read_state.SetIndices(block_idx, 0);
+	read_state.PinData(sorted_data);
+	const auto data_ptr = read_state.DataPtr(sorted_data);
+
+	// Set up a batch of pointers to scan data from
+	Vector addresses(LogicalType::POINTER, result_count);
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+
+	// Set up the data pointers for the values that are actually referenced
+	const idx_t &row_width = sorted_data.layout.GetRowWidth();
+
+	auto prev_idx = result.get_index(0);
+	SelectionVector gsel(result_count);
+	idx_t addr_count = 0;
+	gsel.set_index(0, addr_count);
+	data_pointers[addr_count] = data_ptr + prev_idx * row_width;
+	for (idx_t i = 1; i < result_count; ++i) {
+		const auto row_idx = result.get_index(i);
+		if (row_idx != prev_idx) {
+			data_pointers[++addr_count] = data_ptr + row_idx * row_width;
+			prev_idx = row_idx;
+		}
+		gsel.set_index(i, addr_count);
+	}
+	++addr_count;
+
+	// Unswizzle the offsets back to pointers (if needed)
+	if (!sorted_data.layout.AllConstant() && state.external) {
+		RowOperations::UnswizzlePointers(sorted_data.layout, data_ptr, read_state.payload_heap_handle->Ptr(),
+		                                 addr_count);
+	}
+
+	// Deserialize the payload data
+	auto sel = FlatVector::IncrementalSelectionVector();
+	for (idx_t col_idx = 0; col_idx < sorted_data.layout.ColumnCount(); col_idx++) {
+		const auto col_offset = sorted_data.layout.GetOffsets()[col_idx];
+		auto &col = payload.data[left_cols + col_idx];
+		RowOperations::Gather(addresses, *sel, col, *sel, addr_count, col_offset, col_idx);
+		col.Slice(gsel, result_count);
+	}
+}
+
+idx_t PhysicalRangeJoin::SelectJoinTail(const ExpressionType &condition, Vector &left, Vector &right,
+                                        const SelectionVector *sel, idx_t count, SelectionVector *true_sel) {
+	switch (condition) {
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return VectorOperations::NotEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return VectorOperations::LessThan(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return VectorOperations::GreaterThan(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return VectorOperations::DistinctFrom(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::COMPARE_EQUAL:
+	default:
+		throw InternalException("Unsupported comparison type for PhysicalRangeJoin");
+	}
+
+	return count;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalOrder::PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::ORDER_BY, move(types), estimated_cardinality), orders(move(orders)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class OrderGlobalState : public GlobalSinkState {
+public:
+	OrderGlobalState(BufferManager &buffer_manager, const PhysicalOrder &order, RowLayout &payload_layout)
+	    : global_sort_state(buffer_manager, order.orders, payload_layout) {
+	}
+
+	//! Global sort state
+	GlobalSortState global_sort_state;
+	//! Memory usage per thread
+	idx_t memory_per_thread;
+};
+
+class OrderLocalState : public LocalSinkState {
+public:
+	OrderLocalState() {
+	}
+
+public:
+	//! The local sort state
+	LocalSortState local_sort_state;
+	//! Local copy of the sorting expression executor
+	ExpressionExecutor executor;
+	//! Holds a vector of incoming sorting columns
+	DataChunk sort;
+};
+
+unique_ptr<GlobalSinkState> PhysicalOrder::GetGlobalSinkState(ClientContext &context) const {
+	// Get the payload layout from the return types
+	RowLayout payload_layout;
+	payload_layout.Initialize(types);
+	auto state = make_unique<OrderGlobalState>(BufferManager::GetBufferManager(context), *this, payload_layout);
+	// Set external (can be force with the PRAGMA)
+	state->global_sort_state.external = ClientConfig::GetConfig(context).force_external;
+	// Memory usage per thread should scale with max mem / num threads
+	// We take 1/4th of this, to be conservative
+	idx_t max_memory = BufferManager::GetBufferManager(context).GetMaxMemory();
+	idx_t num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	state->memory_per_thread = (max_memory / num_threads) / 4;
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalOrder::GetLocalSinkState(ExecutionContext &context) const {
+	auto result = make_unique<OrderLocalState>();
+	// Initialize order clause expression executor and DataChunk
+	vector<LogicalType> types;
+	for (auto &order : orders) {
+		types.push_back(order.expression->return_type);
+		result->executor.AddExpression(*order.expression);
+	}
+	result->sort.Initialize(types);
+	return move(result);
+}
+
+SinkResultType PhysicalOrder::Sink(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p,
+                                   DataChunk &input) const {
+	auto &gstate = (OrderGlobalState &)gstate_p;
+	auto &lstate = (OrderLocalState &)lstate_p;
+
+	auto &global_sort_state = gstate.global_sort_state;
+	auto &local_sort_state = lstate.local_sort_state;
+
+	// Initialize local state (if necessary)
+	if (!local_sort_state.initialized) {
+		local_sort_state.Initialize(global_sort_state, BufferManager::GetBufferManager(context.client));
+	}
+
+	// Obtain sorting columns
+	auto &sort = lstate.sort;
+	sort.Reset();
+	lstate.executor.Execute(input, sort);
+
+	// Sink the data into the local sort state
+	sort.Verify();
+	input.Verify();
+	local_sort_state.SinkChunk(sort, input);
+
+	// When sorting data reaches a certain size, we sort it
+	if (local_sort_state.SizeInBytes() >= gstate.memory_per_thread) {
+		local_sort_state.Sort(global_sort_state, true);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalOrder::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (OrderGlobalState &)gstate_p;
+	auto &lstate = (OrderLocalState &)lstate_p;
+	gstate.global_sort_state.AddLocalState(lstate.local_sort_state);
+}
+
+class PhysicalOrderMergeTask : public ExecutorTask {
+public:
+	PhysicalOrderMergeTask(shared_ptr<Event> event_p, ClientContext &context, OrderGlobalState &state)
+	    : ExecutorTask(context), event(move(event_p)), context(context), state(state) {
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		// Initialize merge sorted and iterate until done
+		auto &global_sort_state = state.global_sort_state;
+		MergeSorter merge_sorter(global_sort_state, BufferManager::GetBufferManager(context));
+		merge_sorter.PerformInMergeRound();
+		event->FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	ClientContext &context;
+	OrderGlobalState &state;
+};
+
+class OrderMergeEvent : public Event {
+public:
+	OrderMergeEvent(OrderGlobalState &gstate_p, Pipeline &pipeline_p)
+	    : Event(pipeline_p.executor), gstate(gstate_p), pipeline(pipeline_p) {
+	}
+
+	OrderGlobalState &gstate;
+	Pipeline &pipeline;
+
+public:
+	void Schedule() override {
+		auto &context = pipeline.GetClientContext();
+
+		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
+		auto &ts = TaskScheduler::GetScheduler(context);
+		idx_t num_threads = ts.NumberOfThreads();
+
+		vector<unique_ptr<Task>> merge_tasks;
+		for (idx_t tnum = 0; tnum < num_threads; tnum++) {
+			merge_tasks.push_back(make_unique<PhysicalOrderMergeTask>(shared_from_this(), context, gstate));
+		}
+		SetTasks(move(merge_tasks));
+	}
+
+	void FinishEvent() override {
+		auto &global_sort_state = gstate.global_sort_state;
+
+		global_sort_state.CompleteMergeRound();
+		if (global_sort_state.sorted_blocks.size() > 1) {
+			// Multiple blocks remaining: Schedule the next round
+			PhysicalOrder::ScheduleMergeTasks(pipeline, *this, gstate);
+		}
+	}
+};
+
+SinkFinalizeType PhysicalOrder::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                         GlobalSinkState &gstate_p) const {
+	auto &state = (OrderGlobalState &)gstate_p;
+	auto &global_sort_state = state.global_sort_state;
+
+	if (global_sort_state.sorted_blocks.empty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Prepare for merge sort phase
+	global_sort_state.PrepareMergePhase();
+
+	// Start the merge phase or finish if a merge is not necessary
+	if (global_sort_state.sorted_blocks.size() > 1) {
+		PhysicalOrder::ScheduleMergeTasks(pipeline, event, state);
+	}
+	return SinkFinalizeType::READY;
+}
+
+void PhysicalOrder::ScheduleMergeTasks(Pipeline &pipeline, Event &event, OrderGlobalState &state) {
+	// Initialize global sort state for a round of merging
+	state.global_sort_state.InitializeMergeRound();
+	auto new_event = make_shared<OrderMergeEvent>(state, pipeline);
+	event.InsertEvent(move(new_event));
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PhysicalOrderOperatorState : public GlobalSourceState {
+public:
+	//! Payload scanner
+	unique_ptr<PayloadScanner> scanner;
+};
+
+unique_ptr<GlobalSourceState> PhysicalOrder::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalOrderOperatorState>();
+}
+
+void PhysicalOrder::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                            LocalSourceState &lstate) const {
+	auto &state = (PhysicalOrderOperatorState &)gstate;
+
+	if (!state.scanner) {
+		// Initialize scanner (if not yet initialized)
+		auto &gstate = (OrderGlobalState &)*this->sink_state;
+		auto &global_sort_state = gstate.global_sort_state;
+		if (global_sort_state.sorted_blocks.empty()) {
+			return;
+		}
+		state.scanner =
+		    make_unique<PayloadScanner>(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+	}
+
+	// Scan the next data chunk
+	state.scanner->Scan(chunk);
+}
+
+string PhysicalOrder::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalTopN::PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
+                           idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TOP_N, move(types), estimated_cardinality), orders(move(orders)),
+      limit(limit), offset(offset) {
+}
+
+//===--------------------------------------------------------------------===//
+// Heaps
+//===--------------------------------------------------------------------===//
+class TopNHeap;
+
+struct TopNScanState {
+	unique_ptr<PayloadScanner> scanner;
+	idx_t pos;
+	bool exclude_offset;
+};
+
+class TopNSortState {
+public:
+	explicit TopNSortState(TopNHeap &heap);
+
+	TopNHeap &heap;
+	unique_ptr<LocalSortState> local_state;
+	unique_ptr<GlobalSortState> global_state;
+	idx_t count;
+	bool is_sorted;
+
+public:
+	void Initialize();
+	void Append(DataChunk &sort_chunk, DataChunk &payload);
+
+	void Sink(DataChunk &input);
+	void Finalize();
+
+	void Move(TopNSortState &other);
+
+	void InitializeScan(TopNScanState &state, bool exclude_offset);
+	void Scan(TopNScanState &state, DataChunk &chunk);
+};
+
+class TopNHeap {
+public:
+	TopNHeap(ClientContext &context, const vector<LogicalType> &payload_types, const vector<BoundOrderByNode> &orders,
+	         idx_t limit, idx_t offset);
+
+	ClientContext &context;
+	const vector<LogicalType> &payload_types;
+	const vector<BoundOrderByNode> &orders;
+	idx_t limit;
+	idx_t offset;
+	TopNSortState sort_state;
+	ExpressionExecutor executor;
+	DataChunk sort_chunk;
+	DataChunk compare_chunk;
+	DataChunk payload_chunk;
+	//! A set of boundary values that determine either the minimum or the maximum value we have to consider for our
+	//! top-n
+	DataChunk boundary_values;
+	//! Whether or not the boundary_values has been set. The boundary_values are only set after a reduce step
+	bool has_boundary_values;
+
+	SelectionVector final_sel;
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+	SelectionVector new_remaining_sel;
+
+public:
+	void Sink(DataChunk &input);
+	void Combine(TopNHeap &other);
+	void Reduce();
+	void Finalize();
+
+	void ExtractBoundaryValues(DataChunk &current_chunk, DataChunk &prev_chunk);
+
+	void InitializeScan(TopNScanState &state, bool exclude_offset);
+	void Scan(TopNScanState &state, DataChunk &chunk);
+
+	bool CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload);
+};
+
+//===--------------------------------------------------------------------===//
+// TopNSortState
+//===--------------------------------------------------------------------===//
+TopNSortState::TopNSortState(TopNHeap &heap) : heap(heap), count(0), is_sorted(false) {
+}
+
+void TopNSortState::Initialize() {
+	RowLayout layout;
+	layout.Initialize(heap.payload_types);
+	auto &buffer_manager = BufferManager::GetBufferManager(heap.context);
+	global_state = make_unique<GlobalSortState>(buffer_manager, heap.orders, layout);
+	local_state = make_unique<LocalSortState>();
+	local_state->Initialize(*global_state, buffer_manager);
+}
+
+void TopNSortState::Append(DataChunk &sort_chunk, DataChunk &payload) {
+	D_ASSERT(!is_sorted);
+	if (heap.has_boundary_values) {
+		if (!heap.CheckBoundaryValues(sort_chunk, payload)) {
+			return;
+		}
+	}
+
+	local_state->SinkChunk(sort_chunk, payload);
+	count += payload.size();
+}
+
+void TopNSortState::Sink(DataChunk &input) {
+	// compute the ordering values for the new chunk
+	heap.sort_chunk.Reset();
+	heap.executor.Execute(input, heap.sort_chunk);
+
+	// append the new chunk to what we have already
+	Append(heap.sort_chunk, input);
+}
+
+void TopNSortState::Move(TopNSortState &other) {
+	local_state = move(other.local_state);
+	global_state = move(other.global_state);
+	count = other.count;
+	is_sorted = other.is_sorted;
+}
+
+void TopNSortState::Finalize() {
+	D_ASSERT(!is_sorted);
+	global_state->AddLocalState(*local_state);
+
+	global_state->PrepareMergePhase();
+	while (global_state->sorted_blocks.size() > 1) {
+		MergeSorter merge_sorter(*global_state, BufferManager::GetBufferManager(heap.context));
+		merge_sorter.PerformInMergeRound();
+		global_state->CompleteMergeRound();
+	}
+	is_sorted = true;
+}
+
+void TopNSortState::InitializeScan(TopNScanState &state, bool exclude_offset) {
+	D_ASSERT(is_sorted);
+	if (global_state->sorted_blocks.empty()) {
+		state.scanner = nullptr;
+	} else {
+		D_ASSERT(global_state->sorted_blocks.size() == 1);
+		state.scanner = make_unique<PayloadScanner>(*global_state->sorted_blocks[0]->payload_data, *global_state);
+	}
+	state.pos = 0;
+	state.exclude_offset = exclude_offset && heap.offset > 0;
+}
+
+void TopNSortState::Scan(TopNScanState &state, DataChunk &chunk) {
+	if (!state.scanner) {
+		return;
+	}
+	auto offset = heap.offset;
+	auto limit = heap.limit;
+	D_ASSERT(is_sorted);
+	while (chunk.size() == 0) {
+		state.scanner->Scan(chunk);
+		if (chunk.size() == 0) {
+			break;
+		}
+		idx_t start = state.pos;
+		idx_t end = state.pos + chunk.size();
+		state.pos = end;
+
+		idx_t chunk_start = 0;
+		idx_t chunk_end = chunk.size();
+		if (state.exclude_offset) {
+			// we need to exclude all tuples before the OFFSET
+			// check if we should include anything
+			if (end <= offset) {
+				// end is smaller than offset: include nothing!
+				chunk.Reset();
+				continue;
+			} else if (start < offset) {
+				// we need to slice
+				chunk_start = offset - start;
+			}
+		}
+		// check if we need to truncate at the offset + limit mark
+		if (start >= offset + limit) {
+			// we are finished
+			chunk_end = 0;
+		} else if (end > offset + limit) {
+			// the end extends past the offset + limit
+			// truncate the current chunk
+			chunk_end = offset + limit - start;
+		}
+		D_ASSERT(chunk_end - chunk_start <= STANDARD_VECTOR_SIZE);
+		if (chunk_end == chunk_start) {
+			chunk.Reset();
+			break;
+		} else if (chunk_start > 0) {
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = chunk_start; i < chunk_end; i++) {
+				sel.set_index(i - chunk_start, i);
+			}
+			chunk.Slice(sel, chunk_end - chunk_start);
+		} else if (chunk_end != chunk.size()) {
+			chunk.SetCardinality(chunk_end);
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// TopNHeap
+//===--------------------------------------------------------------------===//
+TopNHeap::TopNHeap(ClientContext &context_p, const vector<LogicalType> &payload_types_p,
+                   const vector<BoundOrderByNode> &orders_p, idx_t limit, idx_t offset)
+    : context(context_p), payload_types(payload_types_p), orders(orders_p), limit(limit), offset(offset),
+      sort_state(*this), has_boundary_values(false), final_sel(STANDARD_VECTOR_SIZE), true_sel(STANDARD_VECTOR_SIZE),
+      false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
+	// initialize the executor and the sort_chunk
+	vector<LogicalType> sort_types;
+	for (auto &order : orders) {
+		auto &expr = order.expression;
+		sort_types.push_back(expr->return_type);
+		executor.AddExpression(*expr);
+	}
+	payload_chunk.Initialize(payload_types);
+	sort_chunk.Initialize(sort_types);
+	compare_chunk.Initialize(sort_types);
+	boundary_values.Initialize(sort_types);
+	sort_state.Initialize();
+}
+
+void TopNHeap::Sink(DataChunk &input) {
+	sort_state.Sink(input);
+}
+
+void TopNHeap::Combine(TopNHeap &other) {
+	other.Finalize();
+
+	TopNScanState state;
+	other.InitializeScan(state, false);
+	while (true) {
+		payload_chunk.Reset();
+		other.Scan(state, payload_chunk);
+		if (payload_chunk.size() == 0) {
+			break;
+		}
+		Sink(payload_chunk);
+	}
+	Reduce();
+}
+
+void TopNHeap::Finalize() {
+	sort_state.Finalize();
+}
+
+void TopNHeap::Reduce() {
+	idx_t min_sort_threshold = MaxValue<idx_t>(STANDARD_VECTOR_SIZE * 5, 2 * (limit + offset));
+	if (sort_state.count < min_sort_threshold) {
+		// only reduce when we pass two times the limit + offset, or 5 vectors (whichever comes first)
+		return;
+	}
+	sort_state.Finalize();
+	TopNSortState new_state(*this);
+	new_state.Initialize();
+
+	TopNScanState state;
+	sort_state.InitializeScan(state, false);
+
+	DataChunk new_chunk;
+	new_chunk.Initialize(payload_types);
+
+	DataChunk *current_chunk = &new_chunk;
+	DataChunk *prev_chunk = &payload_chunk;
+	has_boundary_values = false;
+	while (true) {
+		current_chunk->Reset();
+		Scan(state, *current_chunk);
+		if (current_chunk->size() == 0) {
+			ExtractBoundaryValues(*current_chunk, *prev_chunk);
+			break;
+		}
+		new_state.Sink(*current_chunk);
+		std::swap(current_chunk, prev_chunk);
+	}
+
+	sort_state.Move(new_state);
+}
+
+void TopNHeap::ExtractBoundaryValues(DataChunk &current_chunk, DataChunk &prev_chunk) {
+	// extract the last entry of the prev_chunk and set as minimum value
+	D_ASSERT(prev_chunk.size() > 0);
+	for (idx_t col_idx = 0; col_idx < current_chunk.ColumnCount(); col_idx++) {
+		ConstantVector::Reference(current_chunk.data[col_idx], prev_chunk.data[col_idx], prev_chunk.size() - 1,
+		                          prev_chunk.size());
+	}
+	current_chunk.SetCardinality(1);
+	sort_chunk.Reset();
+	executor.Execute(&current_chunk, sort_chunk);
+
+	boundary_values.Reset();
+	boundary_values.Append(sort_chunk);
+	boundary_values.SetCardinality(1);
+	for (idx_t i = 0; i < boundary_values.ColumnCount(); i++) {
+		boundary_values.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+	has_boundary_values = true;
+}
+
+bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload) {
+	// we have boundary values
+	// from these boundary values, determine which values we should insert (if any)
+	idx_t final_count = 0;
+
+	SelectionVector remaining_sel(nullptr);
+	idx_t remaining_count = sort_chunk.size();
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (remaining_sel.data()) {
+			compare_chunk.data[i].Slice(sort_chunk.data[i], remaining_sel, remaining_count);
+		} else {
+			compare_chunk.data[i].Reference(sort_chunk.data[i]);
+		}
+		bool is_last = i + 1 == orders.size();
+		idx_t true_count;
+		if (orders[i].null_order == OrderByNullType::NULLS_LAST) {
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThan(compare_chunk.data[i], boundary_values.data[i],
+				                                                &remaining_sel, remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count = VectorOperations::DistinctGreaterThanNullsFirst(compare_chunk.data[i],
+				                                                             boundary_values.data[i], &remaining_sel,
+				                                                             remaining_count, &true_sel, &false_sel);
+			}
+		} else {
+			D_ASSERT(orders[i].null_order == OrderByNullType::NULLS_FIRST);
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThanNullsFirst(compare_chunk.data[i],
+				                                                          boundary_values.data[i], &remaining_sel,
+				                                                          remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count =
+				    VectorOperations::DistinctGreaterThan(compare_chunk.data[i], boundary_values.data[i],
+				                                          &remaining_sel, remaining_count, &true_sel, &false_sel);
+			}
+		}
+
+		if (true_count > 0) {
+			memcpy(final_sel.data() + final_count, true_sel.data(), true_count * sizeof(sel_t));
+			final_count += true_count;
+		}
+		idx_t false_count = remaining_count - true_count;
+		if (false_count > 0) {
+			// check what we should continue to check
+			compare_chunk.data[i].Slice(sort_chunk.data[i], false_sel, false_count);
+			remaining_count = VectorOperations::NotDistinctFrom(compare_chunk.data[i], boundary_values.data[i],
+			                                                    &false_sel, false_count, &new_remaining_sel, nullptr);
+			if (is_last) {
+				memcpy(final_sel.data() + final_count, new_remaining_sel.data(), remaining_count * sizeof(sel_t));
+				final_count += remaining_count;
+			} else {
+				remaining_sel.Initialize(new_remaining_sel);
+			}
+		} else {
+			break;
+		}
+	}
+	if (final_count == 0) {
+		return false;
+	}
+	if (final_count < sort_chunk.size()) {
+		sort_chunk.Slice(final_sel, final_count);
+		payload.Slice(final_sel, final_count);
+	}
+	return true;
+}
+
+void TopNHeap::InitializeScan(TopNScanState &state, bool exclude_offset) {
+	sort_state.InitializeScan(state, exclude_offset);
+}
+
+void TopNHeap::Scan(TopNScanState &state, DataChunk &chunk) {
+	sort_state.Scan(state, chunk);
+}
+
+class TopNGlobalState : public GlobalSinkState {
+public:
+	TopNGlobalState(ClientContext &context, const vector<LogicalType> &payload_types,
+	                const vector<BoundOrderByNode> &orders, idx_t limit, idx_t offset)
+	    : heap(context, payload_types, orders, limit, offset) {
+	}
+
+	mutex lock;
+	TopNHeap heap;
+};
+
+class TopNLocalState : public LocalSinkState {
+public:
+	TopNLocalState(ClientContext &context, const vector<LogicalType> &payload_types,
+	               const vector<BoundOrderByNode> &orders, idx_t limit, idx_t offset)
+	    : heap(context, payload_types, orders, limit, offset) {
+	}
+
+	TopNHeap heap;
+};
+
+unique_ptr<LocalSinkState> PhysicalTopN::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<TopNLocalState>(context.client, types, orders, limit, offset);
+}
+
+unique_ptr<GlobalSinkState> PhysicalTopN::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<TopNGlobalState>(context, types, orders, limit, offset);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+SinkResultType PhysicalTopN::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                  DataChunk &input) const {
+	// append to the local sink state
+	auto &sink = (TopNLocalState &)lstate;
+	sink.heap.Sink(input);
+	sink.heap.Reduce();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+void PhysicalTopN::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+	auto &gstate = (TopNGlobalState &)state;
+	auto &lstate = (TopNLocalState &)lstate_p;
+
+	// scan the local top N and append it to the global heap
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.heap.Combine(lstate.heap);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalTopN::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                        GlobalSinkState &gstate_p) const {
+	auto &gstate = (TopNGlobalState &)gstate_p;
+	// global finalize: compute the final top N
+	gstate.heap.Finalize();
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class TopNOperatorState : public GlobalSourceState {
+public:
+	TopNScanState state;
+	bool initialized = false;
+};
+
+unique_ptr<GlobalSourceState> PhysicalTopN::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<TopNOperatorState>();
+}
+
+void PhysicalTopN::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                           LocalSourceState &lstate) const {
+	if (limit == 0) {
+		return;
+	}
+	auto &state = (TopNOperatorState &)gstate_p;
+	auto &gstate = (TopNGlobalState &)*sink_state;
+
+	if (!state.initialized) {
+		gstate.heap.InitializeScan(state.state, true);
+		state.initialized = true;
+	}
+	gstate.heap.Scan(state.state, chunk);
+}
+
+string PhysicalTopN::ParamsToString() const {
+	string result;
+	result += "Top " + to_string(limit);
+	if (offset > 0) {
+		result += "\n";
+		result += "Offset " + to_string(offset);
+	}
+	result += "\n[INFOSEPARATOR]";
+	for (idx_t i = 0; i < orders.size(); i++) {
+		result += "\n";
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+
+namespace duckdb {
+
+static bool ParseBoolean(const Value &value, const string &loption);
+
+static bool ParseBoolean(const vector<Value> &set, const string &loption) {
+	if (set.empty()) {
+		// no option specified: default to true
+		return true;
+	}
+	if (set.size() > 1) {
+		throw BinderException("\"%s\" expects a single argument as a boolean value (e.g. TRUE or 1)", loption);
+	}
+	return ParseBoolean(set[0], loption);
+}
+
+static bool ParseBoolean(const Value &value, const string &loption) {
+
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		return ParseBoolean(children, loption);
+	}
+	if (value.type() == LogicalType::FLOAT || value.type() == LogicalType::DOUBLE ||
+	    value.type().id() == LogicalTypeId::DECIMAL) {
+		throw BinderException("\"%s\" expects a boolean value (e.g. TRUE or 1)", loption);
+	}
+	return BooleanValue::Get(value.CastAs(LogicalType::BOOLEAN));
+}
+
+static string ParseString(const Value &value, const string &loption) {
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		if (children.size() != 1) {
+			throw BinderException("\"%s\" expects a single argument as a string value", loption);
+		}
+		return ParseString(children[0], loption);
+	}
+	if (value.type().id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("\"%s\" expects a string argument!", loption);
+	}
+	return value.GetValue<string>();
+}
+
+static int64_t ParseInteger(const Value &value, const string &loption) {
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		if (children.size() != 1) {
+			// no option specified or multiple options specified
+			throw BinderException("\"%s\" expects a single argument as an integer value", loption);
+		}
+		return ParseInteger(children[0], loption);
+	}
+	return value.GetValue<int64_t>();
+}
+
+static vector<bool> ParseColumnList(const vector<Value> &set, vector<string> &names, const string &loption) {
+	vector<bool> result;
+
+	if (set.empty()) {
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+	// list of options: parse the list
+	unordered_map<string, bool> option_map;
+	for (idx_t i = 0; i < set.size(); i++) {
+		option_map[set[i].ToString()] = false;
+	}
+	result.resize(names.size(), false);
+	for (idx_t i = 0; i < names.size(); i++) {
+		auto entry = option_map.find(names[i]);
+		if (entry != option_map.end()) {
+			result[i] = true;
+			entry->second = true;
+		}
+	}
+	for (auto &entry : option_map) {
+		if (!entry.second) {
+			throw BinderException("\"%s\" expected to find %s, but it was not found in the table", loption,
+			                      entry.first.c_str());
+		}
+	}
+	return result;
+}
+
+static vector<bool> ParseColumnList(const Value &value, vector<string> &names, const string &loption) {
+	vector<bool> result;
+
+	// Only accept a list of arguments
+	if (value.type().id() != LogicalTypeId::LIST) {
+		// Support a single argument if it's '*'
+		if (value.type().id() == LogicalTypeId::VARCHAR && value.GetValue<string>() == "*") {
+			result.resize(names.size(), true);
+			return result;
+		}
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+	auto &children = ListValue::GetChildren(value);
+	// accept '*' as single argument
+	if (children.size() == 1 && children[0].type().id() == LogicalTypeId::VARCHAR &&
+	    children[0].GetValue<string>() == "*") {
+		result.resize(names.size(), true);
+		return result;
+	}
+	return ParseColumnList(children, names, loption);
+}
+
+struct CSVFileHandle {
+public:
+	explicit CSVFileHandle(unique_ptr<FileHandle> file_handle_p) : file_handle(move(file_handle_p)) {
+		can_seek = file_handle->CanSeek();
+		plain_file_source = file_handle->OnDiskFile() && can_seek;
+		file_size = file_handle->GetFileSize();
+	}
+
+	bool CanSeek() {
+		return can_seek;
+	}
+	void Seek(idx_t position) {
+		if (!can_seek) {
+			throw InternalException("Cannot seek in this file");
+		}
+		file_handle->Seek(position);
+	}
+	idx_t SeekPosition() {
+		if (!can_seek) {
+			throw InternalException("Cannot seek in this file");
+		}
+		return file_handle->SeekPosition();
+	}
+	void Reset() {
+		if (plain_file_source) {
+			file_handle->Reset();
+		} else {
+			if (!reset_enabled) {
+				throw InternalException("Reset called but reset is not enabled for this CSV Handle");
+			}
+			read_position = 0;
+		}
+	}
+	bool PlainFileSource() {
+		return plain_file_source;
+	}
+
+	bool OnDiskFile() {
+		return file_handle->OnDiskFile();
+	}
+
+	idx_t FileSize() {
+		return file_size;
+	}
+
+	idx_t Read(void *buffer, idx_t nr_bytes) {
+		if (!plain_file_source) {
+			// not a plain file source: we need to do some bookkeeping around the reset functionality
+			idx_t result_offset = 0;
+			if (read_position < buffer_size) {
+				// we need to read from our cached buffer
+				auto buffer_read_count = MinValue<idx_t>(nr_bytes, buffer_size - read_position);
+				memcpy(buffer, cached_buffer.get() + read_position, buffer_read_count);
+				result_offset += buffer_read_count;
+				read_position += buffer_read_count;
+				if (result_offset == nr_bytes) {
+					return nr_bytes;
+				}
+			} else if (!reset_enabled && cached_buffer) {
+				// reset is disabled but we still have cached data
+				// we can remove any cached data
+				cached_buffer.reset();
+				buffer_size = 0;
+				buffer_capacity = 0;
+				read_position = 0;
+			}
+			// we have data left to read from the file
+			// read directly into the buffer
+			auto bytes_read = file_handle->Read((char *)buffer + result_offset, nr_bytes - result_offset);
+			read_position += bytes_read;
+			if (reset_enabled) {
+				// if reset caching is enabled, we need to cache the bytes that we have read
+				if (buffer_size + bytes_read >= buffer_capacity) {
+					// no space; first enlarge the buffer
+					buffer_capacity = MaxValue<idx_t>(NextPowerOfTwo(buffer_size + bytes_read), buffer_capacity * 2);
+
+					auto new_buffer = unique_ptr<data_t[]>(new data_t[buffer_capacity]);
+					if (buffer_size > 0) {
+						memcpy(new_buffer.get(), cached_buffer.get(), buffer_size);
+					}
+					cached_buffer = move(new_buffer);
+				}
+				memcpy(cached_buffer.get() + buffer_size, (char *)buffer + result_offset, bytes_read);
+				buffer_size += bytes_read;
+			}
+
+			return result_offset + bytes_read;
+		} else {
+			return file_handle->Read(buffer, nr_bytes);
+		}
+	}
+
+	string ReadLine() {
+		string result;
+		char buffer[1];
+		while (true) {
+			idx_t tuples_read = Read(buffer, 1);
+			if (tuples_read == 0 || buffer[0] == '\n') {
+				return result;
+			}
+			if (buffer[0] != '\r') {
+				result += buffer[0];
+			}
+		}
+	}
+
+	void DisableReset() {
+		this->reset_enabled = false;
+	}
+
+private:
+	unique_ptr<FileHandle> file_handle;
+	bool reset_enabled = true;
+	bool can_seek = false;
+	bool plain_file_source = false;
+	idx_t file_size = 0;
+	// reset support
+	unique_ptr<data_t[]> cached_buffer;
+	idx_t read_position = 0;
+	idx_t buffer_size = 0;
+	idx_t buffer_capacity = 0;
+};
+
+void BufferedCSVReaderOptions::SetDelimiter(const string &input) {
+	this->delimiter = StringUtil::Replace(input, "\\t", "\t");
+	this->has_delimiter = true;
+	if (input.empty()) {
+		this->delimiter = string("\0", 1);
+	}
+}
+
+void BufferedCSVReaderOptions::SetDateFormat(LogicalTypeId type, const string &format, bool read_format) {
+	string error;
+	if (read_format) {
+		auto &date_format = this->date_format[type];
+		error = StrTimeFormat::ParseFormatSpecifier(format, date_format);
+		date_format.format_specifier = format;
+	} else {
+		auto &date_format = this->write_date_format[type];
+		error = StrTimeFormat::ParseFormatSpecifier(format, date_format);
+	}
+	if (!error.empty()) {
+		throw InvalidInputException("Could not parse DATEFORMAT: %s", error.c_str());
+	}
+	has_format[type] = true;
+}
+
+void BufferedCSVReaderOptions::SetReadOption(const string &loption, const Value &value,
+                                             vector<string> &expected_names) {
+	if (SetBaseOption(loption, value)) {
+		return;
+	}
+	if (loption == "auto_detect") {
+		auto_detect = ParseBoolean(value, loption);
+	} else if (loption == "sample_size") {
+		int64_t sample_size = ParseInteger(value, loption);
+		if (sample_size < 1 && sample_size != -1) {
+			throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
+		}
+		if (sample_size == -1) {
+			sample_chunks = std::numeric_limits<uint64_t>::max();
+			sample_chunk_size = STANDARD_VECTOR_SIZE;
+		} else if (sample_size <= STANDARD_VECTOR_SIZE) {
+			sample_chunk_size = sample_size;
+			sample_chunks = 1;
+		} else {
+			sample_chunk_size = STANDARD_VECTOR_SIZE;
+			sample_chunks = sample_size / STANDARD_VECTOR_SIZE;
+		}
+	} else if (loption == "skip") {
+		skip_rows = ParseInteger(value, loption);
+	} else if (loption == "max_line_size" || loption == "maximum_line_size") {
+		maximum_line_size = ParseInteger(value, loption);
+	} else if (loption == "sample_chunk_size") {
+		sample_chunk_size = ParseInteger(value, loption);
+		if (sample_chunk_size > STANDARD_VECTOR_SIZE) {
+			throw BinderException(
+			    "Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be bigger than STANDARD_VECTOR_SIZE %d",
+			    STANDARD_VECTOR_SIZE);
+		} else if (sample_chunk_size < 1) {
+			throw BinderException("Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be smaller than 1");
+		}
+	} else if (loption == "sample_chunks") {
+		sample_chunks = ParseInteger(value, loption);
+		if (sample_chunks < 1) {
+			throw BinderException("Unsupported parameter for SAMPLE_CHUNKS: cannot be smaller than 1");
+		}
+	} else if (loption == "force_not_null") {
+		force_not_null = ParseColumnList(value, expected_names, loption);
+	} else if (loption == "date_format" || loption == "dateformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::DATE, format, true);
+	} else if (loption == "timestamp_format" || loption == "timestampformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::TIMESTAMP, format, true);
+	} else if (loption == "escape") {
+		escape = ParseString(value, loption);
+		has_escape = true;
+	} else if (loption == "ignore_errors") {
+		ignore_errors = ParseBoolean(value, loption);
+	} else {
+		throw BinderException("Unrecognized option for CSV reader \"%s\"", loption);
+	}
+}
+
+void BufferedCSVReaderOptions::SetWriteOption(const string &loption, const Value &value) {
+	if (SetBaseOption(loption, value)) {
+		return;
+	}
+
+	if (loption == "force_quote") {
+		force_quote = ParseColumnList(value, names, loption);
+	} else if (loption == "date_format" || loption == "dateformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::DATE, format, false);
+	} else if (loption == "timestamp_format" || loption == "timestampformat") {
+		string format = ParseString(value, loption);
+		if (StringUtil::Lower(format) == "iso") {
+			format = "%Y-%m-%dT%H:%M:%S.%fZ";
+		}
+		SetDateFormat(LogicalTypeId::TIMESTAMP, format, false);
+	} else {
+		throw BinderException("Unrecognized option CSV writer \"%s\"", loption);
+	}
+}
+
+bool BufferedCSVReaderOptions::SetBaseOption(const string &loption, const Value &value) {
+	// Make sure this function was only called after the option was turned into lowercase
+	D_ASSERT(!std::any_of(loption.begin(), loption.end(), ::isupper));
+
+	if (StringUtil::StartsWith(loption, "delim") || StringUtil::StartsWith(loption, "sep")) {
+		SetDelimiter(ParseString(value, loption));
+	} else if (loption == "quote") {
+		quote = ParseString(value, loption);
+		has_quote = true;
+	} else if (loption == "escape") {
+		escape = ParseString(value, loption);
+		has_escape = true;
+	} else if (loption == "header") {
+		header = ParseBoolean(value, loption);
+		has_header = true;
+	} else if (loption == "null" || loption == "nullstr") {
+		null_str = ParseString(value, loption);
+	} else if (loption == "encoding") {
+		auto encoding = StringUtil::Lower(ParseString(value, loption));
+		if (encoding != "utf8" && encoding != "utf-8") {
+			throw BinderException("Copy is only supported for UTF-8 encoded files, ENCODING 'UTF-8'");
+		}
+	} else if (loption == "compression") {
+		compression = FileCompressionTypeFromString(ParseString(value, loption));
+	} else {
+		// unrecognized option in base CSV
+		return false;
+	}
+	return true;
+}
+
+std::string BufferedCSVReaderOptions::ToString() const {
+	return "DELIMITER='" + delimiter + (has_delimiter ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", QUOTE='" + quote + (has_quote ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", ESCAPE='" + escape + (has_escape ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", HEADER=" + std::to_string(header) +
+	       (has_header ? "" : (auto_detect ? " (auto detected)" : "' (default)")) +
+	       ", SAMPLE_SIZE=" + std::to_string(sample_chunk_size * sample_chunks) +
+	       ", IGNORE_ERRORS=" + std::to_string(ignore_errors) + ", ALL_VARCHAR=" + std::to_string(all_varchar);
+}
+
+static string GetLineNumberStr(idx_t linenr, bool linenr_estimated) {
+	string estimated = (linenr_estimated ? string(" (estimated)") : string(""));
+	return to_string(linenr + 1) + estimated;
+}
+
+static bool StartsWithNumericDate(string &separator, const string &value) {
+	auto begin = value.c_str();
+	auto end = begin + value.size();
+
+	//	StrpTimeFormat::Parse will skip whitespace, so we can too
+	auto field1 = std::find_if_not(begin, end, StringUtil::CharacterIsSpace);
+	if (field1 == end) {
+		return false;
+	}
+
+	//	first numeric field must start immediately
+	if (!StringUtil::CharacterIsDigit(*field1)) {
+		return false;
+	}
+	auto literal1 = std::find_if_not(field1, end, StringUtil::CharacterIsDigit);
+	if (literal1 == end) {
+		return false;
+	}
+
+	//	second numeric field must exist
+	auto field2 = std::find_if(literal1, end, StringUtil::CharacterIsDigit);
+	if (field2 == end) {
+		return false;
+	}
+	auto literal2 = std::find_if_not(field2, end, StringUtil::CharacterIsDigit);
+	if (literal2 == end) {
+		return false;
+	}
+
+	//	third numeric field must exist
+	auto field3 = std::find_if(literal2, end, StringUtil::CharacterIsDigit);
+	if (field3 == end) {
+		return false;
+	}
+
+	//	second literal must match first
+	if (((field3 - literal2) != (field2 - literal1)) || strncmp(literal1, literal2, (field2 - literal1)) != 0) {
+		return false;
+	}
+
+	//	copy the literal as the separator, escaping percent signs
+	separator.clear();
+	while (literal1 < field2) {
+		const auto literal_char = *literal1++;
+		if (literal_char == '%') {
+			separator.push_back(literal_char);
+		}
+		separator.push_back(literal_char);
+	}
+
+	return true;
+}
+
+string GenerateDateFormat(const string &separator, const char *format_template) {
+	string format_specifier = format_template;
+
+	//	replace all dashes with the separator
+	for (auto pos = std::find(format_specifier.begin(), format_specifier.end(), '-'); pos != format_specifier.end();
+	     pos = std::find(pos + separator.size(), format_specifier.end(), '-')) {
+		format_specifier.replace(pos, pos + 1, separator);
+	}
+
+	return format_specifier;
+}
+
+TextSearchShiftArray::TextSearchShiftArray() {
+}
+
+TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_term.size()) {
+	if (length > 255) {
+		throw Exception("Size of delimiter/quote/escape in CSV reader is limited to 255 bytes");
+	}
+	// initialize the shifts array
+	shifts = unique_ptr<uint8_t[]>(new uint8_t[length * 255]);
+	memset(shifts.get(), 0, length * 255 * sizeof(uint8_t));
+	// iterate over each of the characters in the array
+	for (idx_t main_idx = 0; main_idx < length; main_idx++) {
+		uint8_t current_char = (uint8_t)search_term[main_idx];
+		// now move over all the remaining positions
+		for (idx_t i = main_idx; i < length; i++) {
+			bool is_match = true;
+			// check if the prefix matches at this position
+			// if it does, we move to this position after encountering the current character
+			for (idx_t j = 0; j < main_idx; j++) {
+				if (search_term[i - main_idx + j] != search_term[j]) {
+					is_match = false;
+				}
+			}
+			if (!is_match) {
+				continue;
+			}
+			shifts[i * 255 + current_char] = main_idx + 1;
+		}
+	}
+}
+
+BufferedCSVReader::BufferedCSVReader(FileSystem &fs_p, FileOpener *opener_p, BufferedCSVReaderOptions options_p,
+                                     const vector<LogicalType> &requested_types)
+    : fs(fs_p), opener(opener_p), options(move(options_p)), buffer_size(0), position(0), start(0) {
+	file_handle = OpenCSV(options);
+	Initialize(requested_types);
+}
+
+BufferedCSVReader::BufferedCSVReader(ClientContext &context, BufferedCSVReaderOptions options_p,
+                                     const vector<LogicalType> &requested_types)
+    : BufferedCSVReader(FileSystem::GetFileSystem(context), FileSystem::GetFileOpener(context), move(options_p),
+                        requested_types) {
+}
+
+BufferedCSVReader::~BufferedCSVReader() {
+}
+
+idx_t BufferedCSVReader::GetFileSize() {
+	return file_handle ? file_handle->FileSize() : 0;
+}
+
+void BufferedCSVReader::Initialize(const vector<LogicalType> &requested_types) {
+	PrepareComplexParser();
+	if (options.auto_detect) {
+		sql_types = SniffCSV(requested_types);
+		if (sql_types.empty()) {
+			throw Exception("Failed to detect column types from CSV: is the file a valid CSV file?");
+		}
+		if (cached_chunks.empty()) {
+			JumpToBeginning(options.skip_rows, options.header);
+		}
+	} else {
+		sql_types = requested_types;
+		ResetBuffer();
+		SkipRowsAndReadHeader(options.skip_rows, options.header);
+	}
+	InitParseChunk(sql_types.size());
+	// we only need reset support during the automatic CSV type detection
+	// since reset support might require caching (in the case of streams), we disable it for the remainder
+	file_handle->DisableReset();
+}
+
+void BufferedCSVReader::PrepareComplexParser() {
+	delimiter_search = TextSearchShiftArray(options.delimiter);
+	escape_search = TextSearchShiftArray(options.escape);
+	quote_search = TextSearchShiftArray(options.quote);
+}
+
+unique_ptr<CSVFileHandle> BufferedCSVReader::OpenCSV(const BufferedCSVReaderOptions &options) {
+	auto file_handle = fs.OpenFile(options.file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK,
+	                               options.compression, this->opener);
+	return make_unique<CSVFileHandle>(move(file_handle));
+}
+
+// Helper function to generate column names
+static string GenerateColumnName(const idx_t total_cols, const idx_t col_number, const string &prefix = "column") {
+	int max_digits = NumericHelper::UnsignedLength(total_cols - 1);
+	int digits = NumericHelper::UnsignedLength(col_number);
+	string leading_zeros = string(max_digits - digits, '0');
+	string value = to_string(col_number);
+	return string(prefix + leading_zeros + value);
+}
+
+// Helper function for UTF-8 aware space trimming
+static string TrimWhitespace(const string &col_name) {
+	utf8proc_int32_t codepoint;
+	auto str = reinterpret_cast<const utf8proc_uint8_t *>(col_name.c_str());
+	idx_t size = col_name.size();
+	// Find the first character that is not left trimmed
+	idx_t begin = 0;
+	while (begin < size) {
+		auto bytes = utf8proc_iterate(str + begin, size - begin, &codepoint);
+		D_ASSERT(bytes > 0);
+		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+			break;
+		}
+		begin += bytes;
+	}
+
+	// Find the last character that is not right trimmed
+	idx_t end;
+	end = begin;
+	for (auto next = begin; next < col_name.size();) {
+		auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
+		D_ASSERT(bytes > 0);
+		next += bytes;
+		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+			end = next;
+		}
+	}
+
+	// return the trimmed string
+	return col_name.substr(begin, end - begin);
+}
+
+static string NormalizeColumnName(const string &col_name) {
+	// normalize UTF8 characters to NFKD
+	auto nfkd = utf8proc_NFKD((const utf8proc_uint8_t *)col_name.c_str(), col_name.size());
+	const string col_name_nfkd = string((const char *)nfkd, strlen((const char *)nfkd));
+	free(nfkd);
+
+	// only keep ASCII characters 0-9 a-z A-Z and replace spaces with regular whitespace
+	string col_name_ascii = "";
+	for (idx_t i = 0; i < col_name_nfkd.size(); i++) {
+		if (col_name_nfkd[i] == '_' || (col_name_nfkd[i] >= '0' && col_name_nfkd[i] <= '9') ||
+		    (col_name_nfkd[i] >= 'A' && col_name_nfkd[i] <= 'Z') ||
+		    (col_name_nfkd[i] >= 'a' && col_name_nfkd[i] <= 'z')) {
+			col_name_ascii += col_name_nfkd[i];
+		} else if (StringUtil::CharacterIsSpace(col_name_nfkd[i])) {
+			col_name_ascii += " ";
+		}
+	}
+
+	// trim whitespace and replace remaining whitespace by _
+	string col_name_trimmed = TrimWhitespace(col_name_ascii);
+	string col_name_cleaned = "";
+	bool in_whitespace = false;
+	for (idx_t i = 0; i < col_name_trimmed.size(); i++) {
+		if (col_name_trimmed[i] == ' ') {
+			if (!in_whitespace) {
+				col_name_cleaned += "_";
+				in_whitespace = true;
+			}
+		} else {
+			col_name_cleaned += col_name_trimmed[i];
+			in_whitespace = false;
+		}
+	}
+
+	// don't leave string empty; if not empty, make lowercase
+	if (col_name_cleaned.empty()) {
+		col_name_cleaned = "_";
+	} else {
+		col_name_cleaned = StringUtil::Lower(col_name_cleaned);
+	}
+
+	// prepend _ if name starts with a digit or is a reserved keyword
+	if (KeywordHelper::IsKeyword(col_name_cleaned) || (col_name_cleaned[0] >= '0' && col_name_cleaned[0] <= '9')) {
+		col_name_cleaned = "_" + col_name_cleaned;
+	}
+	return col_name_cleaned;
+}
+
+void BufferedCSVReader::ResetBuffer() {
+	buffer.reset();
+	buffer_size = 0;
+	position = 0;
+	start = 0;
+	cached_buffers.clear();
+}
+
+void BufferedCSVReader::ResetStream() {
+	if (!file_handle->CanSeek()) {
+		// seeking to the beginning appears to not be supported in all compiler/os-scenarios,
+		// so we have to create a new stream source here for now
+		file_handle->Reset();
+	} else {
+		file_handle->Seek(0);
+	}
+	linenr = 0;
+	linenr_estimated = false;
+	bytes_per_line_avg = 0;
+	sample_chunk_idx = 0;
+	jumping_samples = false;
+}
+
+void BufferedCSVReader::InitParseChunk(idx_t num_cols) {
+	// adapt not null info
+	if (options.force_not_null.size() != num_cols) {
+		options.force_not_null.resize(num_cols, false);
+	}
+	if (num_cols == parse_chunk.ColumnCount()) {
+		parse_chunk.Reset();
+	} else {
+		parse_chunk.Destroy();
+
+		// initialize the parse_chunk with a set of VARCHAR types
+		vector<LogicalType> varchar_types(num_cols, LogicalType::VARCHAR);
+		parse_chunk.Initialize(varchar_types);
+	}
+}
+
+void BufferedCSVReader::JumpToBeginning(idx_t skip_rows = 0, bool skip_header = false) {
+	ResetBuffer();
+	ResetStream();
+	sample_chunk_idx = 0;
+	bytes_in_chunk = 0;
+	end_of_file_reached = false;
+	bom_checked = false;
+	SkipRowsAndReadHeader(skip_rows, skip_header);
+}
+
+void BufferedCSVReader::SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header) {
+	for (idx_t i = 0; i < skip_rows; i++) {
+		// ignore skip rows
+		string read_line = file_handle->ReadLine();
+		linenr++;
+	}
+
+	if (skip_header) {
+		// ignore the first line as a header line
+		InitParseChunk(sql_types.size());
+		ParseCSV(ParserMode::PARSING_HEADER);
+	}
+}
+
+bool BufferedCSVReader::JumpToNextSample() {
+	// get bytes contained in the previously read chunk
+	idx_t remaining_bytes_in_buffer = buffer_size - start;
+	bytes_in_chunk -= remaining_bytes_in_buffer;
+	if (remaining_bytes_in_buffer == 0) {
+		return false;
+	}
+
+	// assess if it makes sense to jump, based on size of the first chunk relative to size of the entire file
+	if (sample_chunk_idx == 0) {
+		idx_t bytes_first_chunk = bytes_in_chunk;
+		double chunks_fit = (file_handle->FileSize() / (double)bytes_first_chunk);
+		jumping_samples = chunks_fit >= options.sample_chunks;
+
+		// jump back to the beginning
+		JumpToBeginning(options.skip_rows, options.header);
+		sample_chunk_idx++;
+		return true;
+	}
+
+	if (end_of_file_reached || sample_chunk_idx >= options.sample_chunks) {
+		return false;
+	}
+
+	// if we deal with any other sources than plaintext files, jumping_samples can be tricky. In that case
+	// we just read x continuous chunks from the stream TODO: make jumps possible for zipfiles.
+	if (!file_handle->PlainFileSource() || !jumping_samples) {
+		sample_chunk_idx++;
+		return true;
+	}
+
+	// update average bytes per line
+	double bytes_per_line = bytes_in_chunk / (double)options.sample_chunk_size;
+	bytes_per_line_avg = ((bytes_per_line_avg * (sample_chunk_idx)) + bytes_per_line) / (sample_chunk_idx + 1);
+
+	// if none of the previous conditions were met, we can jump
+	idx_t partition_size = (idx_t)round(file_handle->FileSize() / (double)options.sample_chunks);
+
+	// calculate offset to end of the current partition
+	int64_t offset = partition_size - bytes_in_chunk - remaining_bytes_in_buffer;
+	auto current_pos = file_handle->SeekPosition();
+
+	if (current_pos + offset < file_handle->FileSize()) {
+		// set position in stream and clear failure bits
+		file_handle->Seek(current_pos + offset);
+
+		// estimate linenr
+		linenr += (idx_t)round((offset + remaining_bytes_in_buffer) / bytes_per_line_avg);
+		linenr_estimated = true;
+	} else {
+		// seek backwards from the end in last chunk and hope to catch the end of the file
+		// TODO: actually it would be good to make sure that the end of file is being reached, because
+		// messy end-lines are quite common. For this case, however, we first need a skip_end detection anyways.
+		file_handle->Seek(file_handle->FileSize() - bytes_in_chunk);
+
+		// estimate linenr
+		linenr = (idx_t)round((file_handle->FileSize() - bytes_in_chunk) / bytes_per_line_avg);
+		linenr_estimated = true;
+	}
+
+	// reset buffers and parse chunk
+	ResetBuffer();
+
+	// seek beginning of next line
+	// FIXME: if this jump ends up in a quoted linebreak, we will have a problem
+	string read_line = file_handle->ReadLine();
+	linenr++;
+
+	sample_chunk_idx++;
+
+	return true;
+}
+
+void BufferedCSVReader::SetDateFormat(const string &format_specifier, const LogicalTypeId &sql_type) {
+	options.has_format[sql_type] = true;
+	auto &date_format = options.date_format[sql_type];
+	date_format.format_specifier = format_specifier;
+	StrTimeFormat::ParseFormatSpecifier(date_format.format_specifier, date_format);
+}
+
+bool BufferedCSVReader::TryCastValue(const Value &value, const LogicalType &sql_type) {
+	if (options.has_format[LogicalTypeId::DATE] && sql_type.id() == LogicalTypeId::DATE) {
+		date_t result;
+		string error_message;
+		return options.date_format[LogicalTypeId::DATE].TryParseDate(string_t(StringValue::Get(value)), result,
+		                                                             error_message);
+	} else if (options.has_format[LogicalTypeId::TIMESTAMP] && sql_type.id() == LogicalTypeId::TIMESTAMP) {
+		timestamp_t result;
+		string error_message;
+		return options.date_format[LogicalTypeId::TIMESTAMP].TryParseTimestamp(string_t(StringValue::Get(value)),
+		                                                                       result, error_message);
+	} else {
+		Value new_value;
+		string error_message;
+		return value.TryCastAs(sql_type, new_value, &error_message, true);
+	}
+}
+
+struct TryCastDateOperator {
+	static bool Operation(BufferedCSVReaderOptions &options, string_t input, date_t &result, string &error_message) {
+		return options.date_format[LogicalTypeId::DATE].TryParseDate(input, result, error_message);
+	}
+};
+
+struct TryCastTimestampOperator {
+	static bool Operation(BufferedCSVReaderOptions &options, string_t input, timestamp_t &result,
+	                      string &error_message) {
+		return options.date_format[LogicalTypeId::TIMESTAMP].TryParseTimestamp(input, result, error_message);
+	}
+};
+
+template <class OP, class T>
+static bool TemplatedTryCastDateVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector,
+                                       idx_t count, string &error_message) {
+	D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
+	bool all_converted = true;
+	UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
+		T result;
+		if (!OP::Operation(options, input, result, error_message)) {
+			all_converted = false;
+		}
+		return result;
+	});
+	return all_converted;
+}
+
+bool TryCastDateVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector, idx_t count,
+                       string &error_message) {
+	return TemplatedTryCastDateVector<TryCastDateOperator, date_t>(options, input_vector, result_vector, count,
+	                                                               error_message);
+}
+
+bool TryCastTimestampVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector, idx_t count,
+                            string &error_message) {
+	return TemplatedTryCastDateVector<TryCastTimestampOperator, timestamp_t>(options, input_vector, result_vector,
+	                                                                         count, error_message);
+}
+
+bool BufferedCSVReader::TryCastVector(Vector &parse_chunk_col, idx_t size, const LogicalType &sql_type) {
+	// try vector-cast from string to sql_type
+	Vector dummy_result(sql_type);
+	if (options.has_format[LogicalTypeId::DATE] && sql_type == LogicalTypeId::DATE) {
+		// use the date format to cast the chunk
+		string error_message;
+		return TryCastDateVector(options, parse_chunk_col, dummy_result, size, error_message);
+	} else if (options.has_format[LogicalTypeId::TIMESTAMP] && sql_type == LogicalTypeId::TIMESTAMP) {
+		// use the timestamp format to cast the chunk
+		string error_message;
+		return TryCastTimestampVector(options, parse_chunk_col, dummy_result, size, error_message);
+	} else {
+		// target type is not varchar: perform a cast
+		string error_message;
+		return VectorOperations::TryCast(parse_chunk_col, dummy_result, size, &error_message, true);
+	}
+}
+
+enum class QuoteRule : uint8_t { QUOTES_RFC = 0, QUOTES_OTHER = 1, NO_QUOTES = 2 };
+
+void BufferedCSVReader::DetectDialect(const vector<LogicalType> &requested_types,
+                                      BufferedCSVReaderOptions &original_options,
+                                      vector<BufferedCSVReaderOptions> &info_candidates, idx_t &best_num_cols) {
+	// set up the candidates we consider for delimiter and quote rules based on user input
+	vector<string> delim_candidates;
+	vector<QuoteRule> quoterule_candidates;
+	vector<vector<string>> quote_candidates_map;
+	vector<vector<string>> escape_candidates_map = {{""}, {"\\"}, {""}};
+
+	if (options.has_delimiter) {
+		// user provided a delimiter: use that delimiter
+		delim_candidates = {options.delimiter};
+	} else {
+		// no delimiter provided: try standard/common delimiters
+		delim_candidates = {",", "|", ";", "\t"};
+	}
+	if (options.has_quote) {
+		// user provided quote: use that quote rule
+		quote_candidates_map = {{options.quote}, {options.quote}, {options.quote}};
+	} else {
+		// no quote rule provided: use standard/common quotes
+		quote_candidates_map = {{"\""}, {"\"", "'"}, {""}};
+	}
+	if (options.has_escape) {
+		// user provided escape: use that escape rule
+		if (options.escape.empty()) {
+			quoterule_candidates = {QuoteRule::QUOTES_RFC};
+		} else {
+			quoterule_candidates = {QuoteRule::QUOTES_OTHER};
+		}
+		escape_candidates_map[static_cast<uint8_t>(quoterule_candidates[0])] = {options.escape};
+	} else {
+		// no escape provided: try standard/common escapes
+		quoterule_candidates = {QuoteRule::QUOTES_RFC, QuoteRule::QUOTES_OTHER, QuoteRule::NO_QUOTES};
+	}
+
+	idx_t best_consistent_rows = 0;
+	for (auto quoterule : quoterule_candidates) {
+		const auto &quote_candidates = quote_candidates_map[static_cast<uint8_t>(quoterule)];
+		for (const auto &quote : quote_candidates) {
+			for (const auto &delim : delim_candidates) {
+				const auto &escape_candidates = escape_candidates_map[static_cast<uint8_t>(quoterule)];
+				for (const auto &escape : escape_candidates) {
+					BufferedCSVReaderOptions sniff_info = original_options;
+					sniff_info.delimiter = delim;
+					sniff_info.quote = quote;
+					sniff_info.escape = escape;
+
+					options = sniff_info;
+					PrepareComplexParser();
+
+					JumpToBeginning(original_options.skip_rows);
+					sniffed_column_counts.clear();
+
+					if (!TryParseCSV(ParserMode::SNIFFING_DIALECT)) {
+						continue;
+					}
+
+					idx_t start_row = original_options.skip_rows;
+					idx_t consistent_rows = 0;
+					idx_t num_cols = 0;
+
+					for (idx_t row = 0; row < sniffed_column_counts.size(); row++) {
+						if (sniffed_column_counts[row] == num_cols) {
+							consistent_rows++;
+						} else {
+							num_cols = sniffed_column_counts[row];
+							start_row = row + original_options.skip_rows;
+							consistent_rows = 1;
+						}
+					}
+
+					// some logic
+					bool more_values = (consistent_rows > best_consistent_rows && num_cols >= best_num_cols);
+					bool single_column_before = best_num_cols < 2 && num_cols > best_num_cols;
+					bool rows_consistent =
+					    start_row + consistent_rows - original_options.skip_rows == sniffed_column_counts.size();
+					bool more_than_one_row = (consistent_rows > 1);
+					bool more_than_one_column = (num_cols > 1);
+					bool start_good = !info_candidates.empty() && (start_row <= info_candidates.front().skip_rows);
+
+					if (!requested_types.empty() && requested_types.size() != num_cols) {
+						continue;
+					} else if ((more_values || single_column_before) && rows_consistent) {
+						sniff_info.skip_rows = start_row;
+						sniff_info.num_cols = num_cols;
+						best_consistent_rows = consistent_rows;
+						best_num_cols = num_cols;
+
+						info_candidates.clear();
+						info_candidates.push_back(sniff_info);
+					} else if (more_than_one_row && more_than_one_column && start_good && rows_consistent) {
+						bool same_quote_is_candidate = false;
+						for (auto &info_candidate : info_candidates) {
+							if (quote.compare(info_candidate.quote) == 0) {
+								same_quote_is_candidate = true;
+							}
+						}
+						if (!same_quote_is_candidate) {
+							sniff_info.skip_rows = start_row;
+							sniff_info.num_cols = num_cols;
+							info_candidates.push_back(sniff_info);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+void BufferedCSVReader::DetectCandidateTypes(const vector<LogicalType> &type_candidates,
+                                             const map<LogicalTypeId, vector<const char *>> &format_template_candidates,
+                                             const vector<BufferedCSVReaderOptions> &info_candidates,
+                                             BufferedCSVReaderOptions &original_options, idx_t best_num_cols,
+                                             vector<vector<LogicalType>> &best_sql_types_candidates,
+                                             std::map<LogicalTypeId, vector<string>> &best_format_candidates,
+                                             DataChunk &best_header_row) {
+	BufferedCSVReaderOptions best_options;
+	idx_t min_varchar_cols = best_num_cols + 1;
+
+	// check which info candidate leads to minimum amount of non-varchar columns...
+	for (const auto &t : format_template_candidates) {
+		best_format_candidates[t.first].clear();
+	}
+	for (auto &info_candidate : info_candidates) {
+		options = info_candidate;
+		vector<vector<LogicalType>> info_sql_types_candidates(options.num_cols, type_candidates);
+		std::map<LogicalTypeId, bool> has_format_candidates;
+		std::map<LogicalTypeId, vector<string>> format_candidates;
+		for (const auto &t : format_template_candidates) {
+			has_format_candidates[t.first] = false;
+			format_candidates[t.first].clear();
+		}
+
+		// set all sql_types to VARCHAR so we can do datatype detection based on VARCHAR values
+		sql_types.clear();
+		sql_types.assign(options.num_cols, LogicalType::VARCHAR);
+
+		// jump to beginning and skip potential header
+		JumpToBeginning(options.skip_rows, true);
+		DataChunk header_row;
+		header_row.Initialize(sql_types);
+		parse_chunk.Copy(header_row);
+
+		if (header_row.size() == 0) {
+			continue;
+		}
+
+		// init parse chunk and read csv with info candidate
+		InitParseChunk(sql_types.size());
+		ParseCSV(ParserMode::SNIFFING_DATATYPES);
+		for (idx_t row_idx = 0; row_idx <= parse_chunk.size(); row_idx++) {
+			bool is_header_row = row_idx == 0;
+			idx_t row = row_idx - 1;
+			for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+				auto &col_type_candidates = info_sql_types_candidates[col];
+				while (col_type_candidates.size() > 1) {
+					const auto &sql_type = col_type_candidates.back();
+					// try cast from string to sql_type
+					Value dummy_val;
+					if (is_header_row) {
+						dummy_val = header_row.GetValue(col, 0);
+					} else {
+						dummy_val = parse_chunk.GetValue(col, row);
+					}
+					// try formatting for date types if the user did not specify one and it starts with numeric values.
+					string separator;
+					if (has_format_candidates.count(sql_type.id()) && !original_options.has_format[sql_type.id()] &&
+					    StartsWithNumericDate(separator, StringValue::Get(dummy_val))) {
+						// generate date format candidates the first time through
+						auto &type_format_candidates = format_candidates[sql_type.id()];
+						const auto had_format_candidates = has_format_candidates[sql_type.id()];
+						if (!has_format_candidates[sql_type.id()]) {
+							has_format_candidates[sql_type.id()] = true;
+							// order by preference
+							auto entry = format_template_candidates.find(sql_type.id());
+							if (entry != format_template_candidates.end()) {
+								const auto &format_template_list = entry->second;
+								for (const auto &t : format_template_list) {
+									const auto format_string = GenerateDateFormat(separator, t);
+									// don't parse ISO 8601
+									if (format_string.find("%Y-%m-%d") == string::npos) {
+										type_format_candidates.emplace_back(format_string);
+									}
+								}
+							}
+							//	initialise the first candidate
+							options.has_format[sql_type.id()] = true;
+							//	all formats are constructed to be valid
+							SetDateFormat(type_format_candidates.back(), sql_type.id());
+						}
+						// check all formats and keep the first one that works
+						StrpTimeFormat::ParseResult result;
+						auto save_format_candidates = type_format_candidates;
+						while (!type_format_candidates.empty()) {
+							//	avoid using exceptions for flow control...
+							auto &current_format = options.date_format[sql_type.id()];
+							if (current_format.Parse(StringValue::Get(dummy_val), result)) {
+								break;
+							}
+							//	doesn't work - move to the next one
+							type_format_candidates.pop_back();
+							options.has_format[sql_type.id()] = (!type_format_candidates.empty());
+							if (!type_format_candidates.empty()) {
+								SetDateFormat(type_format_candidates.back(), sql_type.id());
+							}
+						}
+						//	if none match, then this is not a value of type sql_type,
+						if (type_format_candidates.empty()) {
+							//	so restore the candidates that did work.
+							//	or throw them out if they were generated by this value.
+							if (had_format_candidates) {
+								type_format_candidates.swap(save_format_candidates);
+								if (!type_format_candidates.empty()) {
+									SetDateFormat(type_format_candidates.back(), sql_type.id());
+								}
+							} else {
+								has_format_candidates[sql_type.id()] = false;
+							}
+						}
+					}
+					// try cast from string to sql_type
+					if (TryCastValue(dummy_val, sql_type)) {
+						break;
+					} else {
+						col_type_candidates.pop_back();
+					}
+				}
+			}
+			// reset type detection, because first row could be header,
+			// but only do it if csv has more than one line (including header)
+			if (parse_chunk.size() > 0 && is_header_row) {
+				info_sql_types_candidates = vector<vector<LogicalType>>(options.num_cols, type_candidates);
+				for (auto &f : format_candidates) {
+					f.second.clear();
+				}
+				for (auto &h : has_format_candidates) {
+					h.second = false;
+				}
+			}
+		}
+
+		idx_t varchar_cols = 0;
+		for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+			auto &col_type_candidates = info_sql_types_candidates[col];
+			// check number of varchar columns
+			const auto &col_type = col_type_candidates.back();
+			if (col_type == LogicalType::VARCHAR) {
+				varchar_cols++;
+			}
+		}
+
+		// it's good if the dialect creates more non-varchar columns, but only if we sacrifice < 30% of best_num_cols.
+		if (varchar_cols < min_varchar_cols && parse_chunk.ColumnCount() > (best_num_cols * 0.7)) {
+			// we have a new best_options candidate
+			best_options = info_candidate;
+			min_varchar_cols = varchar_cols;
+			best_sql_types_candidates = info_sql_types_candidates;
+			best_format_candidates = format_candidates;
+			best_header_row.Destroy();
+			auto header_row_types = header_row.GetTypes();
+			best_header_row.Initialize(header_row_types);
+			header_row.Copy(best_header_row);
+		}
+	}
+
+	options = best_options;
+	for (const auto &best : best_format_candidates) {
+		if (!best.second.empty()) {
+			SetDateFormat(best.second.back(), best.first);
+		}
+	}
+}
+
+void BufferedCSVReader::DetectHeader(const vector<vector<LogicalType>> &best_sql_types_candidates,
+                                     const DataChunk &best_header_row) {
+	// information for header detection
+	bool first_row_consistent = true;
+	bool first_row_nulls = false;
+
+	// check if header row is all null and/or consistent with detected column data types
+	first_row_nulls = true;
+	for (idx_t col = 0; col < best_sql_types_candidates.size(); col++) {
+		auto dummy_val = best_header_row.GetValue(col, 0);
+		if (!dummy_val.IsNull()) {
+			first_row_nulls = false;
+		}
+
+		// try cast to sql_type of column
+		const auto &sql_type = best_sql_types_candidates[col].back();
+		if (!TryCastValue(dummy_val, sql_type)) {
+			first_row_consistent = false;
+		}
+	}
+
+	// update parser info, and read, generate & set col_names based on previous findings
+	if (((!first_row_consistent || first_row_nulls) && !options.has_header) || (options.has_header && options.header)) {
+		options.header = true;
+		case_insensitive_map_t<idx_t> name_collision_count;
+		// get header names from CSV
+		for (idx_t col = 0; col < options.num_cols; col++) {
+			const auto &val = best_header_row.GetValue(col, 0);
+			string col_name = val.ToString();
+
+			// generate name if field is empty
+			if (col_name.empty() || val.IsNull()) {
+				col_name = GenerateColumnName(options.num_cols, col);
+			}
+
+			// normalize names or at least trim whitespace
+			if (options.normalize_names) {
+				col_name = NormalizeColumnName(col_name);
+			} else {
+				col_name = TrimWhitespace(col_name);
+			}
+
+			// avoid duplicate header names
+			const string col_name_raw = col_name;
+			while (name_collision_count.find(col_name) != name_collision_count.end()) {
+				name_collision_count[col_name] += 1;
+				col_name = col_name + "_" + to_string(name_collision_count[col_name]);
+			}
+
+			col_names.push_back(col_name);
+			name_collision_count[col_name] = 0;
+		}
+
+	} else {
+		options.header = false;
+		for (idx_t col = 0; col < options.num_cols; col++) {
+			string column_name = GenerateColumnName(options.num_cols, col);
+			col_names.push_back(column_name);
+		}
+	}
+}
+
+vector<LogicalType> BufferedCSVReader::RefineTypeDetection(const vector<LogicalType> &type_candidates,
+                                                           const vector<LogicalType> &requested_types,
+                                                           vector<vector<LogicalType>> &best_sql_types_candidates,
+                                                           map<LogicalTypeId, vector<string>> &best_format_candidates) {
+	// for the type refine we set the SQL types to VARCHAR for all columns
+	sql_types.clear();
+	sql_types.assign(options.num_cols, LogicalType::VARCHAR);
+
+	vector<LogicalType> detected_types;
+
+	// if data types were provided, exit here if number of columns does not match
+	if (!requested_types.empty()) {
+		if (requested_types.size() != options.num_cols) {
+			throw InvalidInputException(
+			    "Error while determining column types: found %lld columns but expected %d. (%s)", options.num_cols,
+			    requested_types.size(), options.ToString());
+		} else {
+			detected_types = requested_types;
+		}
+	} else if (options.all_varchar) {
+		// return all types varchar
+		detected_types = sql_types;
+	} else {
+		// jump through the rest of the file and continue to refine the sql type guess
+		while (JumpToNextSample()) {
+			InitParseChunk(sql_types.size());
+			// if jump ends up a bad line, we just skip this chunk
+			if (!TryParseCSV(ParserMode::SNIFFING_DATATYPES)) {
+				continue;
+			}
+			for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+				vector<LogicalType> &col_type_candidates = best_sql_types_candidates[col];
+				while (col_type_candidates.size() > 1) {
+					const auto &sql_type = col_type_candidates.back();
+					//	narrow down the date formats
+					if (best_format_candidates.count(sql_type.id())) {
+						auto &best_type_format_candidates = best_format_candidates[sql_type.id()];
+						auto save_format_candidates = best_type_format_candidates;
+						while (!best_type_format_candidates.empty()) {
+							if (TryCastVector(parse_chunk.data[col], parse_chunk.size(), sql_type)) {
+								break;
+							}
+							//	doesn't work - move to the next one
+							best_type_format_candidates.pop_back();
+							options.has_format[sql_type.id()] = (!best_type_format_candidates.empty());
+							if (!best_type_format_candidates.empty()) {
+								SetDateFormat(best_type_format_candidates.back(), sql_type.id());
+							}
+						}
+						//	if none match, then this is not a column of type sql_type,
+						if (best_type_format_candidates.empty()) {
+							//	so restore the candidates that did work.
+							best_type_format_candidates.swap(save_format_candidates);
+							if (!best_type_format_candidates.empty()) {
+								SetDateFormat(best_type_format_candidates.back(), sql_type.id());
+							}
+						}
+					}
+
+					if (TryCastVector(parse_chunk.data[col], parse_chunk.size(), sql_type)) {
+						break;
+					} else {
+						col_type_candidates.pop_back();
+					}
+				}
+			}
+
+			if (!jumping_samples) {
+				if ((sample_chunk_idx)*options.sample_chunk_size <= options.buffer_size) {
+					// cache parse chunk
+					// create a new chunk and fill it with the remainder
+					auto chunk = make_unique<DataChunk>();
+					auto parse_chunk_types = parse_chunk.GetTypes();
+					chunk->Move(parse_chunk);
+					cached_chunks.push(move(chunk));
+				} else {
+					while (!cached_chunks.empty()) {
+						cached_chunks.pop();
+					}
+				}
+			}
+		}
+
+		// set sql types
+		for (auto &best_sql_types_candidate : best_sql_types_candidates) {
+			LogicalType d_type = best_sql_types_candidate.back();
+			if (best_sql_types_candidate.size() == type_candidates.size()) {
+				d_type = LogicalType::VARCHAR;
+			}
+			detected_types.push_back(d_type);
+		}
+	}
+
+	return detected_types;
+}
+
+vector<LogicalType> BufferedCSVReader::SniffCSV(const vector<LogicalType> &requested_types) {
+	for (auto &type : requested_types) {
+		// auto detect for blobs not supported: there may be invalid UTF-8 in the file
+		if (type.id() == LogicalTypeId::BLOB) {
+			return requested_types;
+		}
+	}
+
+	// #######
+	// ### dialect detection
+	// #######
+	BufferedCSVReaderOptions original_options = options;
+	vector<BufferedCSVReaderOptions> info_candidates;
+	idx_t best_num_cols = 0;
+
+	DetectDialect(requested_types, original_options, info_candidates, best_num_cols);
+
+	// if no dialect candidate was found, then file was most likely empty and we throw an exception
+	if (info_candidates.empty()) {
+		throw InvalidInputException(
+		    "Error in file \"%s\": CSV options could not be auto-detected. Consider setting parser options manually.",
+		    options.file_path);
+	}
+
+	// #######
+	// ### type detection (initial)
+	// #######
+	// type candidates, ordered by descending specificity (~ from high to low)
+	vector<LogicalType> type_candidates = {
+	    LogicalType::VARCHAR, LogicalType::TIMESTAMP,
+	    LogicalType::DATE,    LogicalType::TIME,
+	    LogicalType::DOUBLE,  /* LogicalType::FLOAT,*/ LogicalType::BIGINT,
+	    LogicalType::INTEGER, /*LogicalType::SMALLINT, LogicalType::TINYINT,*/ LogicalType::BOOLEAN,
+	    LogicalType::SQLNULL};
+	// format template candidates, ordered by descending specificity (~ from high to low)
+	std::map<LogicalTypeId, vector<const char *>> format_template_candidates = {
+	    {LogicalTypeId::DATE, {"%m-%d-%Y", "%m-%d-%y", "%d-%m-%Y", "%d-%m-%y", "%Y-%m-%d", "%y-%m-%d"}},
+	    {LogicalTypeId::TIMESTAMP,
+	     {"%Y-%m-%d %H:%M:%S.%f", "%m-%d-%Y %I:%M:%S %p", "%m-%d-%y %I:%M:%S %p", "%d-%m-%Y %H:%M:%S",
+	      "%d-%m-%y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S"}},
+	};
+	vector<vector<LogicalType>> best_sql_types_candidates;
+	map<LogicalTypeId, vector<string>> best_format_candidates;
+	DataChunk best_header_row;
+	DetectCandidateTypes(type_candidates, format_template_candidates, info_candidates, original_options, best_num_cols,
+	                     best_sql_types_candidates, best_format_candidates, best_header_row);
+
+	// #######
+	// ### header detection
+	// #######
+	options.num_cols = best_num_cols;
+	DetectHeader(best_sql_types_candidates, best_header_row);
+
+	// #######
+	// ### type detection (refining)
+	// #######
+	return RefineTypeDetection(type_candidates, requested_types, best_sql_types_candidates, best_format_candidates);
+}
+
+bool BufferedCSVReader::TryParseComplexCSV(DataChunk &insert_chunk, string &error_message) {
+	// used for parsing algorithm
+	bool finished_chunk = false;
+	idx_t column = 0;
+	vector<idx_t> escape_positions;
+	uint8_t delimiter_pos = 0, escape_pos = 0, quote_pos = 0;
+	idx_t offset = 0;
+
+	// read values into the buffer (if any)
+	if (position >= buffer_size) {
+		if (!ReadBuffer(start)) {
+			return true;
+		}
+	}
+	// start parsing the first value
+	start = position;
+	goto value_start;
+value_start:
+	/* state: value_start */
+	// this state parses the first characters of a value
+	offset = 0;
+	delimiter_pos = 0;
+	quote_pos = 0;
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (delimiter_pos == options.delimiter.size()) {
+				// found a delimiter, add the value
+				offset = options.delimiter.size() - 1;
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				// found a newline, add the row
+				goto add_row;
+			}
+			if (count > quote_pos) {
+				// did not find a quote directly at the start of the value, stop looking for the quote now
+				goto normal;
+			}
+			if (quote_pos == options.quote.size()) {
+				// found a quote, go to quoted loop and skip the initial quote
+				start += options.quote.size();
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	// file ends while scanning for quote/delimiter, go to final state
+	goto final_state;
+normal:
+	/* state: normal parsing state */
+	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			if (delimiter_pos == options.delimiter.size()) {
+				offset = options.delimiter.size() - 1;
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				goto add_row;
+			}
+		}
+	} while (ReadBuffer(start));
+	goto final_state;
+add_value:
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	goto value_start;
+add_row : {
+	// check type of newline (\r or \n)
+	bool carriage_return = buffer[position] == '\r';
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	finished_chunk = AddRow(insert_chunk, column);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after newline, go to final state
+		goto final_state;
+	}
+	if (carriage_return) {
+		// \r newline, go to special state that parses an optional \n afterwards
+		goto carriage_return;
+	} else {
+		// \n newline, move to value start
+		if (finished_chunk) {
+			return true;
+		}
+		goto value_start;
+	}
+}
+in_quotes:
+	/* state: in_quotes */
+	// this state parses the remainder of a quoted value
+	quote_pos = 0;
+	escape_pos = 0;
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			if (quote_pos == options.quote.size()) {
+				goto unquote;
+			} else if (escape_pos == options.escape.size()) {
+				escape_positions.push_back(position - start - (options.escape.size() - 1));
+				goto handle_escape;
+			}
+		}
+	} while (ReadBuffer(start));
+	// still in quoted state at the end of the file, error:
+	error_message = StringUtil::Format("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
+	                                   GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+unquote:
+	/* state: unquote */
+	// this state handles the state directly after we unquote
+	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
+	// or a delimiter/newline, ending the current value and moving on to the next value
+	delimiter_pos = 0;
+	quote_pos = 0;
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		offset = options.quote.size();
+		goto final_state;
+	}
+	if (StringUtil::CharacterIsNewline(buffer[position])) {
+		// quote followed by newline, add row
+		offset = options.quote.size();
+		goto add_row;
+	}
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (count > delimiter_pos && count > quote_pos) {
+				error_message = StringUtil::Format(
+				    "Error in file \"%s\" on line %s: quote should be followed by end of value, end "
+				    "of row or another quote. (%s)",
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+				return false;
+			}
+			if (delimiter_pos == options.delimiter.size()) {
+				// quote followed by delimiter, add value
+				offset = options.quote.size() + options.delimiter.size() - 1;
+				goto add_value;
+			} else if (quote_pos == options.quote.size() &&
+			           (options.escape.empty() || options.escape == options.quote)) {
+				// quote followed by quote, go back to quoted state and add to escape
+				escape_positions.push_back(position - start - (options.quote.size() - 1));
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	error_message = StringUtil::Format(
+	    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of row or another quote. (%s)",
+	    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+handle_escape:
+	escape_pos = 0;
+	quote_pos = 0;
+	position++;
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			count++;
+			if (count > escape_pos && count > quote_pos) {
+				error_message = StringUtil::Format(
+				    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+				return false;
+			}
+			if (quote_pos == options.quote.size() || escape_pos == options.escape.size()) {
+				// found quote or escape: move back to quoted state
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	error_message =
+	    StringUtil::Format("Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
+	                       options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+carriage_return:
+	/* state: carriage_return */
+	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
+	if (buffer[position] == '\n') {
+		// newline after carriage return: skip
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after newline, go to final state
+			goto final_state;
+		}
+	}
+	if (finished_chunk) {
+		return true;
+	}
+	goto value_start;
+final_state:
+	if (finished_chunk) {
+		return true;
+	}
+	if (column > 0 || position > start) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
+	// final stage, only reached after parsing the file is finished
+	// flush the parsed chunk and finalize parsing
+	if (mode == ParserMode::PARSING) {
+		Flush(insert_chunk);
+	}
+
+	end_of_file_reached = true;
+	return true;
+}
+
+bool BufferedCSVReader::TryParseSimpleCSV(DataChunk &insert_chunk, string &error_message) {
+	// used for parsing algorithm
+	bool finished_chunk = false;
+	idx_t column = 0;
+	idx_t offset = 0;
+	vector<idx_t> escape_positions;
+
+	// read values into the buffer (if any)
+	if (position >= buffer_size) {
+		if (!ReadBuffer(start)) {
+			return true;
+		}
+	}
+	// start parsing the first value
+	goto value_start;
+value_start:
+	offset = 0;
+	/* state: value_start */
+	// this state parses the first character of a value
+	if (buffer[position] == options.quote[0]) {
+		// quote: actual value starts in the next position
+		// move to in_quotes state
+		start = position + 1;
+		goto in_quotes;
+	} else {
+		// no quote, move to normal parsing state
+		start = position;
+		goto normal;
+	}
+normal:
+	/* state: normal parsing state */
+	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
+	do {
+		for (; position < buffer_size; position++) {
+			if (buffer[position] == options.delimiter[0]) {
+				// delimiter: end the value and add it to the chunk
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				// newline: add row
+				goto add_row;
+			}
+		}
+	} while (ReadBuffer(start));
+	// file ends during normal scan: go to end state
+	goto final_state;
+add_value:
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	goto value_start;
+add_row : {
+	// check type of newline (\r or \n)
+	bool carriage_return = buffer[position] == '\r';
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	finished_chunk = AddRow(insert_chunk, column);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	if (carriage_return) {
+		// \r newline, go to special state that parses an optional \n afterwards
+		goto carriage_return;
+	} else {
+		// \n newline, move to value start
+		if (finished_chunk) {
+			return true;
+		}
+		goto value_start;
+	}
+}
+in_quotes:
+	/* state: in_quotes */
+	// this state parses the remainder of a quoted value
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			if (buffer[position] == options.quote[0]) {
+				// quote: move to unquoted state
+				goto unquote;
+			} else if (buffer[position] == options.escape[0]) {
+				// escape: store the escaped position and move to handle_escape state
+				escape_positions.push_back(position - start);
+				goto handle_escape;
+			}
+		}
+	} while (ReadBuffer(start));
+	// still in quoted state at the end of the file, error:
+	throw InvalidInputException("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
+	                            GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+unquote:
+	/* state: unquote */
+	// this state handles the state directly after we unquote
+	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
+	// or a delimiter/newline, ending the current value and moving on to the next value
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		offset = 1;
+		goto final_state;
+	}
+	if (buffer[position] == options.quote[0] && (options.escape.empty() || options.escape[0] == options.quote[0])) {
+		// escaped quote, return to quoted state and store escape position
+		escape_positions.push_back(position - start);
+		goto in_quotes;
+	} else if (buffer[position] == options.delimiter[0]) {
+		// delimiter, add value
+		offset = 1;
+		goto add_value;
+	} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+		offset = 1;
+		goto add_row;
+	} else {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of "
+		    "row or another quote. (%s)",
+		    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+handle_escape:
+	/* state: handle_escape */
+	// escape should be followed by a quote or another escape character
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+	if (buffer[position] != options.quote[0] && buffer[position] != options.escape[0]) {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+	// escape was followed by quote or escape, go back to quoted state
+	goto in_quotes;
+carriage_return:
+	/* state: carriage_return */
+	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
+	if (buffer[position] == '\n') {
+		// newline after carriage return: skip
+		// increase position by 1 and move start to the new position
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after delimiter, go to final state
+			goto final_state;
+		}
+	}
+	if (finished_chunk) {
+		return true;
+	}
+	goto value_start;
+final_state:
+	if (finished_chunk) {
+		return true;
+	}
+
+	if (column > 0 || position > start) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
+
+	// final stage, only reached after parsing the file is finished
+	// flush the parsed chunk and finalize parsing
+	if (mode == ParserMode::PARSING) {
+		Flush(insert_chunk);
+	}
+
+	end_of_file_reached = true;
+	return true;
+}
+
+bool BufferedCSVReader::ReadBuffer(idx_t &start) {
+	auto old_buffer = move(buffer);
+
+	// the remaining part of the last buffer
+	idx_t remaining = buffer_size - start;
+
+	bool large_buffers = mode == ParserMode::PARSING && !file_handle->OnDiskFile() && file_handle->CanSeek();
+	idx_t buffer_read_size = large_buffers ? INITIAL_BUFFER_SIZE_LARGE : INITIAL_BUFFER_SIZE;
+
+	while (remaining > buffer_read_size) {
+		buffer_read_size *= 2;
+	}
+
+	// Check line length
+	if (remaining > options.maximum_line_size) {
+		throw InvalidInputException("Maximum line size of %llu bytes exceeded!", options.maximum_line_size);
+	}
+
+	buffer = unique_ptr<char[]>(new char[buffer_read_size + remaining + 1]);
+	buffer_size = remaining + buffer_read_size;
+	if (remaining > 0) {
+		// remaining from last buffer: copy it here
+		memcpy(buffer.get(), old_buffer.get() + start, remaining);
+	}
+	idx_t read_count = file_handle->Read(buffer.get() + remaining, buffer_read_size);
+
+	bytes_in_chunk += read_count;
+	buffer_size = remaining + read_count;
+	buffer[buffer_size] = '\0';
+	if (old_buffer) {
+		cached_buffers.push_back(move(old_buffer));
+	}
+	start = 0;
+	position = remaining;
+	if (!bom_checked) {
+		bom_checked = true;
+		if (read_count >= 3 && buffer[0] == '\xEF' && buffer[1] == '\xBB' && buffer[2] == '\xBF') {
+			position += 3;
+		}
+	}
+
+	return read_count > 0;
+}
+
+void BufferedCSVReader::ParseCSV(DataChunk &insert_chunk) {
+	// if no auto-detect or auto-detect with jumping samples, we have nothing cached and start from the beginning
+	if (cached_chunks.empty()) {
+		cached_buffers.clear();
+	} else {
+		auto &chunk = cached_chunks.front();
+		parse_chunk.Move(*chunk);
+		cached_chunks.pop();
+		Flush(insert_chunk);
+		return;
+	}
+
+	string error_message;
+	if (!TryParseCSV(ParserMode::PARSING, insert_chunk, error_message)) {
+		throw InvalidInputException(error_message);
+	}
+}
+
+bool BufferedCSVReader::TryParseCSV(ParserMode mode) {
+	DataChunk dummy_chunk;
+	string error_message;
+	return TryParseCSV(mode, dummy_chunk, error_message);
+}
+
+void BufferedCSVReader::ParseCSV(ParserMode mode) {
+	DataChunk dummy_chunk;
+	string error_message;
+	if (!TryParseCSV(mode, dummy_chunk, error_message)) {
+		throw InvalidInputException(error_message);
+	}
+}
+
+bool BufferedCSVReader::TryParseCSV(ParserMode parser_mode, DataChunk &insert_chunk, string &error_message) {
+	mode = parser_mode;
+
+	if (options.quote.size() <= 1 && options.escape.size() <= 1 && options.delimiter.size() == 1) {
+		return TryParseSimpleCSV(insert_chunk, error_message);
+	} else {
+		return TryParseComplexCSV(insert_chunk, error_message);
+	}
+}
+
+void BufferedCSVReader::AddValue(char *str_val, idx_t length, idx_t &column, vector<idx_t> &escape_positions) {
+	if (length == 0 && column == 0) {
+		row_empty = true;
+	} else {
+		row_empty = false;
+	}
+
+	if (!sql_types.empty() && column == sql_types.size() && length == 0) {
+		// skip a single trailing delimiter in last column
+		return;
+	}
+	if (mode == ParserMode::SNIFFING_DIALECT) {
+		column++;
+		return;
+	}
+	if (column >= sql_types.size()) {
+		if (options.ignore_errors) {
+			error_column_overflow = true;
+			return;
+		} else {
+			throw InvalidInputException("Error on line %s: expected %lld values per row, but got more. (%s)",
+			                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(),
+			                            options.ToString());
+		}
+	}
+
+	// insert the line number into the chunk
+	idx_t row_entry = parse_chunk.size();
+
+	str_val[length] = '\0';
+
+	// test against null string
+	if (!options.force_not_null[column] && strcmp(options.null_str.c_str(), str_val) == 0) {
+		FlatVector::SetNull(parse_chunk.data[column], row_entry, true);
+	} else {
+		auto &v = parse_chunk.data[column];
+		auto parse_data = FlatVector::GetData<string_t>(v);
+		if (!escape_positions.empty()) {
+			// remove escape characters (if any)
+			string old_val = str_val;
+			string new_val = "";
+			idx_t prev_pos = 0;
+			for (idx_t i = 0; i < escape_positions.size(); i++) {
+				idx_t next_pos = escape_positions[i];
+				new_val += old_val.substr(prev_pos, next_pos - prev_pos);
+
+				if (options.escape.empty() || options.escape == options.quote) {
+					prev_pos = next_pos + options.quote.size();
+				} else {
+					prev_pos = next_pos + options.escape.size();
+				}
+			}
+			new_val += old_val.substr(prev_pos, old_val.size() - prev_pos);
+			escape_positions.clear();
+			parse_data[row_entry] = StringVector::AddStringOrBlob(v, string_t(new_val));
+		} else {
+			parse_data[row_entry] = string_t(str_val, length);
+		}
+	}
+
+	// move to the next column
+	column++;
+}
+
+bool BufferedCSVReader::AddRow(DataChunk &insert_chunk, idx_t &column) {
+	linenr++;
+
+	if (row_empty) {
+		row_empty = false;
+		if (sql_types.size() != 1) {
+			column = 0;
+			return false;
+		}
+	}
+
+	// Error forwarded by 'ignore_errors' - originally encountered in 'AddValue'
+	if (error_column_overflow) {
+		D_ASSERT(options.ignore_errors);
+		error_column_overflow = false;
+		column = 0;
+		return false;
+	}
+
+	if (column < sql_types.size() && mode != ParserMode::SNIFFING_DIALECT) {
+		if (options.ignore_errors) {
+			column = 0;
+			return false;
+		} else {
+			throw InvalidInputException("Error on line %s: expected %lld values per row, but got %d. (%s)",
+			                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(), column,
+			                            options.ToString());
+		}
+	}
+
+	if (mode == ParserMode::SNIFFING_DIALECT) {
+		sniffed_column_counts.push_back(column);
+
+		if (sniffed_column_counts.size() == options.sample_chunk_size) {
+			return true;
+		}
+	} else {
+		parse_chunk.SetCardinality(parse_chunk.size() + 1);
+	}
+
+	if (mode == ParserMode::PARSING_HEADER) {
+		return true;
+	}
+
+	if (mode == ParserMode::SNIFFING_DATATYPES && parse_chunk.size() == options.sample_chunk_size) {
+		return true;
+	}
+
+	if (mode == ParserMode::PARSING && parse_chunk.size() == STANDARD_VECTOR_SIZE) {
+		Flush(insert_chunk);
+		return true;
+	}
+
+	column = 0;
+	return false;
+}
+
+void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
+	if (parse_chunk.size() == 0) {
+		return;
+	}
+
+	bool conversion_error_ignored = false;
+
+	// convert the columns in the parsed chunk to the types of the table
+	insert_chunk.SetCardinality(parse_chunk);
+	for (idx_t col_idx = 0; col_idx < sql_types.size(); col_idx++) {
+		if (sql_types[col_idx].id() == LogicalTypeId::VARCHAR) {
+			// target type is varchar: no need to convert
+			// just test that all strings are valid utf-8 strings
+			auto parse_data = FlatVector::GetData<string_t>(parse_chunk.data[col_idx]);
+			for (idx_t i = 0; i < parse_chunk.size(); i++) {
+				if (!FlatVector::IsNull(parse_chunk.data[col_idx], i)) {
+					auto s = parse_data[i];
+					auto utf_type = Utf8Proc::Analyze(s.GetDataUnsafe(), s.GetSize());
+					if (utf_type == UnicodeType::INVALID) {
+						string col_name = to_string(col_idx);
+						if (col_idx < col_names.size()) {
+							col_name = "\"" + col_names[col_idx] + "\"";
+						}
+						throw InvalidInputException("Error in file \"%s\" between line %llu and %llu in column \"%s\": "
+						                            "file is not valid UTF8. Parser options: %s",
+						                            options.file_path, linenr - parse_chunk.size(), linenr, col_name,
+						                            options.ToString());
+					}
+				}
+			}
+			insert_chunk.data[col_idx].Reference(parse_chunk.data[col_idx]);
+		} else {
+			string error_message;
+			bool success;
+			if (options.has_format[LogicalTypeId::DATE] && sql_types[col_idx].id() == LogicalTypeId::DATE) {
+				// use the date format to cast the chunk
+				success = TryCastDateVector(options, parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                            parse_chunk.size(), error_message);
+			} else if (options.has_format[LogicalTypeId::TIMESTAMP] &&
+			           sql_types[col_idx].id() == LogicalTypeId::TIMESTAMP) {
+				// use the date format to cast the chunk
+				success = TryCastTimestampVector(options, parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                                 parse_chunk.size(), error_message);
+			} else {
+				// target type is not varchar: perform a cast
+				success = VectorOperations::TryCast(parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                                    parse_chunk.size(), &error_message);
+			}
+			if (success) {
+				continue;
+			}
+			if (options.ignore_errors) {
+				conversion_error_ignored = true;
+				continue;
+			}
+			string col_name = to_string(col_idx);
+			if (col_idx < col_names.size()) {
+				col_name = "\"" + col_names[col_idx] + "\"";
+			}
+
+			if (options.auto_detect) {
+				throw InvalidInputException("%s in column %s, between line %llu and %llu. Parser "
+				                            "options: %s. Consider either increasing the sample size "
+				                            "(SAMPLE_SIZE=X [X rows] or SAMPLE_SIZE=-1 [all rows]), "
+				                            "or skipping column conversion (ALL_VARCHAR=1)",
+				                            error_message, col_name, linenr - parse_chunk.size() + 1, linenr,
+				                            options.ToString());
+			} else {
+				throw InvalidInputException("%s between line %llu and %llu in column %s. Parser options: %s ",
+				                            error_message, linenr - parse_chunk.size(), linenr, col_name,
+				                            options.ToString());
+			}
+		}
+	}
+	if (conversion_error_ignored) {
+		D_ASSERT(options.ignore_errors);
+		SelectionVector succesful_rows;
+		succesful_rows.Initialize(parse_chunk.size());
+		idx_t sel_size = 0;
+
+		for (idx_t row_idx = 0; row_idx < parse_chunk.size(); row_idx++) {
+			bool failed = false;
+			for (idx_t column_idx = 0; column_idx < sql_types.size(); column_idx++) {
+
+				auto &inserted_column = insert_chunk.data[column_idx];
+				auto &parsed_column = parse_chunk.data[column_idx];
+
+				bool was_already_null = FlatVector::IsNull(parsed_column, row_idx);
+				if (!was_already_null && FlatVector::IsNull(inserted_column, row_idx)) {
+					failed = true;
+					break;
+				}
+			}
+			if (!failed) {
+				succesful_rows.set_index(sel_size++, row_idx);
+			}
+		}
+		insert_chunk.Slice(succesful_rows, sel_size);
+	}
+	parse_chunk.Reset();
+}
+} // namespace duckdb
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+class CopyToFunctionGlobalState : public GlobalSinkState {
+public:
+	explicit CopyToFunctionGlobalState(unique_ptr<GlobalFunctionData> global_state)
+	    : rows_copied(0), global_state(move(global_state)) {
+	}
+
+	idx_t rows_copied;
+	unique_ptr<GlobalFunctionData> global_state;
+};
+
+class CopyToFunctionLocalState : public LocalSinkState {
+public:
+	explicit CopyToFunctionLocalState(unique_ptr<LocalFunctionData> local_state) : local_state(move(local_state)) {
+	}
+	unique_ptr<LocalFunctionData> local_state;
+};
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+void MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto file_path = tmp_file_path.substr(0, tmp_file_path.length() - 4);
+	if (fs.FileExists(file_path)) {
+		fs.RemoveFile(file_path);
+	}
+	fs.MoveFile(tmp_file_path, file_path);
+}
+
+PhysicalCopyToFile::PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function_p,
+                                       unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::COPY_TO_FILE, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data)) {
+}
+
+SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                        DataChunk &input) const {
+	auto &g = (CopyToFunctionGlobalState &)gstate;
+	auto &l = (CopyToFunctionLocalState &)lstate;
+
+	g.rows_copied += input.size();
+	function.copy_to_sink(context.client, *bind_data, *g.global_state, *l.local_state, input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalCopyToFile::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &g = (CopyToFunctionGlobalState &)gstate;
+	auto &l = (CopyToFunctionLocalState &)lstate;
+
+	if (function.copy_to_combine) {
+		function.copy_to_combine(context.client, *bind_data, *g.global_state, *l.local_state);
+	}
+}
+
+SinkFinalizeType PhysicalCopyToFile::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                              GlobalSinkState &gstate_p) const {
+	auto &gstate = (CopyToFunctionGlobalState &)gstate_p;
+	if (function.copy_to_finalize) {
+		function.copy_to_finalize(context, *bind_data, *gstate.global_state);
+
+		if (use_tmp_file) {
+			MoveTmpFile(context, file_path);
+		}
+	}
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalCopyToFile::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<CopyToFunctionLocalState>(function.copy_to_initialize_local(context.client, *bind_data));
+}
+unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<CopyToFunctionGlobalState>(function.copy_to_initialize_global(context, *bind_data, file_path));
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CopyToFileState : public GlobalSourceState {
+public:
+	CopyToFileState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCopyToFile::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CopyToFileState>();
+}
+
+void PhysicalCopyToFile::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CopyToFileState &)gstate;
+	auto &g = (CopyToFunctionGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::BIGINT(g.rows_copied));
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class DeleteGlobalState : public GlobalSinkState {
+public:
+	DeleteGlobalState() : deleted_count(0), returned_chunk_count(0) {
+	}
+
+	mutex delete_lock;
+	idx_t deleted_count;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class DeleteLocalState : public LocalSinkState {
+public:
+	explicit DeleteLocalState(const vector<LogicalType> &table_types) {
+		delete_chunk.Initialize(table_types);
+	}
+	DataChunk delete_chunk;
+};
+
+SinkResultType PhysicalDelete::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &input) const {
+	auto &gstate = (DeleteGlobalState &)state;
+	auto &ustate = (DeleteLocalState &)lstate;
+
+	// get rows and
+	auto &transaction = Transaction::GetTransaction(context.client);
+	auto &row_identifiers = input.data[row_id_index];
+
+	vector<column_t> column_ids;
+	for (idx_t i = 0; i < table.column_definitions.size(); i++) {
+		column_ids.emplace_back(i);
+	};
+	auto cfs = ColumnFetchState();
+
+	lock_guard<mutex> delete_guard(gstate.delete_lock);
+	if (return_chunk) {
+		row_identifiers.Normalify(input.size());
+		table.Fetch(transaction, ustate.delete_chunk, column_ids, row_identifiers, input.size(), cfs);
+		gstate.return_chunk_collection.Append(ustate.delete_chunk);
+	}
+	gstate.deleted_count += table.Delete(tableref, context.client, row_identifiers, input.size());
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalDelete::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<DeleteGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalDelete::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<DeleteLocalState>(table.GetTypes());
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class DeleteSourceState : public GlobalSourceState {
+public:
+	DeleteSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDelete::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DeleteSourceState>();
+}
+
+void PhysicalDelete::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (DeleteSourceState &)gstate;
+	auto &g = (DeleteGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(g.deleted_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = g.returned_chunk_count;
+	if (chunk_return >= g.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+	chunk.Reference(g.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((g.return_chunk_collection.GetChunk(chunk_return)).size());
+	g.returned_chunk_count += 1;
+	if (g.returned_chunk_count >= g.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+using std::stringstream;
+
+static void WriteCatalogEntries(stringstream &ss, vector<CatalogEntry *> &entries) {
+	for (auto &entry : entries) {
+		if (entry->internal) {
+			continue;
+		}
+		ss << entry->ToSQL() << std::endl;
+	}
+	ss << std::endl;
+}
+
+static void WriteStringStreamToFile(FileSystem &fs, FileOpener *opener, stringstream &ss, const string &path) {
+	auto ss_string = ss.str();
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
+	                          FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	fs.Write(*handle, (void *)ss_string.c_str(), ss_string.size());
+	handle.reset();
+}
+
+static void WriteValueAsSQL(stringstream &ss, Value &val) {
+	if (val.type().IsNumeric()) {
+		ss << val.ToString();
+	} else {
+		ss << "'" << val.ToString() << "'";
+	}
+}
+
+static void WriteCopyStatement(FileSystem &fs, stringstream &ss, TableCatalogEntry *table, CopyInfo &info,
+                               ExportedTableData &exported_table, CopyFunction const &function) {
+	ss << "COPY ";
+
+	if (exported_table.schema_name != DEFAULT_SCHEMA) {
+		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
+	}
+
+	ss << KeywordHelper::WriteOptionallyQuoted(exported_table.table_name) << " FROM '" << exported_table.file_path
+	   << "' (";
+
+	// write the copy options
+	ss << "FORMAT '" << info.format << "'";
+	if (info.format == "csv") {
+		// insert default csv options, if not specified
+		if (info.options.find("header") == info.options.end()) {
+			info.options["header"].push_back(Value::INTEGER(0));
+		}
+		if (info.options.find("delimiter") == info.options.end() && info.options.find("sep") == info.options.end() &&
+		    info.options.find("delim") == info.options.end()) {
+			info.options["delimiter"].push_back(Value(","));
+		}
+		if (info.options.find("quote") == info.options.end()) {
+			info.options["quote"].push_back(Value("\""));
+		}
+	}
+	for (auto &copy_option : info.options) {
+		ss << ", " << copy_option.first << " ";
+		if (copy_option.second.size() == 1) {
+			WriteValueAsSQL(ss, copy_option.second[0]);
+		} else {
+			// FIXME handle multiple options
+			throw NotImplementedException("FIXME: serialize list of options");
+		}
+	}
+	ss << ");" << std::endl;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class ExportSourceState : public GlobalSourceState {
+public:
+	ExportSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalExport::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<ExportSourceState>();
+}
+
+void PhysicalExport::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (ExportSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+
+	auto &ccontext = context.client;
+	auto &fs = FileSystem::GetFileSystem(ccontext);
+	auto *opener = FileSystem::GetFileOpener(ccontext);
+
+	// gather all catalog types to export
+	vector<CatalogEntry *> schemas;
+	vector<CatalogEntry *> custom_types;
+	vector<CatalogEntry *> sequences;
+	vector<CatalogEntry *> tables;
+	vector<CatalogEntry *> views;
+	vector<CatalogEntry *> indexes;
+
+	auto schema_list = Catalog::GetCatalog(ccontext).schemas->GetEntries<SchemaCatalogEntry>(context.client);
+	for (auto &schema : schema_list) {
+		if (!schema->internal) {
+			schemas.push_back(schema);
+		}
+		schema->Scan(context.client, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+			if (entry->internal) {
+				return;
+			}
+			if (entry->type != CatalogType::TABLE_ENTRY) {
+				views.push_back(entry);
+			}
+		});
+		schema->Scan(context.client, CatalogType::SEQUENCE_ENTRY,
+		             [&](CatalogEntry *entry) { sequences.push_back(entry); });
+		schema->Scan(context.client, CatalogType::TYPE_ENTRY,
+		             [&](CatalogEntry *entry) { custom_types.push_back(entry); });
+		schema->Scan(context.client, CatalogType::INDEX_ENTRY, [&](CatalogEntry *entry) { indexes.push_back(entry); });
+	}
+
+	// consider the order of tables because of foreign key constraint
+	for (idx_t i = 0; i < exported_tables.data.size(); i++) {
+		tables.push_back((CatalogEntry *)exported_tables.data[i].entry);
+	}
+
+	// write the schema.sql file
+	// export order is SCHEMA -> SEQUENCE -> TABLE -> VIEW -> INDEX
+
+	stringstream ss;
+	WriteCatalogEntries(ss, schemas);
+	WriteCatalogEntries(ss, custom_types);
+	WriteCatalogEntries(ss, sequences);
+	WriteCatalogEntries(ss, tables);
+	WriteCatalogEntries(ss, views);
+	WriteCatalogEntries(ss, indexes);
+
+	WriteStringStreamToFile(fs, opener, ss, fs.JoinPath(info->file_path, "schema.sql"));
+
+	// write the load.sql file
+	// for every table, we write COPY INTO statement with the specified options
+	stringstream load_ss;
+	for (idx_t i = 0; i < exported_tables.data.size(); i++) {
+		auto &table = exported_tables.data[i].entry;
+		auto exported_table_info = exported_tables.data[i].table_data;
+		WriteCopyStatement(fs, load_ss, table, *info, exported_table_info, function);
+	}
+	WriteStringStreamToFile(fs, opener, load_ss, fs.JoinPath(info->file_path, "load.sql"));
+	state.finished = true;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+SinkResultType PhysicalExport::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                    DataChunk &input) const {
+	// nop
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalExport::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// EXPORT has an optional child
+	// we only need to schedule child pipelines if there is a child
+	state.SetPipelineSource(current, this);
+	if (children.empty()) {
+		return;
+	}
+	PhysicalOperator::BuildPipelines(executor, current, state);
+}
+
+vector<const PhysicalOperator *> PhysicalExport::GetSources() const {
+	return {this};
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class InsertGlobalState : public GlobalSinkState {
+public:
+	InsertGlobalState() : insert_count(0), returned_chunk_count(0) {
+	}
+
+	mutex lock;
+	idx_t insert_count;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class InsertLocalState : public LocalSinkState {
+public:
+	InsertLocalState(const vector<LogicalType> &types, const vector<unique_ptr<Expression>> &bound_defaults)
+	    : default_executor(bound_defaults) {
+		insert_chunk.Initialize(types);
+	}
+
+	DataChunk insert_chunk;
+	ExpressionExecutor default_executor;
+};
+
+PhysicalInsert::PhysicalInsert(vector<LogicalType> types, TableCatalogEntry *table, vector<idx_t> column_index_map,
+                               vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality,
+                               bool return_chunk)
+    : PhysicalOperator(PhysicalOperatorType::INSERT, move(types), estimated_cardinality),
+      column_index_map(std::move(column_index_map)), table(table), bound_defaults(move(bound_defaults)),
+      return_chunk(return_chunk) {
+}
+
+SinkResultType PhysicalInsert::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &chunk) const {
+	auto &gstate = (InsertGlobalState &)state;
+	auto &istate = (InsertLocalState &)lstate;
+
+	chunk.Normalify();
+	istate.default_executor.SetChunk(chunk);
+
+	istate.insert_chunk.Reset();
+	istate.insert_chunk.SetCardinality(chunk);
+
+	if (!column_index_map.empty()) {
+		// columns specified by the user, use column_index_map
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			auto &col = table->columns[i];
+			if (col.Generated()) {
+				continue;
+			}
+			auto storage_idx = col.StorageOid();
+			if (column_index_map[i] == DConstants::INVALID_INDEX) {
+				// insert default value
+				istate.default_executor.ExecuteExpression(i, istate.insert_chunk.data[storage_idx]);
+			} else {
+				// get value from child chunk
+				D_ASSERT((idx_t)column_index_map[i] < chunk.ColumnCount());
+				D_ASSERT(istate.insert_chunk.data[storage_idx].GetType() == chunk.data[column_index_map[i]].GetType());
+				istate.insert_chunk.data[storage_idx].Reference(chunk.data[column_index_map[i]]);
+			}
+		}
+	} else {
+		// no columns specified, just append directly
+		for (idx_t i = 0; i < istate.insert_chunk.ColumnCount(); i++) {
+			D_ASSERT(istate.insert_chunk.data[i].GetType() == chunk.data[i].GetType());
+			istate.insert_chunk.data[i].Reference(chunk.data[i]);
+		}
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	table->storage->Append(*table, context.client, istate.insert_chunk);
+
+	if (return_chunk) {
+		gstate.return_chunk_collection.Append(istate.insert_chunk);
+	}
+
+	gstate.insert_count += chunk.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<InsertGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalInsert::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<InsertLocalState>(table->GetTypes(), bound_defaults);
+}
+
+void PhysicalInsert::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (InsertLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.default_executor, "default_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class InsertSourceState : public GlobalSourceState {
+public:
+	InsertSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalInsert::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<InsertSourceState>();
+}
+
+void PhysicalInsert::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (InsertSourceState &)gstate;
+	auto &insert_gstate = (InsertGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(insert_gstate.insert_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = insert_gstate.returned_chunk_count;
+	if (chunk_return >= insert_gstate.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+
+	chunk.Reference(insert_gstate.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((insert_gstate.return_chunk_collection.GetChunk(chunk_return)).size());
+	insert_gstate.returned_chunk_count += 1;
+	if (insert_gstate.returned_chunk_count >= insert_gstate.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class UpdateGlobalState : public GlobalSinkState {
+public:
+	UpdateGlobalState() : updated_count(0), returned_chunk_count(0) {
+	}
+
+	mutex lock;
+	idx_t updated_count;
+	unordered_set<row_t> updated_columns;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class UpdateLocalState : public LocalSinkState {
+public:
+	UpdateLocalState(const vector<unique_ptr<Expression>> &expressions, const vector<LogicalType> &table_types,
+	                 const vector<unique_ptr<Expression>> &bound_defaults)
+	    : default_executor(bound_defaults) {
+		// initialize the update chunk
+		vector<LogicalType> update_types;
+		update_types.reserve(expressions.size());
+		for (auto &expr : expressions) {
+			update_types.push_back(expr->return_type);
+		}
+		update_chunk.Initialize(update_types);
+		// initialize the mock chunk
+		mock_chunk.Initialize(table_types);
+	}
+
+	DataChunk update_chunk;
+	DataChunk mock_chunk;
+	ExpressionExecutor default_executor;
+};
+
+SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &chunk) const {
+	auto &gstate = (UpdateGlobalState &)state;
+	auto &ustate = (UpdateLocalState &)lstate;
+
+	DataChunk &update_chunk = ustate.update_chunk;
+	DataChunk &mock_chunk = ustate.mock_chunk;
+
+	chunk.Normalify();
+	ustate.default_executor.SetChunk(chunk);
+
+	// update data in the base table
+	// the row ids are given to us as the last column of the child chunk
+	auto &row_ids = chunk.data[chunk.ColumnCount() - 1];
+	update_chunk.SetCardinality(chunk);
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (expressions[i]->type == ExpressionType::VALUE_DEFAULT) {
+			// default expression, set to the default value of the column
+			ustate.default_executor.ExecuteExpression(columns[i], update_chunk.data[i]);
+		} else {
+			D_ASSERT(expressions[i]->type == ExpressionType::BOUND_REF);
+			// index into child chunk
+			auto &binding = (BoundReferenceExpression &)*expressions[i];
+			update_chunk.data[i].Reference(chunk.data[binding.index]);
+		}
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	if (update_is_del_and_insert) {
+		// index update or update on complex type, perform a delete and an append instead
+
+		// figure out which rows have not yet been deleted in this update
+		// this is required since we might see the same row_id multiple times
+		// in the case of an UPDATE query that e.g. has joins
+		auto row_id_data = FlatVector::GetData<row_t>(row_ids);
+		SelectionVector sel(STANDARD_VECTOR_SIZE);
+		idx_t update_count = 0;
+		for (idx_t i = 0; i < update_chunk.size(); i++) {
+			auto row_id = row_id_data[i];
+			if (gstate.updated_columns.find(row_id) == gstate.updated_columns.end()) {
+				gstate.updated_columns.insert(row_id);
+				sel.set_index(update_count++, i);
+			}
+		}
+		if (update_count != update_chunk.size()) {
+			// we need to slice here
+			update_chunk.Slice(sel, update_count);
+		}
+		table.Delete(tableref, context.client, row_ids, update_chunk.size());
+		// for the append we need to arrange the columns in a specific manner (namely the "standard table order")
+		mock_chunk.SetCardinality(update_chunk);
+		for (idx_t i = 0; i < columns.size(); i++) {
+			mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
+		}
+		table.Append(tableref, context.client, mock_chunk);
+	} else {
+		if (return_chunk) {
+			mock_chunk.SetCardinality(update_chunk);
+			for (idx_t i = 0; i < columns.size(); i++) {
+				mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
+			}
+		}
+		table.Update(tableref, context.client, row_ids, columns, update_chunk);
+	}
+
+	if (return_chunk) {
+		gstate.return_chunk_collection.Append(mock_chunk);
+	}
+
+	gstate.updated_count += chunk.size();
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalUpdate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<UpdateGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalUpdate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<UpdateLocalState>(expressions, table.GetTypes(), bound_defaults);
+}
+
+void PhysicalUpdate::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (UpdateLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.default_executor, "default_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class UpdateSourceState : public GlobalSourceState {
+public:
+	UpdateSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalUpdate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<UpdateSourceState>();
+}
+
+void PhysicalUpdate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (UpdateSourceState &)gstate;
+	auto &g = (UpdateGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(g.updated_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = g.returned_chunk_count;
+	if (chunk_return >= g.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+	chunk.Reference(g.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((g.return_chunk_collection.GetChunk(chunk_return)).size());
+	g.returned_chunk_count += 1;
+	if (g.returned_chunk_count >= g.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class ProjectionState : public OperatorState {
+public:
+	explicit ProjectionState(const vector<unique_ptr<Expression>> &expressions) : executor(expressions) {
+	}
+
+	ExpressionExecutor executor;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &executor, "projection", 0);
+	}
+};
+
+PhysicalProjection::PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                                       idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types), estimated_cardinality),
+      select_list(move(select_list)) {
+}
+
+OperatorResultType PhysicalProjection::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                               GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (ProjectionState &)state_p;
+	state.executor.Execute(input, chunk);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<OperatorState> PhysicalProjection::GetOperatorState(ClientContext &context) const {
+	return make_unique<ProjectionState>(select_list);
+}
+
+string PhysicalProjection::ParamsToString() const {
+	string extra_info;
+	for (auto &expr : select_list) {
+		extra_info += expr->GetName() + "\n";
+	}
+	return extra_info;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class TableInOutLocalState : public OperatorState {
+public:
+	TableInOutLocalState() {
+	}
+
+	unique_ptr<LocalTableFunctionState> local_state;
+};
+
+class TableInOutGlobalState : public GlobalOperatorState {
+public:
+	TableInOutGlobalState() {
+	}
+
+	unique_ptr<GlobalTableFunctionState> global_state;
+};
+
+PhysicalTableInOutFunction::PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
+                                                       unique_ptr<FunctionData> bind_data_p,
+                                                       vector<column_t> column_ids_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INOUT_FUNCTION, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)) {
+}
+
+unique_ptr<OperatorState> PhysicalTableInOutFunction::GetOperatorState(ClientContext &context) const {
+	auto result = make_unique<TableInOutLocalState>();
+	if (function.init_local) {
+		TableFunctionInitInput input(bind_data.get(), column_ids, nullptr);
+		result->local_state = function.init_local(context, input, nullptr);
+	}
+	return move(result);
+}
+
+unique_ptr<GlobalOperatorState> PhysicalTableInOutFunction::GetGlobalOperatorState(ClientContext &context) const {
+	auto result = make_unique<TableInOutGlobalState>();
+	if (function.init_global) {
+		TableFunctionInitInput input(bind_data.get(), column_ids, nullptr);
+		result->global_state = function.init_global(context, input);
+	}
+	return move(result);
+}
+
+OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (TableInOutGlobalState &)gstate_p;
+	auto &state = (TableInOutLocalState &)state_p;
+	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
+	return function.in_out_function(context.client, data, input, chunk);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class UnnestOperatorState : public OperatorState {
+public:
+	UnnestOperatorState() : parent_position(0), list_position(0), list_length(-1), first_fetch(true) {
+	}
+
+	idx_t parent_position;
+	idx_t list_position;
+	int64_t list_length;
+	bool first_fetch;
+
+	DataChunk list_data;
+	vector<VectorData> list_vector_data;
+	vector<VectorData> list_child_data;
+};
+
+// this implements a sorted window functions variant
+PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(std::move(select_list)) {
+	D_ASSERT(!this->select_list.empty());
+}
+
+static void UnnestNull(idx_t start, idx_t end, Vector &result) {
+	if (result.GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &children = StructVector::GetEntries(result);
+		for (auto &child : children) {
+			UnnestNull(start, end, *child);
+		}
+	}
+	auto &validity = FlatVector::Validity(result);
+	for (idx_t i = start; i < end; i++) {
+		validity.SetInvalid(i);
+	}
+	if (result.GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &struct_children = StructVector::GetEntries(result);
+		for (auto &child : struct_children) {
+			UnnestNull(start, end, *child);
+		}
+	}
+}
+
+template <class T>
+static void TemplatedUnnest(VectorData &vdata, idx_t start, idx_t end, Vector &result) {
+	auto source_data = (T *)vdata.data;
+	auto &source_mask = vdata.validity;
+	auto result_data = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = start; i < end; i++) {
+		auto source_idx = vdata.sel->get_index(i);
+		auto target_idx = i - start;
+		if (source_mask.RowIsValid(source_idx)) {
+			result_data[target_idx] = source_data[source_idx];
+			result_mask.SetValid(target_idx);
+		} else {
+			result_mask.SetInvalid(target_idx);
+		}
+	}
+}
+
+static void UnnestValidity(VectorData &vdata, idx_t start, idx_t end, Vector &result) {
+	auto &source_mask = vdata.validity;
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = start; i < end; i++) {
+		auto source_idx = vdata.sel->get_index(i);
+		auto target_idx = i - start;
+		result_mask.Set(target_idx, source_mask.RowIsValid(source_idx));
+	}
+}
+
+static void UnnestVector(VectorData &vdata, Vector &source, idx_t list_size, idx_t start, idx_t end, Vector &result) {
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedUnnest<int8_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedUnnest<int16_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedUnnest<int32_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedUnnest<int64_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedUnnest<hugeint_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedUnnest<uint8_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedUnnest<uint16_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedUnnest<uint32_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedUnnest<uint64_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedUnnest<float>(vdata, start, end, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedUnnest<double>(vdata, start, end, result);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedUnnest<interval_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedUnnest<string_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::LIST: {
+		auto &target = ListVector::GetEntry(result);
+		target.Reference(ListVector::GetEntry(source));
+		ListVector::SetListSize(result, ListVector::GetListSize(source));
+		TemplatedUnnest<list_entry_t>(vdata, start, end, result);
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		auto &source_entries = StructVector::GetEntries(source);
+		auto &target_entries = StructVector::GetEntries(result);
+		UnnestValidity(vdata, start, end, result);
+		for (idx_t i = 0; i < source_entries.size(); i++) {
+			VectorData sdata;
+			source_entries[i]->Orrify(list_size, sdata);
+			UnnestVector(sdata, *source_entries[i], list_size, start, end, *target_entries[i]);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for UNNEST");
+	}
+}
+
+unique_ptr<OperatorState> PhysicalUnnest::GetOperatorState(ClientContext &context) const {
+	return PhysicalUnnest::GetState(context);
+}
+
+unique_ptr<OperatorState> PhysicalUnnest::GetState(ClientContext &context) {
+	return make_unique<UnnestOperatorState>();
+}
+
+OperatorResultType PhysicalUnnest::ExecuteInternal(ClientContext &context, DataChunk &input, DataChunk &chunk,
+                                                   OperatorState &state_p,
+                                                   const vector<unique_ptr<Expression>> &select_list,
+                                                   bool include_input) {
+	auto &state = (UnnestOperatorState &)state_p;
+	do {
+		if (state.first_fetch) {
+			// get the list data to unnest
+			ExpressionExecutor executor;
+			vector<LogicalType> list_data_types;
+			for (auto &exp : select_list) {
+				D_ASSERT(exp->type == ExpressionType::BOUND_UNNEST);
+				auto bue = (BoundUnnestExpression *)exp.get();
+				list_data_types.push_back(bue->child->return_type);
+				executor.AddExpression(*bue->child.get());
+			}
+			state.list_data.Destroy();
+			state.list_data.Initialize(list_data_types);
+			executor.Execute(input, state.list_data);
+
+			// paranoia aplenty
+			state.list_data.Verify();
+			D_ASSERT(input.size() == state.list_data.size());
+			D_ASSERT(state.list_data.ColumnCount() == select_list.size());
+
+			// initialize VectorData object so the nullmask can accessed
+			state.list_vector_data.resize(state.list_data.ColumnCount());
+			state.list_child_data.resize(state.list_data.ColumnCount());
+			for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+				auto &list_vector = state.list_data.data[col_idx];
+				list_vector.Orrify(state.list_data.size(), state.list_vector_data[col_idx]);
+
+				if (list_vector.GetType() == LogicalType::SQLNULL) {
+					// UNNEST(NULL)
+					auto &child_vector = list_vector;
+					child_vector.Orrify(0, state.list_child_data[col_idx]);
+				} else {
+					auto list_size = ListVector::GetListSize(list_vector);
+					auto &child_vector = ListVector::GetEntry(list_vector);
+					child_vector.Orrify(list_size, state.list_child_data[col_idx]);
+				}
+			}
+			state.first_fetch = false;
+		}
+		if (state.parent_position >= input.size()) {
+			// finished with this input chunk
+			state.parent_position = 0;
+			state.list_position = 0;
+			state.list_length = -1;
+			state.first_fetch = true;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+
+		// need to figure out how many times we need to repeat for current row
+		if (state.list_length < 0) {
+			for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+				auto &vdata = state.list_vector_data[col_idx];
+				auto current_idx = vdata.sel->get_index(state.parent_position);
+
+				int64_t list_length;
+				// deal with NULL values
+				if (!vdata.validity.RowIsValid(current_idx)) {
+					list_length = 0;
+				} else {
+					auto list_data = (list_entry_t *)vdata.data;
+					auto list_entry = list_data[current_idx];
+					list_length = (int64_t)list_entry.length;
+				}
+
+				if (list_length > state.list_length) {
+					state.list_length = list_length;
+				}
+			}
+		}
+
+		D_ASSERT(state.list_length >= 0);
+
+		auto this_chunk_len = MinValue<idx_t>(STANDARD_VECTOR_SIZE, state.list_length - state.list_position);
+
+		// first cols are from child, last n cols from unnest
+		chunk.SetCardinality(this_chunk_len);
+
+		idx_t output_offset = 0;
+		if (include_input) {
+			for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+				ConstantVector::Reference(chunk.data[col_idx], input.data[col_idx], state.parent_position,
+				                          input.size());
+			}
+			output_offset = input.ColumnCount();
+		}
+
+		for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+			auto &result_vector = chunk.data[col_idx + output_offset];
+
+			if (state.list_data.data[col_idx].GetType() == LogicalType::SQLNULL) {
+				// UNNEST(NULL)
+				chunk.SetCardinality(0);
+			} else {
+				auto &vdata = state.list_vector_data[col_idx];
+				auto &child_data = state.list_child_data[col_idx];
+				auto current_idx = vdata.sel->get_index(state.parent_position);
+
+				auto list_data = (list_entry_t *)vdata.data;
+				auto list_entry = list_data[current_idx];
+
+				idx_t list_count;
+				if (state.list_position >= list_entry.length) {
+					list_count = 0;
+				} else {
+					list_count = MinValue<idx_t>(this_chunk_len, list_entry.length - state.list_position);
+				}
+
+				if (list_entry.length > state.list_position) {
+					if (!vdata.validity.RowIsValid(current_idx)) {
+						UnnestNull(0, list_count, result_vector);
+					} else {
+						auto &list_vector = state.list_data.data[col_idx];
+						auto &child_vector = ListVector::GetEntry(list_vector);
+						auto list_size = ListVector::GetListSize(list_vector);
+
+						auto base_offset = list_entry.offset + state.list_position;
+						UnnestVector(child_data, child_vector, list_size, base_offset, base_offset + list_count,
+						             result_vector);
+					}
+				}
+
+				UnnestNull(list_count, this_chunk_len, result_vector);
+			}
+		}
+
+		state.list_position += this_chunk_len;
+		if ((int64_t)state.list_position == state.list_length) {
+			state.parent_position++;
+			state.list_length = -1;
+			state.list_position = 0;
+		}
+
+		chunk.Verify();
+	} while (chunk.size() == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+OperatorResultType PhysicalUnnest::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state) const {
+	return ExecuteInternal(context.client, input, chunk, state, select_list);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class PhysicalChunkScanState : public GlobalSourceState {
+public:
+	explicit PhysicalChunkScanState() : chunk_index(0) {
+	}
+
+	//! The current position in the scan
+	idx_t chunk_index;
+};
+
+unique_ptr<GlobalSourceState> PhysicalChunkScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalChunkScanState>();
+}
+
+void PhysicalChunkScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                LocalSourceState &lstate) const {
+	auto &state = (PhysicalChunkScanState &)gstate;
+	D_ASSERT(collection);
+	if (collection->Count() == 0) {
+		return;
+	}
+	D_ASSERT(chunk.GetTypes() == collection->Types());
+	if (state.chunk_index >= collection->ChunkCount()) {
+		return;
+	}
+	auto &collection_chunk = collection->GetChunk(state.chunk_index);
+	chunk.Reference(collection_chunk);
+	state.chunk_index++;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalChunkScan::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// check if there is any additional action we need to do depending on the type
+	switch (type) {
+	case PhysicalOperatorType::DELIM_SCAN: {
+		auto entry = state.delim_join_dependencies.find(this);
+		D_ASSERT(entry != state.delim_join_dependencies.end());
+		// this chunk scan introduces a dependency to the current pipeline
+		// namely a dependency on the duplicate elimination pipeline to finish
+		auto delim_dependency = entry->second->shared_from_this();
+		auto delim_sink = state.GetPipelineSink(*delim_dependency);
+		D_ASSERT(delim_sink);
+		D_ASSERT(delim_sink->type == PhysicalOperatorType::DELIM_JOIN);
+		auto &delim_join = (PhysicalDelimJoin &)*delim_sink;
+		current.AddDependency(delim_dependency);
+		state.SetPipelineSource(current, (PhysicalOperator *)delim_join.distinct.get());
+		return;
+	}
+	case PhysicalOperatorType::RECURSIVE_CTE_SCAN:
+		if (!state.recursive_cte) {
+			throw InternalException("Recursive CTE scan found without recursive CTE node");
+		}
+		break;
+	default:
+		break;
+	}
+	D_ASSERT(children.empty());
+	state.SetPipelineSource(current, this);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class DummyScanState : public GlobalSourceState {
+public:
+	DummyScanState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDummyScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DummyScanState>();
+}
+
+void PhysicalDummyScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                LocalSourceState &lstate) const {
+	auto &state = (DummyScanState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	// return a single row on the first call to the dummy scan
+	chunk.SetCardinality(1);
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalEmptyResult::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class ExpressionScanState : public OperatorState {
+public:
+	explicit ExpressionScanState(const PhysicalExpressionScan &op) : expression_index(0) {
+		temp_chunk.Initialize(op.GetTypes());
+	}
+
+	//! The current position in the scan
+	idx_t expression_index;
+	//! Temporary chunk for evaluating expressions
+	DataChunk temp_chunk;
+};
+
+unique_ptr<OperatorState> PhysicalExpressionScan::GetOperatorState(ClientContext &context) const {
+	return make_unique<ExpressionScanState>(*this);
+}
+
+OperatorResultType PhysicalExpressionScan::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (ExpressionScanState &)state_p;
+
+	for (; chunk.size() + input.size() <= STANDARD_VECTOR_SIZE && state.expression_index < expressions.size();
+	     state.expression_index++) {
+		state.temp_chunk.Reset();
+		EvaluateExpression(state.expression_index, &input, state.temp_chunk);
+		chunk.Append(state.temp_chunk);
+	}
+	if (state.expression_index < expressions.size()) {
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	} else {
+		state.expression_index = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+}
+
+void PhysicalExpressionScan::EvaluateExpression(idx_t expression_idx, DataChunk *child_chunk, DataChunk &result) const {
+	ExpressionExecutor executor(expressions[expression_idx]);
+	if (child_chunk) {
+		child_chunk->Verify();
+		executor.Execute(*child_chunk, result);
+	} else {
+		executor.Execute(result);
+	}
+}
+
+bool PhysicalExpressionScan::IsFoldable() const {
+	for (auto &expr_list : expressions) {
+		for (auto &expr : expr_list) {
+			if (!expr->IsFoldable()) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <utility>
+
+namespace duckdb {
+
+PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction function_p,
+                                     unique_ptr<FunctionData> bind_data_p, vector<column_t> column_ids_p,
+                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)), names(move(names_p)),
+      table_filters(move(table_filters_p)) {
+}
+
+class TableScanGlobalSourceState : public GlobalSourceState {
+public:
+	TableScanGlobalSourceState(ClientContext &context, const PhysicalTableScan &op) {
+		if (op.function.init_global) {
+			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.table_filters.get());
+			global_state = op.function.init_global(context, input);
+			if (global_state) {
+				max_threads = global_state->MaxThreads();
+			}
+		} else {
+			max_threads = 1;
+		}
+	}
+
+	idx_t max_threads = 0;
+	unique_ptr<GlobalTableFunctionState> global_state;
+
+	idx_t MaxThreads() override {
+		return max_threads;
+	}
+};
+
+class TableScanLocalSourceState : public LocalSourceState {
+public:
+	TableScanLocalSourceState(ExecutionContext &context, TableScanGlobalSourceState &gstate,
+	                          const PhysicalTableScan &op) {
+		if (op.function.init_local) {
+			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.table_filters.get());
+			local_state = op.function.init_local(context.client, input, gstate.global_state.get());
+		}
+	}
+
+	unique_ptr<LocalTableFunctionState> local_state;
+};
+
+unique_ptr<LocalSourceState> PhysicalTableScan::GetLocalSourceState(ExecutionContext &context,
+                                                                    GlobalSourceState &gstate) const {
+	return make_unique<TableScanLocalSourceState>(context, (TableScanGlobalSourceState &)gstate, *this);
+}
+
+unique_ptr<GlobalSourceState> PhysicalTableScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<TableScanGlobalSourceState>(context, *this);
+}
+
+void PhysicalTableScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                LocalSourceState &lstate) const {
+	D_ASSERT(!column_ids.empty());
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	auto &state = (TableScanLocalSourceState &)lstate;
+
+	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
+	function.function(context.client, data, chunk);
+}
+
+double PhysicalTableScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	if (function.table_scan_progress) {
+		return function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
+	}
+	// if table_scan_progress is not implemented we don't support this function yet in the progress bar
+	return -1;
+}
+
+idx_t PhysicalTableScan::GetBatchIndex(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                       LocalSourceState &lstate) const {
+	D_ASSERT(SupportsBatchIndex());
+	D_ASSERT(function.get_batch_index);
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	auto &state = (TableScanLocalSourceState &)lstate;
+	return function.get_batch_index(context.client, bind_data.get(), state.local_state.get(),
+	                                gstate.global_state.get());
+}
+
+string PhysicalTableScan::GetName() const {
+	return StringUtil::Upper(function.name);
+}
+
+string PhysicalTableScan::ParamsToString() const {
+	string result;
+	if (function.to_string) {
+		result = function.to_string(bind_data.get());
+		result += "\n[INFOSEPARATOR]\n";
+	}
+	if (function.projection_pushdown) {
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (column_ids[i] < names.size()) {
+				if (i > 0) {
+					result += "\n";
+				}
+				result += names[column_ids[i]];
+			}
+		}
+	}
+	if (function.filter_pushdown && table_filters) {
+		result += "\n[INFOSEPARATOR]\n";
+		result += "Filters: ";
+		for (auto &f : table_filters->filters) {
+			auto &column_index = f.first;
+			auto &filter = f.second;
+			if (column_index < names.size()) {
+				result += filter->ToString(names[column_ids[column_index]]);
+				result += "\n";
+			}
+		}
+	}
+	return result;
+}
+
+bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
+	if (type != other_p.type) {
+		return false;
+	}
+	auto &other = (PhysicalTableScan &)other_p;
+	if (function.function != other.function.function) {
+		return false;
+	}
+	if (column_ids != other.column_ids) {
+		return false;
+	}
+	if (!FunctionData::Equals(bind_data.get(), other.bind_data.get())) {
+		return false;
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class AlterSourceState : public GlobalSourceState {
+public:
+	AlterSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalAlter::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<AlterSourceState>();
+}
+
+void PhysicalAlter::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                            LocalSourceState &lstate) const {
+	auto &state = (AlterSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.Alter(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateFunctionSourceState : public GlobalSourceState {
+public:
+	CreateFunctionSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateFunction::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateFunctionSourceState>();
+}
+
+void PhysicalCreateFunction::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	auto &state = (CreateFunctionSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateFunction(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateIndexSourceState : public GlobalSourceState {
+public:
+	CreateIndexSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateIndex::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateIndexSourceState>();
+}
+
+void PhysicalCreateIndex::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &state = (CreateIndexSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	if (column_ids.empty()) {
+		throw BinderException("CREATE INDEX does not refer to any columns in the base table!");
+	}
+
+	auto &schema = *table.schema;
+	auto index_entry = (IndexCatalogEntry *)schema.CreateIndex(context.client, info.get(), &table);
+	if (!index_entry) {
+		// index already exists, but error ignored because of IF NOT EXISTS
+		return;
+	}
+
+	unique_ptr<Index> index;
+	switch (info->index_type) {
+	case IndexType::ART: {
+		index = make_unique<ART>(column_ids, unbound_expressions,
+		                         info->unique ? IndexConstraintType::UNIQUE : IndexConstraintType::NONE);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented index type");
+	}
+	index_entry->index = index.get();
+	index_entry->info = table.storage->info;
+	table.storage->AddIndex(move(index), expressions);
+
+	chunk.SetCardinality(0);
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateSchemaSourceState : public GlobalSourceState {
+public:
+	CreateSchemaSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateSchema::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateSchemaSourceState>();
+}
+
+void PhysicalCreateSchema::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                   LocalSourceState &lstate) const {
+	auto &state = (CreateSchemaSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateSchema(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateSequenceSourceState : public GlobalSourceState {
+public:
+	CreateSequenceSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateSequence::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateSequenceSourceState>();
+}
+
+void PhysicalCreateSequence::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	auto &state = (CreateSequenceSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateSequence(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateTable::PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema,
+                                         unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTableSourceState : public GlobalSourceState {
+public:
+	CreateTableSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateTable::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTableSourceState>();
+}
+
+void PhysicalCreateTable::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &state = (CreateTableSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.CreateTable(context.client, schema, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateTableAs::PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema,
+                                             unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE_AS, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class CreateTableAsGlobalState : public GlobalSinkState {
+public:
+	CreateTableAsGlobalState() {
+		inserted_count = 0;
+	}
+
+	mutex append_lock;
+	TableCatalogEntry *table;
+	int64_t inserted_count;
+};
+
+unique_ptr<GlobalSinkState> PhysicalCreateTableAs::GetGlobalSinkState(ClientContext &context) const {
+	auto sink = make_unique<CreateTableAsGlobalState>();
+	auto &catalog = Catalog::GetCatalog(context);
+	sink->table = (TableCatalogEntry *)catalog.CreateTable(context, schema, info.get());
+	return move(sink);
+}
+
+SinkResultType PhysicalCreateTableAs::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                           DataChunk &input) const {
+	auto &sink = (CreateTableAsGlobalState &)state;
+	if (sink.table) {
+		lock_guard<mutex> client_guard(sink.append_lock);
+		sink.table->storage->Append(*sink.table, context.client, input);
+		sink.inserted_count += input.size();
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTableAsSourceState : public GlobalSourceState {
+public:
+	CreateTableAsSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateTableAs::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTableAsSourceState>();
+}
+
+void PhysicalCreateTableAs::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                    LocalSourceState &lstate) const {
+	auto &state = (CreateTableAsSourceState &)gstate;
+	auto &sink = (CreateTableAsGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (sink.table) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(sink.inserted_count));
+	}
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateType::PhysicalCreateType(unique_ptr<CreateTypeInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TYPE, {LogicalType::BIGINT}, estimated_cardinality),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTypeSourceState : public GlobalSourceState {
+public:
+	CreateTypeSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateType::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTypeSourceState>();
+}
+
+void PhysicalCreateType::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CreateTypeSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.CreateType(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateViewSourceState : public GlobalSourceState {
+public:
+	CreateViewSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateView::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateViewSourceState>();
+}
+
+void PhysicalCreateView::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CreateViewSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateView(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class DropSourceState : public GlobalSourceState {
+public:
+	DropSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDrop::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DropSourceState>();
+}
+
+void PhysicalDrop::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                           LocalSourceState &lstate) const {
+	auto &state = (DropSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	switch (info->type) {
+	case CatalogType::PREPARED_STATEMENT: {
+		// DEALLOCATE silently ignores errors
+		auto &statements = ClientData::Get(context.client).prepared_statements;
+		if (statements.find(info->name) != statements.end()) {
+			statements.erase(info->name);
+		}
+		break;
+	}
+	default:
+		Catalog::GetCatalog(context.client).DropEntry(context.client, info.get());
+		break;
+	}
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalRecursiveCTE::PhysicalRecursiveCTE(vector<LogicalType> types, bool union_all, unique_ptr<PhysicalOperator> top,
+                                           unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types), estimated_cardinality), union_all(union_all) {
+	children.push_back(move(top));
+	children.push_back(move(bottom));
+}
+
+PhysicalRecursiveCTE::~PhysicalRecursiveCTE() {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class RecursiveCTEState : public GlobalSinkState {
+public:
+	explicit RecursiveCTEState(ClientContext &context, const PhysicalRecursiveCTE &op)
+	    : new_groups(STANDARD_VECTOR_SIZE) {
+		ht = make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context), op.types,
+		                                            vector<LogicalType>(), vector<BoundAggregateExpression *>());
+	}
+
+	unique_ptr<GroupedAggregateHashTable> ht;
+
+	bool intermediate_empty = true;
+	ChunkCollection intermediate_table;
+	idx_t chunk_idx = 0;
+	SelectionVector new_groups;
+};
+
+unique_ptr<GlobalSinkState> PhysicalRecursiveCTE::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<RecursiveCTEState>(context, *this);
+}
+
+idx_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, RecursiveCTEState &state) const {
+	Vector dummy_addresses(LogicalType::POINTER);
+
+	// Use the HT to eliminate duplicate rows
+	idx_t new_group_count = state.ht->FindOrCreateGroups(chunk, dummy_addresses, state.new_groups);
+
+	// we only return entries we have not seen before (i.e. new groups)
+	chunk.Slice(state.new_groups, new_group_count);
+
+	return new_group_count;
+}
+
+SinkResultType PhysicalRecursiveCTE::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                          DataChunk &input) const {
+	auto &gstate = (RecursiveCTEState &)state;
+	if (!union_all) {
+		idx_t match_count = ProbeHT(input, gstate);
+		if (match_count > 0) {
+			gstate.intermediate_table.Append(input);
+		}
+	} else {
+		gstate.intermediate_table.Append(input);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+void PhysicalRecursiveCTE::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                   LocalSourceState &lstate) const {
+	auto &gstate = (RecursiveCTEState &)*sink_state;
+	while (chunk.size() == 0) {
+		if (gstate.chunk_idx < gstate.intermediate_table.ChunkCount()) {
+			// scan any chunks we have collected so far
+			chunk.Reference(gstate.intermediate_table.GetChunk(gstate.chunk_idx));
+			gstate.chunk_idx++;
+			break;
+		} else {
+			// we have run out of chunks
+			// now we need to recurse
+			// we set up the working table as the data we gathered in this iteration of the recursion
+			working_table->Reset();
+			working_table->Merge(gstate.intermediate_table);
+			// and we clear the intermediate table
+			gstate.intermediate_table.Reset();
+			gstate.chunk_idx = 0;
+			// now we need to re-execute all of the pipelines that depend on the recursion
+			ExecuteRecursivePipelines(context);
+
+			// check if we obtained any results
+			// if not, we are done
+			if (gstate.intermediate_table.Count() == 0) {
+				break;
+			}
+		}
+	}
+}
+
+void PhysicalRecursiveCTE::ExecuteRecursivePipelines(ExecutionContext &context) const {
+	if (pipelines.empty()) {
+		throw InternalException("Missing pipelines for recursive CTE");
+	}
+
+	for (auto &pipeline : pipelines) {
+		auto sink = pipeline->GetSink();
+		if (sink != this) {
+			// reset the sink state for any intermediate sinks
+			sink->sink_state = sink->GetGlobalSinkState(context.client);
+		}
+		for (auto &op : pipeline->GetOperators()) {
+			if (op) {
+				op->op_state = op->GetGlobalOperatorState(context.client);
+			}
+		}
+		pipeline->Reset();
+	}
+	auto &executor = pipelines[0]->executor;
+
+	vector<shared_ptr<Event>> events;
+	executor.ReschedulePipelines(pipelines, events);
+
+	while (true) {
+		executor.WorkOnTasks();
+		if (executor.HasError()) {
+			executor.ThrowException();
+		}
+		bool finished = true;
+		for (auto &event : events) {
+			if (!event->IsFinished()) {
+				finished = false;
+				break;
+			}
+		}
+		if (finished) {
+			// all pipelines finished: done!
+			break;
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalRecursiveCTE::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	sink_state.reset();
+
+	// recursive CTE
+	state.SetPipelineSource(current, this);
+	// the LHS of the recursive CTE is our initial state
+	// we build this pipeline as normal
+	auto pipeline_child = children[0].get();
+	// for the RHS, we gather all pipelines that depend on the recursive cte
+	// these pipelines need to be rerun
+	if (state.recursive_cte) {
+		throw InternalException("Recursive CTE detected WITHIN a recursive CTE node");
+	}
+	state.recursive_cte = this;
+
+	auto recursive_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*recursive_pipeline, this);
+	children[1]->BuildPipelines(executor, *recursive_pipeline, state);
+
+	pipelines.push_back(move(recursive_pipeline));
+
+	state.recursive_cte = nullptr;
+
+	BuildChildPipeline(executor, current, state, pipeline_child);
+}
+
+vector<const PhysicalOperator *> PhysicalRecursiveCTE::GetSources() const {
+	return {this};
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalUnion::PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top,
+                             unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::UNION, move(types), estimated_cardinality) {
+	children.push_back(move(top));
+	children.push_back(move(bottom));
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalUnion::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	if (state.recursive_cte) {
+		throw NotImplementedException("UNIONS are not supported in recursive CTEs yet");
+	}
+	op_state.reset();
+	sink_state.reset();
+
+	auto union_pipeline = make_shared<Pipeline>(executor);
+	auto pipeline_ptr = union_pipeline.get();
+	auto &child_pipelines = state.GetChildPipelines(executor);
+	auto &child_dependencies = state.GetChildDependencies(executor);
+	auto &union_pipelines = state.GetUnionPipelines(executor);
+	// set up dependencies for any child pipelines to this union pipeline
+	auto child_entry = child_pipelines.find(&current);
+	if (child_entry != child_pipelines.end()) {
+		for (auto &current_child : child_entry->second) {
+			D_ASSERT(child_dependencies.find(current_child.get()) != child_dependencies.end());
+			child_dependencies[current_child.get()].push_back(pipeline_ptr);
+		}
+	}
+	// for the current pipeline, continue building on the LHS
+	state.SetPipelineOperators(*union_pipeline, state.GetPipelineOperators(current));
+	children[0]->BuildPipelines(executor, current, state);
+	// insert the union pipeline as a union pipeline of the current node
+	union_pipelines[&current].push_back(move(union_pipeline));
+
+	// for the union pipeline, build on the RHS
+	state.SetPipelineSink(*pipeline_ptr, state.GetPipelineSink(current));
+	children[1]->BuildPipelines(executor, *pipeline_ptr, state);
+}
+
+vector<const PhysicalOperator *> PhysicalUnion::GetSources() const {
+	vector<const PhysicalOperator *> result;
+	for (auto &child : children) {
+		auto child_sources = child->GetSources();
+		result.insert(result.end(), child_sources.begin(), child_sources.end());
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static idx_t PartitionInfoNPartitions(const idx_t n_partitions_upper_bound) {
+	idx_t n_partitions = 1;
+	while (n_partitions <= n_partitions_upper_bound / 2) {
+		n_partitions *= 2;
+		if (n_partitions >= 256) {
+			break;
+		}
+	}
+	return n_partitions;
+}
+
+static idx_t PartitionInfoRadixBits(const idx_t n_partitions) {
+	idx_t radix_bits = 0;
+	auto radix_partitions_copy = n_partitions;
+	while (radix_partitions_copy - 1) {
+		radix_bits++;
+		radix_partitions_copy >>= 1;
+	}
+	return radix_bits;
+}
+
+static hash_t PartitionInfoRadixMask(const idx_t radix_bits, const idx_t radix_shift) {
+	hash_t radix_mask = 0;
+	// we use the fifth byte of the 64 bit hash as radix source
+	for (idx_t i = 0; i < radix_bits; i++) {
+		radix_mask = (radix_mask << 1) | 1;
+	}
+	radix_mask <<= radix_shift;
+	return radix_mask;
+}
+
+RadixPartitionInfo::RadixPartitionInfo(const idx_t n_partitions_upper_bound)
+    : n_partitions(PartitionInfoNPartitions(n_partitions_upper_bound)),
+      radix_bits(PartitionInfoRadixBits(n_partitions)), radix_mask(PartitionInfoRadixMask(radix_bits, RADIX_SHIFT)) {
+
+	// finalize_threads needs to be a power of 2
+	D_ASSERT(n_partitions > 0);
+	D_ASSERT(n_partitions <= 256);
+	D_ASSERT((n_partitions & (n_partitions - 1)) == 0);
+	D_ASSERT(radix_bits <= 8);
+}
+
+PartitionableHashTable::PartitionableHashTable(BufferManager &buffer_manager_p, RadixPartitionInfo &partition_info_p,
+                                               vector<LogicalType> group_types_p, vector<LogicalType> payload_types_p,
+                                               vector<BoundAggregateExpression *> bindings_p)
+    : buffer_manager(buffer_manager_p), group_types(move(group_types_p)), payload_types(move(payload_types_p)),
+      bindings(move(bindings_p)), is_partitioned(false), partition_info(partition_info_p), hashes(LogicalType::HASH),
+      hashes_subset(LogicalType::HASH) {
+
+	sel_vectors.resize(partition_info.n_partitions);
+	sel_vector_sizes.resize(partition_info.n_partitions);
+	group_subset.Initialize(group_types);
+	if (!payload_types.empty()) {
+		payload_subset.Initialize(payload_types);
+	}
+
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		sel_vectors[r].Initialize();
+	}
+}
+
+idx_t PartitionableHashTable::ListAddChunk(HashTableList &list, DataChunk &groups, Vector &group_hashes,
+                                           DataChunk &payload) {
+	if (list.empty() || list.back()->Size() + groups.size() > list.back()->MaxCapacity()) {
+		if (!list.empty()) {
+			// early release first part of ht and prevent adding of more data
+			list.back()->Finalize();
+		}
+		list.push_back(make_unique<GroupedAggregateHashTable>(buffer_manager, group_types, payload_types, bindings,
+		                                                      HtEntryType::HT_WIDTH_32));
+	}
+	return list.back()->AddChunk(groups, group_hashes, payload);
+}
+
+idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bool do_partition) {
+	groups.Hash(hashes);
+
+	// we partition when we are asked to or when the unpartitioned ht runs out of space
+	if (!IsPartitioned() && do_partition) {
+		Partition();
+	}
+
+	if (!IsPartitioned()) {
+		return ListAddChunk(unpartitioned_hts, groups, hashes, payload);
+	}
+
+	// makes no sense to do this with 1 partition
+	D_ASSERT(partition_info.n_partitions > 0);
+
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		sel_vector_sizes[r] = 0;
+	}
+
+	hashes.Normalify(groups.size());
+	auto hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+
+	for (idx_t i = 0; i < groups.size(); i++) {
+		auto partition = (hashes_ptr[i] & partition_info.radix_mask) >> partition_info.RADIX_SHIFT;
+		D_ASSERT(partition < partition_info.n_partitions);
+		sel_vectors[partition].set_index(sel_vector_sizes[partition]++, i);
+	}
+
+#ifdef DEBUG
+	// make sure we have lost no rows
+	idx_t total_count = 0;
+	for (idx_t r = 0; r < partition_info.n_partitions; r++) {
+		total_count += sel_vector_sizes[r];
+	}
+	D_ASSERT(total_count == groups.size());
+#endif
+	idx_t group_count = 0;
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		group_subset.Slice(groups, sel_vectors[r], sel_vector_sizes[r]);
+		payload_subset.Slice(payload, sel_vectors[r], sel_vector_sizes[r]);
+		hashes_subset.Slice(hashes, sel_vectors[r], sel_vector_sizes[r]);
+
+		group_count += ListAddChunk(radix_partitioned_hts[r], group_subset, hashes_subset, payload_subset);
+	}
+	return group_count;
+}
+
+void PartitionableHashTable::Partition() {
+	D_ASSERT(!IsPartitioned());
+	D_ASSERT(radix_partitioned_hts.size() == 0);
+	D_ASSERT(partition_info.n_partitions > 1);
+
+	vector<GroupedAggregateHashTable *> partition_hts(partition_info.n_partitions);
+	for (auto &unpartitioned_ht : unpartitioned_hts) {
+		for (idx_t r = 0; r < partition_info.n_partitions; r++) {
+			radix_partitioned_hts[r].push_back(make_unique<GroupedAggregateHashTable>(
+			    buffer_manager, group_types, payload_types, bindings, HtEntryType::HT_WIDTH_32));
+			partition_hts[r] = radix_partitioned_hts[r].back().get();
+		}
+		unpartitioned_ht->Partition(partition_hts, partition_info.radix_mask, partition_info.RADIX_SHIFT);
+		unpartitioned_ht.reset();
+	}
+	unpartitioned_hts.clear();
+	is_partitioned = true;
+}
+
+bool PartitionableHashTable::IsPartitioned() {
+	return is_partitioned;
+}
+
+HashTableList PartitionableHashTable::GetPartition(idx_t partition) {
+	D_ASSERT(IsPartitioned());
+	D_ASSERT(partition < partition_info.n_partitions);
+	D_ASSERT(radix_partitioned_hts.size() > partition);
+	return move(radix_partitioned_hts[partition]);
+}
+HashTableList PartitionableHashTable::GetUnpartitioned() {
+	D_ASSERT(!IsPartitioned());
+	return move(unpartitioned_hts);
+}
+
+void PartitionableHashTable::Finalize() {
+	if (IsPartitioned()) {
+		for (auto &ht_list : radix_partitioned_hts) {
+			for (auto &ht : ht_list.second) {
+				D_ASSERT(ht);
+				ht->Finalize();
+			}
+		}
+	} else {
+		for (auto &ht : unpartitioned_hts) {
+			D_ASSERT(ht);
+			ht->Finalize();
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PerfectAggregateHashTable::PerfectAggregateHashTable(BufferManager &buffer_manager,
+                                                     const vector<LogicalType> &group_types_p,
+                                                     vector<LogicalType> payload_types_p,
+                                                     vector<AggregateObject> aggregate_objects_p,
+                                                     vector<Value> group_minima_p, vector<idx_t> required_bits_p)
+    : BaseAggregateHashTable(buffer_manager, move(payload_types_p)), addresses(LogicalType::POINTER),
+      required_bits(move(required_bits_p)), total_required_bits(0), group_minima(move(group_minima_p)),
+      sel(STANDARD_VECTOR_SIZE) {
+	for (auto &group_bits : required_bits) {
+		total_required_bits += group_bits;
+	}
+	// the total amount of groups we allocate space for is 2^required_bits
+	total_groups = 1 << total_required_bits;
+	// we don't need to store the groups in a perfect hash table, since the group keys can be deduced by their location
+	grouping_columns = group_types_p.size();
+	layout.Initialize(move(aggregate_objects_p));
+	tuple_size = layout.GetRowWidth();
+
+	// allocate and null initialize the data
+	owned_data = unique_ptr<data_t[]>(new data_t[tuple_size * total_groups]);
+	data = owned_data.get();
+
+	// set up the empty payloads for every tuple, and initialize the "occupied" flag to false
+	group_is_set = unique_ptr<bool[]>(new bool[total_groups]);
+	memset(group_is_set.get(), 0, total_groups * sizeof(bool));
+}
+
+PerfectAggregateHashTable::~PerfectAggregateHashTable() {
+	Destroy();
+}
+
+template <class T>
+static void ComputeGroupLocationTemplated(VectorData &group_data, Value &min, uintptr_t *address_data,
+                                          idx_t current_shift, idx_t count) {
+	auto data = (T *)group_data.data;
+	auto min_val = min.GetValueUnsafe<T>();
+	if (!group_data.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto index = group_data.sel->get_index(i);
+			// check if the value is NULL
+			// NULL groups are considered as "0" in the hash table
+			// that is to say, they have no effect on the position of the element (because 0 << shift is 0)
+			// we only need to handle non-null values here
+			if (group_data.validity.RowIsValid(index)) {
+				D_ASSERT(data[index] >= min_val);
+				uintptr_t adjusted_value = (data[index] - min_val) + 1;
+				address_data[i] += adjusted_value << current_shift;
+			}
+		}
+	} else {
+		// no null values: we can directly compute the addresses
+		for (idx_t i = 0; i < count; i++) {
+			auto index = group_data.sel->get_index(i);
+			uintptr_t adjusted_value = (data[index] - min_val) + 1;
+			address_data[i] += adjusted_value << current_shift;
+		}
+	}
+}
+
+static void ComputeGroupLocation(Vector &group, Value &min, uintptr_t *address_data, idx_t current_shift, idx_t count) {
+	VectorData vdata;
+	group.Orrify(count, vdata);
+
+	switch (group.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		ComputeGroupLocationTemplated<int8_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT16:
+		ComputeGroupLocationTemplated<int16_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT32:
+		ComputeGroupLocationTemplated<int32_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT64:
+		ComputeGroupLocationTemplated<int64_t>(vdata, min, address_data, current_shift, count);
+		break;
+	default:
+		throw InternalException("Unsupported group type for perfect aggregate hash table");
+	}
+}
+
+void PerfectAggregateHashTable::AddChunk(DataChunk &groups, DataChunk &payload) {
+	// first we need to find the location in the HT of each of the groups
+	auto address_data = FlatVector::GetData<uintptr_t>(addresses);
+	// zero-initialize the address data
+	memset(address_data, 0, groups.size() * sizeof(uintptr_t));
+	D_ASSERT(groups.ColumnCount() == group_minima.size());
+
+	// then compute the actual group location by iterating over each of the groups
+	idx_t current_shift = total_required_bits;
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		current_shift -= required_bits[i];
+		ComputeGroupLocation(groups.data[i], group_minima[i], address_data, current_shift, groups.size());
+	}
+	// now we have the HT entry number for every tuple
+	// compute the actual pointer to the data by adding it to the base HT pointer and multiplying by the tuple size
+	idx_t needs_init = 0;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		D_ASSERT(address_data[i] < total_groups);
+		const auto group = address_data[i];
+		address_data[i] = uintptr_t(data) + address_data[i] * tuple_size;
+		if (!group_is_set[group]) {
+			group_is_set[group] = true;
+			sel.set_index(needs_init++, i);
+			if (needs_init == STANDARD_VECTOR_SIZE) {
+				RowOperations::InitializeStates(layout, addresses, sel, needs_init);
+				needs_init = 0;
+			}
+		}
+	}
+	RowOperations::InitializeStates(layout, addresses, sel, needs_init);
+
+	// after finding the group location we update the aggregates
+	idx_t payload_idx = 0;
+	auto &aggregates = layout.GetAggregates();
+	for (auto &aggregate : aggregates) {
+		auto input_count = (idx_t)aggregate.child_count;
+		if (aggregate.filter) {
+			RowOperations::UpdateFilteredStates(aggregate, addresses, payload, payload_idx);
+		} else {
+			RowOperations::UpdateStates(aggregate, addresses, payload, payload_idx, payload.size());
+		}
+		// move to the next aggregate
+		payload_idx += input_count;
+		VectorOperations::AddInPlace(addresses, aggregate.payload_size, payload.size());
+	}
+}
+
+void PerfectAggregateHashTable::Combine(PerfectAggregateHashTable &other) {
+	D_ASSERT(total_groups == other.total_groups);
+	D_ASSERT(tuple_size == other.tuple_size);
+
+	Vector source_addresses(LogicalType::POINTER);
+	Vector target_addresses(LogicalType::POINTER);
+	auto source_addresses_ptr = FlatVector::GetData<data_ptr_t>(source_addresses);
+	auto target_addresses_ptr = FlatVector::GetData<data_ptr_t>(target_addresses);
+
+	// iterate over all entries of both hash tables and call combine for all entries that can be combined
+	data_ptr_t source_ptr = other.data;
+	data_ptr_t target_ptr = data;
+	idx_t combine_count = 0;
+	idx_t reinit_count = 0;
+	const auto &reinit_sel = *FlatVector::IncrementalSelectionVector();
+	for (idx_t i = 0; i < total_groups; i++) {
+		auto has_entry_source = other.group_is_set[i];
+		// we only have any work to do if the source has an entry for this group
+		if (has_entry_source) {
+			auto has_entry_target = group_is_set[i];
+			if (has_entry_target) {
+				// both source and target have an entry: need to combine
+				source_addresses_ptr[combine_count] = source_ptr;
+				target_addresses_ptr[combine_count] = target_ptr;
+				combine_count++;
+				if (combine_count == STANDARD_VECTOR_SIZE) {
+					RowOperations::CombineStates(layout, source_addresses, target_addresses, combine_count);
+					combine_count = 0;
+				}
+			} else {
+				group_is_set[i] = true;
+				// only source has an entry for this group: we can just memcpy it over
+				memcpy(target_ptr, source_ptr, tuple_size);
+				// we clear this entry in the other HT as we "consume" the entry here
+				other.group_is_set[i] = false;
+			}
+		}
+		source_ptr += tuple_size;
+		target_ptr += tuple_size;
+	}
+	RowOperations::CombineStates(layout, source_addresses, target_addresses, combine_count);
+	RowOperations::InitializeStates(layout, addresses, reinit_sel, reinit_count);
+}
+
+template <class T>
+static void ReconstructGroupVectorTemplated(uint32_t group_values[], Value &min, idx_t mask, idx_t shift,
+                                            idx_t entry_count, Vector &result) {
+	auto data = FlatVector::GetData<T>(result);
+	auto &validity_mask = FlatVector::Validity(result);
+	auto min_data = min.GetValueUnsafe<T>();
+	for (idx_t i = 0; i < entry_count; i++) {
+		// extract the value of this group from the total group index
+		auto group_index = (group_values[i] >> shift) & mask;
+		if (group_index == 0) {
+			// if it is 0, the value is NULL
+			validity_mask.SetInvalid(i);
+		} else {
+			// otherwise we add the value (minus 1) to the min value
+			data[i] = min_data + group_index - 1;
+		}
+	}
+}
+
+static void ReconstructGroupVector(uint32_t group_values[], Value &min, idx_t required_bits, idx_t shift,
+                                   idx_t entry_count, Vector &result) {
+	// construct the mask for this entry
+	idx_t mask = (1 << required_bits) - 1;
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		ReconstructGroupVectorTemplated<int8_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT16:
+		ReconstructGroupVectorTemplated<int16_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT32:
+		ReconstructGroupVectorTemplated<int32_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT64:
+		ReconstructGroupVectorTemplated<int64_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	default:
+		throw InternalException("Invalid type for perfect aggregate HT group");
+	}
+}
+
+void PerfectAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	uint32_t group_values[STANDARD_VECTOR_SIZE];
+
+	// iterate over the HT until we either have exhausted the entire HT, or
+	idx_t entry_count = 0;
+	for (; scan_position < total_groups; scan_position++) {
+		if (group_is_set[scan_position]) {
+			// this group is set: add it to the set of groups to extract
+			data_pointers[entry_count] = data + tuple_size * scan_position;
+			group_values[entry_count] = scan_position;
+			entry_count++;
+			if (entry_count == STANDARD_VECTOR_SIZE) {
+				scan_position++;
+				break;
+			}
+		}
+	}
+	if (entry_count == 0) {
+		// no entries found
+		return;
+	}
+	// first reconstruct the groups from the group index
+	idx_t shift = total_required_bits;
+	for (idx_t i = 0; i < grouping_columns; i++) {
+		shift -= required_bits[i];
+		ReconstructGroupVector(group_values, group_minima[i], required_bits[i], shift, entry_count, result.data[i]);
+	}
+	// then construct the payloads
+	result.SetCardinality(entry_count);
+	RowOperations::FinalizeStates(layout, addresses, result, grouping_columns);
+}
+
+void PerfectAggregateHashTable::Destroy() {
+	// check if there is any destructor to call
+	bool has_destructor = false;
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			has_destructor = true;
+		}
+	}
+	if (!has_destructor) {
+		return;
+	}
+	// there are aggregates with destructors: loop over the hash table
+	// and call the destructor method for each of the aggregates
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	idx_t count = 0;
+
+	// iterate over all initialised slots of the hash table
+	data_ptr_t payload_ptr = data;
+	for (idx_t i = 0; i < total_groups; i++) {
+		if (group_is_set[i]) {
+			data_pointers[count++] = payload_ptr;
+			if (count == STANDARD_VECTOR_SIZE) {
+				RowOperations::DestroyStates(layout, addresses, count);
+				count = 0;
+			}
+		}
+		payload_ptr += tuple_size;
+	}
+	RowOperations::DestroyStates(layout, addresses, count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string PhysicalOperator::GetName() const {
+	return PhysicalOperatorToString(type);
+}
+
+string PhysicalOperator::ToString() const {
+	TreeRenderer renderer;
+	return renderer.ToString(*this);
+}
+
+// LCOV_EXCL_START
+void PhysicalOperator::Print() const {
+	Printer::Print(ToString());
+}
+// LCOV_EXCL_STOP
+
+vector<PhysicalOperator *> PhysicalOperator::GetChildren() const {
+	vector<PhysicalOperator *> result;
+	for (auto &child : children) {
+		result.push_back(child.get());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+unique_ptr<OperatorState> PhysicalOperator::GetOperatorState(ClientContext &context) const {
+	return make_unique<OperatorState>();
+}
+
+unique_ptr<GlobalOperatorState> PhysicalOperator::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<GlobalOperatorState>();
+}
+
+OperatorResultType PhysicalOperator::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                             GlobalOperatorState &gstate, OperatorState &state) const {
+	throw InternalException("Calling Execute on a node that is not an operator!");
+}
+// LCOV_EXCL_STOP
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+unique_ptr<LocalSourceState> PhysicalOperator::GetLocalSourceState(ExecutionContext &context,
+                                                                   GlobalSourceState &gstate) const {
+	return make_unique<LocalSourceState>();
+}
+
+unique_ptr<GlobalSourceState> PhysicalOperator::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<GlobalSourceState>();
+}
+
+// LCOV_EXCL_START
+void PhysicalOperator::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                               LocalSourceState &lstate) const {
+	throw InternalException("Calling GetData on a node that is not a source!");
+}
+
+idx_t PhysicalOperator::GetBatchIndex(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	throw InternalException("Calling GetBatchIndex on a node that does not support it");
+}
+
+double PhysicalOperator::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
+	return -1;
+}
+// LCOV_EXCL_STOP
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+SinkResultType PhysicalOperator::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                      DataChunk &input) const {
+	throw InternalException("Calling Sink on a node that is not a sink!");
+}
+// LCOV_EXCL_STOP
+
+void PhysicalOperator::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+}
+
+SinkFinalizeType PhysicalOperator::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                            GlobalSinkState &gstate) const {
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalOperator::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<LocalSinkState>();
+}
+
+unique_ptr<GlobalSinkState> PhysicalOperator::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<GlobalSinkState>();
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalOperator::AddPipeline(Executor &executor, shared_ptr<Pipeline> pipeline, PipelineBuildState &state) {
+	if (!state.recursive_cte) {
+		// regular pipeline: schedule it
+		state.AddPipeline(executor, move(pipeline));
+	} else {
+		// CTE pipeline! add it to the CTE pipelines
+		auto &cte = (PhysicalRecursiveCTE &)*state.recursive_cte;
+		cte.pipelines.push_back(move(pipeline));
+	}
+}
+
+void PhysicalOperator::BuildChildPipeline(Executor &executor, Pipeline &current, PipelineBuildState &state,
+                                          PhysicalOperator *pipeline_child) {
+	auto pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*pipeline, this);
+	// the current is dependent on this pipeline to complete
+	current.AddDependency(pipeline);
+	// recurse into the pipeline child
+	pipeline_child->BuildPipelines(executor, *pipeline, state);
+	AddPipeline(executor, move(pipeline), state);
+}
+
+void PhysicalOperator::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	if (IsSink()) {
+		// operator is a sink, build a pipeline
+		sink_state.reset();
+
+		// single operator:
+		// the operator becomes the data source of the current pipeline
+		state.SetPipelineSource(current, this);
+		// we create a new pipeline starting from the child
+		D_ASSERT(children.size() == 1);
+
+		BuildChildPipeline(executor, current, state, children[0].get());
+	} else {
+		// operator is not a sink! recurse in children
+		if (children.empty()) {
+			// source
+			state.SetPipelineSource(current, this);
+		} else {
+			if (children.size() != 1) {
+				throw InternalException("Operator not supported in BuildPipelines");
+			}
+			state.AddPipelineOperator(current, this);
+			children[0]->BuildPipelines(executor, current, state);
+		}
+	}
+}
+
+vector<const PhysicalOperator *> PhysicalOperator::GetSources() const {
+	vector<const PhysicalOperator *> result;
+	if (IsSink()) {
+		D_ASSERT(children.size() == 1);
+		result.push_back(this);
+		return result;
+	} else {
+		if (children.empty()) {
+			// source
+			result.push_back(this);
+			return result;
+		} else {
+			if (children.size() != 1) {
+				throw InternalException("Operator not supported in GetSource");
+			}
+			return children[0]->GetSources();
+		}
+	}
+}
+
+bool PhysicalOperator::AllSourcesSupportBatchIndex() const {
+	auto sources = GetSources();
+	for (auto &source : sources) {
+		if (!source->SupportsBatchIndex()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void PhysicalOperator::Verify() {
+#ifdef DEBUG
+	auto sources = GetSources();
+	D_ASSERT(!sources.empty());
+	for (auto &child : children) {
+		child->Verify();
+	}
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static uint32_t RequiredBitsForValue(uint32_t n) {
+	idx_t required_bits = 0;
+	while (n > 0) {
+		n >>= 1;
+		required_bits++;
+	}
+	return required_bits;
+}
+
+static bool CanUsePerfectHashAggregate(ClientContext &context, LogicalAggregate &op, vector<idx_t> &bits_per_group) {
+	if (op.grouping_sets.size() > 1 || !op.grouping_functions.empty()) {
+		return false;
+	}
+	idx_t perfect_hash_bits = 0;
+	if (op.group_stats.empty()) {
+		op.group_stats.resize(op.groups.size());
+	}
+	for (idx_t group_idx = 0; group_idx < op.groups.size(); group_idx++) {
+		auto &group = op.groups[group_idx];
+		auto &stats = op.group_stats[group_idx];
+
+		switch (group->return_type.InternalType()) {
+		case PhysicalType::INT8:
+		case PhysicalType::INT16:
+		case PhysicalType::INT32:
+		case PhysicalType::INT64:
+			break;
+		default:
+			// we only support simple integer types for perfect hashing
+			return false;
+		}
+		// check if the group has stats available
+		auto &group_type = group->return_type;
+		if (!stats) {
+			// no stats, but we might still be able to use perfect hashing if the type is small enough
+			// for small types we can just set the stats to [type_min, type_max]
+			switch (group_type.InternalType()) {
+			case PhysicalType::INT8:
+				stats = make_unique<NumericStatistics>(group_type, Value::MinimumValue(group_type),
+				                                       Value::MaximumValue(group_type), StatisticsType::LOCAL_STATS);
+				break;
+			case PhysicalType::INT16:
+				stats = make_unique<NumericStatistics>(group_type, Value::MinimumValue(group_type),
+				                                       Value::MaximumValue(group_type), StatisticsType::LOCAL_STATS);
+				break;
+			default:
+				// type is too large and there are no stats: skip perfect hashing
+				return false;
+			}
+			// we had no stats before, so we have no clue if there are null values or not
+			stats->validity_stats = make_unique<ValidityStatistics>(true);
+		}
+		auto &nstats = (NumericStatistics &)*stats;
+
+		if (nstats.min.IsNull() || nstats.max.IsNull()) {
+			return false;
+		}
+		// we have a min and a max value for the stats: use that to figure out how many bits we have
+		// we add two here, one for the NULL value, and one to make the computation one-indexed
+		// (e.g. if min and max are the same, we still need one entry in total)
+		int64_t range;
+		switch (group_type.InternalType()) {
+		case PhysicalType::INT8:
+			range = int64_t(nstats.max.GetValueUnsafe<int8_t>()) - int64_t(nstats.min.GetValueUnsafe<int8_t>());
+			break;
+		case PhysicalType::INT16:
+			range = int64_t(nstats.max.GetValueUnsafe<int16_t>()) - int64_t(nstats.min.GetValueUnsafe<int16_t>());
+			break;
+		case PhysicalType::INT32:
+			range = int64_t(nstats.max.GetValueUnsafe<int32_t>()) - int64_t(nstats.min.GetValueUnsafe<int32_t>());
+			break;
+		case PhysicalType::INT64:
+			if (!TrySubtractOperator::Operation(nstats.max.GetValueUnsafe<int64_t>(),
+			                                    nstats.min.GetValueUnsafe<int64_t>(), range)) {
+				return false;
+			}
+			break;
+		default:
+			throw InternalException("Unsupported type for perfect hash (should be caught before)");
+		}
+		// bail out on any range bigger than 2^32
+		if (range >= NumericLimits<int32_t>::Maximum()) {
+			return false;
+		}
+		range += 2;
+		// figure out how many bits we need
+		idx_t required_bits = RequiredBitsForValue(range);
+		bits_per_group.push_back(required_bits);
+		perfect_hash_bits += required_bits;
+		// check if we have exceeded the bits for the hash
+		if (perfect_hash_bits > ClientConfig::GetConfig(context).perfect_ht_threshold) {
+			// too many bits for perfect hash
+			return false;
+		}
+	}
+	for (auto &expression : op.expressions) {
+		auto &aggregate = (BoundAggregateExpression &)*expression;
+		if (aggregate.distinct || !aggregate.function.combine) {
+			// distinct aggregates are not supported in perfect hash aggregates
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
+	unique_ptr<PhysicalOperator> groupby;
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	plan = ExtractAggregateExpressions(move(plan), op.expressions, op.groups);
+
+	if (op.groups.empty()) {
+		// no groups, check if we can use a simple aggregation
+		// special case: aggregate entire columns together
+		bool use_simple_aggregation = true;
+		for (auto &expression : op.expressions) {
+			auto &aggregate = (BoundAggregateExpression &)*expression;
+			if (!aggregate.function.simple_update || aggregate.distinct) {
+				// unsupported aggregate for simple aggregation: use hash aggregation
+				use_simple_aggregation = false;
+				break;
+			}
+		}
+		if (use_simple_aggregation) {
+			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(op.types, move(op.expressions),
+			                                                                      op.estimated_cardinality);
+		} else {
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
+			                                                                    op.estimated_cardinality);
+		}
+	} else {
+		// groups! create a GROUP BY aggregator
+		// use a perfect hash aggregate if possible
+		vector<idx_t> required_bits;
+		if (CanUsePerfectHashAggregate(context, op, required_bits)) {
+			groupby = make_unique_base<PhysicalOperator, PhysicalPerfectHashAggregate>(
+			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits),
+			    op.estimated_cardinality);
+		} else {
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(
+			    context, op.types, move(op.expressions), move(op.groups), move(op.grouping_sets),
+			    move(op.grouping_functions), op.estimated_cardinality);
+		}
+	}
+	groupby->children.push_back(move(plan));
+	return groupby;
+}
+
+unique_ptr<PhysicalOperator>
+PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> child,
+                                                   vector<unique_ptr<Expression>> &aggregates,
+                                                   vector<unique_ptr<Expression>> &groups) {
+	vector<unique_ptr<Expression>> expressions;
+	vector<LogicalType> types;
+
+	for (auto &group : groups) {
+		auto ref = make_unique<BoundReferenceExpression>(group->return_type, expressions.size());
+		types.push_back(group->return_type);
+		expressions.push_back(move(group));
+		group = move(ref);
+	}
+
+	for (auto &aggr : aggregates) {
+		auto &bound_aggr = (BoundAggregateExpression &)*aggr;
+		for (auto &child : bound_aggr.children) {
+			auto ref = make_unique<BoundReferenceExpression>(child->return_type, expressions.size());
+			types.push_back(child->return_type);
+			expressions.push_back(move(child));
+			child = move(ref);
+		}
+		if (bound_aggr.filter) {
+			auto &filter = bound_aggr.filter;
+			auto ref = make_unique<BoundReferenceExpression>(filter->return_type, expressions.size());
+			types.push_back(filter->return_type);
+			expressions.push_back(move(filter));
+			bound_aggr.filter = move(ref);
+		}
+	}
+	if (expressions.empty()) {
+		return child;
+	}
+	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), child->estimated_cardinality);
+	projection->children.push_back(move(child));
+	return move(projection);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
+	// first visit the child nodes
+	D_ASSERT(op.children.size() == 2);
+	D_ASSERT(op.condition);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	// create the blockwise NL join
+	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type,
+	                                            op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &op) {
+	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.collection);
+
+	// create a PhysicalChunkScan pointing towards the owned collection
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(op.collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static bool CanPlanIndexJoin(Transaction &transaction, TableScanBindData *bind_data, PhysicalTableScan &scan) {
+	if (!bind_data) {
+		// not a table scan
+		return false;
+	}
+	auto table = bind_data->table;
+	if (transaction.storage.Find(table->storage.get())) {
+		// transaction local appends: skip index join
+		return false;
+	}
+	if (scan.table_filters && !scan.table_filters->filters.empty()) {
+		// table scan filters
+		return false;
+	}
+	return true;
+}
+
+bool ExtractNumericValue(Value val, int64_t &result) {
+	if (!val.type().IsIntegral()) {
+		switch (val.type().InternalType()) {
+		case PhysicalType::INT16:
+			result = val.GetValueUnsafe<int16_t>();
+			break;
+		case PhysicalType::INT32:
+			result = val.GetValueUnsafe<int32_t>();
+			break;
+		case PhysicalType::INT64:
+			result = val.GetValueUnsafe<int64_t>();
+			break;
+		default:
+			return false;
+		}
+	} else {
+		if (!val.TryCastAs(LogicalType::BIGINT)) {
+			return false;
+		}
+		result = val.GetValue<int64_t>();
+	}
+	return true;
+}
+
+void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &join_state) {
+	// we only do this optimization for inner joins
+	if (op.join_type != JoinType::INNER) {
+		return;
+	}
+	// with one condition
+	if (op.conditions.size() != 1) {
+		return;
+	}
+	// with propagated statistics
+	if (op.join_stats.empty()) {
+		return;
+	}
+	// with equality condition and null values not equal
+	for (auto &&condition : op.conditions) {
+		if (condition.comparison != ExpressionType::COMPARE_EQUAL) {
+			return;
+		}
+	}
+	// with integral internal types
+	for (auto &&join_stat : op.join_stats) {
+		if (!TypeIsInteger(join_stat->type.InternalType()) || join_stat->type.InternalType() == PhysicalType::INT128) {
+			// perfect join not possible for non-integral types or hugeint
+			return;
+		}
+	}
+
+	// and when the build range is smaller than the threshold
+	auto stats_build = reinterpret_cast<NumericStatistics *>(op.join_stats[0].get()); // lhs stats
+	if (stats_build->min.IsNull() || stats_build->max.IsNull()) {
+		return;
+	}
+	int64_t min_value, max_value;
+	if (!ExtractNumericValue(stats_build->min, min_value) || !ExtractNumericValue(stats_build->max, max_value)) {
+		return;
+	}
+	int64_t build_range;
+	if (!TrySubtractOperator::Operation(max_value, min_value, build_range)) {
+		return;
+	}
+
+	// Fill join_stats for invisible join
+	auto stats_probe = reinterpret_cast<NumericStatistics *>(op.join_stats[1].get()); // rhs stats
+
+	// The max size our build must have to run the perfect HJ
+	const idx_t MAX_BUILD_SIZE = 1000000;
+	join_state.probe_min = stats_probe->min;
+	join_state.probe_max = stats_probe->max;
+	join_state.build_min = stats_build->min;
+	join_state.build_max = stats_build->max;
+	join_state.estimated_cardinality = op.estimated_cardinality;
+	join_state.build_range = build_range;
+	if (join_state.build_range > MAX_BUILD_SIZE || stats_probe->max.IsNull() || stats_probe->min.IsNull()) {
+		return;
+	}
+	if (stats_build->min <= stats_probe->min && stats_probe->max <= stats_build->max) {
+		join_state.is_probe_in_domain = true;
+	}
+	join_state.is_build_small = true;
+	return;
+}
+
+static void CanUseIndexJoin(TableScanBindData *tbl, Expression &expr, Index **result_index) {
+	tbl->table->storage->info->indexes.Scan([&](Index &index) {
+		if (index.unbound_expressions.size() != 1) {
+			return false;
+		}
+		if (expr.alias == index.unbound_expressions[0]->alias) {
+			*result_index = &index;
+			return true;
+		}
+		return false;
+	});
+}
+
+void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index **left_index, Index **right_index,
+                        PhysicalOperator *left, PhysicalOperator *right) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// check if one of the tables has an index on column
+	if (op.join_type == JoinType::INNER && op.conditions.size() == 1) {
+		// check if one of the children are table scans and if they have an index in the join attribute
+		// (op.condition)
+		if (left->type == PhysicalOperatorType::TABLE_SCAN) {
+			auto &tbl_scan = (PhysicalTableScan &)*left;
+			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
+			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
+				CanUseIndexJoin(tbl, *op.conditions[0].left, left_index);
+			}
+		}
+		if (right->type == PhysicalOperatorType::TABLE_SCAN) {
+			auto &tbl_scan = (PhysicalTableScan &)*right;
+			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
+			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
+				CanUseIndexJoin(tbl, *op.conditions[0].right, right_index);
+			}
+		}
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {
+	// now visit the children
+	D_ASSERT(op.children.size() == 2);
+	idx_t lhs_cardinality = op.children[0]->EstimateCardinality(context);
+	idx_t rhs_cardinality = op.children[1]->EstimateCardinality(context);
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+	D_ASSERT(left && right);
+
+	if (op.conditions.empty()) {
+		// no conditions: insert a cross product
+		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
+	}
+
+	bool has_equality = false;
+	// bool has_inequality = false;
+	size_t has_range = 0;
+	for (size_t c = 0; c < op.conditions.size(); ++c) {
+		auto &cond = op.conditions[c];
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_EQUAL:
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			has_equality = true;
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			++has_range;
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			// has_inequality = true;
+			break;
+		default:
+			throw NotImplementedException("Unimplemented comparison join");
+		}
+	}
+
+	unique_ptr<PhysicalOperator> plan;
+	if (has_equality) {
+		Index *left_index {}, *right_index {};
+		TransformIndexJoin(context, op, &left_index, &right_index, left.get(), right.get());
+		if (left_index &&
+		    (ClientConfig::GetConfig(context).force_index_join || rhs_cardinality < 0.01 * lhs_cardinality)) {
+			auto &tbl_scan = (PhysicalTableScan &)*left;
+			swap(op.conditions[0].left, op.conditions[0].right);
+			return make_unique<PhysicalIndexJoin>(op, move(right), move(left), move(op.conditions), op.join_type,
+			                                      op.right_projection_map, op.left_projection_map, tbl_scan.column_ids,
+			                                      left_index, false, op.estimated_cardinality);
+		}
+		if (right_index &&
+		    (ClientConfig::GetConfig(context).force_index_join || lhs_cardinality < 0.01 * rhs_cardinality)) {
+			auto &tbl_scan = (PhysicalTableScan &)*right;
+			return make_unique<PhysicalIndexJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                      op.left_projection_map, op.right_projection_map, tbl_scan.column_ids,
+			                                      right_index, true, op.estimated_cardinality);
+		}
+		// Equality join with small number of keys : possible perfect join optimization
+		PerfectHashJoinStats perfect_join_stats;
+		CheckForPerfectJoinOpt(op, perfect_join_stats);
+		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types),
+		                                     op.estimated_cardinality, perfect_join_stats);
+
+	} else {
+		bool can_merge = has_range > 0;
+		bool can_iejoin = has_range >= 2 && rec_ctes.empty();
+		switch (op.join_type) {
+		case JoinType::SEMI:
+		case JoinType::ANTI:
+		case JoinType::MARK:
+			can_merge = can_merge && op.conditions.size() == 1;
+			can_iejoin = false;
+			break;
+		default:
+			break;
+		}
+		if (can_iejoin) {
+			plan = make_unique<PhysicalIEJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                   op.estimated_cardinality);
+		} else if (can_merge) {
+			// range join: use piecewise merge join
+			plan = make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions),
+			                                               op.join_type, op.estimated_cardinality);
+		} else {
+			// inequality join: use nested loop
+			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                           op.estimated_cardinality);
+		}
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
+	auto plan = CreatePlan(*op.children[0]);
+	bool use_tmp_file = op.is_file_and_exists && op.use_tmp_file;
+	if (use_tmp_file) {
+		op.file_path += ".tmp";
+	}
+	// COPY from select statement to file
+	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data), op.estimated_cardinality);
+	copy->file_path = op.file_path;
+	copy->use_tmp_file = use_tmp_file;
+
+	copy->children.push_back(move(plan));
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreate &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)),
+		                                       op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)),
+		                                         op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return make_unique<PhysicalCreateType>(unique_ptr_cast<CreateInfo, CreateTypeInfo>(move(op.info)),
+		                                       op.estimated_cardinality);
+	default:
+		throw NotImplementedException("Unimplemented type for logical simple create");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
+	D_ASSERT(op.children.empty());
+	dependencies.insert(&op.table);
+	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
+	                                        move(op.unbound_expressions), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ExtractDependencies(Expression &expr, unordered_set<CatalogEntry *> &dependencies) {
+	if (expr.type == ExpressionType::BOUND_FUNCTION) {
+		auto &function = (BoundFunctionExpression &)expr;
+		if (function.function.dependency) {
+			function.function.dependency(function, dependencies);
+		}
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { ExtractDependencies(child, dependencies); });
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTable &op) {
+	// extract dependencies from any default values
+	for (auto &default_value : op.info->bound_defaults) {
+		if (default_value) {
+			ExtractDependencies(*default_value, op.info->dependencies);
+		}
+	}
+	auto &create_info = (CreateTableInfo &)*op.info->base;
+	auto &catalog = Catalog::GetCatalog(context);
+	auto existing_entry =
+	    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, create_info.schema, create_info.table, true);
+	bool replace = op.info->Base().on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT;
+	if ((!existing_entry || replace) && !op.children.empty()) {
+		D_ASSERT(op.children.size() == 1);
+		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info), op.estimated_cardinality);
+		auto plan = CreatePlan(*op.children[0]);
+		create->children.push_back(move(plan));
+		return move(create);
+	} else {
+		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info), op.estimated_cardinality);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op) {
+	D_ASSERT(op.children.size() == 1);
+	D_ASSERT(op.expressions.size() == 1);
+	D_ASSERT(op.expressions[0]->type == ExpressionType::BOUND_REF);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	// get the index of the row_id column
+	auto &bound_ref = (BoundReferenceExpression &)*op.expressions[0];
+
+	dependencies.insert(op.table);
+	auto del = make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index,
+	                                       op.estimated_cardinality, op.return_chunk);
+	del->children.push_back(move(plan));
+	return move(del);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &op) {
+	D_ASSERT(op.children.empty());
+
+	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN, op.estimated_cardinality);
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void GatherDelimScans(PhysicalOperator *op, vector<PhysicalOperator *> &delim_scans) {
+	D_ASSERT(op);
+	if (op->type == PhysicalOperatorType::DELIM_SCAN) {
+		delim_scans.push_back(op);
+	}
+	for (auto &child : op->children) {
+		GatherDelimScans(child.get(), delim_scans);
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin &op) {
+	// first create the underlying join
+	auto plan = CreatePlan((LogicalComparisonJoin &)op);
+	// this should create a join, not a cross product
+	D_ASSERT(plan && plan->type != PhysicalOperatorType::CROSS_PRODUCT);
+	// duplicate eliminated join
+	// first gather the scans on the duplicate eliminated data set from the RHS
+	vector<PhysicalOperator *> delim_scans;
+	GatherDelimScans(plan->children[1].get(), delim_scans);
+	if (delim_scans.empty()) {
+		// no duplicate eliminated scans in the RHS!
+		// in this case we don't need to create a delim join
+		// just push the normal join
+		return plan;
+	}
+	vector<LogicalType> delim_types;
+	vector<unique_ptr<Expression>> distinct_groups, distinct_expressions;
+	for (auto &delim_expr : op.duplicate_eliminated_columns) {
+		D_ASSERT(delim_expr->type == ExpressionType::BOUND_REF);
+		auto &bound_ref = (BoundReferenceExpression &)*delim_expr;
+		delim_types.push_back(bound_ref.return_type);
+		distinct_groups.push_back(make_unique<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
+	}
+	// now create the duplicate eliminated join
+	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans, op.estimated_cardinality);
+	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk
+	delim_join->distinct = make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions),
+	                                                          move(distinct_groups), op.estimated_cardinality);
+	return move(delim_join);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<PhysicalOperator> child,
+                                                                     vector<unique_ptr<Expression>> distinct_targets) {
+	D_ASSERT(child);
+	D_ASSERT(!distinct_targets.empty());
+
+	auto &types = child->GetTypes();
+	vector<unique_ptr<Expression>> groups, aggregates, projections;
+	idx_t group_count = distinct_targets.size();
+	unordered_map<idx_t, idx_t> group_by_references;
+	vector<LogicalType> aggregate_types;
+	// creates one group per distinct_target
+	for (idx_t i = 0; i < distinct_targets.size(); i++) {
+		auto &target = distinct_targets[i];
+		if (target->type == ExpressionType::BOUND_REF) {
+			auto &bound_ref = (BoundReferenceExpression &)*target;
+			group_by_references[bound_ref.index] = i;
+		}
+		aggregate_types.push_back(target->return_type);
+		groups.push_back(move(target));
+	}
+	bool requires_projection = false;
+	if (types.size() != group_count) {
+		requires_projection = true;
+	}
+	// we need to create one aggregate per column in the select_list
+	for (idx_t i = 0; i < types.size(); ++i) {
+		auto logical_type = types[i];
+		// check if we can directly refer to a group, or if we need to push an aggregate with FIRST
+		auto entry = group_by_references.find(i);
+		if (entry != group_by_references.end()) {
+			auto group_index = entry->second;
+			// entry is found: can directly refer to a group
+			projections.push_back(make_unique<BoundReferenceExpression>(logical_type, group_index));
+			if (group_index != i) {
+				// we require a projection only if this group element is out of order
+				requires_projection = true;
+			}
+		} else {
+			// entry is not one of the groups: need to push a FIRST aggregate
+			auto bound = make_unique<BoundReferenceExpression>(logical_type, i);
+			vector<unique_ptr<Expression>> first_children;
+			first_children.push_back(move(bound));
+			auto first_aggregate = AggregateFunction::BindAggregateFunction(
+			    context, FirstFun::GetFunction(logical_type), move(first_children), nullptr, false);
+			// add the projection
+			projections.push_back(make_unique<BoundReferenceExpression>(logical_type, group_count + aggregates.size()));
+			// push it to the list of aggregates
+			aggregate_types.push_back(logical_type);
+			aggregates.push_back(move(first_aggregate));
+			requires_projection = true;
+		}
+	}
+
+	child = ExtractAggregateExpressions(move(child), aggregates, groups);
+
+	// we add a physical hash aggregation in the plan to select the distinct groups
+	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),
+	                                                  child->estimated_cardinality);
+	groupby->children.push_back(move(child));
+	if (!requires_projection) {
+		return move(groupby);
+	}
+
+	// we add a physical projection on top of the aggregation to project all members in the select list
+	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections), groupby->estimated_cardinality);
+	aggr_projection->children.push_back(move(groupby));
+	return move(aggr_projection);
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+	return CreateDistinctOn(move(plan), move(op.distinct_targets));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDummyScan &op) {
+	D_ASSERT(op.children.size() == 0);
+	return make_unique<PhysicalDummyScan>(op.types, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
+	D_ASSERT(op.children.size() == 0);
+	return make_unique<PhysicalEmptyResult>(op.types, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExecute &op) {
+	if (!op.prepared->plan) {
+		D_ASSERT(op.children.size() == 1);
+		auto owned_plan = CreatePlan(*op.children[0]);
+		auto execute = make_unique<PhysicalExecute>(owned_plan.get());
+		execute->owned_plan = move(owned_plan);
+		execute->prepared = move(op.prepared);
+		return move(execute);
+	} else {
+		D_ASSERT(op.children.size() == 0);
+		return make_unique<PhysicalExecute>(op.prepared->plan.get());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto logical_plan_opt = op.children[0]->ToString();
+	auto plan = CreatePlan(*op.children[0]);
+	if (op.explain_type == ExplainType::EXPLAIN_ANALYZE) {
+		auto result = make_unique<PhysicalExplainAnalyze>(op.types);
+		result->children.push_back(move(plan));
+		return move(result);
+	}
+
+	op.physical_plan = plan->ToString();
+	// the output of the explain
+	vector<string> keys, values;
+	switch (ClientConfig::GetConfig(context).explain_output_type) {
+	case ExplainOutputType::OPTIMIZED_ONLY:
+		keys = {"logical_opt"};
+		values = {logical_plan_opt};
+		break;
+	case ExplainOutputType::PHYSICAL_ONLY:
+		keys = {"physical_plan"};
+		values = {op.physical_plan};
+		break;
+	default:
+		keys = {"logical_plan", "logical_opt", "physical_plan"};
+		values = {op.logical_plan_unopt, logical_plan_opt, op.physical_plan};
+	}
+
+	// create a ChunkCollection from the output
+	auto collection = make_unique<ChunkCollection>();
+
+	DataChunk chunk;
+	chunk.Initialize(op.types);
+	for (idx_t i = 0; i < keys.size(); i++) {
+		chunk.SetValue(0, chunk.size(), Value(keys[i]));
+		chunk.SetValue(1, chunk.size(), Value(values[i]));
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(chunk);
+			chunk.Reset();
+		}
+	}
+	collection->Append(chunk);
+
+	// create a chunk scan to output the result
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Export is disabled through configuration");
+	}
+	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info), op.estimated_cardinality,
+	                                               op.exported_tables);
+	// plan the underlying copy statements, if any
+	if (!op.children.empty()) {
+		auto plan = CreatePlan(*op.children[0]);
+		export_node->children.push_back(move(plan));
+	}
+	return move(export_node);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpressionGet &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions), op.estimated_cardinality);
+	expr_scan->children.push_back(move(plan));
+	if (!expr_scan->IsFoldable()) {
+		return move(expr_scan);
+	}
+	// simple expression scan (i.e. no subqueries to evaluate and no prepared statement parameters)
+	// we can evaluate all the expressions right now and turn this into a chunk collection scan
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, expr_scan->expressions.size());
+	chunk_scan->owned_collection = make_unique<ChunkCollection>();
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+
+	DataChunk chunk;
+	chunk.Initialize(op.types);
+	for (idx_t expression_idx = 0; expression_idx < expr_scan->expressions.size(); expression_idx++) {
+		chunk.Reset();
+		expr_scan->EvaluateExpression(expression_idx, nullptr, chunk);
+		chunk_scan->owned_collection->Append(chunk);
+	}
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
+	D_ASSERT(op.children.size() == 1);
+	unique_ptr<PhysicalOperator> plan = CreatePlan(*op.children[0]);
+	if (!op.expressions.empty()) {
+		D_ASSERT(plan->types.size() > 0);
+		// create a filter if there is anything to filter
+		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions), op.estimated_cardinality);
+		filter->children.push_back(move(plan));
+		plan = move(filter);
+	}
+	if (!op.projection_map.empty()) {
+		// there is a projection map, generate a physical projection
+		vector<unique_ptr<Expression>> select_list;
+		for (idx_t i = 0; i < op.projection_map.size(); i++) {
+			select_list.push_back(make_unique<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
+		}
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list), op.estimated_cardinality);
+		proj->children.push_back(move(plan));
+		plan = move(proj);
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, vector<column_t> &column_ids) {
+	// create the table filter map
+	auto table_filter_set = make_unique<TableFilterSet>();
+	for (auto &table_filter : table_filters.filters) {
+		// find the relative column index from the absolute column index into the table
+		idx_t column_index = DConstants::INVALID_INDEX;
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (table_filter.first == column_ids[i]) {
+				column_index = i;
+				break;
+			}
+		}
+		if (column_index == DConstants::INVALID_INDEX) {
+			throw InternalException("Could not find column index for table filter");
+		}
+		table_filter_set->filters[column_index] = move(table_filter.second);
+	}
+	return table_filter_set;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
+	if (!op.children.empty()) {
+		// this is for table producing functions that consume subquery results
+		D_ASSERT(op.children.size() == 1);
+		auto node = make_unique<PhysicalTableInOutFunction>(op.returned_types, op.function, move(op.bind_data),
+		                                                    op.column_ids, op.estimated_cardinality);
+		node->children.push_back(CreatePlan(move(op.children[0])));
+		return move(node);
+	}
+
+	unique_ptr<TableFilterSet> table_filters;
+	if (!op.table_filters.filters.empty()) {
+		table_filters = CreateTableFilterSet(op.table_filters, op.column_ids);
+	}
+
+	if (op.function.dependency) {
+		op.function.dependency(dependencies, op.bind_data.get());
+	}
+	// create the table scan node
+	if (!op.function.projection_pushdown) {
+		// function does not support projection pushdown
+		auto node = make_unique<PhysicalTableScan>(op.returned_types, op.function, move(op.bind_data), op.column_ids,
+		                                           op.names, move(table_filters), op.estimated_cardinality);
+		// first check if an additional projection is necessary
+		if (op.column_ids.size() == op.returned_types.size()) {
+			bool projection_necessary = false;
+			for (idx_t i = 0; i < op.column_ids.size(); i++) {
+				if (op.column_ids[i] != i) {
+					projection_necessary = true;
+					break;
+				}
+			}
+			if (!projection_necessary) {
+				// a projection is not necessary if all columns have been requested in-order
+				// in that case we just return the node
+
+				return move(node);
+			}
+		}
+		// push a projection on top that does the projection
+		vector<LogicalType> types;
+		vector<unique_ptr<Expression>> expressions;
+		for (auto &column_id : op.column_ids) {
+			if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
+				types.emplace_back(LogicalType::BIGINT);
+				expressions.push_back(make_unique<BoundConstantExpression>(Value::BIGINT(0)));
+			} else {
+				auto type = op.returned_types[column_id];
+				types.push_back(type);
+				expressions.push_back(make_unique<BoundReferenceExpression>(type, column_id));
+			}
+		}
+
+		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), op.estimated_cardinality);
+		projection->children.push_back(move(node));
+		return move(projection);
+	} else {
+		return make_unique<PhysicalTableScan>(op.types, op.function, move(op.bind_data), op.column_ids, op.names,
+		                                      move(table_filters), op.estimated_cardinality);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op) {
+	unique_ptr<PhysicalOperator> plan;
+	if (!op.children.empty()) {
+		D_ASSERT(op.children.size() == 1);
+		plan = CreatePlan(*op.children[0]);
+	}
+
+	dependencies.insert(op.table);
+	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults),
+	                                          op.estimated_cardinality, op.return_chunk);
+	if (plan) {
+		insert->children.push_back(move(plan));
+	}
+	return move(insert);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+	auto &config = DBConfig::GetConfig(context);
+	unique_ptr<PhysicalOperator> limit;
+	if (!config.preserve_insertion_order) {
+		// use parallel streaming limit if insertion order is not important
+		limit = make_unique<PhysicalStreamingLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+		                                            move(op.offset), op.estimated_cardinality, true);
+	} else {
+		// maintaining insertion order is important
+		bool all_sources_support_batch_index = plan->AllSourcesSupportBatchIndex();
+
+		if (all_sources_support_batch_index) {
+			// source supports batch index: use parallel batch limit
+			limit = make_unique<PhysicalLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+			                                   move(op.offset), op.estimated_cardinality);
+		} else {
+			// source does not support batch index: use a non-parallel streaming limit
+			limit = make_unique<PhysicalStreamingLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+			                                            move(op.offset), op.estimated_cardinality, false);
+		}
+	}
+
+	limit->children.push_back(move(plan));
+	return limit;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimitPercent &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto limit = make_unique<PhysicalLimitPercent>(op.types, op.limit_percent, op.offset_val, move(op.limit),
+	                                               move(op.offset), op.estimated_cardinality);
+	limit->children.push_back(move(plan));
+	return move(limit);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+	if (!op.orders.empty()) {
+		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders), op.estimated_cardinality);
+		order->children.push_back(move(plan));
+		plan = move(order);
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPragma &op) {
+	return make_unique<PhysicalPragma>(op.function, op.info, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	// generate physical plan
+	auto plan = CreatePlan(*op.children[0]);
+	op.prepared->types = plan->types;
+	op.prepared->plan = move(plan);
+
+	return make_unique<PhysicalPrepare>(op.name, move(op.prepared), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+
+#ifdef DEBUG
+	for (auto &expr : op.expressions) {
+		D_ASSERT(!expr->IsWindow());
+		D_ASSERT(!expr->IsAggregate());
+	}
+#endif
+	if (plan->types.size() == op.types.size()) {
+		// check if this projection can be omitted entirely
+		// this happens if a projection simply emits the columns in the same order
+		// e.g. PROJECTION(#0, #1, #2, #3, ...)
+		bool omit_projection = true;
+		for (idx_t i = 0; i < op.types.size(); i++) {
+			if (op.expressions[i]->type == ExpressionType::BOUND_REF) {
+				auto &bound_ref = (BoundReferenceExpression &)*op.expressions[i];
+				if (bound_ref.index == i) {
+					continue;
+				}
+			}
+			omit_projection = false;
+			break;
+		}
+		if (omit_projection) {
+			// the projection only directly projects the child' columns: omit it entirely
+			return plan;
+		}
+	}
+
+	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions), op.estimated_cardinality);
+	projection->children.push_back(move(plan));
+	return move(projection);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	// Create the working_table that the PhysicalRecursiveCTE will use for evaluation.
+	auto working_table = std::make_shared<ChunkCollection>();
+
+	// Add the ChunkCollection to the context of this PhysicalPlanGenerator
+	rec_ctes[op.table_index] = working_table;
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	auto cte =
+	    make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right), op.estimated_cardinality);
+	cte->working_table = working_table;
+
+	return move(cte);
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
+	D_ASSERT(op.children.empty());
+
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN, op.estimated_cardinality);
+
+	// CreatePlan of a LogicalRecursiveCTE must have happened before.
+	auto cte = rec_ctes.find(op.cte_index);
+	if (cte == rec_ctes.end()) {
+		throw Exception("Referenced recursive CTE does not exist.");
+	}
+	chunk_scan->collection = cte->second.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	unique_ptr<PhysicalOperator> sample;
+	switch (op.sample_options->method) {
+	case SampleMethod::RESERVOIR_SAMPLE:
+		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options), op.estimated_cardinality);
+		break;
+	case SampleMethod::SYSTEM_SAMPLE:
+	case SampleMethod::BERNOULLI_SAMPLE:
+		if (!op.sample_options->is_percentage) {
+			throw ParserException("Sample method %s cannot be used with a discrete sample count, either switch to "
+			                      "reservoir sampling or use a sample_size",
+			                      SampleMethodToString(op.sample_options->method));
+		}
+		sample = make_unique<PhysicalStreamingSample>(op.types, op.sample_options->method,
+		                                              op.sample_options->sample_size.GetValue<double>(),
+		                                              op.sample_options->seed, op.estimated_cardinality);
+		break;
+	default:
+		throw InternalException("Unimplemented sample method");
+	}
+	sample->children.push_back(move(plan));
+	return sample;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSet &op) {
+	return make_unique<PhysicalSet>(op.name, op.value, op.scope, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	if (left->GetTypes() != right->GetTypes()) {
+		throw Exception("Type mismatch for SET OPERATION");
+	}
+
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_UNION:
+		// UNION
+		return make_unique<PhysicalUnion>(op.types, move(left), move(right), op.estimated_cardinality);
+	default: {
+		// EXCEPT/INTERSECT
+		D_ASSERT(op.type == LogicalOperatorType::LOGICAL_EXCEPT || op.type == LogicalOperatorType::LOGICAL_INTERSECT);
+		auto &types = left->GetTypes();
+		vector<JoinCondition> conditions;
+		// create equality condition for all columns
+		for (idx_t i = 0; i < types.size(); i++) {
+			JoinCondition cond;
+			cond.left = make_unique<BoundReferenceExpression>(types[i], i);
+			cond.right = make_unique<BoundReferenceExpression>(types[i], i);
+			cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+			conditions.push_back(move(cond));
+		}
+		// EXCEPT is ANTI join
+		// INTERSECT is SEMI join
+		PerfectHashJoinStats join_stats; // used in inner joins only
+		JoinType join_type = op.type == LogicalOperatorType::LOGICAL_EXCEPT ? JoinType::ANTI : JoinType::SEMI;
+		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type,
+		                                     op.estimated_cardinality, join_stats);
+	}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalShow &op) {
+	DataChunk output;
+	output.Initialize(op.types);
+
+	auto collection = make_unique<ChunkCollection>();
+	for (idx_t column_idx = 0; column_idx < op.types_select.size(); column_idx++) {
+		auto type = op.types_select[column_idx];
+		auto &name = op.aliases[column_idx];
+
+		// "name", TypeId::VARCHAR
+		output.SetValue(0, output.size(), Value(name));
+		// "type", TypeId::VARCHAR
+		output.SetValue(1, output.size(), Value(type.ToString()));
+		// "null", TypeId::VARCHAR
+		output.SetValue(2, output.size(), Value("YES"));
+		// "pk", TypeId::BOOL
+		output.SetValue(3, output.size(), Value());
+		// "dflt_value", TypeId::VARCHAR
+		output.SetValue(4, output.size(), Value());
+		// "extra", TypeId::VARCHAR
+		output.SetValue(5, output.size(), Value());
+
+		output.SetCardinality(output.size() + 1);
+		if (output.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(output);
+			output.Reset();
+		}
+	}
+
+	collection->Append(output);
+
+	// create a chunk scan to output the result
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_ALTER:
+		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)),
+		                                  op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_DROP:
+		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)), op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)),
+		                                        op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_VACUUM:
+		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)),
+		                                   op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return make_unique<PhysicalLoad>(unique_ptr_cast<ParseInfo, LoadInfo>(move(op.info)), op.estimated_cardinality);
+	default:
+		throw NotImplementedException("Unimplemented type for logical simple operator");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto top_n =
+	    make_unique<PhysicalTopN>(op.types, move(op.orders), (idx_t)op.limit, op.offset, op.estimated_cardinality);
+	top_n->children.push_back(move(plan));
+	return move(top_n);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions), op.estimated_cardinality);
+	unnest->children.push_back(move(plan));
+	return move(unnest);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	dependencies.insert(op.table);
+	auto update = make_unique<PhysicalUpdate>(op.types, *op.table, *op.table->storage, op.columns, move(op.expressions),
+	                                          move(op.bound_defaults), op.estimated_cardinality, op.return_chunk);
+
+	update->update_is_del_and_insert = op.update_is_del_and_insert;
+	update->children.push_back(move(plan));
+	return move(update);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+static bool IsStreamingWindow(unique_ptr<Expression> &expr) {
+	auto wexpr = reinterpret_cast<BoundWindowExpression *>(expr.get());
+	if (!wexpr->partitions.empty() || !wexpr->orders.empty() || wexpr->ignore_nulls) {
+		return false;
+	}
+	switch (wexpr->type) {
+	// TODO: add more expression types here?
+	case ExpressionType::WINDOW_FIRST_VALUE:
+	case ExpressionType::WINDOW_PERCENT_RANK:
+	case ExpressionType::WINDOW_RANK:
+	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_ROW_NUMBER:
+		return true;
+	default:
+		return false;
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+#ifdef DEBUG
+	for (auto &expr : op.expressions) {
+		D_ASSERT(expr->IsWindow());
+	}
+#endif
+
+	// Slice types
+	auto types = op.types;
+	const auto output_idx = types.size() - op.expressions.size();
+	types.resize(output_idx);
+
+	// Identify streaming windows
+	vector<idx_t> blocking_windows;
+	vector<idx_t> streaming_windows;
+	for (idx_t expr_idx = 0; expr_idx < op.expressions.size(); expr_idx++) {
+		if (IsStreamingWindow(op.expressions[expr_idx])) {
+			streaming_windows.push_back(expr_idx);
+		} else {
+			blocking_windows.push_back(expr_idx);
+		}
+	}
+
+	// Process the window functions by sharing the partition/order definitions
+	vector<idx_t> evaluation_order;
+	while (!blocking_windows.empty() || !streaming_windows.empty()) {
+		const bool process_streaming = blocking_windows.empty();
+		auto &remaining = process_streaming ? streaming_windows : blocking_windows;
+
+		// Find all functions that share the partitioning of the first remaining expression
+		const auto over_idx = remaining[0];
+		auto over_expr = reinterpret_cast<BoundWindowExpression *>(op.expressions[over_idx].get());
+
+		vector<idx_t> matching;
+		vector<idx_t> unprocessed;
+		for (const auto &expr_idx : remaining) {
+			D_ASSERT(op.expressions[expr_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
+			auto wexpr = reinterpret_cast<BoundWindowExpression *>(op.expressions[expr_idx].get());
+			if (over_expr->KeysAreCompatible(wexpr)) {
+				matching.emplace_back(expr_idx);
+			} else {
+				unprocessed.emplace_back(expr_idx);
+			}
+		}
+		remaining.swap(unprocessed);
+
+		// Extract the matching expressions
+		vector<unique_ptr<Expression>> select_list;
+		for (const auto &expr_idx : matching) {
+			select_list.emplace_back(move(op.expressions[expr_idx]));
+			types.emplace_back(op.types[output_idx + expr_idx]);
+		}
+
+		// Chain the new window operator on top of the plan
+		unique_ptr<PhysicalOperator> window;
+		if (process_streaming) {
+			window = make_unique<PhysicalStreamingWindow>(types, move(select_list), op.estimated_cardinality);
+		} else {
+			window = make_unique<PhysicalWindow>(types, move(select_list), op.estimated_cardinality);
+		}
+		window->children.push_back(move(plan));
+		plan = move(window);
+
+		// Remember the projection order if we changed it
+		if (!remaining.empty() || !evaluation_order.empty()) {
+			evaluation_order.insert(evaluation_order.end(), matching.begin(), matching.end());
+		}
+	}
+
+	// Put everything back into place if it moved
+	if (!evaluation_order.empty()) {
+		vector<unique_ptr<Expression>> select_list(op.types.size());
+		// The inputs don't move
+		for (idx_t i = 0; i < output_idx; ++i) {
+			select_list[i] = make_unique<BoundReferenceExpression>(op.types[i], i);
+		}
+		// The outputs have been rearranged
+		for (idx_t i = 0; i < evaluation_order.size(); ++i) {
+			const auto expr_idx = evaluation_order[i] + output_idx;
+			select_list[expr_idx] = make_unique<BoundReferenceExpression>(op.types[expr_idx], i + output_idx);
+		}
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list), op.estimated_cardinality);
+		proj->children.push_back(move(plan));
+		plan = move(proj);
+	}
+
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+class DependencyExtractor : public LogicalOperatorVisitor {
+public:
+	explicit DependencyExtractor(unordered_set<CatalogEntry *> &dependencies) : dependencies(dependencies) {
+	}
+
+protected:
+	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *expr_ptr) override {
+		// extract dependencies from the bound function expression
+		if (expr.function.dependency) {
+			expr.function.dependency(expr, dependencies);
+		}
+		return nullptr;
+	}
+
+private:
+	unordered_set<CatalogEntry *> &dependencies;
+};
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(unique_ptr<LogicalOperator> op) {
+	auto &profiler = QueryProfiler::Get(context);
+
+	// first resolve column references
+	profiler.StartPhase("column_binding");
+	ColumnBindingResolver resolver;
+	resolver.VisitOperator(*op);
+	profiler.EndPhase();
+
+	// now resolve types of all the operators
+	profiler.StartPhase("resolve_types");
+	op->ResolveOperatorTypes();
+	profiler.EndPhase();
+
+	// extract dependencies from the logical plan
+	DependencyExtractor extractor(dependencies);
+	extractor.VisitOperator(*op);
+
+	// then create the main physical plan
+	profiler.StartPhase("create_plan");
+	auto plan = CreatePlan(*op);
+	profiler.EndPhase();
+
+	plan->Verify();
+	return plan;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &op) {
+	op.estimated_cardinality = op.EstimateCardinality(context);
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_GET:
+		return CreatePlan((LogicalGet &)op);
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return CreatePlan((LogicalProjection &)op);
+	case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
+		return CreatePlan((LogicalEmptyResult &)op);
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return CreatePlan((LogicalFilter &)op);
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return CreatePlan((LogicalAggregate &)op);
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return CreatePlan((LogicalWindow &)op);
+	case LogicalOperatorType::LOGICAL_UNNEST:
+		return CreatePlan((LogicalUnnest &)op);
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return CreatePlan((LogicalLimit &)op);
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT:
+		return CreatePlan((LogicalLimitPercent &)op);
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		return CreatePlan((LogicalSample &)op);
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return CreatePlan((LogicalOrder &)op);
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		return CreatePlan((LogicalTopN &)op);
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
+		return CreatePlan((LogicalCopyToFile &)op);
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+		return CreatePlan((LogicalDummyScan &)op);
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		return CreatePlan((LogicalAnyJoin &)op);
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return CreatePlan((LogicalDelimJoin &)op);
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		return CreatePlan((LogicalComparisonJoin &)op);
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return CreatePlan((LogicalCrossProduct &)op);
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return CreatePlan((LogicalSetOperation &)op);
+	case LogicalOperatorType::LOGICAL_INSERT:
+		return CreatePlan((LogicalInsert &)op);
+	case LogicalOperatorType::LOGICAL_DELETE:
+		return CreatePlan((LogicalDelete &)op);
+	case LogicalOperatorType::LOGICAL_CHUNK_GET:
+		return CreatePlan((LogicalChunkGet &)op);
+	case LogicalOperatorType::LOGICAL_DELIM_GET:
+		return CreatePlan((LogicalDelimGet &)op);
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
+		return CreatePlan((LogicalExpressionGet &)op);
+	case LogicalOperatorType::LOGICAL_UPDATE:
+		return CreatePlan((LogicalUpdate &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return CreatePlan((LogicalCreateTable &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_INDEX:
+		return CreatePlan((LogicalCreateIndex &)op);
+	case LogicalOperatorType::LOGICAL_EXPLAIN:
+		return CreatePlan((LogicalExplain &)op);
+	case LogicalOperatorType::LOGICAL_SHOW:
+		return CreatePlan((LogicalShow &)op);
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return CreatePlan((LogicalDistinct &)op);
+	case LogicalOperatorType::LOGICAL_PREPARE:
+		return CreatePlan((LogicalPrepare &)op);
+	case LogicalOperatorType::LOGICAL_EXECUTE:
+		return CreatePlan((LogicalExecute &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return CreatePlan((LogicalCreate &)op);
+	case LogicalOperatorType::LOGICAL_PRAGMA:
+		return CreatePlan((LogicalPragma &)op);
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+	case LogicalOperatorType::LOGICAL_ALTER:
+	case LogicalOperatorType::LOGICAL_DROP:
+	case LogicalOperatorType::LOGICAL_VACUUM:
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return CreatePlan((LogicalSimple &)op);
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+		return CreatePlan((LogicalRecursiveCTE &)op);
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		return CreatePlan((LogicalCTERef &)op);
+	case LogicalOperatorType::LOGICAL_EXPORT:
+		return CreatePlan((LogicalExport &)op);
+	case LogicalOperatorType::LOGICAL_SET:
+		return CreatePlan((LogicalSet &)op);
+	default:
+		throw NotImplementedException("Unimplemented logical operator type!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+RadixPartitionedHashTable::RadixPartitionedHashTable(GroupingSet &grouping_set_p, const PhysicalHashAggregate &op_p)
+    : grouping_set(grouping_set_p), op(op_p) {
+
+	for (idx_t i = 0; i < op.groups.size(); i++) {
+		if (grouping_set.find(i) == grouping_set.end()) {
+			null_groups.push_back(i);
+		}
+	}
+
+	// 10000 seems like a good compromise here
+	radix_limit = 10000;
+
+	if (grouping_set.empty()) {
+		// fake a single group with a constant value for aggregation without groups
+		group_types.emplace_back(LogicalType::TINYINT);
+	}
+	for (auto &entry : grouping_set) {
+		D_ASSERT(entry < op.group_types.size());
+		group_types.push_back(op.group_types[entry]);
+	}
+	// compute the GROUPING values
+	// for each parameter to the GROUPING clause, we check if the hash table groups on this particular group
+	// if it does, we return 0, otherwise we return 1
+	// we then use bitshifts to combine these values
+	for (auto &grouping : op.grouping_functions) {
+		int64_t grouping_value = 0;
+		for (idx_t i = 0; i < grouping.size(); i++) {
+			if (grouping_set.find(grouping[i]) == grouping_set.end()) {
+				// we don't group on this value!
+				grouping_value += 1 << (grouping.size() - (i + 1));
+			}
+		}
+		grouping_values.push_back(Value::BIGINT(grouping_value));
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class RadixHTGlobalState : public GlobalSinkState {
+public:
+	explicit RadixHTGlobalState(ClientContext &context)
+	    : is_empty(true), multi_scan(true), total_groups(0),
+	      partition_info((idx_t)TaskScheduler::GetScheduler(context).NumberOfThreads()) {
+	}
+
+	vector<unique_ptr<PartitionableHashTable>> intermediate_hts;
+	vector<unique_ptr<GroupedAggregateHashTable>> finalized_hts;
+
+	//! Whether or not any tuples were added to the HT
+	bool is_empty;
+	//! Whether or not the hash table should be scannable multiple times
+	bool multi_scan;
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! a counter to determine if we should switch over to p
+	atomic<idx_t> total_groups;
+
+	bool is_finalized = false;
+	bool is_partitioned = false;
+
+	RadixPartitionInfo partition_info;
+};
+
+class RadixHTLocalState : public LocalSinkState {
+public:
+	explicit RadixHTLocalState(const RadixPartitionedHashTable &ht) : is_empty(true) {
+		// if there are no groups we create a fake group so everything has the same group
+		group_chunk.InitializeEmpty(ht.group_types);
+		if (ht.grouping_set.empty()) {
+			group_chunk.data[0].Reference(Value::TINYINT(42));
+		}
+	}
+
+	DataChunk group_chunk;
+	//! The aggregate HT
+	unique_ptr<PartitionableHashTable> ht;
+
+	//! Whether or not any tuples were added to the HT
+	bool is_empty;
+};
+
+void RadixPartitionedHashTable::SetMultiScan(GlobalSinkState &state) {
+	auto &gstate = (RadixHTGlobalState &)state;
+	gstate.multi_scan = true;
+}
+
+unique_ptr<GlobalSinkState> RadixPartitionedHashTable::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<RadixHTGlobalState>(context);
+}
+
+unique_ptr<LocalSinkState> RadixPartitionedHashTable::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<RadixHTLocalState>(*this);
+}
+
+void RadixPartitionedHashTable::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                     DataChunk &input, DataChunk &aggregate_input_chunk) const {
+	auto &llstate = (RadixHTLocalState &)lstate;
+	auto &gstate = (RadixHTGlobalState &)state;
+	D_ASSERT(!gstate.is_finalized);
+
+	DataChunk &group_chunk = llstate.group_chunk;
+	idx_t chunk_index = 0;
+	for (auto &group_idx : grouping_set) {
+		auto &group = op.groups[group_idx];
+		D_ASSERT(group->type == ExpressionType::BOUND_REF);
+		auto &bound_ref_expr = (BoundReferenceExpression &)*group;
+		group_chunk.data[chunk_index++].Reference(input.data[bound_ref_expr.index]);
+	}
+	group_chunk.SetCardinality(input.size());
+	group_chunk.Verify();
+
+	// if we have non-combinable aggregates (e.g. string_agg) or any distinct aggregates we cannot keep parallel hash
+	// tables
+	if (ForceSingleHT(state)) {
+		lock_guard<mutex> glock(gstate.lock);
+		gstate.is_empty = gstate.is_empty && group_chunk.size() == 0;
+		if (gstate.finalized_hts.empty()) {
+			gstate.finalized_hts.push_back(
+			    make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context.client), group_types,
+			                                           op.payload_types, op.bindings, HtEntryType::HT_WIDTH_64));
+		}
+		D_ASSERT(gstate.finalized_hts.size() == 1);
+		D_ASSERT(gstate.finalized_hts[0]);
+		gstate.total_groups += gstate.finalized_hts[0]->AddChunk(group_chunk, aggregate_input_chunk);
+		return;
+	}
+
+	D_ASSERT(!op.any_distinct);
+
+	if (group_chunk.size() > 0) {
+		llstate.is_empty = false;
+	}
+
+	if (!llstate.ht) {
+		llstate.ht =
+		    make_unique<PartitionableHashTable>(BufferManager::GetBufferManager(context.client), gstate.partition_info,
+		                                        group_types, op.payload_types, op.bindings);
+	}
+
+	gstate.total_groups +=
+	    llstate.ht->AddChunk(group_chunk, aggregate_input_chunk,
+	                         gstate.total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
+}
+
+void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkState &state,
+                                        LocalSinkState &lstate) const {
+	auto &llstate = (RadixHTLocalState &)lstate;
+	auto &gstate = (RadixHTGlobalState &)state;
+	D_ASSERT(!gstate.is_finalized);
+
+	// this actually does not do a lot but just pushes the local HTs into the global state so we can later combine them
+	// in parallel
+
+	if (ForceSingleHT(state)) {
+		D_ASSERT(gstate.finalized_hts.size() <= 1);
+		return;
+	}
+
+	if (!llstate.ht) {
+		return; // no data
+	}
+
+	if (!llstate.ht->IsPartitioned() && gstate.partition_info.n_partitions > 1 && gstate.total_groups > radix_limit) {
+		llstate.ht->Partition();
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	D_ASSERT(!op.any_distinct);
+
+	if (!llstate.is_empty) {
+		gstate.is_empty = false;
+	}
+
+	// we will never add new values to these HTs so we can drop the first part of the HT
+	llstate.ht->Finalize();
+
+	// at this point we just collect them the PhysicalHashAggregateFinalizeTask (below) will merge them in parallel
+	gstate.intermediate_hts.push_back(move(llstate.ht));
+}
+
+bool RadixPartitionedHashTable::Finalize(ClientContext &context, GlobalSinkState &gstate_p) const {
+	auto &gstate = (RadixHTGlobalState &)gstate_p;
+	D_ASSERT(!gstate.is_finalized);
+	gstate.is_finalized = true;
+
+	// special case if we have non-combinable aggregates
+	// we have already aggreagted into a global shared HT that does not require any additional finalization steps
+	if (ForceSingleHT(gstate)) {
+		D_ASSERT(gstate.finalized_hts.size() <= 1);
+		D_ASSERT(gstate.finalized_hts.empty() || gstate.finalized_hts[0]);
+		return false;
+	}
+
+	// we can have two cases now, non-partitioned for few groups and radix-partitioned for very many groups.
+	// go through all of the child hts and see if we ever called partition() on any of them
+	// if we did, its the latter case.
+	bool any_partitioned = false;
+	for (auto &pht : gstate.intermediate_hts) {
+		if (pht->IsPartitioned()) {
+			any_partitioned = true;
+			break;
+		}
+	}
+
+	if (any_partitioned) {
+		// if one is partitioned, all have to be
+		// this should mostly have already happened in Combine, but if not we do it here
+		for (auto &pht : gstate.intermediate_hts) {
+			if (!pht->IsPartitioned()) {
+				pht->Partition();
+			}
+		}
+		// schedule additional tasks to combine the partial HTs
+		gstate.finalized_hts.resize(gstate.partition_info.n_partitions);
+		for (idx_t r = 0; r < gstate.partition_info.n_partitions; r++) {
+			gstate.finalized_hts[r] =
+			    make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context), group_types,
+			                                           op.payload_types, op.bindings, HtEntryType::HT_WIDTH_64);
+		}
+		gstate.is_partitioned = true;
+		return true;
+	} else { // in the non-partitioned case we immediately combine all the unpartitioned hts created by the threads.
+		     // TODO possible optimization, if total count < limit for 32 bit ht, use that one
+		     // create this ht here so finalize needs no lock on gstate
+
+		gstate.finalized_hts.push_back(make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context),
+		                                                                      group_types, op.payload_types,
+		                                                                      op.bindings, HtEntryType::HT_WIDTH_64));
+		for (auto &pht : gstate.intermediate_hts) {
+			auto unpartitioned = pht->GetUnpartitioned();
+			for (auto &unpartitioned_ht : unpartitioned) {
+				D_ASSERT(unpartitioned_ht);
+				gstate.finalized_hts[0]->Combine(*unpartitioned_ht);
+				unpartitioned_ht.reset();
+			}
+			unpartitioned.clear();
+		}
+		D_ASSERT(gstate.finalized_hts[0]);
+		gstate.finalized_hts[0]->Finalize();
+		return false;
+	}
+}
+
+// this task is run in multiple threads and combines the radix-partitioned hash tables into a single onen and then
+// folds them into the global ht finally.
+class RadixAggregateFinalizeTask : public ExecutorTask {
+public:
+	RadixAggregateFinalizeTask(Executor &executor, shared_ptr<Event> event_p, RadixHTGlobalState &state_p,
+	                           idx_t radix_p)
+	    : ExecutorTask(executor), event(move(event_p)), state(state_p), radix(radix_p) {
+	}
+
+	static void FinalizeHT(RadixHTGlobalState &gstate, idx_t radix) {
+		D_ASSERT(gstate.partition_info.n_partitions <= gstate.finalized_hts.size());
+		D_ASSERT(gstate.finalized_hts[radix]);
+		for (auto &pht : gstate.intermediate_hts) {
+			for (auto &ht : pht->GetPartition(radix)) {
+				gstate.finalized_hts[radix]->Combine(*ht);
+				ht.reset();
+			}
+		}
+		gstate.finalized_hts[radix]->Finalize();
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		FinalizeHT(state, radix);
+		event->FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	RadixHTGlobalState &state;
+	idx_t radix;
+};
+
+void RadixPartitionedHashTable::ScheduleTasks(Executor &executor, const shared_ptr<Event> &event,
+                                              GlobalSinkState &state, vector<unique_ptr<Task>> &tasks) const {
+	auto &gstate = (RadixHTGlobalState &)state;
+	if (!gstate.is_partitioned) {
+		return;
+	}
+	for (idx_t r = 0; r < gstate.partition_info.n_partitions; r++) {
+		D_ASSERT(gstate.partition_info.n_partitions <= gstate.finalized_hts.size());
+		D_ASSERT(gstate.finalized_hts[r]);
+		tasks.push_back(make_unique<RadixAggregateFinalizeTask>(executor, event, gstate, r));
+	}
+}
+
+bool RadixPartitionedHashTable::ForceSingleHT(GlobalSinkState &state) const {
+	auto &gstate = (RadixHTGlobalState &)state;
+	return op.any_distinct || gstate.partition_info.n_partitions < 2;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class RadixHTGlobalSourceState : public GlobalSourceState {
+public:
+	explicit RadixHTGlobalSourceState(const RadixPartitionedHashTable &ht)
+	    : ht_index(0), ht_scan_position(0), finished(false) {
+		auto scan_chunk_types = ht.group_types;
+		for (auto &aggr_type : ht.op.aggregate_return_types) {
+			scan_chunk_types.push_back(aggr_type);
+		}
+		scan_chunk.Initialize(scan_chunk_types);
+	}
+
+	//! Materialized GROUP BY expressions & aggregates
+	DataChunk scan_chunk;
+	//! The current position to scan the HT for output tuples
+	idx_t ht_index;
+	idx_t ht_scan_position;
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> RadixPartitionedHashTable::GetGlobalSourceState() const {
+	return make_unique<RadixHTGlobalSourceState>(*this);
+}
+
+void RadixPartitionedHashTable::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSinkState &sink_state,
+                                        GlobalSourceState &source_state) const {
+	auto &gstate = (RadixHTGlobalState &)sink_state;
+	auto &state = (RadixHTGlobalSourceState &)source_state;
+	D_ASSERT(gstate.is_finalized);
+	if (state.finished) {
+		return;
+	}
+
+	state.scan_chunk.Reset();
+	// special case hack to sort out aggregating from empty intermediates
+	// for aggregations without groups
+	if (gstate.is_empty && grouping_set.empty()) {
+		D_ASSERT(chunk.ColumnCount() == null_groups.size() + op.aggregates.size());
+		// for each column in the aggregates, set to initial state
+		chunk.SetCardinality(1);
+		for (auto null_group : null_groups) {
+			chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(chunk.data[null_group], true);
+		}
+		for (idx_t i = 0; i < op.aggregates.size(); i++) {
+			D_ASSERT(op.aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*op.aggregates[i];
+			auto aggr_state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size()]);
+			aggr.function.initialize(aggr_state.get());
+
+			AggregateInputData aggr_input_data(aggr.bind_info.get());
+			Vector state_vector(Value::POINTER((uintptr_t)aggr_state.get()));
+			aggr.function.finalize(state_vector, aggr_input_data, chunk.data[null_groups.size() + i], 1, 0);
+			if (aggr.function.destructor) {
+				aggr.function.destructor(state_vector, 1);
+			}
+		}
+		state.finished = true;
+		return;
+	}
+	if (gstate.is_empty && !state.finished) {
+		state.finished = true;
+		return;
+	}
+	idx_t elements_found = 0;
+
+	while (true) {
+		if (state.ht_index == gstate.finalized_hts.size()) {
+			state.finished = true;
+			return;
+		}
+		D_ASSERT(gstate.finalized_hts[state.ht_index]);
+		elements_found = gstate.finalized_hts[state.ht_index]->Scan(state.ht_scan_position, state.scan_chunk);
+
+		if (elements_found > 0) {
+			break;
+		}
+		if (!gstate.multi_scan) {
+			gstate.finalized_hts[state.ht_index].reset();
+		}
+		state.ht_index++;
+		state.ht_scan_position = 0;
+	}
+
+	// compute the final projection list
+	chunk.SetCardinality(elements_found);
+
+	idx_t chunk_index = 0;
+	for (auto &entry : grouping_set) {
+		chunk.data[entry].Reference(state.scan_chunk.data[chunk_index++]);
+	}
+	for (auto null_group : null_groups) {
+		chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(chunk.data[null_group], true);
+	}
+	for (idx_t col_idx = 0; col_idx < op.aggregates.size(); col_idx++) {
+		chunk.data[op.groups.size() + col_idx].Reference(state.scan_chunk.data[group_types.size() + col_idx]);
+	}
+	D_ASSERT(op.grouping_functions.size() == grouping_values.size());
+	for (idx_t i = 0; i < op.grouping_functions.size(); i++) {
+		chunk.data[op.groups.size() + op.aggregates.size() + i].Reference(grouping_values[i]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void ReservoirSample::AddToReservoir(DataChunk &input) {
+	if (sample_count == 0) {
+		return;
+	}
+	// Input: A population V of n weighted items
+	// Output: A reservoir R with a size m
+	// 1: The first m items of V are inserted into R
+	// first we need to check if the reservoir already has "m" elements
+	if (reservoir.Count() < sample_count) {
+		if (FillReservoir(input) == 0) {
+			// entire chunk was consumed by reservoir
+			return;
+		}
+	}
+	// find the position of next_index relative to current_count
+	idx_t remaining = input.size();
+	idx_t base_offset = 0;
+	while (true) {
+		idx_t offset = base_reservoir_sample.next_index - base_reservoir_sample.current_count;
+		if (offset >= remaining) {
+			// not in this chunk! increment current count and go to the next chunk
+			base_reservoir_sample.current_count += remaining;
+			return;
+		}
+		// in this chunk! replace the element
+		ReplaceElement(input, base_offset + offset);
+		// shift the chunk forward
+		remaining -= offset;
+		base_offset += offset;
+	}
+}
+
+unique_ptr<DataChunk> ReservoirSample::GetChunk() {
+	return reservoir.Fetch();
+}
+
+void ReservoirSample::ReplaceElement(DataChunk &input, idx_t index_in_chunk) {
+	// replace the entry in the reservoir
+	// 8. The item in R with the minimum key is replaced by item vi
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+		reservoir.SetValue(col_idx, base_reservoir_sample.min_entry, input.GetValue(col_idx, index_in_chunk));
+	}
+	base_reservoir_sample.ReplaceElement();
+}
+
+idx_t ReservoirSample::FillReservoir(DataChunk &input) {
+	idx_t chunk_count = input.size();
+	input.Normalify();
+
+	// we have not: append to the reservoir
+	idx_t required_count;
+	if (reservoir.Count() + chunk_count >= sample_count) {
+		// have to limit the count of the chunk
+		required_count = sample_count - reservoir.Count();
+	} else {
+		// we copy the entire chunk
+		required_count = chunk_count;
+	}
+	// instead of copying we just change the pointer in the current chunk
+	input.SetCardinality(required_count);
+	reservoir.Append(input);
+
+	base_reservoir_sample.InitializeReservoir(reservoir.Count(), sample_count);
+
+	// check if there are still elements remaining
+	// this happens if we are on a boundary
+	// for example, input.size() is 1024, but our sample size is 10
+	if (required_count == chunk_count) {
+		// we are done here
+		return 0;
+	}
+	// we still need to process a part of the chunk
+	// create a selection vector of the remaining elements
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = required_count; i < chunk_count; i++) {
+		sel.set_index(i - required_count, i);
+	}
+	// slice the input vector and continue
+	input.Slice(sel, chunk_count - required_count);
+	return input.size();
+}
+
+ReservoirSamplePercentage::ReservoirSamplePercentage(double percentage, int64_t seed)
+    : BlockingSample(seed), sample_percentage(percentage / 100.0), current_count(0), is_finalized(false) {
+	reservoir_sample_size = idx_t(sample_percentage * RESERVOIR_THRESHOLD);
+	current_sample = make_unique<ReservoirSample>(reservoir_sample_size, random.NextRandomInteger());
+}
+
+void ReservoirSamplePercentage::AddToReservoir(DataChunk &input) {
+	if (current_count + input.size() > RESERVOIR_THRESHOLD) {
+		// we don't have enough space in our current reservoir
+		// first check what we still need to append to the current sample
+		idx_t append_to_current_sample_count = RESERVOIR_THRESHOLD - current_count;
+		idx_t append_to_next_sample = input.size() - append_to_current_sample_count;
+		if (append_to_current_sample_count > 0) {
+			// we have elements remaining, first add them to the current sample
+			input.Normalify();
+
+			input.SetCardinality(append_to_current_sample_count);
+			current_sample->AddToReservoir(input);
+		}
+		if (append_to_next_sample > 0) {
+			// slice the input for the remainder
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = 0; i < append_to_next_sample; i++) {
+				sel.set_index(i, append_to_current_sample_count + i);
+			}
+			input.Slice(sel, append_to_next_sample);
+		}
+		// now our first sample is filled: append it to the set of finished samples
+		finished_samples.push_back(move(current_sample));
+
+		// allocate a new sample, and potentially add the remainder of the current input to that sample
+		current_sample = make_unique<ReservoirSample>(reservoir_sample_size, random.NextRandomInteger());
+		if (append_to_next_sample > 0) {
+			current_sample->AddToReservoir(input);
+		}
+		current_count = append_to_next_sample;
+	} else {
+		// we can just append to the current sample
+		current_count += input.size();
+		current_sample->AddToReservoir(input);
+	}
+}
+
+unique_ptr<DataChunk> ReservoirSamplePercentage::GetChunk() {
+	if (!is_finalized) {
+		Finalize();
+	}
+	while (!finished_samples.empty()) {
+		auto &front = finished_samples.front();
+		auto chunk = front->GetChunk();
+		if (chunk && chunk->size() > 0) {
+			return chunk;
+		}
+		// move to the next sample
+		finished_samples.erase(finished_samples.begin());
+	}
+	return nullptr;
+}
+
+void ReservoirSamplePercentage::Finalize() {
+	// need to finalize the current sample, if any
+	if (current_count > 0) {
+		// create a new sample
+		auto new_sample_size = idx_t(round(sample_percentage * current_count));
+		auto new_sample = make_unique<ReservoirSample>(new_sample_size, random.NextRandomInteger());
+		while (true) {
+			auto chunk = current_sample->GetChunk();
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
+			new_sample->AddToReservoir(*chunk);
+		}
+		finished_samples.push_back(move(new_sample));
+	}
+	is_finalized = true;
+}
+
+BaseReservoirSampling::BaseReservoirSampling(int64_t seed) : random(seed) {
+	next_index = 0;
+	min_threshold = 0;
+	min_entry = 0;
+	current_count = 0;
+}
+
+BaseReservoirSampling::BaseReservoirSampling() : BaseReservoirSampling(-1) {
+}
+
+void BaseReservoirSampling::InitializeReservoir(idx_t cur_size, idx_t sample_size) {
+	//! 1: The first m items of V are inserted into R
+	//! first we need to check if the reservoir already has "m" elements
+	if (cur_size == sample_size) {
+		//! 2. For each item vi ∈ R: Calculate a key ki = random(0, 1)
+		//! we then define the threshold to enter the reservoir T_w as the minimum key of R
+		//! we use a priority queue to extract the minimum key in O(1) time
+		for (idx_t i = 0; i < sample_size; i++) {
+			double k_i = random.NextRandom();
+			reservoir_weights.push(std::make_pair(-k_i, i));
+		}
+		SetNextEntry();
+	}
+}
+
+void BaseReservoirSampling::SetNextEntry() {
+	//! 4. Let r = random(0, 1) and Xw = log(r) / log(T_w)
+	auto &min_key = reservoir_weights.top();
+	double t_w = -min_key.first;
+	double r = random.NextRandom();
+	double x_w = log(r) / log(t_w);
+	//! 5. From the current item vc skip items until item vi , such that:
+	//! 6. wc +wc+1 +···+wi−1 < Xw <= wc +wc+1 +···+wi−1 +wi
+	//! since all our weights are 1 (uniform sampling), we can just determine the amount of elements to skip
+	min_threshold = t_w;
+	min_entry = min_key.second;
+	next_index = MaxValue<idx_t>(1, idx_t(round(x_w)));
+	current_count = 0;
+}
+
+void BaseReservoirSampling::ReplaceElement() {
+	//! replace the entry in the reservoir
+	//! pop the minimum entry
+	reservoir_weights.pop();
+	//! now update the reservoir
+	//! 8. Let tw = Tw i , r2 = random(tw,1) and vi’s key: ki = (r2)1/wi
+	//! 9. The new threshold Tw is the new minimum key of R
+	//! we generate a random number between (min_threshold, 1)
+	double r2 = random.NextRandom(min_threshold, 1);
+	//! now we insert the new weight into the reservoir
+	reservoir_weights.push(std::make_pair(-r2, min_entry));
+	//! we update the min entry with the new min entry in the reservoir
+	SetNextEntry();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+WindowSegmentTree::WindowSegmentTree(AggregateFunction &aggregate, FunctionData *bind_info,
+                                     const LogicalType &result_type_p, ChunkCollection *input,
+                                     const ValidityMask &filter_mask_p, WindowAggregationMode mode_p)
+    : aggregate(aggregate), bind_info(bind_info), result_type(result_type_p), state(aggregate.state_size()),
+      statep(Value::POINTER((idx_t)state.data())), frame(0, 0), active(0, 1),
+      statev(Value::POINTER((idx_t)state.data())), internal_nodes(0), input_ref(input), filter_mask(filter_mask_p),
+      mode(mode_p) {
+#if STANDARD_VECTOR_SIZE < 512
+	throw NotImplementedException("Window functions are not supported for vector sizes < 512");
+#endif
+	statep.Normalify(STANDARD_VECTOR_SIZE);
+	statev.SetVectorType(VectorType::FLAT_VECTOR); // Prevent conversion of results to constants
+
+	if (input_ref && input_ref->ColumnCount() > 0) {
+		filter_sel.Initialize(STANDARD_VECTOR_SIZE);
+		inputs.Initialize(input_ref->Types());
+		// if we have a frame-by-frame method, share the single state
+		if (aggregate.window && UseWindowAPI()) {
+			AggregateInit();
+			inputs.Reference(input_ref->GetChunk(0));
+		} else if (aggregate.combine && UseCombineAPI()) {
+			ConstructTree();
+		}
+	}
+}
+
+WindowSegmentTree::~WindowSegmentTree() {
+	if (!aggregate.destructor) {
+		// nothing to destroy
+		return;
+	}
+	// call the destructor for all the intermediate states
+	data_ptr_t address_data[STANDARD_VECTOR_SIZE];
+	Vector addresses(LogicalType::POINTER, (data_ptr_t)address_data);
+	idx_t count = 0;
+	for (idx_t i = 0; i < internal_nodes; i++) {
+		address_data[count++] = data_ptr_t(levels_flat_native.get() + i * state.size());
+		if (count == STANDARD_VECTOR_SIZE) {
+			aggregate.destructor(addresses, count);
+			count = 0;
+		}
+	}
+	if (count > 0) {
+		aggregate.destructor(addresses, count);
+	}
+
+	if (aggregate.window && UseWindowAPI()) {
+		aggregate.destructor(statev, 1);
+	}
+}
+
+void WindowSegmentTree::AggregateInit() {
+	aggregate.initialize(state.data());
+}
+
+void WindowSegmentTree::AggegateFinal(Vector &result, idx_t rid) {
+	AggregateInputData aggr_input_data(bind_info);
+	aggregate.finalize(statev, aggr_input_data, result, 1, rid);
+
+	if (aggregate.destructor) {
+		aggregate.destructor(statev, 1);
+	}
+}
+
+void WindowSegmentTree::ExtractFrame(idx_t begin, idx_t end) {
+	const auto size = end - begin;
+	if (size >= STANDARD_VECTOR_SIZE) {
+		throw InternalException("Cannot compute window aggregation: bounds are too large");
+	}
+
+	const idx_t start_in_vector = begin % STANDARD_VECTOR_SIZE;
+	const auto input_count = input_ref->ColumnCount();
+	if (start_in_vector + size <= STANDARD_VECTOR_SIZE) {
+		inputs.SetCardinality(size);
+		auto &chunk = input_ref->GetChunkForRow(begin);
+		for (idx_t i = 0; i < input_count; ++i) {
+			auto &v = inputs.data[i];
+			auto &vec = chunk.data[i];
+			v.Slice(vec, start_in_vector);
+			v.Verify(size);
+		}
+	} else {
+		inputs.Reset();
+		inputs.SetCardinality(size);
+
+		// we cannot just slice the individual vector!
+		auto &chunk_a = input_ref->GetChunkForRow(begin);
+		auto &chunk_b = input_ref->GetChunkForRow(end);
+		idx_t chunk_a_count = chunk_a.size() - start_in_vector;
+		idx_t chunk_b_count = inputs.size() - chunk_a_count;
+		for (idx_t i = 0; i < input_count; ++i) {
+			auto &v = inputs.data[i];
+			VectorOperations::Copy(chunk_a.data[i], v, chunk_a.size(), start_in_vector, 0);
+			VectorOperations::Copy(chunk_b.data[i], v, chunk_b_count, 0, chunk_a_count);
+		}
+	}
+
+	// Slice to any filtered rows
+	if (!filter_mask.AllValid()) {
+		idx_t filtered = 0;
+		for (idx_t i = begin; i < end; ++i) {
+			if (filter_mask.RowIsValid(i)) {
+				filter_sel.set_index(filtered++, i - begin);
+			}
+		}
+		if (filtered != inputs.size()) {
+			inputs.Slice(filter_sel, filtered);
+		}
+	}
+}
+
+void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) {
+	D_ASSERT(begin <= end);
+	if (begin == end) {
+		return;
+	}
+
+	if (end - begin >= STANDARD_VECTOR_SIZE) {
+		throw InternalException("Cannot compute window aggregation: bounds are too large");
+	}
+
+	Vector s(statep, 0);
+	if (l_idx == 0) {
+		ExtractFrame(begin, end);
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.update(&inputs.data[0], aggr_input_data, input_ref->ColumnCount(), s, inputs.size());
+	} else {
+		inputs.Reset();
+		inputs.SetCardinality(end - begin);
+		// find out where the states begin
+		data_ptr_t begin_ptr = levels_flat_native.get() + state.size() * (begin + levels_flat_start[l_idx - 1]);
+		// set up a vector of pointers that point towards the set of states
+		Vector v(LogicalType::POINTER);
+		auto pdata = FlatVector::GetData<data_ptr_t>(v);
+		for (idx_t i = 0; i < inputs.size(); i++) {
+			pdata[i] = begin_ptr + i * state.size();
+		}
+		v.Verify(inputs.size());
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.combine(v, s, aggr_input_data, inputs.size());
+	}
+}
+
+void WindowSegmentTree::ConstructTree() {
+	D_ASSERT(input_ref);
+	D_ASSERT(inputs.ColumnCount() > 0);
+
+	// compute space required to store internal nodes of segment tree
+	internal_nodes = 0;
+	idx_t level_nodes = input_ref->Count();
+	do {
+		level_nodes = (level_nodes + (TREE_FANOUT - 1)) / TREE_FANOUT;
+		internal_nodes += level_nodes;
+	} while (level_nodes > 1);
+	levels_flat_native = unique_ptr<data_t[]>(new data_t[internal_nodes * state.size()]);
+	levels_flat_start.push_back(0);
+
+	idx_t levels_flat_offset = 0;
+	idx_t level_current = 0;
+	// level 0 is data itself
+	idx_t level_size;
+	// iterate over the levels of the segment tree
+	while ((level_size = (level_current == 0 ? input_ref->Count()
+	                                         : levels_flat_offset - levels_flat_start[level_current - 1])) > 1) {
+		for (idx_t pos = 0; pos < level_size; pos += TREE_FANOUT) {
+			// compute the aggregate for this entry in the segment tree
+			AggregateInit();
+			WindowSegmentValue(level_current, pos, MinValue(level_size, pos + TREE_FANOUT));
+
+			memcpy(levels_flat_native.get() + (levels_flat_offset * state.size()), state.data(), state.size());
+
+			levels_flat_offset++;
+		}
+
+		levels_flat_start.push_back(levels_flat_offset);
+		level_current++;
+	}
+
+	// Corner case: single element in the window
+	if (levels_flat_offset == 0) {
+		aggregate.initialize(levels_flat_native.get());
+	}
+}
+
+void WindowSegmentTree::Compute(Vector &result, idx_t rid, idx_t begin, idx_t end) {
+	D_ASSERT(input_ref);
+
+	// No arguments, so just count
+	if (inputs.ColumnCount() == 0) {
+		D_ASSERT(GetTypeIdSize(result_type.InternalType()) == sizeof(idx_t));
+		auto data = FlatVector::GetData<idx_t>(result);
+		// Slice to any filtered rows
+		if (!filter_mask.AllValid()) {
+			idx_t filtered = 0;
+			for (idx_t i = begin; i < end; ++i) {
+				filtered += filter_mask.RowIsValid(i);
+			}
+			data[rid] = filtered;
+		} else {
+			data[rid] = end - begin;
+		}
+		return;
+	}
+
+	// If we have a window function, use that
+	if (aggregate.window && UseWindowAPI()) {
+		// Frame boundaries
+		auto prev = frame;
+		frame = FrameBounds(begin, end);
+
+		// Extract the range
+		auto &coll = *input_ref;
+		const auto prev_active = active;
+		const FrameBounds combined(MinValue(frame.first, prev.first), MaxValue(frame.second, prev.second));
+
+		// The chunk bounds are the range that includes the begin and end - 1
+		const FrameBounds prev_chunks(coll.LocateChunk(prev_active.first), coll.LocateChunk(prev_active.second - 1));
+		const FrameBounds active_chunks(coll.LocateChunk(combined.first), coll.LocateChunk(combined.second - 1));
+
+		// Extract the range
+		if (active_chunks.first == active_chunks.second) {
+			// If all the data is in a single chunk, then just reference it
+			if (prev_chunks != active_chunks || (!prev.first && !prev.second)) {
+				inputs.Reference(coll.GetChunk(active_chunks.first));
+			}
+		} else if (active_chunks.first == prev_chunks.first && prev_chunks.first != prev_chunks.second) {
+			// If the start chunk did not change, and we are not just a reference, then extend if necessary
+			for (auto chunk_idx = prev_chunks.second + 1; chunk_idx <= active_chunks.second; ++chunk_idx) {
+				inputs.Append(coll.GetChunk(chunk_idx), true);
+			}
+		} else {
+			// If the first chunk changed, start over
+			inputs.Reset();
+			for (auto chunk_idx = active_chunks.first; chunk_idx <= active_chunks.second; ++chunk_idx) {
+				inputs.Append(coll.GetChunk(chunk_idx), true);
+			}
+		}
+
+		active = FrameBounds(active_chunks.first * STANDARD_VECTOR_SIZE,
+		                     MinValue((active_chunks.second + 1) * STANDARD_VECTOR_SIZE, coll.Count()));
+
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.window(inputs.data.data(), filter_mask, aggr_input_data, inputs.ColumnCount(), state.data(), frame,
+		                 prev, result, rid, active.first);
+		return;
+	}
+
+	AggregateInit();
+
+	// Aggregate everything at once if we can't combine states
+	if (!aggregate.combine || !UseCombineAPI()) {
+		WindowSegmentValue(0, begin, end);
+		AggegateFinal(result, rid);
+		return;
+	}
+
+	for (idx_t l_idx = 0; l_idx < levels_flat_start.size() + 1; l_idx++) {
+		idx_t parent_begin = begin / TREE_FANOUT;
+		idx_t parent_end = end / TREE_FANOUT;
+		if (parent_begin == parent_end) {
+			WindowSegmentValue(l_idx, begin, end);
+			break;
+		}
+		idx_t group_begin = parent_begin * TREE_FANOUT;
+		if (begin != group_begin) {
+			WindowSegmentValue(l_idx, begin, group_begin + TREE_FANOUT);
+			parent_begin++;
+		}
+		idx_t group_end = parent_end * TREE_FANOUT;
+		if (end != group_end) {
+			WindowSegmentValue(l_idx, group_end, end);
+		}
+		begin = parent_begin;
+		end = parent_end;
+	}
+
+	AggegateFinal(result, rid);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct AvgState {
+	uint64_t count;
+	T value;
+
+	void Initialize() {
+		this->count = 0;
+	}
+
+	void Combine(const AvgState<T> &other) {
+		this->count += other.count;
+		this->value += other.value;
+	}
+};
+
+struct KahanAvgState {
+	uint64_t count;
+	double value;
+	double err;
+
+	void Initialize() {
+		this->count = 0;
+		this->err = 0.0;
+	}
+
+	void Combine(const KahanAvgState &other) {
+		this->count += other.count;
+		KahanAddInternal(other.value, this->value, this->err);
+		KahanAddInternal(other.err, this->value, this->err);
+	}
+};
+
+struct AverageDecimalBindData : public FunctionData {
+	explicit AverageDecimalBindData(double scale) : scale(scale) {
+	}
+
+	double scale;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<AverageDecimalBindData>(scale);
+	};
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (AverageDecimalBindData &)other_p;
+		return scale == other.scale;
+	}
+};
+
+struct AverageSetOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+	template <class STATE>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->Combine(source);
+	}
+	template <class STATE>
+	static void AddValues(STATE *state, idx_t count) {
+		state->count += count;
+	}
+};
+
+template <class T>
+static T GetAverageDivident(uint64_t count, FunctionData *bind_data) {
+	T divident = T(count);
+	if (bind_data) {
+		auto &avg_bind_data = (AverageDecimalBindData &)*bind_data;
+		divident *= avg_bind_data.scale;
+	}
+	return divident;
+}
+
+struct IntegerAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			double divident = GetAverageDivident<double>(state->count, aggr_input_data.bind_data);
+			target[idx] = double(state->value) / divident;
+		}
+	}
+};
+
+struct IntegerAverageOperationHugeint : public BaseSumOperation<AverageSetOperation, HugeintAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			long double divident = GetAverageDivident<long double>(state->count, aggr_input_data.bind_data);
+			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
+		}
+	}
+};
+
+struct HugeintAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			long double divident = GetAverageDivident<long double>(state->count, aggr_input_data.bind_data);
+			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
+		}
+	}
+};
+
+struct NumericAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("AVG is out of range!");
+			}
+			target[idx] = (state->value / state->count);
+		}
+	}
+};
+
+struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, KahanAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("AVG is out of range!");
+			}
+			target[idx] = (state->value / state->count) + (state->err / state->count);
+		}
+	}
+};
+
+AggregateFunction GetAverageAggregate(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
+		    LogicalType::SMALLINT, LogicalType::DOUBLE, true);
+	case PhysicalType::INT32: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
+		        LogicalType::INTEGER, LogicalType::DOUBLE, true);
+		return function;
+	}
+	case PhysicalType::INT64: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
+		        LogicalType::BIGINT, LogicalType::DOUBLE, true);
+		return function;
+	}
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
+		    LogicalType::HUGEINT, LogicalType::DOUBLE, true);
+	default:
+		throw InternalException("Unimplemented average aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindDecimalAvg(ClientContext &context, AggregateFunction &function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = GetAverageAggregate(decimal_type.InternalType());
+	function.name = "avg";
+	function.arguments[0] = decimal_type;
+	function.return_type = LogicalType::DOUBLE;
+	return make_unique<AverageDecimalBindData>(
+	    Hugeint::Cast<double>(Hugeint::POWERS_OF_TEN[DecimalType::GetScale(decimal_type)]));
+}
+
+void AvgFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet avg("avg");
+	avg.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, true, nullptr, BindDecimalAvg));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT16));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT32));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
+	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+	set.AddFunction(avg);
+
+	avg.name = "mean";
+	set.AddFunction(avg);
+
+	AggregateFunctionSet favg("favg");
+	favg.AddFunction(AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+	set.AddFunction(favg);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+void Corr::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("corr");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<CorrState, double, double, double, CorrOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+} // namespace duckdb
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+void CovarPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet covar_pop("covar_pop");
+	covar_pop.AddFunction(AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(covar_pop);
+}
+
+void CovarSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet covar_samp("covar_samp");
+	covar_samp.AddFunction(AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(covar_samp);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+void StdDevSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet stddev_samp("stddev_samp");
+	stddev_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev_samp);
+	AggregateFunctionSet stddev("stddev");
+	stddev.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev);
+}
+
+void StdDevPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet stddev_pop("stddev_pop");
+	stddev_pop.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev_pop);
+}
+
+void VarPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_pop("var_pop");
+	var_pop.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_pop);
+}
+
+void VarSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_samp("var_samp");
+	var_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_samp);
+}
+void VarianceFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_samp("variance");
+	var_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_samp);
+}
+
+void StandardErrorOfTheMeanFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet sem("sem");
+	sem.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, StandardErrorOfTheMeanOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(sem);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterAlgebraicAggregates() {
+	Register<AvgFun>();
+
+	Register<CovarSampFun>();
+	Register<CovarPopFun>();
+
+	Register<StdDevSampFun>();
+	Register<StdDevPopFun>();
+	Register<VarPopFun>();
+	Register<VarSampFun>();
+	Register<VarianceFun>();
+	Register<StandardErrorOfTheMeanFun>();
+	Register<Corr>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ApproxDistinctCountState {
+	HyperLogLog *log;
+};
+
+struct ApproxCountDistinctFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->log = nullptr;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.log) {
+			return;
+		}
+		if (!target->log) {
+			target->log = new HyperLogLog();
+		}
+		D_ASSERT(target->log);
+		D_ASSERT(source.log);
+		auto new_log = target->log->MergePointer(*source.log);
+		delete target->log;
+		target->log = new_log;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->log) {
+			target[idx] = state->log->Count();
+		} else {
+			target[idx] = 0;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->log) {
+			delete state->log;
+		}
+	}
+};
+
+static void ApproxCountDistinctSimpleUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count,
+                                                    data_ptr_t state, idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	auto agg_state = (ApproxDistinctCountState *)state;
+	if (!agg_state->log) {
+		agg_state->log = new HyperLogLog();
+	}
+
+	VectorData vdata;
+	inputs[0].Orrify(count, vdata);
+
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
+
+	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
+	agg_state->log->AddToLog(vdata, count, indices, counts);
+}
+
+static void ApproxCountDistinctUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count,
+                                              Vector &state_vector, idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (ApproxDistinctCountState **)sdata.data;
+
+	for (idx_t i = 0; i < count; i++) {
+		auto agg_state = states[sdata.sel->get_index(i)];
+		if (!agg_state->log) {
+			agg_state->log = new HyperLogLog();
+		}
+	}
+
+	VectorData vdata;
+	inputs[0].Orrify(count, vdata);
+
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
+
+	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
+	HyperLogLog::AddToLogs(vdata, count, indices, counts, (HyperLogLog ***)states, sdata.sel);
+}
+
+AggregateFunction GetApproxCountDistinctFunction(const LogicalType &input_type) {
+	return AggregateFunction(
+	    {input_type}, LogicalTypeId::BIGINT, AggregateFunction::StateSize<ApproxDistinctCountState>,
+	    AggregateFunction::StateInitialize<ApproxDistinctCountState, ApproxCountDistinctFunction>,
+	    ApproxCountDistinctUpdateFunction,
+	    AggregateFunction::StateCombine<ApproxDistinctCountState, ApproxCountDistinctFunction>,
+	    AggregateFunction::StateFinalize<ApproxDistinctCountState, int64_t, ApproxCountDistinctFunction>,
+	    ApproxCountDistinctSimpleUpdateFunction, nullptr,
+	    AggregateFunction::StateDestroy<ApproxDistinctCountState, ApproxCountDistinctFunction>);
+}
+
+void ApproxCountDistinctFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet approx_count("approx_count_distinct");
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UTINYINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::USMALLINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UINTEGER));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UBIGINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TINYINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::SMALLINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::BIGINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::HUGEINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::FLOAT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::DOUBLE));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::VARCHAR));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TIMESTAMP));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TIMESTAMP_TZ));
+	set.AddFunction(approx_count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T, class T2>
+struct ArgMinMaxState {
+	T arg;
+	T2 value;
+	bool is_initialized;
+};
+
+template <class T>
+static void ArgMinMaxDestroyValue(T value) {
+}
+
+template <>
+void ArgMinMaxDestroyValue(string_t value) {
+	if (!value.IsInlined()) {
+		delete[] value.GetDataUnsafe();
+	}
+}
+
+template <class T>
+static void ArgMinMaxAssignValue(T &target, T new_value, bool is_initialized) {
+	target = new_value;
+}
+
+template <>
+void ArgMinMaxAssignValue(string_t &target, string_t new_value, bool is_initialized) {
+	if (is_initialized) {
+		ArgMinMaxDestroyValue(target);
+	}
+	if (new_value.IsInlined()) {
+		target = new_value;
+	} else {
+		// non-inlined string, need to allocate space for it
+		auto len = new_value.GetSize();
+		auto ptr = new char[len];
+		memcpy(ptr, new_value.GetDataUnsafe(), len);
+
+		target = string_t(ptr, len);
+	}
+}
+
+template <class COMPARATOR>
+struct ArgMinMaxBase {
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->is_initialized) {
+			ArgMinMaxDestroyValue(state->arg);
+			ArgMinMaxDestroyValue(state->value);
+		}
+	}
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->is_initialized = false;
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		if (!state->is_initialized) {
+			ArgMinMaxAssignValue<A_TYPE>(state->arg, x_data[xidx], false);
+			ArgMinMaxAssignValue<B_TYPE>(state->value, y_data[yidx], false);
+			state->is_initialized = true;
+		} else {
+			OP::template Execute<A_TYPE, B_TYPE, STATE>(state, x_data[xidx], y_data[yidx]);
+		}
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE>
+	static void Execute(STATE *state, A_TYPE x_data, B_TYPE y_data) {
+		if (COMPARATOR::Operation(y_data, state->value)) {
+			ArgMinMaxAssignValue<A_TYPE>(state->arg, x_data, true);
+			ArgMinMaxAssignValue<B_TYPE>(state->value, y_data, true);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_initialized) {
+			return;
+		}
+		if (!target->is_initialized || COMPARATOR::Operation(source.value, target->value)) {
+			ArgMinMaxAssignValue(target->arg, source.arg, target->is_initialized);
+			ArgMinMaxAssignValue(target->value, source.value, target->is_initialized);
+			target->is_initialized = true;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class COMPARATOR>
+struct StringArgMinMax : public ArgMinMaxBase<COMPARATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_initialized) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->arg);
+		}
+	}
+};
+
+template <class COMPARATOR>
+struct NumericArgMinMax : public ArgMinMaxBase<COMPARATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_initialized) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->arg;
+		}
+	}
+};
+
+using NumericArgMinOperation = NumericArgMinMax<LessThan>;
+using NumericArgMaxOperation = NumericArgMinMax<GreaterThan>;
+using StringArgMinOperation = StringArgMinMax<LessThan>;
+using StringArgMaxOperation = StringArgMinMax<GreaterThan>;
+
+template <class OP, class T, class T2>
+AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &arg_2, const LogicalType &arg) {
+	auto function = AggregateFunction::BinaryAggregate<ArgMinMaxState<T, T2>, T, T2, T, OP>(arg, arg_2, arg);
+	if (arg.InternalType() == PhysicalType::VARCHAR || arg_2.InternalType() == PhysicalType::VARCHAR) {
+		function.destructor = AggregateFunction::StateDestroy<ArgMinMaxState<T, T2>, OP>;
+	}
+	return function;
+}
+template <class OP, class T>
+AggregateFunction GetArgMinMaxFunctionArg2(const LogicalType &arg_2, const LogicalType &arg) {
+	switch (arg_2.InternalType()) {
+	case PhysicalType::INT32:
+		return GetArgMinMaxFunctionInternal<OP, T, int32_t>(arg_2, arg);
+	case PhysicalType::INT64:
+		return GetArgMinMaxFunctionInternal<OP, T, int64_t>(arg_2, arg);
+	case PhysicalType::DOUBLE:
+		return GetArgMinMaxFunctionInternal<OP, T, double>(arg_2, arg);
+	case PhysicalType::VARCHAR:
+		return GetArgMinMaxFunctionInternal<OP, T, string_t>(arg_2, arg);
+	default:
+		throw InternalException("Unimplemented arg_min/arg_max aggregate");
+	}
+}
+
+template <class OP, class T>
+void AddArgMinMaxFunctionArg2(AggregateFunctionSet &fun, const LogicalType &arg) {
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::INTEGER, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::BIGINT, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::DOUBLE, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::VARCHAR, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::DATE, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::TIMESTAMP, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::TIMESTAMP_TZ, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::BLOB, arg));
+}
+
+template <class OP, class STRING_OP>
+static void AddArgMinMaxFunctions(AggregateFunctionSet &fun) {
+	AddArgMinMaxFunctionArg2<OP, int32_t>(fun, LogicalType::INTEGER);
+	AddArgMinMaxFunctionArg2<OP, int64_t>(fun, LogicalType::BIGINT);
+	AddArgMinMaxFunctionArg2<OP, double>(fun, LogicalType::DOUBLE);
+	AddArgMinMaxFunctionArg2<STRING_OP, string_t>(fun, LogicalType::VARCHAR);
+	AddArgMinMaxFunctionArg2<OP, date_t>(fun, LogicalType::DATE);
+	AddArgMinMaxFunctionArg2<OP, timestamp_t>(fun, LogicalType::TIMESTAMP);
+	AddArgMinMaxFunctionArg2<OP, timestamp_t>(fun, LogicalType::TIMESTAMP_TZ);
+	AddArgMinMaxFunctionArg2<STRING_OP, string_t>(fun, LogicalType::BLOB);
+}
+
+void ArgMinFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("argmin");
+	AddArgMinMaxFunctions<NumericArgMinOperation, StringArgMinOperation>(fun);
+	set.AddFunction(fun);
+
+	//! Add min_by alias
+	fun.name = "min_by";
+	set.AddFunction(fun);
+
+	//! Add arg_min alias
+	fun.name = "arg_min";
+	set.AddFunction(fun);
+}
+
+void ArgMaxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("argmax");
+	AddArgMinMaxFunctions<NumericArgMaxOperation, StringArgMaxOperation>(fun);
+	set.AddFunction(fun);
+
+	//! Add max_by alias
+	fun.name = "max_by";
+	set.AddFunction(fun);
+
+	//! Add arg_max alias
+	fun.name = "arg_max";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-4.cpp
+++ b/velox/external/duckdb/duckdb-4.cpp
@@ -1,0 +1,16456 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct BitState {
+	bool is_set;
+	T value;
+};
+
+template <class OP>
+static AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::SMALLINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type);
+	case LogicalTypeId::INTEGER:
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type);
+	case LogicalTypeId::BIGINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type);
+	case LogicalTypeId::HUGEINT:
+		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
+	case LogicalTypeId::UTINYINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type);
+	case LogicalTypeId::USMALLINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type);
+	case LogicalTypeId::UINTEGER:
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type);
+	case LogicalTypeId::UBIGINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type);
+	default:
+		throw InternalException("Unimplemented bitfield type for unary aggregate");
+	}
+}
+
+struct BitAndOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_AND() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value &= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value &= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitAndFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_and("bit_and");
+	for (auto &type : LogicalType::Integral()) {
+		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
+	}
+	set.AddFunction(bit_and);
+}
+
+struct BitOrOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_OR() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value |= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value |= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitOrFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_or("bit_or");
+	for (auto &type : LogicalType::Integral()) {
+		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
+	}
+	set.AddFunction(bit_or);
+}
+
+struct BitXorOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_XOR() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value ^= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value ^= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitXorFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_xor("bit_xor");
+	for (auto &type : LogicalType::Integral()) {
+		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
+	}
+	set.AddFunction(bit_xor);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BoolState {
+	bool empty;
+	bool val;
+};
+
+struct BoolAndFunFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = true;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val = target->val && source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state->empty = false;
+		state->val = input[idx] && state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct BoolOrFunFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = false;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val = target->val || source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state->empty = false;
+		state->val = input[idx] || state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction BoolOrFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<BoolState, bool, bool, BoolOrFunFunction>(
+	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
+	fun.name = "bool_or";
+	return fun;
+}
+
+AggregateFunction BoolAndFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<BoolState, bool, bool, BoolAndFunFunction>(
+	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
+	fun.name = "bool_and";
+	return fun;
+}
+
+void BoolOrFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction bool_or_function = BoolOrFun::GetFunction();
+	AggregateFunctionSet bool_or("bool_or");
+	bool_or.AddFunction(bool_or_function);
+	set.AddFunction(bool_or);
+}
+
+void BoolAndFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction bool_and_function = BoolAndFun::GetFunction();
+	AggregateFunctionSet bool_and("bool_and");
+	bool_and.AddFunction(bool_and_function);
+	set.AddFunction(bool_and);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BaseCountFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		*state = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		*target += source;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		target[idx] = *state;
+	}
+};
+
+struct CountStarFunction : public BaseCountFunction {
+	template <class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, idx_t idx) {
+		*state += 1;
+	}
+
+	template <class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, idx_t count) {
+		*state += count;
+	}
+};
+
+struct CountFunction : public BaseCountFunction {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		*state += 1;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		*state += count;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction CountFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<int64_t, int64_t, int64_t, CountFunction>(
+	    LogicalType(LogicalTypeId::ANY), LogicalType::BIGINT);
+	fun.name = "count";
+	return fun;
+}
+
+AggregateFunction CountStarFun::GetFunction() {
+	auto fun = AggregateFunction::NullaryAggregate<int64_t, int64_t, CountStarFunction>(LogicalType::BIGINT);
+	fun.name = "count_star";
+	return fun;
+}
+
+unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
+                                               FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats,
+                                               NodeStatistics *node_stats) {
+	if (!expr.distinct && child_stats[0] && !child_stats[0]->CanHaveNull()) {
+		// count on a column without null values: use count star
+		expr.function = CountStarFun::GetFunction();
+		expr.function.name = "count_star";
+		expr.children.clear();
+	}
+	return nullptr;
+}
+
+void CountFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction count_function = CountFun::GetFunction();
+	count_function.statistics = CountPropagateStats;
+	AggregateFunctionSet count("count");
+	count.AddFunction(count_function);
+	// the count function can also be called without arguments
+	count_function.arguments.clear();
+	count_function.statistics = nullptr;
+	count.AddFunction(count_function);
+	set.AddFunction(count);
+}
+
+void CountStarFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet count("count_star");
+	count.AddFunction(CountStarFun::GetFunction());
+	set.AddFunction(count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <unordered_map>
+
+namespace duckdb {
+
+template <class T>
+struct EntropyState {
+	using DistinctMap = unordered_map<T, idx_t>;
+
+	idx_t count;
+	DistinctMap *distinct;
+
+	EntropyState &operator=(const EntropyState &other) = delete;
+
+	EntropyState &Assign(const EntropyState &other) {
+		D_ASSERT(!distinct);
+		distinct = new DistinctMap(*other.distinct);
+		count = other.count;
+		return *this;
+	}
+};
+
+struct EntropyFunctionBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->distinct = nullptr;
+		state->count = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.distinct) {
+			return;
+		}
+		if (!target->distinct) {
+			target->Assign(source);
+			return;
+		}
+		for (auto &val : *source.distinct) {
+			auto value = val.first;
+			(*target->distinct)[value] += val.second;
+		}
+		target->count += source.count;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		double count = state->count;
+		if (state->distinct) {
+			double entropy = 0;
+			for (auto &val : *state->distinct) {
+				entropy += (val.second / count) * log2(count / val.second);
+			}
+			target[idx] = entropy;
+		} else {
+			target[idx] = 0;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->distinct) {
+			delete state->distinct;
+		}
+	}
+};
+
+struct EntropyFunction : EntropyFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->distinct) {
+			state->distinct = new unordered_map<INPUT_TYPE, idx_t>();
+		}
+		(*state->distinct)[input[idx]]++;
+		state->count++;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+};
+
+struct EntropyFunctionString : EntropyFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->distinct) {
+			state->distinct = new unordered_map<string, idx_t>();
+		}
+		auto value = input[idx].GetString();
+		(*state->distinct)[value]++;
+		state->count++;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename RESULT_TYPE>
+AggregateFunction GetEntropyFunction(const LogicalType &input_type, const LogicalType &result_type) {
+	return AggregateFunction::UnaryAggregateDestructor<EntropyState<INPUT_TYPE>, INPUT_TYPE, RESULT_TYPE,
+	                                                   EntropyFunction>(input_type, result_type);
+}
+
+AggregateFunction GetEntropyFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::UINT16:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint16_t>, uint16_t, double, EntropyFunction>(
+		    LogicalType::USMALLINT, LogicalType::DOUBLE);
+	case PhysicalType::UINT32:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint32_t>, uint32_t, double, EntropyFunction>(
+		    LogicalType::UINTEGER, LogicalType::DOUBLE);
+	case PhysicalType::UINT64:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint64_t>, uint64_t, double, EntropyFunction>(
+		    LogicalType::UBIGINT, LogicalType::DOUBLE);
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int16_t>, int16_t, double, EntropyFunction>(
+		    LogicalType::SMALLINT, LogicalType::DOUBLE);
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int32_t>, int32_t, double, EntropyFunction>(
+		    LogicalType::INTEGER, LogicalType::DOUBLE);
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int64_t>, int64_t, double, EntropyFunction>(
+		    LogicalType::BIGINT, LogicalType::DOUBLE);
+	case PhysicalType::FLOAT:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<float>, float, double, EntropyFunction>(
+		    LogicalType::FLOAT, LogicalType::DOUBLE);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<double>, double, double, EntropyFunction>(
+		    LogicalType::DOUBLE, LogicalType::DOUBLE);
+	case PhysicalType::VARCHAR:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<string>, string_t, double,
+		                                                   EntropyFunctionString>(LogicalType::VARCHAR,
+		                                                                          LogicalType::DOUBLE);
+
+	default:
+		throw InternalException("Unimplemented approximate_count aggregate");
+	}
+}
+
+void EntropyFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet entropy("entropy");
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT16));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT32));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT64));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::FLOAT));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT16));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT32));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT64));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::DOUBLE));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::VARCHAR));
+	entropy.AddFunction(GetEntropyFunction<int64_t, double>(LogicalType::TIMESTAMP, LogicalType::DOUBLE));
+	entropy.AddFunction(GetEntropyFunction<int64_t, double>(LogicalType::TIMESTAMP_TZ, LogicalType::DOUBLE));
+	set.AddFunction(entropy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct FirstState {
+	T value;
+	bool is_set;
+	bool is_null;
+};
+
+struct FirstFunctionBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->is_set = false;
+		state->is_null = false;
+	}
+
+	static bool IgnoreNull() {
+		return false;
+	}
+};
+
+template <bool LAST>
+struct FirstFunction : public FirstFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (LAST || !state->is_set) {
+			state->is_set = true;
+			if (!mask.RowIsValid(idx)) {
+				state->is_null = true;
+			} else {
+				state->is_null = false;
+				state->value = input[idx];
+			}
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!target->is_set) {
+			*target = source;
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set || state->is_null) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+template <bool LAST>
+struct FirstFunctionString : public FirstFunctionBase {
+	template <class STATE>
+	static void SetValue(STATE *state, string_t value, bool is_null) {
+		state->is_set = true;
+		if (is_null) {
+			state->is_null = true;
+		} else {
+			if (value.IsInlined()) {
+				state->value = value;
+			} else {
+				// non-inlined string, need to allocate space for it
+				auto len = value.GetSize();
+				auto ptr = new char[len];
+				memcpy(ptr, value.GetDataUnsafe(), len);
+
+				state->value = string_t(ptr, len);
+			}
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (LAST || !state->is_set) {
+			SetValue(state, input[idx], !mask.RowIsValid(idx));
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.is_set && (LAST || !target->is_set)) {
+			SetValue(target, source.value, source.is_null);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set || state->is_null) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->is_set && !state->is_null && !state->value.IsInlined()) {
+			delete[] state->value.GetDataUnsafe();
+		}
+	}
+};
+
+struct FirstStateVector {
+	Vector *value;
+};
+
+template <bool LAST>
+struct FirstVectorFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->value) {
+			delete state->value;
+		}
+	}
+	static bool IgnoreNull() {
+		return false;
+	}
+
+	template <class STATE>
+	static void SetValue(STATE *state, Vector &input, const idx_t idx) {
+		if (!state->value) {
+			state->value = new Vector(input.GetType());
+			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+		sel_t selv = idx;
+		SelectionVector sel(&selv);
+		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+	}
+
+	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+
+		auto states = (FirstStateVector **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto state = states[sdata.sel->get_index(i)];
+			if (LAST || !state->value) {
+				SetValue(state, input, i);
+			}
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.value && (LAST || !target->value)) {
+			SetValue(target, *source.value, 0);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->value) {
+			// we need to use FlatVector::SetNull here
+			// since for STRUCT columns only setting the validity mask of the struct is incorrect
+			// as for a struct column, we need to also set ALL child columns to NULL
+			if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				ConstantVector::SetNull(result, true);
+			} else {
+				FlatVector::SetNull(result, idx, true);
+			}
+		} else {
+			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
+};
+
+template <class T, bool LAST>
+static AggregateFunction GetFirstAggregateTemplated(LogicalType type) {
+	auto agg = AggregateFunction::UnaryAggregate<FirstState<T>, T, T, FirstFunction<LAST>>(type, type);
+	return agg;
+}
+
+template <bool LAST>
+static AggregateFunction GetFirstFunction(const LogicalType &type);
+
+template <bool LAST>
+AggregateFunction GetDecimalFirstFunction(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	switch (type.InternalType()) {
+	case PhysicalType::INT16:
+		return GetFirstFunction<LAST>(LogicalType::SMALLINT);
+	case PhysicalType::INT32:
+		return GetFirstFunction<LAST>(LogicalType::INTEGER);
+	case PhysicalType::INT64:
+		return GetFirstFunction<LAST>(LogicalType::BIGINT);
+	default:
+		return GetFirstFunction<LAST>(LogicalType::HUGEINT);
+	}
+}
+
+template <bool LAST>
+static AggregateFunction GetFirstFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return GetFirstAggregateTemplated<int8_t, LAST>(type);
+	case LogicalTypeId::TINYINT:
+		return GetFirstAggregateTemplated<int8_t, LAST>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetFirstAggregateTemplated<int16_t, LAST>(type);
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::DATE:
+		return GetFirstAggregateTemplated<int32_t, LAST>(type);
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetFirstAggregateTemplated<int64_t, LAST>(type);
+	case LogicalTypeId::UTINYINT:
+		return GetFirstAggregateTemplated<uint8_t, LAST>(type);
+	case LogicalTypeId::USMALLINT:
+		return GetFirstAggregateTemplated<uint16_t, LAST>(type);
+	case LogicalTypeId::UINTEGER:
+		return GetFirstAggregateTemplated<uint32_t, LAST>(type);
+	case LogicalTypeId::UBIGINT:
+		return GetFirstAggregateTemplated<uint64_t, LAST>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetFirstAggregateTemplated<hugeint_t, LAST>(type);
+	case LogicalTypeId::FLOAT:
+		return GetFirstAggregateTemplated<float, LAST>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetFirstAggregateTemplated<double, LAST>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetFirstAggregateTemplated<interval_t, LAST>(type);
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::BLOB: {
+		auto agg = AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
+		                                                       FirstFunctionString<LAST>>(type, type);
+		return agg;
+	}
+	case LogicalTypeId::DECIMAL: {
+		type.Verify();
+		AggregateFunction function = GetDecimalFirstFunction<LAST>(type);
+		function.arguments[0] = type;
+		function.return_type = type;
+		return function;
+	}
+	default: {
+		using OP = FirstVectorFunction<LAST>;
+		return AggregateFunction({type}, type, AggregateFunction::StateSize<FirstStateVector>,
+		                         AggregateFunction::StateInitialize<FirstStateVector, OP>, OP::Update,
+		                         AggregateFunction::StateCombine<FirstStateVector, OP>,
+		                         AggregateFunction::StateFinalize<FirstStateVector, void, OP>, nullptr, OP::Bind,
+		                         AggregateFunction::StateDestroy<FirstStateVector, OP>, nullptr, nullptr);
+	}
+	}
+}
+
+AggregateFunction FirstFun::GetFunction(const LogicalType &type) {
+	auto fun = GetFirstFunction<false>(type);
+	fun.name = "first";
+	return fun;
+}
+
+template <bool LAST>
+unique_ptr<FunctionData> BindDecimalFirst(ClientContext &context, AggregateFunction &function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = GetFirstFunction<LAST>(decimal_type);
+	function.name = "first";
+	function.return_type = decimal_type;
+	return nullptr;
+}
+
+void FirstFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet first("first");
+	AggregateFunctionSet last("last");
+	for (auto &type : LogicalType::AllTypes()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			first.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			                                    BindDecimalFirst<false>, nullptr, nullptr, nullptr));
+			last.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			                                   BindDecimalFirst<true>, nullptr, nullptr, nullptr));
+		} else {
+			first.AddFunction(GetFirstFunction<false>(type));
+			last.AddFunction(GetFirstFunction<true>(type));
+		}
+	}
+	set.AddFunction(first);
+	first.name = "arbitrary";
+	set.AddFunction(first);
+
+	set.AddFunction(last);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct KurtosisState {
+	idx_t n;
+	double sum;
+	double sum_sqr;
+	double sum_cub;
+	double sum_four;
+};
+
+struct KurtosisOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->n = 0;
+		state->sum = state->sum_sqr = state->sum_cub = state->sum_four = 0.0;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->n++;
+		state->sum += data[idx];
+		state->sum_sqr += pow(data[idx], 2);
+		state->sum_cub += pow(data[idx], 3);
+		state->sum_four += pow(data[idx], 4);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.n == 0) {
+			return;
+		}
+		target->n += source.n;
+		target->sum += source.sum;
+		target->sum_sqr += source.sum_sqr;
+		target->sum_cub += source.sum_cub;
+		target->sum_four += source.sum_four;
+	}
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		auto n = (double)state->n;
+		if (n <= 3) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double temp = 1 / n;
+		//! This is necessary due to linux 32 bits
+		long double temp_aux = 1 / n;
+		if (state->sum_sqr - state->sum * state->sum * temp == 0 ||
+		    state->sum_sqr - state->sum * state->sum * temp_aux == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double m4 =
+		    temp * (state->sum_four - 4 * state->sum_cub * state->sum * temp +
+		            6 * state->sum_sqr * state->sum * state->sum * temp * temp - 3 * pow(state->sum, 4) * pow(temp, 3));
+
+		double m2 = temp * (state->sum_sqr - state->sum * state->sum * temp);
+		if (((m2 * m2) - 3 * (n - 1)) == 0 || ((n - 2) * (n - 3)) == 0) { // LCOV_EXCL_START
+			mask.SetInvalid(idx);
+		} // LCOV_EXCL_STOP
+		target[idx] = (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3));
+		if (!Value::DoubleIsFinite(target[idx])) {
+			throw OutOfRangeException("Kurtosis is out of range!");
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void KurtosisFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet function_set("kurtosis");
+	function_set.AddFunction(AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(function_set);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct MinMaxState {
+	T value;
+	bool isset;
+};
+
+template <class OP>
+static AggregateFunction GetUnaryAggregate(LogicalType type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::TINYINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::SMALLINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int16_t>, int16_t, int16_t, OP>(type, type);
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::INTEGER:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int32_t>, int32_t, int32_t, OP>(type, type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::BIGINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int64_t>, int64_t, int64_t, OP>(type, type, true);
+	case LogicalTypeId::UTINYINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint8_t>, uint8_t, uint8_t, OP>(type, type, true);
+	case LogicalTypeId::USMALLINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint16_t>, uint16_t, uint16_t, OP>(type, type, true);
+	case LogicalTypeId::UINTEGER:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint32_t>, uint32_t, uint32_t, OP>(type, type, true);
+	case LogicalTypeId::UBIGINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint64_t>, uint64_t, uint64_t, OP>(type, type, true);
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return AggregateFunction::UnaryAggregate<MinMaxState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type, true);
+	case LogicalTypeId::FLOAT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<float>, float, float, OP>(type, type, true);
+	case LogicalTypeId::DOUBLE:
+		return AggregateFunction::UnaryAggregate<MinMaxState<double>, double, double, OP>(type, type, true);
+	case LogicalTypeId::INTERVAL:
+		return AggregateFunction::UnaryAggregate<MinMaxState<interval_t>, interval_t, interval_t, OP>(type, type, true);
+	default:
+		throw InternalException("Unimplemented type for min/max aggregate");
+	}
+}
+
+struct MinMaxBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->isset = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		D_ASSERT(mask.RowIsValid(0));
+		if (!state->isset) {
+			OP::template Assign<INPUT_TYPE, STATE>(state, input[0]);
+			state->isset = true;
+		} else {
+			OP::template Execute<INPUT_TYPE, STATE>(state, input[0]);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			OP::template Assign<INPUT_TYPE, STATE>(state, input[idx]);
+			state->isset = true;
+		} else {
+			OP::template Execute<INPUT_TYPE, STATE>(state, input[idx]);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct NumericMinMaxBase : public MinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Assign(STATE *state, INPUT_TYPE input) {
+		state->value = input;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		mask.Set(idx, state->isset);
+		target[idx] = state->value;
+	}
+};
+
+struct MinOperation : public NumericMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
+			state->value = input;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			*target = source;
+		} else if (GreaterThan::Operation(target->value, source.value)) {
+			target->value = source.value;
+		}
+	}
+};
+
+struct MaxOperation : public NumericMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
+			state->value = input;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			*target = source;
+		} else if (LessThan::Operation(target->value, source.value)) {
+			target->value = source.value;
+		}
+	}
+};
+
+struct StringMinMaxBase : public MinMaxBase {
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->isset && !state->value.IsInlined()) {
+			delete[] state->value.GetDataUnsafe();
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE>
+	static void Assign(STATE *state, INPUT_TYPE input) {
+		Destroy(state);
+		if (input.IsInlined()) {
+			state->value = input;
+		} else {
+			// non-inlined string, need to allocate space for it
+			auto len = input.GetSize();
+			auto ptr = new char[len];
+			memcpy(ptr, input.GetDataUnsafe(), len);
+
+			state->value = string_t(ptr, len);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			Assign(target, source.value);
+			target->isset = true;
+		} else {
+			OP::template Execute<string_t, STATE>(target, source.value);
+		}
+	}
+};
+
+struct MinOperationString : public StringMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
+			Assign(state, input);
+		}
+	}
+};
+
+struct MaxOperationString : public StringMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
+			Assign(state, input);
+		}
+	}
+};
+
+template <typename T, class OP>
+static bool TemplatedOptimumType(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	lidx = lvdata.sel->get_index(lidx);
+	ridx = rvdata.sel->get_index(ridx);
+
+	auto ldata = (const T *)lvdata.data;
+	auto rdata = (const T *)rvdata.data;
+
+	auto &lval = ldata[lidx];
+	auto &rval = rdata[ridx];
+
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+
+	return OP::Operation(lval, rval, lnull, rnull);
+}
+
+template <class OP>
+static bool TemplatedOptimumList(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount);
+
+template <class OP>
+static bool TemplatedOptimumStruct(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount);
+
+template <class OP>
+static bool TemplatedOptimumValue(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedOptimumType<int8_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT16:
+		return TemplatedOptimumType<int16_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT32:
+		return TemplatedOptimumType<int32_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT64:
+		return TemplatedOptimumType<int64_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT8:
+		return TemplatedOptimumType<uint8_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT16:
+		return TemplatedOptimumType<uint16_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT32:
+		return TemplatedOptimumType<uint32_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT64:
+		return TemplatedOptimumType<uint64_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT128:
+		return TemplatedOptimumType<hugeint_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::FLOAT:
+		return TemplatedOptimumType<float, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::DOUBLE:
+		return TemplatedOptimumType<double, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INTERVAL:
+		return TemplatedOptimumType<interval_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::VARCHAR:
+		return TemplatedOptimumType<string_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::LIST:
+		return TemplatedOptimumList<OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		return TemplatedOptimumStruct<OP>(left, lidx, lcount, right, ridx, rcount);
+	default:
+		throw InternalException("Invalid type for distinct comparison");
+	}
+}
+
+template <class OP>
+static bool TemplatedOptimumStruct(Vector &left, idx_t lidx_p, idx_t lcount, Vector &right, idx_t ridx_p,
+                                   idx_t rcount) {
+	// STRUCT dictionaries apply to all the children
+	// so map the indexes first
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	idx_t lidx = lvdata.sel->get_index(lidx_p);
+	idx_t ridx = rvdata.sel->get_index(ridx_p);
+
+	// DISTINCT semantics are in effect for nested types
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+	if (lnull || rnull) {
+		return OP::Operation(0, 0, lnull, rnull);
+	}
+
+	auto &lchildren = StructVector::GetEntries(left);
+	auto &rchildren = StructVector::GetEntries(right);
+
+	D_ASSERT(lchildren.size() == rchildren.size());
+	for (idx_t col_no = 0; col_no < lchildren.size(); ++col_no) {
+		auto &lchild = *lchildren[col_no];
+		auto &rchild = *rchildren[col_no];
+
+		// Strict comparisons use the OP for definite
+		if (TemplatedOptimumValue<OP>(lchild, lidx_p, lcount, rchild, ridx_p, rcount)) {
+			return true;
+		}
+
+		if (col_no == lchildren.size() - 1) {
+			break;
+		}
+
+		// Strict comparisons use IS NOT DISTINCT for possible
+		if (!TemplatedOptimumValue<NotDistinctFrom>(lchild, lidx_p, lcount, rchild, ridx_p, rcount)) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+template <class OP>
+static bool TemplatedOptimumList(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	// Update the indexes and vector sizes for recursion.
+	lidx = lvdata.sel->get_index(lidx);
+	ridx = rvdata.sel->get_index(ridx);
+
+	lcount = ListVector::GetListSize(left);
+	rcount = ListVector::GetListSize(right);
+
+	// DISTINCT semantics are in effect for nested types
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+	if (lnull || rnull) {
+		return OP::Operation(0, 0, lnull, rnull);
+	}
+
+	auto &lchild = ListVector::GetEntry(left);
+	auto &rchild = ListVector::GetEntry(right);
+
+	auto ldata = (const list_entry_t *)lvdata.data;
+	auto rdata = (const list_entry_t *)rvdata.data;
+
+	auto &lval = ldata[lidx];
+	auto &rval = rdata[ridx];
+
+	for (idx_t pos = 0;; ++pos) {
+		// Tie-breaking uses the OP
+		if (pos == lval.length || pos == rval.length) {
+			return OP::Operation(lval.length, rval.length, false, false);
+		}
+
+		// Strict comparisons use the OP for definite
+		lidx = lval.offset + pos;
+		ridx = rval.offset + pos;
+		if (TemplatedOptimumValue<OP>(lchild, lidx, lcount, rchild, ridx, rcount)) {
+			return true;
+		}
+
+		// Strict comparisons use IS NOT DISTINCT for possible
+		if (!TemplatedOptimumValue<NotDistinctFrom>(lchild, lidx, lcount, rchild, ridx, rcount)) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+struct VectorMinMaxState {
+	Vector *value;
+};
+
+struct VectorMinMaxBase {
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->value) {
+			delete state->value;
+		}
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Assign(STATE *state, Vector &input, const idx_t idx) {
+		if (!state->value) {
+			state->value = new Vector(input.GetType());
+			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+		sel_t selv = idx;
+		SelectionVector sel(&selv);
+		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+	}
+
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		Assign(state, input, idx);
+	}
+
+	template <class STATE, class OP>
+	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		VectorData idata;
+		input.Orrify(count, idata);
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+
+		auto states = (STATE **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = idata.sel->get_index(i);
+			if (!idata.validity.RowIsValid(idx)) {
+				continue;
+			}
+			const auto sidx = sdata.sel->get_index(i);
+			auto state = states[sidx];
+			if (!state->value) {
+				Assign(state, input, i);
+			} else {
+				OP::template Execute(state, input, i, count);
+			}
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.value) {
+			return;
+		} else if (!target->value) {
+			Assign(target, *source.value, 0);
+		} else {
+			OP::template Execute(target, *source.value, 0, 1);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->value) {
+			// we need to use SetNull here
+			// since for STRUCT columns only setting the validity mask of the struct is incorrect
+			// as for a struct column, we need to also set ALL child columns to NULL
+			switch (result.GetVectorType()) {
+			case VectorType::FLAT_VECTOR:
+				FlatVector::SetNull(result, idx, true);
+				break;
+			case VectorType::CONSTANT_VECTOR:
+				ConstantVector::SetNull(result, true);
+				break;
+			default:
+				throw InternalException("Invalid result vector type for nested min/max");
+			}
+		} else {
+			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
+};
+
+struct MinOperationVector : public VectorMinMaxBase {
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctLessThan>(input, idx, count, *state->value, 0, 1)) {
+			Assign(state, input, idx);
+		}
+	}
+};
+
+struct MaxOperationVector : public VectorMinMaxBase {
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctGreaterThan>(input, idx, count, *state->value, 0, 1)) {
+			Assign(state, input, idx);
+		}
+	}
+};
+
+template <class OP>
+unique_ptr<FunctionData> BindDecimalMinMax(ClientContext &context, AggregateFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	auto name = function.name;
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		function = GetUnaryAggregate<OP>(LogicalType::SMALLINT);
+		break;
+	case PhysicalType::INT32:
+		function = GetUnaryAggregate<OP>(LogicalType::INTEGER);
+		break;
+	case PhysicalType::INT64:
+		function = GetUnaryAggregate<OP>(LogicalType::BIGINT);
+		break;
+	default:
+		function = GetUnaryAggregate<OP>(LogicalType::HUGEINT);
+		break;
+	}
+	function.name = move(name);
+	function.arguments[0] = decimal_type;
+	function.return_type = decimal_type;
+	return nullptr;
+}
+
+template <typename OP, typename STATE>
+static AggregateFunction GetMinMaxFunction(const LogicalType &type) {
+	return AggregateFunction({type}, type, AggregateFunction::StateSize<STATE>,
+	                         AggregateFunction::StateInitialize<STATE, OP>, OP::template Update<STATE, OP>,
+	                         AggregateFunction::StateCombine<STATE, OP>,
+	                         AggregateFunction::StateFinalize<STATE, void, OP>, nullptr, OP::Bind,
+	                         AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <class OP, class OP_STRING, class OP_VECTOR>
+static void AddMinMaxOperator(AggregateFunctionSet &set) {
+	for (auto &type : LogicalType::AllTypes()) {
+		if (type.id() == LogicalTypeId::VARCHAR || type.id() == LogicalTypeId::BLOB || type.id() == LogicalType::JSON) {
+			set.AddFunction(
+			    AggregateFunction::UnaryAggregateDestructor<MinMaxState<string_t>, string_t, string_t, OP_STRING>(
+			        type.id(), type.id()));
+		} else if (type.id() == LogicalTypeId::DECIMAL) {
+			set.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, false, nullptr,
+			                                  BindDecimalMinMax<OP>));
+		} else if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::MAP ||
+		           type.id() == LogicalTypeId::STRUCT) {
+			set.AddFunction(GetMinMaxFunction<OP_VECTOR, VectorMinMaxState>(type));
+
+		} else {
+			set.AddFunction(GetUnaryAggregate<OP>(type));
+		}
+	}
+}
+
+void MinFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet min("min");
+	AddMinMaxOperator<MinOperation, MinOperationString, MinOperationVector>(min);
+	set.AddFunction(min);
+}
+
+void MaxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet max("max");
+	AddMinMaxOperator<MaxOperation, MaxOperationString, MaxOperationVector>(max);
+	set.AddFunction(max);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct ProductState {
+	bool empty;
+	double val;
+};
+
+struct ProductFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = 1;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val *= source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			state->empty = false;
+		}
+		state->val *= input[idx];
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction ProductFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<ProductState, double, double, ProductFunction>(
+	    LogicalType(LogicalTypeId::DOUBLE), LogicalType::DOUBLE);
+	fun.name = "product";
+	return fun;
+}
+
+void ProductFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction product_function = ProductFun::GetFunction();
+	AggregateFunctionSet product("product");
+	product.AddFunction(product_function);
+	set.AddFunction(product);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct SkewState {
+	size_t n;
+	double sum;
+	double sum_sqr;
+	double sum_cub;
+};
+
+struct SkewnessOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->n = 0;
+		state->sum = state->sum_sqr = state->sum_cub = 0;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->n++;
+		state->sum += data[idx];
+		state->sum_sqr += pow(data[idx], 2);
+		state->sum_cub += pow(data[idx], 3);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.n == 0) {
+			return;
+		}
+
+		target->n += source.n;
+		target->sum += source.sum;
+		target->sum_sqr += source.sum_sqr;
+		target->sum_cub += source.sum_cub;
+	}
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (state->n <= 2) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double n = state->n;
+		double temp = 1 / n;
+		double div = (std::sqrt(std::pow(temp * (state->sum_sqr - state->sum * state->sum * temp), 3)));
+		if (div == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double temp1 = std::sqrt(n * (n - 1)) / (n - 2);
+		target[idx] = temp1 * temp *
+		              (state->sum_cub - 3 * state->sum_sqr * state->sum * temp + 2 * pow(state->sum, 3) * temp * temp) /
+		              div;
+		if (!Value::DoubleIsFinite(target[idx])) {
+			throw OutOfRangeException("SKEW is out of range!");
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void SkewFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet function_set("skewness");
+	function_set.AddFunction(AggregateFunction::UnaryAggregate<SkewState, double, double, SkewnessOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(function_set);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StringAggState {
+	idx_t size;
+	idx_t alloc_size;
+	char *dataptr;
+};
+
+struct StringAggBindData : public FunctionData {
+	explicit StringAggBindData(string sep_p) : sep(move(sep_p)) {
+	}
+
+	string sep;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StringAggBindData>(sep);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (StringAggBindData &)other_p;
+		return sep == other.sep;
+	}
+};
+
+struct StringAggFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->dataptr = nullptr;
+		state->alloc_size = 0;
+		state->size = 0;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->dataptr) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddString(result, state->dataptr, state->size);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->dataptr) {
+			delete[] state->dataptr;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	static inline void PerformOperation(StringAggState *state, const char *str, const char *sep, idx_t str_size,
+	                                    idx_t sep_size) {
+		if (!state->dataptr) {
+			// first iteration: allocate space for the string and copy it into the state
+			state->alloc_size = MaxValue<idx_t>(8, NextPowerOfTwo(str_size));
+			state->dataptr = new char[state->alloc_size];
+			state->size = str_size;
+			memcpy(state->dataptr, str, str_size);
+		} else {
+			// subsequent iteration: first check if we have space to place the string and separator
+			idx_t required_size = state->size + str_size + sep_size;
+			if (required_size > state->alloc_size) {
+				// no space! allocate extra space
+				while (state->alloc_size < required_size) {
+					state->alloc_size *= 2;
+				}
+				auto new_data = new char[state->alloc_size];
+				memcpy(new_data, state->dataptr, state->size);
+				delete[] state->dataptr;
+				state->dataptr = new_data;
+			}
+			// copy the separator
+			memcpy(state->dataptr + state->size, sep, sep_size);
+			state->size += sep_size;
+			// copy the string
+			memcpy(state->dataptr + state->size, str, str_size);
+			state->size += str_size;
+		}
+	}
+
+	static inline void PerformOperation(StringAggState *state, string_t str, FunctionData *data_p) {
+		auto &data = (StringAggBindData &)*data_p;
+		PerformOperation(state, str.GetDataUnsafe(), data.sep.c_str(), str.GetSize(), data.sep.size());
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *str_data,
+	                      ValidityMask &str_mask, idx_t str_idx) {
+		PerformOperation(state, str_data[str_idx], aggr_input_data.bind_data);
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		if (!source.dataptr) {
+			// source is not set: skip combining
+			return;
+		}
+		PerformOperation(target, string_t(source.dataptr, source.size), aggr_input_data.bind_data);
+	}
+};
+
+unique_ptr<FunctionData> StringAggBind(ClientContext &context, AggregateFunction &function,
+                                       vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() == 1) {
+		// single argument: default to comma
+		return make_unique<StringAggBindData>(",");
+	}
+	D_ASSERT(arguments.size() == 2);
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("Separator argument to StringAgg must be a constant");
+	}
+	auto separator_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	if (separator_val.IsNull()) {
+		arguments[0] = make_unique<BoundConstantExpression>(Value(LogicalType::VARCHAR));
+	}
+	function.arguments.erase(function.arguments.begin() + 1);
+	return make_unique<StringAggBindData>(separator_val.ToString());
+}
+
+void StringAggFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet string_agg("string_agg");
+	string_agg.AddFunction(
+	    AggregateFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                      AggregateFunction::StateSize<StringAggState>,
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
+	string_agg.AddFunction(
+	    AggregateFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, AggregateFunction::StateSize<StringAggState>,
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
+	set.AddFunction(string_agg);
+	string_agg.name = "group_concat";
+	set.AddFunction(string_agg);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct SumSetOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+	template <class STATE>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->Combine(source);
+	}
+	template <class STATE>
+	static void AddValues(STATE *state, idx_t count) {
+		state->isset = true;
+	}
+};
+
+struct IntegerSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = Hugeint::Convert(state->value);
+		}
+	}
+};
+
+struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+template <class ADD_OPERATOR>
+struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("SUM is out of range!");
+			}
+			target[idx] = state->value;
+		}
+	}
+};
+
+using NumericSumOperation = DoubleSumOperation<RegularAdd>;
+using KahanSumOperation = DoubleSumOperation<KahanAdd>;
+
+struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
+                                             FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats,
+                                             NodeStatistics *node_stats) {
+	if (child_stats[0] && node_stats && node_stats->has_max_cardinality) {
+		auto &numeric_stats = (NumericStatistics &)*child_stats[0];
+		if (numeric_stats.min.IsNull() || numeric_stats.max.IsNull()) {
+			return nullptr;
+		}
+		auto internal_type = numeric_stats.min.type().InternalType();
+		hugeint_t max_negative;
+		hugeint_t max_positive;
+		switch (internal_type) {
+		case PhysicalType::INT32:
+			max_negative = numeric_stats.min.GetValueUnsafe<int32_t>();
+			max_positive = numeric_stats.max.GetValueUnsafe<int32_t>();
+			break;
+		case PhysicalType::INT64:
+			max_negative = numeric_stats.min.GetValueUnsafe<int64_t>();
+			max_positive = numeric_stats.max.GetValueUnsafe<int64_t>();
+			break;
+		default:
+			throw InternalException("Unsupported type for propagate sum stats");
+		}
+		auto max_sum_negative = max_negative * hugeint_t(node_stats->max_cardinality);
+		auto max_sum_positive = max_positive * hugeint_t(node_stats->max_cardinality);
+		if (max_sum_positive >= NumericLimits<int64_t>::Maximum() ||
+		    max_sum_negative <= NumericLimits<int64_t>::Minimum()) {
+			// sum can potentially exceed int64_t bounds: use hugeint sum
+			return nullptr;
+		}
+		// total sum is guaranteed to fit in a single int64: use int64 sum instead of hugeint sum
+		switch (internal_type) {
+		case PhysicalType::INT32:
+			expr.function =
+			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int32_t, hugeint_t, IntegerSumOperation>(
+			        LogicalType::INTEGER, LogicalType::HUGEINT, true);
+			expr.function.name = "sum";
+			break;
+		case PhysicalType::INT64:
+			expr.function =
+			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int64_t, hugeint_t, IntegerSumOperation>(
+			        LogicalType::BIGINT, LogicalType::HUGEINT, true);
+			expr.function.name = "sum";
+			break;
+		default:
+			throw InternalException("Unsupported type for propagate sum stats");
+		}
+	}
+	return nullptr;
+}
+
+AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
+		    LogicalType::SMALLINT, LogicalType::HUGEINT, true);
+	case PhysicalType::INT32: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int32_t, hugeint_t, SumToHugeintOperation>(
+		        LogicalType::INTEGER, LogicalType::HUGEINT, true);
+		function.statistics = SumPropagateStats;
+		return function;
+	}
+	case PhysicalType::INT64: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int64_t, hugeint_t, SumToHugeintOperation>(
+		        LogicalType::BIGINT, LogicalType::HUGEINT, true);
+		function.statistics = SumPropagateStats;
+		return function;
+	}
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
+		    LogicalType::HUGEINT, LogicalType::HUGEINT, true);
+	default:
+		throw InternalException("Unimplemented sum aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindDecimalSum(ClientContext &context, AggregateFunction &function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = SumFun::GetSumAggregate(decimal_type.InternalType());
+	function.name = "sum";
+	function.arguments[0] = decimal_type;
+	function.return_type = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type));
+	return nullptr;
+}
+
+void SumFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet sum("sum");
+	// decimal
+	sum.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, true, nullptr, BindDecimalSum));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT16));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
+	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+
+	set.AddFunction(sum);
+
+	// fsum
+	AggregateFunctionSet fsum("fsum");
+	fsum.AddFunction(AggregateFunction::UnaryAggregate<KahanSumState, double, double, KahanSumOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+
+	set.AddFunction(fsum);
+
+	fsum.name = "kahan_sum";
+	set.AddFunction(fsum);
+
+	fsum.name = "sumKahan";
+	set.AddFunction(fsum);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterDistributiveAggregates() {
+	Register<BitAndFun>();
+	Register<BitOrFun>();
+	Register<BitXorFun>();
+	Register<CountStarFun>();
+	Register<CountFun>();
+	Register<FirstFun>();
+	Register<MaxFun>();
+	Register<MinFun>();
+	Register<SumFun>();
+	Register<StringAggFun>();
+	Register<ApproxCountDistinctFun>();
+	Register<ProductFun>();
+	Register<BoolOrFun>();
+	Register<BoolAndFun>();
+	Register<ArgMinFun>();
+	Register<ArgMaxFun>();
+	Register<SkewFun>();
+	Register<KurtosisFun>();
+	Register<EntropyFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <stdlib.h>
+
+namespace duckdb {
+
+struct ApproxQuantileState {
+	duckdb_tdigest::TDigest *h;
+	idx_t pos;
+};
+
+struct ApproximateQuantileBindData : public FunctionData {
+	explicit ApproximateQuantileBindData(float quantile_p) : quantiles(1, quantile_p) {
+	}
+
+	explicit ApproximateQuantileBindData(const vector<float> &quantiles_p) : quantiles(quantiles_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ApproximateQuantileBindData>(quantiles);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (ApproximateQuantileBindData &)other_p;
+		return quantiles == other.quantiles;
+	}
+
+	vector<float> quantiles;
+};
+
+struct ApproxQuantileOperation {
+	using SAVE_TYPE = duckdb_tdigest::Value;
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->pos = 0;
+		state->h = nullptr;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		if (!state->h) {
+			state->h = new duckdb_tdigest::TDigest(100);
+		}
+
+		state->h->add(Cast::template Operation<INPUT_TYPE, SAVE_TYPE>(data[idx]));
+		state->pos++;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.pos == 0) {
+			return;
+		}
+		D_ASSERT(source.h);
+		if (!target->h) {
+			target->h = new duckdb_tdigest::TDigest(100);
+		}
+		target->h->merge(source.h);
+		target->pos += source.pos;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->h) {
+			delete state->h;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct ApproxQuantileScalarOperation : public ApproxQuantileOperation {
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(state->h);
+		D_ASSERT(aggr_input_data.bind_data);
+		state->h->compress();
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		target[idx] = Cast::template Operation<SAVE_TYPE, TARGET_TYPE>(state->h->quantile(bind_data->quantiles[0]));
+	}
+};
+
+AggregateFunction GetApproximateQuantileAggregateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int16_t, int16_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::SMALLINT,
+		                                                                                  LogicalType::SMALLINT);
+
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int32_t, int32_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::INTEGER,
+		                                                                                  LogicalType::INTEGER);
+
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int64_t, int64_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::BIGINT,
+		                                                                                  LogicalType::BIGINT);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, double, double,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::DOUBLE,
+		                                                                                  LogicalType::DOUBLE);
+
+	default:
+		throw InternalException("Unimplemented quantile aggregate");
+	}
+}
+
+static float CheckApproxQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<float>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("APPROXIMATE QUANTILE can only take parameters in range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindApproxQuantile(ClientContext &context, AggregateFunction &function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsScalar()) {
+		throw BinderException("APPROXIMATE QUANTILE can only take constant quantile parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+
+	vector<float> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckApproxQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckApproxQuantile(element_val));
+		}
+	}
+
+	// remove the quantile argument so we can use the unary aggregate
+	arguments.pop_back();
+	return make_unique<ApproximateQuantileBindData>(quantiles);
+}
+
+unique_ptr<FunctionData> BindApproxQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindApproxQuantile(context, function, arguments);
+	function = GetApproximateQuantileAggregateFunction(arguments[0]->return_type.InternalType());
+	function.name = "approx_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetApproximateQuantileAggregate(PhysicalType type) {
+	auto fun = GetApproximateQuantileAggregateFunction(type);
+	fun.bind = BindApproxQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::FLOAT);
+	return fun;
+}
+
+template <class CHILD_TYPE>
+struct ApproxQuantileListOperation : public ApproxQuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		D_ASSERT(state->h);
+		state->h->compress();
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		entry.length = bind_data->quantiles.size();
+		for (size_t q = 0; q < entry.length; ++q) {
+			const auto &quantile = bind_data->quantiles[q];
+			rdata[ridx + q] = Cast::template Operation<SAVE_TYPE, CHILD_TYPE>(state->h->quantile(quantile));
+		}
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE_TYPE, class RESULT_TYPE>
+	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
+	                         idx_t offset) {
+		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+
+		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ListVector::Reserve(result, bind_data->quantiles.size());
+
+			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+			auto &mask = ConstantVector::Validity(result);
+			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+		} else {
+			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+			auto &mask = FlatVector::Validity(result);
+			for (idx_t i = 0; i < count; i++) {
+				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+			}
+		}
+
+		result.Verify(count);
+	}
+};
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction ApproxQuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) {
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedApproxQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = ApproxQuantileState;
+	using OP = ApproxQuantileListOperation<INPUT_TYPE>;
+	auto fun = ApproxQuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	return fun;
+}
+
+AggregateFunction GetApproxQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedApproxQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedApproxQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedApproxQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedApproxQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedApproxQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedApproxQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedApproxQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedApproxQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedApproxQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedApproxQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedApproxQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented approximate quantile list aggregate");
+		}
+		break;
+
+	default:
+		// TODO: Add quantitative temporal types
+		throw NotImplementedException("Unimplemented approximate quantile list aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindApproxQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindApproxQuantile(context, function, arguments);
+	function = GetApproxQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "approx_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetApproxQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetApproxQuantileListAggregateFunction(type);
+	fun.bind = BindApproxQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_float = LogicalType::LIST(LogicalType::FLOAT);
+	fun.arguments.push_back(list_of_float);
+	return fun;
+}
+
+void ApproximateQuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet approx_quantile("approx_quantile");
+	approx_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::FLOAT}, LogicalTypeId::DECIMAL,
+	                                              nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                              BindApproxQuantileDecimal));
+
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT16));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT32));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT64));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::DOUBLE));
+
+	// List variants
+	approx_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::FLOAT)},
+	                                              LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                              nullptr, nullptr, nullptr, BindApproxQuantileDecimalList));
+
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::TINYINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::SMALLINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::INTEGER));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::BIGINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::HUGEINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::FLOAT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::DOUBLE));
+
+	set.AddFunction(approx_quantile);
+}
+
+} // namespace duckdb
+// MODE( <expr1> )
+// Returns the most frequent value for the values within expr1.
+// NULL values are ignored. If all the values are NULL, or there are 0 rows, then the function returns NULL.
+
+
+
+
+
+
+
+
+#include <functional>
+
+namespace std {
+
+template <>
+struct hash<duckdb::interval_t> {
+	inline size_t operator()(const duckdb::interval_t &val) const {
+		return hash<int32_t> {}(val.days) ^ hash<int32_t> {}(val.months) ^ hash<int64_t> {}(val.micros);
+	}
+};
+
+template <>
+struct hash<duckdb::hugeint_t> {
+	inline size_t operator()(const duckdb::hugeint_t &val) const {
+		return hash<int64_t> {}(val.upper) ^ hash<int64_t> {}(val.lower);
+	}
+};
+
+} // namespace std
+
+namespace duckdb {
+
+using FrameBounds = std::pair<idx_t, idx_t>;
+
+template <class KEY_TYPE>
+struct ModeState {
+	using Counts = unordered_map<KEY_TYPE, size_t>;
+
+	Counts *frequency_map;
+	KEY_TYPE *mode;
+	size_t nonzero;
+	bool valid;
+	size_t count;
+
+	void Initialize() {
+		frequency_map = nullptr;
+		mode = nullptr;
+		nonzero = 0;
+		valid = false;
+		count = 0;
+	}
+
+	void Destroy() {
+		if (frequency_map) {
+			delete frequency_map;
+		}
+		if (mode) {
+			delete mode;
+		}
+	}
+
+	void Reset() {
+		Counts empty;
+		frequency_map->swap(empty);
+		nonzero = 0;
+		count = 0;
+		valid = false;
+	}
+
+	void ModeAdd(const KEY_TYPE &key) {
+		auto new_count = ((*frequency_map)[key] += 1);
+		if (new_count == 1) {
+			++nonzero;
+		}
+		if (new_count > count) {
+			valid = true;
+			count = new_count;
+			if (mode) {
+				*mode = key;
+			} else {
+				mode = new KEY_TYPE(key);
+			}
+		}
+	}
+
+	void ModeRm(const KEY_TYPE &key) {
+		auto i = frequency_map->find(key);
+		auto old_count = i->second;
+		nonzero -= int(old_count == 1);
+
+		i->second -= 1;
+		if (count == old_count && key == *mode) {
+			valid = false;
+		}
+	}
+
+	typename Counts::const_iterator Scan() const {
+		//! Initialize control variables to first variable of the frequency map
+		auto highest_frequency = frequency_map->begin();
+		for (auto i = highest_frequency; i != frequency_map->end(); ++i) {
+			// Tie break with the lowest
+			if (i->second > highest_frequency->second ||
+			    (i->second == highest_frequency->second && i->first < highest_frequency->first)) {
+				highest_frequency = i;
+			}
+		}
+		return highest_frequency;
+	}
+};
+
+struct ModeIncluded {
+	inline explicit ModeIncluded(const ValidityMask &fmask_p, const ValidityMask &dmask_p, idx_t bias_p)
+	    : fmask(fmask_p), dmask(dmask_p), bias(bias_p) {
+	}
+
+	inline bool operator()(const idx_t &idx) const {
+		return fmask.RowIsValid(idx) && dmask.RowIsValid(idx - bias);
+	}
+	const ValidityMask &fmask;
+	const ValidityMask &dmask;
+	const idx_t bias;
+};
+
+template <typename KEY_TYPE>
+struct ModeFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		auto key = KEY_TYPE(input[idx]);
+		(*state->frequency_map)[key]++;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.frequency_map) {
+			return;
+		}
+		if (!target->frequency_map) {
+			// Copy - don't destroy! Otherwise windowing will break.
+			target->frequency_map = new unordered_map<KEY_TYPE, size_t>(*source.frequency_map);
+			return;
+		}
+		for (auto &val : *source.frequency_map) {
+			(*target->frequency_map)[val.first] += val.second;
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, INPUT_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (!state->frequency_map) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto highest_frequency = state->Scan();
+		if (highest_frequency != state->frequency_map->end()) {
+			target[idx] = INPUT_TYPE(highest_frequency->first);
+		} else {
+			mask.SetInvalid(idx);
+		}
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		auto key = KEY_TYPE(input[0]);
+		(*state->frequency_map)[key] += count;
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   Vector &result, idx_t rid, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		ModeIncluded included(fmask, dmask, bias);
+
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		const double tau = .25;
+		if (state->nonzero <= tau * state->frequency_map->size()) {
+			state->Reset();
+			// for f ∈ F do
+			for (auto f = frame.first; f < frame.second; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+		} else {
+			// for f ∈ P \ F do
+			for (auto p = prev.first; p < frame.first; ++p) {
+				if (included(p)) {
+					state->ModeRm(KEY_TYPE(data[p]));
+				}
+			}
+			for (auto p = frame.second; p < prev.second; ++p) {
+				if (included(p)) {
+					state->ModeRm(KEY_TYPE(data[p]));
+				}
+			}
+
+			// for f ∈ F \ P do
+			for (auto f = frame.first; f < prev.first; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+			for (auto f = prev.second; f < frame.second; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+		}
+
+		if (!state->valid) {
+			// Rescan
+			auto highest_frequency = state->Scan();
+			if (highest_frequency != state->frequency_map->end()) {
+				*(state->mode) = highest_frequency->first;
+				state->count = highest_frequency->second;
+				state->valid = (state->count > 0);
+			}
+		}
+
+		if (state->valid) {
+			rdata[rid] = RESULT_TYPE(*state->mode);
+		} else {
+			rmask.Set(rid, false);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		state->Destroy();
+	}
+};
+
+template <typename INPUT_TYPE, typename KEY_TYPE>
+AggregateFunction GetTypedModeFunction(const LogicalType &type) {
+	using STATE = ModeState<KEY_TYPE>;
+	using OP = ModeFunction<KEY_TYPE>;
+	auto func = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, INPUT_TYPE, OP>(type, type);
+	func.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, INPUT_TYPE, OP>;
+	return func;
+}
+
+AggregateFunction GetModeAggregate(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::INT8:
+		return GetTypedModeFunction<int8_t, int8_t>(type);
+	case PhysicalType::UINT8:
+		return GetTypedModeFunction<uint8_t, uint8_t>(type);
+	case PhysicalType::INT16:
+		return GetTypedModeFunction<int16_t, int16_t>(type);
+	case PhysicalType::UINT16:
+		return GetTypedModeFunction<uint16_t, uint16_t>(type);
+	case PhysicalType::INT32:
+		return GetTypedModeFunction<int32_t, int32_t>(type);
+	case PhysicalType::UINT32:
+		return GetTypedModeFunction<uint32_t, uint32_t>(type);
+	case PhysicalType::INT64:
+		return GetTypedModeFunction<int64_t, int64_t>(type);
+	case PhysicalType::UINT64:
+		return GetTypedModeFunction<uint64_t, uint64_t>(type);
+	case PhysicalType::INT128:
+		return GetTypedModeFunction<hugeint_t, hugeint_t>(type);
+
+	case PhysicalType::FLOAT:
+		return GetTypedModeFunction<float, float>(type);
+	case PhysicalType::DOUBLE:
+		return GetTypedModeFunction<double, double>(type);
+
+	case PhysicalType::INTERVAL:
+		return GetTypedModeFunction<interval_t, interval_t>(type);
+
+	case PhysicalType::VARCHAR:
+		return GetTypedModeFunction<string_t, string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented mode aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindModeDecimal(ClientContext &context, AggregateFunction &function,
+                                         vector<unique_ptr<Expression>> &arguments) {
+	function = GetModeAggregate(arguments[0]->return_type);
+	function.name = "mode";
+	return nullptr;
+}
+
+void ModeFun::RegisterFunction(BuiltinFunctions &set) {
+	const vector<LogicalType> TEMPORAL = {LogicalType::DATE,         LogicalType::TIMESTAMP, LogicalType::TIME,
+	                                      LogicalType::TIMESTAMP_TZ, LogicalType::TIME_TZ,   LogicalType::INTERVAL};
+
+	AggregateFunctionSet mode("mode");
+	mode.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                   nullptr, nullptr, nullptr, BindModeDecimal));
+
+	for (const auto &type : LogicalType::Numeric()) {
+		if (type.id() != LogicalTypeId::DECIMAL) {
+			mode.AddFunction(GetModeAggregate(type));
+		}
+	}
+
+	for (const auto &type : TEMPORAL) {
+		mode.AddFunction(GetModeAggregate(type));
+	}
+
+	mode.AddFunction(GetModeAggregate(LogicalType::VARCHAR));
+
+	set.AddFunction(mode);
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <stdlib.h>
+#include <utility>
+
+namespace duckdb {
+
+// Hugeint arithmetic
+hugeint_t operator*(const hugeint_t &h, const double &d) {
+	D_ASSERT(d >= 0 && d <= 1);
+	return Hugeint::Convert(Hugeint::Cast<double>(h) * d);
+}
+
+// Interval arithmetic
+interval_t operator*(const interval_t &i, const double &d) {
+	D_ASSERT(d >= 0 && d <= 1);
+	return Interval::FromMicro(std::llround(Interval::GetMicro(i) * d));
+}
+
+inline interval_t operator+(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) + Interval::GetMicro(rhs));
+}
+
+inline interval_t operator-(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) - Interval::GetMicro(rhs));
+}
+
+using FrameBounds = std::pair<idx_t, idx_t>;
+
+template <typename SAVE_TYPE>
+struct QuantileState {
+	using SaveType = SAVE_TYPE;
+
+	// Regular aggregation
+	std::vector<SaveType> v;
+
+	// Windowed Quantile indirection
+	std::vector<idx_t> w;
+	idx_t pos;
+
+	// Windowed MAD indirection
+	std::vector<idx_t> m;
+
+	QuantileState() : pos(0) {
+	}
+
+	~QuantileState() {
+	}
+
+	inline void SetPos(size_t pos_p) {
+		pos = pos_p;
+		if (pos >= w.size()) {
+			w.resize(pos);
+		}
+	}
+};
+
+struct QuantileIncluded {
+	inline explicit QuantileIncluded(const ValidityMask &fmask_p, const ValidityMask &dmask_p, idx_t bias_p)
+	    : fmask(fmask_p), dmask(dmask_p), bias(bias_p) {
+	}
+
+	inline bool operator()(const idx_t &idx) const {
+		return fmask.RowIsValid(idx) && dmask.RowIsValid(idx - bias);
+	}
+
+	inline bool AllValid() const {
+		return fmask.AllValid() && dmask.AllValid();
+	}
+
+	const ValidityMask &fmask;
+	const ValidityMask &dmask;
+	const idx_t bias;
+};
+
+void ReuseIndexes(idx_t *index, const FrameBounds &frame, const FrameBounds &prev) {
+	idx_t j = 0;
+
+	//  Copy overlapping indices
+	for (idx_t p = 0; p < (prev.second - prev.first); ++p) {
+		auto idx = index[p];
+
+		//  Shift down into any hole
+		if (j != p) {
+			index[j] = idx;
+		}
+
+		//  Skip overlapping values
+		if (frame.first <= idx && idx < frame.second) {
+			++j;
+		}
+	}
+
+	//  Insert new indices
+	if (j > 0) {
+		// Overlap: append the new ends
+		for (auto f = frame.first; f < prev.first; ++f, ++j) {
+			index[j] = f;
+		}
+		for (auto f = prev.second; f < frame.second; ++f, ++j) {
+			index[j] = f;
+		}
+	} else {
+		//  No overlap: overwrite with new values
+		for (auto f = frame.first; f < frame.second; ++f, ++j) {
+			index[j] = f;
+		}
+	}
+}
+
+static idx_t ReplaceIndex(idx_t *index, const FrameBounds &frame, const FrameBounds &prev) { // NOLINT
+	D_ASSERT(index);
+
+	idx_t j = 0;
+	for (idx_t p = 0; p < (prev.second - prev.first); ++p) {
+		auto idx = index[p];
+		if (j != p) {
+			break;
+		}
+
+		if (frame.first <= idx && idx < frame.second) {
+			++j;
+		}
+	}
+	index[j] = frame.second - 1;
+
+	return j;
+}
+
+template <class INPUT_TYPE>
+static inline int CanReplace(const idx_t *index, const INPUT_TYPE *fdata, const idx_t j, const idx_t k0, const idx_t k1,
+                             const QuantileIncluded &validity) {
+	D_ASSERT(index);
+
+	// NULLs sort to the end, so if we have inserted a NULL,
+	// it must be past the end of the quantile to be replaceable.
+	// Note that the quantile values are never NULL.
+	const auto ij = index[j];
+	if (!validity(ij)) {
+		return k1 < j ? 1 : 0;
+	}
+
+	auto curr = fdata[ij];
+	if (k1 < j) {
+		auto hi = fdata[index[k0]];
+		return hi < curr ? 1 : 0;
+	} else if (j < k0) {
+		auto lo = fdata[index[k1]];
+		return curr < lo ? -1 : 0;
+	}
+
+	return 0;
+}
+
+template <class INPUT_TYPE>
+struct IndirectLess {
+	inline explicit IndirectLess(const INPUT_TYPE *inputs_p) : inputs(inputs_p) {
+	}
+
+	inline bool operator()(const idx_t &lhi, const idx_t &rhi) const {
+		return inputs[lhi] < inputs[rhi];
+	}
+
+	const INPUT_TYPE *inputs;
+};
+
+struct CastInterpolation {
+
+	template <class INPUT_TYPE, class TARGET_TYPE>
+	static inline TARGET_TYPE Cast(const INPUT_TYPE &src, Vector &result) {
+		return Cast::Operation<INPUT_TYPE, TARGET_TYPE>(src);
+	}
+	template <typename TARGET_TYPE>
+	static inline TARGET_TYPE Interpolate(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
+		const auto delta = hi - lo;
+		return lo + delta * d;
+	}
+};
+
+template <>
+interval_t CastInterpolation::Cast(const dtime_t &src, Vector &result) {
+	return {0, 0, src.micros};
+}
+
+template <>
+double CastInterpolation::Interpolate(const double &lo, const double d, const double &hi) {
+	return lo * (1.0 - d) + hi * d;
+}
+
+template <>
+dtime_t CastInterpolation::Interpolate(const dtime_t &lo, const double d, const dtime_t &hi) {
+	return dtime_t(std::llround(lo.micros * (1.0 - d) + hi.micros * d));
+}
+
+template <>
+timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d, const timestamp_t &hi) {
+	return timestamp_t(std::llround(lo.value * (1.0 - d) + hi.value * d));
+}
+
+template <>
+string_t CastInterpolation::Cast(const std::string &src, Vector &result) {
+	return StringVector::AddString(result, src);
+}
+
+template <>
+string_t CastInterpolation::Cast(const string_t &src, Vector &result) {
+	return StringVector::AddString(result, src);
+}
+
+// Direct access
+template <typename T>
+struct QuantileDirect {
+	using INPUT_TYPE = T;
+	using RESULT_TYPE = T;
+
+	inline const INPUT_TYPE &operator()(const INPUT_TYPE &x) const {
+		return x;
+	}
+};
+
+// Indirect access
+template <typename T>
+struct QuantileIndirect {
+	using INPUT_TYPE = idx_t;
+	using RESULT_TYPE = T;
+	const RESULT_TYPE *data;
+
+	explicit QuantileIndirect(const RESULT_TYPE *data_p) : data(data_p) {
+	}
+
+	inline RESULT_TYPE operator()(const idx_t &input) const {
+		return data[input];
+	}
+};
+
+// Composed access
+template <typename OUTER, typename INNER>
+struct QuantileComposed {
+	using INPUT_TYPE = typename INNER::INPUT_TYPE;
+	using RESULT_TYPE = typename OUTER::RESULT_TYPE;
+
+	const OUTER &outer;
+	const INNER &inner;
+
+	explicit QuantileComposed(const OUTER &outer_p, const INNER &inner_p) : outer(outer_p), inner(inner_p) {
+	}
+
+	inline RESULT_TYPE operator()(const idx_t &input) const {
+		return outer(inner(input));
+	}
+};
+
+// Accessed comparison
+template <typename ACCESSOR>
+struct QuantileLess {
+	using INPUT_TYPE = typename ACCESSOR::INPUT_TYPE;
+	const ACCESSOR &accessor;
+	explicit QuantileLess(const ACCESSOR &accessor_p) : accessor(accessor_p) {
+	}
+
+	inline bool operator()(const INPUT_TYPE &lhs, const INPUT_TYPE &rhs) const {
+		return accessor(lhs) < accessor(rhs);
+	}
+};
+
+// Continuous interpolation
+template <bool DISCRETE>
+struct Interpolator {
+	Interpolator(const double q, const idx_t n_p)
+	    : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(ceil(RN)), begin(0), end(n_p) {
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Operation(INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		QuantileLess<ACCESSOR> comp(accessor);
+		if (CRN == FRN) {
+			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+		} else {
+			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+			std::nth_element(v_t + FRN, v_t + CRN, v_t + end, comp);
+			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
+			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+		}
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Replace(const INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		if (CRN == FRN) {
+			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+		} else {
+			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
+			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+		}
+	}
+
+	const idx_t n;
+	const double RN;
+	const idx_t FRN;
+	const idx_t CRN;
+
+	idx_t begin;
+	idx_t end;
+};
+
+// Discrete "interpolation"
+template <>
+struct Interpolator<true> {
+	Interpolator(const double q, const idx_t n_p)
+	    : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(FRN), begin(0), end(n_p) {
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Operation(INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		QuantileLess<ACCESSOR> comp(accessor);
+		std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Replace(const INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+	}
+
+	const idx_t n;
+	const double RN;
+	const idx_t FRN;
+	const idx_t CRN;
+
+	idx_t begin;
+	idx_t end;
+};
+
+struct QuantileBindData : public FunctionData {
+	explicit QuantileBindData(double quantile_p) : quantiles(1, quantile_p), order(1, 0) {
+	}
+
+	explicit QuantileBindData(const vector<double> &quantiles_p) : quantiles(quantiles_p) {
+		for (idx_t i = 0; i < quantiles.size(); ++i) {
+			order.push_back(i);
+		}
+
+		IndirectLess<double> lt(quantiles.data());
+		std::sort(order.begin(), order.end(), lt);
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<QuantileBindData>(quantiles);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (QuantileBindData &)other_p;
+		return quantiles == other.quantiles && order == other.order;
+	}
+
+	vector<double> quantiles;
+	vector<idx_t> order;
+};
+
+struct QuantileOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		new (state) STATE;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->v.emplace_back(data[idx]);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.v.empty()) {
+			return;
+		}
+		target->v.insert(target->v.end(), source.v.begin(), source.v.end());
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		state->~STATE();
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class STATE_TYPE, class RESULT_TYPE, class OP>
+static void ExecuteListFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result,
+                                idx_t count, // NOLINT
+                                idx_t offset) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	D_ASSERT(aggr_input_data.bind_data);
+	auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+	if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ListVector::Reserve(result, bind_data->quantiles.size());
+
+		auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+		auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+		auto &mask = ConstantVector::Validity(result);
+		OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+	} else {
+		D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+		auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < count; i++) {
+			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+		}
+	}
+
+	result.Verify(count);
+}
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction QuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) { // NOLINT
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    ExecuteListFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <bool DISCRETE>
+struct QuantileScalarOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		Interpolator<DISCRETE> interp(bind_data->quantiles[0], state->v.size());
+		target[idx] = interp.template Operation<typename STATE::SaveType, RESULT_TYPE>(state->v.data(), result);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   const FrameBounds &prev, Vector &result, idx_t ridx, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+		D_ASSERT(index);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		// Find the two positions needed
+		const auto q = bind_data->quantiles[0];
+
+		bool replace = false;
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				Interpolator<DISCRETE> interp(q, prev_pos);
+				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+				if (replace) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (!replace && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+		if (state->pos) {
+			Interpolator<DISCRETE> interp(q, state->pos);
+
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			rdata[ridx] = replace ? interp.template Replace<idx_t, RESULT_TYPE, ID>(index, result, indirect)
+			                      : interp.template Operation<idx_t, RESULT_TYPE, ID>(index, result, indirect);
+		} else {
+			rmask.Set(ridx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename SAVED_TYPE>
+AggregateFunction GetTypedDiscreteQuantileAggregateFunction(const LogicalType &type) {
+	using STATE = QuantileState<SAVED_TYPE>;
+	using OP = QuantileScalarOperation<true>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, INPUT_TYPE, OP>(type, type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, INPUT_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedDiscreteQuantileAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedDiscreteQuantileAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedDiscreteQuantileAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedDiscreteQuantileAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedDiscreteQuantileAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetTypedDiscreteQuantileAggregateFunction<interval_t, interval_t>(type);
+
+	case LogicalTypeId::VARCHAR:
+		return GetTypedDiscreteQuantileAggregateFunction<string_t, std::string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile aggregate");
+	}
+}
+
+template <class CHILD_TYPE, bool DISCRETE>
+struct QuantileListOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		auto v_t = state->v.data();
+		D_ASSERT(v_t);
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		idx_t lower = 0;
+		for (const auto &q : bind_data->order) {
+			const auto &quantile = bind_data->quantiles[q];
+			Interpolator<DISCRETE> interp(quantile, state->v.size());
+			interp.begin = lower;
+			rdata[ridx + q] = interp.template Operation<typename STATE::SaveType, CHILD_TYPE>(v_t, result);
+			lower = interp.FRN;
+		}
+		entry.length = bind_data->quantiles.size();
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   const FrameBounds &prev, Vector &list, idx_t lidx, idx_t bias) {
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		// Result is a constant LIST<RESULT_TYPE> with a fixed length
+		auto ldata = FlatVector::GetData<RESULT_TYPE>(list);
+		auto &lmask = FlatVector::Validity(list);
+		auto &lentry = ldata[lidx];
+		lentry.offset = ListVector::GetListSize(list);
+		lentry.length = bind_data->quantiles.size();
+
+		ListVector::Reserve(list, lentry.offset + lentry.length);
+		ListVector::SetListSize(list, lentry.offset + lentry.length);
+		auto &result = ListVector::GetEntry(list);
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+
+		// We can generalise replacement for quantile lists by observing that when a replacement is
+		// valid for a single quantile, it is valid for all quantiles greater/less than that quantile
+		// based on whether the insertion is below/above the quantile location.
+		// So if a replaced index in an IQR is located between Q25 and Q50, but has a value below Q25,
+		// then Q25 must be recomputed, but Q50 and Q75 are unaffected.
+		// For a single element list, this reduces to the scalar case.
+		std::pair<idx_t, idx_t> replaceable {state->pos, 0};
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				for (const auto &q : bind_data->order) {
+					const auto &quantile = bind_data->quantiles[q];
+					Interpolator<DISCRETE> interp(quantile, prev_pos);
+					const auto replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+					if (replace < 0) {
+						//	Replacement is before this quantile, so the rest will be replaceable too.
+						replaceable.first = MinValue(replaceable.first, interp.FRN);
+						replaceable.second = prev_pos;
+						break;
+					} else if (replace > 0) {
+						//	Replacement is after this quantile, so everything before it is replaceable too.
+						replaceable.first = 0;
+						replaceable.second = MaxValue(replaceable.second, interp.CRN);
+					}
+				}
+				if (replaceable.first < replaceable.second) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (replaceable.first >= replaceable.second && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+
+		if (state->pos) {
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			for (const auto &q : bind_data->order) {
+				const auto &quantile = bind_data->quantiles[q];
+				Interpolator<DISCRETE> interp(quantile, state->pos);
+				if (replaceable.first <= interp.FRN && interp.CRN <= replaceable.second) {
+					rdata[lentry.offset + q] = interp.template Replace<idx_t, CHILD_TYPE, ID>(index, result, indirect);
+				} else {
+					// Make sure we don't disturb any replacements
+					if (replaceable.first < replaceable.second) {
+						if (interp.FRN < replaceable.first) {
+							interp.end = replaceable.first;
+						}
+						if (replaceable.second < interp.CRN) {
+							interp.begin = replaceable.second;
+						}
+					}
+					rdata[lentry.offset + q] =
+					    interp.template Operation<idx_t, CHILD_TYPE, ID>(index, result, indirect);
+				}
+			}
+		} else {
+			lmask.Set(lidx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedDiscreteQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = QuantileState<SAVE_TYPE>;
+	using OP = QuantileListOperation<INPUT_TYPE, true>;
+	auto fun = QuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, list_entry_t, OP>;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedDiscreteQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedDiscreteQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedDiscreteQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedDiscreteQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedDiscreteQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedDiscreteQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedDiscreteQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedDiscreteQuantileListAggregateFunction<date_t, date_t>(type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedDiscreteQuantileListAggregateFunction<timestamp_t, timestamp_t>(type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedDiscreteQuantileListAggregateFunction<dtime_t, dtime_t>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetTypedDiscreteQuantileListAggregateFunction<interval_t, interval_t>(type);
+
+	case LogicalTypeId::VARCHAR:
+		return GetTypedDiscreteQuantileListAggregateFunction<string_t, std::string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+	}
+}
+
+template <typename INPUT_TYPE, typename TARGET_TYPE>
+AggregateFunction GetTypedContinuousQuantileAggregateFunction(const LogicalType &input_type,
+                                                              const LogicalType &target_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = QuantileScalarOperation<false>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, TARGET_TYPE, OP>(input_type, target_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, TARGET_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedContinuousQuantileAggregateFunction<int8_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedContinuousQuantileAggregateFunction<int16_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::INTEGER:
+		return GetTypedContinuousQuantileAggregateFunction<int32_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::BIGINT:
+		return GetTypedContinuousQuantileAggregateFunction<int64_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedContinuousQuantileAggregateFunction<hugeint_t, double>(type, LogicalType::DOUBLE);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedContinuousQuantileAggregateFunction<float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedContinuousQuantileAggregateFunction<double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedContinuousQuantileAggregateFunction<int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedContinuousQuantileAggregateFunction<int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedContinuousQuantileAggregateFunction<int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedContinuousQuantileAggregateFunction<hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented continuous quantile DECIMAL aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedContinuousQuantileAggregateFunction<date_t, timestamp_t>(type, LogicalType::TIMESTAMP);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedContinuousQuantileAggregateFunction<timestamp_t, timestamp_t>(type, type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedContinuousQuantileAggregateFunction<dtime_t, dtime_t>(type, type);
+
+	default:
+		throw NotImplementedException("Unimplemented continuous quantile aggregate");
+	}
+}
+
+template <typename INPUT_TYPE, typename CHILD_TYPE>
+AggregateFunction GetTypedContinuousQuantileListAggregateFunction(const LogicalType &input_type,
+                                                                  const LogicalType &result_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = QuantileListOperation<CHILD_TYPE, false>;
+	auto fun = QuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(input_type, result_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, list_entry_t, OP>;
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int8_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int16_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::INTEGER:
+		return GetTypedContinuousQuantileListAggregateFunction<int32_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::BIGINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int64_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, double>(type, LogicalType::DOUBLE);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedContinuousQuantileListAggregateFunction<float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedContinuousQuantileListAggregateFunction<double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedContinuousQuantileListAggregateFunction<int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedContinuousQuantileListAggregateFunction<int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedContinuousQuantileListAggregateFunction<int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile DECIMAL list aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedContinuousQuantileListAggregateFunction<date_t, timestamp_t>(type, LogicalType::TIMESTAMP);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedContinuousQuantileListAggregateFunction<timestamp_t, timestamp_t>(type, type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedContinuousQuantileListAggregateFunction<dtime_t, dtime_t>(type, type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+	}
+}
+
+template <typename T, typename R, typename MEDIAN_TYPE>
+struct MadAccessor {
+	using INPUT_TYPE = T;
+	using RESULT_TYPE = R;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return TryAbsOperator::Operation<RESULT_TYPE, RESULT_TYPE>(delta);
+	}
+};
+
+// hugeint_t - double => undefined
+template <>
+struct MadAccessor<hugeint_t, double, double> {
+	using INPUT_TYPE = hugeint_t;
+	using RESULT_TYPE = double;
+	using MEDIAN_TYPE = double;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = Hugeint::Cast<double>(input) - median;
+		return TryAbsOperator::Operation<double, double>(delta);
+	}
+};
+
+// date_t - timestamp_t => interval_t
+template <>
+struct MadAccessor<date_t, interval_t, timestamp_t> {
+	using INPUT_TYPE = date_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = timestamp_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto dt = Cast::Operation<date_t, timestamp_t>(input);
+		const auto delta = dt - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+// timestamp_t - timestamp_t => int64_t
+template <>
+struct MadAccessor<timestamp_t, interval_t, timestamp_t> {
+	using INPUT_TYPE = timestamp_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = timestamp_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+// dtime_t - dtime_t => int64_t
+template <>
+struct MadAccessor<dtime_t, interval_t, dtime_t> {
+	using INPUT_TYPE = dtime_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = dtime_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+template <typename MEDIAN_TYPE>
+struct MedianAbsoluteDeviationOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, RESULT_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		using SAVE_TYPE = typename STATE::SaveType;
+		Interpolator<false> interp(0.5, state->v.size());
+		const auto med = interp.template Operation<SAVE_TYPE, MEDIAN_TYPE>(state->v.data(), result);
+
+		MadAccessor<SAVE_TYPE, RESULT_TYPE, MEDIAN_TYPE> accessor(med);
+		target[idx] = interp.template Operation<SAVE_TYPE, RESULT_TYPE>(state->v.data(), result, accessor);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   Vector &result, idx_t ridx, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+		D_ASSERT(index);
+
+		// We need a second index for the second pass.
+		if (state->pos > state->m.size()) {
+			state->m.resize(state->pos);
+		}
+
+		auto index2 = state->m.data();
+		D_ASSERT(index2);
+
+		// The replacement trick does not work on the second index because if
+		// the median has changed, the previous order is not correct.
+		// It is probably close, however, and so reuse is helpful.
+		ReuseIndexes(index2, frame, prev);
+		std::partition(index2, index2 + state->pos, included);
+
+		// Find the two positions needed for the median
+		const float q = 0.5;
+
+		bool replace = false;
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				Interpolator<false> interp(q, prev_pos);
+				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+				if (replace) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (!replace && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+
+		if (state->pos) {
+			Interpolator<false> interp(q, state->pos);
+
+			// Compute or replace median from the first index
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			const auto med = replace ? interp.template Replace<idx_t, MEDIAN_TYPE, ID>(index, result, indirect)
+			                         : interp.template Operation<idx_t, MEDIAN_TYPE, ID>(index, result, indirect);
+
+			// Compute mad from the second index
+			using MAD = MadAccessor<INPUT_TYPE, RESULT_TYPE, MEDIAN_TYPE>;
+			MAD mad(med);
+
+			using MadIndirect = QuantileComposed<MAD, ID>;
+			MadIndirect mad_indirect(mad, indirect);
+			rdata[ridx] = interp.template Operation<idx_t, RESULT_TYPE, MadIndirect>(index2, result, mad_indirect);
+		} else {
+			rmask.Set(ridx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename MEDIAN_TYPE, typename TARGET_TYPE>
+AggregateFunction GetTypedMedianAbsoluteDeviationAggregateFunction(const LogicalType &input_type,
+                                                                   const LogicalType &target_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = MedianAbsoluteDeviationOperation<MEDIAN_TYPE>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, TARGET_TYPE, OP>(input_type, target_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, TARGET_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::FLOAT:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<float, float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<double, double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int16_t, int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int32_t, int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int64_t, int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<hugeint_t, hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented Median Absolute Deviation DECIMAL aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<date_t, timestamp_t, interval_t>(type,
+		                                                                                         LogicalType::INTERVAL);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<timestamp_t, timestamp_t, interval_t>(
+		    type, LogicalType::INTERVAL);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<dtime_t, dtime_t, interval_t>(type,
+		                                                                                      LogicalType::INTERVAL);
+
+	default:
+		throw NotImplementedException("Unimplemented Median Absolute Deviation aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindMedian(ClientContext &context, AggregateFunction &function,
+                                    vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<QuantileBindData>(0.5);
+}
+
+unique_ptr<FunctionData> BindMedianDecimal(ClientContext &context, AggregateFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindMedian(context, function, arguments);
+
+	function = GetDiscreteQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "median";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(ClientContext &context, AggregateFunction &function,
+                                                            vector<unique_ptr<Expression>> &arguments) {
+	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->return_type);
+	function.name = "mad";
+	return nullptr;
+}
+
+static double CheckQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<double>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("QUANTILE can only take parameters in the range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction &function,
+                                      vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("QUANTILE can only take constant parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	vector<double> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckQuantile(element_val));
+		}
+	}
+
+	arguments.pop_back();
+	return make_unique<QuantileBindData>(quantiles);
+}
+
+unique_ptr<FunctionData> BindDiscreteQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetDiscreteQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_disc";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindDiscreteQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                         vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetDiscreteQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_disc";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindContinuousQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetContinuousQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_cont";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindContinuousQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetContinuousQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_cont";
+	return bind_data;
+}
+
+static bool CanInterpolate(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::INTERVAL:
+	case LogicalTypeId::VARCHAR:
+		return false;
+	default:
+		return true;
+	}
+}
+
+AggregateFunction GetMedianAggregate(const LogicalType &type) {
+	auto fun = CanInterpolate(type) ? GetContinuousQuantileAggregateFunction(type)
+	                                : GetDiscreteQuantileAggregateFunction(type);
+	fun.bind = BindMedian;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileAggregate(const LogicalType &type) {
+	auto fun = GetDiscreteQuantileAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetDiscreteQuantileListAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileAggregate(const LogicalType &type) {
+	auto fun = GetContinuousQuantileAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetContinuousQuantileListAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+void QuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	const vector<LogicalType> QUANTILES = {LogicalType::TINYINT,  LogicalType::SMALLINT,     LogicalType::INTEGER,
+	                                       LogicalType::BIGINT,   LogicalType::HUGEINT,      LogicalType::FLOAT,
+	                                       LogicalType::DOUBLE,   LogicalType::DATE,         LogicalType::TIMESTAMP,
+	                                       LogicalType::TIME,     LogicalType::TIMESTAMP_TZ, LogicalType::TIME_TZ,
+	                                       LogicalType::INTERVAL, LogicalType::VARCHAR};
+
+	AggregateFunctionSet median("median");
+	median.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                     nullptr, nullptr, nullptr, BindMedianDecimal));
+
+	AggregateFunctionSet quantile_disc("quantile_disc");
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
+	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                            BindDiscreteQuantileDecimal));
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindDiscreteQuantileDecimalList));
+
+	AggregateFunctionSet quantile_cont("quantile_cont");
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
+	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                            BindContinuousQuantileDecimal));
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindContinuousQuantileDecimalList));
+
+	for (const auto &type : QUANTILES) {
+		median.AddFunction(GetMedianAggregate(type));
+		quantile_disc.AddFunction(GetDiscreteQuantileAggregate(type));
+		quantile_disc.AddFunction(GetDiscreteQuantileListAggregate(type));
+		if (CanInterpolate(type)) {
+			quantile_cont.AddFunction(GetContinuousQuantileAggregate(type));
+			quantile_cont.AddFunction(GetContinuousQuantileListAggregate(type));
+		}
+	}
+
+	set.AddFunction(median);
+	set.AddFunction(quantile_disc);
+	set.AddFunction(quantile_cont);
+
+	quantile_disc.name = "quantile";
+	set.AddFunction(quantile_disc);
+
+	AggregateFunctionSet mad("mad");
+	mad.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, nullptr, BindMedianAbsoluteDeviationDecimal));
+
+	const vector<LogicalType> MADS = {LogicalType::FLOAT,     LogicalType::DOUBLE, LogicalType::DATE,
+	                                  LogicalType::TIMESTAMP, LogicalType::TIME,   LogicalType::TIMESTAMP_TZ,
+	                                  LogicalType::TIME_TZ};
+	for (const auto &type : MADS) {
+		mad.AddFunction(GetMedianAbsoluteDeviationAggregateFunction(type));
+	}
+	set.AddFunction(mad);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <stdlib.h>
+
+namespace duckdb {
+
+template <typename T>
+struct ReservoirQuantileState {
+	T *v;
+	idx_t len;
+	idx_t pos;
+	BaseReservoirSampling *r_samp;
+
+	void Resize(idx_t new_len) {
+		if (new_len <= len) {
+			return;
+		}
+		v = (T *)realloc(v, new_len * sizeof(T));
+		if (!v) {
+			throw InternalException("Memory allocation failure");
+		}
+		len = new_len;
+	}
+
+	void ReplaceElement(T &input) {
+		v[r_samp->min_entry] = input;
+		r_samp->ReplaceElement();
+	}
+
+	void FillReservoir(idx_t sample_size, T element) {
+		if (pos < sample_size) {
+			v[pos++] = element;
+			r_samp->InitializeReservoir(pos, len);
+		} else {
+			D_ASSERT(r_samp->next_index >= r_samp->current_count);
+			if (r_samp->next_index == r_samp->current_count) {
+				ReplaceElement(element);
+			}
+		}
+	}
+};
+
+struct ReservoirQuantileBindData : public FunctionData {
+	ReservoirQuantileBindData(double quantile_p, int32_t sample_size_p)
+	    : quantiles(1, quantile_p), sample_size(sample_size_p) {
+	}
+
+	ReservoirQuantileBindData(const vector<double> &quantiles_p, int32_t sample_size_p)
+	    : quantiles(quantiles_p), sample_size(sample_size_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ReservoirQuantileBindData>(quantiles, sample_size);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (ReservoirQuantileBindData &)other_p;
+		return quantiles == other.quantiles && sample_size == other.sample_size;
+	}
+
+	vector<double> quantiles;
+	int32_t sample_size;
+};
+
+struct ReservoirQuantileOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->v = nullptr;
+		state->len = 0;
+		state->pos = 0;
+		state->r_samp = nullptr;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *data, ValidityMask &mask,
+	                      idx_t idx) {
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data);
+		if (state->pos == 0) {
+			state->Resize(bind_data->sample_size);
+		}
+		if (!state->r_samp) {
+			state->r_samp = new BaseReservoirSampling();
+		}
+		D_ASSERT(state->v);
+		state->FillReservoir(bind_data->sample_size, data[idx]);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.pos == 0) {
+			return;
+		}
+		if (target->pos == 0) {
+			target->Resize(source.len);
+		}
+		if (!target->r_samp) {
+			target->r_samp = new BaseReservoirSampling();
+		}
+		for (idx_t src_idx = 0; src_idx < source.pos; src_idx++) {
+			target->FillReservoir(target->len, source.v[src_idx]);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->v) {
+			free(state->v);
+			state->v = nullptr;
+		}
+		if (state->r_samp) {
+			delete state->r_samp;
+			state->r_samp = nullptr;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct ReservoirQuantileScalarOperation : public ReservoirQuantileOperation {
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(state->v);
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+		auto v_t = state->v;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		auto offset = (idx_t)((double)(state->pos - 1) * bind_data->quantiles[0]);
+		std::nth_element(v_t, v_t + offset, v_t + state->pos);
+		target[idx] = v_t[offset];
+	}
+};
+
+AggregateFunction GetReservoirQuantileAggregateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT8:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int8_t>, int8_t, int8_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::TINYINT,
+		                                                                                     LogicalType::TINYINT);
+
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int16_t>, int16_t, int16_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::SMALLINT,
+		                                                                                     LogicalType::SMALLINT);
+
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int32_t>, int32_t, int32_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::INTEGER,
+		                                                                                     LogicalType::INTEGER);
+
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int64_t>, int64_t, int64_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::BIGINT,
+		                                                                                     LogicalType::BIGINT);
+
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<hugeint_t>, hugeint_t, hugeint_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::HUGEINT,
+		                                                                                     LogicalType::HUGEINT);
+	case PhysicalType::FLOAT:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<float>, float, float,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::FLOAT,
+		                                                                                     LogicalType::FLOAT);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<double>, double, double,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::DOUBLE,
+		                                                                                     LogicalType::DOUBLE);
+	default:
+		throw InternalException("Unimplemented reservoir quantile aggregate");
+	}
+}
+
+template <class CHILD_TYPE>
+struct ReservoirQuantileListOperation : public ReservoirQuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		auto v_t = state->v;
+		D_ASSERT(v_t);
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		entry.length = bind_data->quantiles.size();
+		for (size_t q = 0; q < entry.length; ++q) {
+			const auto &quantile = bind_data->quantiles[q];
+			auto offset = (idx_t)((double)(state->pos - 1) * quantile);
+			std::nth_element(v_t, v_t + offset, v_t + state->pos);
+			rdata[ridx + q] = v_t[offset];
+		}
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE_TYPE, class RESULT_TYPE>
+	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
+	                         idx_t offset) {
+		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+
+		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ListVector::Reserve(result, bind_data->quantiles.size());
+
+			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+			auto &mask = ConstantVector::Validity(result);
+			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+		} else {
+			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+			auto &mask = FlatVector::Validity(result);
+			for (idx_t i = 0; i < count; i++) {
+				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+			}
+		}
+
+		result.Verify(count);
+	}
+};
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction ReservoirQuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) {
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedReservoirQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = ReservoirQuantileState<SAVE_TYPE>;
+	using OP = ReservoirQuantileListOperation<INPUT_TYPE>;
+	auto fun = ReservoirQuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	return fun;
+}
+
+AggregateFunction GetReservoirQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedReservoirQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedReservoirQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedReservoirQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedReservoirQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedReservoirQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedReservoirQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedReservoirQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedReservoirQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented reservoir quantile list aggregate");
+		}
+		break;
+
+	default:
+		// TODO: Add quantitative temporal types
+		throw NotImplementedException("Unimplemented reservoir quantile list aggregate");
+	}
+}
+
+static double CheckReservoirQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<double>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("RESERVOIR_QUANTILE can only take parameters in the range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, AggregateFunction &function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("RESERVOIR_QUANTILE can only take constant quantile parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	vector<double> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckReservoirQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckReservoirQuantile(element_val));
+		}
+	}
+
+	if (arguments.size() <= 2) {
+		arguments.pop_back();
+		return make_unique<ReservoirQuantileBindData>(quantiles, 8192);
+	}
+	if (!arguments[2]->IsFoldable()) {
+		throw BinderException("RESERVOIR_QUANTILE can only take constant sample size parameters");
+	}
+	Value sample_size_val = ExpressionExecutor::EvaluateScalar(*arguments[2]);
+	auto sample_size = sample_size_val.GetValue<int32_t>();
+
+	if (sample_size_val.IsNull() || sample_size <= 0) {
+		throw BinderException("Size of the RESERVOIR_QUANTILE sample must be bigger than 0");
+	}
+
+	// remove the quantile argument so we can use the unary aggregate
+	arguments.pop_back();
+	arguments.pop_back();
+	return make_unique<ReservoirQuantileBindData>(quantiles, sample_size);
+}
+
+unique_ptr<FunctionData> BindReservoirQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindReservoirQuantile(context, function, arguments);
+	function = GetReservoirQuantileAggregateFunction(arguments[0]->return_type.InternalType());
+	function.name = "reservoir_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetReservoirQuantileAggregate(PhysicalType type) {
+	auto fun = GetReservoirQuantileAggregateFunction(type);
+	fun.bind = BindReservoirQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+unique_ptr<FunctionData> BindReservoirQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                          vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindReservoirQuantile(context, function, arguments);
+	function = GetReservoirQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "reservoir_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetReservoirQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetReservoirQuantileListAggregateFunction(type);
+	fun.bind = BindReservoirQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+static void DefineReservoirQuantile(AggregateFunctionSet &set, const LogicalType &type) {
+	//	Four versions: type, scalar/list[, count]
+	auto fun = GetReservoirQuantileAggregate(type.InternalType());
+	fun.bind = BindReservoirQuantile;
+	set.AddFunction(fun);
+
+	fun.arguments.emplace_back(LogicalType::INTEGER);
+	set.AddFunction(fun);
+
+	// List variants
+	fun = GetReservoirQuantileListAggregate(type);
+	set.AddFunction(fun);
+
+	fun.arguments.emplace_back(LogicalType::INTEGER);
+	set.AddFunction(fun);
+}
+
+void ReservoirQuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet reservoir_quantile("reservoir_quantile");
+
+	// DECIMAL
+	reservoir_quantile.AddFunction(
+	    AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE, LogicalType::INTEGER}, LogicalTypeId::DECIMAL,
+	                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, BindReservoirQuantileDecimal));
+	reservoir_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE},
+	                                                 LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr, nullptr,
+	                                                 nullptr, nullptr, BindReservoirQuantileDecimal));
+	reservoir_quantile.AddFunction(
+	    AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::INTEGER},
+	                      LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr, nullptr, nullptr,
+	                      nullptr, BindReservoirQuantileDecimalList));
+
+	reservoir_quantile.AddFunction(AggregateFunction(
+	    {LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::LIST(LogicalTypeId::DECIMAL),
+	    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, BindReservoirQuantileDecimalList));
+
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::TINYINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::SMALLINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::INTEGER);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::BIGINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::HUGEINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::FLOAT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::DOUBLE);
+
+	set.AddFunction(reservoir_quantile);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterHolisticAggregates() {
+	Register<QuantileFun>();
+	Register<ModeFun>();
+	Register<ApproximateQuantileFun>();
+	Register<ReservoirQuantileFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct HistogramFunctor {
+	template <class T, class MAP_TYPE = map<T, idx_t>>
+	static void HistogramUpdate(VectorData &sdata, VectorData &input_data, idx_t count) {
+
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			if (input_data.validity.RowIsValid(input_data.sel->get_index(i))) {
+				auto state = states[sdata.sel->get_index(i)];
+				if (!state->hist) {
+					state->hist = new MAP_TYPE();
+				}
+				auto value = (T *)input_data.data;
+				(*state->hist)[value[input_data.sel->get_index(i)]]++;
+			}
+		}
+	}
+
+	template <class T>
+	static Value HistogramFinalize(T first) {
+		return Value::CreateValue(first);
+	}
+};
+
+struct HistogramStringFunctor {
+	template <class T, class MAP_TYPE = map<T, idx_t>>
+	static void HistogramUpdate(VectorData &sdata, VectorData &input_data, idx_t count) {
+
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			if (input_data.validity.RowIsValid(input_data.sel->get_index(i))) {
+				auto state = states[sdata.sel->get_index(i)];
+				if (!state->hist) {
+					state->hist = new MAP_TYPE();
+				}
+				auto value = (string_t *)input_data.data;
+				(*state->hist)[value[input_data.sel->get_index(i)].GetString()]++;
+			}
+		}
+	}
+
+	template <class T>
+	static Value HistogramFinalize(T first) {
+		string_t value = first;
+		return Value::CreateValue(value);
+	}
+};
+
+struct HistogramFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->hist = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->hist) {
+			delete state->hist;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class OP, class T, class MAP_TYPE>
+static void HistogramUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector,
+                                    idx_t count) {
+
+	D_ASSERT(input_count == 1);
+
+	auto &input = inputs[0];
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	VectorData input_data;
+	input.Orrify(count, input_data);
+
+	OP::template HistogramUpdate<T, MAP_TYPE>(sdata, input_data, count);
+}
+
+template <class T, class MAP_TYPE>
+static void HistogramCombineFunction(Vector &state, Vector &combined, AggregateInputData &, idx_t count) {
+
+	VectorData sdata;
+	state.Orrify(count, sdata);
+	auto states_ptr = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+	auto combined_ptr = FlatVector::GetData<HistogramAggState<T, MAP_TYPE> *>(combined);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states_ptr[sdata.sel->get_index(i)];
+		if (!state->hist) {
+			continue;
+		}
+		if (!combined_ptr[i]->hist) {
+			combined_ptr[i]->hist = new MAP_TYPE();
+		}
+		D_ASSERT(combined_ptr[i]->hist);
+		D_ASSERT(state->hist);
+		for (auto &entry : *state->hist) {
+			(*combined_ptr[i]->hist)[entry.first] += entry.second;
+		}
+	}
+}
+
+template <class OP, class T, class MAP_TYPE>
+static void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count,
+                                      idx_t offset) {
+
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+	auto &mask = FlatVector::Validity(result);
+
+	auto &child_entries = StructVector::GetEntries(result);
+	auto &bucket_list = child_entries[0];
+	auto &count_list = child_entries[1];
+
+	auto old_len = ListVector::GetListSize(*bucket_list);
+
+	auto &bucket_validity = FlatVector::Validity(*bucket_list);
+	auto &count_validity = FlatVector::Validity(*count_list);
+
+	for (idx_t i = 0; i < count; i++) {
+
+		const auto rid = i + offset;
+		auto state = states[sdata.sel->get_index(i)];
+		if (!state->hist) {
+			mask.SetInvalid(rid);
+			bucket_validity.SetInvalid(rid);
+			count_validity.SetInvalid(rid);
+			continue;
+		}
+
+		for (auto &entry : *state->hist) {
+			Value bucket_value = OP::template HistogramFinalize<T>(entry.first);
+			ListVector::PushBack(*bucket_list, bucket_value);
+			auto count_value = Value::CreateValue(entry.second);
+			ListVector::PushBack(*count_list, count_value);
+		}
+
+		auto list_struct_data = FlatVector::GetData<list_entry_t>(*bucket_list);
+		list_struct_data[rid].length = ListVector::GetListSize(*bucket_list) - old_len;
+		list_struct_data[rid].offset = old_len;
+
+		list_struct_data = FlatVector::GetData<list_entry_t>(*count_list);
+		list_struct_data[rid].length = ListVector::GetListSize(*count_list) - old_len;
+		list_struct_data[rid].offset = old_len;
+		old_len += list_struct_data[rid].length;
+	}
+}
+
+unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, AggregateFunction &function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(arguments.size() == 1);
+	child_list_t<LogicalType> struct_children;
+	struct_children.push_back({"bucket", LogicalType::LIST(arguments[0]->return_type)});
+	struct_children.push_back({"count", LogicalType::LIST(LogicalType::UBIGINT)});
+	auto struct_type = LogicalType::MAP(move(struct_children));
+
+	function.return_type = struct_type;
+	return make_unique<VariableReturnBindData>(function.return_type);
+}
+
+template <class OP, class T, class MAP_TYPE = map<T, idx_t>>
+static AggregateFunction GetHistogramFunction(const LogicalType &type) {
+
+	using STATE_TYPE = HistogramAggState<T, MAP_TYPE>;
+
+	return AggregateFunction("histogram", {type}, LogicalTypeId::MAP, AggregateFunction::StateSize<STATE_TYPE>,
+	                         AggregateFunction::StateInitialize<STATE_TYPE, HistogramFunction>,
+	                         HistogramUpdateFunction<OP, T, MAP_TYPE>, HistogramCombineFunction<T, MAP_TYPE>,
+	                         HistogramFinalizeFunction<OP, T, MAP_TYPE>, nullptr, HistogramBindFunction,
+	                         AggregateFunction::StateDestroy<STATE_TYPE, HistogramFunction>);
+}
+
+template <class OP, class T, bool IS_ORDERED>
+AggregateFunction GetMapType(const LogicalType &type) {
+
+	if (IS_ORDERED) {
+		return GetHistogramFunction<OP, T>(type);
+	}
+	return GetHistogramFunction<OP, T, unordered_map<T, idx_t>>(type);
+}
+
+template <bool IS_ORDERED = true>
+AggregateFunction GetHistogramFunction(const LogicalType &type) {
+
+	switch (type.id()) {
+	case LogicalType::BOOLEAN:
+		return GetMapType<HistogramFunctor, bool, IS_ORDERED>(type);
+	case LogicalType::UTINYINT:
+		return GetMapType<HistogramFunctor, uint8_t, IS_ORDERED>(type);
+	case LogicalType::USMALLINT:
+		return GetMapType<HistogramFunctor, uint16_t, IS_ORDERED>(type);
+	case LogicalType::UINTEGER:
+		return GetMapType<HistogramFunctor, uint32_t, IS_ORDERED>(type);
+	case LogicalType::UBIGINT:
+		return GetMapType<HistogramFunctor, uint64_t, IS_ORDERED>(type);
+	case LogicalType::TINYINT:
+		return GetMapType<HistogramFunctor, int8_t, IS_ORDERED>(type);
+	case LogicalType::SMALLINT:
+		return GetMapType<HistogramFunctor, int16_t, IS_ORDERED>(type);
+	case LogicalType::INTEGER:
+		return GetMapType<HistogramFunctor, int32_t, IS_ORDERED>(type);
+	case LogicalType::BIGINT:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::FLOAT:
+		return GetMapType<HistogramFunctor, float, IS_ORDERED>(type);
+	case LogicalType::DOUBLE:
+		return GetMapType<HistogramFunctor, double, IS_ORDERED>(type);
+	case LogicalType::VARCHAR:
+		return GetMapType<HistogramStringFunctor, string, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_TZ:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_S:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_MS:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_NS:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIME:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIME_TZ:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::DATE:
+		return GetMapType<HistogramFunctor, int32_t, IS_ORDERED>(type);
+	default:
+		throw InternalException("Unimplemented histogram aggregate");
+	}
+}
+
+void HistogramFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("histogram");
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::BOOLEAN));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UTINYINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::USMALLINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UINTEGER));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UBIGINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TINYINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::SMALLINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::INTEGER));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::BIGINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::FLOAT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::DOUBLE));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::VARCHAR));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_TZ));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_S));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_MS));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_NS));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIME));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIME_TZ));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::DATE));
+	set.AddFunction(fun);
+}
+
+AggregateFunction HistogramFun::GetHistogramUnorderedMap(LogicalType &type) {
+	const auto &const_type = type;
+	return GetHistogramFunction<false>(const_type);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct ListAggState {
+	Vector *list_vector;
+};
+
+struct ListFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->list_vector = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->list_vector) {
+			delete state->list_vector;
+		}
+	}
+	static bool IgnoreNull() {
+		return false;
+	}
+};
+
+static void ListUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector,
+                               idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	auto &input = inputs[0];
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+
+	auto list_vector_type = LogicalType::LIST(input.GetType());
+
+	auto states = (ListAggState **)sdata.data;
+	if (input.GetVectorType() == VectorType::SEQUENCE_VECTOR) {
+		input.Normalify(count);
+	}
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states[sdata.sel->get_index(i)];
+		if (!state->list_vector) {
+			// NOTE: any number bigger than 1 can cause DuckDB to run out of memory for specific queries
+			// consisting of millions of groups in the group by and complex (nested) vectors
+			state->list_vector = new Vector(list_vector_type, 1);
+		}
+		ListVector::Append(*state->list_vector, input, i + 1, i);
+	}
+}
+
+static void ListCombineFunction(Vector &state, Vector &combined, AggregateInputData &, idx_t count) {
+	VectorData sdata;
+	state.Orrify(count, sdata);
+	auto states_ptr = (ListAggState **)sdata.data;
+
+	auto combined_ptr = FlatVector::GetData<ListAggState *>(combined);
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states_ptr[sdata.sel->get_index(i)];
+		if (!state->list_vector) {
+			// NULL, no need to append.
+			continue;
+		}
+		if (!combined_ptr[i]->list_vector) {
+			// NOTE: initializing this with a capacity of ListVector::GetListSize(*state->list_vector) causes
+			// DuckDB to run out of memory for multiple threads with millions of groups in the group by and complex
+			// (nested) vectors
+			combined_ptr[i]->list_vector = new Vector(state->list_vector->GetType(), 1);
+		}
+		ListVector::Append(*combined_ptr[i]->list_vector, ListVector::GetEntry(*state->list_vector),
+		                   ListVector::GetListSize(*state->list_vector));
+	}
+}
+
+static void ListFinalize(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (ListAggState **)sdata.data;
+
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	auto &mask = FlatVector::Validity(result);
+	auto list_struct_data = FlatVector::GetData<list_entry_t>(result);
+	size_t total_len = ListVector::GetListSize(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states[sdata.sel->get_index(i)];
+		const auto rid = i + offset;
+		if (!state->list_vector) {
+			mask.SetInvalid(rid);
+			continue;
+		}
+
+		auto &state_lv = *state->list_vector;
+		auto state_lv_count = ListVector::GetListSize(state_lv);
+		list_struct_data[rid].length = state_lv_count;
+		list_struct_data[rid].offset = total_len;
+		total_len += state_lv_count;
+
+		auto &list_vec_to_append = ListVector::GetEntry(state_lv);
+		ListVector::Append(result, list_vec_to_append, state_lv_count);
+	}
+}
+
+unique_ptr<FunctionData> ListBindFunction(ClientContext &context, AggregateFunction &function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 1);
+	function.return_type = LogicalType::LIST(arguments[0]->return_type);
+	return nullptr;
+}
+
+void ListFun::RegisterFunction(BuiltinFunctions &set) {
+	auto agg =
+	    AggregateFunction("list", {LogicalType::ANY}, LogicalTypeId::LIST, AggregateFunction::StateSize<ListAggState>,
+	                      AggregateFunction::StateInitialize<ListAggState, ListFunction>, ListUpdateFunction,
+	                      ListCombineFunction, ListFinalize, nullptr, ListBindFunction,
+	                      AggregateFunction::StateDestroy<ListAggState, ListFunction>, nullptr, nullptr);
+	set.AddFunction(agg);
+	agg.name = "array_agg";
+	set.AddFunction(agg);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterNestedAggregates() {
+	Register<ListFun>();
+	Register<HistogramFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+struct RegrState {
+	double sum;
+	size_t count;
+};
+
+struct RegrAvgFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->sum = 0;
+		state->count = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->sum += source.sum;
+		target->count += source.count;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->sum / (double)state->count;
+		}
+	}
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+struct RegrAvgXFunction : RegrAvgFunction {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->sum += y_data[yidx];
+		state->count++;
+	}
+};
+
+struct RegrAvgYFunction : RegrAvgFunction {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->sum += x_data[xidx];
+		state->count++;
+	}
+};
+
+void RegrAvgxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_avgx");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgXFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+
+void RegrAvgyFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_avgy");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgYFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+void RegrCountFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_count");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<size_t, double, double, uint32_t, RegrCountFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::UINTEGER));
+	set.AddFunction(corr);
+}
+
+} // namespace duckdb
+//! AVG(y)-REGR_SLOPE(y,x)*AVG(x)
+
+
+
+
+
+namespace duckdb {
+
+struct RegrInterceptState {
+	size_t count;
+	double sum_x;
+	double sum_y;
+	RegrSlopeState slope;
+};
+
+struct RegrInterceptOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->count = 0;
+		state->sum_x = 0;
+		state->sum_y = 0;
+		RegrSlopeOperation::Initialize<RegrSlopeState>(&state->slope);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->count++;
+		state->sum_x += y_data[yidx];
+		state->sum_y += x_data[xidx];
+		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(&state->slope, aggr_input_data, x_data,
+		                                                                  y_data, amask, bmask, xidx, yidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		target->count += source.count;
+		target->sum_x += source.sum_x;
+		target->sum_y += source.sum_y;
+		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, &target->slope, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		RegrSlopeOperation::Finalize<T, RegrSlopeState>(result, aggr_input_data, &state->slope, target, mask, idx);
+		auto x_avg = state->sum_x / state->count;
+		auto y_avg = state->sum_y / state->count;
+		target[idx] = y_avg - target[idx] * x_avg;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrInterceptFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_intercept");
+	fun.AddFunction(
+	    AggregateFunction::BinaryAggregate<RegrInterceptState, double, double, double, RegrInterceptOperation>(
+	        LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// Returns the coefficient of determination for non-null pairs in a group.
+// It is computed for non-null pairs using the following formula:
+// null                 if var_pop(x) = 0, else
+// 1                    if var_pop(y) = 0 and var_pop(x) <> 0, else
+// power(corr(y,x), 2)
+
+
+
+
+
+namespace duckdb {
+struct RegrR2State {
+	CorrState corr;
+	StddevState var_pop_x;
+	StddevState var_pop_y;
+};
+
+struct RegrR2Operation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		CorrOperation::Initialize<CorrState>(&state->corr);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_x);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_y);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(&state->corr, aggr_input_data, y_data, x_data, bmask,
+		                                                        amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_x, aggr_input_data, y_data, bmask,
+		                                                        yidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_y, aggr_input_data, x_data, amask,
+		                                                        xidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		CorrOperation::Combine<CorrState, OP>(source.corr, &target->corr, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, &target->var_pop_x, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, &target->var_pop_y, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		auto var_pop_x = state->var_pop_x.count > 1 ? (state->var_pop_x.dsquared / state->var_pop_x.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop_x)) {
+			throw OutOfRangeException("VARPOP(X) is out of range!");
+		}
+		if (var_pop_x == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto var_pop_y = state->var_pop_y.count > 1 ? (state->var_pop_y.dsquared / state->var_pop_y.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop_y)) {
+			throw OutOfRangeException("VARPOP(Y) is out of range!");
+		}
+		if (var_pop_y == 0) {
+			target[idx] = 1;
+			return;
+		}
+		CorrOperation::Finalize<T, CorrState>(result, aggr_input_data, &state->corr, target, mask, idx);
+		target[idx] = pow(target[idx], 2);
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrR2Fun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_r2");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrR2State, double, double, double, RegrR2Operation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+} // namespace duckdb
+// REGR_SLOPE(y, x)
+// Returns the slope of the linear regression line for non-null pairs in a group.
+// It is computed for non-null pairs using the following formula:
+// COVAR_POP(x,y) / VAR_POP(x)
+
+//! Input : Any numeric type
+//! Output : Double
+
+
+
+
+
+namespace duckdb {
+
+void RegrSlopeFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_slope");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSlopeState, double, double, double, RegrSlopeOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// regr_sxx
+// Returns REGR_COUNT(y, x) * VAR_POP(x) for non-null pairs.
+// regrsyy
+// Returns REGR_COUNT(y, x) * VAR_POP(y) for non-null pairs.
+
+
+
+
+
+namespace duckdb {
+
+struct RegrSState {
+	size_t count;
+	StddevState var_pop;
+};
+
+struct RegrBaseOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		RegrCountFunction::Initialize<size_t>(&state->count);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->var_pop.count == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto var_pop = state->var_pop.count > 1 ? (state->var_pop.dsquared / state->var_pop.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop)) {
+			throw OutOfRangeException("VARPOP is out of range!");
+		}
+		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
+		target[idx] *= var_pop;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct RegrSXXOperation : RegrBaseOperation {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, y_data, bmask, yidx);
+	}
+};
+
+struct RegrSYYOperation : RegrBaseOperation {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, x_data, bmask, xidx);
+	}
+};
+
+void RegrSXXFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_sxx");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSXXOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+void RegrSYYFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_syy");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSYYOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// Returns REGR_COUNT(expr1, expr2) * COVAR_POP(expr1, expr2) for non-null pairs.
+
+
+
+
+
+
+namespace duckdb {
+
+struct RegrSXyState {
+	size_t count;
+	CovarState cov_pop;
+};
+
+struct RegrSXYOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		RegrCountFunction::Initialize<size_t>(&state->count);
+		CovarOperation::Initialize<CovarState>(&state->cov_pop);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(&state->cov_pop, aggr_input_data, x_data, y_data,
+		                                                          amask, bmask, xidx, yidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, aggr_input_data);
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		CovarPopOperation::Finalize<T, CovarState>(result, aggr_input_data, &state->cov_pop, target, mask, idx);
+		auto cov_pop = target[idx];
+		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
+		target[idx] *= cov_pop;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrSXYFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_sxy");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSXyState, double, double, double, RegrSXYOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterRegressiveAggregates() {
+	Register<RegrAvgxFun>();
+	Register<RegrAvgyFun>();
+	Register<RegrCountFun>();
+	Register<RegrSlopeFun>();
+	Register<RegrR2Fun>();
+	Register<RegrSYYFun>();
+	Register<RegrSXXFun>();
+	Register<RegrSXYFun>();
+	Register<RegrInterceptFun>();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct SortedAggregateBindData : public FunctionData {
+
+	// TODO: Collection sorting does not handle OrderByNullType correctly
+	// so this is the third hack around it...
+	static OrderByNullType NormaliseNullOrder(OrderType sense, OrderByNullType null_order) {
+		if (sense != OrderType::DESCENDING) {
+			return null_order;
+		}
+
+		switch (null_order) {
+		case OrderByNullType::NULLS_FIRST:
+			return OrderByNullType::NULLS_LAST;
+		case OrderByNullType::NULLS_LAST:
+			return OrderByNullType::NULLS_FIRST;
+		default:
+			throw InternalException("Unknown NULL order sense");
+		}
+	}
+
+	SortedAggregateBindData(const AggregateFunction &function_p, vector<unique_ptr<Expression>> &children,
+	                        unique_ptr<FunctionData> bind_info_p, const BoundOrderModifier &order_bys)
+	    : function(function_p), bind_info(move(bind_info_p)) {
+		arg_types.reserve(children.size());
+		for (const auto &child : children) {
+			arg_types.emplace_back(child->return_type);
+		}
+		for (auto &order : order_bys.orders) {
+			order_sense.emplace_back(order.type);
+			null_order.emplace_back(NormaliseNullOrder(order.type, order.null_order));
+			sort_types.emplace_back(order.expression->return_type);
+		}
+	}
+
+	SortedAggregateBindData(const SortedAggregateBindData &other)
+	    : function(other.function), arg_types(other.arg_types), order_sense(other.order_sense),
+	      null_order(other.null_order), sort_types(other.sort_types) {
+		if (other.bind_info) {
+			bind_info = other.bind_info->Copy();
+		}
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<SortedAggregateBindData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const SortedAggregateBindData &)other_p;
+		if (bind_info && other.bind_info) {
+			if (!bind_info->Equals(*other.bind_info)) {
+				return false;
+			}
+		} else if (bind_info || other.bind_info) {
+			return false;
+		}
+		return function == other.function && order_sense == other.order_sense && null_order == other.null_order &&
+		       sort_types == other.sort_types;
+	}
+
+	AggregateFunction function;
+	vector<LogicalType> arg_types;
+	unique_ptr<FunctionData> bind_info;
+
+	vector<OrderType> order_sense;
+	vector<OrderByNullType> null_order;
+	vector<LogicalType> sort_types;
+};
+
+struct SortedAggregateState {
+	SortedAggregateState() : nsel(0) {
+	}
+
+	ChunkCollection arguments;
+	ChunkCollection ordering;
+
+	// Selection for scattering
+	SelectionVector sel;
+	idx_t nsel;
+};
+
+struct SortedAggregateFunction {
+	template <typename STATE>
+	static void Initialize(STATE *state) {
+		new (state) STATE();
+	}
+
+	template <typename STATE>
+	static void Destroy(STATE *state) {
+		state->~STATE();
+	}
+
+	static void ProjectInputs(Vector inputs[], SortedAggregateBindData *order_bind, idx_t input_count, idx_t count,
+	                          DataChunk &arg_chunk, DataChunk &sort_chunk) {
+		idx_t col = 0;
+
+		arg_chunk.InitializeEmpty(order_bind->arg_types);
+		for (auto &dst : arg_chunk.data) {
+			dst.Reference(inputs[col++]);
+		}
+		arg_chunk.SetCardinality(count);
+
+		sort_chunk.InitializeEmpty(order_bind->sort_types);
+		for (auto &dst : sort_chunk.data) {
+			dst.Reference(inputs[col++]);
+		}
+		sort_chunk.SetCardinality(count);
+	}
+
+	static void SimpleUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, data_ptr_t state,
+	                         idx_t count) {
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+		DataChunk arg_chunk;
+		DataChunk sort_chunk;
+		ProjectInputs(inputs, order_bind, input_count, count, arg_chunk, sort_chunk);
+
+		const auto order_state = (SortedAggregateState *)state;
+		order_state->arguments.Append(arg_chunk);
+		order_state->ordering.Append(sort_chunk);
+	}
+
+	static void ScatterUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
+	                          idx_t count) {
+		if (!count) {
+			return;
+		}
+
+		// Append the arguments to the two sub-collections
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+		DataChunk arg_inputs;
+		DataChunk sort_inputs;
+		ProjectInputs(inputs, order_bind, input_count, count, arg_inputs, sort_inputs);
+
+		// We have to scatter the chunks one at a time
+		// so build a selection vector for each one.
+		VectorData svdata;
+		states.Orrify(count, svdata);
+
+		// Build the selection vector for each state.
+		auto sdata = (SortedAggregateState **)svdata.data;
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = svdata.sel->get_index(i);
+			auto order_state = sdata[sidx];
+			if (!order_state->sel.data()) {
+				order_state->sel.Initialize();
+			}
+			order_state->sel.set_index(order_state->nsel++, i);
+		}
+
+		// Append nonempty slices to the arguments
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = svdata.sel->get_index(i);
+			auto order_state = sdata[sidx];
+			if (!order_state->nsel) {
+				continue;
+			}
+
+			DataChunk arg_chunk;
+			arg_chunk.InitializeEmpty(arg_inputs.GetTypes());
+			arg_chunk.Slice(arg_inputs, order_state->sel, order_state->nsel);
+			order_state->arguments.Append(arg_chunk);
+
+			DataChunk sort_chunk;
+			sort_chunk.InitializeEmpty(sort_inputs.GetTypes());
+			sort_chunk.Slice(sort_inputs, order_state->sel, order_state->nsel);
+			order_state->ordering.Append(sort_chunk);
+
+			// Mark the slice as empty now we have consumed it.
+			order_state->nsel = 0;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.arguments.Count() == 0) {
+			return;
+		}
+		target->arguments.Append(const_cast<ChunkCollection &>(source.arguments));
+		target->ordering.Append(const_cast<ChunkCollection &>(source.ordering));
+	}
+
+	static void Finalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+	                     idx_t offset) {
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+
+		//	 Reusable inner state
+		vector<data_t> agg_state(order_bind->function.state_size());
+		Vector agg_state_vec(Value::POINTER((idx_t)agg_state.data()));
+
+		// Sorting buffer
+		vector<idx_t> reordering;
+
+		// State variables
+		const auto input_count = order_bind->function.arguments.size();
+		auto bind_info = order_bind->bind_info.get();
+		AggregateInputData aggr_bind_info(bind_info);
+
+		// Inner aggregate APIs
+		auto initialize = order_bind->function.initialize;
+		auto destructor = order_bind->function.destructor;
+		auto simple_update = order_bind->function.simple_update;
+		auto update = order_bind->function.update;
+		auto finalize = order_bind->function.finalize;
+
+		auto sdata = FlatVector::GetData<SortedAggregateState *>(states);
+		for (idx_t i = 0; i < count; ++i) {
+			initialize(agg_state.data());
+			auto state = sdata[i];
+
+			// Apply the sort before delegating the chunks
+			const auto agg_count = state->ordering.Count();
+			if (agg_count > 0) {
+				reordering.resize(agg_count);
+				state->ordering.Sort(order_bind->order_sense, order_bind->null_order, reordering.data());
+				state->arguments.Reorder(reordering.data());
+			}
+
+			for (auto &chunk : state->arguments.Chunks()) {
+				// These are all simple updates, so use it if available
+				if (simple_update) {
+					simple_update(chunk->data.data(), aggr_bind_info, input_count, agg_state.data(), chunk->size());
+				} else {
+					// We are only updating a constant state
+					agg_state_vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+					update(chunk->data.data(), aggr_bind_info, input_count, agg_state_vec, chunk->size());
+				}
+			}
+
+			// Finalize a single value at the next offset
+			agg_state_vec.SetVectorType(states.GetVectorType());
+			finalize(agg_state_vec, aggr_bind_info, result, 1, i + offset);
+
+			if (destructor) {
+				destructor(agg_state_vec, 1);
+			}
+		}
+	}
+};
+
+unique_ptr<FunctionData> AggregateFunction::BindSortedAggregate(AggregateFunction &bound_function,
+                                                                vector<unique_ptr<Expression>> &children,
+                                                                unique_ptr<FunctionData> bind_info,
+                                                                unique_ptr<BoundOrderModifier> order_bys) {
+
+	auto sorted_bind = make_unique<SortedAggregateBindData>(bound_function, children, move(bind_info), *order_bys);
+
+	// The arguments are the children plus the sort columns.
+	for (auto &order : order_bys->orders) {
+		children.emplace_back(move(order.expression));
+	}
+
+	vector<LogicalType> arguments;
+	arguments.reserve(children.size());
+	for (const auto &child : children) {
+		arguments.emplace_back(child->return_type);
+	}
+
+	// Replace the aggregate with the wrapper
+	bound_function = AggregateFunction(
+	    bound_function.name, arguments, bound_function.return_type, AggregateFunction::StateSize<SortedAggregateState>,
+	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction>,
+	    SortedAggregateFunction::ScatterUpdate,
+	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
+	    SortedAggregateFunction::Finalize, SortedAggregateFunction::SimpleUpdate, nullptr,
+	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>);
+
+	return move(sorted_bind);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//! The target type determines the preferred implicit casts
+static int64_t TargetTypeCost(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::INTEGER:
+		return 103;
+	case LogicalTypeId::BIGINT:
+		return 101;
+	case LogicalTypeId::DOUBLE:
+		return 102;
+	case LogicalTypeId::HUGEINT:
+		return 120;
+	case LogicalTypeId::TIMESTAMP:
+		return 120;
+	case LogicalTypeId::VARCHAR:
+		return 149;
+	case LogicalTypeId::DECIMAL:
+		return 104;
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::LIST:
+		return 160;
+	default:
+		return 110;
+	}
+}
+
+static int64_t ImplicitCastTinyint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastSmallint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastInteger(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastBigint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUTinyint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUSmallint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUInteger(const LogicalType &to) {
+	switch (to.id()) {
+
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUBigint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastFloat(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::DOUBLE:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDouble(const LogicalType &to) {
+	switch (to.id()) {
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDecimal(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastHugeint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDate(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::TIMESTAMP:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) {
+	if (to.id() == LogicalTypeId::ANY) {
+		// anything can be cast to ANY type for no cost
+		return 0;
+	}
+	if (from.id() == LogicalTypeId::SQLNULL) {
+		// NULL expression can be cast to anything
+		return TargetTypeCost(to);
+	}
+	if (from.id() == LogicalTypeId::UNKNOWN) {
+		// parameter expression can be cast to anything for no cost
+		return 0;
+	}
+	if (from.id() == LogicalTypeId::BLOB && to.id() == LogicalTypeId::VARCHAR) {
+		// Implicit cast not allowed from BLOB to VARCHAR
+		return -1;
+	}
+	if ((from.id() == LogicalTypeId::VARCHAR && to.id() == LogicalTypeId::JSON) ||
+	    (from.id() == LogicalTypeId::JSON && to.id() == LogicalTypeId::VARCHAR)) {
+		// Virtually no cost, just a different tag
+		return 1;
+	}
+	if (to.id() == LogicalTypeId::VARCHAR || to.id() == LogicalTypeId::JSON) {
+		// everything can be cast to VARCHAR/JSON, but this cast has a high cost
+		return TargetTypeCost(to);
+	}
+	if (from.id() == LogicalTypeId::LIST && to.id() == LogicalTypeId::LIST) {
+		// Lists can be cast if their child types can be cast
+		return ImplicitCast(ListType::GetChildType(from), ListType::GetChildType(to));
+	}
+	if ((from.id() == LogicalTypeId::TIMESTAMP_SEC || from.id() == LogicalTypeId::TIMESTAMP_MS ||
+	     from.id() == LogicalTypeId::TIMESTAMP_NS) &&
+	    to.id() == LogicalTypeId::TIMESTAMP) {
+		//! Any timestamp type can be converted to the default (us) type at low cost
+		return 101;
+	}
+	if ((to.id() == LogicalTypeId::TIMESTAMP_SEC || to.id() == LogicalTypeId::TIMESTAMP_MS ||
+	     to.id() == LogicalTypeId::TIMESTAMP_NS) &&
+	    from.id() == LogicalTypeId::TIMESTAMP) {
+		//! Any timestamp type can be converted to the default (us) type at low cost
+		return 100;
+	}
+	switch (from.id()) {
+	case LogicalTypeId::TINYINT:
+		return ImplicitCastTinyint(to);
+	case LogicalTypeId::SMALLINT:
+		return ImplicitCastSmallint(to);
+	case LogicalTypeId::INTEGER:
+		return ImplicitCastInteger(to);
+	case LogicalTypeId::BIGINT:
+		return ImplicitCastBigint(to);
+	case LogicalTypeId::UTINYINT:
+		return ImplicitCastUTinyint(to);
+	case LogicalTypeId::USMALLINT:
+		return ImplicitCastUSmallint(to);
+	case LogicalTypeId::UINTEGER:
+		return ImplicitCastUInteger(to);
+	case LogicalTypeId::UBIGINT:
+		return ImplicitCastUBigint(to);
+	case LogicalTypeId::HUGEINT:
+		return ImplicitCastHugeint(to);
+	case LogicalTypeId::FLOAT:
+		return ImplicitCastFloat(to);
+	case LogicalTypeId::DOUBLE:
+		return ImplicitCastDouble(to);
+	case LogicalTypeId::DATE:
+		return ImplicitCastDate(to);
+	case LogicalTypeId::DECIMAL:
+		return ImplicitCastDecimal(to);
+	default:
+		return -1;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+typedef CompressionFunction (*get_compression_function_t)(PhysicalType type);
+typedef bool (*compression_supports_type_t)(PhysicalType type);
+
+struct DefaultCompressionMethod {
+	CompressionType type;
+	get_compression_function_t get_function;
+	compression_supports_type_t supports_type;
+};
+
+static DefaultCompressionMethod internal_compression_methods[] = {
+    {CompressionType::COMPRESSION_CONSTANT, ConstantFun::GetFunction, ConstantFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_UNCOMPRESSED, UncompressedFun::GetFunction, UncompressedFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_RLE, RLEFun::GetFunction, RLEFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_BITPACKING, BitpackingFun::GetFunction, BitpackingFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_DICTIONARY, DictionaryCompressionFun::GetFunction,
+     DictionaryCompressionFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_AUTO, nullptr, nullptr}};
+
+static CompressionFunction *FindCompressionFunction(CompressionFunctionSet &set, CompressionType type,
+                                                    PhysicalType data_type) {
+	auto &functions = set.functions;
+	auto comp_entry = functions.find(type);
+	if (comp_entry != functions.end()) {
+		auto &type_functions = comp_entry->second;
+		auto type_entry = type_functions.find(data_type);
+		if (type_entry != type_functions.end()) {
+			return &type_entry->second;
+		}
+	}
+	return nullptr;
+}
+
+static CompressionFunction *LoadCompressionFunction(CompressionFunctionSet &set, CompressionType type,
+                                                    PhysicalType data_type) {
+	for (idx_t index = 0; internal_compression_methods[index].get_function; index++) {
+		const auto &method = internal_compression_methods[index];
+		if (method.type == type) {
+			// found the correct compression type
+			if (!method.supports_type(data_type)) {
+				// but it does not support this data type: bail out
+				return nullptr;
+			}
+			// the type is supported: create the function and insert it into the set
+			auto function = method.get_function(data_type);
+			set.functions[type].insert(make_pair(data_type, function));
+			return FindCompressionFunction(set, type, data_type);
+		}
+	}
+	throw InternalException("Unsupported compression function type");
+}
+
+static void TryLoadCompression(DBConfig &config, vector<CompressionFunction *> &result, CompressionType type,
+                               PhysicalType data_type) {
+	auto function = config.GetCompressionFunction(type, data_type);
+	if (!function) {
+		return;
+	}
+	result.push_back(function);
+}
+
+vector<CompressionFunction *> DBConfig::GetCompressionFunctions(PhysicalType data_type) {
+	vector<CompressionFunction *> result;
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_UNCOMPRESSED, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_RLE, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_BITPACKING, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_DICTIONARY, data_type);
+	return result;
+}
+
+CompressionFunction *DBConfig::GetCompressionFunction(CompressionType type, PhysicalType data_type) {
+	// check if the function is already loaded
+	auto function = FindCompressionFunction(*compression_functions, type, data_type);
+	if (function) {
+		return function;
+	}
+	// else load the function
+	return LoadCompressionFunction(*compression_functions, type, data_type);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+FunctionData::~FunctionData() {
+}
+
+bool FunctionData::Equals(const FunctionData *left, const FunctionData *right) {
+	if (left == right) {
+		return true;
+	}
+	if (!left || !right) {
+		return false;
+	}
+	return left->Equals(*right);
+}
+
+TableFunctionData::~TableFunctionData() {
+}
+
+unique_ptr<FunctionData> TableFunctionData::Copy() const {
+	throw InternalException("Copy not supported for TableFunctionData");
+}
+
+bool TableFunctionData::Equals(const FunctionData &other) const {
+	return false;
+}
+
+Function::Function(string name_p) : name(move(name_p)) {
+}
+Function::~Function() {
+}
+
+SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType varargs_p)
+    : Function(move(name_p)), arguments(move(arguments_p)), varargs(move(varargs_p)) {
+}
+
+SimpleFunction::~SimpleFunction() {
+}
+
+string SimpleFunction::ToString() {
+	return Function::CallToString(name, arguments);
+}
+
+bool SimpleFunction::HasVarArgs() const {
+	return varargs.id() != LogicalTypeId::INVALID;
+}
+
+SimpleNamedParameterFunction::SimpleNamedParameterFunction(string name_p, vector<LogicalType> arguments_p,
+                                                           LogicalType varargs_p)
+    : SimpleFunction(move(name_p), move(arguments_p), move(varargs_p)) {
+}
+
+SimpleNamedParameterFunction::~SimpleNamedParameterFunction() {
+}
+
+string SimpleNamedParameterFunction::ToString() {
+	return Function::CallToString(name, arguments, named_parameters);
+}
+
+bool SimpleNamedParameterFunction::HasNamedParameters() {
+	return !named_parameters.empty();
+}
+
+BaseScalarFunction::BaseScalarFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type_p,
+                                       bool has_side_effects, LogicalType varargs_p, bool propagates_null_values_p)
+    : SimpleFunction(move(name_p), move(arguments_p), move(varargs_p)), return_type(move(return_type_p)),
+      has_side_effects(has_side_effects), propagates_null_values(propagates_null_values_p) {
+}
+
+BaseScalarFunction::~BaseScalarFunction() {
+}
+
+string BaseScalarFunction::ToString() {
+	return Function::CallToString(name, arguments, return_type);
+}
+
+// add your initializer for new functions here
+void BuiltinFunctions::Initialize() {
+	RegisterSQLiteFunctions();
+	RegisterReadFunctions();
+	RegisterTableFunctions();
+	RegisterArrowFunctions();
+
+	RegisterAlgebraicAggregates();
+	RegisterDistributiveAggregates();
+	RegisterNestedAggregates();
+	RegisterHolisticAggregates();
+	RegisterRegressiveAggregates();
+
+	RegisterDateFunctions();
+	RegisterEnumFunctions();
+	RegisterGenericFunctions();
+	RegisterMathFunctions();
+	RegisterOperators();
+	RegisterSequenceFunctions();
+	RegisterStringFunctions();
+	RegisterNestedFunctions();
+	RegisterTrigonometricsFunctions();
+
+	RegisterPragmaFunctions();
+
+	// initialize collations
+	AddCollation("nocase", LowerFun::GetFunction(), true);
+	AddCollation("noaccent", StripAccentsFun::GetFunction());
+	AddCollation("nfc", NFCNormalizeFun::GetFunction());
+}
+
+BuiltinFunctions::BuiltinFunctions(ClientContext &context, Catalog &catalog) : context(context), catalog(catalog) {
+}
+
+void BuiltinFunctions::AddCollation(string name, ScalarFunction function, bool combinable,
+                                    bool not_required_for_equality) {
+	CreateCollationInfo info(move(name), move(function), combinable, not_required_for_equality);
+	catalog.CreateCollation(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(AggregateFunctionSet set) {
+	CreateAggregateFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(AggregateFunction function) {
+	CreateAggregateFunctionInfo info(move(function));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(PragmaFunction function) {
+	CreatePragmaFunctionInfo info(move(function));
+	catalog.CreatePragmaFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(const string &name, vector<PragmaFunction> functions) {
+	CreatePragmaFunctionInfo info(name, move(functions));
+	catalog.CreatePragmaFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(ScalarFunction function) {
+	CreateScalarFunctionInfo info(move(function));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(const vector<string> &names, ScalarFunction function) { // NOLINT: false positive
+	for (auto &name : names) {
+		function.name = name;
+		AddFunction(function);
+	}
+}
+
+void BuiltinFunctions::AddFunction(ScalarFunctionSet set) {
+	CreateScalarFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(TableFunction function) {
+	CreateTableFunctionInfo info(move(function));
+	catalog.CreateTableFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(TableFunctionSet set) {
+	CreateTableFunctionInfo info(move(set));
+	catalog.CreateTableFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(CopyFunction function) {
+	CreateCopyFunctionInfo info(move(function));
+	catalog.CreateCopyFunction(context, &info);
+}
+
+hash_t BaseScalarFunction::Hash() const {
+	hash_t hash = return_type.Hash();
+	for (auto &arg : arguments) {
+		duckdb::CombineHash(hash, arg.Hash());
+	}
+	return hash;
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments) {
+	string result = name + "(";
+	result += StringUtil::Join(arguments, arguments.size(), ", ",
+	                           [](const LogicalType &argument) { return argument.ToString(); });
+	return result + ")";
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+                              const LogicalType &return_type) {
+	string result = CallToString(name, arguments);
+	result += " -> " + return_type.ToString();
+	return result;
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+                              const named_parameter_type_map_t &named_parameters) {
+	vector<string> input_arguments;
+	input_arguments.reserve(arguments.size() + named_parameters.size());
+	for (auto &arg : arguments) {
+		input_arguments.push_back(arg.ToString());
+	}
+	for (auto &kv : named_parameters) {
+		input_arguments.push_back(StringUtil::Format("%s : %s", kv.first, kv.second.ToString()));
+	}
+	return StringUtil::Format("%s(%s)", name, StringUtil::Join(input_arguments, ", "));
+}
+
+static int64_t BindVarArgsFunctionCost(SimpleFunction &func, vector<LogicalType> &arguments) {
+	if (arguments.size() < func.arguments.size()) {
+		// not enough arguments to fulfill the non-vararg part of the function
+		return -1;
+	}
+	int64_t cost = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		LogicalType arg_type = i < func.arguments.size() ? func.arguments[i] : func.varargs;
+		if (arguments[i] == arg_type) {
+			// arguments match: do nothing
+			continue;
+		}
+		int64_t cast_cost = CastRules::ImplicitCast(arguments[i], arg_type);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += cast_cost;
+		} else {
+			// we can't implicitly cast: throw an error
+			return -1;
+		}
+	}
+	return cost;
+}
+
+static int64_t BindFunctionCost(SimpleFunction &func, vector<LogicalType> &arguments) {
+	if (func.HasVarArgs()) {
+		// special case varargs function
+		return BindVarArgsFunctionCost(func, arguments);
+	}
+	if (func.arguments.size() != arguments.size()) {
+		// invalid argument count: check the next function
+		return -1;
+	}
+	int64_t cost = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id() == func.arguments[i].id()) {
+			// arguments match: do nothing
+			continue;
+		}
+		int64_t cast_cost = CastRules::ImplicitCast(arguments[i], func.arguments[i]);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += cast_cost;
+		} else {
+			// we can't implicitly cast: throw an error
+			return -1;
+		}
+	}
+	return cost;
+}
+
+template <class T>
+static vector<idx_t> BindFunctionsFromArguments(const string &name, vector<T> &functions,
+                                                vector<LogicalType> &arguments, string &error) {
+	idx_t best_function = DConstants::INVALID_INDEX;
+	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
+	vector<idx_t> candidate_functions;
+	for (idx_t f_idx = 0; f_idx < functions.size(); f_idx++) {
+		auto &func = functions[f_idx];
+		// check the arguments of the function
+		int64_t cost = BindFunctionCost(func, arguments);
+		if (cost < 0) {
+			// auto casting was not possible
+			continue;
+		}
+		if (cost == lowest_cost) {
+			candidate_functions.push_back(f_idx);
+			continue;
+		}
+		if (cost > lowest_cost) {
+			continue;
+		}
+		candidate_functions.clear();
+		lowest_cost = cost;
+		best_function = f_idx;
+	}
+	if (best_function == DConstants::INVALID_INDEX) {
+		// no matching function was found, throw an error
+		string call_str = Function::CallToString(name, arguments);
+		string candidate_str = "";
+		for (auto &f : functions) {
+			candidate_str += "\t" + f.ToString() + "\n";
+		}
+		error = StringUtil::Format("No function matches the given name and argument types '%s'. You might need to add "
+		                           "explicit type casts.\n\tCandidate functions:\n%s",
+		                           call_str, candidate_str);
+		return candidate_functions;
+	}
+	candidate_functions.push_back(best_function);
+	return candidate_functions;
+}
+
+template <class T>
+static idx_t MultipleCandidateException(const string &name, vector<T> &functions, vector<idx_t> &candidate_functions,
+                                        vector<LogicalType> &arguments, string &error) {
+	D_ASSERT(functions.size() > 1);
+	// there are multiple possible function definitions
+	// throw an exception explaining which overloads are there
+	string call_str = Function::CallToString(name, arguments);
+	string candidate_str = "";
+	for (auto &conf : candidate_functions) {
+		auto &f = functions[conf];
+		candidate_str += "\t" + f.ToString() + "\n";
+	}
+	error = StringUtil::Format("Could not choose a best candidate function for the function call \"%s\". In order to "
+	                           "select one, please add explicit type casts.\n\tCandidate functions:\n%s",
+	                           call_str, candidate_str);
+	return DConstants::INVALID_INDEX;
+}
+
+template <class T>
+static idx_t BindFunctionFromArguments(const string &name, vector<T> &functions, vector<LogicalType> &arguments,
+                                       string &error, bool &cast_parameters) {
+	auto candidate_functions = BindFunctionsFromArguments<T>(name, functions, arguments, error);
+	if (candidate_functions.empty()) {
+		// no candidates
+		return DConstants::INVALID_INDEX;
+	}
+	cast_parameters = true;
+	if (candidate_functions.size() > 1) {
+		// multiple candidates, check if there are any unknown arguments
+		bool has_parameters = false;
+		for (auto &arg_type : arguments) {
+			if (arg_type.id() == LogicalTypeId::UNKNOWN) {
+				//! there are! disable casting of parameters, but do not throw an error
+				cast_parameters = false;
+				has_parameters = true;
+				break;
+			}
+		}
+		if (!has_parameters) {
+			return MultipleCandidateException(name, functions, candidate_functions, arguments, error);
+		}
+	}
+	return candidate_functions[0];
+}
+
+idx_t Function::BindFunction(const string &name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments,
+                             string &error, bool &cast_parameters) {
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments,
+                             string &error, bool &cast_parameters) {
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments,
+                             string &error) {
+	bool cast_parameters;
+	return BindFunction(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<TableFunction> &functions, vector<LogicalType> &arguments,
+                             string &error) {
+	bool cast_parameters;
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<PragmaFunction> &functions, PragmaInfo &info, string &error) {
+	vector<LogicalType> types;
+	for (auto &value : info.parameters) {
+		types.push_back(value.type());
+	}
+	bool cast_parameters;
+	idx_t entry = BindFunctionFromArguments(name, functions, types, error, cast_parameters);
+	if (entry == DConstants::INVALID_INDEX) {
+		throw BinderException(error);
+	}
+	auto &candidate_function = functions[entry];
+	// cast the input parameters
+	for (idx_t i = 0; i < info.parameters.size(); i++) {
+		auto target_type =
+		    i < candidate_function.arguments.size() ? candidate_function.arguments[i] : candidate_function.varargs;
+		info.parameters[i] = info.parameters[i].CastAs(target_type);
+	}
+	return entry;
+}
+
+vector<LogicalType> GetLogicalTypesFromExpressions(vector<unique_ptr<Expression>> &arguments) {
+	vector<LogicalType> types;
+	types.reserve(arguments.size());
+	for (auto &argument : arguments) {
+		types.push_back(argument->return_type);
+	}
+	return types;
+}
+
+idx_t Function::BindFunction(const string &name, vector<ScalarFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error, bool &cast_parameters) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error);
+}
+
+idx_t Function::BindFunction(const string &name, vector<TableFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error);
+}
+
+enum class LogicalTypeComparisonResult { IDENTICAL_TYPE, TARGET_IS_ANY, DIFFERENT_TYPES };
+
+LogicalTypeComparisonResult RequiresCast(const LogicalType &source_type, const LogicalType &target_type) {
+	if (target_type.id() == LogicalTypeId::ANY) {
+		return LogicalTypeComparisonResult::TARGET_IS_ANY;
+	}
+	if (source_type == target_type) {
+		return LogicalTypeComparisonResult::IDENTICAL_TYPE;
+	}
+	if (source_type.id() == LogicalTypeId::LIST && target_type.id() == LogicalTypeId::LIST) {
+		return RequiresCast(ListType::GetChildType(source_type), ListType::GetChildType(target_type));
+	}
+	return LogicalTypeComparisonResult::DIFFERENT_TYPES;
+}
+
+void BaseScalarFunction::CastToFunctionArguments(vector<unique_ptr<Expression>> &children,
+                                                 bool cast_parameter_expressions) {
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto target_type = i < this->arguments.size() ? this->arguments[i] : this->varargs;
+		target_type.Verify();
+		// check if the source type is a paramter, and we have disabled casting of parameters
+		if (children[i]->return_type.id() == LogicalTypeId::UNKNOWN && !cast_parameter_expressions) {
+			continue;
+		}
+		// check if the type of child matches the type of function argument
+		// if not we need to add a cast
+		auto cast_result = RequiresCast(children[i]->return_type, target_type);
+		// except for one special case: if the function accepts ANY argument
+		// in that case we don't add a cast
+		if (cast_result == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
+			children[i] = BoundCastExpression::AddCastToType(move(children[i]), target_type);
+		}
+	}
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context, const string &schema,
+                                                                       const string &name,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       string &error, bool is_operator) {
+	// bind the function
+	auto function = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, schema, name);
+	D_ASSERT(function && function->type == CatalogType::SCALAR_FUNCTION_ENTRY);
+	return ScalarFunction::BindScalarFunction(context, (ScalarFunctionCatalogEntry &)*function, move(children), error,
+	                                          is_operator);
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context,
+                                                                       ScalarFunctionCatalogEntry &func,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       string &error, bool is_operator) {
+	// bind the function
+	bool cast_parameters;
+	idx_t best_function = Function::BindFunction(func.name, func.functions, children, error, cast_parameters);
+	if (best_function == DConstants::INVALID_INDEX) {
+		return nullptr;
+	}
+
+	// found a matching function!
+	auto &bound_function = func.functions[best_function];
+	return ScalarFunction::BindScalarFunction(context, bound_function, move(children), is_operator, cast_parameters);
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context,
+                                                                       ScalarFunction bound_function,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       bool is_operator, bool cast_parameters) {
+	unique_ptr<FunctionData> bind_info;
+	if (bound_function.bind) {
+		bind_info = bound_function.bind(context, bound_function, children);
+	}
+	// check if we need to add casts to the children
+	bound_function.CastToFunctionArguments(children, cast_parameters);
+
+	// now create the function
+	auto return_type = bound_function.return_type;
+	return make_unique<BoundFunctionExpression>(move(return_type), move(bound_function), move(children),
+	                                            move(bind_info), is_operator);
+}
+
+unique_ptr<BoundAggregateExpression> AggregateFunction::BindAggregateFunction(
+    ClientContext &context, AggregateFunction bound_function, vector<unique_ptr<Expression>> children,
+    unique_ptr<Expression> filter, bool is_distinct, unique_ptr<BoundOrderModifier> order_bys, bool cast_parameters) {
+	unique_ptr<FunctionData> bind_info;
+	if (bound_function.bind) {
+		bind_info = bound_function.bind(context, bound_function, children);
+		// we may have lost some arguments in the bind
+		children.resize(MinValue(bound_function.arguments.size(), children.size()));
+	}
+
+	// check if we need to add casts to the children
+	bound_function.CastToFunctionArguments(children, cast_parameters);
+
+	// Special case: for ORDER BY aggregates, we wrap the aggregate function in a SortedAggregateFunction
+	// The children are the sort clauses and the binding contains the ordering data.
+	if (order_bys && !order_bys->orders.empty()) {
+		bind_info = BindSortedAggregate(bound_function, children, move(bind_info), move(order_bys));
+	}
+
+	return make_unique<BoundAggregateExpression>(move(bound_function), move(children), move(filter), move(bind_info),
+	                                             is_distinct);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// MacroFunction::MacroFunction(unique_ptr<ParsedExpression> expression) : expression(move(expression)) {}
+
+MacroFunction::MacroFunction(MacroType type) : type(type) {
+}
+
+string MacroFunction::ValidateArguments(MacroFunction &macro_def, const string &name, FunctionExpression &function_expr,
+                                        vector<unique_ptr<ParsedExpression>> &positionals,
+                                        unordered_map<string, unique_ptr<ParsedExpression>> &defaults) {
+
+	// separate positional and default arguments
+	for (auto &arg : function_expr.children) {
+		if (arg->type == ExpressionType::VALUE_CONSTANT && !arg->alias.empty()) {
+			// default argument
+			if (macro_def.default_parameters.find(arg->alias) == macro_def.default_parameters.end()) {
+				return StringUtil::Format("Macro %s does not have default parameter %s!", name, arg->alias);
+			} else if (defaults.find(arg->alias) != defaults.end()) {
+				return StringUtil::Format("Duplicate default parameters %s!", arg->alias);
+			}
+			defaults[arg->alias] = move(arg);
+		} else if (!defaults.empty()) {
+			return "Positional parameters cannot come after parameters with a default value!";
+		} else {
+			// positional argument
+			positionals.push_back(move(arg));
+		}
+	}
+
+	// validate if the right number of arguments was supplied
+	string error;
+	auto &parameters = macro_def.parameters;
+	if (parameters.size() != positionals.size()) {
+		error = StringUtil::Format(
+		    "Macro function '%s(%s)' requires ", name,
+		    StringUtil::Join(parameters, parameters.size(), ", ", [](const unique_ptr<ParsedExpression> &p) {
+			    return ((ColumnRefExpression &)*p).column_names[0];
+		    }));
+		error += parameters.size() == 1 ? "a single positional argument"
+		                                : StringUtil::Format("%i positional arguments", parameters.size());
+		error += ", but ";
+		error += positionals.size() == 1 ? "a single positional argument was"
+		                                 : StringUtil::Format("%i positional arguments were", positionals.size());
+		error += " provided.";
+		return error;
+	}
+
+	// fill in default value where this was not supplied
+	for (auto it = macro_def.default_parameters.begin(); it != macro_def.default_parameters.end(); it++) {
+		if (defaults.find(it->first) == defaults.end()) {
+			defaults[it->first] = it->second->Copy();
+		}
+	}
+
+	return error;
+}
+
+void MacroFunction::CopyProperties(MacroFunction &other) {
+	other.type = type;
+	for (auto &param : parameters) {
+		other.parameters.push_back(param->Copy());
+	}
+	for (auto &kv : default_parameters) {
+		other.default_parameters[kv.first] = kv.second->Copy();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+
+namespace duckdb {
+
+static void PragmaEnableProfilingStatement(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.profiler_print_format = ProfilerPrintFormat::QUERY_TREE;
+	config.enable_profiler = true;
+}
+
+void RegisterEnableProfiling(BuiltinFunctions &set) {
+	vector<PragmaFunction> functions;
+	functions.push_back(PragmaFunction::PragmaStatement(string(), PragmaEnableProfilingStatement));
+
+	set.AddFunction("enable_profile", functions);
+	set.AddFunction("enable_profiling", functions);
+}
+
+static void PragmaDisableProfiling(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.enable_profiler = false;
+	config.profiler_print_format = ProfilerPrintFormat::NONE;
+}
+
+static void PragmaEnableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_progress_bar = true;
+}
+
+static void PragmaDisableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_progress_bar = false;
+}
+
+static void PragmaEnablePrintProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).print_progress_bar = true;
+}
+
+static void PragmaDisablePrintProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).print_progress_bar = false;
+}
+
+static void PragmaEnableVerification(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).query_verification_enabled = true;
+}
+
+static void PragmaDisableVerification(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).query_verification_enabled = false;
+}
+
+static void PragmaEnableForceParallelism(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).verify_parallelism = true;
+}
+
+static void PragmaEnableForceIndexJoin(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).force_index_join = true;
+}
+
+static void PragmaForceCheckpoint(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).force_checkpoint = true;
+}
+
+static void PragmaDisableForceParallelism(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).verify_parallelism = false;
+}
+
+static void PragmaEnableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).object_cache_enable = true;
+}
+
+static void PragmaDisableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).object_cache_enable = false;
+}
+
+static void PragmaEnableCheckpointOnShutdown(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).checkpoint_on_shutdown = true;
+}
+
+static void PragmaDisableCheckpointOnShutdown(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).checkpoint_on_shutdown = false;
+}
+
+static void PragmaEnableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_optimizer = true;
+}
+
+static void PragmaDisableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_optimizer = false;
+}
+
+void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
+	RegisterEnableProfiling(set);
+
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_profile", PragmaDisableProfiling));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_profiling", PragmaDisableProfiling));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_verification", PragmaEnableVerification));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_verification", PragmaDisableVerification));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("verify_parallelism", PragmaEnableForceParallelism));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_verify_parallelism", PragmaDisableForceParallelism));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_object_cache", PragmaEnableObjectCache));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_object_cache", PragmaDisableObjectCache));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_optimizer", PragmaEnableOptimizer));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_optimizer", PragmaDisableOptimizer));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("force_index_join", PragmaEnableForceIndexJoin));
+	set.AddFunction(PragmaFunction::PragmaStatement("force_checkpoint", PragmaForceCheckpoint));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_progress_bar", PragmaEnableProgressBar));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_progress_bar", PragmaDisableProgressBar));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_print_progress_bar", PragmaEnablePrintProgressBar));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_print_progress_bar", PragmaDisablePrintProgressBar));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_checkpoint_on_shutdown", PragmaEnableCheckpointOnShutdown));
+	set.AddFunction(
+	    PragmaFunction::PragmaStatement("disable_checkpoint_on_shutdown", PragmaDisableCheckpointOnShutdown));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+string PragmaTableInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return StringUtil::Format("SELECT * FROM pragma_table_info('%s');", parameters.values[0].ToString());
+}
+
+string PragmaShowTables(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT name FROM sqlite_master ORDER BY name;";
+}
+
+string PragmaShowTablesExpanded(ClientContext &context, const FunctionParameters &parameters) {
+	return R"(
+			SELECT
+				t.table_name,
+				LIST(c.column_name order by c.column_name) AS column_names,
+				LIST(c.data_type order by c.column_name) AS column_types,
+				FIRST(t.temporary) AS temporary
+			FROM duckdb_tables t
+			JOIN duckdb_columns c
+			USING (table_oid)
+			GROUP BY t.table_name
+			ORDER BY t.table_name;
+	)";
+}
+
+string PragmaAllProfiling(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_last_profiling_output() JOIN pragma_detailed_profiling_output() ON "
+	       "(pragma_last_profiling_output.operator_id);";
+}
+
+string PragmaDatabaseList(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_database_list() ORDER BY 1;";
+}
+
+string PragmaCollations(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_collations() ORDER BY 1;";
+}
+
+string PragmaFunctionsQuery(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_functions() ORDER BY 1;";
+}
+
+string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {
+	// PRAGMA table_info but with some aliases
+	return StringUtil::Format(
+	    "SELECT name AS \"column_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
+	    "END AS \"null\", NULL AS \"key\", dflt_value AS \"default\", NULL AS \"extra\" FROM pragma_table_info('%s');",
+	    parameters.values[0].ToString());
+}
+
+string PragmaVersion(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_version();";
+}
+
+string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Import is disabled through configuration");
+	}
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto *opener = FileSystem::GetFileOpener(context);
+
+	string query;
+	// read the "shema.sql" and "load.sql" files
+	vector<string> files = {"schema.sql", "load.sql"};
+	for (auto &file : files) {
+		auto file_path = fs.JoinPath(parameters.values[0].ToString(), file);
+		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+		                          FileSystem::DEFAULT_COMPRESSION, opener);
+		auto fsize = fs.GetFileSize(*handle);
+		auto buffer = unique_ptr<char[]>(new char[fsize]);
+		fs.Read(*handle, buffer.get(), fsize);
+
+		query += string(buffer.get(), fsize);
+	}
+	return query;
+}
+
+string PragmaDatabaseSize(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_database_size();";
+}
+
+string PragmaStorageInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return StringUtil::Format("SELECT * FROM pragma_storage_info('%s');", parameters.values[0].ToString());
+}
+
+void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(PragmaFunction::PragmaCall("table_info", PragmaTableInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("show_tables", PragmaShowTables));
+	set.AddFunction(PragmaFunction::PragmaStatement("show_tables_expanded", PragmaShowTablesExpanded));
+	set.AddFunction(PragmaFunction::PragmaStatement("database_list", PragmaDatabaseList));
+	set.AddFunction(PragmaFunction::PragmaStatement("collations", PragmaCollations));
+	set.AddFunction(PragmaFunction::PragmaCall("show", PragmaShow, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("version", PragmaVersion));
+	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
+	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));
+	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("all_profiling_output", PragmaAllProfiling));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PragmaFunction::PragmaFunction(string name, PragmaType pragma_type, pragma_query_t query, pragma_function_t function,
+                               vector<LogicalType> arguments, LogicalType varargs)
+    : SimpleNamedParameterFunction(move(name), move(arguments), move(varargs)), type(pragma_type), query(query),
+      function(function) {
+}
+
+PragmaFunction PragmaFunction::PragmaCall(const string &name, pragma_query_t query, vector<LogicalType> arguments,
+                                          LogicalType varargs) {
+	return PragmaFunction(name, PragmaType::PRAGMA_CALL, query, nullptr, move(arguments), move(varargs));
+}
+
+PragmaFunction PragmaFunction::PragmaCall(const string &name, pragma_function_t function, vector<LogicalType> arguments,
+                                          LogicalType varargs) {
+	return PragmaFunction(name, PragmaType::PRAGMA_CALL, nullptr, function, move(arguments), move(varargs));
+}
+
+PragmaFunction PragmaFunction::PragmaStatement(const string &name, pragma_query_t query) {
+	vector<LogicalType> types;
+	return PragmaFunction(name, PragmaType::PRAGMA_STATEMENT, query, nullptr, move(types), LogicalType::INVALID);
+}
+
+PragmaFunction PragmaFunction::PragmaStatement(const string &name, pragma_function_t function) {
+	vector<LogicalType> types;
+	return PragmaFunction(name, PragmaType::PRAGMA_STATEMENT, nullptr, function, move(types), LogicalType::INVALID);
+}
+
+string PragmaFunction::ToString() {
+	switch (type) {
+	case PragmaType::PRAGMA_STATEMENT:
+		return StringUtil::Format("PRAGMA %s", name);
+	case PragmaType::PRAGMA_CALL: {
+		return StringUtil::Format("PRAGMA %s", SimpleNamedParameterFunction::ToString());
+	}
+	default:
+		return "UNKNOWN";
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct Base64EncodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto result_str = StringVector::EmptyString(result, Blob::ToBase64Size(input));
+		Blob::ToBase64(input, result_str.GetDataWriteable());
+		result_str.Finalize();
+		return result_str;
+	}
+};
+
+struct Base64DecodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto result_size = Blob::FromBase64Size(input);
+		auto result_blob = StringVector::EmptyString(result, result_size);
+		Blob::FromBase64(input, (data_ptr_t)result_blob.GetDataWriteable(), result_size);
+		result_blob.Finalize();
+		return result_blob;
+	}
+};
+
+static void Base64EncodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::ExecuteString<string_t, string_t, Base64EncodeOperator>(args.data[0], result, args.size());
+}
+
+static void Base64DecodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::ExecuteString<string_t, string_t, Base64DecodeOperator>(args.data[0], result, args.size());
+}
+
+void Base64Fun::RegisterFunction(BuiltinFunctions &set) {
+	// base64 encode
+	ScalarFunction to_base64({LogicalType::BLOB}, LogicalType::VARCHAR, Base64EncodeFunction);
+	set.AddFunction({"base64", "to_base64"}, to_base64); // to_base64 is a mysql alias
+
+	set.AddFunction(ScalarFunction("from_base64", {LogicalType::VARCHAR}, LogicalType::BLOB, Base64DecodeFunction));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+static void EncodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// encode is essentially a nop cast from varchar to blob
+	// we only need to reinterpret the data using the blob type
+	result.Reinterpret(args.data[0]);
+}
+
+struct BlobDecodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		if (Utf8Proc::Analyze(input_data, input_length) == UnicodeType::INVALID) {
+			throw ConversionException(
+			    "Failure in decode: could not convert blob to UTF8 string, the blob contained invalid UTF8 characters");
+		}
+		return input;
+	}
+};
+
+static void DecodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::Execute<string_t, string_t, BlobDecodeOperator>(args.data[0], result, args.size());
+	StringVector::AddHeapReference(result, args.data[0]);
+}
+
+void EncodeFun::RegisterFunction(BuiltinFunctions &set) {
+	// encode goes from varchar -> blob, this never fails
+	set.AddFunction(ScalarFunction("encode", {LogicalType::VARCHAR}, LogicalType::BLOB, EncodeFunction));
+	// decode goes from blob -> varchar, this fails if the varchar is not valid utf8
+	set.AddFunction(ScalarFunction("decode", {LogicalType::BLOB}, LogicalType::VARCHAR, DecodeFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void AgeFunctionStandard(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+	auto current_timestamp = Timestamp::GetCurrentTimestamp();
+
+	UnaryExecutor::ExecuteWithNulls<timestamp_t, interval_t>(input.data[0], result, input.size(),
+	                                                         [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
+		                                                         if (Timestamp::IsFinite(input)) {
+			                                                         return Interval::GetAge(current_timestamp, input);
+		                                                         } else {
+			                                                         mask.SetInvalid(idx);
+			                                                         return interval_t();
+		                                                         }
+	                                                         });
+}
+
+static void AgeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 2);
+
+	BinaryExecutor::ExecuteWithNulls<timestamp_t, timestamp_t, interval_t>(
+	    input.data[0], input.data[1], result, input.size(),
+	    [&](timestamp_t input1, timestamp_t input2, ValidityMask &mask, idx_t idx) {
+		    if (Timestamp::IsFinite(input1) && Timestamp::IsFinite(input2)) {
+			    return Interval::GetAge(input1, input2);
+		    } else {
+			    mask.SetInvalid(idx);
+			    return interval_t();
+		    }
+	    });
+}
+
+void AgeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet age("age");
+	age.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunctionStandard));
+	age.AddFunction(
+	    ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunction));
+	set.AddFunction(age);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct CurrentBindData : public FunctionData {
+	ClientContext &context;
+
+	explicit CurrentBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<CurrentBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+static timestamp_t GetTransactionTimestamp(ExpressionState &state) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (CurrentBindData &)*func_expr.bind_info;
+	return info.context.ActiveTransaction().start_timestamp;
+}
+
+static void CurrentTimeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::TIME(Timestamp::GetTime(GetTransactionTimestamp(state)));
+	result.Reference(val);
+}
+
+static void CurrentDateFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::DATE(Timestamp::GetDate(GetTransactionTimestamp(state)));
+	result.Reference(val);
+}
+
+static void CurrentTimestampFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::TIMESTAMP(GetTransactionTimestamp(state));
+	result.Reference(val);
+}
+
+unique_ptr<FunctionData> BindCurrentTime(ClientContext &context, ScalarFunction &bound_function,
+                                         vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<CurrentBindData>(context);
+}
+
+void CurrentTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("get_current_time", {}, LogicalType::TIME, CurrentTimeFunction, false, BindCurrentTime));
+}
+
+void CurrentDateFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("current_date", {}, LogicalType::DATE, CurrentDateFunction, false, BindCurrentTime));
+}
+
+void CurrentTimestampFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    {"now", "get_current_timestamp"},
+	    ScalarFunction({}, LogicalType::TIMESTAMP, CurrentTimestampFunction, false, false, BindCurrentTime));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// This function is an implementation of the "period-crossing" date difference function from T-SQL
+// https://docs.microsoft.com/en-us/sql/t-sql/functions/datediff-transact-sql?view=sql-server-ver15
+struct DateDiff {
+	template <class TA, class TB, class TR, class OP>
+	static inline void BinaryExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::ExecuteWithNulls<TA, TB, TR>(
+		    left, right, result, count, [&](TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+			    if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+				    return OP::template Operation<TA, TB, TR>(startdate, enddate);
+			    } else {
+				    mask.SetInvalid(idx);
+				    return TR();
+			    }
+		    });
+	}
+
+	struct YearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) - Date::ExtractYear(startdate);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			int32_t start_year, start_month, start_day;
+			Date::Convert(startdate, start_year, start_month, start_day);
+			int32_t end_year, end_month, end_day;
+			Date::Convert(enddate, end_year, end_month, end_day);
+
+			return (end_year * 12 + end_month - 1) - (start_year * 12 + start_month - 1);
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochDays(enddate) - Date::EpochDays(startdate);
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 10 - Date::ExtractYear(startdate) / 10;
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 100 - Date::ExtractYear(startdate) / 100;
+		}
+	};
+
+	struct MilleniumOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 1000 - Date::ExtractYear(startdate) / 1000;
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			int32_t start_year, start_month, start_day;
+			Date::Convert(startdate, start_year, start_month, start_day);
+			int32_t end_year, end_month, end_day;
+			Date::Convert(enddate, end_year, end_month, end_day);
+
+			return (end_year * 12 + end_month - 1) / Interval::MONTHS_PER_QUARTER -
+			       (start_year * 12 + start_month - 1) / Interval::MONTHS_PER_QUARTER;
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_WEEK - Date::Epoch(startdate) / Interval::SECS_PER_WEEK;
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractISOYearNumber(enddate) - Date::ExtractISOYearNumber(startdate);
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochNanoseconds(enddate) / Interval::NANOS_PER_MICRO -
+			       Date::EpochNanoseconds(startdate) / Interval::NANOS_PER_MICRO;
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochNanoseconds(enddate) / Interval::NANOS_PER_MSEC -
+			       Date::EpochNanoseconds(startdate) / Interval::NANOS_PER_MSEC;
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) - Date::Epoch(startdate);
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_MINUTE -
+			       Date::Epoch(startdate) / Interval::SECS_PER_MINUTE;
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_HOUR - Date::Epoch(startdate) / Interval::SECS_PER_HOUR;
+		}
+	};
+};
+
+// TIMESTAMP specialisations
+template <>
+int64_t DateDiff::YearOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return YearOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MonthOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return MonthOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                         Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::DayOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return DayOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::DecadeOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return DecadeOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                          Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::CenturyOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return CenturyOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MilleniumOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return MilleniumOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                             Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::QuarterOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return QuarterOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::WeekOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return WeekOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::ISOYearOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return ISOYearOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MicrosecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate);
+}
+
+template <>
+int64_t DateDiff::MillisecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochMs(enddate) - Timestamp::GetEpochMs(startdate);
+}
+
+template <>
+int64_t DateDiff::SecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) - Timestamp::GetEpochSeconds(startdate);
+}
+
+template <>
+int64_t DateDiff::MinutesOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_MINUTE -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_MINUTE;
+}
+
+template <>
+int64_t DateDiff::HoursOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_HOUR -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_HOUR;
+}
+
+// TIME specialisations
+template <>
+int64_t DateDiff::YearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MonthOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DateDiff::DayOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DateDiff::DecadeOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DateDiff::CenturyOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MilleniumOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DateDiff::QuarterOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DateDiff::WeekOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DateDiff::ISOYearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros - startdate.micros;
+}
+
+template <>
+int64_t DateDiff::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_MSEC - startdate.micros / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DateDiff::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_SEC - startdate.micros / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DateDiff::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_MINUTE - startdate.micros / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DateDiff::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_HOUR - startdate.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <typename TA, typename TB, typename TR>
+static int64_t DifferenceDates(DatePartSpecifier type, TA startdate, TB enddate) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		return DateDiff::YearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MONTH:
+		return DateDiff::MonthOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateDiff::DayOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DECADE:
+		return DateDiff::DecadeOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::CENTURY:
+		return DateDiff::CenturyOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLENNIUM:
+		return DateDiff::MilleniumOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::QUARTER:
+		return DateDiff::QuarterOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateDiff::WeekOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::ISOYEAR:
+		return DateDiff::ISOYearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateDiff::MicrosecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateDiff::MillisecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateDiff::SecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MINUTE:
+		return DateDiff::MinutesOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::HOUR:
+		return DateDiff::HoursOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEDIFF");
+	}
+}
+
+struct DateDiffTernaryOperator {
+	template <typename TS, typename TA, typename TB, typename TR>
+	static inline TR Operation(TS part, TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+		if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+			return DifferenceDates<TA, TB, TR>(GetDatePartSpecifier(part.GetString()), startdate, enddate);
+		} else {
+			mask.SetInvalid(idx);
+			return TR();
+		}
+	}
+};
+
+template <typename TA, typename TB, typename TR>
+static void DateDiffBinaryExecutor(DatePartSpecifier type, Vector &left, Vector &right, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::YearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MonthOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::DayOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::DecadeOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::CenturyOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLENNIUM:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MilleniumOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::QuarterOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::WeekOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::ISOYEAR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::ISOYearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MicrosecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MillisecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::SecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MinutesOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::HoursOperator>(left, right, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEDIFF");
+	}
+}
+
+template <typename T>
+static void DateDiffFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	auto &part_arg = args.data[0];
+	auto &start_arg = args.data[1];
+	auto &end_arg = args.data[2];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateDiffBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+		}
+	} else {
+		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
+		    part_arg, start_arg, end_arg, result, args.size(),
+		    DateDiffTernaryOperator::Operation<string_t, T, T, int64_t>);
+	}
+}
+
+void DateDiffFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_diff("date_diff");
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE},
+	                                     LogicalType::BIGINT, DateDiffFunction<date_t>));
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP},
+	                                     LogicalType::BIGINT, DateDiffFunction<timestamp_t>));
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
+	                                     LogicalType::BIGINT, DateDiffFunction<dtime_t>));
+	set.AddFunction(date_diff);
+
+	date_diff.name = "datediff";
+	set.AddFunction(date_diff);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+bool TryGetDatePartSpecifier(const string &specifier_p, DatePartSpecifier &result) {
+	auto specifier = StringUtil::Lower(specifier_p);
+	if (specifier == "year" || specifier == "y" || specifier == "years") {
+		result = DatePartSpecifier::YEAR;
+	} else if (specifier == "month" || specifier == "mon" || specifier == "months" || specifier == "mons") {
+		result = DatePartSpecifier::MONTH;
+	} else if (specifier == "day" || specifier == "days" || specifier == "d" || specifier == "dayofmonth") {
+		result = DatePartSpecifier::DAY;
+	} else if (specifier == "decade" || specifier == "decades") {
+		result = DatePartSpecifier::DECADE;
+	} else if (specifier == "century" || specifier == "centuries") {
+		result = DatePartSpecifier::CENTURY;
+	} else if (specifier == "millennium" || specifier == "millennia" || specifier == "millenium") {
+		result = DatePartSpecifier::MILLENNIUM;
+	} else if (specifier == "microseconds" || specifier == "microsecond") {
+		result = DatePartSpecifier::MICROSECONDS;
+	} else if (specifier == "milliseconds" || specifier == "millisecond" || specifier == "ms" || specifier == "msec" ||
+	           specifier == "msecs") {
+		result = DatePartSpecifier::MILLISECONDS;
+	} else if (specifier == "second" || specifier == "seconds" || specifier == "s") {
+		result = DatePartSpecifier::SECOND;
+	} else if (specifier == "minute" || specifier == "minutes" || specifier == "m") {
+		result = DatePartSpecifier::MINUTE;
+	} else if (specifier == "hour" || specifier == "hours" || specifier == "h") {
+		result = DatePartSpecifier::HOUR;
+	} else if (specifier == "epoch") {
+		// seconds since 1970-01-01
+		result = DatePartSpecifier::EPOCH;
+	} else if (specifier == "dow" || specifier == "dayofweek" || specifier == "weekday") {
+		// day of the week (Sunday = 0, Saturday = 6)
+		result = DatePartSpecifier::DOW;
+	} else if (specifier == "isodow") {
+		// isodow (Monday = 1, Sunday = 7)
+		result = DatePartSpecifier::ISODOW;
+	} else if (specifier == "week" || specifier == "weeks" || specifier == "w" || specifier == "weekofyear") {
+		// ISO week number
+		result = DatePartSpecifier::WEEK;
+	} else if (specifier == "doy" || specifier == "dayofyear") {
+		// day of the year (1-365/366)
+		result = DatePartSpecifier::DOY;
+	} else if (specifier == "quarter" || specifier == "quarters") {
+		// quarter of the year (1-4)
+		result = DatePartSpecifier::QUARTER;
+	} else if (specifier == "yearweek") {
+		// Combined isoyear and isoweek YYYYWW
+		result = DatePartSpecifier::YEARWEEK;
+	} else if (specifier == "isoyear") {
+		// ISO year (first week of the year may be in previous year)
+		result = DatePartSpecifier::ISOYEAR;
+	} else if (specifier == "era") {
+		result = DatePartSpecifier::ERA;
+	} else if (specifier == "timezone") {
+		result = DatePartSpecifier::TIMEZONE;
+	} else if (specifier == "timezone_hour") {
+		result = DatePartSpecifier::TIMEZONE_HOUR;
+	} else if (specifier == "timezone_minute") {
+		result = DatePartSpecifier::TIMEZONE_MINUTE;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+DatePartSpecifier GetDatePartSpecifier(const string &specifier) {
+	DatePartSpecifier result;
+	if (!TryGetDatePartSpecifier(specifier, result)) {
+		throw ConversionException("extract specifier \"%s\" not recognized", specifier);
+	}
+	return result;
+}
+
+DatePartSpecifier GetDateTypePartSpecifier(const string &specifier, LogicalType &type) {
+	const auto part = GetDatePartSpecifier(specifier);
+	switch (type.id()) {
+	case LogicalType::TIMESTAMP:
+	case LogicalType::TIMESTAMP_TZ:
+		return part;
+	case LogicalType::DATE:
+		switch (part) {
+		case DatePartSpecifier::YEAR:
+		case DatePartSpecifier::MONTH:
+		case DatePartSpecifier::DAY:
+		case DatePartSpecifier::DECADE:
+		case DatePartSpecifier::CENTURY:
+		case DatePartSpecifier::MILLENNIUM:
+		case DatePartSpecifier::DOW:
+		case DatePartSpecifier::ISODOW:
+		case DatePartSpecifier::ISOYEAR:
+		case DatePartSpecifier::WEEK:
+		case DatePartSpecifier::QUARTER:
+		case DatePartSpecifier::DOY:
+		case DatePartSpecifier::YEARWEEK:
+		case DatePartSpecifier::ERA:
+			return part;
+		default:
+			break;
+		}
+		break;
+	case LogicalType::TIME:
+		switch (part) {
+		case DatePartSpecifier::MICROSECONDS:
+		case DatePartSpecifier::MILLISECONDS:
+		case DatePartSpecifier::SECOND:
+		case DatePartSpecifier::MINUTE:
+		case DatePartSpecifier::HOUR:
+		case DatePartSpecifier::EPOCH:
+		case DatePartSpecifier::TIMEZONE:
+		case DatePartSpecifier::TIMEZONE_HOUR:
+		case DatePartSpecifier::TIMEZONE_MINUTE:
+			return part;
+		default:
+			break;
+		}
+		break;
+	case LogicalType::INTERVAL:
+		switch (part) {
+		case DatePartSpecifier::YEAR:
+		case DatePartSpecifier::MONTH:
+		case DatePartSpecifier::DAY:
+		case DatePartSpecifier::DECADE:
+		case DatePartSpecifier::CENTURY:
+		case DatePartSpecifier::QUARTER:
+		case DatePartSpecifier::MILLENNIUM:
+		case DatePartSpecifier::MICROSECONDS:
+		case DatePartSpecifier::MILLISECONDS:
+		case DatePartSpecifier::SECOND:
+		case DatePartSpecifier::MINUTE:
+		case DatePartSpecifier::HOUR:
+		case DatePartSpecifier::EPOCH:
+			return part;
+		default:
+			break;
+		}
+		break;
+	default:
+		break;
+	}
+
+	throw NotImplementedException("\"%s\" units \"%s\" not recognized", LogicalTypeIdToString(type.id()), specifier);
+}
+
+template <int64_t MIN, int64_t MAX>
+static unique_ptr<BaseStatistics> PropagateSimpleDatePartStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+	// we can always propagate simple date part statistics
+	// since the min and max can never exceed these bounds
+	auto result = make_unique<NumericStatistics>(LogicalType::BIGINT, Value::BIGINT(MIN), Value::BIGINT(MAX),
+	                                             StatisticsType::LOCAL_STATS);
+	if (!child_stats[0]) {
+		// if there are no child stats, we don't know
+		result->validity_stats = make_unique<ValidityStatistics>(true);
+	} else if (child_stats[0]->validity_stats) {
+		result->validity_stats = child_stats[0]->validity_stats->Copy();
+	}
+	return move(result);
+}
+
+struct DatePart {
+	template <class T, class OP>
+	static unique_ptr<BaseStatistics> PropagateDatePartStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+		// we can only propagate complex date part stats if the child has stats
+		if (!child_stats[0]) {
+			return nullptr;
+		}
+		auto &nstats = (NumericStatistics &)*child_stats[0];
+		if (nstats.min.IsNull() || nstats.max.IsNull()) {
+			return nullptr;
+		}
+		// run the operator on both the min and the max, this gives us the [min, max] bound
+		auto min = nstats.min.GetValueUnsafe<T>();
+		auto max = nstats.max.GetValueUnsafe<T>();
+		if (min > max) {
+			return nullptr;
+		}
+		// Infinities prevent us from computing generic ranges
+		if (!Value::IsFinite(min) || !Value::IsFinite(max)) {
+			return nullptr;
+		}
+		auto min_part = OP::template Operation<T, int64_t>(min);
+		auto max_part = OP::template Operation<T, int64_t>(max);
+		auto result = make_unique<NumericStatistics>(LogicalType::BIGINT, Value::BIGINT(min_part),
+		                                             Value::BIGINT(max_part), StatisticsType::LOCAL_STATS);
+		if (child_stats[0]->validity_stats) {
+			result->validity_stats = child_stats[0]->validity_stats->Copy();
+		}
+		return move(result);
+	}
+
+	template <typename OP>
+	struct PartOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input, ValidityMask &mask, idx_t idx, void *dataptr) {
+			if (Value::IsFinite(input)) {
+				return OP::template Operation<TA, TR>(input);
+			} else {
+				mask.SetInvalid(idx);
+				return TR();
+			}
+		}
+	};
+
+	template <class TA, class TR, class OP>
+	static void UnaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+		D_ASSERT(input.ColumnCount() >= 1);
+		using IOP = PartOperator<OP>;
+		UnaryExecutor::GenericExecute<TA, TR, IOP>(input.data[0], result, input.size(), nullptr, true);
+	}
+
+	struct YearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractYear(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearOperator>(input.child_stats);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractMonth(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of month operator is [1, 12]
+			return PropagateSimpleDatePartStatistics<1, 12>(input.child_stats);
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractDay(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of day operator is [1, 31]
+			return PropagateSimpleDatePartStatistics<1, 31>(input.child_stats);
+		}
+	};
+
+	struct DecadeOperator {
+		// From the PG docs: "The year field divided by 10"
+		template <typename TR>
+		static inline TR DecadeFromYear(TR yyyy) {
+			return yyyy / 10;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return DecadeFromYear(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, DecadeOperator>(input.child_stats);
+		}
+	};
+
+	struct CenturyOperator {
+		// From the PG docs:
+		// "The first century starts at 0001-01-01 00:00:00 AD, although they did not know it at the time.
+		// This definition applies to all Gregorian calendar countries.
+		// There is no century number 0, you go from -1 century to 1 century.
+		// If you disagree with this, please write your complaint to: Pope, Cathedral Saint-Peter of Roma, Vatican."
+		// (To be fair, His Holiness had nothing to do with this -
+		// it was the lack of zero in the counting systems of the time...)
+		template <typename TR>
+		static inline TR CenturyFromYear(TR yyyy) {
+			if (yyyy > 0) {
+				return ((yyyy - 1) / 100) + 1;
+			} else {
+				return (yyyy / 100) - 1;
+			}
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return CenturyFromYear(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, CenturyOperator>(input.child_stats);
+		}
+	};
+
+	struct MillenniumOperator {
+		// See the century comment
+		template <typename TR>
+		static inline TR MillenniumFromYear(TR yyyy) {
+			if (yyyy > 0) {
+				return ((yyyy - 1) / 1000) + 1;
+			} else {
+				return (yyyy / 1000) - 1;
+			}
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return MillenniumFromYear<TR>(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, MillenniumOperator>(input.child_stats);
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TR>
+		static inline TR QuarterFromMonth(TR mm) {
+			return (mm - 1) / Interval::MONTHS_PER_QUARTER + 1;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return QuarterFromMonth(Date::ExtractMonth(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of quarter operator is [1, 4]
+			return PropagateSimpleDatePartStatistics<1, 4>(input.child_stats);
+		}
+	};
+
+	struct DayOfWeekOperator {
+		template <class TR>
+		static inline TR DayOfWeekFromISO(TR isodow) {
+			// day of the week (Sunday = 0, Saturday = 6)
+			// turn sunday into 0 by doing mod 7
+			return isodow % 7;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return DayOfWeekFromISO(Date::ExtractISODayOfTheWeek(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 6>(input.child_stats);
+		}
+	};
+
+	struct ISODayOfWeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			// isodow (Monday = 1, Sunday = 7)
+			return Date::ExtractISODayOfTheWeek(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 7>(input.child_stats);
+		}
+	};
+
+	struct DayOfYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractDayOfTheYear(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 366>(input.child_stats);
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractISOWeekNumber(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractISOYearNumber(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, ISOYearOperator>(input.child_stats);
+		}
+	};
+
+	struct YearWeekOperator {
+		template <class TR>
+		static inline TR YearWeekFromParts(TR yyyy, TR ww) {
+			return yyyy * 100 + ((yyyy > 0) ? ww : -ww);
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t yyyy, ww;
+			Date::ExtractISOYearWeek(input, yyyy, ww);
+			return YearWeekFromParts(yyyy, ww);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearWeekOperator>(input.child_stats);
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 24>(input.child_stats);
+		}
+	};
+
+	struct EpochOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::Epoch(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, EpochOperator>(input.child_stats);
+		}
+	};
+
+	struct EraOperator {
+		template <class TR>
+		static inline TR EraFromYear(TR yyyy) {
+			return yyyy > 0 ? 1 : 0;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return EraFromYear(Date::ExtractYear(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 1>(input.child_stats);
+		}
+	};
+
+	struct TimezoneOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			// Regular timestamps are UTC.
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 0>(input.child_stats);
+		}
+	};
+
+	// These are all zero and have the same restrictions
+	using TimezoneHourOperator = TimezoneOperator;
+	using TimezoneMinuteOperator = TimezoneOperator;
+
+	struct StructOperator {
+		using part_codes_t = vector<DatePartSpecifier>;
+		using part_mask_t = uint64_t;
+
+		enum MaskBits : uint8_t {
+			YMD = 1 << 0,
+			DOW = 1 << 1,
+			DOY = 1 << 2,
+			EPOCH = 1 << 3,
+			TIME = 1 << 4,
+			ZONE = 1 << 5,
+			ISO = 1 << 6
+		};
+
+		static part_mask_t GetMask(const part_codes_t &part_codes) {
+			part_mask_t mask = 0;
+			for (const auto &part_code : part_codes) {
+				switch (part_code) {
+				case DatePartSpecifier::YEAR:
+				case DatePartSpecifier::MONTH:
+				case DatePartSpecifier::DAY:
+				case DatePartSpecifier::DECADE:
+				case DatePartSpecifier::CENTURY:
+				case DatePartSpecifier::MILLENNIUM:
+				case DatePartSpecifier::QUARTER:
+				case DatePartSpecifier::ERA:
+					mask |= YMD;
+					break;
+				case DatePartSpecifier::YEARWEEK:
+				case DatePartSpecifier::WEEK:
+				case DatePartSpecifier::ISOYEAR:
+					mask |= ISO;
+					break;
+				case DatePartSpecifier::DOW:
+				case DatePartSpecifier::ISODOW:
+					mask |= DOW;
+					break;
+				case DatePartSpecifier::DOY:
+					mask |= DOY;
+					break;
+				case DatePartSpecifier::EPOCH:
+					mask |= EPOCH;
+					break;
+				case DatePartSpecifier::MICROSECONDS:
+				case DatePartSpecifier::MILLISECONDS:
+				case DatePartSpecifier::SECOND:
+				case DatePartSpecifier::MINUTE:
+				case DatePartSpecifier::HOUR:
+					mask |= TIME;
+					break;
+				case DatePartSpecifier::TIMEZONE:
+				case DatePartSpecifier::TIMEZONE_HOUR:
+				case DatePartSpecifier::TIMEZONE_MINUTE:
+					mask |= ZONE;
+					break;
+				}
+			}
+			return mask;
+		}
+
+		template <typename P>
+		static inline P HasPartValue(P *part_values, DatePartSpecifier part) {
+			return part_values[int(part)];
+		}
+
+		template <class TA, class TR>
+		static inline void Operation(TR **part_values, const TA &input, const idx_t idx, const part_mask_t mask) {
+			TR *part_data;
+			// YMD calculations
+			int32_t yyyy = 1970;
+			int32_t mm = 0;
+			int32_t dd = 1;
+			if (mask & YMD) {
+				Date::Convert(input, yyyy, mm, dd);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEAR))) {
+					part_data[idx] = yyyy;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::MONTH))) {
+					part_data[idx] = mm;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DAY))) {
+					part_data[idx] = dd;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DECADE))) {
+					part_data[idx] = DecadeOperator::DecadeFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::CENTURY))) {
+					part_data[idx] = CenturyOperator::CenturyFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLENNIUM))) {
+					part_data[idx] = MillenniumOperator::MillenniumFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::QUARTER))) {
+					part_data[idx] = QuarterOperator::QuarterFromMonth(mm);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ERA))) {
+					part_data[idx] = EraOperator::EraFromYear(yyyy);
+				}
+			}
+
+			// Week calculations
+			if (mask & DOW) {
+				auto isodow = Date::ExtractISODayOfTheWeek(input);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DOW))) {
+					part_data[idx] = DayOfWeekOperator::DayOfWeekFromISO(isodow);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ISODOW))) {
+					part_data[idx] = isodow;
+				}
+			}
+
+			// ISO calculations
+			if (mask & ISO) {
+				int32_t ww = 0;
+				int32_t iyyy = 0;
+				Date::ExtractISOYearWeek(input, iyyy, ww);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::WEEK))) {
+					part_data[idx] = ww;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ISOYEAR))) {
+					part_data[idx] = iyyy;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEARWEEK))) {
+					part_data[idx] = YearWeekOperator::YearWeekFromParts(iyyy, ww);
+				}
+			}
+
+			if (mask & EPOCH) {
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+					part_data[idx] = Date::Epoch(input);
+				}
+			}
+			if (mask & DOY) {
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DOY))) {
+					part_data[idx] = Date::ExtractDayOfTheYear(input);
+				}
+			}
+		}
+	};
+};
+
+template <class T>
+static void LastYearFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	int32_t last_year = 0;
+	UnaryExecutor::ExecuteWithNulls<T, int64_t>(args.data[0], result, args.size(),
+	                                            [&](T input, ValidityMask &mask, idx_t idx) {
+		                                            if (Value::IsFinite(input)) {
+			                                            return Date::ExtractYear(input, &last_year);
+		                                            } else {
+			                                            mask.SetInvalid(idx);
+			                                            return 0;
+		                                            }
+	                                            });
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_YEAR;
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(interval_t input) {
+	return input.months % Interval::MONTHS_PER_YEAR;
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(interval_t input) {
+	return input.days;
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DatePart::DecadeOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_DECADE;
+}
+
+template <>
+int64_t DatePart::DecadeOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DatePart::CenturyOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_CENTURY;
+}
+
+template <>
+int64_t DatePart::CenturyOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DatePart::MillenniumOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_MILLENIUM;
+}
+
+template <>
+int64_t DatePart::MillenniumOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(interval_t input) {
+	return MonthOperator::Operation<interval_t, int64_t>(input) / Interval::MONTHS_PER_QUARTER + 1;
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(timestamp_t input) {
+	return DayOfWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"dow\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"dow\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(timestamp_t input) {
+	return ISODayOfWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"isodow\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"isodow\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(timestamp_t input) {
+	return DayOfYearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"doy\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"doy\" not recognized");
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"week\" not recognized");
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(timestamp_t input) {
+	return YearWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(interval_t input) {
+	const auto yyyy = YearOperator::Operation<interval_t, int64_t>(input);
+	const auto ww = WeekOperator::Operation<interval_t, int64_t>(input);
+	return YearWeekOperator::YearWeekFromParts<int64_t>(yyyy, ww);
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"yearweek\" not recognized");
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(timestamp_t input) {
+	auto time = Timestamp::GetTime(input);
+	// remove everything but the second & microsecond part
+	return time.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(interval_t input) {
+	// remove everything but the second & microsecond part
+	return input.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(dtime_t input) {
+	// remove everything but the second & microsecond part
+	return input.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(timestamp_t input) {
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(interval_t input) {
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(dtime_t input) {
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(timestamp_t input) {
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(interval_t input) {
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(dtime_t input) {
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(timestamp_t input) {
+	auto time = Timestamp::GetTime(input);
+	// remove the hour part, and truncate to minutes
+	return (time.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(interval_t input) {
+	// remove the hour part, and truncate to minutes
+	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(dtime_t input) {
+	// remove the hour part, and truncate to minutes
+	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(timestamp_t input) {
+	return Timestamp::GetTime(input).micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(interval_t input) {
+	return input.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(dtime_t input) {
+	return input.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(timestamp_t input) {
+	return Timestamp::GetEpochSeconds(input);
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(interval_t input) {
+	int64_t interval_years = input.months / Interval::MONTHS_PER_YEAR;
+	int64_t interval_days;
+	interval_days = Interval::DAYS_PER_YEAR * interval_years;
+	interval_days += Interval::DAYS_PER_MONTH * (input.months % Interval::MONTHS_PER_YEAR);
+	interval_days += input.days;
+	int64_t interval_epoch;
+	interval_epoch = interval_days * Interval::SECS_PER_DAY;
+	// we add 0.25 days per year to sort of account for leap days
+	interval_epoch += interval_years * (Interval::SECS_PER_DAY / 4);
+	interval_epoch += input.micros / Interval::MICROS_PER_SEC;
+	return interval_epoch;
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(dtime_t input) {
+	return input.micros / Interval::MICROS_PER_SEC;
+}
+
+template <>
+unique_ptr<BaseStatistics> DatePart::EpochOperator::PropagateStatistics<dtime_t>(ClientContext &context,
+                                                                                 FunctionStatisticsInput &input) {
+	// time seconds range over a single day
+	return PropagateSimpleDatePartStatistics<0, 86400>(input.child_stats);
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(timestamp_t input) {
+	return EraOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"era\" not recognized");
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"era\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(date_t input) {
+	throw NotImplementedException("\"date\" units \"timezone\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(interval_t input) {
+	throw NotImplementedException("\"interval\" units \"timezone\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(dtime_t input) {
+	return 0;
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const dtime_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	int64_t *part_data;
+	if (mask & TIME) {
+		const auto micros = MicrosecondsOperator::Operation<dtime_t, int64_t>(input);
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MICROSECONDS))) {
+			part_data[idx] = micros;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLISECONDS))) {
+			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::SECOND))) {
+			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MINUTE))) {
+			part_data[idx] = MinutesOperator::Operation<dtime_t, int64_t>(input);
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::HOUR))) {
+			part_data[idx] = HoursOperator::Operation<dtime_t, int64_t>(input);
+		}
+	}
+
+	if (mask & EPOCH) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+			part_data[idx] = EpochOperator::Operation<dtime_t, int64_t>(input);
+			;
+		}
+	}
+
+	if (mask & ZONE) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE))) {
+			part_data[idx] = 0;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE_HOUR))) {
+			part_data[idx] = 0;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE_MINUTE))) {
+			part_data[idx] = 0;
+		}
+	}
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const timestamp_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	date_t d;
+	dtime_t t;
+	Timestamp::Convert(input, d, t);
+
+	// Both define epoch, and the correct value is the sum.
+	// So mask it out and compute it separately.
+	Operation(part_values, d, idx, mask & ~EPOCH);
+	Operation(part_values, t, idx, mask & ~EPOCH);
+
+	if (mask & EPOCH) {
+		auto part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH);
+		if (part_data) {
+			part_data[idx] = EpochOperator::Operation<timestamp_t, int64_t>(input);
+		}
+	}
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const interval_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	int64_t *part_data;
+	if (mask & YMD) {
+		const auto mm = input.months % Interval::MONTHS_PER_YEAR;
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEAR))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_YEAR;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MONTH))) {
+			part_data[idx] = mm;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::DAY))) {
+			part_data[idx] = input.days;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::DECADE))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_DECADE;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::CENTURY))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_CENTURY;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLENNIUM))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_MILLENIUM;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::QUARTER))) {
+			part_data[idx] = mm / Interval::MONTHS_PER_QUARTER + 1;
+		}
+	}
+
+	if (mask & TIME) {
+		const auto micros = MicrosecondsOperator::Operation<interval_t, int64_t>(input);
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MICROSECONDS))) {
+			part_data[idx] = micros;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLISECONDS))) {
+			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::SECOND))) {
+			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MINUTE))) {
+			part_data[idx] = MinutesOperator::Operation<interval_t, int64_t>(input);
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::HOUR))) {
+			part_data[idx] = HoursOperator::Operation<interval_t, int64_t>(input);
+		}
+	}
+
+	if (mask & EPOCH) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+			part_data[idx] = EpochOperator::Operation<interval_t, int64_t>(input);
+		}
+	}
+}
+
+template <typename T>
+static int64_t ExtractElement(DatePartSpecifier type, T element) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		return DatePart::YearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MONTH:
+		return DatePart::MonthOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DAY:
+		return DatePart::DayOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DECADE:
+		return DatePart::DecadeOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::CENTURY:
+		return DatePart::CenturyOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MILLENNIUM:
+		return DatePart::MillenniumOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::QUARTER:
+		return DatePart::QuarterOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DOW:
+		return DatePart::DayOfWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ISODOW:
+		return DatePart::ISODayOfWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DOY:
+		return DatePart::DayOfYearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::WEEK:
+		return DatePart::WeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ISOYEAR:
+		return DatePart::ISOYearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::YEARWEEK:
+		return DatePart::YearWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::EPOCH:
+		return DatePart::EpochOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MICROSECONDS:
+		return DatePart::MicrosecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MILLISECONDS:
+		return DatePart::MillisecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::SECOND:
+		return DatePart::SecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MINUTE:
+		return DatePart::MinutesOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::HOUR:
+		return DatePart::HoursOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ERA:
+		return DatePart::EraOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::TIMEZONE:
+	case DatePartSpecifier::TIMEZONE_HOUR:
+	case DatePartSpecifier::TIMEZONE_MINUTE:
+		return DatePart::TimezoneOperator::template Operation<T, int64_t>(element);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEPART");
+	}
+}
+
+template <typename T>
+static void DatePartFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &spec_arg = args.data[0];
+	auto &date_arg = args.data[1];
+
+	BinaryExecutor::ExecuteWithNulls<string_t, T, int64_t>(
+	    spec_arg, date_arg, result, args.size(), [&](string_t specifier, T date, ValidityMask &mask, idx_t idx) {
+		    if (Value::IsFinite(date)) {
+			    return ExtractElement<T>(GetDatePartSpecifier(specifier.GetString()), date);
+		    } else {
+			    mask.SetInvalid(idx);
+			    return int64_t(0);
+		    }
+	    });
+}
+
+void AddGenericDatePartOperator(BuiltinFunctions &set, const string &name, scalar_function_t date_func,
+                                scalar_function_t ts_func, scalar_function_t interval_func,
+                                function_statistics_t date_stats, function_statistics_t ts_stats) {
+	ScalarFunctionSet operator_set(name);
+	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BIGINT, move(date_func), false, false,
+	                                        nullptr, nullptr, date_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, move(ts_func), false, false,
+	                                        nullptr, nullptr, ts_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, move(interval_func)));
+	set.AddFunction(operator_set);
+}
+
+template <class OP>
+static void AddDatePartOperator(BuiltinFunctions &set, string name) {
+	AddGenericDatePartOperator(set, name, DatePart::UnaryFunction<date_t, int64_t, OP>,
+	                           DatePart::UnaryFunction<timestamp_t, int64_t, OP>,
+	                           ScalarFunction::UnaryFunction<interval_t, int64_t, OP>,
+	                           OP::template PropagateStatistics<date_t>, OP::template PropagateStatistics<timestamp_t>);
+}
+
+void AddGenericTimePartOperator(BuiltinFunctions &set, const string &name, scalar_function_t date_func,
+                                scalar_function_t ts_func, scalar_function_t interval_func, scalar_function_t time_func,
+                                function_statistics_t date_stats, function_statistics_t ts_stats,
+                                function_statistics_t time_stats) {
+	ScalarFunctionSet operator_set(name);
+	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BIGINT, move(date_func), false, false,
+	                                        nullptr, nullptr, date_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, move(ts_func), false, false,
+	                                        nullptr, nullptr, ts_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, move(interval_func)));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIME}, LogicalType::BIGINT, move(time_func), false, false,
+	                                        nullptr, nullptr, time_stats));
+	set.AddFunction(operator_set);
+}
+
+template <class OP>
+static void AddTimePartOperator(BuiltinFunctions &set, string name) {
+	AddGenericTimePartOperator(
+	    set, name, DatePart::UnaryFunction<date_t, int64_t, OP>, DatePart::UnaryFunction<timestamp_t, int64_t, OP>,
+	    ScalarFunction::UnaryFunction<interval_t, int64_t, OP>, ScalarFunction::UnaryFunction<dtime_t, int64_t, OP>,
+	    OP::template PropagateStatistics<date_t>, OP::template PropagateStatistics<timestamp_t>,
+	    OP::template PropagateStatistics<dtime_t>);
+}
+
+struct LastDayOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		int32_t yyyy, mm, dd;
+		Date::Convert(input, yyyy, mm, dd);
+		yyyy += (mm / 12);
+		mm %= 12;
+		++mm;
+		return Date::FromDate(yyyy, mm, 1) - 1;
+	}
+};
+
+template <>
+date_t LastDayOperator::Operation(timestamp_t input) {
+	return LastDayOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+struct MonthNameOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Date::MONTH_NAMES[DatePart::MonthOperator::Operation<TA, int64_t>(input) - 1];
+	}
+};
+
+struct DayNameOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Date::DAY_NAMES[DatePart::DayOfWeekOperator::Operation<TA, int64_t>(input)];
+	}
+};
+
+struct StructDatePart {
+	using part_codes_t = vector<DatePartSpecifier>;
+
+	struct BindData : public VariableReturnBindData {
+		part_codes_t part_codes;
+
+		explicit BindData(const LogicalType &stype, const part_codes_t &part_codes_p)
+		    : VariableReturnBindData(stype), part_codes(part_codes_p) {
+		}
+
+		unique_ptr<FunctionData> Copy() const override {
+			return make_unique<BindData>(stype, part_codes);
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		// collect names and deconflict, construct return type
+		if (!arguments[0]->IsFoldable()) {
+			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+		}
+
+		case_insensitive_set_t name_collision_set;
+		child_list_t<LogicalType> struct_children;
+		part_codes_t part_codes;
+
+		Value parts_list = ExpressionExecutor::EvaluateScalar(*arguments[0]);
+		if (parts_list.type().id() == LogicalTypeId::LIST) {
+			auto &list_children = ListValue::GetChildren(parts_list);
+			if (list_children.empty()) {
+				throw BinderException("%s requires non-empty lists of part names", bound_function.name);
+			}
+			for (const auto &part_value : list_children) {
+				if (part_value.IsNull()) {
+					throw BinderException("NULL struct entry name in %s", bound_function.name);
+				}
+				const auto part_name = part_value.ToString();
+				const auto part_code = GetDateTypePartSpecifier(part_name, arguments[1]->return_type);
+				if (name_collision_set.find(part_name) != name_collision_set.end()) {
+					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name, bound_function.name);
+				}
+				name_collision_set.insert(part_name);
+				part_codes.emplace_back(part_code);
+				struct_children.emplace_back(make_pair(part_name, LogicalType::BIGINT));
+			}
+		} else {
+			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+		}
+
+		arguments.erase(arguments.begin());
+		bound_function.arguments.erase(bound_function.arguments.begin());
+		bound_function.return_type = LogicalType::STRUCT(move(struct_children));
+		return make_unique<BindData>(bound_function.return_type, part_codes);
+	}
+
+	template <typename INPUT_TYPE>
+	static void Function(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		auto &info = (BindData &)*func_expr.bind_info;
+		D_ASSERT(args.ColumnCount() == 1);
+
+		const auto count = args.size();
+		Vector &input = args.data[0];
+		vector<int64_t *> part_values(int(DatePartSpecifier::TIMEZONE_MINUTE) + 1, nullptr);
+		const auto part_mask = DatePart::StructOperator::GetMask(info.part_codes);
+
+		auto &child_entries = StructVector::GetEntries(result);
+
+		// The first computer of a part "owns" it
+		// and other requestors just reference the owner
+		vector<size_t> owners(int(DatePartSpecifier::TIMEZONE_MINUTE) + 1, child_entries.size());
+		for (size_t col = 0; col < child_entries.size(); ++col) {
+			const auto part_index = size_t(info.part_codes[col]);
+			if (owners[part_index] == child_entries.size()) {
+				owners[part_index] = col;
+			}
+		}
+
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+			if (ConstantVector::IsNull(input)) {
+				ConstantVector::SetNull(result, true);
+			} else {
+				ConstantVector::SetNull(result, false);
+				for (size_t col = 0; col < child_entries.size(); ++col) {
+					auto &child_entry = child_entries[col];
+					ConstantVector::SetNull(*child_entry, false);
+					const auto part_index = size_t(info.part_codes[col]);
+					if (owners[part_index] == col) {
+						part_values[part_index] = ConstantVector::GetData<int64_t>(*child_entry);
+					}
+				}
+				auto tdata = ConstantVector::GetData<INPUT_TYPE>(input);
+				if (Value::IsFinite(tdata[0])) {
+					DatePart::StructOperator::Operation(part_values.data(), tdata[0], 0, part_mask);
+				} else {
+					for (auto &child_entry : child_entries) {
+						ConstantVector::SetNull(*child_entry, true);
+					}
+				}
+			}
+		} else {
+			VectorData rdata;
+			input.Orrify(count, rdata);
+
+			const auto &arg_valid = rdata.validity;
+			auto tdata = (const INPUT_TYPE *)rdata.data;
+
+			// Start with a valid flat vector
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			auto &res_valid = FlatVector::Validity(result);
+			if (res_valid.GetData()) {
+				res_valid.SetAllValid(count);
+			}
+
+			// Start with valid children
+			for (size_t col = 0; col < child_entries.size(); ++col) {
+				auto &child_entry = child_entries[col];
+				child_entry->SetVectorType(VectorType::FLAT_VECTOR);
+				auto &child_validity = FlatVector::Validity(*child_entry);
+				if (child_validity.GetData()) {
+					child_validity.SetAllValid(count);
+				}
+
+				// Pre-multiplex
+				const auto part_index = size_t(info.part_codes[col]);
+				if (owners[part_index] == col) {
+					part_values[part_index] = FlatVector::GetData<int64_t>(*child_entry);
+				}
+			}
+
+			for (idx_t i = 0; i < count; ++i) {
+				const auto idx = rdata.sel->get_index(i);
+				if (arg_valid.RowIsValid(idx)) {
+					if (Value::IsFinite(tdata[idx])) {
+						DatePart::StructOperator::Operation(part_values.data(), tdata[idx], idx, part_mask);
+					} else {
+						for (auto &child_entry : child_entries) {
+							FlatVector::Validity(*child_entry).SetInvalid(idx);
+						}
+					}
+				} else {
+					res_valid.SetInvalid(idx);
+					for (auto &child_entry : child_entries) {
+						FlatVector::Validity(*child_entry).SetInvalid(idx);
+					}
+				}
+			}
+		}
+
+		// Reference any duplicate parts
+		for (size_t col = 0; col < child_entries.size(); ++col) {
+			const auto part_index = size_t(info.part_codes[col]);
+			const auto owner = owners[part_index];
+			if (owner != col) {
+				child_entries[col]->Reference(*child_entries[owner]);
+			}
+		}
+
+		result.Verify(count);
+	}
+
+	template <typename INPUT_TYPE>
+	static ScalarFunction GetFunction(const LogicalType &temporal_type) {
+		auto part_type = LogicalType::LIST(LogicalType::VARCHAR);
+		auto result_type = LogicalType::STRUCT({});
+		return ScalarFunction({part_type, temporal_type}, result_type, Function<INPUT_TYPE>, false, false, Bind);
+	}
+};
+
+void DatePartFun::RegisterFunction(BuiltinFunctions &set) {
+	// register the individual operators
+	AddGenericDatePartOperator(set, "year", LastYearFunction<date_t>, LastYearFunction<timestamp_t>,
+	                           ScalarFunction::UnaryFunction<interval_t, int64_t, DatePart::YearOperator>,
+	                           DatePart::YearOperator::PropagateStatistics<date_t>,
+	                           DatePart::YearOperator::PropagateStatistics<timestamp_t>);
+	AddDatePartOperator<DatePart::MonthOperator>(set, "month");
+	AddDatePartOperator<DatePart::DayOperator>(set, "day");
+	AddDatePartOperator<DatePart::DecadeOperator>(set, "decade");
+	AddDatePartOperator<DatePart::CenturyOperator>(set, "century");
+	AddDatePartOperator<DatePart::MillenniumOperator>(set, "millennium");
+	AddDatePartOperator<DatePart::QuarterOperator>(set, "quarter");
+	AddDatePartOperator<DatePart::DayOfWeekOperator>(set, "dayofweek");
+	AddDatePartOperator<DatePart::ISODayOfWeekOperator>(set, "isodow");
+	AddDatePartOperator<DatePart::DayOfYearOperator>(set, "dayofyear");
+	AddDatePartOperator<DatePart::WeekOperator>(set, "week");
+	AddDatePartOperator<DatePart::ISOYearOperator>(set, "isoyear");
+	AddDatePartOperator<DatePart::EraOperator>(set, "era");
+	AddDatePartOperator<DatePart::TimezoneOperator>(set, "timezone");
+	AddDatePartOperator<DatePart::TimezoneHourOperator>(set, "timezone_hour");
+	AddDatePartOperator<DatePart::TimezoneMinuteOperator>(set, "timezone_minute");
+	AddTimePartOperator<DatePart::EpochOperator>(set, "epoch");
+	AddTimePartOperator<DatePart::MicrosecondsOperator>(set, "microsecond");
+	AddTimePartOperator<DatePart::MillisecondsOperator>(set, "millisecond");
+	AddTimePartOperator<DatePart::SecondsOperator>(set, "second");
+	AddTimePartOperator<DatePart::MinutesOperator>(set, "minute");
+	AddTimePartOperator<DatePart::HoursOperator>(set, "hour");
+
+	//  register combinations
+	AddDatePartOperator<DatePart::YearWeekOperator>(set, "yearweek");
+
+	//  register various aliases
+	AddDatePartOperator<DatePart::DayOperator>(set, "dayofmonth");
+	AddDatePartOperator<DatePart::DayOfWeekOperator>(set, "weekday");
+	AddDatePartOperator<DatePart::WeekOperator>(set, "weekofyear"); //  Note that WeekOperator is ISO-8601, not US
+
+	//  register the last_day function
+	ScalarFunctionSet last_day("last_day");
+	last_day.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::DATE,
+	                                    DatePart::UnaryFunction<date_t, date_t, LastDayOperator>));
+	last_day.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::DATE,
+	                                    DatePart::UnaryFunction<timestamp_t, date_t, LastDayOperator>));
+	set.AddFunction(last_day);
+
+	//  register the monthname function
+	ScalarFunctionSet monthname("monthname");
+	monthname.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::VARCHAR,
+	                                     DatePart::UnaryFunction<date_t, string_t, MonthNameOperator>));
+	monthname.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                     DatePart::UnaryFunction<timestamp_t, string_t, MonthNameOperator>));
+	set.AddFunction(monthname);
+
+	//  register the dayname function
+	ScalarFunctionSet dayname("dayname");
+	dayname.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::VARCHAR,
+	                                   DatePart::UnaryFunction<date_t, string_t, DayNameOperator>));
+	dayname.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                   DatePart::UnaryFunction<timestamp_t, string_t, DayNameOperator>));
+	set.AddFunction(dayname);
+
+	// finally the actual date_part function
+	ScalarFunctionSet date_part("date_part");
+	date_part.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::BIGINT, DatePartFunction<date_t>));
+	date_part.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::BIGINT,
+	                                     DatePartFunction<timestamp_t>));
+	date_part.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME}, LogicalType::BIGINT, DatePartFunction<dtime_t>));
+	date_part.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTERVAL}, LogicalType::BIGINT,
+	                                     DatePartFunction<interval_t>));
+
+	// struct variants
+	date_part.AddFunction(StructDatePart::GetFunction<date_t>(LogicalType::DATE));
+	date_part.AddFunction(StructDatePart::GetFunction<timestamp_t>(LogicalType::TIMESTAMP));
+	date_part.AddFunction(StructDatePart::GetFunction<dtime_t>(LogicalType::TIME));
+	date_part.AddFunction(StructDatePart::GetFunction<interval_t>(LogicalType::INTERVAL));
+
+	set.AddFunction(date_part);
+	date_part.name = "datepart";
+	set.AddFunction(date_part);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DateSub {
+	template <class TA, class TB, class TR, class OP>
+	static inline void BinaryExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::ExecuteWithNulls<TA, TB, TR>(
+		    left, right, result, count, [&](TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+			    if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+				    return OP::template Operation<TA, TB, TR>(startdate, enddate);
+			    } else {
+				    mask.SetInvalid(idx);
+				    return TR();
+			    }
+		    });
+	}
+
+	struct MonthOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+
+			if (start_ts > end_ts) {
+				return -MonthOperator::Operation<TA, TB, TR>(end_ts, start_ts);
+			}
+			// The number of complete months depends on whether end_ts is on the last day of the month.
+			date_t end_date;
+			dtime_t end_time;
+			Timestamp::Convert(end_ts, end_date, end_time);
+
+			int32_t yyyy, mm, dd;
+			Date::Convert(end_date, yyyy, mm, dd);
+			const auto end_days = Date::MonthDays(yyyy, mm);
+			if (end_days == dd) {
+				// Now check whether the start day is after the end day
+				date_t start_date;
+				dtime_t start_time;
+				Timestamp::Convert(start_ts, start_date, start_time);
+				Date::Convert(start_date, yyyy, mm, dd);
+				if (dd > end_days || (dd == end_days && start_time < end_time)) {
+					// Move back to the same time on the last day of the (shorter) end month
+					start_date = Date::FromDate(yyyy, mm, end_days);
+					start_ts = Timestamp::FromDatetime(start_date, start_time);
+				}
+			}
+
+			// Our interval difference will now give the correct result.
+			// Note that PG gives different interval subtraction results,
+			// so if we change this we will have to reimplement.
+			return Interval::GetAge(end_ts, start_ts).months;
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_QUARTER;
+		}
+	};
+
+	struct YearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_YEAR;
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_DECADE;
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_CENTURY;
+		}
+	};
+
+	struct MilleniumOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_MILLENIUM;
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_DAY;
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_WEEK;
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate));
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_MSEC;
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_SEC;
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_MINUTE;
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_HOUR;
+		}
+	};
+};
+
+// DATE specialisations
+template <>
+int64_t DateSub::YearOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return YearOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                  Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MonthOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MonthOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                   Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::DayOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return DayOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                 Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::DecadeOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return DecadeOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                    Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::CenturyOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return CenturyOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MilleniumOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MilleniumOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                       Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::QuarterOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return QuarterOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::WeekOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return WeekOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                  Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MicrosecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MicrosecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                          Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MillisecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MillisecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                          Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::SecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return SecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MinutesOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MinutesOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::HoursOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return HoursOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                   Timestamp::FromDatetime(enddate, t0));
+}
+
+// TIME specialisations
+template <>
+int64_t DateSub::YearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DateSub::MonthOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DateSub::DayOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DateSub::DecadeOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DateSub::CenturyOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DateSub::MilleniumOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DateSub::QuarterOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DateSub::WeekOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DateSub::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros - startdate.micros;
+}
+
+template <>
+int64_t DateSub::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DateSub::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DateSub::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DateSub::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_HOUR;
+}
+
+template <typename TA, typename TB, typename TR>
+static int64_t SubtractDateParts(DatePartSpecifier type, TA startdate, TB enddate) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::ISOYEAR:
+		return DateSub::YearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MONTH:
+		return DateSub::MonthOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateSub::DayOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DECADE:
+		return DateSub::DecadeOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::CENTURY:
+		return DateSub::CenturyOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLENNIUM:
+		return DateSub::MilleniumOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::QUARTER:
+		return DateSub::QuarterOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateSub::WeekOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateSub::MicrosecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateSub::MillisecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateSub::SecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MINUTE:
+		return DateSub::MinutesOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::HOUR:
+		return DateSub::HoursOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATESUB");
+	}
+}
+
+struct DateSubTernaryOperator {
+	template <typename TS, typename TA, typename TB, typename TR>
+	static inline TR Operation(TS part, TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+		if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+			return SubtractDateParts<TA, TB, TR>(GetDatePartSpecifier(part.GetString()), startdate, enddate);
+		} else {
+			mask.SetInvalid(idx);
+			return TR();
+		}
+	}
+};
+
+template <typename TA, typename TB, typename TR>
+static void DateSubBinaryExecutor(DatePartSpecifier type, Vector &left, Vector &right, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::ISOYEAR:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::YearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MonthOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::DayOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::DecadeOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::CenturyOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLENNIUM:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MilleniumOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::QuarterOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::WeekOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MicrosecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MillisecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::SecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MinutesOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::HoursOperator>(left, right, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATESUB");
+	}
+}
+
+template <typename T>
+static void DateSubFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	auto &part_arg = args.data[0];
+	auto &start_arg = args.data[1];
+	auto &end_arg = args.data[2];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateSubBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+		}
+	} else {
+		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
+		    part_arg, start_arg, end_arg, result, args.size(),
+		    DateSubTernaryOperator::Operation<string_t, T, T, int64_t>);
+	}
+}
+
+void DateSubFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_sub("date_sub");
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE},
+	                                    LogicalType::BIGINT, DateSubFunction<date_t>));
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP},
+	                                    LogicalType::BIGINT, DateSubFunction<timestamp_t>));
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
+	                                    LogicalType::BIGINT, DateSubFunction<dtime_t>));
+	set.AddFunction(date_sub);
+
+	date_sub.name = "datesub";
+	set.AddFunction(date_sub);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DateTrunc {
+	template <class TA, class TR, class OP>
+	static inline TR UnaryFunction(TA input) {
+		if (Value::IsFinite(input)) {
+			return OP::template Operation<TA, TR>(input);
+		} else {
+			return Cast::template Operation<TA, TR>(input);
+		}
+	}
+
+	template <class TA, class TR, class OP>
+	static inline void UnaryExecute(Vector &left, Vector &result, idx_t count) {
+		UnaryExecutor::Execute<TA, TR>(left, result, count, UnaryFunction<TA, TR, OP>);
+	}
+
+	struct MillenniumOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 1000) * 1000, 1, 1);
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 100) * 100, 1, 1);
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 10) * 10, 1, 1);
+		}
+	};
+
+	struct YearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate(Date::ExtractYear(input), 1, 1);
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t yyyy, mm, dd;
+			Date::Convert(input, yyyy, mm, dd);
+			mm = 1 + (((mm - 1) / 3) * 3);
+			return Date::FromDate(yyyy, mm, 1);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate(Date::ExtractYear(input), Date::ExtractMonth(input), 1);
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::GetMondayOfCurrentWeek(input);
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			date_t date = Date::GetMondayOfCurrentWeek(input);
+			date.days -= (Date::ExtractISOWeekNumber(date) - 1) * Interval::DAYS_PER_WEEK;
+
+			return date;
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return input;
+		}
+	};
+
+	struct HourOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, 0, 0, 0));
+		}
+	};
+
+	struct MinuteOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, 0, 0));
+		}
+	};
+
+	struct SecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, 0));
+		}
+	};
+
+	struct MillisecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			micros -= micros % Interval::MICROS_PER_MSEC;
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, micros));
+		}
+	};
+
+	struct MicrosecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return input;
+		}
+	};
+};
+
+// DATE specialisations
+template <>
+date_t DateTrunc::MillenniumOperator::Operation(timestamp_t input) {
+	return MillenniumOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::MillenniumOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(MillenniumOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::MillenniumOperator::Operation(timestamp_t input) {
+	return MillenniumOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::CenturyOperator::Operation(timestamp_t input) {
+	return CenturyOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::CenturyOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(CenturyOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::CenturyOperator::Operation(timestamp_t input) {
+	return CenturyOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::DecadeOperator::Operation(timestamp_t input) {
+	return DecadeOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::DecadeOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(DecadeOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::DecadeOperator::Operation(timestamp_t input) {
+	return DecadeOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::YearOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(YearOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::QuarterOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(QuarterOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::MonthOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(MonthOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::WeekOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(WeekOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::ISOYearOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(ISOYearOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::DayOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(DayOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::HourOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::HourOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::HourOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(HourOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MinuteOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MinuteOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MinuteOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(HourOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::SecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::SecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::SecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(DayOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MillisecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MillisecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MillisecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(MillisecondOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MicrosecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MicrosecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MicrosecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(MicrosecondOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+// INTERVAL specialisations
+template <>
+interval_t DateTrunc::MillenniumOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_MILLENIUM) * Interval::MONTHS_PER_MILLENIUM;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::CenturyOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_CENTURY) * Interval::MONTHS_PER_CENTURY;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::DecadeOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_DECADE) * Interval::MONTHS_PER_DECADE;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::YearOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_YEAR) * Interval::MONTHS_PER_YEAR;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::QuarterOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_QUARTER) * Interval::MONTHS_PER_QUARTER;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MonthOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::WeekOperator::Operation(interval_t input) {
+	input.micros = 0;
+	input.days = (input.days / Interval::DAYS_PER_WEEK) * Interval::DAYS_PER_WEEK;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::ISOYearOperator::Operation(interval_t input) {
+	return YearOperator::Operation<interval_t, interval_t>(input);
+}
+
+template <>
+interval_t DateTrunc::DayOperator::Operation(interval_t input) {
+	input.micros = 0;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::HourOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_HOUR) * Interval::MICROS_PER_HOUR;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MinuteOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_MINUTE) * Interval::MICROS_PER_MINUTE;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::SecondOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_SEC) * Interval::MICROS_PER_SEC;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MillisecondOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_MSEC) * Interval::MICROS_PER_MSEC;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MicrosecondOperator::Operation(interval_t input) {
+	return input;
+}
+
+template <class TA, class TR>
+static TR TruncateElement(DatePartSpecifier type, TA element) {
+	if (!Value::IsFinite(element)) {
+		return Cast::template Operation<TA, TR>(element);
+	}
+
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		return DateTrunc::MillenniumOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::CENTURY:
+		return DateTrunc::CenturyOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::DECADE:
+		return DateTrunc::DecadeOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::YEAR:
+		return DateTrunc::YearOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::QUARTER:
+		return DateTrunc::QuarterOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MONTH:
+		return DateTrunc::MonthOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateTrunc::WeekOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::ISOYEAR:
+		return DateTrunc::ISOYearOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateTrunc::DayOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::HOUR:
+		return DateTrunc::HourOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MINUTE:
+		return DateTrunc::MinuteOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateTrunc::SecondOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateTrunc::MillisecondOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateTrunc::MicrosecondOperator::Operation<TA, TR>(element);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC");
+	}
+}
+
+struct DateTruncBinaryOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA specifier, TB date) {
+		return TruncateElement<TB, TR>(GetDatePartSpecifier(specifier.GetString()), date);
+	}
+};
+
+template <typename TA, typename TR>
+static void DateTruncUnaryExecutor(DatePartSpecifier type, Vector &left, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MillenniumOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::CenturyOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::DecadeOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::YEAR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::YearOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::QuarterOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MonthOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::WeekOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::ISOYEAR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::ISOYearOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::DayOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::HourOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MinuteOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::SecondOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MillisecondOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MicrosecondOperator>(left, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC");
+	}
+}
+
+template <typename TA, typename TR>
+static void DateTruncFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &part_arg = args.data[0];
+	auto &date_arg = args.data[1];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateTruncUnaryExecutor<TA, TR>(type, date_arg, result, args.size());
+		}
+	} else {
+		BinaryExecutor::ExecuteStandard<string_t, TA, TR, DateTruncBinaryOperator>(part_arg, date_arg, result,
+		                                                                           args.size());
+	}
+}
+
+template <class TA, class TR, class OP>
+static unique_ptr<BaseStatistics> DateTruncStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+	// we can only propagate date stats if the child has stats
+	if (!child_stats[1]) {
+		return nullptr;
+	}
+	auto &nstats = (NumericStatistics &)*child_stats[1];
+	if (nstats.min.IsNull() || nstats.max.IsNull()) {
+		return nullptr;
+	}
+	// run the operator on both the min and the max, this gives us the [min, max] bound
+	auto min = nstats.min.GetValueUnsafe<TA>();
+	auto max = nstats.max.GetValueUnsafe<TA>();
+	if (min > max) {
+		throw InternalException("Invalid DATETRUNC child statistics");
+	}
+
+	// Infinite values are unmodified
+	auto min_part = DateTrunc::UnaryFunction<TA, TR, OP>(min);
+	auto max_part = DateTrunc::UnaryFunction<TA, TR, OP>(max);
+
+	auto min_value = Value::CreateValue(min_part);
+	auto max_value = Value::CreateValue(max_part);
+	auto result = make_unique<NumericStatistics>(min_value.type(), min_value, max_value, StatisticsType::LOCAL_STATS);
+	if (child_stats[0]->validity_stats) {
+		result->validity_stats = child_stats[1]->validity_stats->Copy();
+	}
+	return move(result);
+}
+
+template <class TA, class TR, class OP>
+static unique_ptr<BaseStatistics> PropagateDateTruncStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+	return DateTruncStatistics<TA, TR, OP>(input.child_stats);
+}
+
+template <typename TA, typename TR>
+static function_statistics_t DateTruncStats(DatePartSpecifier type) {
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MillenniumOperator>;
+	case DatePartSpecifier::CENTURY:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::CenturyOperator>;
+	case DatePartSpecifier::DECADE:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::DecadeOperator>;
+	case DatePartSpecifier::YEAR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::YearOperator>;
+	case DatePartSpecifier::QUARTER:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::QuarterOperator>;
+	case DatePartSpecifier::MONTH:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MonthOperator>;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::WeekOperator>;
+	case DatePartSpecifier::ISOYEAR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::ISOYearOperator>;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::DayOperator>;
+	case DatePartSpecifier::HOUR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::HourOperator>;
+	case DatePartSpecifier::MINUTE:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MinuteOperator>;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::SecondOperator>;
+	case DatePartSpecifier::MILLISECONDS:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MillisecondOperator>;
+	case DatePartSpecifier::MICROSECONDS:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MicrosecondOperator>;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC statistics");
+	}
+}
+
+static unique_ptr<FunctionData> DateTruncBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[0]->IsFoldable()) {
+		return nullptr;
+	}
+
+	// Rebind to return a date if we are truncating that far
+	Value part_value = ExpressionExecutor::EvaluateScalar(*arguments[0]);
+	if (part_value.IsNull()) {
+		return nullptr;
+	}
+	const auto part_name = part_value.ToString();
+	const auto part_code = GetDatePartSpecifier(part_name);
+	switch (part_code) {
+	case DatePartSpecifier::MILLENNIUM:
+	case DatePartSpecifier::CENTURY:
+	case DatePartSpecifier::DECADE:
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::QUARTER:
+	case DatePartSpecifier::MONTH:
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+	case DatePartSpecifier::ISOYEAR:
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		switch (arguments[1]->return_type.id()) {
+		case LogicalType::TIMESTAMP:
+			bound_function.function = DateTruncFunction<timestamp_t, date_t>;
+			bound_function.statistics = DateTruncStats<timestamp_t, date_t>(part_code);
+			break;
+		case LogicalType::DATE:
+			bound_function.function = DateTruncFunction<date_t, date_t>;
+			bound_function.statistics = DateTruncStats<date_t, date_t>(part_code);
+			break;
+		default:
+			break;
+		}
+		bound_function.return_type = LogicalType::DATE;
+		break;
+	default:
+		switch (arguments[1]->return_type.id()) {
+		case LogicalType::TIMESTAMP:
+			bound_function.statistics = DateTruncStats<timestamp_t, timestamp_t>(part_code);
+			break;
+		case LogicalType::DATE:
+			bound_function.statistics = DateTruncStats<timestamp_t, date_t>(part_code);
+			break;
+		default:
+			break;
+		}
+		break;
+	}
+
+	return nullptr;
+}
+
+void DateTruncFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_trunc("date_trunc");
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::TIMESTAMP,
+	                                      DateTruncFunction<timestamp_t, timestamp_t>, false, false, DateTruncBind));
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::TIMESTAMP,
+	                                      DateTruncFunction<date_t, timestamp_t>, false, false, DateTruncBind));
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTERVAL}, LogicalType::INTERVAL,
+	                                      DateTruncFunction<interval_t, interval_t>));
+	set.AddFunction(date_trunc);
+	date_trunc.name = "datetrunc";
+	set.AddFunction(date_trunc);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct EpochSecOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		return Timestamp::FromEpochSeconds(input);
+	}
+};
+
+static void EpochSecFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	UnaryExecutor::Execute<int64_t, timestamp_t, EpochSecOperator>(input.data[0], result, input.size());
+}
+
+struct EpochMillisOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		return Timestamp::FromEpochMs(input);
+	}
+};
+
+static void EpochMillisFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	UnaryExecutor::Execute<int64_t, timestamp_t, EpochMillisOperator>(input.data[0], result, input.size());
+}
+
+void EpochFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet epoch("epoch_ms");
+	epoch.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, EpochMillisFunction));
+	set.AddFunction(epoch);
+	// to_timestamp is an alias from Postgres that converts the time in seconds to a timestamp
+	ScalarFunctionSet to_timestamp("to_timestamp");
+	to_timestamp.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, EpochSecFunction));
+	set.AddFunction(to_timestamp);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+struct MakeDateOperator {
+	template <typename YYYY, typename MM, typename DD, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(YYYY yyyy, MM mm, DD dd) {
+		return Date::FromDate(yyyy, mm, dd);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeDate(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 3);
+	auto &yyyy = input.data[0];
+	auto &mm = input.data[1];
+	auto &dd = input.data[2];
+
+	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(),
+	                                          MakeDateOperator::Operation<T, T, T, date_t>);
+}
+
+template <typename T>
+static void ExecuteStructMakeDate(DataChunk &input, ExpressionState &state, Vector &result) {
+	// this should be guaranteed by the binder
+	D_ASSERT(input.ColumnCount() == 1);
+	auto &vec = input.data[0];
+
+	auto &children = StructVector::GetEntries(vec);
+	D_ASSERT(children.size() == 3);
+	auto &yyyy = *children[0];
+	auto &mm = *children[1];
+	auto &dd = *children[2];
+
+	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(), Date::FromDate);
+}
+
+struct MakeTimeOperator {
+	template <typename HH, typename MM, typename SS, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(HH hh, MM mm, SS ss) {
+		int64_t secs = ss;
+		int64_t micros = std::round((ss - secs) * Interval::MICROS_PER_SEC);
+		return Time::FromTime(hh, mm, secs, micros);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeTime(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 3);
+	auto &yyyy = input.data[0];
+	auto &mm = input.data[1];
+	auto &dd = input.data[2];
+
+	TernaryExecutor::Execute<T, T, double, dtime_t>(yyyy, mm, dd, result, input.size(),
+	                                                MakeTimeOperator::Operation<T, T, double, dtime_t>);
+}
+
+struct MakeTimestampOperator {
+	template <typename YYYY, typename MM, typename DD, typename HR, typename MN, typename SS, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(YYYY yyyy, MM mm, DD dd, HR hr, MN mn, SS ss) {
+		const auto d = MakeDateOperator::Operation<YYYY, MM, DD, date_t>(yyyy, mm, dd);
+		const auto t = MakeTimeOperator::Operation<HR, MN, SS, dtime_t>(hr, mn, ss);
+		return Timestamp::FromDatetime(d, t);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeTimestamp(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 6);
+
+	auto func = MakeTimestampOperator::Operation<T, T, T, T, T, double, timestamp_t>;
+	SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(input, result, func);
+}
+
+void MakeDateFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet make_date("make_date");
+	make_date.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::DATE, ExecuteMakeDate<int64_t>));
+
+	child_list_t<LogicalType> make_date_children {
+	    {"year", LogicalType::BIGINT}, {"month", LogicalType::BIGINT}, {"day", LogicalType::BIGINT}};
+	make_date.AddFunction(
+	    ScalarFunction({LogicalType::STRUCT(make_date_children)}, LogicalType::DATE, ExecuteStructMakeDate<int64_t>));
+	set.AddFunction(make_date);
+
+	ScalarFunctionSet make_time("make_time");
+	make_time.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE},
+	                                     LogicalType::TIME, ExecuteMakeTime<int64_t>));
+	set.AddFunction(make_time);
+
+	ScalarFunctionSet make_timestamp("make_timestamp");
+	make_timestamp.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
+	                                           LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE},
+	                                          LogicalType::TIMESTAMP, ExecuteMakeTimestamp<int64_t>));
+	set.AddFunction(make_timestamp);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+
+namespace duckdb {
+
+idx_t StrfTimepecifierSize(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+	case StrTimeSpecifier::ABBREVIATED_MONTH_NAME:
+		return 3;
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return 1;
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+	case StrTimeSpecifier::HOUR_24_PADDED:
+	case StrTimeSpecifier::HOUR_12_PADDED:
+	case StrTimeSpecifier::MINUTE_PADDED:
+	case StrTimeSpecifier::SECOND_PADDED:
+	case StrTimeSpecifier::AM_PM:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		return 2;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		return 6;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+		return 3;
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+		return 3;
+	default:
+		return 0;
+	}
+}
+
+void StrTimeFormat::AddLiteral(string literal) {
+	constant_size += literal.size();
+	literals.push_back(move(literal));
+}
+
+void StrTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	AddLiteral(move(preceding_literal));
+	specifiers.push_back(specifier);
+}
+
+void StrfTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	is_date_specifier.push_back(IsDateSpecifier(specifier));
+	idx_t specifier_size = StrfTimepecifierSize(specifier);
+	if (specifier_size == 0) {
+		// variable length specifier
+		var_length_specifiers.push_back(specifier);
+	} else {
+		// constant size specifier
+		constant_size += specifier_size;
+	}
+	StrTimeFormat::AddFormatSpecifier(move(preceding_literal), specifier);
+}
+
+idx_t StrfTimeFormat::GetSpecifierLength(StrTimeSpecifier specifier, date_t date, dtime_t time, int32_t utc_offset,
+                                         const char *tz_name) {
+	switch (specifier) {
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+		return Date::DAY_NAMES[Date::ExtractISODayOfTheWeek(date) % 7].GetSize();
+	case StrTimeSpecifier::FULL_MONTH_NAME:
+		return Date::MONTH_NAMES[Date::ExtractMonth(date) - 1].GetSize();
+	case StrTimeSpecifier::YEAR_DECIMAL: {
+		auto year = Date::ExtractYear(date);
+		return NumericHelper::SignedLength<int32_t, uint32_t>(year);
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL: {
+		idx_t len = 1;
+		auto month = Date::ExtractMonth(date);
+		len += month >= 10;
+		return len;
+	}
+	case StrTimeSpecifier::UTC_OFFSET:
+		// ±HH or ±HH:MM
+		return (utc_offset % 60) ? 6 : 3;
+	case StrTimeSpecifier::TZ_NAME:
+		if (tz_name) {
+			return strlen(tz_name);
+		}
+		// empty for now
+		return 0;
+	case StrTimeSpecifier::HOUR_24_DECIMAL:
+	case StrTimeSpecifier::HOUR_12_DECIMAL:
+	case StrTimeSpecifier::MINUTE_DECIMAL:
+	case StrTimeSpecifier::SECOND_DECIMAL: {
+		// time specifiers
+		idx_t len = 1;
+		int32_t hour, min, sec, msec;
+		Time::Convert(time, hour, min, sec, msec);
+		switch (specifier) {
+		case StrTimeSpecifier::HOUR_24_DECIMAL:
+			len += hour >= 10;
+			break;
+		case StrTimeSpecifier::HOUR_12_DECIMAL:
+			hour = hour % 12;
+			if (hour == 0) {
+				hour = 12;
+			}
+			len += hour >= 10;
+			break;
+		case StrTimeSpecifier::MINUTE_DECIMAL:
+			len += min >= 10;
+			break;
+		case StrTimeSpecifier::SECOND_DECIMAL:
+			len += sec >= 10;
+			break;
+		default:
+			throw InternalException("Time specifier mismatch");
+		}
+		return len;
+	}
+	case StrTimeSpecifier::DAY_OF_MONTH:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractDay(date));
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractDayOfTheYear(date));
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractYear(date) % 100);
+	default:
+		throw InternalException("Unimplemented specifier for GetSpecifierLength");
+	}
+}
+
+//! Returns the total length of the date formatted by this format specifier
+idx_t StrfTimeFormat::GetLength(date_t date, dtime_t time, int32_t utc_offset, const char *tz_name) {
+	idx_t size = constant_size;
+	if (!var_length_specifiers.empty()) {
+		for (auto &specifier : var_length_specifiers) {
+			size += GetSpecifierLength(specifier, date, time, utc_offset, tz_name);
+		}
+	}
+	return size;
+}
+
+char *StrfTimeFormat::WriteString(char *target, const string_t &str) {
+	idx_t size = str.GetSize();
+	memcpy(target, str.GetDataUnsafe(), size);
+	return target + size;
+}
+
+// write a value in the range of 0..99 unpadded (e.g. "1", "2", ... "98", "99")
+char *StrfTimeFormat::Write2(char *target, uint8_t value) {
+	D_ASSERT(value < 100);
+	if (value >= 10) {
+		return WritePadded2(target, value);
+	} else {
+		*target = char(uint8_t('0') + value);
+		return target + 1;
+	}
+}
+
+// write a value in the range of 0..99 padded to 2 digits
+char *StrfTimeFormat::WritePadded2(char *target, uint32_t value) {
+	D_ASSERT(value < 100);
+	auto index = static_cast<unsigned>(value * 2);
+	*target++ = duckdb_fmt::internal::data::digits[index];
+	*target++ = duckdb_fmt::internal::data::digits[index + 1];
+	return target;
+}
+
+// write a value in the range of 0..999 padded
+char *StrfTimeFormat::WritePadded3(char *target, uint32_t value) {
+	D_ASSERT(value < 1000);
+	if (value >= 100) {
+		WritePadded2(target + 1, value % 100);
+		*target = char(uint8_t('0') + value / 100);
+		return target + 3;
+	} else {
+		*target = '0';
+		target++;
+		return WritePadded2(target, value);
+	}
+}
+
+// write a value in the range of 0..999999 padded to 6 digits
+char *StrfTimeFormat::WritePadded(char *target, uint32_t value, size_t padding) {
+	D_ASSERT(padding % 2 == 0);
+	for (size_t i = 0; i < padding / 2; i++) {
+		int decimals = value % 100;
+		WritePadded2(target + padding - 2 * (i + 1), decimals);
+		value /= 100;
+	}
+	return target + padding;
+}
+
+bool StrfTimeFormat::IsDateSpecifier(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return true;
+	default:
+		return false;
+	}
+}
+
+char *StrfTimeFormat::WriteDateSpecifier(StrTimeSpecifier specifier, date_t date, char *target) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		target = WriteString(target, Date::DAY_NAMES_ABBREVIATED[dow % 7]);
+		break;
+	}
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		target = WriteString(target, Date::DAY_NAMES[dow % 7]);
+		break;
+	}
+	case StrTimeSpecifier::WEEKDAY_DECIMAL: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		*target = char('0' + uint8_t(dow % 7));
+		target++;
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED: {
+		int32_t doy = Date::ExtractDayOfTheYear(date);
+		target = WritePadded3(target, doy);
+		break;
+	}
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		target = WritePadded2(target, Date::ExtractWeekNumberRegular(date, true));
+		break;
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+		target = WritePadded2(target, Date::ExtractWeekNumberRegular(date, false));
+		break;
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL: {
+		uint32_t doy = Date::ExtractDayOfTheYear(date);
+		target += NumericHelper::UnsignedLength<uint32_t>(doy);
+		NumericHelper::FormatUnsigned(doy, target);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented date specifier for strftime");
+	}
+	return target;
+}
+
+char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name,
+                                             char *target) {
+	// data contains [0] year, [1] month, [2] day, [3] hour, [4] minute, [5] second, [6] msec, [7] utc
+	switch (specifier) {
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+		target = WritePadded2(target, data[2]);
+		break;
+	case StrTimeSpecifier::ABBREVIATED_MONTH_NAME: {
+		auto &month_name = Date::MONTH_NAMES_ABBREVIATED[data[1] - 1];
+		return WriteString(target, month_name);
+	}
+	case StrTimeSpecifier::FULL_MONTH_NAME: {
+		auto &month_name = Date::MONTH_NAMES[data[1] - 1];
+		return WriteString(target, month_name);
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+		target = WritePadded2(target, data[1]);
+		break;
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+		target = WritePadded2(target, AbsValue(data[0]) % 100);
+		break;
+	case StrTimeSpecifier::YEAR_DECIMAL:
+		if (data[0] >= 0 && data[0] <= 9999) {
+			target = WritePadded(target, data[0], 4);
+		} else {
+			int32_t year = data[0];
+			if (data[0] < 0) {
+				*target = '-';
+				year = -year;
+				target++;
+			}
+			auto len = NumericHelper::UnsignedLength<uint32_t>(year);
+			NumericHelper::FormatUnsigned(year, target + len);
+			target += len;
+		}
+		break;
+	case StrTimeSpecifier::HOUR_24_PADDED: {
+		target = WritePadded2(target, data[3]);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_12_PADDED: {
+		int hour = data[3] % 12;
+		if (hour == 0) {
+			hour = 12;
+		}
+		target = WritePadded2(target, hour);
+		break;
+	}
+	case StrTimeSpecifier::AM_PM:
+		*target++ = data[3] >= 12 ? 'P' : 'A';
+		*target++ = 'M';
+		break;
+	case StrTimeSpecifier::MINUTE_PADDED: {
+		target = WritePadded2(target, data[4]);
+		break;
+	}
+	case StrTimeSpecifier::SECOND_PADDED:
+		target = WritePadded2(target, data[5]);
+		break;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		target = WritePadded(target, data[6], 6);
+		break;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+		target = WritePadded3(target, data[6] / 1000);
+		break;
+	case StrTimeSpecifier::UTC_OFFSET: {
+		*target++ = (data[7] < 0) ? '-' : '+';
+
+		auto offset = abs(data[7]);
+		auto offset_hours = offset / Interval::MINS_PER_HOUR;
+		auto offset_minutes = offset % Interval::MINS_PER_HOUR;
+		target = WritePadded2(target, offset_hours);
+		if (offset_minutes) {
+			*target++ = ':';
+			target = WritePadded2(target, offset_minutes);
+		}
+		break;
+	}
+	case StrTimeSpecifier::TZ_NAME:
+		if (tz_name) {
+			strcpy(target, tz_name);
+			target += strlen(tz_name);
+		}
+		break;
+	case StrTimeSpecifier::DAY_OF_MONTH: {
+		target = Write2(target, data[2] % 100);
+		break;
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL: {
+		target = Write2(target, data[1]);
+		break;
+	}
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY: {
+		target = Write2(target, data[0] % 100);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_24_DECIMAL: {
+		target = Write2(target, data[3]);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_12_DECIMAL: {
+		int hour = data[3] % 12;
+		if (hour == 0) {
+			hour = 12;
+		}
+		target = Write2(target, hour);
+		break;
+	}
+	case StrTimeSpecifier::MINUTE_DECIMAL: {
+		target = Write2(target, data[4]);
+		break;
+	}
+	case StrTimeSpecifier::SECOND_DECIMAL: {
+		target = Write2(target, data[5]);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented specifier for WriteStandardSpecifier in strftime");
+	}
+	return target;
+}
+
+void StrfTimeFormat::FormatString(date_t date, int32_t data[8], const char *tz_name, char *target) {
+	D_ASSERT(specifiers.size() + 1 == literals.size());
+	idx_t i;
+	for (i = 0; i < specifiers.size(); i++) {
+		// first copy the current literal
+		memcpy(target, literals[i].c_str(), literals[i].size());
+		target += literals[i].size();
+		// now copy the specifier
+		if (is_date_specifier[i]) {
+			target = WriteDateSpecifier(specifiers[i], date, target);
+		} else {
+			target = WriteStandardSpecifier(specifiers[i], data, tz_name, target);
+		}
+	}
+	// copy the final literal into the target
+	memcpy(target, literals[i].c_str(), literals[i].size());
+}
+
+void StrfTimeFormat::FormatString(date_t date, dtime_t time, char *target) {
+	int32_t data[8]; // year, month, day, hour, min, sec, µs, offset
+	Date::Convert(date, data[0], data[1], data[2]);
+	Time::Convert(time, data[3], data[4], data[5], data[6]);
+	data[7] = 0;
+
+	FormatString(date, data, nullptr, target);
+}
+
+string StrfTimeFormat::Format(timestamp_t timestamp, const string &format_str) {
+	StrfTimeFormat format;
+	format.ParseFormatSpecifier(format_str, format);
+
+	auto date = Timestamp::GetDate(timestamp);
+	auto time = Timestamp::GetTime(timestamp);
+
+	auto len = format.GetLength(date, time, 0, nullptr);
+	auto result = unique_ptr<char[]>(new char[len]);
+	format.FormatString(date, time, result.get());
+	return string(result.get(), len);
+}
+
+string StrTimeFormat::ParseFormatSpecifier(const string &format_string, StrTimeFormat &format) {
+	if (format_string.empty()) {
+		return "Empty format string";
+	}
+	format.specifiers.clear();
+	format.literals.clear();
+	format.numeric_width.clear();
+	format.constant_size = 0;
+	idx_t pos = 0;
+	string current_literal;
+	for (idx_t i = 0; i < format_string.size(); i++) {
+		if (format_string[i] == '%') {
+			if (i + 1 == format_string.size()) {
+				return "Trailing format character %";
+			}
+			if (i > pos) {
+				// push the previous string to the current literal
+				current_literal += format_string.substr(pos, i - pos);
+			}
+			char format_char = format_string[++i];
+			if (format_char == '%') {
+				// special case: %%
+				// set the pos for the next literal and continue
+				pos = i;
+				continue;
+			}
+			StrTimeSpecifier specifier;
+			if (format_char == '-' && i + 1 < format_string.size()) {
+				format_char = format_string[++i];
+				switch (format_char) {
+				case 'd':
+					specifier = StrTimeSpecifier::DAY_OF_MONTH;
+					break;
+				case 'm':
+					specifier = StrTimeSpecifier::MONTH_DECIMAL;
+					break;
+				case 'y':
+					specifier = StrTimeSpecifier::YEAR_WITHOUT_CENTURY;
+					break;
+				case 'H':
+					specifier = StrTimeSpecifier::HOUR_24_DECIMAL;
+					break;
+				case 'I':
+					specifier = StrTimeSpecifier::HOUR_12_DECIMAL;
+					break;
+				case 'M':
+					specifier = StrTimeSpecifier::MINUTE_DECIMAL;
+					break;
+				case 'S':
+					specifier = StrTimeSpecifier::SECOND_DECIMAL;
+					break;
+				case 'j':
+					specifier = StrTimeSpecifier::DAY_OF_YEAR_DECIMAL;
+					break;
+				default:
+					return "Unrecognized format for strftime/strptime: %-" + string(1, format_char);
+				}
+			} else {
+				switch (format_char) {
+				case 'a':
+					specifier = StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME;
+					break;
+				case 'A':
+					specifier = StrTimeSpecifier::FULL_WEEKDAY_NAME;
+					break;
+				case 'w':
+					specifier = StrTimeSpecifier::WEEKDAY_DECIMAL;
+					break;
+				case 'd':
+					specifier = StrTimeSpecifier::DAY_OF_MONTH_PADDED;
+					break;
+				case 'h':
+				case 'b':
+					specifier = StrTimeSpecifier::ABBREVIATED_MONTH_NAME;
+					break;
+				case 'B':
+					specifier = StrTimeSpecifier::FULL_MONTH_NAME;
+					break;
+				case 'm':
+					specifier = StrTimeSpecifier::MONTH_DECIMAL_PADDED;
+					break;
+				case 'y':
+					specifier = StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED;
+					break;
+				case 'Y':
+					specifier = StrTimeSpecifier::YEAR_DECIMAL;
+					break;
+				case 'H':
+					specifier = StrTimeSpecifier::HOUR_24_PADDED;
+					break;
+				case 'I':
+					specifier = StrTimeSpecifier::HOUR_12_PADDED;
+					break;
+				case 'p':
+					specifier = StrTimeSpecifier::AM_PM;
+					break;
+				case 'M':
+					specifier = StrTimeSpecifier::MINUTE_PADDED;
+					break;
+				case 'S':
+					specifier = StrTimeSpecifier::SECOND_PADDED;
+					break;
+				case 'f':
+					specifier = StrTimeSpecifier::MICROSECOND_PADDED;
+					break;
+				case 'g':
+					specifier = StrTimeSpecifier::MILLISECOND_PADDED;
+					break;
+				case 'z':
+					specifier = StrTimeSpecifier::UTC_OFFSET;
+					break;
+				case 'Z':
+					specifier = StrTimeSpecifier::TZ_NAME;
+					break;
+				case 'j':
+					specifier = StrTimeSpecifier::DAY_OF_YEAR_PADDED;
+					break;
+				case 'U':
+					specifier = StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST;
+					break;
+				case 'W':
+					specifier = StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST;
+					break;
+				case 'c':
+				case 'x':
+				case 'X':
+				case 'T': {
+					string subformat;
+					if (format_char == 'c') {
+						// %c: Locale’s appropriate date and time representation.
+						// we push the ISO timestamp representation here
+						subformat = "%Y-%m-%d %H:%M:%S";
+					} else if (format_char == 'x') {
+						// %x - Locale’s appropriate date representation.
+						// we push the ISO date format here
+						subformat = "%Y-%m-%d";
+					} else if (format_char == 'X' || format_char == 'T') {
+						// %X - Locale’s appropriate time representation.
+						// we push the ISO time format here
+						subformat = "%H:%M:%S";
+					}
+					// parse the subformat in a separate format specifier
+					StrfTimeFormat locale_format;
+					string error = StrTimeFormat::ParseFormatSpecifier(subformat, locale_format);
+					D_ASSERT(error.empty());
+					// add the previous literal to the first literal of the subformat
+					locale_format.literals[0] = move(current_literal) + locale_format.literals[0];
+					current_literal = "";
+					// now push the subformat into the current format specifier
+					for (idx_t i = 0; i < locale_format.specifiers.size(); i++) {
+						format.AddFormatSpecifier(move(locale_format.literals[i]), locale_format.specifiers[i]);
+					}
+					pos = i + 1;
+					continue;
+				}
+				default:
+					return "Unrecognized format for strftime/strptime: %" + string(1, format_char);
+				}
+			}
+			format.AddFormatSpecifier(move(current_literal), specifier);
+			current_literal = "";
+			pos = i + 1;
+		}
+	}
+	// add the final literal
+	if (pos < format_string.size()) {
+		current_literal += format_string.substr(pos, format_string.size() - pos);
+	}
+	format.AddLiteral(move(current_literal));
+	return string();
+}
+
+struct StrfTimeBindData : public FunctionData {
+	explicit StrfTimeBindData(StrfTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
+	}
+
+	StrfTimeFormat format;
+	string format_string;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrfTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrfTimeBindData &)other_p;
+		return format_string == other.format_string;
+	}
+};
+
+template <bool REVERSED>
+static unique_ptr<FunctionData> StrfTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[REVERSED ? 0 : 1]->IsFoldable()) {
+		throw InvalidInputException("strftime format must be a constant");
+	}
+	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[REVERSED ? 0 : 1]);
+	auto format_string = options_str.GetValue<string>();
+	StrfTimeFormat format;
+	if (!options_str.IsNull()) {
+		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+		if (!error.empty()) {
+			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+		}
+	}
+	return make_unique<StrfTimeBindData>(format, format_string);
+}
+
+void StrfTimeFormat::ConvertDateVector(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::DATE);
+	D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
+	UnaryExecutor::ExecuteWithNulls<date_t, string_t>(input, result, count,
+	                                                  [&](date_t input, ValidityMask &mask, idx_t idx) {
+		                                                  if (Date::IsFinite(input)) {
+			                                                  dtime_t time(0);
+			                                                  idx_t len = GetLength(input, time, 0, nullptr);
+			                                                  string_t target = StringVector::EmptyString(result, len);
+			                                                  FormatString(input, time, target.GetDataWriteable());
+			                                                  target.Finalize();
+			                                                  return target;
+		                                                  } else {
+			                                                  mask.SetInvalid(idx);
+			                                                  return string_t();
+		                                                  }
+	                                                  });
+}
+
+template <bool REVERSED>
+static void StrfTimeFunctionDate(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrfTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[REVERSED ? 0 : 1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	info.format.ConvertDateVector(args.data[REVERSED ? 1 : 0], result, args.size());
+}
+
+void StrfTimeFormat::ConvertTimestampVector(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::TIMESTAMP);
+	D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
+	UnaryExecutor::ExecuteWithNulls<timestamp_t, string_t>(
+	    input, result, count, [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
+		    if (Timestamp::IsFinite(input)) {
+			    date_t date;
+			    dtime_t time;
+			    Timestamp::Convert(input, date, time);
+			    idx_t len = GetLength(date, time, 0, nullptr);
+			    string_t target = StringVector::EmptyString(result, len);
+			    FormatString(date, time, target.GetDataWriteable());
+			    target.Finalize();
+			    return target;
+		    } else {
+			    mask.SetInvalid(idx);
+			    return string_t();
+		    }
+	    });
+}
+
+template <bool REVERSED>
+static void StrfTimeFunctionTimestamp(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrfTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[REVERSED ? 0 : 1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	info.format.ConvertTimestampVector(args.data[REVERSED ? 1 : 0], result, args.size());
+}
+
+void StrfTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet strftime("strftime");
+
+	strftime.AddFunction(ScalarFunction({LogicalType::DATE, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionDate<false>, false, false, StrfTimeBindFunction<false>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<false>, false, false, StrfTimeBindFunction<false>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionDate<true>, false, false, StrfTimeBindFunction<true>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<true>, false, false, StrfTimeBindFunction<true>));
+
+	set.AddFunction(strftime);
+}
+
+void StrpTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	numeric_width.push_back(NumericSpecifierWidth(specifier));
+	StrTimeFormat::AddFormatSpecifier(move(preceding_literal), specifier);
+}
+
+int StrpTimeFormat::NumericSpecifierWidth(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return 1;
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::DAY_OF_MONTH:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+	case StrTimeSpecifier::HOUR_24_PADDED:
+	case StrTimeSpecifier::HOUR_24_DECIMAL:
+	case StrTimeSpecifier::HOUR_12_PADDED:
+	case StrTimeSpecifier::HOUR_12_DECIMAL:
+	case StrTimeSpecifier::MINUTE_PADDED:
+	case StrTimeSpecifier::MINUTE_DECIMAL:
+	case StrTimeSpecifier::SECOND_PADDED:
+	case StrTimeSpecifier::SECOND_DECIMAL:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		return 2;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+		return 3;
+	case StrTimeSpecifier::YEAR_DECIMAL:
+		return 4;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		return 6;
+	default:
+		return -1;
+	}
+}
+
+enum class TimeSpecifierAMOrPM : uint8_t { TIME_SPECIFIER_NONE = 0, TIME_SPECIFIER_AM = 1, TIME_SPECIFIER_PM = 2 };
+
+int32_t StrpTimeFormat::TryParseCollection(const char *data, idx_t &pos, idx_t size, const string_t collection[],
+                                           idx_t collection_count) {
+	for (idx_t c = 0; c < collection_count; c++) {
+		auto &entry = collection[c];
+		auto entry_data = entry.GetDataUnsafe();
+		auto entry_size = entry.GetSize();
+		// check if this entry matches
+		if (pos + entry_size > size) {
+			// too big: can't match
+			continue;
+		}
+		// compare the characters
+		idx_t i;
+		for (i = 0; i < entry_size; i++) {
+			if (std::tolower(entry_data[i]) != std::tolower(data[pos + i])) {
+				break;
+			}
+		}
+		if (i == entry_size) {
+			// full match
+			pos += entry_size;
+			return c;
+		}
+	}
+	return -1;
+}
+
+//! Parses a timestamp using the given specifier
+bool StrpTimeFormat::Parse(string_t str, ParseResult &result) {
+	auto &result_data = result.data;
+	auto &error_message = result.error_message;
+	auto &error_position = result.error_position;
+
+	// initialize the result
+	result_data[0] = 1900;
+	result_data[1] = 1;
+	result_data[2] = 1;
+	result_data[3] = 0;
+	result_data[4] = 0;
+	result_data[5] = 0;
+	result_data[6] = 0;
+	result_data[7] = 0;
+
+	auto data = str.GetDataUnsafe();
+	idx_t size = str.GetSize();
+	// skip leading spaces
+	while (StringUtil::CharacterIsSpace(*data)) {
+		data++;
+		size--;
+	}
+	idx_t pos = 0;
+	TimeSpecifierAMOrPM ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_NONE;
+
+	// Year offset state (Year+W/j)
+	auto offset_specifier = StrTimeSpecifier::WEEKDAY_DECIMAL;
+	uint64_t weekno = 0;
+	uint64_t weekday = 0;
+	uint64_t yearday = 0;
+
+	for (idx_t i = 0;; i++) {
+		D_ASSERT(i < literals.size());
+		// first compare the literal
+		const auto &literal = literals[i];
+		for (size_t l = 0; l < literal.size();) {
+			// Match runs of spaces to runs of spaces.
+			if (StringUtil::CharacterIsSpace(literal[l])) {
+				if (!StringUtil::CharacterIsSpace(data[pos])) {
+					error_message = "Space does not match, expected " + literals[i];
+					error_position = pos;
+					return false;
+				}
+				for (++pos; pos < size && StringUtil::CharacterIsSpace(data[pos]); ++pos) {
+					continue;
+				}
+				for (++l; l < literal.size() && StringUtil::CharacterIsSpace(literal[l]); ++l) {
+					continue;
+				}
+				continue;
+			}
+			// literal does not match
+			if (data[pos++] != literal[l++]) {
+				error_message = "Literal does not match, expected " + literal;
+				error_position = pos;
+				return false;
+			}
+		}
+		if (i == specifiers.size()) {
+			break;
+		}
+		// now parse the specifier
+		if (numeric_width[i] > 0) {
+			// numeric specifier: parse a number
+			uint64_t number = 0;
+			size_t start_pos = pos;
+			size_t end_pos = start_pos + numeric_width[i];
+			while (pos < size && pos < end_pos && StringUtil::CharacterIsDigit(data[pos])) {
+				number = number * 10 + data[pos] - '0';
+				pos++;
+			}
+			if (pos == start_pos) {
+				// expected a number here
+				error_message = "Expected a number";
+				error_position = start_pos;
+				return false;
+			}
+			switch (specifiers[i]) {
+			case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+			case StrTimeSpecifier::DAY_OF_MONTH:
+				if (number < 1 || number > 31) {
+					error_message = "Day out of range, expected a value between 1 and 31";
+					error_position = start_pos;
+					return false;
+				}
+				// day of the month
+				result_data[2] = number;
+				offset_specifier = specifiers[i];
+				break;
+			case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+			case StrTimeSpecifier::MONTH_DECIMAL:
+				if (number < 1 || number > 12) {
+					error_message = "Month out of range, expected a value between 1 and 12";
+					error_position = start_pos;
+					return false;
+				}
+				// month number
+				result_data[1] = number;
+				offset_specifier = specifiers[i];
+				break;
+			case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+			case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+				// year without century..
+				// Python uses 69 as a crossover point (i.e. >= 69 is 19.., < 69 is 20..)
+				if (number >= 100) {
+					// %y only supports numbers between [0..99]
+					error_message = "Year without century out of range, expected a value between 0 and 99";
+					error_position = start_pos;
+					return false;
+				}
+				if (number >= 69) {
+					result_data[0] = int32_t(1900 + number);
+				} else {
+					result_data[0] = int32_t(2000 + number);
+				}
+				break;
+			case StrTimeSpecifier::YEAR_DECIMAL:
+				// year as full number
+				result_data[0] = number;
+				break;
+			case StrTimeSpecifier::HOUR_24_PADDED:
+			case StrTimeSpecifier::HOUR_24_DECIMAL:
+				if (number >= 24) {
+					error_message = "Hour out of range, expected a value between 0 and 23";
+					error_position = start_pos;
+					return false;
+				}
+				// hour as full number
+				result_data[3] = number;
+				break;
+			case StrTimeSpecifier::HOUR_12_PADDED:
+			case StrTimeSpecifier::HOUR_12_DECIMAL:
+				if (number < 1 || number > 12) {
+					error_message = "Hour12 out of range, expected a value between 1 and 12";
+					error_position = start_pos;
+					return false;
+				}
+				// 12-hour number: start off by just storing the number
+				result_data[3] = number;
+				break;
+			case StrTimeSpecifier::MINUTE_PADDED:
+			case StrTimeSpecifier::MINUTE_DECIMAL:
+				if (number >= 60) {
+					error_message = "Minutes out of range, expected a value between 0 and 59";
+					error_position = start_pos;
+					return false;
+				}
+				// minutes
+				result_data[4] = number;
+				break;
+			case StrTimeSpecifier::SECOND_PADDED:
+			case StrTimeSpecifier::SECOND_DECIMAL:
+				if (number >= 60) {
+					error_message = "Seconds out of range, expected a value between 0 and 59";
+					error_position = start_pos;
+					return false;
+				}
+				// seconds
+				result_data[5] = number;
+				break;
+			case StrTimeSpecifier::MICROSECOND_PADDED:
+				D_ASSERT(number < 1000000ULL); // enforced by the length of the number
+				// milliseconds
+				result_data[6] = number;
+				break;
+			case StrTimeSpecifier::MILLISECOND_PADDED:
+				D_ASSERT(number < 1000ULL); // enforced by the length of the number
+				// milliseconds
+				result_data[6] = number * 1000;
+				break;
+			case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+			case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+				// m/d overrides WU/w but does not conflict
+				switch (offset_specifier) {
+				case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+				case StrTimeSpecifier::DAY_OF_MONTH:
+				case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+				case StrTimeSpecifier::MONTH_DECIMAL:
+					// Just validate, don't use
+					break;
+				case StrTimeSpecifier::WEEKDAY_DECIMAL:
+					// First offset specifier
+					offset_specifier = specifiers[i];
+					break;
+				default:
+					error_message = "Multiple year offsets specified";
+					error_position = start_pos;
+					return false;
+				}
+				if (number > 53) {
+					error_message = "Week out of range, expected a value between 0 and 53";
+					error_position = start_pos;
+					return false;
+				}
+				weekno = number;
+				break;
+			case StrTimeSpecifier::WEEKDAY_DECIMAL:
+				if (number > 6) {
+					error_message = "Weekday out of range, expected a value between 0 and 6";
+					error_position = start_pos;
+					return false;
+				}
+				weekday = number;
+				break;
+			case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+			case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+				// m/d overrides j but does not conflict
+				switch (offset_specifier) {
+				case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+				case StrTimeSpecifier::DAY_OF_MONTH:
+				case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+				case StrTimeSpecifier::MONTH_DECIMAL:
+					// Just validate, don't use
+					break;
+				case StrTimeSpecifier::WEEKDAY_DECIMAL:
+					// First offset specifier
+					offset_specifier = specifiers[i];
+					break;
+				default:
+					error_message = "Multiple year offsets specified";
+					error_position = start_pos;
+					return false;
+				}
+				if (number < 1 || number > 366) {
+					error_message = "Year day out of range, expected a value between 1 and 366";
+					error_position = start_pos;
+					return false;
+				}
+				yearday = number;
+				break;
+			default:
+				throw NotImplementedException("Unsupported specifier for strptime");
+			}
+		} else {
+			switch (specifiers[i]) {
+			case StrTimeSpecifier::AM_PM: {
+				// parse the next 2 characters
+				if (pos + 2 > size) {
+					// no characters left to parse
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				char pa_char = char(std::tolower(data[pos]));
+				char m_char = char(std::tolower(data[pos + 1]));
+				if (m_char != 'm') {
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				if (pa_char == 'p') {
+					ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_PM;
+				} else if (pa_char == 'a') {
+					ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_AM;
+				} else {
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				pos += 2;
+				break;
+			}
+			// we parse weekday names, but we don't use them as information
+			case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+				if (TryParseCollection(data, pos, size, Date::DAY_NAMES_ABBREVIATED, 7) < 0) {
+					error_message = "Expected an abbreviated day name (Mon, Tue, Wed, Thu, Fri, Sat, Sun)";
+					error_position = pos;
+					return false;
+				}
+				break;
+			case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+				if (TryParseCollection(data, pos, size, Date::DAY_NAMES, 7) < 0) {
+					error_message = "Expected a full day name (Monday, Tuesday, etc...)";
+					error_position = pos;
+					return false;
+				}
+				break;
+			case StrTimeSpecifier::ABBREVIATED_MONTH_NAME: {
+				int32_t month = TryParseCollection(data, pos, size, Date::MONTH_NAMES_ABBREVIATED, 12);
+				if (month < 0) {
+					error_message = "Expected an abbreviated month name (Jan, Feb, Mar, etc..)";
+					error_position = pos;
+					return false;
+				}
+				result_data[1] = month + 1;
+				break;
+			}
+			case StrTimeSpecifier::FULL_MONTH_NAME: {
+				int32_t month = TryParseCollection(data, pos, size, Date::MONTH_NAMES, 12);
+				if (month < 0) {
+					error_message = "Expected a full month name (January, February, etc...)";
+					error_position = pos;
+					return false;
+				}
+				result_data[1] = month + 1;
+				break;
+			}
+			case StrTimeSpecifier::UTC_OFFSET: {
+				int hour_offset, minute_offset;
+				if (!Timestamp::TryParseUTCOffset(data, pos, size, hour_offset, minute_offset)) {
+					error_message = "Expected +HH[MM] or -HH[MM]";
+					error_position = pos;
+					return false;
+				}
+				result_data[7] = hour_offset * Interval::MINS_PER_HOUR + minute_offset;
+				break;
+			}
+			case StrTimeSpecifier::TZ_NAME: {
+				// skip leading spaces
+				while (pos < size && StringUtil::CharacterIsSpace(data[pos])) {
+					pos++;
+				}
+				const auto tz_begin = data + pos;
+				// stop when we encounter a space or the end of the string
+				while (pos < size && !StringUtil::CharacterIsSpace(data[pos])) {
+					pos++;
+				}
+				const auto tz_end = data + pos;
+				// Can't fully validate without a list - caller's responsibility.
+				// But tz must not be empty.
+				if (tz_end == tz_begin) {
+					error_message = "Empty Time Zone name";
+					error_position = tz_begin - data;
+					return false;
+				}
+				result.tz.assign(tz_begin, tz_end);
+				break;
+			}
+			default:
+				throw NotImplementedException("Unsupported specifier for strptime");
+			}
+		}
+	}
+	// skip trailing spaces
+	while (pos < size && StringUtil::CharacterIsSpace(data[pos])) {
+		pos++;
+	}
+	if (pos != size) {
+		error_message = "Full specifier did not match: trailing characters";
+		error_position = pos;
+		return false;
+	}
+	if (ampm != TimeSpecifierAMOrPM::TIME_SPECIFIER_NONE) {
+		if (result_data[3] > 12) {
+			error_message =
+			    "Invalid hour: " + to_string(result_data[3]) + " AM/PM, expected an hour within the range [0..12]";
+			return false;
+		}
+		// adjust the hours based on the AM or PM specifier
+		if (ampm == TimeSpecifierAMOrPM::TIME_SPECIFIER_AM) {
+			// AM: 12AM=0, 1AM=1, 2AM=2, ..., 11AM=11
+			if (result_data[3] == 12) {
+				result_data[3] = 0;
+			}
+		} else {
+			// PM: 12PM=12, 1PM=13, 2PM=14, ..., 11PM=23
+			if (result_data[3] != 12) {
+				result_data[3] += 12;
+			}
+		}
+	}
+	switch (offset_specifier) {
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST: {
+		// Adjust weekday to be 0-based for the week type
+		weekday = (weekday + 7 - int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST)) % 7;
+		// Get the start of week 1, move back 7 days and then weekno * 7 + weekday gives the date
+		const auto jan1 = Date::FromDate(result_data[0], 1, 1);
+		auto yeardate = Date::GetMondayOfCurrentWeek(jan1);
+		yeardate -= int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST);
+		// Is there a week 0?
+		yeardate -= 7 * int(yeardate >= jan1);
+		yeardate += weekno * 7 + weekday;
+		Date::Convert(yeardate, result_data[0], result_data[1], result_data[2]);
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL: {
+		auto yeardate = Date::FromDate(result_data[0], 1, 1);
+		yeardate += yearday - 1;
+		Date::Convert(yeardate, result_data[0], result_data[1], result_data[2]);
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::DAY_OF_MONTH:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL:
+		// m/d overrides UWw/j
+		break;
+	default:
+		D_ASSERT(offset_specifier == StrTimeSpecifier::WEEKDAY_DECIMAL);
+		break;
+	}
+
+	return true;
+}
+
+struct StrpTimeBindData : public FunctionData {
+	explicit StrpTimeBindData(StrpTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
+	}
+
+	StrpTimeFormat format;
+	string format_string;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrpTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrpTimeBindData &)other_p;
+		return format_string == other.format_string;
+	}
+};
+
+static unique_ptr<FunctionData> StrpTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw InvalidInputException("strptime format must be a constant");
+	}
+	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	string format_string = options_str.ToString();
+	StrpTimeFormat format;
+	if (!options_str.IsNull()) {
+		if (options_str.type().id() != LogicalTypeId::VARCHAR) {
+			throw InvalidInputException("strptime format must be a string");
+		}
+		format.format_specifier = format_string;
+		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+		if (!error.empty()) {
+			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+		}
+		if (format.HasFormatSpecifier(StrTimeSpecifier::UTC_OFFSET)) {
+			bound_function.return_type = LogicalType::TIMESTAMP_TZ;
+		}
+	}
+	return make_unique<StrpTimeBindData>(format, format_string);
+}
+
+StrpTimeFormat::ParseResult StrpTimeFormat::Parse(const string &format_string, const string &text) {
+	StrpTimeFormat format;
+	format.format_specifier = format_string;
+	string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+	if (!error.empty()) {
+		throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+	}
+	StrpTimeFormat::ParseResult result;
+	if (!format.Parse(text, result)) {
+		throw InvalidInputException("Failed to parse string \"%s\" with format specifier \"%s\"", text, format_string);
+	}
+	return result;
+}
+
+string StrpTimeFormat::FormatStrpTimeError(const string &input, idx_t position) {
+	if (position == DConstants::INVALID_INDEX) {
+		return string();
+	}
+	return input + "\n" + string(position, ' ') + "^";
+}
+
+date_t StrpTimeFormat::ParseResult::ToDate() {
+	return Date::FromDate(data[0], data[1], data[2]);
+}
+
+timestamp_t StrpTimeFormat::ParseResult::ToTimestamp() {
+	date_t date = Date::FromDate(data[0], data[1], data[2]);
+	const auto hour_offset = data[7] / Interval::MINS_PER_HOUR;
+	const auto mins_offset = data[7] % Interval::MINS_PER_HOUR;
+	dtime_t time = Time::FromTime(data[3] - hour_offset, data[4] - mins_offset, data[5], data[6]);
+	return Timestamp::FromDatetime(date, time);
+}
+
+string StrpTimeFormat::ParseResult::FormatError(string_t input, const string &format_specifier) {
+	return StringUtil::Format("Could not parse string \"%s\" according to format specifier \"%s\"\n%s\nError: %s",
+	                          input.GetString(), format_specifier,
+	                          FormatStrpTimeError(input.GetString(), error_position), error_message);
+}
+
+bool StrpTimeFormat::TryParseDate(string_t input, date_t &result, string &error_message) {
+	ParseResult parse_result;
+	if (!Parse(input, parse_result)) {
+		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	result = parse_result.ToDate();
+	return true;
+}
+
+bool StrpTimeFormat::TryParseTimestamp(string_t input, timestamp_t &result, string &error_message) {
+	ParseResult parse_result;
+	if (!Parse(input, parse_result)) {
+		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	result = parse_result.ToTimestamp();
+	return true;
+}
+
+date_t StrpTimeFormat::ParseDate(string_t input) {
+	ParseResult result;
+	if (!Parse(input, result)) {
+		throw InvalidInputException(result.FormatError(input, format_specifier));
+	}
+	return result.ToDate();
+}
+
+timestamp_t StrpTimeFormat::ParseTimestamp(string_t input) {
+	ParseResult result;
+	if (!Parse(input, result)) {
+		throw InvalidInputException(result.FormatError(input, format_specifier));
+	}
+	return result.ToTimestamp();
+}
+
+static void StrpTimeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrpTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	UnaryExecutor::Execute<string_t, timestamp_t>(args.data[0], result, args.size(),
+	                                              [&](string_t input) { return info.format.ParseTimestamp(input); });
+}
+
+void StrpTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet strptime("strptime");
+
+	strptime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::TIMESTAMP,
+	                                    StrpTimeFunction, false, false, StrpTimeBindFunction));
+
+	set.AddFunction(strptime);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct ToYearsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.days = 0;
+		result.micros = 0;
+		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::MONTHS_PER_YEAR,
+		                                                               result.months)) {
+			throw OutOfRangeException("Interval value %d years out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMonthsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = input;
+		result.days = 0;
+		result.micros = 0;
+		return result;
+	}
+};
+
+struct ToDaysOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = input;
+		result.micros = 0;
+		return result;
+	}
+};
+
+struct ToHoursOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_HOUR,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d hours out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMinutesOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d minutes out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_SEC,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d seconds out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMilliSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MSEC,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d milliseconds out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMicroSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		result.micros = input;
+		return result;
+	}
+};
+
+void ToIntervalFun::RegisterFunction(BuiltinFunctions &set) {
+	// register the individual operators
+	set.AddFunction(ScalarFunction("to_years", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToYearsOperator>));
+	set.AddFunction(ScalarFunction("to_months", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToMonthsOperator>));
+	set.AddFunction(ScalarFunction("to_days", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToDaysOperator>));
+	set.AddFunction(ScalarFunction("to_hours", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToHoursOperator>));
+	set.AddFunction(ScalarFunction("to_minutes", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMinutesOperator>));
+	set.AddFunction(ScalarFunction("to_seconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToSecondsOperator>));
+	set.AddFunction(ScalarFunction("to_milliseconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMilliSecondsOperator>));
+	set.AddFunction(ScalarFunction("to_microseconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMicroSecondsOperator>));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterDateFunctions() {
+	Register<AgeFun>();
+	Register<DateDiffFun>();
+	Register<DatePartFun>();
+	Register<DateSubFun>();
+	Register<DateTruncFun>();
+	Register<CurrentTimeFun>();
+	Register<CurrentDateFun>();
+	Register<CurrentTimestampFun>();
+	Register<EpochFun>();
+	Register<MakeDateFun>();
+	Register<StrfTimeFun>();
+	Register<StrpTimeFun>();
+	Register<ToIntervalFun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void EnumFirstFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	auto val = Value(enum_vector.GetValue(0));
+	result.Reference(val);
+}
+
+static void EnumLastFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto enum_size = EnumType::GetSize(input.GetTypes()[0]);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	auto val = Value(enum_vector.GetValue(enum_size - 1));
+	result.Reference(val);
+}
+
+static void EnumRangeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto enum_size = EnumType::GetSize(input.GetTypes()[0]);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	vector<Value> enum_values;
+	for (idx_t i = 0; i < enum_size; i++) {
+		enum_values.emplace_back(enum_vector.GetValue(i));
+	}
+	auto val = Value::LIST(enum_values);
+	result.Reference(val);
+}
+
+static void EnumRangeBoundaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 2);
+	idx_t start, end;
+	auto first_param = input.GetValue(0, 0);
+	auto second_param = input.GetValue(1, 0);
+
+	auto &enum_vector = first_param.IsNull() ? EnumType::GetValuesInsertOrder(input.GetTypes()[1])
+	                                         : EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+
+	if (first_param.IsNull()) {
+		start = 0;
+	} else {
+		start = first_param.GetValue<uint32_t>();
+	}
+	if (second_param.IsNull()) {
+		end = EnumType::GetSize(input.GetTypes()[0]);
+	} else {
+		end = second_param.GetValue<uint32_t>() + 1;
+	}
+	vector<Value> enum_values;
+	for (idx_t i = start; i < end; i++) {
+		enum_values.emplace_back(enum_vector.GetValue(i));
+	}
+	Value val;
+	if (enum_values.empty()) {
+		val = Value::EMPTYLIST(LogicalType::VARCHAR);
+	} else {
+		val = Value::LIST(enum_values);
+	}
+	result.Reference(val);
+}
+
+unique_ptr<FunctionData> BindEnumFunction(ClientContext &context, ScalarFunction &bound_function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	return nullptr;
+}
+
+unique_ptr<FunctionData> BindEnumRangeBoundaryFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM && arguments[0]->return_type != LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[1]->return_type.id() != LogicalTypeId::ENUM && arguments[1]->return_type != LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[0]->return_type == LogicalType::SQLNULL && arguments[1]->return_type == LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[0]->return_type.id() == LogicalTypeId::ENUM &&
+	    arguments[1]->return_type.id() == LogicalTypeId::ENUM &&
+	    arguments[0]->return_type != arguments[1]->return_type) {
+
+		throw BinderException("The parameters need to link to ONLY one enum OR be NULL ");
+	}
+	return nullptr;
+}
+
+void EnumFirst::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_first", {LogicalType::ANY}, LogicalType::VARCHAR, EnumFirstFunction, false,
+	                               BindEnumFunction));
+}
+
+void EnumLast::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_last", {LogicalType::ANY}, LogicalType::VARCHAR, EnumLastFunction, false,
+	                               BindEnumFunction));
+}
+
+void EnumRange::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_range", {LogicalType::ANY}, LogicalType::LIST(LogicalType::VARCHAR),
+	                               EnumRangeFunction, false, BindEnumFunction));
+}
+
+void EnumRangeBoundary::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_range_boundary", {LogicalType::ANY, LogicalType::ANY},
+	                               LogicalType::LIST(LogicalType::VARCHAR), EnumRangeBoundaryFunction, false,
+	                               BindEnumRangeBoundaryFunction));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterEnumFunctions() {
+	Register<EnumFirst>();
+	Register<EnumLast>();
+	Register<EnumRange>();
+	Register<EnumRangeBoundary>();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+static void AliasFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	Value v(state.expr.alias.empty() ? func_expr.children[0]->GetName() : state.expr.alias);
+	result.Reference(v);
+}
+
+void AliasFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("alias", {LogicalType::ANY}, LogicalType::VARCHAR, AliasFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct ConstantOrNullBindData : public FunctionData {
+	explicit ConstantOrNullBindData(Value val) : value(move(val)) {
+	}
+
+	Value value;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ConstantOrNullBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ConstantOrNullBindData &)other_p;
+		return value == other.value;
+	}
+};
+
+static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ConstantOrNullBindData &)*func_expr.bind_info;
+	result.Reference(info.value);
+	for (idx_t idx = 0; idx < args.ColumnCount(); idx++) {
+		switch (args.data[idx].GetVectorType()) {
+		case VectorType::FLAT_VECTOR: {
+			auto &input_mask = FlatVector::Validity(args.data[idx]);
+			if (!input_mask.AllValid()) {
+				// there are null values: need to merge them into the result
+				result.Normalify(args.size());
+				auto &result_mask = FlatVector::Validity(result);
+				result_mask.Combine(input_mask, args.size());
+			}
+			break;
+		}
+		case VectorType::CONSTANT_VECTOR: {
+			if (ConstantVector::IsNull(args.data[idx])) {
+				// input is constant null, return constant null
+				result.Reference(info.value);
+				ConstantVector::SetNull(result, true);
+				return;
+			}
+			break;
+		}
+		default: {
+			VectorData vdata;
+			args.data[idx].Orrify(args.size(), vdata);
+			if (!vdata.validity.AllValid()) {
+				result.Normalify(args.size());
+				auto &result_mask = FlatVector::Validity(result);
+				for (idx_t i = 0; i < args.size(); i++) {
+					if (!vdata.validity.RowIsValid(vdata.sel->get_index(i))) {
+						result_mask.SetInvalid(i);
+					}
+				}
+			}
+			break;
+		}
+		}
+	}
+}
+
+ScalarFunction ConstantOrNull::GetFunction(LogicalType return_type) {
+	return ScalarFunction("constant_or_null", {}, move(return_type), ConstantOrNullFunction);
+}
+
+unique_ptr<FunctionData> ConstantOrNull::Bind(Value value) {
+	return make_unique<ConstantOrNullBindData>(move(value));
+}
+
+bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value &val) {
+	if (expr.function.name != "constant_or_null") {
+		return false;
+	}
+	D_ASSERT(expr.bind_info);
+	auto &bind_data = (ConstantOrNullBindData &)*expr.bind_info;
+	D_ASSERT(bind_data.value.type() == val.type());
+	return bind_data.value == val;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct CurrentSettingBindData : public FunctionData {
+	explicit CurrentSettingBindData(Value value_p) : value(move(value_p)) {
+	}
+
+	Value value;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<CurrentSettingBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const CurrentSettingBindData &)other_p;
+		return Value::NotDistinctFrom(value, other.value);
+	}
+};
+
+static void CurrentSettingFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (CurrentSettingBindData &)*func_expr.bind_info;
+	result.Reference(info.value);
+}
+
+unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+
+	auto &key_child = arguments[0];
+
+	if (key_child->return_type.id() != LogicalTypeId::VARCHAR ||
+	    key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+		throw ParserException("Key name for current_setting needs to be a constant string");
+	}
+	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
+	D_ASSERT(key_val.type().id() == LogicalTypeId::VARCHAR);
+	auto &key_str = StringValue::Get(key_val);
+	if (key_val.IsNull() || key_str.empty()) {
+		throw ParserException("Key name for current_setting needs to be neither NULL nor empty");
+	}
+
+	auto key = StringUtil::Lower(key_str);
+	Value val;
+	if (!context.TryGetCurrentSetting(key, val)) {
+		throw InvalidInputException("unrecognized configuration parameter \"%s\"", key_str);
+	}
+
+	bound_function.return_type = val.type();
+	return make_unique<CurrentSettingBindData>(val);
+}
+
+void CurrentSettingFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("current_setting", {LogicalType::VARCHAR}, LogicalType::ANY, CurrentSettingFunction,
+	                               false, CurrentSettingBind));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	args.Hash(result);
+}
+
+void HashFun::RegisterFunction(BuiltinFunctions &set) {
+	auto hash_fun = ScalarFunction("hash", {LogicalType::ANY}, LogicalType::HASH, HashFunction);
+	hash_fun.varargs = LogicalType::ANY;
+	set.AddFunction(hash_fun);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct LeastOperator {
+	template <class T>
+	static T Operation(T left, T right) {
+		return OP::Operation(left, right) ? left : right;
+	}
+};
+
+template <class T, class OP, bool IS_STRING = false>
+static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	if (args.ColumnCount() == 1) {
+		// single input: nop
+		result.Reference(args.data[0]);
+		return;
+	}
+	auto result_type = VectorType::CONSTANT_VECTOR;
+	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			// non-constant input: result is not a constant vector
+			result_type = VectorType::FLAT_VECTOR;
+		}
+		if (IS_STRING) {
+			// for string vectors we add a reference to the heap of the children
+			StringVector::AddHeapReference(result, args.data[col_idx]);
+		}
+	}
+
+	auto result_data = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+	// copy over the first column
+	bool result_has_value[STANDARD_VECTOR_SIZE];
+	{
+		VectorData vdata;
+		args.data[0].Orrify(args.size(), vdata);
+		auto input_data = (T *)vdata.data;
+		for (idx_t i = 0; i < args.size(); i++) {
+			auto vindex = vdata.sel->get_index(i);
+			if (vdata.validity.RowIsValid(vindex)) {
+				result_data[i] = input_data[vindex];
+				result_has_value[i] = true;
+			} else {
+				result_has_value[i] = false;
+			}
+		}
+	}
+	// now handle the remainder of the columns
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
+		    ConstantVector::IsNull(args.data[col_idx])) {
+			// ignore null vector
+			continue;
+		}
+
+		VectorData vdata;
+		args.data[col_idx].Orrify(args.size(), vdata);
+
+		auto input_data = (T *)vdata.data;
+		if (!vdata.validity.AllValid()) {
+			// potential new null entries: have to check the null mask
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
+				if (vdata.validity.RowIsValid(vindex)) {
+					// not a null entry: perform the operation and add to new set
+					auto ivalue = input_data[vindex];
+					if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+						result_has_value[i] = true;
+						result_data[i] = ivalue;
+					}
+				}
+			}
+		} else {
+			// no new null entries: only need to perform the operation
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
+
+				auto ivalue = input_data[vindex];
+				if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+					result_has_value[i] = true;
+					result_data[i] = ivalue;
+				}
+			}
+		}
+	}
+	for (idx_t i = 0; i < args.size(); i++) {
+		if (!result_has_value[i]) {
+			result_mask.SetInvalid(i);
+		}
+	}
+	result.SetVectorType(result_type);
+}
+
+template <typename T, class OP>
+ScalarFunction GetLeastGreatestFunction(const LogicalType &type) {
+	return ScalarFunction({type}, type, LeastGreatestFunction<T, OP>, true, false, nullptr, nullptr, nullptr, nullptr,
+	                      type);
+}
+
+template <class OP>
+static void RegisterLeastGreatest(BuiltinFunctions &set, const string &fun_name) {
+	ScalarFunctionSet fun_set(fun_name);
+	fun_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BIGINT, LeastGreatestFunction<int64_t, OP>,
+	                                   true, false, nullptr, nullptr, nullptr, nullptr, LogicalType::BIGINT));
+	fun_set.AddFunction(ScalarFunction({LogicalType::HUGEINT}, LogicalType::HUGEINT,
+	                                   LeastGreatestFunction<hugeint_t, OP>, true, false, nullptr, nullptr, nullptr,
+	                                   nullptr, LogicalType::HUGEINT));
+	fun_set.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE, LeastGreatestFunction<double, OP>,
+	                                   true, false, nullptr, nullptr, nullptr, nullptr, LogicalType::DOUBLE));
+	fun_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                   LeastGreatestFunction<string_t, OP, true>, true, false, nullptr, nullptr,
+	                                   nullptr, nullptr, LogicalType::VARCHAR));
+
+	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP));
+	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME));
+	fun_set.AddFunction(GetLeastGreatestFunction<date_t, OP>(LogicalType::DATE));
+
+	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP_TZ));
+	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME_TZ));
+
+	set.AddFunction(fun_set);
+}
+
+void LeastFun::RegisterFunction(BuiltinFunctions &set) {
+	RegisterLeastGreatest<duckdb::LessThan>(set, "least");
+}
+
+void GreatestFun::RegisterFunction(BuiltinFunctions &set) {
+	RegisterLeastGreatest<duckdb::GreaterThan>(set, "greatest");
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct StatsBindData : public FunctionData {
+	explicit StatsBindData(string stats_p = string()) : stats(move(stats_p)) {
+	}
+
+	string stats;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StatsBindData>(stats);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StatsBindData &)other_p;
+		return stats == other.stats;
+	}
+};
+
+static void StatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StatsBindData &)*func_expr.bind_info;
+	if (info.stats.empty()) {
+		info.stats = "No statistics";
+	}
+	Value v(info.stats);
+	result.Reference(v);
+}
+
+unique_ptr<FunctionData> StatsBind(ClientContext &context, ScalarFunction &bound_function,
+                                   vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<StatsBindData>();
+}
+
+static unique_ptr<BaseStatistics> StatsPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &bind_data = input.bind_data;
+	if (child_stats[0]) {
+		auto &info = (StatsBindData &)*bind_data;
+		info.stats = child_stats[0]->ToString();
+	}
+	return nullptr;
+}
+
+void StatsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("stats", {LogicalType::ANY}, LogicalType::VARCHAR, StatsFunction, true, StatsBind,
+	                               nullptr, StatsPropagateStats));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void TypeOfFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	Value v(args.data[0].GetType().ToString());
+	result.Reference(v);
+}
+
+void TypeOfFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("typeof", {LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterGenericFunctions() {
+	Register<AliasFun>();
+	Register<HashFun>();
+	Register<LeastFun>();
+	Register<GreatestFun>();
+	Register<StatsFun>();
+	Register<TypeOfFun>();
+	Register<CurrentSettingFun>();
+	Register<SystemFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INDEX_TYPE ValueOffset(const INPUT_TYPE &value) {
+	return 0;
+}
+
+template <>
+int64_t ValueOffset(const list_entry_t &value) {
+	return value.offset;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INDEX_TYPE ValueLength(const INPUT_TYPE &value) {
+	return 0;
+}
+
+template <>
+int64_t ValueLength(const list_entry_t &value) {
+	return value.length;
+}
+
+template <>
+int32_t ValueLength(const string_t &value) {
+	return LengthFun::Length<string_t, int32_t>(value);
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+bool ClampIndex(INDEX_TYPE &index, const INPUT_TYPE &value) {
+	const auto length = ValueLength<INPUT_TYPE, INDEX_TYPE>(value);
+	if (index < 0) {
+		if (-index > length) {
+			return false;
+		}
+		index = length + index;
+	} else if (index > length) {
+		index = length;
+	}
+	return true;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+static bool ClampSlice(const INPUT_TYPE &value, INDEX_TYPE &begin, INDEX_TYPE &end, bool begin_valid, bool end_valid) {
+	// Clamp offsets
+	begin = begin_valid ? begin : 0;
+	end = end_valid ? end : ValueLength<INPUT_TYPE, INDEX_TYPE>(value);
+	if (!ClampIndex(begin, value) || !ClampIndex(end, value)) {
+		return false;
+	}
+	end = MaxValue<INDEX_TYPE>(begin, end);
+
+	return true;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INPUT_TYPE SliceValue(Vector &result, INPUT_TYPE input, INDEX_TYPE begin, INDEX_TYPE end) {
+	return input;
+}
+
+template <>
+list_entry_t SliceValue(Vector &result, list_entry_t input, int64_t begin, int64_t end) {
+	input.offset += begin;
+	input.length = end - begin;
+	return input;
+}
+
+template <>
+string_t SliceValue(Vector &result, string_t input, int32_t begin, int32_t end) {
+	// one-based - zero has strange semantics
+	return SubstringFun::SubstringScalarFunction(result, input, begin + 1, end - begin);
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+static void ExecuteSlice(Vector &result, Vector &s, Vector &b, Vector &e, const idx_t count) {
+	if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto rdata = ConstantVector::GetData<INPUT_TYPE>(result);
+		auto sdata = ConstantVector::GetData<INPUT_TYPE>(s);
+		auto bdata = ConstantVector::GetData<INDEX_TYPE>(b);
+		auto edata = ConstantVector::GetData<INDEX_TYPE>(e);
+
+		auto sliced = sdata[0];
+		auto begin = (bdata[0] > 0) ? bdata[0] - 1 : bdata[0];
+		auto end = edata[0];
+
+		auto svalid = !ConstantVector::IsNull(s);
+		auto bvalid = !ConstantVector::IsNull(b);
+		auto evalid = !ConstantVector::IsNull(e);
+
+		// Try to slice
+		if (!svalid || !ClampSlice(sliced, begin, end, bvalid, evalid)) {
+			ConstantVector::SetNull(result, true);
+		} else {
+			rdata[0] = SliceValue<INPUT_TYPE, INDEX_TYPE>(result, sliced, begin, end);
+		}
+	} else {
+		VectorData sdata, bdata, edata;
+
+		s.Orrify(count, sdata);
+		b.Orrify(count, bdata);
+		e.Orrify(count, edata);
+
+		auto rdata = FlatVector::GetData<INPUT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = sdata.sel->get_index(i);
+			auto bidx = bdata.sel->get_index(i);
+			auto eidx = edata.sel->get_index(i);
+
+			auto sliced = ((INPUT_TYPE *)sdata.data)[sidx];
+			auto begin = ((INDEX_TYPE *)bdata.data)[bidx];
+			auto end = ((INDEX_TYPE *)edata.data)[eidx];
+
+			begin = (begin > 0) ? begin - 1 : begin;
+
+			auto svalid = sdata.validity.RowIsValid(sidx);
+			auto bvalid = bdata.validity.RowIsValid(bidx);
+			auto evalid = edata.validity.RowIsValid(eidx);
+
+			// Try to slice
+			if (!svalid || !ClampSlice(sliced, begin, end, bvalid, evalid)) {
+				rmask.SetInvalid(i);
+			} else {
+				rdata[i] = SliceValue<INPUT_TYPE, INDEX_TYPE>(result, sliced, begin, end);
+			}
+		}
+	}
+
+	result.Verify(count);
+}
+
+static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	D_ASSERT(args.data.size() == 3);
+	auto count = args.size();
+
+	Vector &s = args.data[0];
+	Vector &b = args.data[1];
+	Vector &e = args.data[2];
+
+	s.Normalify(count);
+	switch (result.GetType().id()) {
+	case LogicalTypeId::LIST:
+		// Share the value dictionary as we are just going to slice it
+		ListVector::ReferenceEntry(result, s);
+		ExecuteSlice<list_entry_t, int64_t>(result, s, b, e, count);
+		break;
+	case LogicalTypeId::VARCHAR:
+		ExecuteSlice<string_t, int32_t>(result, s, b, e, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented");
+	}
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			break;
+		}
+	}
+}
+
+static unique_ptr<FunctionData> ArraySliceBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 3);
+	switch (arguments[0]->return_type.id()) {
+	case LogicalTypeId::LIST:
+		// The result is the same type
+		bound_function.return_type = arguments[0]->return_type;
+		break;
+	case LogicalTypeId::VARCHAR:
+		// string slice returns a string, but can only accept 32 bit integers
+		bound_function.return_type = arguments[0]->return_type;
+		bound_function.arguments[1] = LogicalType::INTEGER;
+		bound_function.arguments[2] = LogicalType::INTEGER;
+		break;
+	case LogicalTypeId::UNKNOWN:
+		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
+		bound_function.return_type = LogicalType::SQLNULL;
+		break;
+	default:
+		throw BinderException("ARRAY_SLICE can only operate on LISTs and VARCHARs");
+	}
+
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void ArraySliceFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun({LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::ANY,
+	                   ArraySliceFunction, false, false, ArraySliceBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction({"array_slice", "list_slice"}, fun);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static inline bool ValueEqualsOrNot(const T &left, const T &right) {
+	return left == right;
+}
+
+template <>
+inline bool ValueEqualsOrNot(const string_t &left, const string_t &right) {
+	return StringComparisonOperators::EqualsOrNot<false>(left, right);
+}
+
+struct ContainsFunctor {
+	static inline bool Initialize() {
+		return false;
+	}
+	static inline bool UpdateResultEntries(idx_t child_idx) {
+		return true;
+	}
+};
+
+struct PositionFunctor {
+	static inline int32_t Initialize() {
+		return 0;
+	}
+	static inline int32_t UpdateResultEntries(idx_t child_idx) {
+		return child_idx + 1;
+	}
+};
+
+template <class CHILD_TYPE, class RETURN_TYPE, class OP>
+static void TemplatedContainsOrPosition(DataChunk &args, ExpressionState &state, Vector &result,
+                                        bool is_nested = false) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+	Vector &list = args.data[0];
+	Vector &value_vector = args.data[1];
+
+	// Create a result vector of type RETURN_TYPE
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<RETURN_TYPE>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (list.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	auto list_size = ListVector::GetListSize(list);
+	auto &child_vector = ListVector::GetEntry(list);
+
+	VectorData child_data;
+	child_vector.Orrify(list_size, child_data);
+
+	VectorData list_data;
+	list.Orrify(count, list_data);
+	auto list_entries = (list_entry_t *)list_data.data;
+
+	VectorData value_data;
+	value_vector.Orrify(count, value_data);
+
+	// not required for a comparison of nested types
+	auto child_value = FlatVector::GetData<CHILD_TYPE>(child_vector);
+	auto values = FlatVector::GetData<CHILD_TYPE>(value_vector);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		auto value_index = value_data.sel->get_index(i);
+
+		if (!list_data.validity.RowIsValid(list_index) || !value_data.validity.RowIsValid(value_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		const auto &list_entry = list_entries[list_index];
+
+		result_entries[i] = OP::Initialize();
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			auto child_value_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			if (!child_data.validity.RowIsValid(child_value_idx)) {
+				continue;
+			}
+
+			if (!is_nested) {
+				if (ValueEqualsOrNot<CHILD_TYPE>(child_value[child_value_idx], values[value_index])) {
+					result_entries[i] = OP::UpdateResultEntries(child_idx);
+					break; // Found value in list, no need to look further
+				}
+			} else {
+				// FIXME: using Value is less efficient than modifying the vector comparison code
+				// to more efficiently compare nested types
+				if (ValueEqualsOrNot<Value>(child_vector.GetValue(child_value_idx),
+				                            value_vector.GetValue(value_index))) {
+					result_entries[i] = OP::UpdateResultEntries(child_idx);
+					break; // Found value in list, no need to look further
+				}
+			}
+		}
+	}
+}
+
+template <class T, class OP>
+static void ListContainsOrPosition(DataChunk &args, ExpressionState &state, Vector &result) {
+	switch (args.data[1].GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedContainsOrPosition<int8_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedContainsOrPosition<int16_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedContainsOrPosition<int32_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedContainsOrPosition<int64_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedContainsOrPosition<hugeint_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedContainsOrPosition<uint8_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedContainsOrPosition<uint16_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedContainsOrPosition<uint32_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedContainsOrPosition<uint64_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedContainsOrPosition<float, T, OP>(args, state, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedContainsOrPosition<double, T, OP>(args, state, result);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedContainsOrPosition<string_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+		TemplatedContainsOrPosition<int8_t, T, OP>(args, state, result, true);
+		break;
+	default:
+		throw NotImplementedException("This function has not been implemented for this type");
+	}
+}
+
+static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	return ListContainsOrPosition<bool, ContainsFunctor>(args, state, result);
+}
+
+static void ListPositionFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	return ListContainsOrPosition<int32_t, PositionFunctor>(args, state, result);
+}
+
+template <LogicalTypeId RETURN_TYPE>
+static unique_ptr<FunctionData> ListContainsOrPositionBind(ClientContext &context, ScalarFunction &bound_function,
+                                                           vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	const auto &list = arguments[0]->return_type; // change to list
+	const auto &value = arguments[1]->return_type;
+	if (list.id() == LogicalTypeId::SQLNULL && value.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.arguments[1] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else if (list.id() == LogicalTypeId::SQLNULL || value.id() == LogicalTypeId::SQLNULL) {
+		// In case either the list or the value is NULL, return NULL
+		// Similar to behaviour of prestoDB
+		bound_function.arguments[0] = list;
+		bound_function.arguments[1] = value;
+		bound_function.return_type = LogicalTypeId::SQLNULL;
+	} else if (list.id() == LogicalTypeId::UNKNOWN) {
+		bound_function.return_type = RETURN_TYPE;
+		if (value.id() != LogicalTypeId::UNKNOWN) {
+			// only list is a parameter, cast it to a list of value type
+			bound_function.arguments[0] = LogicalType::LIST(value);
+			bound_function.arguments[1] = value;
+		}
+	} else if (value.id() == LogicalTypeId::UNKNOWN) {
+		// only value is a parameter: we expect the child type of list
+		auto const &child_type = ListType::GetChildType(list);
+		bound_function.arguments[0] = list;
+		bound_function.arguments[1] = child_type;
+		bound_function.return_type = RETURN_TYPE;
+	} else {
+		auto const &child_type = ListType::GetChildType(list);
+		auto max_child_type = LogicalType::MaxLogicalType(child_type, value);
+		auto list_type = LogicalType::LIST(max_child_type);
+
+		bound_function.arguments[0] = list_type;
+		bound_function.arguments[1] = value == max_child_type ? value : max_child_type;
+
+		// list_contains and list_position only differ in their return type
+		bound_function.return_type = RETURN_TYPE;
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<FunctionData> ListContainsBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	return ListContainsOrPositionBind<LogicalType::BOOLEAN>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListPositionBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	return ListContainsOrPositionBind<LogicalType::INTEGER>(context, bound_function, arguments);
+}
+
+ScalarFunction ListContainsFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::ANY}, // argument list
+	                      LogicalType::BOOLEAN,                                    // return type
+	                      ListContainsFunction, false, false, ListContainsBind, nullptr);
+}
+
+ScalarFunction ListPositionFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::ANY}, // argument list
+	                      LogicalType::INTEGER,                                    // return type
+	                      ListPositionFunction, false, false, ListPositionBind, nullptr);
+}
+
+void ListContainsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_contains", "array_contains", "list_has", "array_has"}, GetFunction());
+}
+
+void ListPositionFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_position", "list_indexof", "array_position", "array_indexof"}, GetFunction());
+}
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+void ListFlattenFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 1);
+
+	Vector &input = args.data[0];
+	if (input.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(input);
+		return;
+	}
+
+	idx_t count = args.size();
+
+	VectorData list_data;
+	input.Orrify(count, list_data);
+	auto list_entries = (list_entry_t *)list_data.data;
+
+	auto &child_vector = ListVector::GetEntry(input);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (child_vector.GetType().id() == LogicalTypeId::SQLNULL) {
+		auto result_entries = FlatVector::GetData<list_entry_t>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto list_index = list_data.sel->get_index(i);
+			if (!list_data.validity.RowIsValid(list_index)) {
+				result_validity.SetInvalid(i);
+				continue;
+			}
+			result_entries[i].offset = 0;
+			result_entries[i].length = 0;
+		}
+		return;
+	}
+
+	auto child_size = ListVector::GetListSize(input);
+	VectorData child_data;
+	child_vector.Orrify(child_size, child_data);
+	auto child_entries = (list_entry_t *)child_data.data;
+	auto &data_vector = ListVector::GetEntry(child_vector);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		if (!list_data.validity.RowIsValid(list_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		auto list_entry = list_entries[list_index];
+
+		idx_t source_offset = 0;
+		// Find first valid child list entry to get offset
+		for (idx_t j = 0; j < list_entry.length; j++) {
+			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
+			if (child_data.validity.RowIsValid(child_list_index)) {
+				source_offset = child_entries[child_list_index].offset;
+				break;
+			}
+		}
+
+		idx_t length = 0;
+		// Find last valid child list entry to get length
+		for (idx_t j = list_entry.length - 1; j != (idx_t)-1; j--) {
+			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
+			if (child_data.validity.RowIsValid(child_list_index)) {
+				auto child_entry = child_entries[child_list_index];
+				length = child_entry.offset + child_entry.length - source_offset;
+				break;
+			}
+		}
+		ListVector::Append(result, data_vector, source_offset + length, source_offset);
+
+		result_entries[i].offset = offset;
+		result_entries[i].length = length;
+		offset += length;
+	}
+
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> ListFlattenBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 1);
+
+	auto &input_type = arguments[0]->return_type;
+	bound_function.arguments[0] = input_type;
+	if (input_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType(LogicalTypeId::SQLNULL);
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+	if (input_type.id() == LogicalTypeId::UNKNOWN) {
+		bound_function.arguments[0] = LogicalType(LogicalTypeId::UNKNOWN);
+		bound_function.return_type = LogicalType(LogicalTypeId::SQLNULL);
+		return nullptr;
+	}
+	D_ASSERT(input_type.id() == LogicalTypeId::LIST);
+
+	auto child_type = ListType::GetChildType(input_type);
+	if (child_type.id() == LogicalType::SQLNULL) {
+		bound_function.return_type = input_type;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+	D_ASSERT(child_type.id() == LogicalTypeId::LIST);
+
+	bound_function.return_type = child_type;
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &list_stats = (ListStatistics &)*child_stats[0];
+	if (!list_stats.child_stats || list_stats.child_stats->type == LogicalTypeId::SQLNULL) {
+		return nullptr;
+	}
+
+	auto child_copy = list_stats.child_stats->Copy();
+	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
+	return child_copy;
+}
+
+void ListFlattenFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun({LogicalType::LIST(LogicalType::LIST(LogicalType::ANY))}, LogicalType::LIST(LogicalType::ANY),
+	                   ListFlattenFunction, false, false, ListFlattenBind, nullptr, ListFlattenStats);
+	set.AddFunction({"flatten"}, fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// FIXME: use a local state for each thread to increase performance?
+// FIXME: benchmark the use of simple_update against using update (if applicable)
+
+struct ListAggregatesBindData : public FunctionData {
+	ListAggregatesBindData(const LogicalType &stype_p, unique_ptr<Expression> aggr_expr_p);
+	~ListAggregatesBindData() override;
+
+	LogicalType stype;
+	unique_ptr<Expression> aggr_expr;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ListAggregatesBindData>(stype, aggr_expr->Copy());
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ListAggregatesBindData &)other_p;
+		return stype == other.stype && aggr_expr->Equals(other.aggr_expr.get());
+	}
+};
+
+ListAggregatesBindData::ListAggregatesBindData(const LogicalType &stype_p, unique_ptr<Expression> aggr_expr_p)
+    : stype(stype_p), aggr_expr(move(aggr_expr_p)) {
+}
+
+ListAggregatesBindData::~ListAggregatesBindData() {
+}
+
+struct StateVector {
+	StateVector(idx_t count_p, unique_ptr<Expression> aggr_expr_p)
+	    : count(count_p), aggr_expr(move(aggr_expr_p)), state_vector(Vector(LogicalType::POINTER, count_p)) {
+	}
+
+	~StateVector() {
+		// destroy objects within the aggregate states
+		auto &aggr = (BoundAggregateExpression &)*aggr_expr;
+		if (aggr.function.destructor) {
+			aggr.function.destructor(state_vector, count);
+		}
+	}
+
+	idx_t count;
+	unique_ptr<Expression> aggr_expr;
+	Vector state_vector;
+};
+
+struct FinalizeValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		return Value::CreateValue(first);
+	}
+};
+
+struct FinalizeStringValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		string_t value = first;
+		return Value::CreateValue(value);
+	}
+};
+
+struct AggregateFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+	}
+};
+
+struct DistinctFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+
+		idx_t offset = 0;
+		for (idx_t i = 0; i < count; i++) {
+
+			auto state = states[sdata.sel->get_index(i)];
+			result_data[i].offset = offset;
+
+			if (!state->hist) {
+				result_data[i].length = 0;
+				continue;
+			}
+
+			result_data[i].length = state->hist->size();
+			offset += state->hist->size();
+
+			for (auto &entry : *state->hist) {
+				Value bucket_value = OP::template FinalizeValue<T>(entry.first);
+				ListVector::PushBack(result, bucket_value);
+			}
+		}
+		result.Verify(count);
+	}
+};
+
+struct UniqueFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+		auto result_data = FlatVector::GetData<uint64_t>(result);
+
+		for (idx_t i = 0; i < count; i++) {
+
+			auto state = states[sdata.sel->get_index(i)];
+
+			if (!state->hist) {
+				result_data[i] = 0;
+				continue;
+			}
+
+			result_data[i] = state->hist->size();
+		}
+		result.Verify(count);
+	}
+};
+
+template <class FUNCTION_FUNCTOR, bool IS_AGGR = false>
+static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	auto count = args.size();
+	Vector &lists = args.data[0];
+
+	// set the result vector
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	// get the aggregate function
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ListAggregatesBindData &)*func_expr.bind_info;
+	auto &aggr = (BoundAggregateExpression &)*info.aggr_expr;
+	AggregateInputData aggr_input_data(aggr.bind_info.get());
+
+	D_ASSERT(aggr.function.update);
+
+	auto lists_size = ListVector::GetListSize(lists);
+	auto &child_vector = ListVector::GetEntry(lists);
+
+	VectorData child_data;
+	child_vector.Orrify(lists_size, child_data);
+
+	VectorData lists_data;
+	lists.Orrify(count, lists_data);
+	auto list_entries = (list_entry_t *)lists_data.data;
+
+	// state_buffer holds the state for each list of this chunk
+	idx_t size = aggr.function.state_size();
+	auto state_buffer = unique_ptr<data_t[]>(new data_t[size * count]);
+
+	// state vector for initialize and finalize
+	StateVector state_vector(count, info.aggr_expr->Copy());
+	auto states = FlatVector::GetData<data_ptr_t>(state_vector.state_vector);
+
+	// state vector of STANDARD_VECTOR_SIZE holds the pointers to the states
+	Vector state_vector_update = Vector(LogicalType::POINTER);
+	auto states_update = FlatVector::GetData<data_ptr_t>(state_vector_update);
+
+	// selection vector pointing to the data
+	SelectionVector sel_vector(STANDARD_VECTOR_SIZE);
+	idx_t states_idx = 0;
+
+	for (idx_t i = 0; i < count; i++) {
+
+		// initialize the state for this list
+		auto state_ptr = state_buffer.get() + size * i;
+		states[i] = state_ptr;
+		aggr.function.initialize(states[i]);
+
+		auto lists_index = lists_data.sel->get_index(i);
+		const auto &list_entry = list_entries[lists_index];
+
+		// nothing to do for this list
+		if (!lists_data.validity.RowIsValid(lists_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// skip empty list
+		if (list_entry.length == 0) {
+			continue;
+		}
+
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			// states vector is full, update
+			if (states_idx == STANDARD_VECTOR_SIZE) {
+
+				// update the aggregate state(s)
+				Vector slice = Vector(child_vector, sel_vector, states_idx);
+				aggr.function.update(&slice, aggr_input_data, 1, state_vector_update, states_idx);
+
+				// reset values
+				states_idx = 0;
+			}
+
+			auto source_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			sel_vector.set_index(states_idx, source_idx);
+			states_update[states_idx] = state_ptr;
+			states_idx++;
+		}
+	}
+
+	// update the remaining elements of the last list(s)
+	if (states_idx != 0) {
+		Vector slice = Vector(child_vector, sel_vector, states_idx);
+		aggr.function.update(&slice, aggr_input_data, 1, state_vector_update, states_idx);
+	}
+
+	if (IS_AGGR) {
+		// finalize all the aggregate states
+		aggr.function.finalize(state_vector.state_vector, aggr_input_data, result, count, 0);
+
+	} else {
+		// finalize manually to use the map
+		D_ASSERT(aggr.function.arguments.size() == 1);
+		auto key_type = aggr.function.arguments[0];
+
+		switch (key_type.InternalType()) {
+		case PhysicalType::BOOL:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, bool>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT8:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint8_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT16:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint16_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT8:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int8_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT16:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int16_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::FLOAT:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, float>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DOUBLE:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, double>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DATE32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DATE64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIMESTAMP:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIME32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIME64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::STRING:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::LARGE_STRING:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::VARCHAR:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		default:
+			throw InternalException("Unimplemented histogram aggregate");
+		}
+	}
+}
+
+static void ListAggregateFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 2);
+	ListAggregatesFunction<AggregateFunctor, true>(args, state, result);
+}
+
+static void ListDistinctFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 1);
+	ListAggregatesFunction<DistinctFunctor>(args, state, result);
+}
+
+static void ListUniqueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 1);
+	ListAggregatesFunction<UniqueFunctor>(args, state, result);
+}
+
+template <bool IS_AGGR = false>
+static unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                           const LogicalType &list_child_type,
+                                                           AggregateFunction &aggr_function) {
+
+	// create the child expression and its type
+	vector<unique_ptr<Expression>> children;
+	auto expr = make_unique<BoundConstantExpression>(Value(list_child_type));
+	children.push_back(move(expr));
+
+	auto bound_aggr_function = AggregateFunction::BindAggregateFunction(context, aggr_function, move(children));
+	bound_function.arguments[0] = LogicalType::LIST(bound_aggr_function->function.arguments[0]);
+
+	if (IS_AGGR) {
+		bound_function.return_type = bound_aggr_function->function.return_type;
+	}
+
+	return make_unique<ListAggregatesBindData>(bound_function.return_type, move(bound_aggr_function));
+}
+
+template <bool IS_AGGR = false>
+static unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+
+	bool is_parameter = arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN;
+	auto list_child_type = is_parameter ? LogicalTypeId::UNKNOWN : ListType::GetChildType(arguments[0]->return_type);
+
+	string function_name = "histogram";
+	if (IS_AGGR) { // get the name of the aggregate function
+
+		if (!arguments[1]->IsFoldable()) {
+			throw InvalidInputException("Aggregate function name must be a constant");
+		}
+		// get the function name
+		Value function_value = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		function_name = function_value.ToString();
+	}
+
+	// look up the aggregate function in the catalog
+	QueryErrorContext error_context(nullptr, 0);
+	auto func = (AggregateFunctionCatalogEntry *)Catalog::GetCatalog(context).GetEntry<AggregateFunctionCatalogEntry>(
+	    context, DEFAULT_SCHEMA, function_name, false, error_context);
+	D_ASSERT(func->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+
+	if (is_parameter) {
+		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return nullptr;
+	}
+
+	// find a matching aggregate function
+	string error;
+	vector<LogicalType> types;
+	types.push_back(list_child_type);
+	auto best_function_idx = Function::BindFunction(func->name, func->functions, types, error);
+	if (best_function_idx == DConstants::INVALID_INDEX) {
+		throw BinderException("No matching aggregate function");
+	}
+
+	// found a matching function, bind it as an aggregate
+	auto &best_function = func->functions[best_function_idx];
+
+	if (IS_AGGR) {
+		return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, list_child_type, best_function);
+	}
+
+	// create the unordered map histogram function
+	D_ASSERT(best_function.arguments.size() == 1);
+	auto key_type = best_function.arguments[0];
+	auto aggr_function = HistogramFun::GetHistogramUnorderedMap(key_type);
+	return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, list_child_type, aggr_function);
+}
+
+static unique_ptr<FunctionData> ListAggregateBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+
+	// the list column and the name of the aggregate function
+	D_ASSERT(bound_function.arguments.size() == 2);
+	D_ASSERT(arguments.size() == 2);
+
+	return ListAggregatesBind<true>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListDistinctBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1);
+	D_ASSERT(arguments.size() == 1);
+	bound_function.return_type = arguments[0]->return_type;
+
+	return ListAggregatesBind<>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListUniqueBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1);
+	D_ASSERT(arguments.size() == 1);
+	bound_function.return_type = LogicalType::UBIGINT;
+
+	return ListAggregatesBind<>(context, bound_function, arguments);
+}
+
+ScalarFunction ListAggregateFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR}, LogicalType::ANY,
+	                      ListAggregateFunction, false, false, ListAggregateBind);
+}
+
+ScalarFunction ListDistinctFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY),
+	                      ListDistinctFunction, false, false, ListDistinctBind);
+}
+
+ScalarFunction ListUniqueFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::UBIGINT, ListUniqueFunction, false, false,
+	                      ListUniqueBind);
+}
+
+void ListAggregateFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_aggregate", "array_aggregate", "list_aggr", "array_aggr"}, GetFunction());
+}
+
+void ListDistinctFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_distinct", "array_distinct"}, GetFunction());
+}
+
+void ListUniqueFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_unique", "array_unique"}, GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	Vector &lhs = args.data[0];
+	Vector &rhs = args.data[1];
+	if (lhs.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(rhs);
+		return;
+	}
+	if (rhs.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(lhs);
+		return;
+	}
+
+	VectorData lhs_data;
+	VectorData rhs_data;
+	lhs.Orrify(count, lhs_data);
+	rhs.Orrify(count, rhs_data);
+	auto lhs_entries = (list_entry_t *)lhs_data.data;
+	auto rhs_entries = (list_entry_t *)rhs_data.data;
+
+	auto lhs_list_size = ListVector::GetListSize(lhs);
+	auto rhs_list_size = ListVector::GetListSize(rhs);
+	auto &lhs_child = ListVector::GetEntry(lhs);
+	auto &rhs_child = ListVector::GetEntry(rhs);
+	VectorData lhs_child_data;
+	VectorData rhs_child_data;
+	lhs_child.Orrify(lhs_list_size, lhs_child_data);
+	rhs_child.Orrify(rhs_list_size, rhs_child_data);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto lhs_list_index = lhs_data.sel->get_index(i);
+		auto rhs_list_index = rhs_data.sel->get_index(i);
+		if (!lhs_data.validity.RowIsValid(lhs_list_index) && !rhs_data.validity.RowIsValid(rhs_list_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		result_entries[i].offset = offset;
+		result_entries[i].length = 0;
+		if (lhs_data.validity.RowIsValid(lhs_list_index)) {
+			const auto &lhs_entry = lhs_entries[lhs_list_index];
+			result_entries[i].length += lhs_entry.length;
+			ListVector::Append(result, lhs_child, *lhs_child_data.sel, lhs_entry.offset + lhs_entry.length,
+			                   lhs_entry.offset);
+		}
+		if (rhs_data.validity.RowIsValid(rhs_list_index)) {
+			const auto &rhs_entry = rhs_entries[rhs_list_index];
+			result_entries[i].length += rhs_entry.length;
+			ListVector::Append(result, rhs_child, *rhs_child_data.sel, rhs_entry.offset + rhs_entry.length,
+			                   rhs_entry.offset);
+		}
+		offset += result_entries[i].length;
+	}
+	D_ASSERT(ListVector::GetListSize(result) == offset);
+
+	if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR && rhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> ListConcatBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	auto &lhs = arguments[0]->return_type;
+	auto &rhs = arguments[1]->return_type;
+	if (lhs.id() == LogicalTypeId::SQLNULL && rhs.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else if (lhs.id() == LogicalTypeId::SQLNULL || rhs.id() == LogicalTypeId::SQLNULL) {
+		// we mimic postgres behaviour: list_concat(NULL, my_list) = my_list
+		bound_function.arguments[0] = lhs;
+		bound_function.arguments[1] = rhs;
+		bound_function.return_type = rhs.id() == LogicalTypeId::SQLNULL ? lhs : rhs;
+	} else {
+		D_ASSERT(lhs.id() == LogicalTypeId::LIST);
+		D_ASSERT(rhs.id() == LogicalTypeId::LIST);
+
+		// Resolve list type
+		LogicalType child_type = LogicalType::SQLNULL;
+		for (const auto &argument : arguments) {
+			child_type = LogicalType::MaxLogicalType(child_type, ListType::GetChildType(argument->return_type));
+		}
+		auto list_type = LogicalType::LIST(move(child_type));
+
+		bound_function.arguments[0] = list_type;
+		bound_function.arguments[1] = list_type;
+		bound_function.return_type = list_type;
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	D_ASSERT(child_stats.size() == 2);
+	if (!child_stats[0] || !child_stats[1]) {
+		return nullptr;
+	}
+
+	auto &left_stats = (ListStatistics &)*child_stats[0];
+	auto &right_stats = (ListStatistics &)*child_stats[1];
+
+	auto stats = left_stats.Copy();
+	stats->Merge(right_stats);
+
+	return stats;
+}
+
+ScalarFunction ListConcatFun::GetFunction() {
+	// the arguments and return types are actually set in the binder function
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)},
+	                      LogicalType::LIST(LogicalType::ANY), ListConcatFunction, false, false, ListConcatBind,
+	                      nullptr, ListConcatStats);
+}
+
+void ListConcatFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_concat", "list_cat", "array_concat", "array_cat"}, GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T, bool HEAP_REF = false, bool VALIDITY_ONLY = false>
+void ListExtractTemplate(idx_t count, VectorData &list_data, VectorData &offsets_data, Vector &child_vector,
+                         idx_t list_size, Vector &result) {
+	VectorData child_data;
+	child_vector.Orrify(list_size, child_data);
+
+	T *result_data;
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	if (!VALIDITY_ONLY) {
+		result_data = FlatVector::GetData<T>(result);
+	}
+	auto &result_mask = FlatVector::Validity(result);
+
+	// heap-ref once
+	if (HEAP_REF) {
+		StringVector::AddHeapReference(result, child_vector);
+	}
+
+	// this is lifted from ExecuteGenericLoop because we can't push the list child data into this otherwise
+	// should have gone with GetValue perhaps
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		auto offsets_index = offsets_data.sel->get_index(i);
+		if (list_data.validity.RowIsValid(list_index) && offsets_data.validity.RowIsValid(offsets_index)) {
+			auto list_entry = ((list_entry_t *)list_data.data)[list_index];
+			auto offsets_entry = ((int64_t *)offsets_data.data)[offsets_index];
+
+			// 1-based indexing
+			if (offsets_entry == 0) {
+				result_mask.SetInvalid(i);
+				continue;
+			}
+			offsets_entry = (offsets_entry > 0) ? offsets_entry - 1 : offsets_entry;
+
+			idx_t child_offset;
+			if (offsets_entry < 0) {
+				if ((idx_t)-offsets_entry > list_entry.length) {
+					result_mask.SetInvalid(i);
+					continue;
+				}
+				child_offset = list_entry.offset + list_entry.length + offsets_entry;
+			} else {
+				if ((idx_t)offsets_entry >= list_entry.length) {
+					result_mask.SetInvalid(i);
+					continue;
+				}
+				child_offset = list_entry.offset + offsets_entry;
+			}
+			if (child_data.validity.RowIsValid(child_offset)) {
+				if (!VALIDITY_ONLY) {
+					result_data[i] = ((T *)child_data.data)[child_offset];
+				}
+			} else {
+				result_mask.SetInvalid(i);
+			}
+		} else {
+			result_mask.SetInvalid(i);
+		}
+	}
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+static void ExecuteListExtractInternal(const idx_t count, VectorData &list, VectorData &offsets, Vector &child_vector,
+                                       idx_t list_size, Vector &result) {
+	D_ASSERT(child_vector.GetType() == result.GetType());
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		ListExtractTemplate<int8_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT16:
+		ListExtractTemplate<int16_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT32:
+		ListExtractTemplate<int32_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT64:
+		ListExtractTemplate<int64_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT128:
+		ListExtractTemplate<hugeint_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT8:
+		ListExtractTemplate<uint8_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT16:
+		ListExtractTemplate<uint16_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT32:
+		ListExtractTemplate<uint32_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT64:
+		ListExtractTemplate<uint64_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::FLOAT:
+		ListExtractTemplate<float>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::DOUBLE:
+		ListExtractTemplate<double>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::VARCHAR:
+		ListExtractTemplate<string_t, true>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INTERVAL:
+		ListExtractTemplate<interval_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::STRUCT: {
+		auto &entries = StructVector::GetEntries(child_vector);
+		auto &result_entries = StructVector::GetEntries(result);
+		D_ASSERT(entries.size() == result_entries.size());
+		// extract the child entries of the struct
+		for (idx_t i = 0; i < entries.size(); i++) {
+			ExecuteListExtractInternal(count, list, offsets, *entries[i], list_size, *result_entries[i]);
+		}
+		// extract the validity mask
+		ListExtractTemplate<bool, false, true>(count, list, offsets, child_vector, list_size, result);
+		break;
+	}
+	case PhysicalType::LIST: {
+		// nested list: we have to reference the child
+		auto &child_child_list = ListVector::GetEntry(child_vector);
+
+		ListVector::GetEntry(result).Reference(child_child_list);
+		ListVector::SetListSize(result, ListVector::GetListSize(child_vector));
+		ListExtractTemplate<list_entry_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for LIST_EXTRACT");
+	}
+}
+
+static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, const idx_t count) {
+	D_ASSERT(list.GetType().id() == LogicalTypeId::LIST);
+	VectorData list_data;
+	VectorData offsets_data;
+
+	list.Orrify(count, list_data);
+	offsets.Orrify(count, offsets_data);
+	ExecuteListExtractInternal(count, list_data, offsets_data, ListVector::GetEntry(list),
+	                           ListVector::GetListSize(list), result);
+	result.Verify(count);
+}
+
+static void ExecuteStringExtract(Vector &result, Vector &input_vector, Vector &subscript_vector, const idx_t count) {
+	BinaryExecutor::Execute<string_t, int64_t, string_t>(
+	    input_vector, subscript_vector, result, count, [&](string_t input_string, int64_t subscript) {
+		    return SubstringFun::SubstringScalarFunction(result, input_string, subscript, 1);
+	    });
+}
+
+static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	Vector &base = args.data[0];
+	Vector &subscript = args.data[1];
+
+	switch (base.GetType().id()) {
+	case LogicalTypeId::LIST:
+		ExecuteListExtract(result, base, subscript, count);
+		break;
+	case LogicalTypeId::VARCHAR:
+		ExecuteStringExtract(result, base, subscript, count);
+		break;
+	case LogicalTypeId::SQLNULL:
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented");
+	}
+}
+
+static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else {
+		D_ASSERT(LogicalTypeId::LIST == arguments[0]->return_type.id());
+		// list extract returns the child type of the list as return type
+		bound_function.return_type = ListType::GetChildType(arguments[0]->return_type);
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &list_stats = (ListStatistics &)*child_stats[0];
+	if (!list_stats.child_stats) {
+		return nullptr;
+	}
+	auto child_copy = list_stats.child_stats->Copy();
+	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
+	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
+	return child_copy;
+}
+
+void ListExtractFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction lfun({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT}, LogicalType::ANY,
+	                    ListExtractFunction, false, false, ListExtractBind, nullptr, ListExtractStats);
+
+	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, ListExtractFunction, false,
+	                    false, nullptr);
+
+	ScalarFunctionSet list_extract("list_extract");
+	list_extract.AddFunction(lfun);
+	list_extract.AddFunction(sfun);
+	set.AddFunction(list_extract);
+
+	ScalarFunctionSet list_element("list_element");
+	list_element.AddFunction(lfun);
+	list_element.AddFunction(sfun);
+	set.AddFunction(list_element);
+
+	ScalarFunctionSet array_extract("array_extract");
+	array_extract.AddFunction(lfun);
+	array_extract.AddFunction(sfun);
+	array_extract.AddFunction(StructExtractFun::GetFunction());
+	set.AddFunction(array_extract);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ListSortBindData : public FunctionData {
+	ListSortBindData(OrderType order_type_p, OrderByNullType null_order_p, const LogicalType &return_type_p,
+	                 const LogicalType &child_type_p, ClientContext &context_p);
+	~ListSortBindData() override;
+
+	OrderType order_type;
+	OrderByNullType null_order;
+	LogicalType return_type;
+	LogicalType child_type;
+
+	vector<LogicalType> types;
+	vector<LogicalType> payload_types;
+
+	ClientContext &context;
+	unique_ptr<GlobalSortState> global_sort_state;
+	RowLayout payload_layout;
+	vector<BoundOrderByNode> orders;
+
+public:
+	bool Equals(const FunctionData &other_p) const override;
+	unique_ptr<FunctionData> Copy() const override;
+};
+
+ListSortBindData::ListSortBindData(OrderType order_type_p, OrderByNullType null_order_p,
+                                   const LogicalType &return_type_p, const LogicalType &child_type_p,
+                                   ClientContext &context_p)
+    : order_type(order_type_p), null_order(null_order_p), return_type(return_type_p), child_type(child_type_p),
+      context(context_p) {
+
+	// get the vector types
+	types.emplace_back(LogicalType::USMALLINT);
+	types.emplace_back(child_type);
+	D_ASSERT(types.size() == 2);
+
+	// get the payload types
+	payload_types.emplace_back(LogicalType::UINTEGER);
+	D_ASSERT(payload_types.size() == 1);
+
+	// initialize the payload layout
+	payload_layout.Initialize(payload_types);
+
+	// get the BoundOrderByNode
+	auto idx_col_expr = make_unique_base<Expression, BoundReferenceExpression>(LogicalType::USMALLINT, 0);
+	auto lists_col_expr = make_unique_base<Expression, BoundReferenceExpression>(child_type, 1);
+	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::ORDER_DEFAULT, move(idx_col_expr));
+	orders.emplace_back(order_type, null_order, move(lists_col_expr));
+}
+
+unique_ptr<FunctionData> ListSortBindData::Copy() const {
+	return make_unique<ListSortBindData>(order_type, null_order, return_type, child_type, context);
+}
+
+bool ListSortBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (ListSortBindData &)other_p;
+	return order_type == other.order_type && null_order == other.null_order;
+}
+
+ListSortBindData::~ListSortBindData() {
+}
+
+// create the key_chunk and the payload_chunk and sink them into the local_sort_state
+void SinkDataChunk(Vector *child_vector, SelectionVector &sel, idx_t offset_lists_indices, vector<LogicalType> &types,
+                   vector<LogicalType> &payload_types, Vector &payload_vector, LocalSortState &local_sort_state,
+                   bool &data_to_sort, Vector &lists_indices) {
+
+	// slice the child vector
+	Vector slice(*child_vector, sel, offset_lists_indices);
+
+	// initialize and fill key_chunk
+	DataChunk key_chunk;
+	key_chunk.InitializeEmpty(types);
+	key_chunk.data[0].Reference(lists_indices);
+	key_chunk.data[1].Reference(slice);
+	key_chunk.SetCardinality(offset_lists_indices);
+
+	// initialize and fill key_chunk and payload_chunk
+	DataChunk payload_chunk;
+	payload_chunk.InitializeEmpty(payload_types);
+	payload_chunk.data[0].Reference(payload_vector);
+	payload_chunk.SetCardinality(offset_lists_indices);
+
+	// sink
+	local_sort_state.SinkChunk(key_chunk, payload_chunk);
+	data_to_sort = true;
+}
+
+static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() >= 1 && args.ColumnCount() <= 3);
+	auto count = args.size();
+	Vector &lists = args.data[0];
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ListSortBindData &)*func_expr.bind_info;
+
+	// initialize the global and local sorting state
+	auto &buffer_manager = BufferManager::GetBufferManager(info.context);
+	info.global_sort_state = make_unique<GlobalSortState>(buffer_manager, info.orders, info.payload_layout);
+	auto &global_sort_state = *info.global_sort_state;
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(global_sort_state, buffer_manager);
+
+	// get the child vector
+	auto lists_size = ListVector::GetListSize(lists);
+	auto &child_vector = ListVector::GetEntry(lists);
+	VectorData child_data;
+	child_vector.Orrify(lists_size, child_data);
+
+	// get the lists data
+	VectorData lists_data;
+	lists.Orrify(count, lists_data);
+	auto list_entries = (list_entry_t *)lists_data.data;
+
+	// create the lists_indices vector, this contains an element for each list's entry,
+	// the element corresponds to the list's index, e.g. for [1, 2, 4], [5, 4]
+	// lists_indices contains [0, 0, 0, 1, 1]
+	Vector lists_indices(LogicalType::USMALLINT);
+	auto lists_indices_data = FlatVector::GetData<uint16_t>(lists_indices);
+
+	// create the payload_vector, this is just a vector containing incrementing integers
+	// this will later be used as the 'new' selection vector of the child_vector, after
+	// rearranging the payload according to the sorting order
+	Vector payload_vector(LogicalType::UINTEGER);
+	auto payload_vector_data = FlatVector::GetData<uint32_t>(payload_vector);
+
+	// selection vector pointing to the data of the child vector,
+	// used for slicing the child_vector correctly
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+
+	idx_t offset_lists_indices = 0;
+	uint32_t incr_payload_count = 0;
+	bool data_to_sort = false;
+
+	for (idx_t i = 0; i < count; i++) {
+
+		auto lists_index = lists_data.sel->get_index(i);
+		const auto &list_entry = list_entries[lists_index];
+
+		// nothing to do for this list
+		if (!lists_data.validity.RowIsValid(lists_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// empty list, no sorting required
+		if (list_entry.length == 0) {
+			continue;
+		}
+
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			// lists_indices vector is full, sink
+			if (offset_lists_indices == STANDARD_VECTOR_SIZE) {
+				SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
+				              local_sort_state, data_to_sort, lists_indices);
+				offset_lists_indices = 0;
+			}
+
+			auto source_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			sel.set_index(offset_lists_indices, source_idx);
+			lists_indices_data[offset_lists_indices] = (uint32_t)i;
+			payload_vector_data[offset_lists_indices] = incr_payload_count;
+			offset_lists_indices++;
+			incr_payload_count++;
+		}
+	}
+
+	if (offset_lists_indices != 0) {
+		SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
+		              local_sort_state, data_to_sort, lists_indices);
+	}
+
+	if (data_to_sort) {
+
+		// add local state to global state, which sorts the data
+		global_sort_state.AddLocalState(local_sort_state);
+		global_sort_state.PrepareMergePhase();
+
+		// selection vector that is to be filled with the 'sorted' payload
+		SelectionVector sel_sorted(incr_payload_count);
+		idx_t sel_sorted_idx = 0;
+
+		// scan the sorted row data
+		PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+		for (;;) {
+			DataChunk result_chunk;
+			result_chunk.Initialize(info.payload_types);
+			result_chunk.SetCardinality(0);
+			scanner.Scan(result_chunk);
+			if (result_chunk.size() == 0) {
+				break;
+			}
+
+			// construct the selection vector with the new order from the result vectors
+			Vector result_vector(result_chunk.data[0]);
+			auto result_data = FlatVector::GetData<uint32_t>(result_vector);
+			auto row_count = result_chunk.size();
+
+			for (idx_t i = 0; i < row_count; i++) {
+				sel_sorted.set_index(sel_sorted_idx, result_data[i]);
+				sel_sorted_idx++;
+			}
+		}
+
+		D_ASSERT(sel_sorted_idx == incr_payload_count);
+		child_vector.Slice(sel_sorted, sel_sorted_idx);
+		child_vector.Normalify(sel_sorted_idx);
+	}
+
+	result.Reference(lists);
+}
+
+static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                             vector<unique_ptr<Expression>> &arguments, OrderType &order,
+                                             OrderByNullType &null_order) {
+
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+
+	bound_function.arguments[0] = arguments[0]->return_type;
+	bound_function.return_type = arguments[0]->return_type;
+	auto child_type = ListType::GetChildType(arguments[0]->return_type);
+
+	return make_unique<ListSortBindData>(order, null_order, bound_function.return_type, child_type, context);
+}
+
+OrderByNullType GetNullOrder(vector<unique_ptr<Expression>> &arguments, idx_t idx) {
+
+	if (!arguments[idx]->IsFoldable()) {
+		throw InvalidInputException("Null sorting order must be a constant");
+	}
+	Value null_order_value = ExpressionExecutor::EvaluateScalar(*arguments[idx]);
+	auto null_order_name = null_order_value.ToString();
+	std::transform(null_order_name.begin(), null_order_name.end(), null_order_name.begin(), ::toupper);
+	if (null_order_name != "NULLS FIRST" && null_order_name != "NULLS LAST") {
+		throw InvalidInputException("Null sorting order must be either NULLS FIRST or NULLS LAST");
+	}
+
+	if (null_order_name == "NULLS LAST") {
+		return OrderByNullType::NULLS_LAST;
+	}
+	return OrderByNullType::NULLS_FIRST;
+}
+
+static unique_ptr<FunctionData> ListNormalSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() >= 1 && bound_function.arguments.size() <= 3);
+	D_ASSERT(arguments.size() >= 1 && arguments.size() <= 3);
+
+	// set default values
+	auto &config = DBConfig::GetConfig(context);
+	auto order = config.default_order_type;
+	auto null_order = config.default_null_order;
+
+	// get the sorting order
+	if (arguments.size() >= 2) {
+
+		if (!arguments[1]->IsFoldable()) {
+			throw InvalidInputException("Sorting order must be a constant");
+		}
+		Value order_value = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		auto order_name = order_value.ToString();
+		std::transform(order_name.begin(), order_name.end(), order_name.begin(), ::toupper);
+		if (order_name != "DESC" && order_name != "ASC") {
+			throw InvalidInputException("Sorting order must be either ASC or DESC");
+		}
+		if (order_name == "DESC") {
+			order = OrderType::DESCENDING;
+		} else {
+			order = OrderType::ASCENDING;
+		}
+	}
+
+	// get the null sorting order
+	if (arguments.size() == 3) {
+		null_order = GetNullOrder(arguments, 2);
+	}
+
+	return ListSortBind(context, bound_function, arguments, order, null_order);
+}
+
+static unique_ptr<FunctionData> ListReverseSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                                    vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1 || bound_function.arguments.size() == 2);
+	D_ASSERT(arguments.size() == 1 || arguments.size() == 2);
+
+	// set (reverse) default values
+	auto &config = DBConfig::GetConfig(context);
+	auto order = (config.default_order_type == OrderType::ASCENDING) ? OrderType::DESCENDING : OrderType::ASCENDING;
+	auto null_order = config.default_null_order;
+
+	// get the null sorting order
+	if (arguments.size() == 2) {
+		null_order = GetNullOrder(arguments, 1);
+	}
+
+	return ListSortBind(context, bound_function, arguments, order, null_order);
+}
+
+void ListSortFun::RegisterFunction(BuiltinFunctions &set) {
+
+	// normal sort
+
+	// one parameter: list
+	ScalarFunction sort({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY), ListSortFunction,
+	                    false, false, ListNormalSortBind);
+
+	// two parameters: list, order
+	ScalarFunction sort_order({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR},
+	                          LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false, ListNormalSortBind);
+
+	// three parameters: list, order, null order
+	ScalarFunction sort_orders({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                           LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false, ListNormalSortBind);
+
+	ScalarFunctionSet list_sort("list_sort");
+	list_sort.AddFunction(sort);
+	list_sort.AddFunction(sort_order);
+	list_sort.AddFunction(sort_orders);
+	set.AddFunction(list_sort);
+
+	ScalarFunctionSet array_sort("array_sort");
+	array_sort.AddFunction(sort);
+	array_sort.AddFunction(sort_order);
+	array_sort.AddFunction(sort_orders);
+	set.AddFunction(array_sort);
+
+	// reverse sort
+
+	// one parameter: list
+	ScalarFunction sort_reverse({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY),
+	                            ListSortFunction, false, false, ListReverseSortBind);
+
+	// two parameters: list, null order
+	ScalarFunction sort_reverse_null_order({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR},
+	                                       LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false,
+	                                       ListReverseSortBind);
+
+	ScalarFunctionSet list_reverse_sort("list_reverse_sort");
+	list_reverse_sort.AddFunction(sort_reverse);
+	list_reverse_sort.AddFunction(sort_reverse_null_order);
+	set.AddFunction(list_reverse_sort);
+
+	ScalarFunctionSet array_reverse_sort("array_reverse_sort");
+	array_reverse_sort.AddFunction(sort_reverse);
+	array_reverse_sort.AddFunction(sort_reverse_null_order);
+	set.AddFunction(array_reverse_sort);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+	auto &child_type = ListType::GetChildType(result.GetType());
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i].offset = ListVector::GetListSize(result);
+		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+			auto val = args.GetValue(col_idx, i).CastAs(child_type);
+			ListVector::PushBack(result, val);
+		}
+		result_data[i].length = args.ColumnCount();
+	}
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	// collect names and deconflict, construct return type
+	LogicalType child_type = LogicalType::SQLNULL;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		child_type = LogicalType::MaxLogicalType(child_type, arguments[i]->return_type);
+	}
+
+	// this is more for completeness reasons
+	bound_function.varargs = child_type;
+	bound_function.return_type = LogicalType::LIST(move(child_type));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	auto list_stats = make_unique<ListStatistics>(expr.return_type);
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		if (child_stats[i]) {
+			list_stats->child_stats->Merge(*child_stats[i]);
+		} else {
+			list_stats->child_stats.reset();
+			return move(list_stats);
+		}
+	}
+	return move(list_stats);
+}
+
+void ListValueFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun("list_value", {}, LogicalTypeId::LIST, ListValueFunction, false, ListValueBind, nullptr,
+	                   ListValueStats);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+	fun.name = "list_pack";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct NumericRangeInfo {
+	using TYPE = int64_t;
+	using INCREMENT_TYPE = int64_t;
+
+	static int64_t DefaultStart() {
+		return 0;
+	}
+	static int64_t DefaultIncrement() {
+		return 1;
+	}
+
+	static uint64_t ListLength(int64_t start_value, int64_t end_value, int64_t increment_value, bool inclusive_bound) {
+		if (increment_value == 0) {
+			return 0;
+		}
+		if (start_value > end_value && increment_value > 0) {
+			return 0;
+		}
+		if (start_value < end_value && increment_value < 0) {
+			return 0;
+		}
+		hugeint_t total_diff = AbsValue(hugeint_t(end_value) - hugeint_t(start_value));
+		hugeint_t increment = AbsValue(hugeint_t(increment_value));
+		hugeint_t total_values = total_diff / increment;
+		if (total_diff % increment == 0) {
+			if (inclusive_bound) {
+				total_values += 1;
+			}
+		} else {
+			total_values += 1;
+		}
+		if (total_values > NumericLimits<uint32_t>::Maximum()) {
+			throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+		}
+		return Hugeint::Cast<uint64_t>(total_values);
+	}
+
+	static void Increment(int64_t &input, int64_t increment) {
+		input += increment;
+	}
+};
+struct TimestampRangeInfo {
+	using TYPE = timestamp_t;
+	using INCREMENT_TYPE = interval_t;
+
+	static timestamp_t DefaultStart() {
+		throw InternalException("Default start not implemented for timestamp range");
+	}
+	static interval_t DefaultIncrement() {
+		throw InternalException("Default increment not implemented for timestamp range");
+	}
+	static uint64_t ListLength(timestamp_t start_value, timestamp_t end_value, interval_t increment_value,
+	                           bool inclusive_bound) {
+		bool is_positive = increment_value.months > 0 || increment_value.days > 0 || increment_value.micros > 0;
+		bool is_negative = increment_value.months < 0 || increment_value.days < 0 || increment_value.micros < 0;
+		if (!is_negative && !is_positive) {
+			// interval is 0: no result
+			return 0;
+		}
+		// We don't allow infinite bounds because they generate errors or infinite loops
+		if (!Timestamp::IsFinite(start_value) || !Timestamp::IsFinite(end_value)) {
+			throw InvalidInputException("Interval infinite bounds not supported");
+		}
+
+		if (is_negative && is_positive) {
+			// we don't allow a mix of
+			throw InvalidInputException("Interval with mix of negative/positive entries not supported");
+		}
+		if (start_value > end_value && is_positive) {
+			return 0;
+		}
+		if (start_value < end_value && is_negative) {
+			return 0;
+		}
+		int64_t total_values = 0;
+		if (is_negative) {
+			// negative interval, start_value is going down
+			while (inclusive_bound ? start_value >= end_value : start_value > end_value) {
+				start_value = Interval::Add(start_value, increment_value);
+				total_values++;
+				if (total_values > NumericLimits<uint32_t>::Maximum()) {
+					throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+				}
+			}
+		} else {
+			// positive interval, start_value is going up
+			while (inclusive_bound ? start_value <= end_value : start_value < end_value) {
+				start_value = Interval::Add(start_value, increment_value);
+				total_values++;
+				if (total_values > NumericLimits<uint32_t>::Maximum()) {
+					throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+				}
+			}
+		}
+		return total_values;
+	}
+
+	static void Increment(timestamp_t &input, interval_t increment) {
+		input = Interval::Add(input, increment);
+	}
+};
+
+template <class OP, bool INCLUSIVE_BOUND>
+class RangeInfoStruct {
+public:
+	explicit RangeInfoStruct(DataChunk &args_p) : args(args_p) {
+		switch (args.ColumnCount()) {
+		case 1:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			break;
+		case 2:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			args.data[1].Orrify(args.size(), vdata[1]);
+			break;
+		case 3:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			args.data[1].Orrify(args.size(), vdata[1]);
+			args.data[2].Orrify(args.size(), vdata[2]);
+			break;
+		default:
+			throw InternalException("Unsupported number of parameters for range");
+		}
+	}
+
+	bool RowIsValid(idx_t row_idx) {
+		for (idx_t i = 0; i < args.ColumnCount(); i++) {
+			auto idx = vdata[i].sel->get_index(row_idx);
+			if (!vdata[i].validity.RowIsValid(idx)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	typename OP::TYPE StartListValue(idx_t row_idx) {
+		if (args.ColumnCount() == 1) {
+			return OP::DefaultStart();
+		} else {
+			auto data = (typename OP::TYPE *)vdata[0].data;
+			auto idx = vdata[0].sel->get_index(row_idx);
+			return data[idx];
+		}
+	}
+
+	typename OP::TYPE EndListValue(idx_t row_idx) {
+		idx_t vdata_idx = args.ColumnCount() == 1 ? 0 : 1;
+		auto data = (typename OP::TYPE *)vdata[vdata_idx].data;
+		auto idx = vdata[vdata_idx].sel->get_index(row_idx);
+		return data[idx];
+	}
+
+	typename OP::INCREMENT_TYPE ListIncrementValue(idx_t row_idx) {
+		if (args.ColumnCount() < 3) {
+			return OP::DefaultIncrement();
+		} else {
+			auto data = (typename OP::INCREMENT_TYPE *)vdata[2].data;
+			auto idx = vdata[2].sel->get_index(row_idx);
+			return data[idx];
+		}
+	}
+
+	void GetListValues(idx_t row_idx, typename OP::TYPE &start_value, typename OP::TYPE &end_value,
+	                   typename OP::INCREMENT_TYPE &increment_value) {
+		start_value = StartListValue(row_idx);
+		end_value = EndListValue(row_idx);
+		increment_value = ListIncrementValue(row_idx);
+	}
+
+	uint64_t ListLength(idx_t row_idx) {
+		typename OP::TYPE start_value;
+		typename OP::TYPE end_value;
+		typename OP::INCREMENT_TYPE increment_value;
+		GetListValues(row_idx, start_value, end_value, increment_value);
+		return OP::ListLength(start_value, end_value, increment_value, INCLUSIVE_BOUND);
+	}
+
+private:
+	DataChunk &args;
+	VectorData vdata[3];
+};
+
+template <class OP, bool INCLUSIVE_BOUND>
+static void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	RangeInfoStruct<OP, INCLUSIVE_BOUND> info(args);
+	idx_t args_size = 1;
+	auto result_type = VectorType::CONSTANT_VECTOR;
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			args_size = args.size();
+			result_type = VectorType::FLAT_VECTOR;
+			break;
+		}
+	}
+	auto list_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	int64_t total_size = 0;
+	for (idx_t i = 0; i < args_size; i++) {
+		if (!info.RowIsValid(i)) {
+			result_validity.SetInvalid(i);
+			list_data[i].offset = total_size;
+			list_data[i].length = 0;
+		} else {
+			list_data[i].offset = total_size;
+			list_data[i].length = info.ListLength(i);
+			total_size += list_data[i].length;
+		}
+	}
+
+	// now construct the child vector of the list
+	ListVector::Reserve(result, total_size);
+	auto range_data = FlatVector::GetData<typename OP::TYPE>(ListVector::GetEntry(result));
+	idx_t total_idx = 0;
+	for (idx_t i = 0; i < args_size; i++) {
+		typename OP::TYPE start_value = info.StartListValue(i);
+		typename OP::INCREMENT_TYPE increment = info.ListIncrementValue(i);
+
+		typename OP::TYPE range_value = start_value;
+		for (idx_t range_idx = 0; range_idx < list_data[i].length; range_idx++) {
+			if (range_idx > 0) {
+				OP::Increment(range_value, increment);
+			}
+			range_data[total_idx++] = range_value;
+		}
+	}
+
+	ListVector::SetListSize(result, total_size);
+	result.SetVectorType(result_type);
+
+	result.Verify(args.size());
+}
+
+void ListRangeFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunctionSet range_set("range");
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                     LogicalType::LIST(LogicalType::TIMESTAMP),
+	                                     ListRangeFunction<TimestampRangeInfo, false>));
+	set.AddFunction(range_set);
+
+	ScalarFunctionSet generate_series("generate_series");
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
+	                                           LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                           LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                           LogicalType::LIST(LogicalType::TIMESTAMP),
+	                                           ListRangeFunction<TimestampRangeInfo, true>));
+	set.AddFunction(generate_series);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &map = args.data[0];
+	VectorData list_data;
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<uint64_t>(result);
+
+	auto &children = StructVector::GetEntries(map);
+	children[0]->Orrify(args.size(), list_data);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto list_entry = ((list_entry_t *)list_data.data)[list_data.sel->get_index(row)];
+		result_data[row] = list_entry.length;
+	}
+
+	if (args.size() == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> CardinalityBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+
+	if (arguments[0]->return_type.id() != LogicalTypeId::MAP) {
+		throw BinderException("Cardinality can only operate on MAPs");
+	}
+
+	bound_function.return_type = LogicalType::UBIGINT;
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void CardinalityFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun("cardinality", {LogicalType::ANY}, LogicalType::UBIGINT, CardinalityFunction, false,
+	                   CardinalityBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// TODO: this doesn't recursively verify maps if maps are nested
+MapInvalidReason CheckMapValidity(Vector &map, idx_t count, const SelectionVector &sel) {
+	D_ASSERT(map.GetType().id() == LogicalTypeId::MAP);
+	VectorData map_vdata;
+	map.Orrify(count, map_vdata);
+	auto &map_validity = map_vdata.validity;
+
+	auto &key_vector = *(StructVector::GetEntries(map)[0]);
+	VectorData key_vdata;
+	key_vector.Orrify(count, key_vdata);
+	auto key_data = (list_entry_t *)key_vdata.data;
+	auto &key_validity = key_vdata.validity;
+
+	auto &key_entries = ListVector::GetEntry(key_vector);
+	VectorData key_entry_vdata;
+	key_entries.Orrify(count, key_entry_vdata);
+	auto &entry_validity = key_entry_vdata.validity;
+
+	for (idx_t row = 0; row < count; row++) {
+		auto mapped_row = sel.get_index(row);
+		auto row_idx = map_vdata.sel->get_index(mapped_row);
+		// map is allowed to be NULL
+		if (!map_validity.RowIsValid(row_idx)) {
+			continue;
+		}
+		row_idx = key_vdata.sel->get_index(row);
+		if (!key_validity.RowIsValid(row_idx)) {
+			return MapInvalidReason::NULL_KEY_LIST;
+		}
+		value_set_t unique_keys;
+		for (idx_t i = 0; i < key_data[row_idx].length; i++) {
+			auto index = key_data[row_idx].offset + i;
+			index = key_entry_vdata.sel->get_index(index);
+			if (!entry_validity.RowIsValid(index)) {
+				return MapInvalidReason::NULL_KEY;
+			}
+			auto value = key_entries.GetValue(index);
+			auto result = unique_keys.insert(value);
+			if (!result.second) {
+				return MapInvalidReason::DUPLICATE_KEY;
+			}
+		}
+	}
+	return MapInvalidReason::VALID;
+}
+
+static void MapConversionVerify(Vector &vector, idx_t count) {
+	auto valid_check = CheckMapValidity(vector, count);
+	switch (valid_check) {
+	case MapInvalidReason::VALID:
+		break;
+	case MapInvalidReason::DUPLICATE_KEY: {
+		throw InvalidInputException("Map keys have to be unique");
+	}
+	case MapInvalidReason::NULL_KEY: {
+		throw InvalidInputException("Map keys can not be NULL");
+	}
+	case MapInvalidReason::NULL_KEY_LIST: {
+		throw InvalidInputException("The list of map keys is not allowed to be NULL");
+	}
+	default: {
+		throw InternalException("MapInvalidReason not implemented");
+	}
+	}
+}
+
+static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::MAP);
+
+	//! Otherwise if its not a constant vector, this breaks the optimizer
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	auto &child_entries = StructVector::GetEntries(result);
+	D_ASSERT(child_entries.size() == 2);
+	auto &key_vector = *child_entries[0];
+	auto &value_vector = *child_entries[1];
+	if (args.data.empty()) {
+		// no arguments: construct an empty map
+		ListVector::SetListSize(key_vector, 0);
+		key_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto list_data = ConstantVector::GetData<list_entry_t>(key_vector);
+		list_data->offset = 0;
+		list_data->length = 0;
+
+		ListVector::SetListSize(value_vector, 0);
+		value_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		list_data = ConstantVector::GetData<list_entry_t>(value_vector);
+		list_data->offset = 0;
+		list_data->length = 0;
+
+		result.Verify(args.size());
+		return;
+	}
+
+	if (ListVector::GetListSize(args.data[0]) != ListVector::GetListSize(args.data[1])) {
+		throw Exception("Key list has a different size from Value list");
+	}
+
+	key_vector.Reference(args.data[0]);
+	value_vector.Reference(args.data[1]);
+	MapConversionVerify(result, args.size());
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> MapBind(ClientContext &context, ScalarFunction &bound_function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	child_list_t<LogicalType> child_types;
+
+	if (arguments.size() != 2 && !arguments.empty()) {
+		throw Exception("We need exactly two lists for a map");
+	}
+	if (arguments.size() == 2) {
+		if (arguments[0]->return_type.id() != LogicalTypeId::LIST) {
+			throw Exception("First argument is not a list");
+		}
+		if (arguments[1]->return_type.id() != LogicalTypeId::LIST) {
+			throw Exception("Second argument is not a list");
+		}
+		child_types.push_back(make_pair("key", arguments[0]->return_type));
+		child_types.push_back(make_pair("value", arguments[1]->return_type));
+	}
+
+	if (arguments.empty()) {
+		auto empty = LogicalType::LIST(LogicalTypeId::SQLNULL);
+		child_types.push_back(make_pair("key", empty));
+		child_types.push_back(make_pair("value", empty));
+	}
+
+	//! this is more for completeness reasons
+	bound_function.return_type = LogicalType::MAP(move(child_types));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void MapFun::RegisterFunction(BuiltinFunctions &set) {
+	//! the arguments and return types are actually set in the binder function
+	ScalarFunction fun("map", {}, LogicalTypeId::MAP, MapFunction, false, MapBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+void FillResult(Value &values, Vector &result, idx_t row) {
+	//! First Initialize List Vector
+	idx_t current_offset = ListVector::GetListSize(result);
+	//! Push Values to List Vector
+	auto &list_values = ListValue::GetChildren(values);
+	for (idx_t i = 0; i < list_values.size(); i++) {
+		ListVector::PushBack(result, list_values[i]);
+	}
+
+	//! now set the pointer
+	auto &entry = ((list_entry_t *)result.GetData())[row];
+	entry.length = list_values.size();
+	entry.offset = current_offset;
+}
+
+static void MapExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.data.size() == 2);
+	D_ASSERT(args.data[0].GetType().id() == LogicalTypeId::MAP);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &map = args.data[0];
+	auto &key = args.data[1];
+
+	auto key_value = key.GetValue(0);
+	VectorData offset_data;
+
+	auto &children = StructVector::GetEntries(map);
+	children[0]->Orrify(args.size(), offset_data);
+	auto &key_type = ListType::GetChildType(children[0]->GetType());
+	if (key_type != LogicalTypeId::SQLNULL) {
+		key_value = key_value.CastAs(key_type);
+	}
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto offsets = ListVector::Search(*children[0], key_value, offset_data.sel->get_index(row));
+		auto values = ListVector::GetValuesFromOffsets(*children[1], offsets);
+		FillResult(values, result, row);
+	}
+
+	if (args.size() == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> MapExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() != 2) {
+		throw BinderException("MAP_EXTRACT must have exactly two arguments");
+	}
+	if (arguments[0]->return_type.id() != LogicalTypeId::MAP) {
+		throw BinderException("MAP_EXTRACT can only operate on MAPs");
+	}
+	auto &child_types = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &value_type = ListType::GetChildType(child_types[1].second);
+
+	//! Here we have to construct the List Type that will be returned
+	bound_function.return_type = LogicalType::LIST(value_type);
+	return make_unique<VariableReturnBindData>(value_type);
+}
+
+void MapExtractFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun("map_extract", {LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, MapExtractFunction, false,
+	                   MapExtractBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+	fun.name = "element_at";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+#include <errno.h>
+
+namespace duckdb {
+
+template <class TR, class OP>
+static scalar_function_t GetScalarIntegerUnaryFunctionFixedReturn(const LogicalType &type) {
+	scalar_function_t function;
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		function = &ScalarFunction::UnaryFunction<int8_t, TR, OP>;
+		break;
+	case LogicalTypeId::SMALLINT:
+		function = &ScalarFunction::UnaryFunction<int16_t, TR, OP>;
+		break;
+	case LogicalTypeId::INTEGER:
+		function = &ScalarFunction::UnaryFunction<int32_t, TR, OP>;
+		break;
+	case LogicalTypeId::BIGINT:
+		function = &ScalarFunction::UnaryFunction<int64_t, TR, OP>;
+		break;
+	case LogicalTypeId::HUGEINT:
+		function = &ScalarFunction::UnaryFunction<hugeint_t, TR, OP>;
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarIntegerUnaryFunctionFixedReturn");
+	}
+	return function;
+}
+
+//===--------------------------------------------------------------------===//
+// nextafter
+//===--------------------------------------------------------------------===//
+struct NextAfterOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA base, TB exponent) {
+		throw NotImplementedException("Unimplemented type for NextAfter Function");
+	}
+
+	template <class TA, class TB, class TR>
+	static inline double Operation(double input, double approximate_to) {
+		return nextafter(input, approximate_to);
+	}
+	template <class TA, class TB, class TR>
+	static inline float Operation(float input, float approximate_to) {
+		return nextafterf(input, approximate_to);
+	}
+};
+
+void NextAfterFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet next_after_fun("nextafter");
+	next_after_fun.AddFunction(
+	    ScalarFunction("nextafter", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::BinaryFunction<double, double, double, NextAfterOperator>, false));
+	next_after_fun.AddFunction(ScalarFunction("nextafter", {LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT,
+	                                          ScalarFunction::BinaryFunction<float, float, float, NextAfterOperator>,
+	                                          false));
+	set.AddFunction(next_after_fun);
+}
+
+//===--------------------------------------------------------------------===//
+// abs
+//===--------------------------------------------------------------------===//
+static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &lstats = (NumericStatistics &)*child_stats[0];
+	Value new_min, new_max;
+	bool potential_overflow = true;
+	if (!lstats.min.IsNull() && !lstats.max.IsNull()) {
+		switch (expr.return_type.InternalType()) {
+		case PhysicalType::INT8:
+			potential_overflow = lstats.min.GetValue<int8_t>() == NumericLimits<int8_t>::Minimum();
+			break;
+		case PhysicalType::INT16:
+			potential_overflow = lstats.min.GetValue<int16_t>() == NumericLimits<int16_t>::Minimum();
+			break;
+		case PhysicalType::INT32:
+			potential_overflow = lstats.min.GetValue<int32_t>() == NumericLimits<int32_t>::Minimum();
+			break;
+		case PhysicalType::INT64:
+			potential_overflow = lstats.min.GetValue<int64_t>() == NumericLimits<int64_t>::Minimum();
+			break;
+		default:
+			return nullptr;
+		}
+	}
+	if (potential_overflow) {
+		new_min = Value(expr.return_type);
+		new_max = Value(expr.return_type);
+	} else {
+		// no potential overflow
+
+		// compute stats
+		auto current_min = lstats.min.GetValue<int64_t>();
+		auto current_max = lstats.max.GetValue<int64_t>();
+
+		int64_t min_val, max_val;
+
+		if (current_min < 0 && current_max < 0) {
+			// if both min and max are below zero, then min=abs(cur_max) and max=abs(cur_min)
+			min_val = AbsValue(current_max);
+			max_val = AbsValue(current_min);
+		} else if (current_min < 0) {
+			D_ASSERT(current_max >= 0);
+			// if min is below zero and max is above 0, then min=0 and max=max(cur_max, abs(cur_min))
+			min_val = 0;
+			max_val = MaxValue(AbsValue(current_min), current_max);
+		} else {
+			// if both current_min and current_max are > 0, then the abs is a no-op and can be removed entirely
+			*input.expr_ptr = move(input.expr.children[0]);
+			return move(child_stats[0]);
+		}
+		new_min = Value::Numeric(expr.return_type, min_val);
+		new_max = Value::Numeric(expr.return_type, max_val);
+		expr.function.function = ScalarFunction::GetScalarUnaryFunction<AbsOperator>(expr.return_type);
+	}
+	auto stats =
+	    make_unique<NumericStatistics>(expr.return_type, move(new_min), move(new_max), StatisticsType::LOCAL_STATS);
+	stats->validity_stats = lstats.validity_stats->Copy();
+	return move(stats);
+}
+
+template <class OP>
+unique_ptr<FunctionData> DecimalUnaryOpBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::SMALLINT);
+		break;
+	case PhysicalType::INT32:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::INTEGER);
+		break;
+	case PhysicalType::INT64:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::BIGINT);
+		break;
+	default:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::HUGEINT);
+		break;
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = decimal_type;
+	return nullptr;
+}
+
+void AbsFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet abs("abs");
+	for (auto &type : LogicalType::Numeric()) {
+		switch (type.id()) {
+		case LogicalTypeId::DECIMAL:
+			abs.AddFunction(ScalarFunction({type}, type, nullptr, false, false, DecimalUnaryOpBind<AbsOperator>));
+			break;
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT: {
+			ScalarFunction func({type}, type, ScalarFunction::GetScalarUnaryFunction<TryAbsOperator>(type));
+			func.statistics = PropagateAbsStats;
+			abs.AddFunction(func);
+			break;
+		}
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+			abs.AddFunction(ScalarFunction({type}, type, ScalarFunction::NopFunction));
+			break;
+		default:
+			abs.AddFunction(ScalarFunction({type}, type, ScalarFunction::GetScalarUnaryFunction<AbsOperator>(type)));
+			break;
+		}
+	}
+	set.AddFunction(abs);
+	abs.name = "@";
+	set.AddFunction(abs);
+}
+
+//===--------------------------------------------------------------------===//
+// bit_count
+//===--------------------------------------------------------------------===//
+struct BitCntOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		using TU = typename std::make_unsigned<TA>::type;
+		TR count = 0;
+		for (auto value = TU(input); value > 0; value >>= 1) {
+			count += TR(value & 1);
+		}
+		return count;
+	}
+};
+
+void BitCountFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("bit_count");
+	functions.AddFunction(ScalarFunction({LogicalType::TINYINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int8_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::SMALLINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int16_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::INTEGER}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int32_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int64_t, int8_t, BitCntOperator>));
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// sign
+//===--------------------------------------------------------------------===//
+struct SignOperator {
+	template <class TA, class TR>
+	static TR Operation(TA input) {
+		if (input == TA(0)) {
+			return 0;
+		} else if (input > TA(0)) {
+			return 1;
+		} else {
+			return -1;
+		}
+	}
+};
+
+template <>
+int8_t SignOperator::Operation(float input) {
+	if (input == 0 || Value::IsNan(input)) {
+		return 0;
+	} else if (input > 0) {
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+template <>
+int8_t SignOperator::Operation(double input) {
+	if (input == 0 || Value::IsNan(input)) {
+		return 0;
+	} else if (input > 0) {
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+void SignFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet sign("sign");
+	for (auto &type : LogicalType::Numeric()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			continue;
+		} else {
+			sign.AddFunction(
+			    ScalarFunction({type}, LogicalType::TINYINT,
+			                   ScalarFunction::GetScalarUnaryFunctionFixedReturn<int8_t, SignOperator>(type)));
+		}
+	}
+	set.AddFunction(sign);
+}
+
+//===--------------------------------------------------------------------===//
+// ceil
+//===--------------------------------------------------------------------===//
+struct CeilOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::ceil(left);
+	}
+};
+
+template <class T, class POWERS_OF_TEN, class OP>
+static void GenericRoundFunctionDecimal(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	OP::template Operation<T, POWERS_OF_TEN>(input, DecimalType::GetScale(func_expr.children[0]->return_type), result);
+}
+
+template <class OP>
+unique_ptr<FunctionData> BindGenericRoundFunctionDecimal(ClientContext &context, ScalarFunction &bound_function,
+                                                         vector<unique_ptr<Expression>> &arguments) {
+	// ceil essentially removes the scale
+	auto &decimal_type = arguments[0]->return_type;
+	auto scale = DecimalType::GetScale(decimal_type);
+	auto width = DecimalType::GetWidth(decimal_type);
+	if (scale == 0) {
+		bound_function.function = ScalarFunction::NopFunction;
+	} else {
+		switch (decimal_type.InternalType()) {
+		case PhysicalType::INT16:
+			bound_function.function = GenericRoundFunctionDecimal<int16_t, NumericHelper, OP>;
+			break;
+		case PhysicalType::INT32:
+			bound_function.function = GenericRoundFunctionDecimal<int32_t, NumericHelper, OP>;
+			break;
+		case PhysicalType::INT64:
+			bound_function.function = GenericRoundFunctionDecimal<int64_t, NumericHelper, OP>;
+			break;
+		default:
+			bound_function.function = GenericRoundFunctionDecimal<hugeint_t, Hugeint, OP>;
+			break;
+		}
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = LogicalType::DECIMAL(width, 0);
+	return nullptr;
+}
+
+struct CeilDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				// below 0 we floor the number (e.g. -10.5 -> -10)
+				return input / power_of_ten;
+			} else {
+				// above 0 we ceil the number
+				return ((input - 1) / power_of_ten) + 1;
+			}
+		});
+	}
+};
+
+void CeilFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet ceil("ceil");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		if (type.IsIntegral()) {
+			// no ceil for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			func = ScalarFunction::UnaryFunction<float, float, CeilOperator>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			func = ScalarFunction::UnaryFunction<double, double, CeilOperator>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<CeilDecimalOperator>;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"ceil\"");
+		}
+		ceil.AddFunction(ScalarFunction({type}, type, func, false, false, bind_func));
+	}
+
+	set.AddFunction(ceil);
+	ceil.name = "ceiling";
+	set.AddFunction(ceil);
+}
+
+//===--------------------------------------------------------------------===//
+// floor
+//===--------------------------------------------------------------------===//
+struct FloorOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::floor(left);
+	}
+};
+
+struct FloorDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				// below 0 we ceil the number (e.g. -10.5 -> -11)
+				return ((input + 1) / power_of_ten) - 1;
+			} else {
+				// above 0 we floor the number
+				return input / power_of_ten;
+			}
+		});
+	}
+};
+
+void FloorFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet floor("floor");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		if (type.IsIntegral()) {
+			// no floor for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			func = ScalarFunction::UnaryFunction<float, float, FloorOperator>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			func = ScalarFunction::UnaryFunction<double, double, FloorOperator>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<FloorDecimalOperator>;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"floor\"");
+		}
+		floor.AddFunction(ScalarFunction({type}, type, func, false, false, bind_func));
+	}
+	set.AddFunction(floor);
+}
+
+//===--------------------------------------------------------------------===//
+// round
+//===--------------------------------------------------------------------===//
+struct RoundOperatorPrecision {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA input, TB precision) {
+		double rounded_value;
+		if (precision < 0) {
+			double modifier = std::pow(10, -precision);
+			rounded_value = (std::round(input / modifier)) * modifier;
+			if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+				return 0;
+			}
+		} else {
+			double modifier = std::pow(10, precision);
+			rounded_value = (std::round(input * modifier)) / modifier;
+			if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+				return input;
+			}
+		}
+		return rounded_value;
+	}
+};
+
+struct RoundOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		double rounded_value = round(input);
+		if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+			return input;
+		}
+		return rounded_value;
+	}
+};
+
+struct RoundDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		T addition = power_of_ten / 2;
+		// regular round rounds towards the nearest number
+		// in case of a tie we round away from zero
+		// i.e. -10.5 -> -11, 10.5 -> 11
+		// we implement this by adding (positive) or subtracting (negative) 0.5
+		// and then flooring the number
+		// e.g. 10.5 + 0.5 = 11, floor(11) = 11
+		//      10.4 + 0.5 = 10.9, floor(10.9) = 10
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				input -= addition;
+			} else {
+				input += addition;
+			}
+			return input / power_of_ten;
+		});
+	}
+};
+
+struct RoundPrecisionFunctionData : public FunctionData {
+	explicit RoundPrecisionFunctionData(int32_t target_scale) : target_scale(target_scale) {
+	}
+
+	int32_t target_scale;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<RoundPrecisionFunctionData>(target_scale);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RoundPrecisionFunctionData &)other_p;
+		return target_scale == other.target_scale;
+	}
+};
+
+template <class T, class POWERS_OF_TEN_CLASS>
+static void DecimalRoundNegativePrecisionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RoundPrecisionFunctionData &)*func_expr.bind_info;
+	auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+	auto width = DecimalType::GetWidth(func_expr.children[0]->return_type);
+	if (-info.target_scale >= width) {
+		// scale too big for width
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.SetValue(0, Value::INTEGER(0));
+		return;
+	}
+	T divide_power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale + source_scale];
+	T multiply_power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale];
+	T addition = divide_power_of_ten / 2;
+
+	UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+		if (input < 0) {
+			input -= addition;
+		} else {
+			input += addition;
+		}
+		return input / divide_power_of_ten * multiply_power_of_ten;
+	});
+}
+
+template <class T, class POWERS_OF_TEN_CLASS>
+static void DecimalRoundPositivePrecisionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RoundPrecisionFunctionData &)*func_expr.bind_info;
+	auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+	T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[source_scale - info.target_scale];
+	T addition = power_of_ten / 2;
+	UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+		if (input < 0) {
+			input -= addition;
+		} else {
+			input += addition;
+		}
+		return input / power_of_ten;
+	});
+}
+
+unique_ptr<FunctionData> BindDecimalRoundPrecision(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	auto &decimal_type = arguments[0]->return_type;
+	if (!arguments[1]->IsFoldable()) {
+		throw NotImplementedException("ROUND(DECIMAL, INTEGER) with non-constant precision is not supported");
+	}
+	Value val = ExpressionExecutor::EvaluateScalar(*arguments[1]).CastAs(LogicalType::INTEGER);
+	if (val.IsNull()) {
+		throw NotImplementedException("ROUND(DECIMAL, INTEGER) with non-constant precision is not supported");
+	}
+	// our new precision becomes the round value
+	// e.g. ROUND(DECIMAL(18,3), 1) -> DECIMAL(18,1)
+	// but ONLY if the round value is positive
+	// if it is negative the scale becomes zero
+	// i.e. ROUND(DECIMAL(18,3), -1) -> DECIMAL(18,0)
+	int32_t round_value = IntegerValue::Get(val);
+	uint8_t target_scale;
+	auto width = DecimalType::GetWidth(decimal_type);
+	auto scale = DecimalType::GetScale(decimal_type);
+	if (round_value < 0) {
+		target_scale = 0;
+		switch (decimal_type.InternalType()) {
+		case PhysicalType::INT16:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int16_t, NumericHelper>;
+			break;
+		case PhysicalType::INT32:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int32_t, NumericHelper>;
+			break;
+		case PhysicalType::INT64:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int64_t, NumericHelper>;
+			break;
+		default:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<hugeint_t, Hugeint>;
+			break;
+		}
+	} else {
+		if (round_value >= (int32_t)scale) {
+			// if round_value is bigger than or equal to scale we do nothing
+			bound_function.function = ScalarFunction::NopFunction;
+			target_scale = scale;
+		} else {
+			target_scale = round_value;
+			switch (decimal_type.InternalType()) {
+			case PhysicalType::INT16:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int16_t, NumericHelper>;
+				break;
+			case PhysicalType::INT32:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int32_t, NumericHelper>;
+				break;
+			case PhysicalType::INT64:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int64_t, NumericHelper>;
+				break;
+			default:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<hugeint_t, Hugeint>;
+				break;
+			}
+		}
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = LogicalType::DECIMAL(width, target_scale);
+	return make_unique<RoundPrecisionFunctionData>(round_value);
+}
+
+void RoundFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet round("round");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t round_prec_func = nullptr;
+		scalar_function_t round_func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		bind_scalar_function_t bind_prec_func = nullptr;
+		if (type.IsIntegral()) {
+			// no round for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			round_func = ScalarFunction::UnaryFunction<float, float, RoundOperator>;
+			round_prec_func = ScalarFunction::BinaryFunction<float, int32_t, float, RoundOperatorPrecision>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			round_func = ScalarFunction::UnaryFunction<double, double, RoundOperator>;
+			round_prec_func = ScalarFunction::BinaryFunction<double, int32_t, double, RoundOperatorPrecision>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<RoundDecimalOperator>;
+			bind_prec_func = BindDecimalRoundPrecision;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"floor\"");
+		}
+		round.AddFunction(ScalarFunction({type}, type, round_func, false, false, bind_func));
+		round.AddFunction(
+		    ScalarFunction({type, LogicalType::INTEGER}, type, round_prec_func, false, false, bind_prec_func));
+	}
+	set.AddFunction(round);
+}
+
+//===--------------------------------------------------------------------===//
+// exp
+//===--------------------------------------------------------------------===//
+struct ExpOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::exp(left);
+	}
+};
+
+void ExpFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("exp", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, ExpOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// pow
+//===--------------------------------------------------------------------===//
+struct PowOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA base, TB exponent) {
+		return std::pow(base, exponent);
+	}
+};
+
+void PowFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction power_function("pow", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                              ScalarFunction::BinaryFunction<double, double, double, PowOperator>);
+	set.AddFunction(power_function);
+	power_function.name = "power";
+	set.AddFunction(power_function);
+	power_function.name = "**";
+	set.AddFunction(power_function);
+	power_function.name = "^";
+	set.AddFunction(power_function);
+}
+
+//===--------------------------------------------------------------------===//
+// sqrt
+//===--------------------------------------------------------------------===//
+struct SqrtOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take square root of a negative number");
+		}
+		return std::sqrt(input);
+	}
+};
+
+void SqrtFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("sqrt", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, SqrtOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// cbrt
+//===--------------------------------------------------------------------===//
+struct CbRtOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::cbrt(left);
+	}
+};
+
+void CbrtFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("cbrt", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, CbRtOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// ln
+//===--------------------------------------------------------------------===//
+
+struct LnOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log(input);
+	}
+};
+
+void LnFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("ln", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, LnOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// log
+//===--------------------------------------------------------------------===//
+struct Log10Operator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log10(input);
+	}
+};
+
+void Log10Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"log10", "log"}, ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                                                 ScalarFunction::UnaryFunction<double, double, Log10Operator>));
+}
+
+//===--------------------------------------------------------------------===//
+// log2
+//===--------------------------------------------------------------------===//
+struct Log2Operator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log2(input);
+	}
+};
+
+void Log2Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("log2", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, Log2Operator>));
+}
+
+//===--------------------------------------------------------------------===//
+// pi
+//===--------------------------------------------------------------------===//
+static void PiFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	Value pi_value = Value::DOUBLE(PI);
+	result.Reference(pi_value);
+}
+
+void PiFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("pi", {}, LogicalType::DOUBLE, PiFunction));
+}
+
+//===--------------------------------------------------------------------===//
+// degrees
+//===--------------------------------------------------------------------===//
+struct DegreesOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return left * (180 / PI);
+	}
+};
+
+void DegreesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("degrees", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, DegreesOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// radians
+//===--------------------------------------------------------------------===//
+struct RadiansOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return left * (PI / 180);
+	}
+};
+
+void RadiansFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("radians", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, RadiansOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// isnan
+//===--------------------------------------------------------------------===//
+struct IsNanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Value::IsNan(input);
+	}
+};
+
+void IsNanFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isnan");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsNanOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsNanOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// isinf
+//===--------------------------------------------------------------------===//
+struct IsInfiniteOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return !Value::IsNan(input) && !Value::IsFinite(input);
+	}
+};
+
+template <>
+bool IsInfiniteOperator::Operation(date_t input) {
+	return !Value::IsFinite(input);
+}
+
+template <>
+bool IsInfiniteOperator::Operation(timestamp_t input) {
+	return !Value::IsFinite(input);
+}
+
+void IsInfiniteFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isinf");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<date_t, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsInfiniteOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// isfinite
+//===--------------------------------------------------------------------===//
+struct IsFiniteOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Value::IsFinite(input);
+	}
+};
+
+void IsFiniteFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isfinite");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<date_t, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsFiniteOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// sin
+//===--------------------------------------------------------------------===//
+template <class OP>
+struct NoInfiniteDoubleWrapper {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		if (DUCKDB_UNLIKELY(!Value::IsFinite(input))) {
+			if (Value::IsNan(input)) {
+				return input;
+			}
+			throw OutOfRangeException("input value %lf is out of range for numeric function", input);
+		}
+		return OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input);
+	}
+};
+
+struct SinOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return std::sin(input);
+	}
+};
+
+void SinFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("sin", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<SinOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// cos
+//===--------------------------------------------------------------------===//
+struct CosOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::cos(input);
+	}
+};
+
+void CosFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("cos", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<CosOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// tan
+//===--------------------------------------------------------------------===//
+struct TanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::tan(input);
+	}
+};
+
+void TanFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("tan", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<TanOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// asin
+//===--------------------------------------------------------------------===//
+struct ASinOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < -1 || input > 1) {
+			throw Exception("ASIN is undefined outside [-1,1]");
+		}
+		return (double)std::asin(input);
+	}
+};
+
+void AsinFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("asin", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<ASinOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// atan
+//===--------------------------------------------------------------------===//
+struct ATanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::atan(input);
+	}
+};
+
+void AtanFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("atan", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, ATanOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// atan2
+//===--------------------------------------------------------------------===//
+struct ATan2 {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return (double)std::atan2(left, right);
+	}
+};
+
+void Atan2Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("atan2", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::BinaryFunction<double, double, double, ATan2>));
+}
+
+//===--------------------------------------------------------------------===//
+// acos
+//===--------------------------------------------------------------------===//
+struct ACos {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::acos(input);
+	}
+};
+
+void AcosFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("acos", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<ACos>>));
+}
+
+//===--------------------------------------------------------------------===//
+// cot
+//===--------------------------------------------------------------------===//
+struct CotOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return 1.0 / (double)std::tan(input);
+	}
+};
+
+void CotFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("cot", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<CotOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct GammaOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input == 0) {
+			throw OutOfRangeException("cannot take gamma of zero");
+		}
+		return std::tgamma(input);
+	}
+};
+
+void GammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("gamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, GammaOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct LogGammaOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input == 0) {
+			throw OutOfRangeException("cannot take log gamma of zero");
+		}
+		return std::lgamma(input);
+	}
+};
+
+void LogGammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("lgamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, LogGammaOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// factorial(), !
+//===--------------------------------------------------------------------===//
+
+struct FactorialOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		TR ret = 1;
+		for (TA i = 2; i <= left; i++) {
+			ret *= i;
+		}
+		return ret;
+	}
+};
+
+void FactorialFun::RegisterFunction(BuiltinFunctions &set) {
+	auto fun = ScalarFunction({LogicalType::INTEGER}, LogicalType::HUGEINT,
+	                          ScalarFunction::UnaryFunction<int32_t, hugeint_t, FactorialOperator>);
+
+	set.AddFunction({"factorial", "!__postfix"}, fun);
+}
+
+//===--------------------------------------------------------------------===//
+// even
+//===--------------------------------------------------------------------===//
+struct EvenOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		double value;
+		if (left >= 0) {
+			value = std::ceil(left);
+		} else {
+			value = std::ceil(-left);
+			value = -value;
+		}
+		if (std::floor(value / 2) * 2 != value) {
+			if (left >= 0) {
+				return value += 1;
+			}
+			return value -= 1;
+		}
+		return value;
+	}
+};
+
+void EvenFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("even", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, EvenOperator>));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct RandomBindData : public FunctionData {
+	ClientContext &context;
+
+	explicit RandomBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<RandomBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+struct RandomLocalState : public FunctionLocalState {
+	explicit RandomLocalState(uint32_t seed) : random_engine(seed) {
+	}
+
+	RandomEngine random_engine;
+};
+
+static void RandomFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	auto &lstate = (RandomLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<double>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i] = lstate.random_engine.NextRandom();
+	}
+}
+
+unique_ptr<FunctionData> RandomBind(ClientContext &context, ScalarFunction &bound_function,
+                                    vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<RandomBindData>(context);
+}
+
+static unique_ptr<FunctionLocalState> RandomInitLocalState(const BoundFunctionExpression &expr,
+                                                           FunctionData *bind_data) {
+	auto &info = (RandomBindData &)*bind_data;
+	auto &random_engine = RandomEngine::Get(info.context);
+	return make_unique<RandomLocalState>(random_engine.NextRandomInteger());
+}
+
+void RandomFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("random", {}, LogicalType::DOUBLE, RandomFunction, true, RandomBind, nullptr,
+	                               nullptr, RandomInitLocalState));
+}
+
+static void GenerateUUIDFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	auto &lstate = (RandomLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<hugeint_t>(result);
+
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i] = UUID::GenerateRandomUUID(lstate.random_engine);
+	}
+}
+
+void UUIDFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction uuid_function({}, LogicalType::UUID, GenerateUUIDFunction, false, true, RandomBind, nullptr, nullptr,
+	                             RandomInitLocalState);
+	// generate a random uuid
+	set.AddFunction({"uuid", "gen_random_uuid"}, uuid_function);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct SetseedBindData : public FunctionData {
+	//! The client context for the function call
+	ClientContext &context;
+
+	explicit SetseedBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<SetseedBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+static void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (SetseedBindData &)*func_expr.bind_info;
+	auto &input = args.data[0];
+	input.Normalify(args.size());
+
+	auto input_seeds = FlatVector::GetData<double>(input);
+	uint32_t half_max = NumericLimits<uint32_t>::Maximum() / 2;
+
+	auto &random_engine = RandomEngine::Get(info.context);
+	for (idx_t i = 0; i < args.size(); i++) {
+		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0) {
+			throw Exception("SETSEED accepts seed values between -1.0 and 1.0, inclusive");
+		}
+		uint32_t norm_seed = (input_seeds[i] + 1.0) * half_max;
+		random_engine.SetSeed(norm_seed);
+	}
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::SetNull(result, true);
+}
+
+unique_ptr<FunctionData> SetSeedBind(ClientContext &context, ScalarFunction &bound_function,
+                                     vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<SetseedBindData>(context);
+}
+
+void SetseedFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("setseed", {LogicalType::DOUBLE}, LogicalType::SQLNULL, SetSeedFunction, true, SetSeedBind));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterMathFunctions() {
+	Register<AbsFun>();
+	Register<SignFun>();
+
+	Register<CeilFun>();
+	Register<FloorFun>();
+	Register<RoundFun>();
+
+	Register<DegreesFun>();
+	Register<RadiansFun>();
+
+	Register<CbrtFun>();
+	Register<ExpFun>();
+	Register<Log2Fun>();
+	Register<Log10Fun>();
+	Register<LnFun>();
+	Register<PowFun>();
+	Register<RandomFun>();
+	Register<SetseedFun>();
+	Register<SqrtFun>();
+
+	Register<PiFun>();
+
+	Register<BitCountFun>();
+
+	Register<GammaFun>();
+	Register<LogGammaFun>();
+
+	Register<FactorialFun>();
+
+	Register<NextAfterFun>();
+
+	Register<EvenFun>();
+
+	Register<IsNanFun>();
+	Register<IsInfiniteFun>();
+	Register<IsFiniteFun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterNestedFunctions() {
+	Register<ArraySliceFun>();
+	Register<StructPackFun>();
+	Register<StructExtractFun>();
+	Register<StructInsertFun>();
+	Register<ListConcatFun>();
+	Register<ListContainsFun>();
+	Register<ListPositionFun>();
+	Register<ListAggregateFun>();
+	Register<ListDistinctFun>();
+	Register<ListUniqueFun>();
+	Register<ListValueFun>();
+	Register<ListExtractFun>();
+	Register<ListSortFun>();
+	Register<ListRangeFun>();
+	Register<ListFlattenFun>();
+	Register<MapFun>();
+	Register<MapExtractFun>();
+	Register<CardinalityFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// + [add]
+//===--------------------------------------------------------------------===//
+template <>
+float AddOperator::Operation(float left, float right) {
+	auto result = left + right;
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in addition of float!");
+	}
+	return result;
+}
+
+template <>
+double AddOperator::Operation(double left, double right) {
+	auto result = left + right;
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in addition of double!");
+	}
+	return result;
+}
+
+template <>
+interval_t AddOperator::Operation(interval_t left, interval_t right) {
+	left.months = AddOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.months, right.months);
+	left.days = AddOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.days, right.days);
+	left.micros = AddOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(left.micros, right.micros);
+	return left;
+}
+
+template <>
+date_t AddOperator::Operation(date_t left, int32_t right) {
+	if (!Value::IsFinite(left)) {
+		return left;
+	}
+	int32_t days;
+	if (!TryAddOperator::Operation(left.days, right, days)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	date_t result(days);
+	if (!Value::IsFinite(result)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	return result;
+}
+
+template <>
+date_t AddOperator::Operation(int32_t left, date_t right) {
+	return AddOperator::Operation<date_t, int32_t, date_t>(right, left);
+}
+
+template <>
+timestamp_t AddOperator::Operation(date_t left, dtime_t right) {
+	if (left == date_t::infinity()) {
+		return timestamp_t::infinity();
+	} else if (left == date_t::ninfinity()) {
+		return timestamp_t::ninfinity();
+	}
+	timestamp_t result;
+	if (!Timestamp::TryFromDatetime(left, right, result)) {
+		throw OutOfRangeException("Timestamp out of range");
+	}
+	return result;
+}
+
+template <>
+timestamp_t AddOperator::Operation(dtime_t left, date_t right) {
+	return AddOperator::Operation<date_t, dtime_t, timestamp_t>(right, left);
+}
+
+template <>
+date_t AddOperator::Operation(date_t left, interval_t right) {
+	return Interval::Add(left, right);
+}
+
+template <>
+date_t AddOperator::Operation(interval_t left, date_t right) {
+	return AddOperator::Operation<date_t, interval_t, date_t>(right, left);
+}
+
+template <>
+timestamp_t AddOperator::Operation(timestamp_t left, interval_t right) {
+	return Interval::Add(left, right);
+}
+
+template <>
+timestamp_t AddOperator::Operation(interval_t left, timestamp_t right) {
+	return AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(right, left);
+}
+
+//===--------------------------------------------------------------------===//
+// + [add] with overflow check
+//===--------------------------------------------------------------------===//
+struct OverflowCheckedAddition {
+	template <class SRCTYPE, class UTYPE>
+	static inline bool Operation(SRCTYPE left, SRCTYPE right, SRCTYPE &result) {
+		UTYPE uresult = AddOperator::Operation<UTYPE, UTYPE, UTYPE>(UTYPE(left), UTYPE(right));
+		if (uresult < NumericLimits<SRCTYPE>::Minimum() || uresult > NumericLimits<SRCTYPE>::Maximum()) {
+			return false;
+		}
+		result = SRCTYPE(uresult);
+		return true;
+	}
+};
+
+template <>
+bool TryAddOperator::Operation(uint8_t left, uint8_t right, uint8_t &result) {
+	return OverflowCheckedAddition::Operation<uint8_t, uint16_t>(left, right, result);
+}
+template <>
+bool TryAddOperator::Operation(uint16_t left, uint16_t right, uint16_t &result) {
+	return OverflowCheckedAddition::Operation<uint16_t, uint32_t>(left, right, result);
+}
+template <>
+bool TryAddOperator::Operation(uint32_t left, uint32_t right, uint32_t &result) {
+	return OverflowCheckedAddition::Operation<uint32_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(uint64_t left, uint64_t right, uint64_t &result) {
+	if (NumericLimits<uint64_t>::Maximum() - left < right) {
+		return false;
+	}
+	return OverflowCheckedAddition::Operation<uint64_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int8_t left, int8_t right, int8_t &result) {
+	return OverflowCheckedAddition::Operation<int8_t, int16_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int16_t left, int16_t right, int16_t &result) {
+	return OverflowCheckedAddition::Operation<int16_t, int32_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int32_t left, int32_t right, int32_t &result) {
+	return OverflowCheckedAddition::Operation<int32_t, int64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t &result) {
+#if (__GNUC__ >= 5) || defined(__clang__)
+	if (__builtin_add_overflow(left, right, &result)) {
+		return false;
+	}
+#else
+	// https://blog.regehr.org/archives/1139
+	result = int64_t((uint64_t)left + (uint64_t)right);
+	if ((left < 0 && right < 0 && result >= 0) || (left >= 0 && right >= 0 && result < 0)) {
+		return false;
+	}
+#endif
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// add decimal with overflow check
+//===--------------------------------------------------------------------===//
+template <class T, T min, T max>
+bool TryDecimalAddTemplated(T left, T right, T &result) {
+	if (right < 0) {
+		if (min - right > left) {
+			return false;
+		}
+	} else {
+		if (max - right < left) {
+			return false;
+		}
+	}
+	result = left + right;
+	return true;
+}
+
+template <>
+bool TryDecimalAdd::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalAddTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalAddTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalAddTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left + right;
+	if (result <= -Hugeint::POWERS_OF_TEN[38] || result >= Hugeint::POWERS_OF_TEN[38]) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+hugeint_t DecimalAddOverflowCheck::Operation(hugeint_t left, hugeint_t right) {
+	hugeint_t result;
+	if (!TryDecimalAdd::Operation(left, right, result)) {
+		throw OutOfRangeException("Overflow in addition of DECIMAL(38) (%s + %s);", left.ToString(), right.ToString());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// add time operator
+//===--------------------------------------------------------------------===//
+template <>
+dtime_t AddTimeOperator::Operation(dtime_t left, interval_t right) {
+	date_t date(0);
+	return Interval::Add(left, right, date);
+}
+
+template <>
+dtime_t AddTimeOperator::Operation(interval_t left, dtime_t right) {
+	return AddTimeOperator::Operation<dtime_t, interval_t, dtime_t>(right, left);
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Summary:
Splitting the large DuckDB amalgamated .cpp file into 8 units, which
can be compiled in parallel. DuckDB supports a --splits=8 parameter when
calling the amalgamation script.
With this change, a recompilation of duckdb code goes from +3mins to
<50sec in my local development environment. allow-large-files
.

Differential Revision: D37572383

